### PR TITLE
Fix useConnect() type

### DIFF
--- a/packages/react-core/src/core/types/wallet.ts
+++ b/packages/react-core/src/core/types/wallet.ts
@@ -27,7 +27,9 @@ export type SupportedWalletInstance = InstanceType<
   connector?: TWConnector;
 };
 
-export type SupportedWallet = {
+export type SupportedWallet<
+  X extends SupportedWalletInstance = SupportedWalletInstance,
+> = {
   id: string;
-  new (options: WalletOptions): SupportedWalletInstance;
+  new (options: WalletOptions): X;
 };

--- a/packages/react-core/src/evm/index.ts
+++ b/packages/react-core/src/evm/index.ts
@@ -35,6 +35,7 @@ export { shouldNeverPersistQuery } from "../core/query-utils/query-key";
 export type { RequiredParam } from "../core/query-utils/required-param";
 export type {
   SupportedWallet,
+  SupportedWalletInstance,
   ExtraCoreWalletOptions,
 } from "../core/types/wallet";
 

--- a/packages/wallets/src/evm/wallets/device-wallet.ts
+++ b/packages/wallets/src/evm/wallets/device-wallet.ts
@@ -1,6 +1,6 @@
 import { AsyncStorage } from "../../core";
 import { thirdwebChains } from "../constants/chains";
-import { TWConnector } from "../interfaces/tw-connector";
+import { ConnectParams, TWConnector } from "../interfaces/tw-connector";
 import { AbstractWallet } from "./abstract";
 import { AbstractBrowserWallet, WalletOptions } from "./base";
 import { Chain } from "@thirdweb-dev/chains";
@@ -88,6 +88,11 @@ export class DeviceBrowserWallet extends AbstractBrowserWallet<
 
   static getDataStorageKey() {
     return STORAGE_KEY_DATA;
+  }
+
+  // enforcing that connectOptions is required and not optional
+  connect(connectOptions: ConnectParams<DeviceWalletConnectionArgs>) {
+    return super.connect(connectOptions);
   }
 }
 


### PR DESCRIPTION
* Device wallet's connect method requires connectParams - it can not be optional
* the `connect` function returned from `useConnect` should reflect the same
* if the wallet's connect method does require connectParams, `connect` should be able to accept only one arg - the wallet class

## Before 
```js
const connect = useConnect();

connect(MetamaskWallet, {}) // must provide second arg
```

## After 
```js
const connect = useConnect();

connect(MetamaskWallet) // ok
connect(DeviceWallet) // type error - connectParams are required
connect(DeviceWallet, { password: '123xyz' }) // ok
```