### PR TITLE
Remove ipfs-2 gateway

### DIFF
--- a/.changeset/twelve-moons-do.md
+++ b/.changeset/twelve-moons-do.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/storage": patch
+---
+
+Remove the ipfs-2 gateway due to connectivity errors that seem to happen with certain ISPs

--- a/packages/storage/src/common/urls.ts
+++ b/packages/storage/src/common/urls.ts
@@ -6,7 +6,6 @@ import { GatewayUrls } from "../types";
 export const DEFAULT_GATEWAY_URLS: GatewayUrls = {
   // Note: Gateway URLs should have trailing slashes (we clean this on user input)
   "ipfs://": [
-    "https://ipfs-2.thirdwebcdn.com/ipfs/",
     "https://ipfs-3.thirdwebcdn.com/ipfs/",
     "https://ipfs-4.thirdwebcdn.com/ipfs/",
     "https://ipfs-5.thirdwebcdn.com/ipfs/",


### PR DESCRIPTION
This removes a gateway destination that does not seem to work with many ISPs.