### PR TITLE
fix: always use latest CLI version to prevent build failures in CI

### DIFF
--- a/.changeset/brown-points-sin.md
+++ b/.changeset/brown-points-sin.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+fix: always use latest CLI version in CI

--- a/packages/cli/src/generate/command.ts
+++ b/packages/cli/src/generate/command.ts
@@ -197,8 +197,8 @@ export async function generate(options: GenerateOptions) {
 
   const postinstall = packageJson.scripts?.postinstall
     ? packageJson.scripts.postinstall +
-      ` && export THIRDWEB_CLI_SKIP_INTRO=true && npx thirdweb generate --skip-update-check`
-    : `export THIRDWEB_CLI_SKIP_INTRO=true && npx thirdweb generate --skip-update-check`;
+      ` && export THIRDWEB_CLI_SKIP_INTRO=true && npx --yes thirdweb@latest generate`
+    : `export THIRDWEB_CLI_SKIP_INTRO=true && npx --yes thirdweb@latest generate`;
 
   fs.writeFileSync(
     packageJsonPath,


### PR DESCRIPTION
Sometimes in builds it would use the old version and the build fails. 

`command not found 'generate'`

This should prevent that happening by fetching latest versions always 