### PR TITLE
[SDK] Add proper error catching for when user has no funds

### DIFF
--- a/.changeset/beige-lizards-hug.md
+++ b/.changeset/beige-lizards-hug.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/sdk": patch
+---
+
+Add proper error hanling for no funds error

--- a/packages/sdk/src/evm/common/error.ts
+++ b/packages/sdk/src/evm/common/error.ts
@@ -273,6 +273,7 @@ export type TransactionErrorInfo = {
   data?: string;
   rpcUrl?: string;
   value?: BigNumber;
+  hash?: string;
 };
 
 /**
@@ -300,6 +301,10 @@ export class TransactionError extends Error {
       } catch (e2) {
         // ignore if can't parse URL
       }
+    }
+
+    if (info.hash) {
+      errorMessage += withSpaces(`tx hash`, info.hash);
     }
 
     if (info.value && info.value.gt(0)) {

--- a/packages/sdk/src/evm/core/classes/contract-deployer.ts
+++ b/packages/sdk/src/evm/core/classes/contract-deployer.ts
@@ -489,7 +489,6 @@ export class ContractDeployer extends RPCConnectionHandler {
       parsedMetadata,
       contractURI,
     );
-
     return this.deployReleasedContract(
       // 0xdd99b75f095d0c4d5112aCe938e4e6ed962fb024 === deployer.thirdweb.eth
       "0xdd99b75f095d0c4d5112aCe938e4e6ed962fb024",

--- a/packages/sdk/src/evm/core/classes/contract-wrapper.ts
+++ b/packages/sdk/src/evm/core/classes/contract-wrapper.ts
@@ -415,6 +415,7 @@ export class ContractWrapper<
             ...(callOverrides.value ? [{ value: callOverrides.value }] : []),
           );
         } catch (err: any) {
+          console.log("Throwing hre instead!");
           throw await this.formatError(err, fn, args, callOverrides);
         }
       }
@@ -424,6 +425,7 @@ export class ContractWrapper<
     try {
       return await func(...args, callOverrides);
     } catch (err) {
+      console.log("Throwing hre instead!");
       const from = await (callOverrides.from || this.getSignerAddress());
       const value = await (callOverrides.value ? callOverrides.value : 0);
       const balance = await this.getProvider().getBalance(from);

--- a/packages/sdk/src/evm/core/classes/contract-wrapper.ts
+++ b/packages/sdk/src/evm/core/classes/contract-wrapper.ts
@@ -415,7 +415,6 @@ export class ContractWrapper<
             ...(callOverrides.value ? [{ value: callOverrides.value }] : []),
           );
         } catch (err: any) {
-          console.log("Throwing hre instead!");
           throw await this.formatError(err, fn, args, callOverrides);
         }
       }
@@ -425,7 +424,6 @@ export class ContractWrapper<
     try {
       return await func(...args, callOverrides);
     } catch (err) {
-      console.log("Throwing hre instead!");
       const from = await (callOverrides.from || this.getSignerAddress());
       const value = await (callOverrides.value ? callOverrides.value : 0);
       const balance = await this.getProvider().getBalance(from);

--- a/packages/sdk/src/evm/core/classes/contract-wrapper.ts
+++ b/packages/sdk/src/evm/core/classes/contract-wrapper.ts
@@ -401,6 +401,8 @@ export class ContractWrapper<
       throw new Error(`invalid function: "${fn.toString()}"`);
     }
 
+    let insufficientBalance = false;
+
     // First, if no gasLimit is passed, call estimate gas ourselves
     if (!callOverrides.gasLimit) {
       try {
@@ -415,14 +417,23 @@ export class ContractWrapper<
             ...(callOverrides.value ? [{ value: callOverrides.value }] : []),
           );
         } catch (err: any) {
-          throw await this.formatError(err, fn, args, callOverrides);
-        }
+          const from = await (callOverrides.from || this.getSignerAddress());
+          const value = await (callOverrides.value ? callOverrides.value : 0);
+          const balance = await this.getProvider().getBalance(from);
 
-        // If call static doesn't throw an error, estimateGas likely failed because the signer
-        // account has insufficient funds (or other reasons, we can case on later).
-        throw new Error(
-          "Failed to estimate gas for transaction. You may have insufficient funds in your account to execute this transaction.",
-        );
+          // First we check if the error is an insufficient balance error (and save it for later)
+          // We do it like this so if anything goes wrong with the balance check above, the default
+          // code path is for the error to get thrown below
+          if (balance.eq(0) || (value && balance.lt(value))) {
+            insufficientBalance = true;
+          }
+
+          // If it is, then we skip over throwing here, so we can let sendTransaction go through
+          // This is desireable because users will be able to see insufficient funds messages on their wallets
+          if (!insufficientBalance) {
+            throw await this.formatError(err, fn, args, callOverrides);
+          }
+        }
       }
     }
 
@@ -430,6 +441,14 @@ export class ContractWrapper<
     try {
       return await func(...args, callOverrides);
     } catch (err) {
+      // Now we can throw the nice insufficient funds error after it has already been
+      // displayed in user wallets.
+      if (insufficientBalance) {
+        throw new Error(
+          "You have insufficient funds in your account to execute this transaction.",
+        );
+      }
+
       throw await this.formatError(err, fn, args, callOverrides);
     }
   }

--- a/packages/sdk/src/evm/core/classes/contract-wrapper.ts
+++ b/packages/sdk/src/evm/core/classes/contract-wrapper.ts
@@ -380,7 +380,26 @@ export class ContractWrapper<
         callOverrides,
       );
       this.emitTransactionEvent("submitted", tx.hash);
-      const receipt = tx.wait();
+
+      // tx.wait() can fail so we need to wrap it with a catch
+      let receipt;
+      try {
+        receipt = await tx.wait();
+      } catch (err) {
+        try {
+          // If tx.wait() fails, it just gives us a generic "transaction failed"
+          // error. So instead, we need to call static to get an informative error message
+          await this.writeContract.callStatic[fn as string](
+            ...args,
+            ...(callOverrides.value ? [{ value: callOverrides.value }] : []),
+          );
+        } catch (staticErr: any) {
+          throw await this.formatError(staticErr, fn, args, callOverrides);
+        }
+
+        throw await this.formatError(err, fn, args, callOverrides);
+      }
+
       this.emitTransactionEvent("completed", tx.hash);
       return receipt;
     }
@@ -483,6 +502,10 @@ export class ContractWrapper<
             .join(",\n") +
           "\n";
     const method = `${functionSignature.name}(${joinedArgs})`;
+    const hash =
+      error.transactionHash ||
+      error.transaction?.hash ||
+      error.receipt?.transactionHash;
 
     // Parse the revert reason from the error
     const reason = parseRevertReason(error);
@@ -496,6 +519,7 @@ export class ContractWrapper<
       network,
       rpcUrl,
       value,
+      hash,
     });
   }
 

--- a/packages/sdk/test/evm/errors.test.ts
+++ b/packages/sdk/test/evm/errors.test.ts
@@ -1,15 +1,16 @@
+import { ThirdwebSDK } from "../../src/evm";
 import { expectError, sdk } from "./before-setup";
 import { expect } from "chai";
 import { ethers } from "ethers";
 
 describe("Error Handling", async () => {
-  it("should throw proper error on no gas", async () => {
-    sdk.updateSignerOrProvider(
+  it("should throw proper error on account with no balance", async () => {
+    const newSdk = ThirdwebSDK.fromSigner(
       ethers.Wallet.createRandom().connect(sdk.getProvider()),
     );
 
     try {
-      await sdk.deployer.deployNFTCollection({
+      await newSdk.deployer.deployNFTCollection({
         name: "Should Fail Collection",
         primary_sale_recipient: "0x0000000000000000000000000000000000000000",
       });
@@ -18,6 +19,85 @@ describe("Error Handling", async () => {
       expectError(
         err,
         "You have insufficient funds in your account to execute this transaction.",
+      );
+    }
+  });
+
+  it("should throw !BALNFT revert message without gas limit", async () => {
+    const collectionAddress = await sdk.deployer.deployNFTCollection({
+      name: "Test Collection",
+      primary_sale_recipient: "0x0000000000000000000000000000000000000000",
+    });
+    const marketplaceAddress = await sdk.deployer.deployMarketplace({
+      name: "Test Marketplace",
+    });
+
+    const collection = await sdk.getContract(collectionAddress);
+    await collection.erc721.mintTo(marketplaceAddress, { name: "Test NFT" });
+
+    const marketplace = await sdk.getContract(marketplaceAddress);
+    try {
+      await marketplace.call("createListing", {
+        assetContract: collectionAddress,
+        tokenId: 0,
+        startTime: 1000000000000,
+        secondsUntilEndTime: 10000000000000,
+        quantityToList: 1,
+        currencyToAccept: "0x0000000000000000000000000000000000000000",
+        reservePricePerToken: 0,
+        buyoutPricePerToken: 0,
+        listingType: 0,
+      });
+      expect.fail();
+    } catch (err) {
+      // In this case, call static should go through before sendTransaction
+      // so there should be no tx hash on the error
+      expectError(err, "!BALNFT");
+      // eslint-disable-next-line no-unused-expressions
+      expect(err.info.hash).to.be.undefined;
+    }
+  });
+
+  // Here we hit a different code path by passing gas limit, send transaction should go through
+  it("should throw !BALNFT revert message without gas limit", async () => {
+    const collectionAddress = await sdk.deployer.deployNFTCollection({
+      name: "Test Collection",
+      primary_sale_recipient: "0x0000000000000000000000000000000000000000",
+    });
+    const marketplaceAddress = await sdk.deployer.deployMarketplace({
+      name: "Test Marketplace",
+    });
+
+    const collection = await sdk.getContract(collectionAddress);
+    await collection.erc721.mintTo(marketplaceAddress, { name: "Test NFT" });
+
+    const marketplace = await sdk.getContract(marketplaceAddress);
+    try {
+      await marketplace.call(
+        "createListing",
+        {
+          assetContract: collectionAddress,
+          tokenId: 0,
+          startTime: 1000000000000,
+          secondsUntilEndTime: 10000000000000,
+          quantityToList: 1,
+          currencyToAccept: "0x0000000000000000000000000000000000000000",
+          reservePricePerToken: 0,
+          buyoutPricePerToken: 0,
+          listingType: 0,
+        },
+        {
+          gasLimit: 800000,
+        },
+      );
+      expect.fail();
+    } catch (err) {
+      // In this case, call static should go through after sendTransaction
+      // so we should have a hash on the error
+      expectError(err, "!BALNFT");
+      expect(err.info.hash).to.be.a("string");
+      expect(err.info.hash).to.satisfy(
+        (hash: string) => hash.startsWith("0x") && hash.length === 66,
       );
     }
   });

--- a/packages/sdk/test/evm/errors.test.ts
+++ b/packages/sdk/test/evm/errors.test.ts
@@ -13,7 +13,7 @@ describe("Error Handling", async () => {
         name: "Should Fail Collection",
         primary_sale_recipient: "0x0000000000000000000000000000000000000000",
       });
-      // expect.fail();
+      expect.fail();
     } catch (err) {
       expect(err.message).to.contain(
         "You have insufficient funds in your account to execute this transaction.",

--- a/packages/sdk/test/evm/errors.test.ts
+++ b/packages/sdk/test/evm/errors.test.ts
@@ -1,4 +1,4 @@
-import { sdk } from "./before-setup";
+import { expectError, sdk } from "./before-setup";
 import { expect } from "chai";
 import { ethers } from "ethers";
 
@@ -15,7 +15,8 @@ describe("Error Handling", async () => {
       });
       expect.fail();
     } catch (err) {
-      expect(err.message).to.contain(
+      expectError(
+        err,
         "You have insufficient funds in your account to execute this transaction.",
       );
     }

--- a/packages/sdk/test/evm/errors.test.ts
+++ b/packages/sdk/test/evm/errors.test.ts
@@ -1,0 +1,23 @@
+import { sdk } from "./before-setup";
+import { expect } from "chai";
+import { ethers } from "ethers";
+
+describe("Error Handling", async () => {
+  it("should throw proper error on no gas", async () => {
+    sdk.updateSignerOrProvider(
+      ethers.Wallet.createRandom().connect(sdk.getProvider()),
+    );
+
+    try {
+      await sdk.deployer.deployNFTCollection({
+        name: "Should Fail Collection",
+        primary_sale_recipient: "0x0000000000000000000000000000000000000000",
+      });
+      // expect.fail();
+    } catch (err) {
+      expect(err.message).to.contain(
+        "You have insufficient funds in your account to execute this transaction.",
+      );
+    }
+  });
+});


### PR DESCRIPTION
When the user has no funds, we want to throw a more informative error that lets users know this. However, we also need to preserve the UX of a transaction popping for users with wallets like MetaMask where they will see on UI that they have insufficient funds for the transaction, so we can't throw before `sendTransaction`.

The solution is to let `estimateGas` fail, but then if the error is due to insufficient funds, `callStatic` will succeed and we can let it pass through to `sendTransaction`. Then, when we catch `sendTransaction`, we can check if user balance is insufficient and throw an informative error.

**Update:** Additionally, if we manually set `gasLimit`, `sendTransaction` will always go through. However, `sendTransaction` can succeed, and then we can error on `tx.wait()` - in order to account for this, we also need to catch `tx.wait()` which will return a generic `transaction failed` error message, and make an `eth_call` to extract the proper error.