### PR TITLE
[SDK] Return early for claim checks when possible

### DIFF
--- a/.changeset/ninety-camels-share.md
+++ b/.changeset/ninety-camels-share.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/sdk": patch
+---
+
+Return early for claim checks when possible

--- a/packages/sdk/src/evm/core/classes/drop-claim-conditions.ts
+++ b/packages/sdk/src/evm/core/classes/drop-claim-conditions.ts
@@ -272,6 +272,7 @@ export class DropClaimConditions<
 
       if (supplyWithDecimals.lt(quantityWithDecimals)) {
         reasons.push(ClaimEligibility.NotEnoughSupply);
+        return reasons;
       }
     }
 
@@ -464,6 +465,7 @@ export class DropClaimConditions<
         } else {
           reasons.push(ClaimEligibility.WaitBeforeNextClaimTransaction);
         }
+        return reasons;
       }
     }
 

--- a/packages/sdk/src/evm/core/classes/drop-erc1155-claim-conditions.ts
+++ b/packages/sdk/src/evm/core/classes/drop-erc1155-claim-conditions.ts
@@ -270,6 +270,7 @@ export class DropErc1155ClaimConditions<
     if (claimCondition.availableSupply !== "unlimited") {
       if (BigNumber.from(claimCondition.availableSupply).lt(quantity)) {
         reasons.push(ClaimEligibility.NotEnoughSupply);
+        return reasons;
       }
     }
 
@@ -470,6 +471,7 @@ export class DropErc1155ClaimConditions<
       } else {
         reasons.push(ClaimEligibility.WaitBeforeNextClaimTransaction);
       }
+      return reasons;
     }
 
     // if not within a browser conetext, check for wallet balance.


### PR DESCRIPTION
## Problem solved

speed up getClaimIneligibility checks when a ineligibility condition is hit

## Changes made

- [ ] Public API changes: none
- [x] Internal API changes: getClaimIneligibilty()

## How to test

- [x] Automated tests
