### PR TITLE
[React] Lazy load <ConnectModal />

### DIFF
--- a/.changeset/tiny-llamas-complain.md
+++ b/.changeset/tiny-llamas-complain.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/react": patch
+---
+
+(Code splitting) Lazy load <ConnectModal />

--- a/packages/react/src/evm/providers/thirdweb-provider.tsx
+++ b/packages/react/src/evm/providers/thirdweb-provider.tsx
@@ -5,10 +5,10 @@ import {
   WalletConfig,
 } from "@thirdweb-dev/react-core";
 import { WalletUIStatesProvider } from "./wallet-ui-states-provider";
-import { ConnectModal } from "../../wallet/ConnectWallet/ConnectModal";
+const ConnectModal = lazy(() => import("../../wallet/ConnectWallet/ConnectModal"));
 import { ThemeProvider } from "@emotion/react";
 import { darkTheme, lightTheme } from "../../design-system";
-import { PropsWithChildren } from "react";
+import { PropsWithChildren, lazy } from "react";
 import type { Chain, defaultChains } from "@thirdweb-dev/chains";
 import { defaultWallets } from "../../wallet/wallets/defaultWallets";
 

--- a/packages/react/src/wallet/ConnectWallet/ConnectModal.tsx
+++ b/packages/react/src/wallet/ConnectWallet/ConnectModal.tsx
@@ -20,7 +20,7 @@ import { GetStartedWithWallets } from "./screens/GetStartedWithWallets";
 import { reservedScreens } from "./constants";
 import { HeadlessConnectUI } from "../wallets/headlessConnectUI";
 
-export const ConnectModal = () => {
+export default function ConnectModal() {
   const { theme, title } = useContext(ModalConfigCtx);
   const walletConfigs = useWallets();
   const initialScreen =


### PR DESCRIPTION
The component `<ConnectModal />` is being imported alongside `<ThirdwebProvider />`. However, it's not being used immediately nor visible by default. I don't see why we can't just lazy load this.
```
<WalletUIStatesProvider theme={theme}>
  <ThemeProvider theme={theme === "dark" ? darkTheme : lightTheme}>
    <ThirdwebProviderCore
      theme={theme}
      thirdwebApiKey={thirdwebApiKey}
      supportedWallets={wallets}
      {...restProps}
    >
      {children}
      <ConnectModal /> // <--------------------------------
    </ThirdwebProviderCore>
  </ThemeProvider>
</WalletUIStatesProvider>
```
Looking for your feedback ^