### PR TITLE
[Smart Wallet] Fix Celo support

### DIFF
--- a/.changeset/cyan-chefs-compete.md
+++ b/.changeset/cyan-chefs-compete.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/wallets": patch
+---
+
+Fix Celo BASEFEE check

--- a/packages/wallets/src/evm/connectors/smart-wallet/lib/base-api.ts
+++ b/packages/wallets/src/evm/connectors/smart-wallet/lib/base-api.ts
@@ -284,10 +284,10 @@ export abstract class BaseAccountAPI {
       if (!maxFeePerGas) {
         maxFeePerGas = feeData.maxFeePerGas ?? undefined;
         const network = await this.provider.getNetwork();
-        const chainId = network.chainId
+        const chainId = network.chainId;
 
         if (chainId === Celo.chainId || chainId === CeloAlfajoresTestnet.chainId || chainId === CeloBaklavaTestnet.chainId) {
-          maxPriorityFeePerGas = maxFeePerGas
+          maxPriorityFeePerGas = maxFeePerGas;
         }
       }
       if (!maxPriorityFeePerGas) {

--- a/packages/wallets/src/evm/connectors/smart-wallet/lib/base-api.ts
+++ b/packages/wallets/src/evm/connectors/smart-wallet/lib/base-api.ts
@@ -15,6 +15,7 @@ import {
 import { TransactionDetailsForUserOp } from "./transaction-details";
 import { getUserOpHashV06 } from "./utils";
 import { DUMMY_PAYMASTER_AND_DATA, SIG_SIZE } from "./paymaster";
+import { CeloAlfajoresTestnet, CeloBaklavaTestnet, Celo } from "@thirdweb-dev/chains"
 
 export interface BaseApiParams {
   provider: providers.Provider;
@@ -282,6 +283,12 @@ export abstract class BaseAccountAPI {
       const feeData = await this.provider.getFeeData();
       if (!maxFeePerGas) {
         maxFeePerGas = feeData.maxFeePerGas ?? undefined;
+        const network = await this.provider.getNetwork();
+        const chainId = network.chainId
+
+        if (chainId === Celo.chainId || chainId === CeloAlfajoresTestnet.chainId || chainId === CeloBaklavaTestnet.chainId) {
+          maxPriorityFeePerGas = maxFeePerGas
+        }
       }
       if (!maxPriorityFeePerGas) {
         maxPriorityFeePerGas = feeData.maxPriorityFeePerGas ?? undefined;


### PR DESCRIPTION
Celo and its testnets do not support the BASEFEE opcode, which is called by the ERC-4337 EntryPoint when doing on-chain gas price checks. This can be avoided however by setting the maxPriorityFeePerGas to be the same as the maxFeePerGas