### PR TITLE
update sepolia weth to an address that does not have a mint function

### DIFF
--- a/packages/sdk/src/evm/constants/currency.ts
+++ b/packages/sdk/src/evm/constants/currency.ts
@@ -37,7 +37,7 @@ export const NATIVE_TOKENS: Record<number, NativeToken> = {
     symbol: "SEP",
     decimals: 18,
     wrapped: {
-      address: "0xD0dF82dE051244f04BfF3A8bB1f62E1cD39eED92",
+      address: "0x7b79995e5f793A07Bc00c21412e50Ecae098E7f9",
       name: "Wrapped Ether",
       symbol: "WETH",
     },


### PR DESCRIPTION
an update from https://github.com/thirdweb-dev/js/pull/987

as brought to my attention by [this twitter thread](https://twitter.com/kassandraeth/status/1659586527498780676?s=12&t=FJ9Ia-2v_9ftxl0My0axTg), the Aave WETH contract has a mint function in it. WETH should not have a mint function that can be called by the contract owner. Until a defacto standard emerges, we should move to a WETH contract that mirrors mainnet and has a lot of usage. 

@joaquim-verges [was right](https://github.com/thirdweb-dev/js/pull/987#pullrequestreview-1425799427), this contract is the better one.