### PR TITLE
fix: postinstall check keeps adding to itself

### DIFF
--- a/.changeset/happy-poets-hang.md
+++ b/.changeset/happy-poets-hang.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+fix: postinstall check keeps adding to itself

--- a/packages/cli/src/generate/command.ts
+++ b/packages/cli/src/generate/command.ts
@@ -205,8 +205,8 @@ export async function generate(options: GenerateOptions, apiSecretKey: string) {
 
   const postinstall = packageJson.scripts?.postinstall
     ? packageJson.scripts.postinstall +
-      ` && export THIRDWEB_CLI_SKIP_INTRO=true && npx --yes thirdweb@latest generate`
-    : `export THIRDWEB_CLI_SKIP_INTRO=true && npx --yes thirdweb@latest generate`;
+      `npx --yes thirdweb@latest generate`
+    : `npx --yes thirdweb@latest generate`;
 
   fs.writeFileSync(
     packageJsonPath,

--- a/packages/cli/src/generate/command.ts
+++ b/packages/cli/src/generate/command.ts
@@ -199,7 +199,7 @@ export async function generate(options: GenerateOptions, apiSecretKey: string) {
   }
 
   const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
-  if (packageJson.scripts?.postinstall?.includes("thirdweb generate")) {
+  if (packageJson.scripts?.postinstall?.includes("thirdweb generate") || packageJson.scripts?.postinstall?.includes("thirdweb@latest generate")) {
     return;
   }
 


### PR DESCRIPTION
Post install now adds `thirdweb@latest generate`, but checks for `thirdweb generate`, so every time you run it it adds to itself