### PR TITLE
[sdk] Reduce circular dependencies

### DIFF
--- a/.changeset/khaki-apricots-flow.md
+++ b/.changeset/khaki-apricots-flow.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/sdk": patch
+---
+
+Reduce circular dependencies

--- a/packages/sdk/src/evm/common/feature-detection/fetchPreDeployMetadata.ts
+++ b/packages/sdk/src/evm/common/feature-detection/fetchPreDeployMetadata.ts
@@ -2,7 +2,7 @@ import {
   PreDeployMetadataFetched,
   PreDeployMetadataFetchedSchema,
 } from "../../schema/contracts/custom";
-import { fetchContractMetadata } from "../metadata-resolver";
+import { fetchContractMetadata } from "../fetchContractMetadata";
 import { ThirdwebStorage } from "@thirdweb-dev/storage";
 import { fetchRawPredeployMetadata } from "./fetchRawPredeployMetadata";
 

--- a/packages/sdk/src/evm/common/fetchContractMetadata.ts
+++ b/packages/sdk/src/evm/common/fetchContractMetadata.ts
@@ -1,0 +1,46 @@
+import {
+  PublishedMetadata,
+  AbiSchema,
+  ContractInfoSchema,
+} from "../schema/contracts/custom";
+import type { ThirdwebStorage } from "@thirdweb-dev/storage";
+
+/**
+ * @internal
+ * @param compilerMetadataUri
+ * @param storage
+ */
+
+export async function fetchContractMetadata(
+  compilerMetadataUri: string,
+  storage: ThirdwebStorage,
+): Promise<PublishedMetadata> {
+  const metadata = await storage.downloadJSON(compilerMetadataUri);
+  if (!metadata || !metadata.output) {
+    throw new Error(
+      `Could not resolve metadata for contract at ${compilerMetadataUri}`,
+    );
+  }
+  const abi = AbiSchema.parse(metadata.output.abi);
+  const compilationTarget = metadata.settings.compilationTarget;
+  const targets = Object.keys(compilationTarget);
+  const name = compilationTarget[targets[0]];
+  const info = ContractInfoSchema.parse({
+    title: metadata.output.devdoc.title,
+    author: metadata.output.devdoc.author,
+    details: metadata.output.devdoc.detail,
+    notice: metadata.output.userdoc.notice,
+  });
+  const licenses: string[] = [
+    ...new Set(
+      Object.entries(metadata.sources).map(([, src]) => (src as any).license),
+    ),
+  ];
+  return {
+    name,
+    abi,
+    metadata,
+    info,
+    licenses,
+  };
+}

--- a/packages/sdk/src/evm/common/fetchSourceFilesFromMetadata.ts
+++ b/packages/sdk/src/evm/common/fetchSourceFilesFromMetadata.ts
@@ -1,0 +1,46 @@
+import { PublishedMetadata, ContractSource } from "../schema/contracts/custom";
+import type { ThirdwebStorage } from "@thirdweb-dev/storage";
+
+/**
+ * @internal
+ * @param publishedMetadata
+ * @param storage
+ */
+
+export async function fetchSourceFilesFromMetadata(
+  publishedMetadata: PublishedMetadata,
+  storage: ThirdwebStorage,
+): Promise<ContractSource[]> {
+  return await Promise.all(
+    Object.entries(publishedMetadata.metadata.sources).map(
+      async ([path, info]) => {
+        const urls = (info as any).urls as string[];
+        const ipfsLink = urls
+          ? urls.find((url) => url.includes("ipfs"))
+          : undefined;
+        if (ipfsLink) {
+          const ipfsHash = ipfsLink.split("ipfs/")[1];
+          // 3 sec timeout for sources that haven't been uploaded to ipfs
+          const timeout = new Promise<string>((_r, rej) =>
+            setTimeout(() => rej("timeout"), 3000),
+          );
+          const source = await Promise.race([
+            (await storage.download(`ipfs://${ipfsHash}`)).text(),
+            timeout,
+          ]);
+          return {
+            filename: path,
+            source,
+          };
+        } else {
+          return {
+            filename: path,
+            source:
+              (info as any).content ||
+              "Could not find source for this contract",
+          };
+        }
+      },
+    ),
+  );
+}

--- a/packages/sdk/src/evm/common/metadata-resolver.ts
+++ b/packages/sdk/src/evm/common/metadata-resolver.ts
@@ -1,15 +1,10 @@
 import { ThirdwebSDK } from "../core/sdk";
-import {
-  Abi,
-  PublishedMetadata,
-  AbiSchema,
-  ContractInfoSchema,
-  ContractSource,
-} from "../schema/contracts/custom";
+import { Abi, PublishedMetadata } from "../schema/contracts/custom";
 import { Address } from "../schema/shared/Address";
 import { resolveContractUriFromAddress } from "./feature-detection/resolveContractUriFromAddress";
 import { ThirdwebStorage } from "@thirdweb-dev/storage";
 import { providers } from "ethers";
+import { fetchContractMetadata } from "./fetchContractMetadata";
 
 // Internal static cache
 const metadataCache: Record<string, PublishedMetadata> = {};
@@ -115,86 +110,4 @@ export async function fetchAbiFromAddress(
     // will fallback to embedded ABIs for prebuilts
   }
   return undefined;
-}
-
-/**
- * @internal
- * @param compilerMetadataUri
- * @param storage
- */
-export async function fetchContractMetadata(
-  compilerMetadataUri: string,
-  storage: ThirdwebStorage,
-): Promise<PublishedMetadata> {
-  const metadata = await storage.downloadJSON(compilerMetadataUri);
-  if (!metadata || !metadata.output) {
-    throw new Error(
-      `Could not resolve metadata for contract at ${compilerMetadataUri}`,
-    );
-  }
-  const abi = AbiSchema.parse(metadata.output.abi);
-  const compilationTarget = metadata.settings.compilationTarget;
-  const targets = Object.keys(compilationTarget);
-  const name = compilationTarget[targets[0]];
-  const info = ContractInfoSchema.parse({
-    title: metadata.output.devdoc.title,
-    author: metadata.output.devdoc.author,
-    details: metadata.output.devdoc.detail,
-    notice: metadata.output.userdoc.notice,
-  });
-  const licenses: string[] = [
-    ...new Set(
-      Object.entries(metadata.sources).map(([, src]) => (src as any).license),
-    ),
-  ];
-  return {
-    name,
-    abi,
-    metadata,
-    info,
-    licenses,
-  };
-}
-
-/**
- * @internal
- * @param publishedMetadata
- * @param storage
- */
-export async function fetchSourceFilesFromMetadata(
-  publishedMetadata: PublishedMetadata,
-  storage: ThirdwebStorage,
-): Promise<ContractSource[]> {
-  return await Promise.all(
-    Object.entries(publishedMetadata.metadata.sources).map(
-      async ([path, info]) => {
-        const urls = (info as any).urls as string[];
-        const ipfsLink = urls
-          ? urls.find((url) => url.includes("ipfs"))
-          : undefined;
-        if (ipfsLink) {
-          const ipfsHash = ipfsLink.split("ipfs/")[1];
-          // 3 sec timeout for sources that haven't been uploaded to ipfs
-          const timeout = new Promise<string>((_r, rej) =>
-            setTimeout(() => rej("timeout"), 3000),
-          );
-          const source = await Promise.race([
-            (await storage.download(`ipfs://${ipfsHash}`)).text(),
-            timeout,
-          ]);
-          return {
-            filename: path,
-            source,
-          };
-        } else {
-          return {
-            filename: path,
-            source:
-              (info as any).content ||
-              "Could not find source for this contract",
-          };
-        }
-      },
-    ),
-  );
 }

--- a/packages/sdk/src/evm/common/verification.ts
+++ b/packages/sdk/src/evm/common/verification.ts
@@ -4,7 +4,7 @@ import { getEncodedConstructorParamsForThirdwebContract } from "./any-evm-utils/
 import { getThirdwebContractAddress } from "./any-evm-utils/getThirdwebContractAddress";
 import { extractConstructorParamsFromAbi } from "./feature-detection/extractConstructorParamsFromAbi";
 import { resolveContractUriFromAddress } from "./feature-detection/resolveContractUriFromAddress";
-import { fetchSourceFilesFromMetadata } from "./metadata-resolver";
+import { fetchSourceFilesFromMetadata } from "./fetchSourceFilesFromMetadata";
 import { ThirdwebStorage } from "@thirdweb-dev/storage";
 import { Abi } from "../schema/contracts/custom";
 import { ethers, utils } from "ethers";

--- a/packages/sdk/src/evm/core/classes/contract-publisher.ts
+++ b/packages/sdk/src/evm/core/classes/contract-publisher.ts
@@ -6,11 +6,9 @@ import { extractConstructorParams } from "../../common/feature-detection/extract
 import { fetchExtendedReleaseMetadata } from "../../common/feature-detection/fetchExtendedReleaseMetadata";
 import { fetchRawPredeployMetadata } from "../../common/feature-detection/fetchRawPredeployMetadata";
 import { resolveContractUriFromAddress } from "../../common/feature-detection/resolveContractUriFromAddress";
-import {
-  fetchContractMetadataFromAddress,
-  fetchSourceFilesFromMetadata,
-  fetchContractMetadata,
-} from "../../common/metadata-resolver";
+import { fetchContractMetadataFromAddress } from "../../common/metadata-resolver";
+import { fetchContractMetadata } from "../../common/fetchContractMetadata";
+import { fetchSourceFilesFromMetadata } from "../../common/fetchSourceFilesFromMetadata";
 import { getCompositePluginABI } from "../../common/plugin/getCompositePluginABI";
 import { buildTransactionFunction } from "../../common/transactions";
 import { isIncrementalVersion } from "../../common/version-checker";

--- a/packages/sdk/src/evm/core/classes/contract-wrapper.ts
+++ b/packages/sdk/src/evm/core/classes/contract-wrapper.ts
@@ -2,10 +2,8 @@ import { computeEOAForwarderAddress } from "../../common/any-evm-utils/computeEO
 import { computeForwarderAddress } from "../../common/any-evm-utils/computeForwarderAddress";
 import { parseRevertReason, TransactionError } from "../../common/error";
 import { extractFunctionsFromAbi } from "../../common/feature-detection/extractFunctionsFromAbi";
-import {
-  fetchContractMetadataFromAddress,
-  fetchSourceFilesFromMetadata,
-} from "../../common/metadata-resolver";
+import { fetchContractMetadataFromAddress } from "../../common/metadata-resolver";
+import { fetchSourceFilesFromMetadata } from "../../common/fetchSourceFilesFromMetadata";
 import {
   BiconomyForwarderAbi,
   ChainAwareForwardRequest,

--- a/packages/sdk/src/evm/core/classes/transactions.ts
+++ b/packages/sdk/src/evm/core/classes/transactions.ts
@@ -1,9 +1,7 @@
 import { TransactionError, parseRevertReason } from "../../common/error";
 import { getPolygonGasPriorityFee } from "../../common/gas-price";
-import {
-  fetchContractMetadataFromAddress,
-  fetchSourceFilesFromMetadata,
-} from "../../common/metadata-resolver";
+import { fetchContractMetadataFromAddress } from "../../common/metadata-resolver";
+import { fetchSourceFilesFromMetadata } from "../../common/fetchSourceFilesFromMetadata";
 import { isRouterContract } from "../../common/plugin/isRouterContract";
 // import { defaultGaslessSendFunction } from "../../common/transactions";
 import { isBrowser } from "../../common/utils";


### PR DESCRIPTION
Move `fetchContractMetadata` and `fetchSourceFilesFromMetadata` to their own files