### PR TITLE
[SDK] Allow overrides for read actions

### DIFF
--- a/.changeset/five-frogs-learn.md
+++ b/.changeset/five-frogs-learn.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/sdk": patch
+---
+
+allow overrides for read actions

--- a/packages/sdk/src/evm/core/classes/contract-wrapper.ts
+++ b/packages/sdk/src/evm/core/classes/contract-wrapper.ts
@@ -315,7 +315,7 @@ export class ContractWrapper<
     // TODO validate each argument
     if (fn.stateMutability === "view" || fn.stateMutability === "pure") {
       // read function
-      return (this.readContract as any)[fnName](...args);
+      return (this.readContract as any)[fnName](...args, txOptions);
     } else {
       // write function
       const receipt = await this.sendTransaction(fnName, args, txOptions);

--- a/packages/sdk/src/evm/core/classes/contract-wrapper.ts
+++ b/packages/sdk/src/evm/core/classes/contract-wrapper.ts
@@ -315,7 +315,9 @@ export class ContractWrapper<
     // TODO validate each argument
     if (fn.stateMutability === "view" || fn.stateMutability === "pure") {
       // read function
-      return (this.readContract as any)[fnName](...args, txOptions);
+      return txOptions
+        ? (this.readContract as any)[fnName](...args, txOptions)
+        : (this.readContract as any)[fnName](...args);
     } else {
       // write function
       const receipt = await this.sendTransaction(fnName, args, txOptions);


### PR DESCRIPTION
Read calls to view/pure functions can have `from` and `blockTag` as call overrides.