### PR TITLE
[SDK] Adding and event to return transaction hash immediately after calling deploy

### DIFF
--- a/.changeset/weak-schools-march.md
+++ b/.changeset/weak-schools-march.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/sdk": patch
+---
+
+[SDK] Added event for submitted deploy transaction

--- a/packages/sdk/src/evm/common/currency.ts
+++ b/packages/sdk/src/evm/common/currency.ts
@@ -205,6 +205,9 @@ export function toUnits(amount: Amount, decimals: BigNumberish): BigNumber {
   return utils.parseUnits(AmountSchema.parse(amount), decimals);
 }
 
-export function toDisplayValue(amount: BigNumberish, decimals: BigNumberish): string {
+export function toDisplayValue(
+  amount: BigNumberish,
+  decimals: BigNumberish,
+): string {
   return utils.formatUnits(amount, decimals);
 }

--- a/packages/sdk/src/evm/core/classes/contract-deployer.ts
+++ b/packages/sdk/src/evm/core/classes/contract-deployer.ts
@@ -805,9 +805,9 @@ export class ContractDeployer extends RPCConnectionHandler {
     const deployer = await new ethers.ContractFactory(abi, bytecode)
       .connect(signer)
       .deploy(...constructorParams);
-	this.events.emit("contractDeploySubmitted", {		
-		transactionHash: deployer.deployTransaction.hash,
-	});	  
+    this.events.emit("contractDeploySubmitted", {
+      transactionHash: deployer.deployTransaction.hash,
+    });
     const deployedContract = await deployer.deployed();
     this.events.emit("contractDeployed", {
       contractAddress: deployedContract.address,
@@ -821,7 +821,7 @@ export class ContractDeployer extends RPCConnectionHandler {
    * @param listener the listener to add
    */
   public addDeployListener(listener: (event: DeployEvent) => void) {
-	this.events.on("contractDeploySubmitted", listener);		
+    this.events.on("contractDeploySubmitted", listener);
     this.events.on("contractDeployed", listener);
   }
 
@@ -830,7 +830,7 @@ export class ContractDeployer extends RPCConnectionHandler {
    * @param listener the listener to remove
    */
   public removeDeployListener(listener: (event: DeployEvent) => void) {
-	this.events.off("contractDeploySubmitted", listener);		
+    this.events.off("contractDeploySubmitted", listener);
     this.events.off("contractDeployed", listener);
   }
 
@@ -838,7 +838,7 @@ export class ContractDeployer extends RPCConnectionHandler {
    * Remove all deploy listeners
    */
   public removeAllDeployListeners() {
-	this.events.removeAllListeners("contractDeploySubmitted");		
+    this.events.removeAllListeners("contractDeploySubmitted");
     this.events.removeAllListeners("contractDeployed");
   }
 }

--- a/packages/sdk/src/evm/core/classes/contract-deployer.ts
+++ b/packages/sdk/src/evm/core/classes/contract-deployer.ts
@@ -805,6 +805,9 @@ export class ContractDeployer extends RPCConnectionHandler {
     const deployer = await new ethers.ContractFactory(abi, bytecode)
       .connect(signer)
       .deploy(...constructorParams);
+	this.events.emit("contractDeploySubmitted", {		
+		transactionHash: deployer.deployTransaction.hash,
+	});	  
     const deployedContract = await deployer.deployed();
     this.events.emit("contractDeployed", {
       contractAddress: deployedContract.address,
@@ -818,6 +821,7 @@ export class ContractDeployer extends RPCConnectionHandler {
    * @param listener the listener to add
    */
   public addDeployListener(listener: (event: DeployEvent) => void) {
+	this.events.on("contractDeploySubmitted", listener);		
     this.events.on("contractDeployed", listener);
   }
 
@@ -826,6 +830,7 @@ export class ContractDeployer extends RPCConnectionHandler {
    * @param listener the listener to remove
    */
   public removeDeployListener(listener: (event: DeployEvent) => void) {
+	this.events.off("contractDeploySubmitted", listener);		
     this.events.off("contractDeployed", listener);
   }
 
@@ -833,6 +838,7 @@ export class ContractDeployer extends RPCConnectionHandler {
    * Remove all deploy listeners
    */
   public removeAllDeployListeners() {
+	this.events.removeAllListeners("contractDeploySubmitted");		
     this.events.removeAllListeners("contractDeployed");
   }
 }

--- a/packages/sdk/src/evm/core/classes/contract-wrapper.ts
+++ b/packages/sdk/src/evm/core/classes/contract-wrapper.ts
@@ -36,6 +36,8 @@ import {
   providers,
 } from "ethers";
 import invariant from "tiny-invariant";
+import { EventEmitter } from "eventemitter3";
+import { DeployEvents } from "../../types";
 
 /**
  * @internal
@@ -327,6 +329,7 @@ export class ContractWrapper<
     fn: keyof TContract["functions"] | (string & {}),
     args: any[],
     callOverrides?: CallOverrides,
+	eventEmitter?: EventEmitter<DeployEvents>,
   ): Promise<providers.TransactionReceipt> {
     if (!callOverrides) {
       callOverrides = await this.getCallOverrides();
@@ -353,6 +356,7 @@ export class ContractWrapper<
       const provider = this.getProvider();
       const txHash = await this.sendGaslessTransaction(fn, args, callOverrides);
       this.emitTransactionEvent("submitted", txHash);
+	  if (eventEmitter) eventEmitter.emit("contractDeploySubmitted", { transactionHash: txHash });
       const receipt = await provider.waitForTransaction(txHash);
       this.emitTransactionEvent("completed", txHash);
       return receipt;
@@ -375,6 +379,7 @@ export class ContractWrapper<
         callOverrides,
       );
       this.emitTransactionEvent("submitted", tx.hash);
+	  if (eventEmitter) eventEmitter.emit("contractDeploySubmitted", { transactionHash: tx.hash });
       const receipt = tx.wait();
       this.emitTransactionEvent("completed", tx.hash);
       return receipt;

--- a/packages/sdk/src/evm/core/classes/contract-wrapper.ts
+++ b/packages/sdk/src/evm/core/classes/contract-wrapper.ts
@@ -15,6 +15,7 @@ import { EventType } from "../../constants/events";
 import { CallOverrideSchema } from "../../schema";
 import { AbiSchema } from "../../schema/contracts/custom";
 import { SDKOptions } from "../../schema/sdk-options";
+import { DeployEvents } from "../../types";
 import {
   ForwardRequestMessage,
   GaslessTransaction,
@@ -35,9 +36,8 @@ import {
   ethers,
   providers,
 } from "ethers";
-import invariant from "tiny-invariant";
 import { EventEmitter } from "eventemitter3";
-import { DeployEvents } from "../../types";
+import invariant from "tiny-invariant";
 
 /**
  * @internal
@@ -329,7 +329,7 @@ export class ContractWrapper<
     fn: keyof TContract["functions"] | (string & {}),
     args: any[],
     callOverrides?: CallOverrides,
-	eventEmitter?: EventEmitter<DeployEvents>,
+    eventEmitter?: EventEmitter<DeployEvents>,
   ): Promise<providers.TransactionReceipt> {
     if (!callOverrides) {
       callOverrides = await this.getCallOverrides();
@@ -356,7 +356,10 @@ export class ContractWrapper<
       const provider = this.getProvider();
       const txHash = await this.sendGaslessTransaction(fn, args, callOverrides);
       this.emitTransactionEvent("submitted", txHash);
-	  if (eventEmitter) eventEmitter.emit("contractDeploySubmitted", { transactionHash: txHash });
+      if (eventEmitter)
+        eventEmitter.emit("contractDeploySubmitted", {
+          transactionHash: txHash,
+        });
       const receipt = await provider.waitForTransaction(txHash);
       this.emitTransactionEvent("completed", txHash);
       return receipt;
@@ -379,7 +382,10 @@ export class ContractWrapper<
         callOverrides,
       );
       this.emitTransactionEvent("submitted", tx.hash);
-	  if (eventEmitter) eventEmitter.emit("contractDeploySubmitted", { transactionHash: tx.hash });
+      if (eventEmitter)
+        eventEmitter.emit("contractDeploySubmitted", {
+          transactionHash: tx.hash,
+        });
       const receipt = tx.wait();
       this.emitTransactionEvent("completed", tx.hash);
       return receipt;

--- a/packages/sdk/src/evm/core/classes/factory.ts
+++ b/packages/sdk/src/evm/core/classes/factory.ts
@@ -115,8 +115,8 @@ export class ContractFactory extends ContractWrapper<TWFactory> {
       implementationAddress,
       encodedFunc,
       salt,
-	  undefined, 
-	  eventEmitter	  
+      undefined,
+      eventEmitter,
     ]);
 
     const events = this.parseLogs<ProxyDeployedEvent>(
@@ -149,11 +149,16 @@ export class ContractFactory extends ContractWrapper<TWFactory> {
     ).encodeFunctionData(initializerFunction, initializerArgs);
 
     const blockNumber = await this.getProvider().getBlockNumber();
-    const receipt = await this.sendTransaction("deployProxyByImplementation", [
-      implementationAddress,
-      encodedFunc,
-      ethers.utils.formatBytes32String(blockNumber.toString()),
-	], undefined, eventEmitter);
+    const receipt = await this.sendTransaction(
+      "deployProxyByImplementation",
+      [
+        implementationAddress,
+        encodedFunc,
+        ethers.utils.formatBytes32String(blockNumber.toString()),
+      ],
+      undefined,
+      eventEmitter,
+    );
 
     const events = this.parseLogs<ProxyDeployedEvent>(
       "ProxyDeployed",

--- a/packages/sdk/src/evm/core/classes/factory.ts
+++ b/packages/sdk/src/evm/core/classes/factory.ts
@@ -115,6 +115,8 @@ export class ContractFactory extends ContractWrapper<TWFactory> {
       implementationAddress,
       encodedFunc,
       salt,
+	  undefined, 
+	  eventEmitter	  
     ]);
 
     const events = this.parseLogs<ProxyDeployedEvent>(
@@ -151,7 +153,7 @@ export class ContractFactory extends ContractWrapper<TWFactory> {
       implementationAddress,
       encodedFunc,
       ethers.utils.formatBytes32String(blockNumber.toString()),
-    ]);
+	], undefined, eventEmitter);
 
     const events = this.parseLogs<ProxyDeployedEvent>(
       "ProxyDeployed",

--- a/packages/sdk/src/evm/types/deploy/deploy-events.ts
+++ b/packages/sdk/src/evm/types/deploy/deploy-events.ts
@@ -1,8 +1,9 @@
 export interface DeployEvent {
   transactionHash: string;
-  contractAddress: string;
+  contractAddress?: string;
 }
 
 export interface DeployEvents {
   contractDeployed: [DeployEvent];
+  contractDeploySubmitted: [DeployEvent];
 }


### PR DESCRIPTION
Added implementation to emit a submitted event when deploy methods are called, in order to receive transaction hash as soon as transaction is send to network, before to wait to deploy to be finished and confirmed. 

The whole reason for this is to get the transaction hash early on, so we can react... in edge cases like user leaving the dapp, or his connections breaks etc... this way ... we know what transaction to follow when we get back....

so the idea is to:

- send transaction (deploy selected module)
- get the transaction hash back immediately
- handle the rest as before, like get the deployed feedback or anything else...

Hope it makes sense

(Metamask is not shown in the video)

https://user-images.githubusercontent.com/5519725/212624621-1405d672-224b-4d84-8303-3d7b0fd65bc3.mp4

