### PR TITLE
[SDK] Expose erc721.claimConditions.getSupplyClaimedByWallet()

### DIFF
--- a/.changeset/proud-kings-beam.md
+++ b/.changeset/proud-kings-beam.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/sdk": patch
+---
+
+Expose erc721.claimConditions.getSupplyClaimedByWallet()

--- a/packages/sdk/src/evm/core/classes/drop-claim-conditions.ts
+++ b/packages/sdk/src/evm/core/classes/drop-claim-conditions.ts
@@ -394,8 +394,6 @@ export class DropClaimConditions<
       this.isNewSinglePhaseDrop(this.contractWrapper) ||
       this.isNewMultiphaseDrop(this.contractWrapper)
     ) {
-      const claimerProofs = await this.getClaimerProofs(resolvedAddress);
-
       let claimedSupply = BigNumber.from(0);
       let maxClaimable = convertQuantityToBigNumber(
         claimCondition.maxClaimablePerWallet,
@@ -408,9 +406,9 @@ export class DropClaimConditions<
         // no-op
       }
 
-      if (claimerProofs) {
+      if (allowListEntry) {
         maxClaimable = convertQuantityToBigNumber(
-          claimerProofs.maxClaimable,
+          allowListEntry.maxClaimable,
           decimals,
         );
       }

--- a/packages/sdk/src/evm/core/classes/drop-erc1155-claim-conditions.ts
+++ b/packages/sdk/src/evm/core/classes/drop-erc1155-claim-conditions.ts
@@ -50,6 +50,7 @@ import { processClaimConditionInputs } from "../../common/claim-conditions/proce
 import { transformResultToClaimCondition } from "../../common/claim-conditions/transformResultToClaimCondition";
 import { updateExistingClaimConditions } from "../../common/claim-conditions/updateExistingClaimConditions";
 import { fetchSnapshotEntryForAddress } from "../../common/claim-conditions/fetchSnapshotEntryForAddress";
+import { convertQuantityToBigNumber } from "../../common/claim-conditions/convertQuantityToBigNumber";
 
 /**
  * Manages claim conditions for Edition Drop contracts
@@ -371,7 +372,25 @@ export class DropErc1155ClaimConditions<
             "Merkle proof verification failed:",
             "reason" in e ? e.reason : e,
           );
-          reasons.push(ClaimEligibility.AddressNotAllowed);
+          const reason = (e as any).reason;
+          switch (reason) {
+            case "!Qty":
+              reasons.push(ClaimEligibility.OverMaxClaimablePerWallet);
+              break;
+            case "!PriceOrCurrency":
+              reasons.push(ClaimEligibility.WrongPriceOrCurrency);
+              break;
+            case "!MaxSupply":
+              reasons.push(ClaimEligibility.NotEnoughSupply);
+              break;
+            case "cant claim yet":
+              reasons.push(ClaimEligibility.ClaimPhaseNotStarted);
+              break;
+            default: {
+              reasons.push(ClaimEligibility.AddressNotAllowed);
+              break;
+            }
+          }
           return reasons;
         }
       }
@@ -381,8 +400,37 @@ export class DropErc1155ClaimConditions<
       this.isNewSinglePhaseDrop(this.contractWrapper) ||
       this.isNewMultiphaseDrop(this.contractWrapper)
     ) {
+      let claimedSupply = BigNumber.from(0);
+      let maxClaimable = convertQuantityToBigNumber(
+        claimCondition.maxClaimablePerWallet,
+        0,
+      );
+
+      try {
+        claimedSupply = await this.getSupplyClaimedByWallet(
+          tokenId,
+          resolvedAddress,
+        );
+      } catch (e) {
+        // no-op
+      }
+
+      if (allowListEntry) {
+        maxClaimable = convertQuantityToBigNumber(
+          allowListEntry.maxClaimable,
+          0,
+        );
+      }
+
+      if (maxClaimable.gt(0) && maxClaimable.lt(claimedSupply.add(quantity))) {
+        reasons.push(ClaimEligibility.OverMaxClaimablePerWallet);
+        return reasons;
+      }
+
+      // if there is no allowlist, or if there is an allowlist and the address is not in it
+      // if maxClaimable is 0, we consider it as the address is not allowed
       if (!hasAllowList || (hasAllowList && !allowListEntry)) {
-        if (claimCondition.maxClaimablePerWallet === "0") {
+        if (maxClaimable.lte(claimedSupply) || maxClaimable.eq(0)) {
           reasons.push(ClaimEligibility.AddressNotAllowed);
           return reasons;
         }
@@ -481,6 +529,39 @@ export class DropErc1155ClaimConditions<
     } else {
       return null;
     }
+  }
+
+  /**
+   * Get the total supply claimed by a specific wallet
+   * @param walletAddress the wallet address to check
+   * @returns the total supply claimed
+   */
+  public async getSupplyClaimedByWallet(
+    tokenId: BigNumberish,
+    walletAddress: AddressOrEns,
+  ): Promise<BigNumber> {
+    const resolvedAddress = await resolveAddress(walletAddress);
+    if (this.isNewSinglePhaseDrop(this.contractWrapper)) {
+      return await this.contractWrapper.readContract.getSupplyClaimedByWallet(
+        tokenId,
+        resolvedAddress,
+      );
+    }
+
+    if (this.isNewMultiphaseDrop(this.contractWrapper)) {
+      const activeClaimConditionId =
+        await this.contractWrapper.readContract.getActiveClaimConditionId(
+          tokenId,
+        );
+      return await this.contractWrapper.readContract.getSupplyClaimedByWallet(
+        tokenId,
+        activeClaimConditionId,
+        resolvedAddress,
+      );
+    }
+    throw new Error(
+      "This contract does not support the getSupplyClaimedByWallet function",
+    );
   }
 
   /** ***************************************

--- a/packages/sdk/src/evm/enums/ClaimEligibility.ts
+++ b/packages/sdk/src/evm/enums/ClaimEligibility.ts
@@ -5,7 +5,13 @@ export enum ClaimEligibility {
 
   WaitBeforeNextClaimTransaction = "Not enough time since last claim transaction. Please wait.",
 
+  ClaimPhaseNotStarted = "Claim phase has not started yet.",
+
   AlreadyClaimed = "You have already claimed the token.",
+
+  WrongPriceOrCurrency = "Incorrect price or currency.",
+
+  OverMaxClaimablePerWallet = "Cannot claim more than maximum allowed quantity.",
 
   NotEnoughTokens = "There are not enough tokens in the wallet to pay for the claim.",
 

--- a/packages/sdk/test/evm/edition-drop-v4.test.ts
+++ b/packages/sdk/test/evm/edition-drop-v4.test.ts
@@ -326,6 +326,121 @@ describe("Edition Drop Contract (V4)", async () => {
     expect(balance).to.deep.equal(BigNumber.from(2));
   });
 
+  it("should check eligibility reasons max claims per wallet with allowlist", async () => {
+    await bdContract.createBatch([
+      { name: "name", description: "description" },
+    ]);
+    await bdContract.claimConditions.set(0, [{}]);
+    let c = await bdContract.claimConditions.getSupplyClaimedByWallet(
+      0,
+      w1.address,
+    );
+    expect(c.toNumber()).to.eq(0);
+
+    await sdk.updateSignerOrProvider(w1);
+    await bdContract.claim(0, 2);
+
+    c = await bdContract.claimConditions.getSupplyClaimedByWallet(
+      0,
+      w1.address,
+    );
+
+    expect(c.toNumber()).to.eq(2);
+  });
+
+  it("should check eligibility reasons max claims per wallet with allowlist", async () => {
+    await bdContract.createBatch([
+      { name: "name", description: "description" },
+    ]);
+    await bdContract.claimConditions.set(0, [
+      {
+        maxClaimablePerWallet: 0,
+        snapshot: [
+          { address: w1.address, maxClaimable: 2 },
+          { address: w2.address, maxClaimable: 1 },
+        ],
+      },
+    ]);
+    let r = await bdContract.claimConditions.getClaimIneligibilityReasons(
+      0,
+      2,
+      await w1.getAddress(),
+    );
+    expect(r.length).to.eq(0);
+
+    r = await bdContract.claimConditions.getClaimIneligibilityReasons(
+      0,
+      10,
+      await w1.getAddress(),
+    );
+    expect(r[0]).to.eq(ClaimEligibility.OverMaxClaimablePerWallet);
+
+    r = await bdContract.claimConditions.getClaimIneligibilityReasons(
+      0,
+      10,
+      await w3.getAddress(),
+    );
+    expect(r[0]).to.eq(ClaimEligibility.AddressNotAllowed);
+
+    await sdk.updateSignerOrProvider(w1);
+    await bdContract.claim(0, 2);
+
+    r = await bdContract.claimConditions.getClaimIneligibilityReasons(
+      0,
+      1,
+      await w1.getAddress(),
+    );
+    expect(r[0]).to.eq(ClaimEligibility.OverMaxClaimablePerWallet);
+
+    r = await bdContract.claimConditions.getClaimIneligibilityReasons(
+      0,
+      2,
+      await w2.getAddress(),
+    );
+    expect(r[0]).to.eq(ClaimEligibility.OverMaxClaimablePerWallet);
+
+    r = await bdContract.claimConditions.getClaimIneligibilityReasons(
+      0,
+      2,
+      await w3.getAddress(),
+    );
+    expect(r[0]).to.eq(ClaimEligibility.AddressNotAllowed);
+  });
+
+  it("should check eligibility reasons max claims per wallet", async () => {
+    await bdContract.createBatch([
+      { name: "name", description: "description" },
+    ]);
+    await bdContract.claimConditions.set(0, [
+      {
+        maxClaimablePerWallet: 1,
+      },
+    ]);
+    let r = await bdContract.claimConditions.getClaimIneligibilityReasons(
+      0,
+      1,
+      await w1.getAddress(),
+    );
+    expect(r.length).to.eq(0);
+
+    r = await bdContract.claimConditions.getClaimIneligibilityReasons(
+      0,
+      2,
+      await w1.getAddress(),
+    );
+    expect(r[0]).to.eq(ClaimEligibility.OverMaxClaimablePerWallet);
+
+    await sdk.updateSignerOrProvider(w1);
+    await bdContract.claim(0, 1);
+
+    r = await bdContract.claimConditions.getClaimIneligibilityReasons(
+      0,
+      1,
+      await w1.getAddress(),
+    );
+    expect(r[0]).to.eq(ClaimEligibility.OverMaxClaimablePerWallet);
+  });
+
   it("should return addresses of all the claimers", async () => {
     await bdContract.createBatch([
       {


### PR DESCRIPTION
## Problem solved

- We weren't exposing an easy way to check how many tokens have been claimed by a wallet
- We weren't returning a proper ineligibility reason when trying to claim more than maxClaimablePerWallet

## Changes made

- [ ] Public API changes: new `erc721.claimConditions.getSupplyClaimedByWallet()`
- [ ] Internal API changes: changes to `getClaimIneligibilityReason()`

## How to test

- [ ] Automated tests: tests/evm/nft_drop_v4.ts
