### PR TITLE
[SDK] Update signTypedData domain to match contract

### DIFF
--- a/.changeset/khaki-panthers-grin.md
+++ b/.changeset/khaki-panthers-grin.md
@@ -2,4 +2,4 @@
 "@thirdweb-dev/sdk": patch
 ---
 
-Updated signTypedData domain to match contract from TokenERC1155 to SignatureMintERC1155
+Correctly handle contracts using the SignatureMintERC1155 ContractKit extension

--- a/.changeset/khaki-panthers-grin.md
+++ b/.changeset/khaki-panthers-grin.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/sdk": patch
+---
+
+Updated signTypedData domain to match contract from TokenERC1155 to SignatureMintERC1155

--- a/packages/sdk/src/evm/core/classes/erc-1155-signature-mintable.ts
+++ b/packages/sdk/src/evm/core/classes/erc-1155-signature-mintable.ts
@@ -1,4 +1,5 @@
 import { normalizePriceValue, setErc20Allowance } from "../../common/currency";
+import { getPrebuiltInfo } from "../../common/legacy";
 import { uploadOrExtractURIs } from "../../common/nft";
 import { FEATURE_EDITION_SIGNATURE_MINTABLE } from "../../constants/erc1155-features";
 import type { NFTCollectionInitializer } from "../../contracts";
@@ -330,6 +331,12 @@ export class Erc1155SignatureMintable implements DetectableFeature {
     const signer = this.contractWrapper.getSigner();
     invariant(signer, "No signer available");
 
+    const contractInfo = await getPrebuiltInfo(
+      this.contractWrapper.readContract.address,
+      this.contractWrapper.getProvider(),
+    );
+    const isLegacyContract = contractInfo?.type === "TokenERC1155";
+
     return await Promise.all(
       parsedRequests.map(async (m, i) => {
         const uri = uris[i];
@@ -340,7 +347,7 @@ export class Erc1155SignatureMintable implements DetectableFeature {
         const signature = await this.contractWrapper.signTypedData(
           signer,
           {
-            name: "SignatureMintERC1155",
+            name: isLegacyContract ? "TokenERC1155" : "SignatureMintERC1155",
             version: "1",
             chainId,
             verifyingContract: this.contractWrapper.readContract.address,

--- a/packages/sdk/src/evm/core/classes/erc-1155-signature-mintable.ts
+++ b/packages/sdk/src/evm/core/classes/erc-1155-signature-mintable.ts
@@ -340,7 +340,7 @@ export class Erc1155SignatureMintable implements DetectableFeature {
         const signature = await this.contractWrapper.signTypedData(
           signer,
           {
-            name: "TokenERC1155",
+            name: "SignatureMintERC1155",
             version: "1",
             chainId,
             verifyingContract: this.contractWrapper.readContract.address,


### PR DESCRIPTION
This is a patch for the ERC1155 Signature Mint function in the SDK.

The current function uses the domain `TokenERC1155` which should actually match the domain in the smart contract, which is [`SignatureMintERC1155`](https://github.com/thirdweb-dev/contracts/blob/main/contracts/extension/SignatureMintERC1155.sol#L18). Because the domains do not match, the signer recovered after processing the request will always be different. This means all transactions will fail as the signer recovered is not expected.

This change was also communicated and discussed with @adam-maj on Discord after a week of debugging.

Changes were tested according to contributing guidelines!