### PR TITLE
[CLI] Only run react-native ios specific tasks on macOS envs

### DIFF
--- a/.changeset/real-poets-swim.md
+++ b/.changeset/real-poets-swim.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+[CLI] Only checks ruby version and attempts to run pod install if the platform is macOS

--- a/packages/cli/src/create/helpers/create-app.ts
+++ b/packages/cli/src/create/helpers/create-app.ts
@@ -62,6 +62,24 @@ export async function createApp({
     }
   }
 
+  const isReactNative =
+    template?.includes("react-native") || framework === "react-native";
+  function isReactNativeCLI() {
+    return (
+      isReactNative &&
+      (language === "typescript" || (template && !template.includes("expo")))
+    );
+  }
+
+  function isMacOS() {
+    return process.platform === "darwin";
+  }
+
+  if (isReactNativeCLI() && isMacOS()) {
+    // fail early if the user doesn't have the right version of Ruby installed on macOS
+    await checkRubyVersion();
+  }
+
   const root = path.resolve(appPath);
 
   if (!(await isWriteable(path.dirname(root)))) {
@@ -96,20 +114,6 @@ export async function createApp({
       err !== null &&
       typeof (err as { message?: unknown }).message === "string"
     );
-  }
-
-  const isReactNative =
-    template?.includes("react-native") || framework === "react-native";
-  function isReactNativeCLI() {
-    return (
-      isReactNative &&
-      (language === "typescript" || (template && !template.includes("expo")))
-    );
-  }
-
-  if (isReactNativeCLI()) {
-    // fail early if the user doesn't have the right version of Ruby installed
-    await checkRubyVersion();
   }
 
   if (template) {
@@ -199,7 +203,7 @@ export async function createApp({
     console.log();
   }
 
-  if (isReactNativeCLI()) {
+  if (isReactNativeCLI() && isMacOS()) {
     await podInstall(root, isOnline);
   }
 


### PR DESCRIPTION
Only checks ruby version and attempts to run pod install if the platform is macOS.

Uses `process.platform` to identify OS: https://nodejs.org/api/process.html#processplatform