### PR TITLE
[Wallets] use RPCs with no client id when adding to external wallets

### DIFF
--- a/.changeset/funny-waves-nail.md
+++ b/.changeset/funny-waves-nail.md
@@ -1,0 +1,6 @@
+---
+"@thirdweb-dev/react-native": patch
+"@thirdweb-dev/wallets": patch
+---
+
+Pass unauth'd RPCs to wallets when adding new chains

--- a/packages/react-native/src/evm/utils/uri.ts
+++ b/packages/react-native/src/evm/utils/uri.ts
@@ -1,3 +1,4 @@
+import { Chain, getValidChainRPCs } from "@thirdweb-dev/chains";
 import { WCMeta } from "../wallets/types/wc";
 
 /**
@@ -19,4 +20,20 @@ export function formatWalletConnectDisplayUri(
         links.native.endsWith(":") ? "//" : "/"
       }wc?uri=${encodedUri}`
     : `${uri}`;
+}
+
+export function getValidPublicRPCUrl(chain: Chain) {
+  return getValidChainRPCs(chain).map((rpc) => {
+    try {
+      const url = new URL(rpc);
+      // remove client id from url
+      if (url.hostname.endsWith(".thirdweb.com")) {
+        url.pathname = "";
+        url.search = "";
+      }
+      return url.toString();
+    } catch (e) {
+      return rpc;
+    }
+  });
 }

--- a/packages/react-native/src/evm/wallets/connectors/coinbase-wallet/index.ts
+++ b/packages/react-native/src/evm/wallets/connectors/coinbase-wallet/index.ts
@@ -4,7 +4,6 @@ import type {
   WalletMobileSDKProviderOptions,
 } from "@coinbase/wallet-mobile-sdk/build/WalletMobileSDKEVMProvider";
 import type { ConfigurationParams } from "@coinbase/wallet-mobile-sdk/src/CoinbaseWalletSDK.types";
-import { getValidChainRPCs } from "@thirdweb-dev/chains";
 import {
   UserRejectedRequestError,
   ChainNotConfiguredError,
@@ -18,6 +17,7 @@ import {
 } from "@thirdweb-dev/wallets";
 import type { Address } from "abitype";
 import { providers, utils } from "ethers";
+import { getValidPublicRPCUrl } from "evm/utils/uri";
 
 export type CoinbaseWalletConnectorOptions = WalletMobileSDKProviderOptions &
   ConfigurationParams & {
@@ -227,7 +227,7 @@ export class CoinbaseWalletConnector extends WagmiConnector<
                 chainId: id,
                 chainName: chain.name,
                 nativeCurrency: chain.nativeCurrency,
-                rpcUrls: getValidChainRPCs(chain), // no client id on purpose here
+                rpcUrls: getValidPublicRPCUrl(chain), // no client id on purpose here
                 blockExplorerUrls: this.getBlockExplorerUrls(chain),
               },
             ],

--- a/packages/react-native/src/evm/wallets/connectors/coinbase-wallet/index.ts
+++ b/packages/react-native/src/evm/wallets/connectors/coinbase-wallet/index.ts
@@ -227,7 +227,7 @@ export class CoinbaseWalletConnector extends WagmiConnector<
                 chainId: id,
                 chainName: chain.name,
                 nativeCurrency: chain.nativeCurrency,
-                rpcUrls: [getValidChainRPCs(chain)],
+                rpcUrls: getValidChainRPCs(chain), // no client id on purpose here
                 blockExplorerUrls: this.getBlockExplorerUrls(chain),
               },
             ],

--- a/packages/wallets/src/evm/connectors/blocto/index.ts
+++ b/packages/wallets/src/evm/connectors/blocto/index.ts
@@ -15,7 +15,7 @@ import type {
 import BloctoSDK from "@blocto/sdk";
 import { providers, utils } from "ethers";
 import { walletIds } from "../../constants/walletIds";
-import { Chain } from "@thirdweb-dev/chains";
+import { Chain, getValidChainRPCs } from "@thirdweb-dev/chains";
 
 type BloctoSigner = providers.JsonRpcSigner;
 type BloctoOptions = Partial<EthereumProviderConfig>;
@@ -165,7 +165,12 @@ export class BloctoConnector extends WagmiConnector<
     try {
       await provider.request({
         method: "wallet_addEthereumChain",
-        params: [{ chainId: id, rpcUrls: [chain?.rpc[0] ?? ""] }],
+        params: [
+          {
+            chainId: id,
+            rpcUrls: getValidChainRPCs(chain), // no client id on purpose here
+          },
+        ],
       });
 
       await provider.request({

--- a/packages/wallets/src/evm/connectors/blocto/index.ts
+++ b/packages/wallets/src/evm/connectors/blocto/index.ts
@@ -16,6 +16,7 @@ import BloctoSDK from "@blocto/sdk";
 import { providers, utils } from "ethers";
 import { walletIds } from "../../constants/walletIds";
 import { Chain, getValidChainRPCs } from "@thirdweb-dev/chains";
+import { getValidPublicRPCUrl } from "../../utils/url";
 
 type BloctoSigner = providers.JsonRpcSigner;
 type BloctoOptions = Partial<EthereumProviderConfig>;
@@ -168,7 +169,7 @@ export class BloctoConnector extends WagmiConnector<
         params: [
           {
             chainId: id,
-            rpcUrls: getValidChainRPCs(chain), // no client id on purpose here
+            rpcUrls: getValidPublicRPCUrl(chain), // no client id on purpose here
           },
         ],
       });

--- a/packages/wallets/src/evm/connectors/blocto/index.ts
+++ b/packages/wallets/src/evm/connectors/blocto/index.ts
@@ -15,7 +15,7 @@ import type {
 import BloctoSDK from "@blocto/sdk";
 import { providers, utils } from "ethers";
 import { walletIds } from "../../constants/walletIds";
-import { Chain, getValidChainRPCs } from "@thirdweb-dev/chains";
+import type { Chain } from "@thirdweb-dev/chains";
 import { getValidPublicRPCUrl } from "../../utils/url";
 
 type BloctoSigner = providers.JsonRpcSigner;

--- a/packages/wallets/src/evm/connectors/coinbase-wallet/index.ts
+++ b/packages/wallets/src/evm/connectors/coinbase-wallet/index.ts
@@ -12,7 +12,7 @@ import type {
   CoinbaseWalletSDK,
 } from "@coinbase/wallet-sdk";
 import type { CoinbaseWalletSDKOptions } from "@coinbase/wallet-sdk/dist/CoinbaseWalletSDK";
-import { getValidChainRPCs, type Chain } from "@thirdweb-dev/chains";
+import type { Chain } from "@thirdweb-dev/chains";
 import { providers, utils } from "ethers";
 import { walletIds } from "../../constants/walletIds";
 import { getValidPublicRPCUrl } from "../../utils/url";

--- a/packages/wallets/src/evm/connectors/coinbase-wallet/index.ts
+++ b/packages/wallets/src/evm/connectors/coinbase-wallet/index.ts
@@ -12,7 +12,7 @@ import type {
   CoinbaseWalletSDK,
 } from "@coinbase/wallet-sdk";
 import type { CoinbaseWalletSDKOptions } from "@coinbase/wallet-sdk/dist/CoinbaseWalletSDK";
-import type { Chain } from "@thirdweb-dev/chains";
+import { getValidChainRPCs, type Chain } from "@thirdweb-dev/chains";
 import { providers, utils } from "ethers";
 import { walletIds } from "../../constants/walletIds";
 
@@ -231,7 +231,7 @@ export class CoinbaseWalletConnector extends WagmiConnector<
                 chainId: id,
                 chainName: chain.name,
                 nativeCurrency: chain.nativeCurrency,
-                rpcUrls: chain.rpc,
+                rpcUrls: getValidChainRPCs(chain), // no client id on purpose here
                 blockExplorerUrls: this.getBlockExplorerUrls(chain),
               },
             ],

--- a/packages/wallets/src/evm/connectors/coinbase-wallet/index.ts
+++ b/packages/wallets/src/evm/connectors/coinbase-wallet/index.ts
@@ -15,6 +15,7 @@ import type { CoinbaseWalletSDKOptions } from "@coinbase/wallet-sdk/dist/Coinbas
 import { getValidChainRPCs, type Chain } from "@thirdweb-dev/chains";
 import { providers, utils } from "ethers";
 import { walletIds } from "../../constants/walletIds";
+import { getValidPublicRPCUrl } from "../../utils/url";
 
 type Options = CoinbaseWalletSDKOptions & {
   /**
@@ -231,7 +232,7 @@ export class CoinbaseWalletConnector extends WagmiConnector<
                 chainId: id,
                 chainName: chain.name,
                 nativeCurrency: chain.nativeCurrency,
-                rpcUrls: getValidChainRPCs(chain), // no client id on purpose here
+                rpcUrls: getValidPublicRPCUrl(chain), // no client id on purpose here
                 blockExplorerUrls: this.getBlockExplorerUrls(chain),
               },
             ],

--- a/packages/wallets/src/evm/connectors/frame/index.ts
+++ b/packages/wallets/src/evm/connectors/frame/index.ts
@@ -16,6 +16,7 @@ import {
 } from "../../../lib/wagmi-core";
 import { Ethereum } from "../injected/types";
 import { AsyncStorage } from "../../../core";
+import { getValidPublicRPCUrl } from "../../utils/url";
 
 export type FrameConnectorOptions = {
   /**
@@ -241,7 +242,7 @@ export class FrameConnector extends WagmiConnector<
                 chainId: chainIdHex,
                 chainName: chain.name,
                 nativeCurrency: chain.nativeCurrency,
-                rpcUrls: getValidChainRPCs(chain), // no client id on purpose here
+                rpcUrls: getValidPublicRPCUrl(chain), // no client id on purpose here
                 blockExplorerUrls: this.getBlockExplorerUrls(chain),
               },
             ],

--- a/packages/wallets/src/evm/connectors/frame/index.ts
+++ b/packages/wallets/src/evm/connectors/frame/index.ts
@@ -1,7 +1,7 @@
 import { providers, utils } from "ethers";
 import type Provider from "ethereum-provider";
 import type { Address } from "abitype";
-import type { Chain } from "@thirdweb-dev/chains";
+import { getValidChainRPCs, type Chain } from "@thirdweb-dev/chains";
 
 import { WagmiConnector } from "../../../lib/wagmi-connectors";
 import {
@@ -241,7 +241,7 @@ export class FrameConnector extends WagmiConnector<
                 chainId: chainIdHex,
                 chainName: chain.name,
                 nativeCurrency: chain.nativeCurrency,
-                rpc: [chain.rpc[0] ?? ""],
+                rpcUrls: getValidChainRPCs(chain), // no client id on purpose here
                 blockExplorerUrls: this.getBlockExplorerUrls(chain),
               },
             ],

--- a/packages/wallets/src/evm/connectors/frame/index.ts
+++ b/packages/wallets/src/evm/connectors/frame/index.ts
@@ -1,7 +1,7 @@
 import { providers, utils } from "ethers";
 import type Provider from "ethereum-provider";
 import type { Address } from "abitype";
-import { getValidChainRPCs, type Chain } from "@thirdweb-dev/chains";
+import type { Chain } from "@thirdweb-dev/chains";
 
 import { WagmiConnector } from "../../../lib/wagmi-connectors";
 import {

--- a/packages/wallets/src/evm/connectors/injected/index.ts
+++ b/packages/wallets/src/evm/connectors/injected/index.ts
@@ -14,7 +14,7 @@ import {
 import { assertWindowEthereum } from "../../utils/assertWindowEthereum";
 import { getInjectedName } from "../../utils/getInjectedName";
 import { Ethereum } from "./types";
-import type { Chain } from "@thirdweb-dev/chains";
+import { getValidChainRPCs, type Chain } from "@thirdweb-dev/chains";
 import { utils, providers } from "ethers";
 
 export type InjectedConnectorOptions = {
@@ -348,7 +348,7 @@ export class InjectedConnector extends WagmiConnector<
                 chainId: chainIdHex,
                 chainName: chain.name,
                 nativeCurrency: chain.nativeCurrency,
-                rpcUrls: chain.rpc as string[],
+                rpcUrls: getValidChainRPCs(chain), // no client id on purpose here
                 blockExplorerUrls: this.getBlockExplorerUrls(chain),
               },
             ],

--- a/packages/wallets/src/evm/connectors/injected/index.ts
+++ b/packages/wallets/src/evm/connectors/injected/index.ts
@@ -13,6 +13,7 @@ import {
 } from "../../../lib/wagmi-core";
 import { assertWindowEthereum } from "../../utils/assertWindowEthereum";
 import { getInjectedName } from "../../utils/getInjectedName";
+import { getValidPublicRPCUrl } from "../../utils/url";
 import { Ethereum } from "./types";
 import { getValidChainRPCs, type Chain } from "@thirdweb-dev/chains";
 import { utils, providers } from "ethers";
@@ -340,6 +341,7 @@ export class InjectedConnector extends WagmiConnector<
           ?.originalError?.code === 4902
       ) {
         try {
+          console.log("adding chain", getValidChainRPCs(chain));
           // request provider to add chain
           await provider.request({
             method: "wallet_addEthereumChain",
@@ -348,7 +350,7 @@ export class InjectedConnector extends WagmiConnector<
                 chainId: chainIdHex,
                 chainName: chain.name,
                 nativeCurrency: chain.nativeCurrency,
-                rpcUrls: getValidChainRPCs(chain), // no client id on purpose here
+                rpcUrls: getValidPublicRPCUrl(chain), // no client id on purpose here
                 blockExplorerUrls: this.getBlockExplorerUrls(chain),
               },
             ],

--- a/packages/wallets/src/evm/connectors/wallet-connect/index.ts
+++ b/packages/wallets/src/evm/connectors/wallet-connect/index.ts
@@ -6,11 +6,12 @@ import {
   UserRejectedRequestError,
   WagmiConnector,
 } from "../../../lib/wagmi-core";
-import { getValidChainRPCs, type Chain } from "@thirdweb-dev/chains";
+import { type Chain } from "@thirdweb-dev/chains";
 import type WalletConnectProvider from "@walletconnect/ethereum-provider";
 import { providers, utils } from "ethers";
 import { walletIds } from "../../constants/walletIds";
 import { QRModalOptions } from "./qrModalOptions";
+import { getValidPublicRPCUrl } from "../../utils/url";
 
 const chainsToRequest = new Set([1, 137, 10, 42161, 56]);
 
@@ -291,7 +292,7 @@ export class WalletConnectConnector extends WagmiConnector<
               chainId: utils.hexValue(chain.chainId),
               chainName: chain.name,
               nativeCurrency: chain.nativeCurrency,
-              rpcUrls: getValidChainRPCs(chain), // no clientId on purpose
+              rpcUrls: getValidPublicRPCUrl(chain), // no clientId on purpose
               ...blockExplorerUrls,
             },
           ],

--- a/packages/wallets/src/evm/connectors/wallet-connect/index.ts
+++ b/packages/wallets/src/evm/connectors/wallet-connect/index.ts
@@ -6,7 +6,7 @@ import {
   UserRejectedRequestError,
   WagmiConnector,
 } from "../../../lib/wagmi-core";
-import type { Chain } from "@thirdweb-dev/chains";
+import { getValidChainRPCs, type Chain } from "@thirdweb-dev/chains";
 import type WalletConnectProvider from "@walletconnect/ethereum-provider";
 import { providers, utils } from "ethers";
 import { walletIds } from "../../constants/walletIds";
@@ -291,7 +291,7 @@ export class WalletConnectConnector extends WagmiConnector<
               chainId: utils.hexValue(chain.chainId),
               chainName: chain.name,
               nativeCurrency: chain.nativeCurrency,
-              rpcUrls: [...chain.rpc],
+              rpcUrls: getValidChainRPCs(chain), // no clientId on purpose
               ...blockExplorerUrls,
             },
           ],

--- a/packages/wallets/src/evm/utils/url.ts
+++ b/packages/wallets/src/evm/utils/url.ts
@@ -1,6 +1,24 @@
+import { getValidChainRPCs, type Chain } from "@thirdweb-dev/chains";
+
 export function isTwUrl(url: string): boolean {
   const host = new URL(url).hostname;
   return (
     host.endsWith(".thirdweb.com") || host === "localhost" || host === "0.0.0.0"
   );
+}
+
+export function getValidPublicRPCUrl(chain: Chain) {
+  return getValidChainRPCs(chain).map((rpc) => {
+    try {
+      const url = new URL(rpc);
+      // remove client id from url
+      if (url.hostname.endsWith(".thirdweb.com")) {
+        url.pathname = "";
+        url.search = "";
+      }
+      return url.toString();
+    } catch (e) {
+      return rpc;
+    }
+  });
 }


### PR DESCRIPTION
## Problem solved

We were passing RPC urls with client id restrictions to external wallets

## Changes made

- [ ] Public API changes: none
- [ ] Internal API changes: only pass non-authenticated RPC urls to wallets when adding chains

## How to test

- [ ] Manual tests: tested in web app
