### PR TITLE
[SDK] return fallback metadata when tokenId is not found on nft contract

### DIFF
--- a/.changeset/modern-monkeys-turn.md
+++ b/.changeset/modern-monkeys-turn.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/sdk": patch
+---
+
+Return default metadata when failing to fetch a given tokenId on NFT contracts

--- a/packages/sdk/src/evm/common/nft.ts
+++ b/packages/sdk/src/evm/common/nft.ts
@@ -24,7 +24,7 @@ import type {
 } from "@thirdweb-dev/storage";
 import { BigNumber, BigNumberish, Contract, ethers, providers } from "ethers";
 
-const FALLBACK_METADATA = {
+export const FALLBACK_METADATA = {
   name: "Failed to load NFT metadata",
 };
 

--- a/packages/sdk/src/evm/core/classes/erc-1155.ts
+++ b/packages/sdk/src/evm/core/classes/erc-1155.ts
@@ -7,7 +7,7 @@ import {
   hasFunction,
   NotFoundError,
 } from "../../common";
-import { fetchTokenMetadata } from "../../common/nft";
+import { FALLBACK_METADATA, fetchTokenMetadata } from "../../common/nft";
 import {
   FEATURE_EDITION,
   FEATURE_EDITION_BATCH_MINTABLE,
@@ -128,7 +128,11 @@ export class Erc1155<
       this.contractWrapper.readContract
         .totalSupply(tokenId)
         .catch(() => BigNumber.from(0)),
-      this.getTokenMetadata(tokenId),
+      this.getTokenMetadata(tokenId).catch(() => ({
+        id: tokenId.toString(),
+        uri: "",
+        ...FALLBACK_METADATA,
+      })),
     ]);
     return {
       owner: ethers.constants.AddressZero,

--- a/packages/sdk/src/evm/core/classes/erc-721.ts
+++ b/packages/sdk/src/evm/core/classes/erc-721.ts
@@ -7,7 +7,7 @@ import {
   hasFunction,
   NotFoundError,
 } from "../../common";
-import { fetchTokenMetadata } from "../../common/nft";
+import { FALLBACK_METADATA, fetchTokenMetadata } from "../../common/nft";
 import {
   FEATURE_NFT,
   FEATURE_NFT_BATCH_MINTABLE,
@@ -124,7 +124,11 @@ export class Erc721<
   public async get(tokenId: BigNumberish): Promise<NFT> {
     const [owner, metadata] = await Promise.all([
       this.ownerOf(tokenId).catch(() => constants.AddressZero),
-      this.getTokenMetadata(tokenId),
+      this.getTokenMetadata(tokenId).catch(() => ({
+        id: tokenId.toString(),
+        uri: "",
+        ...FALLBACK_METADATA,
+      })),
     ]);
     return { owner, metadata, type: "ERC721", supply: 1 };
   }


### PR DESCRIPTION
For contracts that don't have sequential tokenIds or start at a given index, avoid failing the entire getAll() call. Instead return a "failure" metadata when trying to get non-existent token ids. Like this one https://thirdweb.com/ethereum/0xeb4e856f69158052ac0aaf7dc26f63dcb1ee067f

Put it in the single get() to make it consistent between getAll() and get(). But open to changing it.