### PR TITLE
feat(urls): add clientId parameter to getGatewayUrlForCid

### DIFF
--- a/.changeset/curly-mirrors-hunt.md
+++ b/.changeset/curly-mirrors-hunt.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/storage": patch
+---
+
+fix storage secretKey and clientId handling

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "hotlink-revert": "node ./scripts/hotlink/hotlink-revert.mjs",
     "explain:major": "node ./scripts/changeset-explain-major.mjs"
   },
-  "packageManager": "pnpm@8.1.0",
+  "packageManager": "pnpm@8.6.12",
   "dependencies": {
     "@changesets/changelog-github": "^0.4.8",
     "@changesets/cli": "^2.26.2",

--- a/packages/storage/src/common/urls.ts
+++ b/packages/storage/src/common/urls.ts
@@ -66,7 +66,11 @@ export function parseGatewayUrls(
 /**
  * @internal
  */
-export function getGatewayUrlForCid(gatewayUrl: string, cid: string): string {
+export function getGatewayUrlForCid(
+  gatewayUrl: string,
+  cid: string,
+  clientId?: string,
+): string {
   const parts = cid.split("/");
   const hash = convertCidToV1(parts[0]);
   const filePath = parts.slice(1).join("/");
@@ -85,6 +89,15 @@ export function getGatewayUrlForCid(gatewayUrl: string, cid: string): string {
   // If those tokens don't exist, use the canonical gateway URL format
   else {
     url += `${hash}/${filePath}`;
+  }
+  // if the URL contains the {clientId} token, replace it with the client ID
+  if (gatewayUrl.includes("{clientId}")) {
+    if (!clientId) {
+      throw new Error(
+        "Cannot use {clientId} in gateway URL without providing a client ID",
+      );
+    }
+    url = url.replace("{clientId}", clientId);
   }
 
   return url;

--- a/packages/storage/src/common/urls.ts
+++ b/packages/storage/src/common/urls.ts
@@ -3,6 +3,7 @@ import CIDTool from "cid-tool";
 import { getProcessEnv } from "./process";
 
 const TW_HOSTNAME_SUFFIX = ".ipfscdn.io";
+const TW_STAGINGHOSTNAME_SUFFIX = ".thirdwebstorage-staging.com";
 const TW_GATEWAY_URLS = [
   `https://{clientId}${TW_HOSTNAME_SUFFIX}/ipfs/{cid}/{path}`,
 ];
@@ -13,7 +14,13 @@ const TW_GATEWAY_URLS = [
  * @returns
  */
 export function isTwGatewayUrl(url: string): boolean {
-  return new URL(url).hostname.endsWith(TW_HOSTNAME_SUFFIX);
+  const hostname = new URL(url).hostname;
+  const isProd = hostname.endsWith(TW_HOSTNAME_SUFFIX);
+  if (isProd) {
+    return true;
+  }
+  // fall back to also handle staging urls
+  return hostname.endsWith(TW_STAGINGHOSTNAME_SUFFIX);
 }
 
 const PUBLIC_GATEWAY_URLS = [

--- a/packages/storage/src/common/utils.ts
+++ b/packages/storage/src/common/utils.ts
@@ -148,6 +148,7 @@ export function replaceSchemeWithGatewayUrl(
   uri: string,
   gatewayUrls: GatewayUrls,
   index = 0,
+  clientId?: string,
 ): string | undefined {
   const scheme = Object.keys(gatewayUrls).find((s) => uri.startsWith(s));
   const schemeGatewayUrls = scheme ? gatewayUrls[scheme] : [];
@@ -161,7 +162,7 @@ export function replaceSchemeWithGatewayUrl(
   }
 
   const path = uri.replace(scheme, "");
-  return getGatewayUrlForCid(schemeGatewayUrls[index], path);
+  return getGatewayUrlForCid(schemeGatewayUrls[index], path, clientId);
 }
 
 /**
@@ -206,9 +207,15 @@ export function replaceObjectGatewayUrlsWithSchemes<TData = unknown>(
 export function replaceObjectSchemesWithGatewayUrls<TData = unknown>(
   data: TData,
   gatewayUrls: GatewayUrls,
+  clientId?: string,
 ): TData {
   if (typeof data === "string") {
-    return replaceSchemeWithGatewayUrl(data, gatewayUrls) as any as TData;
+    return replaceSchemeWithGatewayUrl(
+      data,
+      gatewayUrls,
+      0,
+      clientId,
+    ) as any as TData;
   }
   if (typeof data === "object") {
     if (!data) {
@@ -219,13 +226,13 @@ export function replaceObjectSchemesWithGatewayUrls<TData = unknown>(
     }
     if (Array.isArray(data)) {
       return data.map((entry) =>
-        replaceObjectSchemesWithGatewayUrls(entry, gatewayUrls),
+        replaceObjectSchemesWithGatewayUrls(entry, gatewayUrls, clientId),
       ) as any as TData;
     }
     return Object.fromEntries(
       Object.entries(data).map(([key, value]) => [
         key,
-        replaceObjectSchemesWithGatewayUrls(value, gatewayUrls),
+        replaceObjectSchemesWithGatewayUrls(value, gatewayUrls, clientId),
       ]),
     ) as any as TData;
   }

--- a/packages/storage/src/core/downloaders/storage-downloader.ts
+++ b/packages/storage/src/core/downloaders/storage-downloader.ts
@@ -54,7 +54,12 @@ export class StorageDownloader implements IStorageDownloader {
     }
 
     // Replace recognized scheme with the highest priority gateway URL that hasn't already been attempted
-    let resolvedUri = replaceSchemeWithGatewayUrl(uri, gatewayUrls, attempts);
+    let resolvedUri = replaceSchemeWithGatewayUrl(
+      uri,
+      gatewayUrls,
+      attempts,
+      this.clientId,
+    );
     // If every gateway URL we know about for the designated scheme has been tried (via recursion) and failed, throw an error
     if (!resolvedUri) {
       console.error(

--- a/packages/storage/src/core/storage.ts
+++ b/packages/storage/src/core/storage.ts
@@ -60,6 +60,7 @@ export class ThirdwebStorage<T extends UploadOptions = IpfsUploadBatchOptions>
   private uploader: IStorageUploader<T>;
   private downloader: IStorageDownloader;
   private gatewayUrls: GatewayUrls;
+  private clientId?: string;
 
   constructor(options?: ThirdwebStorageOptions<T>) {
     this.uploader =
@@ -80,6 +81,7 @@ export class ThirdwebStorage<T extends UploadOptions = IpfsUploadBatchOptions>
       options?.clientId,
       options?.secretKey,
     );
+    this.clientId = options?.clientId;
   }
 
   /**
@@ -96,7 +98,12 @@ export class ThirdwebStorage<T extends UploadOptions = IpfsUploadBatchOptions>
    * ```
    */
   resolveScheme(url: string): string {
-    return replaceSchemeWithGatewayUrl(url, this.gatewayUrls) as string;
+    return replaceSchemeWithGatewayUrl(
+      url,
+      this.gatewayUrls,
+      0,
+      this.clientId,
+    ) as string;
   }
 
   /**
@@ -133,7 +140,11 @@ export class ThirdwebStorage<T extends UploadOptions = IpfsUploadBatchOptions>
 
     // If we get a JSON object, recursively replace any schemes with gatewayUrls
     const json = await res.json();
-    return replaceObjectSchemesWithGatewayUrls(json, this.gatewayUrls) as TJSON;
+    return replaceObjectSchemesWithGatewayUrls(
+      json,
+      this.gatewayUrls,
+      this.clientId,
+    ) as TJSON;
   }
 
   /**
@@ -257,6 +268,7 @@ export class ThirdwebStorage<T extends UploadOptions = IpfsUploadBatchOptions>
       cleaned = replaceObjectSchemesWithGatewayUrls(
         cleaned,
         this.gatewayUrls,
+        this.clientId,
       ) as unknown[];
     }
 


### PR DESCRIPTION
## Problem solved

`resolveScheme` did not consider `clientId` at all

## Changes made

- [x] `resolveScheme` now considers `clientId` if present in options and if the gateways are tokenized to contain it (`{clientId}`)

## How to test

- [ ] Automated tests: link to unit test file
- [ ] Manual tests: step by step instructions on how to test
