### PR TITLE
updated error messages for API Keys

### DIFF
--- a/.changeset/olive-crabs-compete.md
+++ b/.changeset/olive-crabs-compete.md
@@ -1,0 +1,7 @@
+---
+"@thirdweb-dev/service-utils": patch
+"@thirdweb-dev/react-core": patch
+"@thirdweb-dev/sdk": patch
+---
+
+Updated the error messages

--- a/packages/react-core/src/evm/providers/thirdweb-sdk-provider.tsx
+++ b/packages/react-core/src/evm/providers/thirdweb-sdk-provider.tsx
@@ -171,7 +171,7 @@ export const ThirdwebSDKProvider = <TChains extends Chain[]>({
 }: React.PropsWithChildren<ThirdwebSDKProviderProps<TChains>>) => {
   if (!clientId) {
     checkClientIdOrSecretKey(
-      "No clientId provided in ThirdwebSDK. You will have limited access to thirdweb's services for storage, RPC, and account abstraction. You can get a clientId from https://thirdweb.com/create-api-key",
+      "No API key. Please provide a clientId. It is required to access thirdweb's services. You can create a key at https://thirdweb.com/create-api-key",
       clientId,
       undefined,
     );

--- a/packages/sdk/src/evm/core/sdk.ts
+++ b/packages/sdk/src/evm/core/sdk.ts
@@ -113,6 +113,7 @@ import { LoyaltyCardContractDeploy } from "../schema/contracts/loyalty-card";
 import { getDefaultTrustedForwarders } from "../constants";
 import { checkClientIdOrSecretKey } from "../../core/utils/apiKey";
 import { getProcessEnv } from "../../core/utils/process";
+import { type } from "os";
 
 /**
  * The main entry point for the thirdweb SDK
@@ -263,11 +264,11 @@ export class ThirdwebSDK extends RPCConnectionHandler {
     storage?: IThirdwebStorage,
   ) {
     const apiKeyType = typeof window !== "undefined" ? "clientId" : "secretKey";
-    checkClientIdOrSecretKey(
-      `No ${apiKeyType} provided in ThirdwebSDK. You will have limited access to thirdweb's services for storage, RPC, and account abstraction. You can get a ${apiKeyType} from https://thirdweb.com/create-api-key`,
-      options.clientId,
-      options.secretKey,
-    );
+    let warnMessage = `No API key. Please provide a ${apiKeyType}. It is required to access thirdweb's services. You can create a key at https://thirdweb.com/create-api-key`;
+    if (typeof window === "undefined" && !options.secretKey) {
+      warnMessage = `Please provide a secret key instead of the clientId. Create a new API Key at https://thirdweb.com/create-api-key`;
+    }
+    checkClientIdOrSecretKey(warnMessage, options.clientId, options.secretKey);
 
     if (isChainConfig(network)) {
       options = {
@@ -708,13 +709,10 @@ export class ThirdwebSDK extends RPCConnectionHandler {
       walletAddress,
     );
 
-    const chainMap = chains.reduce(
-      (acc, chain) => {
-        acc[chain.chainId] = chain;
-        return acc;
-      },
-      {} as Record<number, Chain>,
-    );
+    const chainMap = chains.reduce((acc, chain) => {
+      acc[chain.chainId] = chain;
+      return acc;
+    }, {} as Record<number, Chain>);
 
     const sdkMap: Record<number, ThirdwebSDK> = {};
 

--- a/packages/sdk/src/evm/core/sdk.ts
+++ b/packages/sdk/src/evm/core/sdk.ts
@@ -113,7 +113,6 @@ import { LoyaltyCardContractDeploy } from "../schema/contracts/loyalty-card";
 import { getDefaultTrustedForwarders } from "../constants";
 import { checkClientIdOrSecretKey } from "../../core/utils/apiKey";
 import { getProcessEnv } from "../../core/utils/process";
-import { type } from "os";
 
 /**
  * The main entry point for the thirdweb SDK

--- a/packages/service-utils/src/core/authorize/client.test.ts
+++ b/packages/service-utils/src/core/authorize/client.test.ts
@@ -74,7 +74,7 @@ describe("authorizeClient", () => {
     ) as any;
     expect(result.authorized).toBe(false);
     expect(result.errorMessage).toBe(
-      "The bundleId: com.foo.bar, is not authorized for this key. Please update your key permissions on the thirdweb dashboard",
+      "Invalid request: Unauthorized Bundle ID: com.foo.bar. You can view the restrictions on this API key at https://thirdweb.com/create-api-key",
     );
     expect(result.errorCode).toBe("BUNDLE_UNAUTHORIZED");
     expect(result.status).toBe(401);
@@ -93,7 +93,7 @@ describe("authorizeClient", () => {
     ) as any;
     expect(result.authorized).toBe(false);
     expect(result.errorMessage).toBe(
-      "The secret is invalid. Please check you secret-key",
+      "Incorrect key provided. You can view your active API keys at https://thirdweb.com/dashboard/settings",
     );
     expect(result.errorCode).toBe("SECRET_INVALID");
     expect(result.status).toBe(401);
@@ -112,7 +112,7 @@ describe("authorizeClient", () => {
     ) as any;
     expect(result.authorized).toBe(false);
     expect(result.errorMessage).toBe(
-      "The domain: unauthorized.com, is not authorized for this key. Please update your key permissions on the thirdweb dashboard",
+      "Invalid request: Unauthorized domain: unauthorized.com. You can view the restrictions on this API key at https://thirdweb.com/create-api-key",
     );
     expect(result.errorCode).toBe("ORIGIN_UNAUTHORIZED");
     expect(result.status).toBe(401);

--- a/packages/service-utils/src/core/authorize/client.ts
+++ b/packages/service-utils/src/core/authorize/client.ts
@@ -35,7 +35,8 @@ export function authorizeClient(
     if (secretHash !== providedSecretHash) {
       return {
         authorized: false,
-        errorMessage: "The secret is invalid. Please check you secret-key",
+        errorMessage:
+          "Incorrect key provided. You can view your active API keys at https://thirdweb.com/dashboard/settings",
         errorCode: "SECRET_INVALID",
         status: 401,
       };
@@ -77,7 +78,7 @@ export function authorizeClient(
 
     return {
       authorized: false,
-      errorMessage: `The domain: ${origin}, is not authorized for this key. Please update your key permissions on the thirdweb dashboard`,
+      errorMessage: `Invalid request: Unauthorized domain: ${origin}. You can view the restrictions on this API key at https://thirdweb.com/create-api-key`,
       errorCode: "ORIGIN_UNAUTHORIZED",
       status: 401,
     };
@@ -100,7 +101,7 @@ export function authorizeClient(
 
     return {
       authorized: false,
-      errorMessage: `The bundleId: ${bundleId}, is not authorized for this key. Please update your key permissions on the thirdweb dashboard`,
+      errorMessage: `Invalid request: Unauthorized Bundle ID: ${bundleId}. You can view the restrictions on this API key at https://thirdweb.com/create-api-key`,
       errorCode: "BUNDLE_UNAUTHORIZED",
       status: 401,
     };

--- a/packages/service-utils/src/core/authorize/service.test.ts
+++ b/packages/service-utils/src/core/authorize/service.test.ts
@@ -80,7 +80,7 @@ describe("authorizeService", () => {
     ) as any;
     expect(result.authorized).toBe(false);
     expect(result.errorMessage).toBe(
-      'The service "rpc" is not authorized for this key. Please update your key permissions on the thirdweb dashboard.',
+      "Invalid request: Unauthorized service: rpc. You can view the restrictions on this API key in your dashboard:  https://thirdweb.com/create-api-key",
     );
     expect(result.errorCode).toBe("SERVICE_UNAUTHORIZED");
     expect(result.status).toBe(403);
@@ -101,7 +101,7 @@ describe("authorizeService", () => {
     ) as any;
     expect(result.authorized).toBe(false);
     expect(result.errorMessage).toBe(
-      'The service "storage" action "unauthorized-action" is not authorized for this key. Please update your key permissions on the thirdweb dashboard.',
+      "Invalid request: Unauthorized action: storage unauthorized-action. You can view the restrictions on this API key in your dashboard:  https://thirdweb.com/create-api-key",
     );
     expect(result.errorCode).toBe("SERVICE_ACTION_UNAUTHORIZED");
     expect(result.status).toBe(403);
@@ -119,7 +119,7 @@ describe("authorizeService", () => {
     ) as any;
     expect(result.authorized).toBe(false);
     expect(result.errorMessage).toBe(
-      'The target address: unauthorized-target, for service "storage" is not authorized for this key. Please update your key permissions on the thirdweb dashboard.',
+      "Invalid request: Unauthorized address: storage unauthorized-target. You can view the restrictions on this API key in your dashboard:  https://thirdweb.com/create-api-key",
     );
     expect(result.errorCode).toBe("SERVICE_TARGET_ADDRESS_UNAUTHORIZED");
     expect(result.status).toBe(403);
@@ -137,7 +137,7 @@ describe("authorizeService", () => {
     ) as any;
     expect(result.authorized).toBe(false);
     expect(result.errorMessage).toBe(
-      'The target address: target1,target2,target3, for service "storage" is not authorized for this key. Please update your key permissions on the thirdweb dashboard.',
+      "Invalid request: Unauthorized address: storage target1,target2,target3. You can view the restrictions on this API key in your dashboard:  https://thirdweb.com/create-api-key",
     );
     expect(result.errorCode).toBe("SERVICE_TARGET_ADDRESS_UNAUTHORIZED");
     expect(result.status).toBe(403);

--- a/packages/service-utils/src/core/authorize/service.ts
+++ b/packages/service-utils/src/core/authorize/service.ts
@@ -16,7 +16,7 @@ export function authorizeService(
   if (!service) {
     return {
       authorized: false,
-      errorMessage: `The service "${serviceConfig.serviceScope}" is not authorized for this key. Please update your key permissions on the thirdweb dashboard.`,
+      errorMessage: `Invalid request: Unauthorized service: ${serviceConfig.serviceScope}. You can view the restrictions on this API key in your dashboard:  https://thirdweb.com/create-api-key`,
       errorCode: "SERVICE_UNAUTHORIZED",
       status: 403,
     };
@@ -30,7 +30,7 @@ export function authorizeService(
     if (!isActionAllowed) {
       return {
         authorized: false,
-        errorMessage: `The service "${serviceConfig.serviceScope}" action "${serviceConfig.serviceAction}" is not authorized for this key. Please update your key permissions on the thirdweb dashboard.`,
+        errorMessage: `Invalid request: Unauthorized action: ${serviceConfig.serviceScope} ${serviceConfig.serviceAction}. You can view the restrictions on this API key in your dashboard:  https://thirdweb.com/create-api-key`,
         errorCode: "SERVICE_ACTION_UNAUTHORIZED",
         status: 403,
       };
@@ -52,7 +52,7 @@ export function authorizeService(
     ) {
       return {
         authorized: false,
-        errorMessage: `The target address: ${checkedAddresses}, for service "${serviceConfig.serviceScope}" is not authorized for this key. Please update your key permissions on the thirdweb dashboard.`,
+        errorMessage: `Invalid request: Unauthorized address: ${serviceConfig.serviceScope} ${checkedAddresses}. You can view the restrictions on this API key in your dashboard:  https://thirdweb.com/create-api-key`,
         errorCode: "SERVICE_TARGET_ADDRESS_UNAUTHORIZED",
         status: 403,
       };


### PR DESCRIPTION
This [Error Doc](https://docs.google.com/spreadsheets/d/11pdtjsZAPThBtuP8oez0Uzt5eFg5Rc7_kpXfxJybxoQ/edit#gid=0) has the details on the Error messages that needs to be sent.

on SDK : 

we detect if its backend & `clientId` is provided, we show warning/error message, `Please provide a secret key instead of the clientId. Create a new API Key at https://thirdweb.com/create-api-key`