### PR TITLE
[React] Fix passing wrong RPC url to UserWallet when using an external signer

### DIFF
--- a/.changeset/dry-pandas-clap.md
+++ b/.changeset/dry-pandas-clap.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/react": patch
+---
+
+Fix SIWE when using an external signer

--- a/packages/react/src/evm/contexts/thirdweb-config.tsx
+++ b/packages/react/src/evm/contexts/thirdweb-config.tsx
@@ -3,7 +3,7 @@ import {
   SupportedChainId,
   defaultSupportedChains,
 } from "../constants/chain";
-import { ChainId } from "@thirdweb-dev/sdk";
+import { DEFAULT_RPC_URLS } from "@thirdweb-dev/sdk";
 import React, { PropsWithChildren, createContext, useContext } from "react";
 
 interface ThirdwebConfigContext {
@@ -11,17 +11,8 @@ interface ThirdwebConfigContext {
   supportedChains: Chain[];
 }
 
-export const defaultChainRpc: Record<SupportedChainId | number, string> = {
-  [ChainId.Mainnet]: "mainnet",
-  [ChainId.Goerli]: "goerli",
-  [ChainId.Polygon]: "polygon",
-  [ChainId.Mumbai]: "mumbai",
-  [ChainId.Fantom]: "fantom",
-  [ChainId.Avalanche]: "avalanche",
-};
-
 const ThirdwebConfigContext = createContext<ThirdwebConfigContext>({
-  rpcUrlMap: defaultChainRpc,
+  rpcUrlMap: DEFAULT_RPC_URLS,
   supportedChains: defaultSupportedChains,
 });
 

--- a/packages/react/src/evm/contexts/thirdweb-wallet.tsx
+++ b/packages/react/src/evm/contexts/thirdweb-wallet.tsx
@@ -30,6 +30,8 @@ const ThirdwebConnectedWalletContext =
 export const ThirdwebConnectedWalletProvider: React.FC<
   PropsWithChildren<{ signer?: Signer }>
 > = ({ signer, children }) => {
+  const { rpcUrlMap } = useThirdwebConfigContext();
+
   const [contextValue, setContextValue] =
     useState<ThirdwebConnectedWalletContext>(INITIAL_CONTEXT_VALUE);
 
@@ -39,9 +41,17 @@ export const ThirdwebConnectedWalletProvider: React.FC<
       // just get both of these up front and keep them around with the context
       Promise.all([signer.getAddress(), signer.getChainId()])
         .then(([address, chainId]) => {
+          const rpcUrl = rpcUrlMap[chainId];
           // only if the signer is still the same!
           if (signer === s) {
-            const wallet = new UserWallet(signer, {});
+            const wallet = new UserWallet(signer, {
+              readonlySettings: rpcUrl
+                ? {
+                    rpcUrl,
+                    chainId,
+                  }
+                : undefined,
+            });
             setContextValue({ wallet, address, chainId, signer });
           }
         })

--- a/packages/react/src/evm/contexts/thirdweb-wallet.tsx
+++ b/packages/react/src/evm/contexts/thirdweb-wallet.tsx
@@ -30,8 +30,6 @@ const ThirdwebConnectedWalletContext =
 export const ThirdwebConnectedWalletProvider: React.FC<
   PropsWithChildren<{ signer?: Signer }>
 > = ({ signer, children }) => {
-  const { rpcUrlMap } = useThirdwebConfigContext();
-
   const [contextValue, setContextValue] =
     useState<ThirdwebConnectedWalletContext>(INITIAL_CONTEXT_VALUE);
 
@@ -41,17 +39,9 @@ export const ThirdwebConnectedWalletProvider: React.FC<
       // just get both of these up front and keep them around with the context
       Promise.all([signer.getAddress(), signer.getChainId()])
         .then(([address, chainId]) => {
-          const rpcUrl = rpcUrlMap[chainId];
           // only if the signer is still the same!
           if (signer === s) {
-            const wallet = new UserWallet(signer, {
-              readonlySettings: rpcUrl
-                ? {
-                    rpcUrl,
-                    chainId,
-                  }
-                : undefined,
-            });
+            const wallet = new UserWallet(signer, {});
             setContextValue({ wallet, address, chainId, signer });
           }
         })

--- a/packages/react/src/evm/providers/full.tsx
+++ b/packages/react/src/evm/providers/full.tsx
@@ -9,10 +9,7 @@ import {
   defaultSupportedChains,
 } from "../constants/chain";
 import { ThirdwebAuthConfig } from "../contexts/thirdweb-auth";
-import {
-  ThirdwebConfigProvider,
-  defaultChainRpc,
-} from "../contexts/thirdweb-config";
+import { ThirdwebConfigProvider } from "../contexts/thirdweb-config";
 import { ThirdwebSDKProvider, ThirdwebSDKProviderProps } from "./base";
 import { QueryClient } from "@tanstack/react-query";
 import {
@@ -20,6 +17,7 @@ import {
   getProviderForNetwork,
   SDKOptionsOutput,
 } from "@thirdweb-dev/sdk";
+import { DEFAULT_RPC_URLS } from "@thirdweb-dev/sdk";
 import type { ThirdwebStorage } from "@thirdweb-dev/storage";
 import React, { useMemo } from "react";
 import {
@@ -223,7 +221,7 @@ export const ThirdwebProvider = <
   TSupportedChain extends SupportedChain = SupportedChain,
 >({
   sdkOptions,
-  chainRpc = defaultChainRpc,
+  chainRpc = DEFAULT_RPC_URLS,
   supportedChains = defaultSupportedChains.map(
     (c) => c.id,
   ) as TSupportedChain[],

--- a/packages/sdk/src/evm/constants/urls.ts
+++ b/packages/sdk/src/evm/constants/urls.ts
@@ -1,5 +1,6 @@
 import { SignerOrProvider } from "../core/types";
 import { StaticJsonRpcBatchProvider } from "../lib/static-batch-rpc";
+import { ChainId, SUPPORTED_CHAIN_ID, SUPPORTED_CHAIN_IDS } from "./chains";
 import { ethers, providers } from "ethers";
 
 /**
@@ -26,13 +27,15 @@ export const PINATA_IPFS_URL = `https://api.pinata.cloud/pinning/pinFileToIPFS`;
 
 /**
  * @internal
+ * This is a community API key that is subject to rate limiting. Please use your own key.
  */
-export type ChainOrRpc =
+const DEFAULT_API_KEY = "_gg7wSSi0KMBsdKnGVfHDueq6xMB9EkC";
+
+type ChainNames =
   | "mumbai"
   | "polygon"
   // common alias for `polygon`
   | "matic"
-  | "rinkeby"
   | "goerli"
   | "mainnet"
   // common alias for `mainnet`
@@ -44,21 +47,53 @@ export type ChainOrRpc =
   // actual name
   | "avalanche-fuji"
   | "optimism"
-  | "optimism-kovan"
   | "optimism-goerli"
   | "arbitrum"
-  | "arbitrum-rinkeby"
   | "arbitrum-goerli"
   | "binance"
-  | "binance-testnet"
-  // ideally we could use `https://${string}` notation here, but doing that causes anything that is a generic string to throw a type error => not worth the hassle for now
-  | (string & {});
-
+  | "binance-testnet";
 /**
  * @internal
- * This is a community API key that is subject to rate limiting. Please use your own key.
  */
-const DEFAULT_API_KEY = "_gg7wSSi0KMBsdKnGVfHDueq6xMB9EkC";
+export type ChainOrRpc =
+  // ideally we could use `https://${string}` notation here, but doing that causes anything that is a generic string to throw a type error => not worth the hassle for now
+  ChainNames | (string & {});
+
+export const CHAIN_NAME_TO_ID: Record<ChainNames, SUPPORTED_CHAIN_ID> = {
+  "avalanche-fuji": ChainId.AvalancheFujiTestnet,
+  "avalanche-testnet": ChainId.AvalancheFujiTestnet,
+  "fantom-testnet": ChainId.FantomTestnet,
+  ethereum: ChainId.Mainnet,
+  matic: ChainId.Polygon,
+  mumbai: ChainId.Mumbai,
+  goerli: ChainId.Goerli,
+  polygon: ChainId.Polygon,
+  mainnet: ChainId.Mainnet,
+  optimism: ChainId.Optimism,
+  "optimism-goerli": ChainId.OptimismGoerli,
+  arbitrum: ChainId.Arbitrum,
+  "arbitrum-goerli": ChainId.ArbitrumGoerli,
+  fantom: ChainId.Fantom,
+  avalanche: ChainId.Avalanche,
+  binance: ChainId.BinanceSmartChainMainnet,
+  "binance-testnet": ChainId.BinanceSmartChainTestnet,
+};
+
+export const CHAIN_ID_TO_NAME = Object.fromEntries(
+  Object.entries(CHAIN_NAME_TO_ID).map(([name, id]) => [id, name]),
+) as Record<ChainId, ChainNames>;
+
+function buildDefaultMap() {
+  return SUPPORTED_CHAIN_IDS.reduce((previousValue, currentValue) => {
+    previousValue[currentValue] = getProviderForNetwork(
+      CHAIN_ID_TO_NAME[currentValue],
+    ) as string;
+    return previousValue;
+  }, {} as Record<SUPPORTED_CHAIN_ID, string>);
+}
+
+export const DEFAULT_RPC_URLS: Record<SUPPORTED_CHAIN_ID, string> =
+  buildDefaultMap();
 
 /**
  * @internal


### PR DESCRIPTION
The problem was that we were *always* passing a readonly url to UserWallet, but this readonly url relies on passing a rpcURLMap from ThirdwebProvider which seems wrong. 

When using ThirdwebSDKProvider we don't let you pass that rpcUrl map at all.

What would happen is that `const rpcUrl = rpcUrlMap[chainId];` would resolve in "mumbai" and would try to override the provider within the signer with a readonly provider, only to fail and throw since `ethers.getProvider("mumbai")` throws. That would manifest in no signer being available when doing things like SIWE. See thread in https://discord.com/channels/834227967404146718/1019059287030505562/1030917794939813988