### PR TITLE
Connect wallet v2 various improvements

### DIFF
--- a/packages/react-core/src/core/providers/thirdweb-provider.tsx
+++ b/packages/react-core/src/core/providers/thirdweb-provider.tsx
@@ -5,7 +5,6 @@ import {
 } from "../../evm/providers/thirdweb-sdk-provider";
 import { DAppMetaData } from "../types/dAppMeta";
 import { SupportedWallet } from "../types/wallet";
-import { showDeprecationWarning } from "../utils";
 import { ThirdwebThemeContext } from "./theme-context";
 import {
   ThirdwebWalletProvider,
@@ -93,16 +92,14 @@ export interface ThirdwebProviderCoreProps<
   alchemyApiKey?: string;
   infuraApiKey?: string;
 
-  /**
-   * A partial map of chainIds to rpc urls to use for certain chains
-   * If not provided, will default to the rpcUrls of the chain objects for the supported chains
-   * @deprecated - use `chains` instead
-   */
-  chainRpc?: Record<number, string>;
-
   theme?: "light" | "dark";
 
   createWalletStorage: CreateAsyncStorage;
+
+  /**
+   * Whether or not to automatically switch to wallet's network to active chain
+   */
+  autoSwitch?: boolean;
 }
 
 // SDK handles this under the hood for us
@@ -117,33 +114,22 @@ export const ThirdwebProviderCore = <
 >(
   props: React.PropsWithChildren<ThirdwebProviderCoreProps<TChains>>,
 ) => {
-  // deprecations
-  if (props.chainRpc) {
-    showDeprecationWarning("chainRpc", "supportedChains");
-  }
-
   const supportedChains =
     props.supportedChains || (defaultChains as any as TChains);
 
   const dAppMeta = props.dAppMeta || defaultdAppMeta;
+
   const activeChainObj = useMemo(() => {
-    if (!props.activeChain) {
-      return supportedChains[0];
-    }
     if (typeof props.activeChain === "number") {
-      return (
-        supportedChains.find((chain) => chain.chainId === props.activeChain) ||
-        supportedChains[0]
+      return supportedChains.find(
+        (chain) => chain.chainId === props.activeChain,
       );
     }
     if (typeof props.activeChain === "string") {
-      return (
-        supportedChains.find((chain) => chain.slug === props.activeChain) ||
-        supportedChains[0]
-      );
+      return supportedChains.find((chain) => chain.slug === props.activeChain);
     }
 
-    return props.activeChain || supportedChains[0] || defaultChains[0];
+    return props.activeChain;
   }, [props.activeChain, supportedChains]);
 
   return (
@@ -155,12 +141,13 @@ export const ThirdwebProviderCore = <
         createWalletStorage={props.createWalletStorage}
         dAppMeta={dAppMeta}
         activeChain={activeChainObj}
+        autoSwitch={props.autoSwitch}
       >
         <ThirdwebSDKProviderWrapper
           queryClient={props.queryClient}
           sdkOptions={props.sdkOptions}
           supportedChains={supportedChains}
-          activeChain={activeChainObj.chainId}
+          activeChain={activeChainObj}
           storageInterface={props.storageInterface}
           authConfig={props.authConfig}
           thirdwebApiKey={props.thirdwebApiKey}

--- a/packages/react-core/src/core/utils.ts
+++ b/packages/react-core/src/core/utils.ts
@@ -1,23 +1,3 @@
-import { __DEV__ } from "./constants/runtime";
-
-const warnSet = new Set<`${string}:${string}`>();
-
-export function showDeprecationWarning(
-  deprecated: string,
-  replacement: string,
-) {
-  // deprecation warnings only in dev only in dev
-  if (__DEV__) {
-    if (warnSet.has(`${deprecated}:${replacement}`)) {
-      return;
-    }
-    warnSet.add(`${deprecated}:${replacement}`);
-    console.warn(
-      `\`${deprecated}\` is deprecated and will be removed in a future major version. Please use \`${replacement}\` instead.`,
-    );
-  }
-}
-
 // it rejects the promise if the given promise does not resolve within the given time
 export const timeoutPromise = <T>(
   ms: number,

--- a/packages/react-core/src/index.ts
+++ b/packages/react-core/src/index.ts
@@ -1,2 +1,12 @@
 // main entry point = evm
 export * from "./evm";
+
+// export types from thirdweb-dev/sdk
+export type {
+  NFTMetadataInput,
+  NFT,
+  NFTMetadata,
+  NFTMetadataOrUri,
+} from "@thirdweb-dev/sdk";
+export type { CurrencyValue, TokenMetadata } from "@thirdweb-dev/sdk";
+export type { QueryAllParams } from "@thirdweb-dev/sdk";

--- a/packages/react-native/src/evm/wallets/connectors/coinbase-wallet/index.ts
+++ b/packages/react-native/src/evm/wallets/connectors/coinbase-wallet/index.ts
@@ -4,6 +4,7 @@ import type {
   WalletMobileSDKProviderOptions,
 } from "@coinbase/wallet-mobile-sdk/build/WalletMobileSDKEVMProvider";
 import type { ConfigurationParams } from "@coinbase/wallet-mobile-sdk/src/CoinbaseWalletSDK.types";
+import { getChainRPC } from "@thirdweb-dev/chains";
 import {
   UserRejectedRequestError,
   ChainNotConfiguredError,
@@ -226,7 +227,7 @@ export class CoinbaseWalletConnector extends Connector<
                 chainId: id,
                 chainName: chain.name,
                 nativeCurrency: chain.nativeCurrency,
-                rpcUrls: [chain.rpc[0] ?? ""],
+                rpcUrls: [getChainRPC(chain)],
                 blockExplorerUrls: this.getBlockExplorerUrls(chain),
               },
             ],

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -126,6 +126,7 @@
     "@radix-ui/react-dialog": "^1.0.2",
     "@radix-ui/react-dropdown-menu": "^2.0.2",
     "@radix-ui/react-icons": "^1.1.1",
+    "@radix-ui/react-popover": "^1.0.5",
     "@radix-ui/react-tabs": "^1.0.2",
     "@radix-ui/react-tooltip": "^1.0.4",
     "@react-icons/all-files": "^4.1.0",

--- a/packages/react/src/components/Popover.tsx
+++ b/packages/react/src/components/Popover.tsx
@@ -1,0 +1,59 @@
+import { fontSize, radius, shadow, spacing, Theme } from "../design-system";
+import { keyframes } from "@emotion/react";
+import styled from "@emotion/styled";
+import * as RXPopover from "@radix-ui/react-popover";
+
+export type PopoverProps = {
+  children: React.ReactNode;
+  content: React.ReactNode;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+};
+
+export const Popover = (props: PopoverProps) => {
+  return (
+    <RXPopover.Root open={props.open} onOpenChange={props.onOpenChange}>
+      <RXPopover.Trigger asChild>{props.children}</RXPopover.Trigger>
+      <RXPopover.Portal>
+        <PopoverContent sideOffset={7} side="top">
+          <FlexWrapper>{props.content}</FlexWrapper>
+          <PopoverArrow />
+        </PopoverContent>
+      </RXPopover.Portal>
+    </RXPopover.Root>
+  );
+};
+
+const slideUpAndFade = keyframes`
+from {
+    opacity: 0;
+    transform: translateY(2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+`;
+
+const PopoverContent = styled(RXPopover.Content)<{ theme?: Theme }>`
+  border-radius: ${radius.sm};
+  padding: ${spacing.sm} ${spacing.md};
+  background-color: ${(p) => p.theme.bg.inverted};
+  box-shadow: ${shadow.md};
+  animation-duration: 400ms;
+  animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
+  will-change: transform, opacity;
+  animation-name: ${slideUpAndFade};
+  color: ${(p) => p.theme.text.inverted};
+  font-size: ${fontSize.md};
+`;
+
+const PopoverArrow = styled(RXPopover.Arrow)<{ theme?: Theme }>`
+  fill: ${(p) => p.theme.bg.inverted};
+`;
+
+const FlexWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${spacing.sm};
+`;

--- a/packages/react/src/components/Spinner.tsx
+++ b/packages/react/src/components/Spinner.tsx
@@ -1,11 +1,12 @@
-import { iconSize } from "../design-system";
-import { keyframes } from "@emotion/react";
+import { iconSize, Theme } from "../design-system";
+import { keyframes, useTheme } from "@emotion/react";
 import styled from "@emotion/styled";
 
 export const Spinner: React.FC<{
-  color: string;
+  color: keyof Theme["icon"];
   size: keyof typeof iconSize;
 }> = (props) => {
+  const theme = useTheme() as Theme;
   return (
     <Svg
       style={{
@@ -19,7 +20,7 @@ export const Spinner: React.FC<{
         cy="25"
         r="20"
         fill="none"
-        stroke={props.color || "white"}
+        stroke={theme.icon[props.color || "primary"]}
         strokeWidth="4"
       />
     </Svg>

--- a/packages/react/src/design-system/index.ts
+++ b/packages/react/src/design-system/index.ts
@@ -21,12 +21,15 @@ export const darkTheme = {
     neutral: mauveDark.mauve12,
     inverted: mauveDark.mauve1,
     secondary: mauveDark.mauve9,
+    danger: tomato.tomato9,
   },
   icon: {
     secondary: mauveDark.mauve11,
     primary: mauveDark.mauve12,
+    inverted: mauveDark.mauve1,
     danger: tomato.tomato9,
     success: green.green7,
+    link: blue.blue9,
   },
   link: {
     primary: blue.blue9,
@@ -61,12 +64,15 @@ export const lightTheme: typeof darkTheme = {
     neutral: mauve.mauve12,
     inverted: mauve.mauve1,
     secondary: mauve.mauve10,
+    danger: tomato.tomato9,
   },
   icon: {
     secondary: mauve.mauve10,
     primary: mauve.mauve12,
+    inverted: mauve.mauve1,
     danger: tomato.tomato9,
     success: green.green9,
+    link: blue.blue11,
   },
   link: {
     primary: blue.blue11,
@@ -109,6 +115,7 @@ export const radius = {
 };
 
 export const iconSize = {
+  xs: "12px",
   sm: "16px",
   md: "24px",
   lg: "32px",

--- a/packages/react/src/wallet/ConnectWallet/Connect.tsx
+++ b/packages/react/src/wallet/ConnectWallet/Connect.tsx
@@ -1,7 +1,7 @@
 import { Modal } from "../../components/Modal";
 import { Spinner } from "../../components/Spinner";
 import { Button } from "../../components/buttons";
-import { iconSize, Theme } from "../../design-system";
+import { iconSize } from "../../design-system";
 import { isMobile } from "../../evm/utils/isMobile";
 import { useInstalledWallets } from "../hooks/useInstalledWallets";
 import { WalletMeta } from "../types";
@@ -17,7 +17,6 @@ import { ConnectToDeviceWallet } from "./screens/DeviceWallet/DeviceWalletSetup"
 import { MetamaskConnecting } from "./screens/Metamask/MetamaskConnecting";
 import { MetamaskGetStarted } from "./screens/Metamask/MetamaskGetStarted";
 import { ScanMetamask } from "./screens/Metamask/MetamaskScan";
-import { useTheme } from "@emotion/react";
 import {
   SupportedWallet,
   useConnect,
@@ -135,8 +134,6 @@ export const ConnectWalletFlow: React.FC<{
 
   const handleBack = () => setShowScreen("walletList");
 
-  const theme = useTheme() as Theme;
-
   return (
     <Modal
       style={{
@@ -158,7 +155,7 @@ export const ConnectWalletFlow: React.FC<{
         >
           {connectionStatus === "connecting" ||
           connectionStatus === "unknown" ? (
-            <Spinner size="sm" color={theme.text.inverted} />
+            <Spinner size="sm" color="inverted" />
           ) : (
             btnTitle
           )}

--- a/packages/react/src/wallet/ConnectWallet/Details.tsx
+++ b/packages/react/src/wallet/ConnectWallet/Details.tsx
@@ -143,7 +143,7 @@ export const ConnectedWalletDetails: React.FC<{
       >
         <ChainIcon chain={chain || unknownChain} size={iconSize.lg} active />
       </div>
-      {chain?.name || unknownChain?.name || "Unknown Chain"}
+      {chain?.name || unknownChain?.name || "Wrong Network"}
       <StyledGearIcon
         style={{
           flexShrink: 0,

--- a/packages/react/src/wallet/ConnectWallet/screens/Coinbase/CoinbaseScan.tsx
+++ b/packages/react/src/wallet/ConnectWallet/screens/Coinbase/CoinbaseScan.tsx
@@ -30,7 +30,7 @@ export const ScanCoinbase: React.FC<{
 
     coinbaseWallet
       .connect({
-        chainId: twWalletContext.chainIdToConnect || 1,
+        chainId: twWalletContext.chainToConnect?.chainId,
       })
       .then(() => {
         twWalletContext.handleWalletConnect(coinbaseWallet);

--- a/packages/react/src/wallet/ConnectWallet/screens/ConnectingScreen.tsx
+++ b/packages/react/src/wallet/ConnectWallet/screens/ConnectingScreen.tsx
@@ -10,7 +10,6 @@ import { iconSize, media, spacing } from "../../../design-system";
 import { isMobile } from "../../../evm/utils/isMobile";
 import { IconFC } from "../icons/types";
 import styled from "@emotion/styled";
-import { blue } from "@radix-ui/colors";
 
 export const ConnectingScreen: React.FC<{
   onBack: () => void;
@@ -28,7 +27,7 @@ export const ConnectingScreen: React.FC<{
       <Spacer y="lg" />
       <TitleContainer>
         <ModalTitle>Connecting your wallet</ModalTitle>
-        <Spinner size="md" color={blue.blue10} />
+        <Spinner size="md" color="link" />
       </TitleContainer>
       <Spacer y="md" />
       <Desc>

--- a/packages/react/src/wallet/ConnectWallet/screens/DeviceWallet/DeviceWalletSetup.tsx
+++ b/packages/react/src/wallet/ConnectWallet/screens/DeviceWallet/DeviceWalletSetup.tsx
@@ -15,7 +15,6 @@ import { useDeviceWalletStorage } from "../../../hooks/useDeviceWalletStorage";
 import { DeviceWallet } from "../../../wallets";
 import { DeviceWalletIcon } from "../../icons/DeviceWalletIcon";
 import styled from "@emotion/styled";
-import { blue } from "@radix-ui/colors";
 import { EyeClosedIcon, EyeOpenIcon } from "@radix-ui/react-icons";
 import { useConnect } from "@thirdweb-dev/react-core";
 import { useEffect, useState } from "react";
@@ -28,7 +27,7 @@ export const ConnectToDeviceWallet: React.FC<{ onBack: () => void }> = (
   if (!deviceStorage) {
     return (
       <LoadingSpinnerContainer>
-        <Spinner size="lg" color={blue.blue10} />
+        <Spinner size="lg" color="primary" />
       </LoadingSpinnerContainer>
     );
   }
@@ -78,7 +77,7 @@ export const CreateDeviceWallet = () => {
   const passwordMismatch = confirmPassword && password !== confirmPassword;
 
   const handleConnect = () => {
-    if (passwordMismatch){
+    if (passwordMismatch) {
       return;
     }
     connect(DeviceWallet, {

--- a/packages/react/src/wallet/ConnectWallet/screens/Metamask/MetamaskScan.tsx
+++ b/packages/react/src/wallet/ConnectWallet/screens/Metamask/MetamaskScan.tsx
@@ -25,7 +25,7 @@ export const ScanMetamask: React.FC<{
     >;
 
     metamask.connectWithQrCode({
-      chainId: twWalletContext.chainIdToConnect || 1,
+      chainId: twWalletContext.chainToConnect?.chainId,
       onQrCodeUri(uri) {
         setQrCodeUri(uri);
       },

--- a/packages/react/src/wallet/ConnectWallet/screens/ScanScreen.tsx
+++ b/packages/react/src/wallet/ConnectWallet/screens/ScanScreen.tsx
@@ -10,7 +10,6 @@ import { fontSize, iconSize, spacing } from "../../../design-system";
 import { Theme } from "../../../design-system/index";
 import { IconFC } from "../icons/types";
 import styled from "@emotion/styled";
-import { blue } from "@radix-ui/colors";
 
 export const ScanScreen: React.FC<{
   onBack: () => void;
@@ -59,7 +58,7 @@ export const ScanScreen: React.FC<{
             justifyContent: "center",
           }}
         >
-          <Spinner size="md" color={blue.blue10} />
+          <Spinner size="md" color="link" />
         </div>
 
         <Spacer y="xl" />

--- a/packages/react/src/wallet/hooks/useCanSwitchNetwork.ts
+++ b/packages/react/src/wallet/hooks/useCanSwitchNetwork.ts
@@ -9,14 +9,29 @@ export function useCanSwitchNetwork() {
   const activeWallet = useWallet();
   const supportedChains = useSupportedChains();
   const networkMismatch = useNetworkMismatch();
-  const installedWallets = useInstalledWallets();
 
-  const disableNetworkSwitching =
+  const canNotSwitchNetwork =
     !activeWallet ||
     (supportedChains.length === 1 && !networkMismatch) ||
     activeWallet.walletId === "walletConnectV1" ||
-    activeWallet.walletId === "walletConnectV2" ||
-    (activeWallet.walletId === "metamask" && !installedWallets.metamask);
+    activeWallet.walletId === "walletConnectV2";
 
-  return !disableNetworkSwitching;
+  return !canNotSwitchNetwork;
+}
+
+/**
+ *
+ * @returns `true` if the the a confirmation is required to switch networks in the active wallet
+ */
+export function useWalletRequiresConfirmation() {
+  const activeWallet = useWallet();
+  const installedWallets = useInstalledWallets();
+
+  return (
+    activeWallet &&
+    (activeWallet.walletId === "walletConnectV1" ||
+      activeWallet.walletId === "walletConnectV2" ||
+      (activeWallet.walletId === "metamask" && !installedWallets.metamask) ||
+      (activeWallet.walletId === "coinbase" && !installedWallets.coinbase))
+  );
 }

--- a/packages/wallets/src/evm/connectors/coinbase-wallet/index.ts
+++ b/packages/wallets/src/evm/connectors/coinbase-wallet/index.ts
@@ -12,7 +12,7 @@ import type {
   CoinbaseWalletSDK,
 } from "@coinbase/wallet-sdk";
 import type { CoinbaseWalletSDKOptions } from "@coinbase/wallet-sdk/dist/CoinbaseWalletSDK";
-import { Chain } from "@thirdweb-dev/chains";
+import { Chain, getChainRPC } from "@thirdweb-dev/chains";
 import type { Address } from "abitype";
 import { providers } from "ethers";
 import { getAddress, hexValue } from "ethers/lib/utils.js";
@@ -232,7 +232,7 @@ export class CoinbaseWalletConnector extends Connector<
                 chainId: id,
                 chainName: chain.name,
                 nativeCurrency: chain.nativeCurrency,
-                rpcUrls: chain.rpc[0],
+                rpcUrls: [getChainRPC(chain)],
                 blockExplorerUrls: this.getBlockExplorerUrls(chain),
               },
             ],

--- a/packages/wallets/src/evm/connectors/injected/index.ts
+++ b/packages/wallets/src/evm/connectors/injected/index.ts
@@ -13,7 +13,7 @@ import {
   Ethereum,
 } from "../../../lib/wagmi-core";
 import { getInjectedName } from "../../utils/getInjectedName";
-import { Chain } from "@thirdweb-dev/chains";
+import { Chain, getChainRPC } from "@thirdweb-dev/chains";
 import type { Address } from "abitype";
 import { providers } from "ethers";
 import { utils } from "ethers";
@@ -360,7 +360,7 @@ export class InjectedConnector extends Connector<
                 chainId: chainIdHex,
                 chainName: chain.name,
                 nativeCurrency: chain.nativeCurrency,
-                rpcUrls: [chain.rpc[0] || ""],
+                rpcUrls: [getChainRPC(chain)],
                 blockExplorerUrls: this.getBlockExplorerUrls(chain),
               },
             ],

--- a/packages/wallets/src/evm/wallets/base.ts
+++ b/packages/wallets/src/evm/wallets/base.ts
@@ -96,6 +96,12 @@ export abstract class AbstractBrowserWallet<
       const address = await connector.getAddress();
       connector.setupListeners();
       await saveToStorage();
+
+      // ensure that connector is connected to the correct chain
+      if (connectOptions?.chainId) {
+        await connector.switchChain(connectOptions?.chainId);
+      }
+
       return address;
     } else {
       const address = await connector.connect(connectOptions);

--- a/packages/wallets/src/evm/wallets/metamask.ts
+++ b/packages/wallets/src/evm/wallets/metamask.ts
@@ -9,7 +9,7 @@ export type MetamaskWalletOptions = WalletOptions<{
 }>;
 
 type ConnectWithQrCodeArgs = {
-  chainId: number;
+  chainId?: number;
   onQrCodeUri: (uri: string) => void;
   onConnected: (accountAddress: string) => void;
 };

--- a/packages/wallets/src/lib/wagmi-connectors/Connector.ts
+++ b/packages/wallets/src/lib/wagmi-connectors/Connector.ts
@@ -66,10 +66,8 @@ export abstract class Connector<
   protected abstract onDisconnect(error: Error): void;
 
   protected getBlockExplorerUrls(chain: Chain) {
-    const explorers = chain.explorers ?? [];
-    if (explorers.length > 0) {
-      return Object.values(explorers).map((x) => x.url);
-    }
+    const explorers = chain.explorers?.map((x) => x.url) ?? [];
+    return explorers.length > 0 ? explorers : undefined;
   }
 
   protected isChainUnsupported(chainId: number) {

--- a/scripts/hotlink/changes.mjs
+++ b/scripts/hotlink/changes.mjs
@@ -6,209 +6,66 @@ export const changes = [
   // react
   {
     path: "./packages/react/package.json",
-    entry: {
-      original: "dist/thirdweb-dev-react.cjs.js",
-      hotlink: "./src/index.ts",
-    },
-    types: {
-      hotlink: "",
-      original: "dist/thirdweb-dev-react.cjs.d.ts",
-    },
+    entry: "./src/index.ts",
     exports: {
-      ".": {
-        original: "./dist/thirdweb-dev-react.esm.js",
-        hotlink: "./src/index.ts",
-      },
-      "./evm": {
-        original: "./evm/dist/thirdweb-dev-react-evm.esm.js",
-        hotlink: "./src/evm/index.ts",
-      },
-      "./solana": {
-        original: "./solana/dist/thirdweb-dev-react-solana.esm.js",
-        hotlink: "./src/solana/index.ts",
-      },
-      "./evm/connectors/magic": {
-        original:
-          "./evm/connectors/magic/dist/thirdweb-dev-react-evm-connectors-magic.esm.js",
-        hotlink: "./src/evm/connectors/magic.ts",
-      },
-      "./evm/connectors/gnosis-safe": {
-        original:
-          "./evm/connectors/gnosis-safe/dist/thirdweb-dev-react-evm-connectors-gnosis-safe.esm.js",
-        hotlink: "./src/evm/connectors/gnosis-safe.ts",
-      },
+      ".": "./src/index.ts",
+      "./evm": "./src/evm/index.ts",
+      "./solana": "./src/solana/index.ts",
+      "./evm/connectors/magic": "./src/evm/connectors/magic.ts",
+      "./evm/connectors/gnosis-safe": "./src/evm/connectors/gnosis-safe.ts",
     },
   },
   // react-core
   {
     path: "./packages/react-core/package.json",
-    entry: {
-      original: "dist/thirdweb-dev-react-core.cjs.js",
-      hotlink: "./src/index.ts",
-    },
-    types: {
-      original: "dist/thirdweb-dev-react-core.cjs.d.ts",
-      hotlink: "",
-    },
+    entry: "./src/index.ts",
     exports: {
-      ".": {
-        original: "./dist/thirdweb-dev-react-core.esm.js",
-        hotlink: "./src/index.ts",
-      },
-      "./evm": {
-        original: "./evm/dist/thirdweb-dev-react-core-evm.esm.js",
-        hotlink: "./src/evm/index.ts",
-      },
-      "./solana": {
-        original: "./solana/dist/thirdweb-dev-react-core-solana.esm.js",
-        hotlink: "./src/solana/index.ts",
-      },
+      ".": "./src/index.ts",
+      "./evm": "./src/evm/index.ts",
+      "./solana": "./src/solana/index.ts",
     },
   },
   // wallets
   {
     path: "./packages/wallets/package.json",
-    entry: {
-      original: "dist/thirdweb-dev-wallets.cjs.js",
-      hotlink: "./src/index.ts",
-    },
-    types: {
-      original: "dist/thirdweb-dev-wallets.cjs.d.ts",
-      hotlink: "",
-    },
+    entry: "./src/index.ts",
     exports: {
-      ".": {
-        original: "./dist/thirdweb-dev-wallets.esm.js",
-        hotlink: "./src/index.ts",
-      },
-      "./evm": {
-        original: "./evm/dist/thirdweb-dev-wallets-evm.esm.js",
-        hotlink: "./src/evm/index.ts",
-      },
-      "./solana": {
-        original: "./solana/dist/thirdweb-dev-wallets-solana.esm.js",
-        hotlink: "./src/solana/index.ts",
-      },
-      "./evm/wallets/base": {
-        original:
-          "./evm/wallets/base/dist/thirdweb-dev-wallets-evm-wallets-base.esm.js",
-        hotlink: "./src/evm/wallets/base.ts",
-      },
-      "./evm/wallets/ethers": {
-        original:
-          "./evm/wallets/ethers/dist/thirdweb-dev-wallets-evm-wallets-ethers.esm.js",
-        hotlink: "./src/evm/wallets/ethers.ts",
-      },
-      "./evm/wallets/aws-kms": {
-        original:
-          "./evm/wallets/aws-kms/dist/thirdweb-dev-wallets-evm-wallets-aws-kms.esm.js",
-        hotlink: "./src/evm/wallets/awa-kms.ts",
-      },
-      "./solana/wallets/base": {
-        original:
-          "./solana/wallets/base/dist/thirdweb-dev-wallets-solana-wallets-base.esm.js",
-        hotlink: "./src/solana/wallets/base.ts",
-      },
-      "./evm/wallets/abstract": {
-        original:
-          "./evm/wallets/abstract/dist/thirdweb-dev-wallets-evm-wallets-abstract.esm.js",
-        hotlink: "./src/evm/wallets/abstract.ts",
-      },
-      "./evm/wallets/injected": {
-        original:
-          "./evm/wallets/injected/dist/thirdweb-dev-wallets-evm-wallets-injected.esm.js",
-        hotlink: "./src/evm/wallets/injected.ts",
-      },
-      "./evm/wallets/metamask": {
-        original:
-          "./evm/wallets/metamask/dist/thirdweb-dev-wallets-evm-wallets-metamask.esm.js",
-        hotlink: "./src/evm/wallets/metamask.ts",
-      },
-      "./solana/wallets/signer": {
-        original:
-          "./solana/wallets/signer/dist/thirdweb-dev-wallets-solana-wallets-signer.esm.js",
-        hotlink: "./src/solana/wallets/signer.ts",
-      },
-      "./evm/wallets/magic-auth": {
-        original:
-          "./evm/wallets/magic-auth/dist/thirdweb-dev-wallets-evm-wallets-magic-auth.esm.js",
-        hotlink: "./src/evm/wallets/magic-auth.ts",
-      },
-      "./solana/wallets/keypair": {
-        original:
-          "./solana/wallets/keypair/dist/thirdweb-dev-wallets-solana-wallets-keypair.esm.js",
-        hotlink: "./src/solana/wallets/keypair.ts",
-      },
-      "./evm/wallets/private-key": {
-        original:
-          "./evm/wallets/private-key/dist/thirdweb-dev-wallets-evm-wallets-private-key.esm.js",
-        hotlink: "./src/evm/wallets/private-key.ts",
-      },
-      "./evm/wallets/email-wallet": {
-        original:
-          "./evm/wallets/email-wallet/dist/thirdweb-dev-wallets-evm-wallets-email-wallet.esm.js",
-        hotlink: "./src/evm/wallets/email-wallet.ts",
-      },
-      "./evm/wallets/device-wallet": {
-        original:
-          "./evm/wallets/device-wallet/dist/thirdweb-dev-wallets-evm-wallets-device-wallet.esm.js",
-        hotlink: "./src/evm/wallets/device-wallet.ts",
-      },
-      "./evm/connectors/email": {
-        original:
-          "./evm/connectors/email/dist/thirdweb-dev-wallets-evm-connectors-email.esm.js",
-        hotlink: "./src/evm/connectors/email/index.ts",
-      },
-      "./evm/connectors/magic": {
-        original:
-          "./evm/connectors/magic/dist/thirdweb-dev-wallets-evm-connectors-magic.esm.js",
-        hotlink: "./src/evm/connectors/magic/index.ts",
-      },
-      "./evm/wallets/wallet-connect": {
-        original:
-          "./evm/wallets/wallet-connect/dist/thirdweb-dev-wallets-evm-wallets-wallet-connect.esm.js",
-        hotlink: "./src/evm/connectors/wallet-connect/index.ts",
-      },
-      "./solana/wallets/private-key": {
-        original:
-          "./solana/wallets/private-key/dist/thirdweb-dev-wallets-solana-wallets-private-key.esm.js",
-        hotlink: "./src/solana/wallets/private-key.ts",
-      },
-      "./evm/wallets/coinbase-wallet": {
-        original:
-          "./evm/wallets/coinbase-wallet/dist/thirdweb-dev-wallets-evm-wallets-coinbase-wallet.esm.js",
-        hotlink: "./src/evm/wallets/coinbase-wallet.ts",
-      },
-      "./evm/connectors/injected": {
-        original:
-          "./evm/connectors/injected/dist/thirdweb-dev-wallets-evm-connectors-injected.esm.js",
-        hotlink: "./src/evm/connectors/injected/index.ts",
-      },
-      "./evm/connectors/metamask": {
-        original:
-          "./evm/connectors/metamask/dist/thirdweb-dev-wallets-evm-connectors-metamask.esm.js",
-        hotlink: "./src/evm/connectors/metamask/index.ts",
-      },
-      "./evm/wallets/aws-secrets-manager": {
-        original:
-          "./evm/wallets/aws-secrets-manager/dist/thirdweb-dev-wallets-evm-wallets-aws-secrets-manager.esm.js",
-        hotlink: "./src/evm/wallets/aws-secrets-manager.ts",
-      },
-      "./evm/connectors/device-wallet": {
-        original:
-          "./evm/connectors/device-wallet/dist/thirdweb-dev-wallets-evm-connectors-device-wallet.esm.js",
-        hotlink: "./src/evm/connectors/device-wallet/index.ts",
-      },
-      "./evm/connectors/wallet-connect": {
-        original:
-          "./evm/connectors/wallet-connect/dist/thirdweb-dev-wallets-evm-connectors-wallet-connect.esm.js",
-        hotlink: "./src/evm/connectors/wallet-connect/index.ts",
-      },
-      "./evm/connectors/coinbase-wallet": {
-        original:
-          "./evm/connectors/coinbase-wallet/dist/thirdweb-dev-wallets-evm-connectors-coinbase-wallet.esm.js",
-        hotlink: "./src/evm/connectors/coinbase-wallet/index.ts",
-      },
+      ".": "./src/index.ts",
+      "./evm": "./src/evm/index.ts",
+      "./solana": "./src/solana/index.ts",
+      "./evm/wallets/base": "./src/evm/wallets/base.ts",
+      "./evm/wallets/ethers": "./src/evm/wallets/ethers.ts",
+      "./evm/wallets/aws-kms": "./src/evm/wallets/awa-kms.ts",
+      "./solana/wallets/base": "./src/solana/wallets/base.ts",
+      "./evm/wallets/abstract": "./src/evm/wallets/abstract.ts",
+      "./evm/wallets/injected": "./src/evm/wallets/injected.ts",
+      "./evm/wallets/metamask": "./src/evm/wallets/metamask.ts",
+      "./solana/wallets/signer": "./src/solana/wallets/signer.ts",
+      "./evm/wallets/magic-auth": "./src/evm/wallets/magic-auth.ts",
+      "./solana/wallets/keypair": "./src/solana/wallets/keypair.ts",
+      "./evm/wallets/private-key": "./src/evm/wallets/private-key.ts",
+      "./evm/wallets/device-wallet": "./src/evm/wallets/device-wallet.ts",
+      "./evm/connectors/magic": "./src/evm/connectors/magic/index.ts",
+      "./evm/wallets/wallet-connect":
+        "./src/evm/connectors/wallet-connect/index.ts",
+      "./solana/wallets/private-key": "./src/solana/wallets/private-key.ts",
+      "./evm/wallets/coinbase-wallet": "./src/evm/wallets/coinbase-wallet.ts",
+      "./evm/connectors/injected": "./src/evm/connectors/injected/index.ts",
+      "./evm/connectors/metamask": "./src/evm/connectors/metamask/index.ts",
+      "./evm/wallets/aws-secrets-manager":
+        "./src/evm/wallets/aws-secrets-manager.ts",
+      "./evm/connectors/device-wallet":
+        "./src/evm/connectors/device-wallet/index.ts",
+      "./evm/connectors/wallet-connect":
+        "./src/evm/connectors/wallet-connect/index.ts",
+      "./evm/connectors/coinbase-wallet":
+        "./src/evm/connectors/coinbase-wallet/index.ts",
+      "./evm/wallets/paper-wallet": "./src/evm/wallets/paper-wallet.ts",
+      "./evm/connectors/wallet-connect-v1":
+        "./src/evm/connectors/wallet-connect-v1/index.ts",
+      "./evm/connectors/paper": "./src/evm/connectors/paper/index.ts",
+      "./evm/wallets/wallet-connect-v1":
+        "./src/evm/wallets/wallet-connect-v1.ts",
     },
   },
 ];
@@ -230,12 +87,35 @@ export function updatePackages(changeKey) {
     const pkg = JSON.parse(fs.readFileSync(absPath(change.path), "utf8"));
 
     // apply changes
-    pkg.main = change.entry[changeKey];
-    for (const key in change.exports) {
-      pkg.exports[key].module = change.exports[key][changeKey];
+    if (changeKey === "hotlink") {
+      pkg._main = pkg.main;
+      pkg.main = change.entry;
+    } else {
+      pkg.main = pkg._main;
+      delete pkg._main;
     }
 
-    pkg.types = change.types[changeKey];
+    if (changeKey === "hotlink") {
+      // save entire pkg.exports deep copy
+      pkg._exports = JSON.parse(JSON.stringify(pkg.exports));
+
+      for (const key in change.exports) {
+        pkg.exports[key].module = change.exports[key];
+        delete pkg.exports[key].default;
+      }
+    } else {
+      // revert pkg.exports
+      pkg.exports = pkg._exports;
+      delete pkg._exports;
+    }
+
+    if (changeKey === "hotlink") {
+      pkg._types = pkg.types;
+      pkg.types = "";
+    } else {
+      pkg.types = pkg._types;
+      delete pkg._types;
+    }
 
     // save file
     fs.writeFileSync(

--- a/yarn.lock
+++ b/yarn.lock
@@ -8705,17 +8705,7 @@ ansi-html-community@^0.0.8:
   resolved "https://registry.yarnpkg.com/ansi-html-community/-/ansi-html-community-0.0.8.tgz#69fbc4d6ccbe383f9736934ae34c3f8290f1bf41"
   integrity sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==
 
-ansi-regex@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.1.tgz#164daac87ab2d6f6db3a29875e2d1766582dabed"
-  integrity sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==
-
-ansi-regex@^5.0.0, ansi-regex@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
-  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
-
-ansi-regex@^6.0.1:
+ansi-regex@^4.1.0, ansi-regex@^5.0.0, ansi-regex@^5.0.1, ansi-regex@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.0.1.tgz#3183e38fae9a65d7cb5e53945cd5897d0260a06a"
   integrity sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==
@@ -23254,15 +23244,10 @@ typedarray-to-buffer@3.1.5, typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.6.2, typescript@^4.7.4:
+typescript@^4.6.2, typescript@^4.7.4, typescript@~4.8.4:
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
-
-typescript@~4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
 
 typical@^4.0.0:
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4780,6 +4780,28 @@
     aria-hidden "^1.1.1"
     react-remove-scroll "2.5.5"
 
+"@radix-ui/react-popover@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-popover/-/react-popover-1.0.5.tgz#9c58100ed6809eb611c0acbf032f9ab58c0b55d1"
+  integrity sha512-GRHZ8yD12MrN2NLobHPE8Rb5uHTxd9x372DE9PPNnBjpczAQHcZ5ne0KXG4xpf+RDdXSzdLv9ym6mYJCDTaUZg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.0"
+    "@radix-ui/react-compose-refs" "1.0.0"
+    "@radix-ui/react-context" "1.0.0"
+    "@radix-ui/react-dismissable-layer" "1.0.3"
+    "@radix-ui/react-focus-guards" "1.0.0"
+    "@radix-ui/react-focus-scope" "1.0.2"
+    "@radix-ui/react-id" "1.0.0"
+    "@radix-ui/react-popper" "1.1.1"
+    "@radix-ui/react-portal" "1.0.2"
+    "@radix-ui/react-presence" "1.0.0"
+    "@radix-ui/react-primitive" "1.0.2"
+    "@radix-ui/react-slot" "1.0.1"
+    "@radix-ui/react-use-controllable-state" "1.0.0"
+    aria-hidden "^1.1.1"
+    react-remove-scroll "2.5.5"
+
 "@radix-ui/react-popper@1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-popper/-/react-popper-1.1.1.tgz#54f060941c981e965ff5d6b64e152d6298d2326e"


### PR DESCRIPTION
## react-core
- Stop forcing network switch when connecting wallet
- add autoSwitch option to force network switch in ThirdwebProvider
- remove deprecated and unused `chainRpc` prop from `ThirdwebProvider` 
- remove unused and confusing state 'activeChain' in wallet-provider
- Re export types from /sdk in /react-core

## wallets
- Fix wrong RPC urls and explorer URLs in wallets package
- make switchChain public in wallet connect v1 and remove walletName check


## react
- Add "Confirm in Wallet" UI in Web3Button, Network Switcher

## Other
- Fix hotlink DX
