### PR TITLE
[ReactCoreSDK] pass default key to the sdkprovider

### DIFF
--- a/packages/react-core/src/evm/providers/thirdweb-sdk-provider.tsx
+++ b/packages/react-core/src/evm/providers/thirdweb-sdk-provider.tsx
@@ -91,7 +91,7 @@ const WrappedThirdwebSDKProvider = <
   activeChain,
   signer,
   children,
-  thirdwebApiKey = DEFAULT_API_KEY,
+  thirdwebApiKey,
   infuraApiKey,
   alchemyApiKey,
 }: React.PropsWithChildren<
@@ -229,7 +229,7 @@ export const ThirdwebSDKProvider = <
   // @ts-expect-error - different subtype of Chain[] but this works fine
   supportedChains = defaultChains,
   activeChain,
-  thirdwebApiKey,
+  thirdwebApiKey = DEFAULT_API_KEY,
   alchemyApiKey,
   infuraApiKey,
   ...restProps


### PR DESCRIPTION
Passing the default key in the top most provider so that it propagates correctly to the rest of the providers (ThirdwebConnectedWalletProvider was not getting the key since it was not being set in the Context)