### PR TITLE
useSwitchChain instead of wallet.switchChain

### DIFF
--- a/.changeset/modern-plants-design.md
+++ b/.changeset/modern-plants-design.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/react": patch
+---
+
+Fixes the issue of Magic Link's "Switch Network" not working with Smart Wallet and Safe

--- a/packages/react/src/wallet/wallets/safe/SelectAccount.tsx
+++ b/packages/react/src/wallet/wallets/safe/SelectAccount.tsx
@@ -24,6 +24,7 @@ import {
   useConnect,
   useConnectionStatus,
   useSupportedChains,
+  useSwitchChain,
   useWallet,
 } from "@thirdweb-dev/react-core";
 import { SafeSupportedChainsSet } from "@thirdweb-dev/wallets";
@@ -99,6 +100,8 @@ export const SelectAccount: React.FC<{
 
   const isValidAddress = utils.isAddress(safeAddress);
   const disableNetworkSelection = supportedChains.length === 1;
+
+  const switchChain = useSwitchChain();
 
   return (
     <>
@@ -317,7 +320,7 @@ export const SelectAccount: React.FC<{
                 setSwitchError(false);
                 setSwitchingNetwork(true);
                 try {
-                  await activeWallet.switchChain(safeChainId);
+                  await switchChain(safeChainId);
                 } catch (e) {
                   setSwitchError(true);
                 } finally {

--- a/packages/react/src/wallet/wallets/smartWallet/SmartWalletConnecting.tsx
+++ b/packages/react/src/wallet/wallets/smartWallet/SmartWalletConnecting.tsx
@@ -19,6 +19,7 @@ import {
   useNetworkMismatch,
   useWalletContext,
   useWallet,
+  useSwitchChain,
 } from "@thirdweb-dev/react-core";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Flex } from "../../../components/basic";
@@ -55,6 +56,8 @@ export const SmartWalletConnecting: React.FC<{
 
   const { onConnect } = props;
   const connectStarted = useRef(false);
+
+  const switchChain = useSwitchChain();
 
   const handleConnect = useCallback(async () => {
     if (!activeWallet || !connectedChain || connectStarted.current) {
@@ -148,7 +151,7 @@ export const SmartWalletConnecting: React.FC<{
           setSwitchError(false);
           setSwitchingNetwork(true);
           try {
-            await activeWallet.switchChain(targetChain.chainId);
+            await switchChain(targetChain.chainId);
           } catch (e) {
             setSwitchError(true);
           } finally {


### PR DESCRIPTION
Fixes the issue of Magic Link's "Switch Network" not working with Smart Wallet and Safe