### PR TITLE
[SDK] Expose Transaction.populateTransaction()

### DIFF
--- a/.changeset/sixty-garlics-dance.md
+++ b/.changeset/sixty-garlics-dance.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/sdk": patch
+---
+
+Expose Transaction.populateTransaction()

--- a/packages/sdk/src/evm/core/classes/transactions.ts
+++ b/packages/sdk/src/evm/core/classes/transactions.ts
@@ -413,6 +413,12 @@ export class Transaction<
    * Get the signed transaction
    */
   async sign(): Promise<string> {
+    const populatedTx = await this.populateTransaction();
+    const signedTx = await this.contract.signer.signTransaction(populatedTx);
+    return signedTx;
+  }
+
+  async populateTransaction(): Promise<providers.TransactionRequest> {
     const gasOverrides = await this.getGasOverrides();
     const overrides: CallOverrides = { ...gasOverrides, ...this.overrides };
 
@@ -426,8 +432,7 @@ export class Transaction<
       overrides,
     );
     const populatedTx = await this.contract.signer.populateTransaction(tx);
-    const signedTx = await this.contract.signer.signTransaction(populatedTx);
-    return signedTx;
+    return populatedTx;
   }
 
   /**
@@ -845,7 +850,7 @@ export class DeployTransaction extends TransactionContext {
     return contractAddress;
   }
 
-  private async populateTransaction(): Promise<providers.TransactionRequest> {
+  public async populateTransaction(): Promise<providers.TransactionRequest> {
     const gasOverrides = await this.getGasOverrides();
     const overrides: CallOverrides = { ...gasOverrides, ...this.overrides };
 


### PR DESCRIPTION
## Problem solved

expose a way to get the fully populated tx for signing somewhere else

## Changes made

- [ ] Public API changes: Transaction.populateTransction()
- [ ] Internal API changes: none

