### PR TITLE
[ReactNative] Make magic deps and camera deps optional

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -39,12 +39,9 @@
     "expo-document-picker": "^11.2.2",
     "expo-file-system": "^15.2.2",
     "expo-secure-store": "^12.1.1",
-    "react-native-device-info": "10.6.0",
     "react-native-mmkv": "2.5.1",
     "react-native-modal": "^13.0.1",
-    "react-native-safe-area-context": "4.5.3",
     "react-native-svg": "^13.8.0",
-    "react-native-webview": "12.1.0",
     "tiny-invariant": "^1.2.0"
   },
   "resolutions": {
@@ -76,14 +73,22 @@
     "react": "^18.2.0",
     "react-native": "^0.71.0",
     "react-native-camera": "^4.2.1",
+    "react-native-device-info": "10.6.0",
+    "react-native-safe-area-context": "4.5.3",
+    "react-native-webview": "12.1.0",
     "typescript": "^4.7.4"
+  },
+  "optionalDependencies": {
+    "react-native-camera": "^4.2.1",
+    "react-native-device-info": "10.6.0",
+    "react-native-safe-area-context": "4.5.3",
+    "react-native-webview": "12.1.0"
   },
   "peerDependencies": {
     "ethers": ">=5.5.1 <6",
     "expo": "^47.0.0",
     "react": ">=18.0.0",
-    "react-native": ">=0.70.0",
-    "react-native-camera": "^4.2.1"
+    "react-native": ">=0.70.0"
   },
   "engines": {
     "node": ">= 16.0.0"

--- a/packages/react-native/src/evm/providers/thirdweb-provider.tsx
+++ b/packages/react-native/src/evm/providers/thirdweb-provider.tsx
@@ -5,7 +5,7 @@ import {
   ThirdwebProviderCoreProps,
   WalletConfig,
 } from "@thirdweb-dev/react-core";
-import { PropsWithChildren } from "react";
+import { PropsWithChildren, useMemo } from "react";
 import type { Chain, defaultChains } from "@thirdweb-dev/chains";
 import { SecureStorage } from "../../core/SecureStorage";
 import { useCoinbaseWalletListener } from "../wallets/hooks/useCoinbaseWalletListener";
@@ -15,6 +15,7 @@ import { UIContextProvider } from "./ui-context-provider";
 import { MainModal } from "../components/MainModal";
 import { ThemeProvider } from "../styles/ThemeProvider";
 import { SafeAreaProvider } from "react-native-safe-area-context";
+import { walletIds } from "@thirdweb-dev/wallets";
 
 interface ThirdwebProviderProps<TChains extends Chain[]>
   extends Omit<ThirdwebProviderCoreProps<TChains>, "supportedWallets"> {
@@ -66,6 +67,11 @@ export const ThirdwebProvider = <
 }: PropsWithChildren<ThirdwebProviderProps<TChains>>) => {
   useCoinbaseWalletListener();
 
+  const hasMagicConfig = useMemo(
+    () => !!supportedWallets.find((wc) => wc.id === walletIds.magicLink),
+    [supportedWallets],
+  );
+
   return (
     <ThirdwebProviderCore
       thirdwebApiKey={thirdwebApiKey}
@@ -81,16 +87,21 @@ export const ThirdwebProvider = <
       {...restProps}
     >
       <ThemeProvider theme={theme}>
-        <SafeAreaProvider>
-          <UIContextProvider>
+        <UIContextProvider>
+          {hasMagicConfig ? (
             <SafeAreaProvider>
               <DappContextProvider>
                 {children}
                 <MainModal />
               </DappContextProvider>
             </SafeAreaProvider>
-          </UIContextProvider>
-        </SafeAreaProvider>
+          ) : (
+            <DappContextProvider>
+              {children}
+              <MainModal />
+            </DappContextProvider>
+          )}
+        </UIContextProvider>
       </ThemeProvider>
     </ThirdwebProviderCore>
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -786,6 +786,10 @@ importers:
       tiny-invariant:
         specifier: ^1.2.0
         version: 1.3.1
+    optionalDependencies:
+      react-native-camera:
+        specifier: ^4.2.1
+        version: 4.2.1
     devDependencies:
       '@babel/core':
         specifier: ^7.19.3
@@ -856,9 +860,6 @@ importers:
       react-native:
         specifier: ^0.71.0
         version: 0.71.4(@babel/core@7.21.3)(@babel/preset-env@7.20.2)(react@18.2.0)
-      react-native-camera:
-        specifier: ^4.2.1
-        version: 4.2.1
       typescript:
         specifier: ^4.7.4
         version: 4.9.5
@@ -26529,9 +26530,11 @@ packages:
 
   /react-native-camera@4.2.1:
     resolution: {integrity: sha512-+Vkql24PFYQfsPRznJCvPwJQfyzCnjlcww/iZ4Ej80bgivKjL9eU0IMQIXp4yi6XCrKi4voWXxIDPMupQZKeIQ==}
+    requiresBuild: true
     dependencies:
       prop-types: 15.8.1
-    dev: true
+    dev: false
+    optional: true
 
   /react-native-codegen@0.71.5:
     resolution: {integrity: sha512-rfsuc0zkuUuMjFnrT55I1mDZ+pBRp2zAiRwxck3m6qeGJBGK5OV5JH66eDQ4aa+3m0of316CqrJDRzVlYufzIg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -765,24 +765,15 @@ importers:
       expo-secure-store:
         specifier: ^12.1.1
         version: 12.1.1(expo@47.0.13)
-      react-native-device-info:
-        specifier: 10.6.0
-        version: 10.6.0(react-native@0.71.4)
       react-native-mmkv:
         specifier: 2.5.1
         version: 2.5.1(react-native@0.71.4)(react@18.2.0)
       react-native-modal:
         specifier: ^13.0.1
         version: 13.0.1(react-native@0.71.4)(react@18.2.0)
-      react-native-safe-area-context:
-        specifier: 4.5.3
-        version: 4.5.3(react-native@0.71.4)(react@18.2.0)
       react-native-svg:
         specifier: ^13.8.0
         version: 13.8.0(react-native@0.71.4)(react@18.2.0)
-      react-native-webview:
-        specifier: 12.1.0
-        version: 12.1.0(react-native@0.71.4)(react@18.2.0)
       tiny-invariant:
         specifier: ^1.2.0
         version: 1.3.1
@@ -790,6 +781,15 @@ importers:
       react-native-camera:
         specifier: ^4.2.1
         version: 4.2.1
+      react-native-device-info:
+        specifier: 10.6.0
+        version: 10.6.0(react-native@0.71.4)
+      react-native-safe-area-context:
+        specifier: 4.5.3
+        version: 4.5.3(react-native@0.71.4)(react@18.2.0)
+      react-native-webview:
+        specifier: 12.1.0
+        version: 12.1.0(react-native@0.71.4)(react@18.2.0)
     devDependencies:
       '@babel/core':
         specifier: ^7.19.3
@@ -26560,6 +26560,7 @@ packages:
 
   /react-native-device-info@10.6.0(react-native@0.71.4):
     resolution: {integrity: sha512-/MmINdojWdw2/9rwYpH/dX+1gFP0o78p8yYPjwxiPhoySSL2rZaNi+Mq9VwC+zFi/yQmJUvHntkKSw2KUc7rFw==}
+    requiresBuild: true
     peerDependencies:
       react-native: '*'
     dependencies:
@@ -26612,6 +26613,7 @@ packages:
 
   /react-native-safe-area-context@4.5.3(react-native@0.71.4)(react@18.2.0):
     resolution: {integrity: sha512-ihYeGDEBSkYH+1aWnadNhVtclhppVgd/c0tm4mj0+HV11FoiWJ8N6ocnnZnRLvM5Fxc+hUqxR9bm5AXU3rXiyA==}
+    requiresBuild: true
     peerDependencies:
       react: '*'
       react-native: '*'
@@ -26634,6 +26636,7 @@ packages:
 
   /react-native-webview@12.1.0(react-native@0.71.4)(react@18.2.0):
     resolution: {integrity: sha512-fuMyF4PBSIHHxv/3GgWO0LQbd7hRkLLDvZZIZw7gplSvH1YTahzw2wxnAt2K4Ua9UmsZ3w2MKgDamQCrdk4tdw==}
+    requiresBuild: true
     peerDependencies:
       react: '*'
       react-native: '*'


### PR DESCRIPTION
Makes:
Needed by Connect an App feature
- react-native-camera  
On Android, users need to add `missingDimensionStrategy 'react-native-camera', 'general'` in `android/app/build.gradle`

```javascript
defaultConfig {
        applicationId "com.test15"
        minSdkVersion rootProject.ext.minSdkVersion
        targetSdkVersion rootProject.ext.targetSdkVersion
        missingDimensionStrategy 'react-native-camera', 'general'
        versionCode 1
        versionName "1.0"
    }
```

Needed by Magic implementation
- react-native-safe-area-context
- react-native-webview
- react-native-device-info