### PR TITLE
[SDK] Rename deployReleasedContract to deployPublishedContract

### DIFF
--- a/.changeset/quick-rabbits-sniff.md
+++ b/.changeset/quick-rabbits-sniff.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/sdk": patch
+---
+
+Rename deployReleasedContract to deployPublishedContnract

--- a/packages/sdk/src/evm/core/classes/contract-deployer.ts
+++ b/packages/sdk/src/evm/core/classes/contract-deployer.ts
@@ -560,7 +560,7 @@ export class ContractDeployer extends RPCConnectionHandler {
    * @param contractName the name of the contract to deploy
    * @param constructorParams the constructor params to pass to the contract
    */
-  deployReleasedContract = buildDeployTransactionFunction(
+  deployPublishedContract = buildDeployTransactionFunction(
     async (
       publisherAddress: AddressOrEns,
       contractName: string,


### PR DESCRIPTION
Only function missing from the renaming, we're not using it internally anywhere so safe to rename without minor/major version.