### PR TITLE
[ReactSDK] Changes useClaimedNFTs to only fetch claimed NFTs

### DIFF
--- a/.changeset/rich-pigs-cry.md
+++ b/.changeset/rich-pigs-cry.md
@@ -1,5 +1,5 @@
 ---
-"@thirdweb-dev/react": minor
+"@thirdweb-dev/react": patch
 ---
 
-[ReactSDK] update useClaimedNFTs to only fetch claimed NFTs
+Updates useClaimedNFTs to only fetch claimed NFTs

--- a/.changeset/rich-pigs-cry.md
+++ b/.changeset/rich-pigs-cry.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/react": minor
+---
+
+[ReactSDK] update useClaimedNFTs to only fetch claimed NFTs

--- a/packages/react/src/evm/hooks/async/drop.ts
+++ b/packages/react/src/evm/hooks/async/drop.ts
@@ -83,10 +83,23 @@ export function useUnclaimedNFTs(
  * @beta
  */
 export function useClaimedNFTs(
-  contract: RequiredParam<NFTContract>,
+  contract: RequiredParam<NFTDrop>,
   queryParams?: QueryAllParams,
 ) {
-  return useNFTs(contract, queryParams);
+  const contractAddress = contract?.getAddress();
+  return useQueryWithNetwork(
+    cacheKeys.contract.nft.drop.getAllClaimed(contractAddress, queryParams),
+    () => {
+      requiredParamInvariant(contract, "No Contract instance provided");
+      // TODO make this work for custom contracts (needs ABI change)
+      invariant(
+        contract.getAllClaimed,
+        "Contract instance does not support getAllClaimed",
+      );
+      return contract.getAllClaimed(queryParams);
+    },
+    { enabled: !!contract },
+  );
 }
 
 /**

--- a/packages/react/src/evm/hooks/async/drop.ts
+++ b/packages/react/src/evm/hooks/async/drop.ts
@@ -10,7 +10,6 @@ import {
   DropContract,
   RevealLazyMintInput,
   getErcs,
-  NFTContract,
   RevealableContract,
 } from "../../types";
 import {
@@ -18,7 +17,6 @@ import {
   invalidateContractAndBalances,
 } from "../../utils/cache-keys";
 import { useQueryWithNetwork } from "../query-utils/useQueryWithNetwork";
-import { useNFTs } from "./nft";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   NFTMetadataInput,

--- a/packages/react/src/evm/utils/cache-keys.ts
+++ b/packages/react/src/evm/utils/cache-keys.ts
@@ -181,6 +181,14 @@ export const cacheKeys = {
             contractAddress,
             params ? ["getAllUnclaimed", params] : ["getAllUnclaimed"],
           ),
+        getAllClaimed: (
+          contractAddress: RequiredParam<ContractAddress>,
+          params?: QueryAllParams,
+        ) =>
+          createContractCacheKey(
+            contractAddress,
+            params ? ["getAllClaimed", params] : ["getAllClaimed"],
+          ),
         totalUnclaimedSupply: (
           contractAddress: RequiredParam<ContractAddress>,
         ) => createContractCacheKey(contractAddress, ["totalUnclaimedSupply"]),
@@ -306,11 +314,11 @@ export const cacheKeys = {
           contractAddress,
           tokenId
             ? [
-                "claimConditions",
-                "getIneligibilityReasons",
-                { tokenId },
-                params,
-              ]
+              "claimConditions",
+              "getIneligibilityReasons",
+              { tokenId },
+              params,
+            ]
             : ["claimConditions", "getIneligibilityReasons", params],
         ),
       // combinations of queries cache keys
@@ -323,11 +331,11 @@ export const cacheKeys = {
           contractAddress,
           tokenId
             ? [
-                "claimConditions",
-                "useActiveClaimConditionForWallet",
-                { tokenId, walletAddress },
-                ,
-              ]
+              "claimConditions",
+              "useActiveClaimConditionForWallet",
+              { tokenId, walletAddress },
+              ,
+            ]
             : ["claimConditions", "getIneligibilityReasons", { walletAddress }],
         ),
     },


### PR DESCRIPTION
`useClaimedNFTs` was fetching all nfts from the contract by calling `useNFTs`. This makes it so we call getAllClaimed from the contract

Tested:
- Locally imported the package and made sure only claimed NFTs were returned