### PR TITLE
[SDK] Dont parse abis on detect features

### DIFF
--- a/.changeset/curly-rice-wash.md
+++ b/.changeset/curly-rice-wash.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/sdk": patch
+---
+
+[SDK] avoid recursively parsing the abi

--- a/packages/sdk/src/evm/common/feature-detection.ts
+++ b/packages/sdk/src/evm/common/feature-detection.ts
@@ -101,6 +101,19 @@ export async function extractConstructorParams(
 
 /**
  * @internal
+ * @param predeployMetadataUri
+ * @param storage
+ */
+export async function extractFunctions(
+  predeployMetadataUri: string,
+  storage: ThirdwebStorage,
+): Promise<AbiFunction[]> {
+  const metadata = await fetchPreDeployMetadata(predeployMetadataUri, storage);
+  return extractFunctionsFromAbi(metadata.abi, metadata.metadata);
+}
+
+/**
+ * @internal
  * @param name
  * @param metadata
  * @param type

--- a/packages/sdk/src/evm/common/feature-detection.ts
+++ b/packages/sdk/src/evm/common/feature-detection.ts
@@ -101,19 +101,6 @@ export async function extractConstructorParams(
 
 /**
  * @internal
- * @param predeployMetadataUri
- * @param storage
- */
-export async function extractFunctions(
-  predeployMetadataUri: string,
-  storage: ThirdwebStorage,
-): Promise<AbiFunction[]> {
-  const metadata = await fetchPreDeployMetadata(predeployMetadataUri, storage);
-  return extractFunctionsFromAbi(metadata.abi, metadata.metadata);
-}
-
-/**
- * @internal
  * @param name
  * @param metadata
  * @param type
@@ -182,8 +169,7 @@ export function extractFunctionsFromAbi(
   abi: AbiInput,
   metadata?: Record<string, any>,
 ): AbiFunction[] {
-  const parsedAbi = AbiSchema.parse(abi || []);
-  const functions = parsedAbi.filter((el) => el.type === "function");
+  const functions = (abi || []).filter((el) => el.type === "function");
 
   const parsed: AbiFunction[] = [];
   for (const f of functions) {
@@ -196,7 +182,9 @@ export function extractFunctionsFromAbi(
     const promise = out ? `: Promise<${out}>` : `: Promise<TransactionResult>`;
     const signature = `contract.call("${f.name}"${fargs})${promise}`;
     parsed.push({
+      /// @ts-ignore we know AbiTypeBaseSchema.name is not going to be undefined since we're doing `.default("")`
       inputs: f.inputs || [],
+      // @ts-ignore we know the AbiTypeBaseSchema.name is not going to be undefined since we're doing `.default("")`
       outputs: f.outputs || [],
       name: f.name || "unknown",
       signature,

--- a/packages/sdk/src/evm/common/feature-detection.ts
+++ b/packages/sdk/src/evm/common/feature-detection.ts
@@ -182,7 +182,7 @@ export function extractFunctionsFromAbi(
     const promise = out ? `: Promise<${out}>` : `: Promise<TransactionResult>`;
     const signature = `contract.call("${f.name}"${fargs})${promise}`;
     parsed.push({
-      /// @ts-ignore we know AbiTypeBaseSchema.name is not going to be undefined since we're doing `.default("")`
+      // @ts-ignore we know AbiTypeBaseSchema.name is not going to be undefined since we're doing `.default("")`
       inputs: f.inputs || [],
       // @ts-ignore we know the AbiTypeBaseSchema.name is not going to be undefined since we're doing `.default("")`
       outputs: f.outputs || [],

--- a/packages/sdk/src/evm/core/classes/contract-publisher.ts
+++ b/packages/sdk/src/evm/core/classes/contract-publisher.ts
@@ -1,5 +1,6 @@
 import {
   extractConstructorParams,
+  extractFunctions,
   fetchContractMetadataFromAddress,
   fetchExtendedReleaseMetadata,
   fetchPreDeployMetadata,
@@ -12,6 +13,7 @@ import { resolveAddress } from "../../common/ens";
 import { buildTransactionFunction } from "../../common/transactions";
 import { getContractPublisherAddress } from "../../constants";
 import {
+  AbiFunction,
   AddressOrEns,
   ContractParam,
   ContractSource,
@@ -77,6 +79,16 @@ export class ContractPublisher extends RPCConnectionHandler {
     metadataUri: string,
   ): Promise<ContractParam[]> {
     return extractConstructorParams(metadataUri, this.storage);
+  }
+
+  /**
+   * @internal
+   * @param predeployMetadataUri
+   */
+  public async extractFunctions(
+    predeployMetadataUri: string,
+  ): Promise<AbiFunction[]> {
+    return extractFunctions(predeployMetadataUri, this.storage);
   }
 
   /**

--- a/packages/sdk/src/evm/core/classes/contract-publisher.ts
+++ b/packages/sdk/src/evm/core/classes/contract-publisher.ts
@@ -1,6 +1,5 @@
 import {
   extractConstructorParams,
-  extractFunctions,
   fetchContractMetadataFromAddress,
   fetchExtendedReleaseMetadata,
   fetchPreDeployMetadata,
@@ -13,7 +12,6 @@ import { resolveAddress } from "../../common/ens";
 import { buildTransactionFunction } from "../../common/transactions";
 import { getContractPublisherAddress } from "../../constants";
 import {
-  AbiFunction,
   AddressOrEns,
   ContractParam,
   ContractSource,
@@ -79,16 +77,6 @@ export class ContractPublisher extends RPCConnectionHandler {
     metadataUri: string,
   ): Promise<ContractParam[]> {
     return extractConstructorParams(metadataUri, this.storage);
-  }
-
-  /**
-   * @internal
-   * @param predeployMetadataUri
-   */
-  public async extractFunctions(
-    predeployMetadataUri: string,
-  ): Promise<AbiFunction[]> {
-    return extractFunctions(predeployMetadataUri, this.storage);
   }
 
   /**


### PR DESCRIPTION
Removing abischema.parse from `extractFunctionsAbi` for perf improvements. It improved loading times by 26x since we call extractFunctionsFromAbi ~2k times the first time we load an ABI. This should be save to remove since we do set a default value in the schema, it's just that zod treats `.default` as an optional when it comes to the types.

Follow ups:
- Investigate how to improve extractFunctionsAbi, maybe look into parsing the ABI only once and store the parsed value during the creation of the contract?
