### PR TITLE
[SDK] Fixed issue 487, return tx hash when deploy transaction is sent

### DIFF
--- a/.changeset/tender-moons-allow.md
+++ b/.changeset/tender-moons-allow.md
@@ -1,0 +1,7 @@
+---
+"@thirdweb-dev/sdk": patch
+---
+
+Added a contractWrapper accessor method to FactoryEvents
+Added a callEmitListener public method to call internal emitListener
+Propagate deployTransaction emitted event from deployViaProxy method

--- a/packages/sdk/src/evm/common/currency.ts
+++ b/packages/sdk/src/evm/common/currency.ts
@@ -205,6 +205,9 @@ export function toUnits(amount: Amount, decimals: BigNumberish): BigNumber {
   return utils.parseUnits(AmountSchema.parse(amount), decimals);
 }
 
-export function toDisplayValue(amount: BigNumberish, decimals: BigNumberish): string {
+export function toDisplayValue(
+  amount: BigNumberish,
+  decimals: BigNumberish,
+): string {
   return utils.formatUnits(amount, decimals);
 }

--- a/packages/sdk/src/evm/core/classes/contract-deployer.ts
+++ b/packages/sdk/src/evm/core/classes/contract-deployer.ts
@@ -517,6 +517,12 @@ export class ContractDeployer extends RPCConnectionHandler {
       this.storage,
       this.options,
     );
+	console.log("TEEEEESTING PR");
+	const contractWrapper = this.events?.getContractWrapper();		
+	this.events = new FactoryEvents(proxyFactory);
+	this.events.addDeployListener((event:any) => {		
+		contractWrapper?.callEmitTransactionEvent(event.status, event.transactionHash);		
+	});		
     return await proxyFactory.deployProxyByImplementation(
       implementationAddress,
       implementationAbi,

--- a/packages/sdk/src/evm/core/classes/contract-deployer.ts
+++ b/packages/sdk/src/evm/core/classes/contract-deployer.ts
@@ -516,7 +516,7 @@ export class ContractDeployer extends RPCConnectionHandler {
       this.getSignerOrProvider(),
       this.storage,
       this.options,
-    );	
+    );   	
 	const contractWrapper = this.events?.getContractWrapper();		
 	this.events = new FactoryEvents(proxyFactory);
 	this.events.addDeployListener((event:any) => {		

--- a/packages/sdk/src/evm/core/classes/contract-deployer.ts
+++ b/packages/sdk/src/evm/core/classes/contract-deployer.ts
@@ -516,12 +516,15 @@ export class ContractDeployer extends RPCConnectionHandler {
       this.getSignerOrProvider(),
       this.storage,
       this.options,
-    );   	
-	const contractWrapper = this.events?.getContractWrapper();		
-	this.events = new FactoryEvents(proxyFactory);
-	this.events.addDeployListener((event:any) => {		
-		contractWrapper?.callEmitTransactionEvent(event.status, event.transactionHash);		
-	});		
+    );
+    const contractWrapper = this.events?.getContractWrapper();
+    this.events = new FactoryEvents(proxyFactory);
+    this.events.addDeployListener((event: any) => {
+      contractWrapper?.callEmitTransactionEvent(
+        event.status,
+        event.transactionHash,
+      );
+    });
     return await proxyFactory.deployProxyByImplementation(
       implementationAddress,
       implementationAbi,

--- a/packages/sdk/src/evm/core/classes/contract-deployer.ts
+++ b/packages/sdk/src/evm/core/classes/contract-deployer.ts
@@ -516,8 +516,7 @@ export class ContractDeployer extends RPCConnectionHandler {
       this.getSignerOrProvider(),
       this.storage,
       this.options,
-    );
-	console.log("TEEEEESTING PR");
+    );	
 	const contractWrapper = this.events?.getContractWrapper();		
 	this.events = new FactoryEvents(proxyFactory);
 	this.events.addDeployListener((event:any) => {		

--- a/packages/sdk/src/evm/core/classes/contract-wrapper.ts
+++ b/packages/sdk/src/evm/core/classes/contract-wrapper.ts
@@ -234,6 +234,16 @@ export class ContractWrapper<
   }
 
   /**
+   * @external
+   */  
+  public callEmitTransactionEvent(
+		status: "submitted" | "completed",
+  	transactionHash: string,
+	) {
+		this.emitTransactionEvent(status, transactionHash);
+  }
+
+  /**
    * @internal
    */
   public async multiCall(

--- a/packages/sdk/src/evm/core/classes/contract-wrapper.ts
+++ b/packages/sdk/src/evm/core/classes/contract-wrapper.ts
@@ -235,12 +235,12 @@ export class ContractWrapper<
 
   /**
    * @external
-   */  
+   */
   public callEmitTransactionEvent(
-		status: "submitted" | "completed",
-  	transactionHash: string,
-	) {
-		this.emitTransactionEvent(status, transactionHash);
+    status: "submitted" | "completed",
+    transactionHash: string,
+  ) {
+    this.emitTransactionEvent(status, transactionHash);
   }
 
   /**

--- a/packages/sdk/src/evm/core/classes/factory-events.ts
+++ b/packages/sdk/src/evm/core/classes/factory-events.ts
@@ -19,32 +19,32 @@ export class FactoryEvents extends ContractEvents<TWFactory> {
         return;
       }
 
-			const receipt = await this.contractWrapper
-				.getProvider()
-				.getTransactionReceipt(event.transactionHash);
+      const receipt = await this.contractWrapper
+        .getProvider()
+        .getTransactionReceipt(event.transactionHash);
 
-			if (receipt && receipt.logs){
-				const events = this.contractWrapper.parseLogs<ProxyDeployedEvent>(
-					"ProxyDeployed",
-					receipt.logs,
-				);
+      if (receipt && receipt.logs) {
+        const events = this.contractWrapper.parseLogs<ProxyDeployedEvent>(
+          "ProxyDeployed",
+          receipt.logs,
+        );
 
-				if (events.length > 0) {
-					listener({
-					...event,
-					contractAddress: events[0].args.proxy,
-					});
-				}
-			}else{
-				listener({
-					...event,
-					transactionHash: event.transactionHash,
-				});
-			}
+        if (events.length > 0) {
+          listener({
+            ...event,
+            contractAddress: events[0].args.proxy,
+          });
+        }
+      } else {
+        listener({
+          ...event,
+          transactionHash: event.transactionHash,
+        });
+      }
     });
   }
 
   public getContractWrapper(): ContractWrapper<TWFactory> {
-		return this.contractWrapper;	
-  }  
+    return this.contractWrapper;
+  }
 }

--- a/packages/sdk/src/evm/core/classes/factory-events.ts
+++ b/packages/sdk/src/evm/core/classes/factory-events.ts
@@ -19,20 +19,32 @@ export class FactoryEvents extends ContractEvents<TWFactory> {
         return;
       }
 
-      const receipt = await this.contractWrapper
-        .getProvider()
-        .getTransactionReceipt(event.transactionHash);
-      const events = this.contractWrapper.parseLogs<ProxyDeployedEvent>(
-        "ProxyDeployed",
-        receipt.logs,
-      );
+			const receipt = await this.contractWrapper
+				.getProvider()
+				.getTransactionReceipt(event.transactionHash);
 
-      if (events.length > 0) {
-        listener({
-          ...event,
-          contractAddress: events[0].args.proxy,
-        });
-      }
+			if (receipt && receipt.logs){
+				const events = this.contractWrapper.parseLogs<ProxyDeployedEvent>(
+					"ProxyDeployed",
+					receipt.logs,
+				);
+
+				if (events.length > 0) {
+					listener({
+					...event,
+					contractAddress: events[0].args.proxy,
+					});
+				}
+			}else{
+				listener({
+					...event,
+					transactionHash: event.transactionHash,
+				});
+			}
     });
   }
+
+  public getContractWrapper(): ContractWrapper<TWFactory> {
+		return this.contractWrapper;	
+  }  
 }


### PR DESCRIPTION
This patch will propagate deploy transaction event to the parent EventFactory and allow to get transaction hash once sent while wait for deploy to finish and return proxy address.