### PR TITLE
[SDK] Fix getting domain separator error

### DIFF
--- a/.changeset/purple-stingrays-pull.md
+++ b/.changeset/purple-stingrays-pull.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/sdk": patch
+---
+
+Getting the domain separator is not a required function. If an error occurs there, the permit it self will not be possible. Therefore, error handling should be performed appropriately.

--- a/packages/sdk/src/evm/common/permit.ts
+++ b/packages/sdk/src/evm/common/permit.ts
@@ -71,7 +71,14 @@ async function getDomainSeperator(signer: Signer, contractAddress: string) {
   try {
     return await contract.DOMAIN_SEPARATOR();
   } catch (err) {
-    return await contract.getDomainSeperator();
+    try {
+      return await contract.getDomainSeperator();
+    } catch (err2) {
+      console.error(
+        'Error getting domain separator',
+        err2
+      )
+    }
   }
 }
 


### PR DESCRIPTION
When executing a permit with a token called JPYC, which is a Japanese yen stablecoin, it was interrupted by a runtime error. The cause was to get the domain separator, and JPYC did not have that function. However, getting the domain separator should not be a required feature of the permit. So shouldn't we properly handle errors so that runtime errors do not occur?