### PR TITLE
[Auth] Update peerDependencies

### DIFF
--- a/.changeset/good-seahorses-applaud.md
+++ b/.changeset/good-seahorses-applaud.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/auth": patch
+---
+
+Remove next major version pin on auth

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -16,9 +16,13 @@
 Install the latest version of the SDK with either `npm` or `yarn`:
 
 ```shell
-npm install @thirdweb-dev/auth @thirdweb-dev/sdk ethers
+npm install @thirdweb-dev/auth
 ```
 
 ```shell
-yarn add @thirdweb-dev/auth @thirdweb-dev/sdk ethers
+yarn add @thirdweb-dev/auth
 ```
+
+## Documentation
+
+- [Auth Docs](https://portal.thirdweb.com/auth)

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -102,7 +102,7 @@
     "cookie-parser": "^1.4.6",
     "ethers": ">=5.5.1",
     "express": "^4.18.1",
-    "next": "^12.2.0",
+    "next": "^12 || ^13",
     "next-auth": "^4.10.3",
     "tweetnacl": "^1.0.3"
   },

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -66,7 +66,6 @@
     "@solana/web3.js": "^1.73.0",
     "@swc-node/register": "^1.5.4",
     "@swc/core": "^1.3.23",
-    "@thirdweb-dev/sdk": "*",
     "@thirdweb-dev/wallets": "*",
     "@types/bs58": "^4.0.1",
     "@types/chai": "^4.3.4",
@@ -97,13 +96,12 @@
   "peerDependencies": {
     "@noble/ed25519": "^1.7.1",
     "@solana/web3.js": "^1.73.0",
-    "@thirdweb-dev/sdk": "*",
     "bs58": "^5.0.0",
     "cookie-parser": "^1.4.6",
-    "ethers": ">=5.5.1",
-    "express": "^4.18.1",
+    "ethers": "^5",
+    "express": "^4",
     "next": "^12 || ^13",
-    "next-auth": "^4.10.3",
+    "next-auth": "^4",
     "tweetnacl": "^1.0.3"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
Made this change because if you install `@thirdweb-dev/auth` with `npm` instead of `yarn`, it throws error on peer dependencies not matching:
- Switched  `next` peer dependency to `^12 || ^13` to allow both next 12 and 13 setups.
- Switched `ethers`, `express`, and `next-auth` to just specify major version
- Removed `@thirdweb-dev/sdk` as peer dependency from auth since it's no longer used