### PR TITLE
[React] Add ability to configure gatewayUrl on MediaRenderer

### DIFF
--- a/.changeset/lazy-eels-sit.md
+++ b/.changeset/lazy-eels-sit.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/react": patch
+---
+
+Add ability to configure gatewayUrl and pull gatewayUrl from storage in MediaRenderer


### PR DESCRIPTION
- Allows you to configure `gatewayUrl` on `MediaRenderer`
- By default, pull `gatewayUrl` from configured storage