### PR TITLE
[React] Fix accepted types for some hooks

### DIFF
--- a/.changeset/witty-lizards-doubt.md
+++ b/.changeset/witty-lizards-doubt.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/react-core": patch
+---
+
+Updated params for claiming hooks to reflect the correct type of contract that can be used

--- a/packages/react-core/src/evm/hooks/async/drop.ts
+++ b/packages/react-core/src/evm/hooks/async/drop.ts
@@ -21,6 +21,8 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   NFTMetadataInput,
   QueryAllParams,
+  SignatureDrop,
+  SmartContract,
   UploadProgressEvent,
 } from "@thirdweb-dev/sdk";
 import { NFTDrop } from "@thirdweb-dev/sdk/dist/declarations/src/evm/contracts/prebuilt-implementations/nft-drop";
@@ -102,11 +104,13 @@ export function useClaimedNFTs(
 
 /**
  *
- * @param contract - an instance of a {@link NFTDrop}
+ * @param contract - an instance of a contract that extends the Erc721 spec (nft drop, custom contract that follows the Erc721 & drop spec)
  * @returns a response object that includes the number of NFTs that are unclaimed
  * @twfeature ERC721LazyMintable
  */
-export function useUnclaimedNFTSupply(contract: RequiredParam<NFTDrop>) {
+export function useUnclaimedNFTSupply(
+  contract: RequiredParam<NFTDrop | SignatureDrop | SmartContract | null>,
+) {
   const contractAddress = contract?.getAddress();
   const { erc721 } = getErcs(contract);
   return useQueryWithNetwork(
@@ -126,11 +130,13 @@ export function useUnclaimedNFTSupply(contract: RequiredParam<NFTDrop>) {
 /**
  * Get the total number of claimed NFTs
  *
- * @param contract - an instance of a {@link NFTDrop}
+ * @param contract - an instance of a contract that extends the Erc721 spec (nft drop, custom contract that follows the Erc721 & drop spec)
  * @returns a response object that includes the number of NFTs that are claimed
  * @twfeature ERC721LazyMintable
  */
-export function useClaimedNFTSupply(contract: RequiredParam<NFTDrop>) {
+export function useClaimedNFTSupply(
+  contract: RequiredParam<NFTDrop | SignatureDrop | SmartContract | null>,
+) {
   const contractAddress = contract?.getAddress();
   const { erc721 } = getErcs(contract);
   return useQueryWithNetwork(

--- a/packages/react-core/src/evm/hooks/async/drop.ts
+++ b/packages/react-core/src/evm/hooks/async/drop.ts
@@ -40,7 +40,7 @@ import invariant from "tiny-invariant";
  * const { data: unclaimedNfts, isLoading, error } = useUnclaimedNFTs(contract, { start: 0, count: 100 });
  * ```
  *
- * @param contract - an instance of a contract that extends the ERC721 spec (NFT drop, Signature Drop,  or any custom contract that extends the ERC721 spec)
+ * @param contract - an instance of a contract that extends the ERC721 spec (NFT drop, Signature Drop, or any custom contract that extends the ERC721 spec)
  * @param queryParams - query params to pass to the query for the sake of pagination
  * @returns a response object that includes an array of NFTs that are unclaimed
  * @twfeature ERC721LazyMintable
@@ -76,7 +76,7 @@ export function useUnclaimedNFTs(
  * const { data: claimedNFTs, isLoading, error } = useClaimedNFTs(contract, { start: 0, count: 100 });
  * ```
  *
- * @param contract - an instance of a contract that extends the ERC721 spec (NFT drop, Signature Drop,  or any custom contract that extends the ERC721 spec)
+ * @param contract - an instance of a contract that extends the ERC721 spec (NFT drop, Signature Drop, or any custom contract that extends the ERC721 spec)
  * @param queryParams - query params to pass to the query for the sake of pagination
  * @returns a response object that includes an array of NFTs that are claimed
  * @twfeature ERC721LazyMintable
@@ -104,7 +104,7 @@ export function useClaimedNFTs(
 
 /**
  *
- * @param contract - an instance of a contract that extends the ERC721 spec (NFT drop, Signature Drop,  or any custom contract that extends the ERC721 spec)
+ * @param contract - an instance of a contract that extends the ERC721 spec (NFT drop, Signature Drop, or any custom contract that extends the ERC721 spec)
  * @returns a response object that includes the number of NFTs that are unclaimed
  * @twfeature ERC721LazyMintable
  */
@@ -130,7 +130,7 @@ export function useUnclaimedNFTSupply(
 /**
  * Get the total number of claimed NFTs
  *
- * @param contract - an instance of a contract that extends the ERC721 spec (NFT drop, Signature Drop,  or any custom contract that extends the ERC721 spec)
+ * @param contract - an instance of a contract that extends the ERC721 spec (NFT drop, Signature Drop, or any custom contract that extends the ERC721 spec)
  * @returns a response object that includes the number of NFTs that are claimed
  * @twfeature ERC721LazyMintable
  */

--- a/packages/react-core/src/evm/hooks/async/drop.ts
+++ b/packages/react-core/src/evm/hooks/async/drop.ts
@@ -38,10 +38,10 @@ import invariant from "tiny-invariant";
  * const { data: unclaimedNfts, isLoading, error } = useUnclaimedNFTs(contract, { start: 0, count: 100 });
  * ```
  *
- * @param contract - an instance of a contract that extends the Erc721 spec (nft drop, custom contract that follows the Erc721 & drop spec)
+ * @param contract - an instance of a {@link NFTDrop}.
  * @param queryParams - query params to pass to the query for the sake of pagination
  * @returns a response object that includes an array of NFTs that are unclaimed
- * @twfeature ERC721LazyMintable | ERC1155LazyMintable
+ * @twfeature ERC721LazyMintable
  * @beta
  */
 export function useUnclaimedNFTs(
@@ -74,10 +74,10 @@ export function useUnclaimedNFTs(
  * const { data: claimedNFTs, isLoading, error } = useClaimedNFTs(contract, { start: 0, count: 100 });
  * ```
  *
- * @param contract - an instance of a {@link DropContract}
+ * @param contract - an instance of a {@link NFTDrop}
  * @param queryParams - query params to pass to the query for the sake of pagination
  * @returns a response object that includes an array of NFTs that are claimed
- * @twfeature ERC721LazyMintable | ERC1155LazyMintable
+ * @twfeature ERC721LazyMintable
  * @beta
  */
 export function useClaimedNFTs(
@@ -104,9 +104,9 @@ export function useClaimedNFTs(
  *
  * @param contract - an instance of a {@link NFTDrop}
  * @returns a response object that includes the number of NFTs that are unclaimed
- * @twfeature ERC721LazyMintable | ERC1155LazyMintable
+ * @twfeature ERC721LazyMintable
  */
-export function useUnclaimedNFTSupply(contract: RequiredParam<DropContract>) {
+export function useUnclaimedNFTSupply(contract: RequiredParam<NFTDrop>) {
   const contractAddress = contract?.getAddress();
   const { erc721 } = getErcs(contract);
   return useQueryWithNetwork(
@@ -126,11 +126,11 @@ export function useUnclaimedNFTSupply(contract: RequiredParam<DropContract>) {
 /**
  * Get the total number of claimed NFTs
  *
- * @param contract - an instance of a {@link DropContract}
+ * @param contract - an instance of a {@link NFTDrop}
  * @returns a response object that includes the number of NFTs that are claimed
- * @twfeature ERC721LazyMintable | ERC1155LazyMintable
+ * @twfeature ERC721LazyMintable
  */
-export function useClaimedNFTSupply(contract: RequiredParam<DropContract>) {
+export function useClaimedNFTSupply(contract: RequiredParam<NFTDrop>) {
   const contractAddress = contract?.getAddress();
   const { erc721 } = getErcs(contract);
   return useQueryWithNetwork(
@@ -266,7 +266,7 @@ export function useClaimNFT<TContract extends DropContract>(
 
 /**
  * Lazy mint NFTs
- * 
+ *
  * @example
  * ```jsx
  * const Component = () => {
@@ -338,7 +338,7 @@ export function useLazyMint<TContract extends DropContract>(
 
 /**
  * Lazy mint NFTs with delayed reveal
- * 
+ *
  * @example
  * ```jsx
  * const Component = () => {
@@ -419,7 +419,7 @@ export function useDelayedRevealLazyMint<TContract extends RevealableContract>(
 
 /**
  * Reveal a batch of delayed reveal NFTs
- * 
+ *
  * @example
  * ```jsx
  * const Component = () => {

--- a/packages/react-core/src/evm/hooks/async/drop.ts
+++ b/packages/react-core/src/evm/hooks/async/drop.ts
@@ -21,11 +21,11 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   NFTMetadataInput,
   QueryAllParams,
-  SignatureDrop,
-  SmartContract,
   UploadProgressEvent,
 } from "@thirdweb-dev/sdk";
 import { NFTDrop } from "@thirdweb-dev/sdk/dist/declarations/src/evm/contracts/prebuilt-implementations/nft-drop";
+import { SignatureDrop } from "@thirdweb-dev/sdk/dist/declarations/src/evm/contracts/prebuilt-implementations/signature-drop";
+import { SmartContract } from "@thirdweb-dev/sdk/dist/declarations/src/evm/contracts/smart-contract";
 import invariant from "tiny-invariant";
 
 /** **********************/

--- a/packages/react-core/src/evm/hooks/async/drop.ts
+++ b/packages/react-core/src/evm/hooks/async/drop.ts
@@ -40,7 +40,7 @@ import invariant from "tiny-invariant";
  * const { data: unclaimedNfts, isLoading, error } = useUnclaimedNFTs(contract, { start: 0, count: 100 });
  * ```
  *
- * @param contract - an instance of a {@link NFTDrop}.
+ * @param contract - an instance of a contract that extends the ERC721 spec (NFT drop, Signature Drop,  or any custom contract that extends the ERC721 spec)
  * @param queryParams - query params to pass to the query for the sake of pagination
  * @returns a response object that includes an array of NFTs that are unclaimed
  * @twfeature ERC721LazyMintable
@@ -76,7 +76,7 @@ export function useUnclaimedNFTs(
  * const { data: claimedNFTs, isLoading, error } = useClaimedNFTs(contract, { start: 0, count: 100 });
  * ```
  *
- * @param contract - an instance of a {@link NFTDrop}
+ * @param contract - an instance of a contract that extends the ERC721 spec (NFT drop, Signature Drop,  or any custom contract that extends the ERC721 spec)
  * @param queryParams - query params to pass to the query for the sake of pagination
  * @returns a response object that includes an array of NFTs that are claimed
  * @twfeature ERC721LazyMintable
@@ -104,7 +104,7 @@ export function useClaimedNFTs(
 
 /**
  *
- * @param contract - an instance of a contract that extends the Erc721 spec (nft drop, custom contract that follows the Erc721 & drop spec)
+ * @param contract - an instance of a contract that extends the ERC721 spec (NFT drop, Signature Drop,  or any custom contract that extends the ERC721 spec)
  * @returns a response object that includes the number of NFTs that are unclaimed
  * @twfeature ERC721LazyMintable
  */
@@ -130,7 +130,7 @@ export function useUnclaimedNFTSupply(
 /**
  * Get the total number of claimed NFTs
  *
- * @param contract - an instance of a contract that extends the Erc721 spec (nft drop, custom contract that follows the Erc721 & drop spec)
+ * @param contract - an instance of a contract that extends the ERC721 spec (NFT drop, Signature Drop,  or any custom contract that extends the ERC721 spec)
  * @returns a response object that includes the number of NFTs that are claimed
  * @twfeature ERC721LazyMintable
  */


### PR DESCRIPTION
Hooks `useUnclaimedNFTs()`, `useClaimedNFTs()`, `useUnclaimedNFTSupply()`, and `useClaimedNFTSupply()` don't work with edition drop contracts, however, the comments on these hooks specified they could.