### PR TITLE
Try/catch parseSnapshotInputs

### DIFF
--- a/packages/sdk/src/evm/common/parseSnapshotInputs.ts
+++ b/packages/sdk/src/evm/common/parseSnapshotInputs.ts
@@ -2,16 +2,23 @@ import { SnapshotInputSchema } from "../schema/contracts/common/snapshots";
 import { SnapshotInput } from "../types/claim-conditions/claim-conditions";
 
 export async function parseSnapshotInputs(inputs: SnapshotInput) {
-  const chunkSize = 25000;
-  const chunks = Array.from(
-    { length: Math.ceil(inputs.length / chunkSize) },
-    (_, i) => inputs.slice(i * chunkSize, i * chunkSize + chunkSize),
-  );
+  try {
+    const chunkSize = 25000;
 
-  const results = [];
-  for (const chunk of chunks) {
-    results.push(...(await SnapshotInputSchema.parseAsync(chunk)));
+    const chunks = Array.from(
+      { length: Math.ceil(inputs.length / chunkSize) },
+      (_, i) => inputs.slice(i * chunkSize, i * chunkSize + chunkSize),
+    );
+
+    const results = [];
+
+    for (const chunk of chunks) {
+      results.push(...(await SnapshotInputSchema.parseAsync(chunk)));
+    }
+
+    return results;
+
+  } catch (err: any) {
+    throw new Error(`Failed to parse snapshot inputs: ${err.message}`);
   }
-
-  return results;
 }


### PR DESCRIPTION
## Problem solved

Make it so we throw instead of silently failing when parsing

## Changes made

- [x] try/catch parseSnapshotInputs
