### PR TITLE
[react] Improve rendering of long Network List in ConnectWallet Modal

### DIFF
--- a/.changeset/swift-donkeys-help.md
+++ b/.changeset/swift-donkeys-help.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/react": patch
+---
+
+Improve rendering of long network list in ConnectWallet Modal

--- a/packages/react/src/wallet/ConnectWallet/NetworkSelector.tsx
+++ b/packages/react/src/wallet/ConnectWallet/NetworkSelector.tsx
@@ -36,6 +36,9 @@ import type { Chain } from "@thirdweb-dev/chains";
 import Fuse from "fuse.js";
 import { Button } from "../../components/buttons";
 import { isMobile } from "../../evm/utils/isMobile";
+import { useEffect } from "react";
+import { Flex } from "../../components/basic";
+import { SecondaryText } from "../../components/text";
 
 type RenderChain = React.FC<{
   chain: Chain;
@@ -397,6 +400,29 @@ const NetworkList = memo(function NetworkList(props: {
     }
   };
   const RenderChain = props.renderChain;
+
+  const [isLoading, setIsLoading] = useState(props.chains.length > 100);
+
+  useEffect(() => {
+    if (isLoading) {
+      setIsLoading(false);
+    }
+  }, [isLoading]);
+
+  if (isLoading) {
+    return (
+      <Flex
+        justifyContent="center"
+        alignItems="center"
+        style={{
+          height: "250px",
+        }}
+      >
+        {/* Don't put a spinner here - it's gonna freeze */}
+        <SecondaryText>Loading</SecondaryText>
+      </Flex>
+    );
+  }
 
   return (
     <NetworkListUl>


### PR DESCRIPTION
If the `supportedChains` are very long - opening the network switcher takes a long time - it feels unresponsive. ( Happens in Dashboard )

So, instead of rendering that upfront - defer rendering it and show a "loading" text while that's being done. Do this only when `supportedChains.length > 100`

We can not show a spinner - because rendering the list blocks the paint (animations)