### PR TITLE
Add option to hide the [Request Testnet Funds] button

### DIFF
--- a/packages/react-native/src/evm/components/ConnectWallet.tsx
+++ b/packages/react-native/src/evm/components/ConnectWallet.tsx
@@ -19,6 +19,11 @@ export type ConnectWalletProps = {
    * render custom rows in the Connect Wallet Details modal
    */
   extraRows?: ConnectWalletDetailsProps["extraRows"];
+
+  /**
+   * Show/hide the [Request Testnet Funds] button
+   */
+  hideFaucetButton?: boolean;
 } & ConnectWalletButtonProps;
 
 export const ConnectWallet = ({
@@ -27,6 +32,7 @@ export const ConnectWallet = ({
   buttonTitle,
   modalTitle,
   extraRows,
+  hideFaucetButton,
 }: ConnectWalletProps) => {
   const fadeAnim = useRef(new Animated.Value(0)).current;
   const address = useAddress();
@@ -47,6 +53,7 @@ export const ConnectWallet = ({
             address={address}
             detailsButton={detailsButton}
             extraRows={extraRows}
+            hideFaucetButton={hideFaucetButton}
           />
         ) : (
           <ConnectWalletButton

--- a/packages/react-native/src/evm/components/ConnectWalletDetails/ConnectWalletDetailsModal.tsx
+++ b/packages/react-native/src/evm/components/ConnectWalletDetails/ConnectWalletDetailsModal.tsx
@@ -32,11 +32,13 @@ export const ConnectWalletDetailsModal = ({
   onClosePress,
   extraRows,
   address,
+  hideFaucetButton,
 }: {
   isVisible: boolean;
   onClosePress: () => void;
   extraRows?: React.FC;
   address?: string;
+  hideFaucetButton?: boolean;
 }) => {
   const theme = useAppTheme();
   const [isExportModalVisible, setIsExportModalVisible] = useState(false);
@@ -198,7 +200,7 @@ export const ConnectWalletDetailsModal = ({
             <Text variant="bodySmallSecondary">Current Network</Text>
           </View>
           <NetworkButton chain={chain} enableSwitchModal={true} />
-          {chain?.testnet && chain?.faucets?.length ? (
+          {!hideFaucetButton && chain?.testnet && chain?.faucets?.length ? (
             <IconTextButton
               mt="xs"
               text="Request Testnet Funds"

--- a/packages/react-native/src/evm/components/ConnectWalletDetails/WalletDetailsButton.tsx
+++ b/packages/react-native/src/evm/components/ConnectWalletDetails/WalletDetailsButton.tsx
@@ -14,12 +14,14 @@ export type ConnectWalletDetailsProps = {
   address?: string;
   detailsButton?: React.FC<{ onPress: () => void }>;
   extraRows?: React.FC;
+  hideFaucetButton?: boolean
 };
 
 export const WalletDetailsButton = ({
   address,
   detailsButton,
   extraRows,
+  hideFaucetButton
 }: ConnectWalletDetailsProps) => {
   const activeWallet = useWallet();
   const chain = useChain();
@@ -46,6 +48,7 @@ export const WalletDetailsButton = ({
         onClosePress={onPress}
         extraRows={extraRows}
         address={address}
+        hideFaucetButton={hideFaucetButton}
       />
       {detailsButton ? (
         detailsButton({ onPress })

--- a/packages/react/src/wallet/ConnectWallet/ConnectWallet.tsx
+++ b/packages/react/src/wallet/ConnectWallet/ConnectWallet.tsx
@@ -47,6 +47,11 @@ type ConnectWalletProps = {
   };
   style?: React.CSSProperties;
   networkSelector?: Omit<NetworkSelectorProps, "theme" | "onClose" | "chains">;
+
+  /**
+   * Show/hide the [Request Testnet Funds] button
+   */
+  hideFaucetButton?: boolean;
 };
 
 const TW_CONNECT_WALLET = "tw-connect-wallet";
@@ -163,6 +168,7 @@ export const ConnectWallet: React.FC<ConnectWalletProps> = (props) => {
             theme={theme}
             style={props.style}
             detailsBtn={props.detailsBtn}
+            hideFaucetButton={props.hideFaucetButton}
             onDisconnect={() => {
               if (authConfig?.authUrl) {
                 logout();

--- a/packages/react/src/wallet/ConnectWallet/Details.tsx
+++ b/packages/react/src/wallet/ConnectWallet/Details.tsx
@@ -65,6 +65,7 @@ export const ConnectedWalletDetails: React.FC<{
   networkSelector?: Omit<NetworkSelectorProps, "theme" | "onClose" | "chains">;
   className?: string;
   detailsBtn?: () => JSX.Element;
+  hideFaucetButton?: boolean;
 }> = (props) => {
   const disconnect = useDisconnect();
   const chains = useSupportedChains();
@@ -322,32 +323,33 @@ export const ConnectedWalletDetails: React.FC<{
           )}
 
         {/* Request Testnet funds */}
-        {((chain?.faucets && chain.faucets.length > 0) ||
-          chain?.chainId === Localhost.chainId) && (
-          <MenuLink
-            href={chain?.faucets ? chain.faucets[0] : "#"}
-            target="_blank"
-            as="a"
-            onClick={async (e) => {
-              if (chain.chainId === Localhost.chainId) {
-                e.preventDefault();
-                setOpen(false);
-                await sdk?.wallet.requestFunds(10);
-                await balanceQuery.refetch();
-              }
-            }}
-            style={{
-              textDecoration: "none",
-              color: "inherit",
-              fontSize: fontSize.sm,
-            }}
-          >
-            <SecondaryIconContainer>
-              <FundsIcon size={iconSize.sm} />
-            </SecondaryIconContainer>
-            Request Testnet Funds
-          </MenuLink>
-        )}
+        {!props.hideFaucetButton &&
+          ((chain?.faucets && chain.faucets.length > 0) ||
+            chain?.chainId === Localhost.chainId) && (
+            <MenuLink
+              href={chain?.faucets ? chain.faucets[0] : "#"}
+              target="_blank"
+              as="a"
+              onClick={async (e) => {
+                if (chain.chainId === Localhost.chainId) {
+                  e.preventDefault();
+                  setOpen(false);
+                  await sdk?.wallet.requestFunds(10);
+                  await balanceQuery.refetch();
+                }
+              }}
+              style={{
+                textDecoration: "none",
+                color: "inherit",
+                fontSize: fontSize.sm,
+              }}
+            >
+              <SecondaryIconContainer>
+                <FundsIcon size={iconSize.sm} />
+              </SecondaryIconContainer>
+              Request Testnet Funds
+            </MenuLink>
+          )}
 
         {/* Export  Wallet */}
         {activeWallet?.walletId === walletIds.localWallet && (


### PR DESCRIPTION
Currently there's no way to hide the [Request Testnet Fund] manually. I don't want that button in production. It confuses the average users. So maybe we should allow an option to hide it?
![image](https://github.com/thirdweb-dev/js/assets/26052673/33465d46-b581-4269-8b25-0abedb02c8f3)

@MananTank Would you be able to take a look at this?