### PR TITLE
[service-utils] Silence publishUsageEvents() output

### DIFF
--- a/.changeset/smart-cheetahs-doubt.md
+++ b/.changeset/smart-cheetahs-doubt.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+Silence output for publishUsageEvents()

--- a/packages/service-utils/src/cf-worker/usage.ts
+++ b/packages/service-utils/src/cf-worker/usage.ts
@@ -64,7 +64,7 @@ export async function publishUsageEvents(
     secretAccessKey: string;
     region?: string;
   },
-): Promise<string> {
+): Promise<void> {
   const {
     queueUrl,
     accessKeyId,
@@ -86,7 +86,7 @@ export async function publishUsageEvents(
     secretAccessKey,
     region,
   });
-  const res = await aws.fetch(`https://sqs.${region}.amazonaws.com`, {
+  await aws.fetch(`https://sqs.${region}.amazonaws.com`, {
     headers: {
       "X-Amz-Target": "AmazonSQS.SendMessageBatch",
       "X-Amz-Date": new Date().toISOString(),
@@ -97,5 +97,4 @@ export async function publishUsageEvents(
       Entries: entries,
     }),
   });
-  return await res.text();
 }


### PR DESCRIPTION
## Problem solved

The response body did not match Amazon's custom content-type header and logs a warning to console:

```
Called .text() on an HTTP body which does not appear to be text. The body's Content-Type is "application/x-amz-json-1.0". The result will probably be corrupted. Consider checking the Content-Type header before interpreting entities as text.
```

## Changes made

- [x] Internal API changes: Silence the `publishUsageEvents()` output.

## How to test

- [x] Tested by linking to an internal service.
