### PR TITLE
[ReactNative] Make web3button action return a promise

### DIFF
--- a/.changeset/rotten-badgers-build.md
+++ b/.changeset/rotten-badgers-build.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/react-native": patch
+---
+
+[ReactNative] Enforce web3button action to return a promise to make sure onSuccess and onError are triggered correctly

--- a/packages/react-native/src/evm/components/Web3Button.tsx
+++ b/packages/react-native/src/evm/components/Web3Button.tsx
@@ -19,7 +19,7 @@ import { PropsWithChildren, useEffect } from "react";
 import { ActivityIndicator, StyleSheet } from "react-native";
 import invariant from "tiny-invariant";
 
-type ActionFn = (contract: SmartContract) => any;
+type ActionFn = (contract: SmartContract) => Promise<any>;
 
 interface Web3ButtonProps<TActionFn extends ActionFn> {
   contractAddress: `0x${string}` | `${string}.eth` | string;


### PR DESCRIPTION
The Web3Button action prop didn't return a promise, meaning devs can do:

```
<Web3Button action={() => {contract.call()}} ...
```
This will return `void` which breaks the `onError` and `onSuccess` props.

Forcing the `action` prop to return a Promise will raise an error in the example above and make the user return a promise, like so:
```
<Web3Button action={() => {return contract.call()}} ...
```
which will make the other props work as expected