### PR TITLE
[SDK] Make metadata signature 721 output optional

### DIFF
--- a/.changeset/cool-spies-melt.md
+++ b/.changeset/cool-spies-melt.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/sdk": patch
+---
+
+Make metadata optional on signature input

--- a/packages/sdk/src/evm/schema/contracts/common/signature.ts
+++ b/packages/sdk/src/evm/schema/contracts/common/signature.ts
@@ -65,6 +65,7 @@ export const Signature721PayloadInput = BaseSignaturePayloadInput.extend({
  * @internal
  */
 export const Signature721PayloadOutput = Signature721PayloadInput.extend({
+  metadata: NFTInputOrUriSchema.default(""),
   uri: z.string(),
   royaltyBps: BigNumberSchema,
   mintStartTime: BigNumberSchema,


### PR DESCRIPTION
For compatibility reasons with other SDKs and performance (you don't need the metadata in this call, so don't force people to fetch it down just to pass it here)