### PR TITLE
[REACT] Add onLogin callback to ConnectWallet authOptions props

### DIFF
--- a/.changeset/spicy-carrots-grin.md
+++ b/.changeset/spicy-carrots-grin.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/react": patch
+---
+
+Added onLogin callback to ConnectWallet authOptions props

--- a/packages/react/src/wallet/ConnectWallet/ConnectWallet.tsx
+++ b/packages/react/src/wallet/ConnectWallet/ConnectWallet.tsx
@@ -36,6 +36,7 @@ type ConnectWalletProps = {
   auth?: {
     loginOptions?: LoginOptions;
     loginOptional?: boolean;
+    onLogin?: (token: string) => void;
   };
   style?: React.CSSProperties;
   networkSelector?: Omit<NetworkSelectorProps, "theme" | "onClose" | "chains">;
@@ -77,7 +78,8 @@ export const ConnectWallet: React.FC<ConnectWalletProps> = (props) => {
   const signIn = async () => {
     try {
       setShowSignatureModal(true);
-      await login(props.auth?.loginOptions);
+      const token = await login(props.auth?.loginOptions);
+      props?.auth?.onLogin?.(token);
     } catch (err) {
       console.error("failed to log in", err);
     }


### PR DESCRIPTION
Added an onLogin callback to the authOptions props of the ConnectWallet.tsx component to be able to use the JWT