### PR TITLE
Allow styles on MediaRenderer video tags

### DIFF
--- a/packages/react/src/evm/components/MediaRenderer.tsx
+++ b/packages/react/src/evm/components/MediaRenderer.tsx
@@ -139,6 +139,7 @@ const VideoPlayer = /* @__PURE__ */ React.forwardRef<
             zIndex: 1,
             transition: "opacity .5s",
             opacity: !poster ? 1 : playing ? 1 : 0,
+            ...style,
           }}
         />
         {poster && (
@@ -161,13 +162,15 @@ const VideoPlayer = /* @__PURE__ */ React.forwardRef<
             alt={alt}
           />
         )}
-        <PlayButton
-          onClick={() => {
-            setPlaying((prev) => !prev);
-            setMuted(false);
-          }}
-          isPlaying={playing}
-        />
+        {controls && (
+          <PlayButton
+            onClick={() => {
+              setPlaying((prev) => !prev);
+              setMuted(false);
+            }}
+            isPlaying={playing}
+          />
+        )}
       </div>
     );
   },


### PR DESCRIPTION
### Description
The MediaRenderer component currently does not provide a way to style the video tag that is produced by the component (it only allows for styling a div that wraps the video component). Therefore, it is not possible to change the objectFit property of the video tag.

This PR allows for users to apply styles directly to the video tag if desired as well as optionally hide the play button that overlays the video media.

### Use Case:
My NFT Marketplace has a banner at the top of the page that is rendered via the MediaRenderer. 
![Screenshot 2023-08-05 at 10 57 18 AM](https://github.com/thirdweb-dev/js/assets/89474773/cd8fbe94-5ad8-49eb-927e-7294501e3317)

I want to allow videos to cover that entire banner.

The react code looks like this:
![Screenshot 2023-08-05 at 10 55 49 AM](https://github.com/thirdweb-dev/js/assets/89474773/3d4ca1ef-8eb8-4dc3-b8af-c6a27c24156e)

But since the MediaRender component renders the video tag with hardcoded styles, my video does not cover the div.
![Screenshot 2023-08-05 at 10 58 52 AM](https://github.com/thirdweb-dev/js/assets/89474773/15f311d4-e779-47c5-8ffc-d8d7c58a4e14)

https://github.com/thirdweb-dev/js/assets/89474773/06934f02-f372-45d1-a1cc-697c672998fe

### Proposed Solution:
Allow the user to directly apply styles to the video tag with the existing styles prop on the MediaRenderer.

Here is what my NFT Marketplace looks like after implementing this change:

https://github.com/thirdweb-dev/js/assets/89474773/50822881-d1ed-43c4-843a-82faa0ed2f50

As an aside, I also wanted to optionally remove the play button that gets painted over the video. If the user specifies controls to be false, the play button gets hidden as well.

Open to feedback on this PR!