### PR TITLE
[multi] only evaluate auth token if it is a valid string

### DIFF
--- a/.changeset/chilled-planets-search.md
+++ b/.changeset/chilled-planets-search.md
@@ -1,0 +1,7 @@
+---
+"@thirdweb-dev/storage": patch
+"@thirdweb-dev/wallets": patch
+"@thirdweb-dev/sdk": patch
+---
+
+do not pass empty auth tokens

--- a/.changeset/loud-stingrays-hide.md
+++ b/.changeset/loud-stingrays-hide.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+handle possible empty auth tokens

--- a/packages/sdk/src/evm/constants/urls.ts
+++ b/packages/sdk/src/evm/constants/urls.ts
@@ -203,7 +203,11 @@ export function getProviderFromRpcUrl(
       }
 
       // if we *also* have a tw auth token on global context add it to the headers (in addition to anything else)
-      if (typeof globalThis !== "undefined" && "TW_AUTH_TOKEN" in globalThis) {
+      if (
+        typeof globalThis !== "undefined" &&
+        "TW_AUTH_TOKEN" in globalThis &&
+        typeof (globalThis as any).TW_AUTH_TOKEN === "string"
+      ) {
         headers["authorization"] = `Bearer ${
           (globalThis as any).TW_AUTH_TOKEN as string
         }`;

--- a/packages/service-utils/src/cf-worker/index.ts
+++ b/packages/service-utils/src/cf-worker/index.ts
@@ -138,7 +138,7 @@ export async function extractAuthorizationData(
     const authHeader = headers.get("authorization");
     if (authHeader) {
       const [type, token] = authHeader.split(" ");
-      if (type.toLowerCase() === "bearer") {
+      if (type.toLowerCase() === "bearer" && !!token) {
         jwt = token;
       }
     }

--- a/packages/service-utils/src/core/authorize/index.ts
+++ b/packages/service-utils/src/core/authorize/index.ts
@@ -115,7 +115,7 @@ export async function authorize(
           authorized: false,
           status: 500,
           errorMessage: "Failed to get account information.",
-          errorCode: "FAILED_TO_ACCOUNT",
+          errorCode: "FAILED_TO_LOAD_ACCOUNT",
         };
       }
     }

--- a/packages/service-utils/src/node/index.ts
+++ b/packages/service-utils/src/node/index.ts
@@ -125,7 +125,7 @@ export function extractAuthorizationData(
   const authorizationHeader = getHeader(headers, "authorization");
   if (authorizationHeader) {
     const [type, token] = authorizationHeader.split(" ");
-    if (type.toLowerCase() === "bearer") {
+    if (type.toLowerCase() === "bearer" && !!token) {
       jwt = token;
     }
   }

--- a/packages/storage/src/core/downloaders/storage-downloader.ts
+++ b/packages/storage/src/core/downloaders/storage-downloader.ts
@@ -93,7 +93,11 @@ export class StorageDownloader implements IStorageDownloader {
         };
       }
       // if we have a authorization token on global context then add that to the headers
-      if (typeof globalThis !== "undefined" && "TW_AUTH_TOKEN" in globalThis) {
+      if (
+        typeof globalThis !== "undefined" &&
+        "TW_AUTH_TOKEN" in globalThis &&
+        typeof (globalThis as any).TW_AUTH_TOKEN === "string"
+      ) {
         headers = {
           ...headers,
           authorization: `Bearer ${

--- a/packages/storage/src/core/uploaders/ipfs-uploader.ts
+++ b/packages/storage/src/core/uploaders/ipfs-uploader.ts
@@ -286,7 +286,11 @@ export class IpfsUploader implements IStorageUploader<IpfsUploadBatchOptions> {
       }
 
       // if we have a authorization token on global context then add that to the headers
-      if (typeof globalThis !== "undefined" && "TW_AUTH_TOKEN" in globalThis) {
+      if (
+        typeof globalThis !== "undefined" &&
+        "TW_AUTH_TOKEN" in globalThis &&
+        typeof (globalThis as any).TW_AUTH_TOKEN === "string"
+      ) {
         xhr.setRequestHeader(
           "authorization",
           `Bearer ${(globalThis as any).TW_AUTH_TOKEN as string}`,
@@ -319,7 +323,11 @@ export class IpfsUploader implements IStorageUploader<IpfsUploadBatchOptions> {
     }
 
     // if we have a authorization token on global context then add that to the headers
-    if (typeof globalThis !== "undefined" && "TW_AUTH_TOKEN" in globalThis) {
+    if (
+      typeof globalThis !== "undefined" &&
+      "TW_AUTH_TOKEN" in globalThis &&
+      typeof (globalThis as any).TW_AUTH_TOKEN === "string"
+    ) {
       headers["authorization"] = `Bearer ${
         (globalThis as any).TW_AUTH_TOKEN as string
       }`;

--- a/packages/wallets/src/evm/connectors/smart-wallet/lib/http-rpc-client.ts
+++ b/packages/wallets/src/evm/connectors/smart-wallet/lib/http-rpc-client.ts
@@ -46,7 +46,11 @@ export class HttpRpcClient {
         }
       }
 
-      if (typeof globalThis !== "undefined" && "TW_AUTH_TOKEN" in globalThis) {
+      if (
+        typeof globalThis !== "undefined" &&
+        "TW_AUTH_TOKEN" in globalThis &&
+        typeof (globalThis as any).TW_AUTH_TOKEN === "string"
+      ) {
         headers["authorization"] = `Bearer ${
           (globalThis as any).TW_AUTH_TOKEN as string
         }`;

--- a/packages/wallets/src/evm/connectors/smart-wallet/lib/paymaster.ts
+++ b/packages/wallets/src/evm/connectors/smart-wallet/lib/paymaster.ts
@@ -46,7 +46,11 @@ class VerifyingPaymasterAPI extends PaymasterAPI {
           headers["x-bundle-id"] = (globalThis as any).APP_BUNDLE_ID as string;
         }
       }
-      if (typeof globalThis !== "undefined" && "TW_AUTH_TOKEN" in globalThis) {
+      if (
+        typeof globalThis !== "undefined" &&
+        "TW_AUTH_TOKEN" in globalThis &&
+        typeof (globalThis as any).TW_AUTH_TOKEN === "string"
+      ) {
         headers["authorization"] = `Bearer ${
           (globalThis as any).TW_AUTH_TOKEN as string
         }`;


### PR DESCRIPTION
## Problem solved

previously client libs were possibly sending empty auth tokens, and service utils was treating them as valid

## Changes made

- [ ] service utils no longer considers empty auth tokens valid tokens
- [ ] client libraries no longer pass empty auth tokens
