### PR TITLE
Fix Wrong Currency symbol in non-default chains

### DIFF
--- a/.changeset/stupid-moles-boil.md
+++ b/.changeset/stupid-moles-boil.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/react-core": patch
+---
+
+Fix Wrong Currency symbol in non-default chains

--- a/packages/react-core/src/evm/providers/thirdweb-sdk-provider.tsx
+++ b/packages/react-core/src/evm/providers/thirdweb-sdk-provider.tsx
@@ -147,10 +147,17 @@ const WrappedThirdwebSDKProvider = <
       }
     }
 
+    // TODO: find a better way to fix the type error
+    type ForcedChainType = {
+      rpc: string[];
+      chainId: number;
+      nativeCurrency: { symbol: string; name: string; decimals: 18 };
+    };
+
     const mergedOptions = {
       readonlySettings,
       ...sdkOptions,
-      chains: supportedChains,
+      supportedChains: supportedChains as any as ForcedChainType[],
     };
 
     let sdk_: ThirdwebSDK | undefined = undefined;


### PR DESCRIPTION


Fixed: 

<img width="459" alt="image" src="https://user-images.githubusercontent.com/22043396/222083462-188ac3b7-e8f6-48d1-8df4-935ca6c2495e.png">
