### PR TITLE
feat(sdk): centralize contract reads

### DIFF
--- a/.changeset/sweet-apricots-guess.md
+++ b/.changeset/sweet-apricots-guess.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/sdk": patch
+---
+
+internal(sdk): update read calls to be centralized in contract-wrapper.ts

--- a/packages/chains/chains/165.ts
+++ b/packages/chains/chains/165.ts
@@ -1,10 +1,10 @@
 import type { Chain } from "../src/types";
 export default {
-  "name": "Omni Testnet 1",
+  "name": "Omni Testnet",
   "chain": "Omni",
   "rpc": [
-    "https://omni-testnet-1.rpc.thirdweb.com/${THIRDWEB_API_KEY}",
-    "https://testnet-1.omni.network"
+    "https://omni-testnet.rpc.thirdweb.com/${THIRDWEB_API_KEY}",
+    "https://testnet.omni.network"
   ],
   "features": [
     {
@@ -24,10 +24,10 @@ export default {
   "explorers": [
     {
       "name": "Omni Explorer",
-      "url": "https://testnet-1.explorer.omni.network",
+      "url": "https://testnet.explorer.omni.network",
       "standard": "EIP3091"
     }
   ],
   "testnet": true,
-  "slug": "omni-testnet-1"
+  "slug": "omni-testnet"
 } as const satisfies Chain;

--- a/packages/chains/chains/1663.ts
+++ b/packages/chains/chains/1663.ts
@@ -11,8 +11,8 @@ export default {
   },
   "rpc": [
     "https://horizen-gobi-testnet.rpc.thirdweb.com/${THIRDWEB_API_KEY}",
-    "https://gobi-testnet.horizenlabs.io/ethv1",
-    "https://rpc.ankr.com/horizen_testnet_evm"
+    "https://gobi-rpc.horizenlabs.io/ethv1",
+    "https://rpc.ankr.com/horizen_gobi_testnet"
   ],
   "features": [
     {

--- a/packages/chains/src/index.ts
+++ b/packages/chains/src/index.ts
@@ -1141,7 +1141,7 @@ export { default as ArmoniaEvaChain } from "../chains/160"
 export { default as ArmoniaEvaChainTestnet } from "../chains/161"
 export { default as LightstreamsTestnet } from "../chains/162"
 export { default as Lightstreams } from "../chains/163"
-export { default as OmniTestnet1 } from "../chains/165"
+export { default as OmniTestnet } from "../chains/165"
 export { default as AtoshiTestnet } from "../chains/167"
 export { default as AiozNetwork } from "../chains/168"
 export { default as HooSmartChainTestnet } from "../chains/170"
@@ -3155,7 +3155,7 @@ type ChainIdsBySlug = {
 "armonia-eva-chain-testnet": 161,
 "lightstreams-testnet": 162,
 "lightstreams": 163,
-"omni-testnet-1": 165,
+"omni-testnet": 165,
 "atoshi-testnet": 167,
 "aioz-network": 168,
 "hoo-smart-chain-testnet": 170,

--- a/packages/sdk/src/evm/common/currency/approveErc20Allowance.ts
+++ b/packages/sdk/src/evm/common/currency/approveErc20Allowance.ts
@@ -1,7 +1,7 @@
-import { ContractWrapper } from "../../core/classes/contract-wrapper";
 import type { IERC20 } from "@thirdweb-dev/contracts-js";
 import ERC20Abi from "@thirdweb-dev/contracts-js/dist/abis/IERC20.json";
-import { BigNumber, type BigNumberish, utils } from "ethers";
+import { BigNumber, utils, type BigNumberish } from "ethers";
+import { ContractWrapper } from "../../core/classes/contract-wrapper";
 
 export async function approveErc20Allowance(
   contractToApprove: ContractWrapper<any>,
@@ -20,8 +20,8 @@ export async function approveErc20Allowance(
     contractToApprove.storage,
   );
   const owner = await contractToApprove.getSignerAddress();
-  const spender = contractToApprove.readContract.address;
-  const allowance = await erc20.readContract.allowance(owner, spender);
+  const spender = contractToApprove.address;
+  const [allowance] = await erc20.read("allowance", [owner, spender]);
   const totalPrice = BigNumber.from(price)
     .mul(BigNumber.from(quantity))
     .div(utils.parseUnits("1", tokenDecimals));

--- a/packages/sdk/src/evm/common/currency/approveErc20Allowance.ts
+++ b/packages/sdk/src/evm/common/currency/approveErc20Allowance.ts
@@ -21,7 +21,7 @@ export async function approveErc20Allowance(
   );
   const owner = await contractToApprove.getSignerAddress();
   const spender = contractToApprove.address;
-  const [allowance] = await erc20.read("allowance", [owner, spender]);
+  const allowance = await erc20.read("allowance", [owner, spender]);
   const totalPrice = BigNumber.from(price)
     .mul(BigNumber.from(quantity))
     .div(utils.parseUnits("1", tokenDecimals));

--- a/packages/sdk/src/evm/common/currency/hasERC20Allowance.ts
+++ b/packages/sdk/src/evm/common/currency/hasERC20Allowance.ts
@@ -18,6 +18,6 @@ export async function hasERC20Allowance(
   );
   const owner = await contractToApprove.getSignerAddress();
   const spender = contractToApprove.address;
-  const [allowance] = await erc20.read("allowance", [owner, spender]);
+  const allowance = await erc20.read("allowance", [owner, spender]);
   return allowance.gte(value);
 }

--- a/packages/sdk/src/evm/common/currency/hasERC20Allowance.ts
+++ b/packages/sdk/src/evm/common/currency/hasERC20Allowance.ts
@@ -1,7 +1,7 @@
-import { ContractWrapper } from "../../core/classes/contract-wrapper";
 import type { IERC20 } from "@thirdweb-dev/contracts-js";
 import ERC20Abi from "@thirdweb-dev/contracts-js/dist/abis/IERC20.json";
 import { BigNumber } from "ethers";
+import { ContractWrapper } from "../../core/classes/contract-wrapper";
 
 export async function hasERC20Allowance(
   contractToApprove: ContractWrapper<any>,
@@ -17,7 +17,7 @@ export async function hasERC20Allowance(
     contractToApprove.storage,
   );
   const owner = await contractToApprove.getSignerAddress();
-  const spender = contractToApprove.readContract.address;
-  const allowance = await erc20.readContract.allowance(owner, spender);
+  const spender = contractToApprove.address;
+  const [allowance] = await erc20.read("allowance", [owner, spender]);
   return allowance.gte(value);
 }

--- a/packages/sdk/src/evm/common/currency/normalizeAmount.ts
+++ b/packages/sdk/src/evm/common/currency/normalizeAmount.ts
@@ -1,13 +1,13 @@
+import { BigNumber, utils } from "ethers";
 import { AmountSchema } from "../../../core/schema/shared";
 import { ContractWrapper } from "../../core/classes/contract-wrapper";
 import { Amount } from "../../types/currency";
 import { BaseERC20 } from "../../types/eips";
-import { BigNumber, utils } from "ethers";
 
 export async function normalizeAmount(
   contractWrapper: ContractWrapper<BaseERC20>,
   amount: Amount,
 ): Promise<BigNumber> {
-  const decimals = await contractWrapper.readContract.decimals();
+  const [decimals] = await contractWrapper.read("decimals", []);
   return utils.parseUnits(AmountSchema.parse(amount), decimals);
 }

--- a/packages/sdk/src/evm/common/currency/normalizeAmount.ts
+++ b/packages/sdk/src/evm/common/currency/normalizeAmount.ts
@@ -8,6 +8,6 @@ export async function normalizeAmount(
   contractWrapper: ContractWrapper<BaseERC20>,
   amount: Amount,
 ): Promise<BigNumber> {
-  const [decimals] = await contractWrapper.read("decimals", []);
+  const decimals = await contractWrapper.read("decimals", []);
   return utils.parseUnits(AmountSchema.parse(amount), decimals);
 }

--- a/packages/sdk/src/evm/contracts/prebuilt-implementations/edition-drop.ts
+++ b/packages/sdk/src/evm/contracts/prebuilt-implementations/edition-drop.ts
@@ -48,7 +48,7 @@ export class EditionDrop extends StandardErc1155<PrebuiltEditionDrop> {
   private static contractRoles = NFT_BASE_CONTRACT_ROLES;
 
   public abi: Abi;
-  public sales: ContractPrimarySale<PrebuiltEditionDrop>;
+  public sales: ContractPrimarySale;
   public platformFees: ContractPlatformFee<PrebuiltEditionDrop>;
   public encoder: ContractEncoder<PrebuiltEditionDrop>;
   public estimator: GasCostEstimator<PrebuiltEditionDrop>;

--- a/packages/sdk/src/evm/contracts/prebuilt-implementations/edition.ts
+++ b/packages/sdk/src/evm/contracts/prebuilt-implementations/edition.ts
@@ -56,7 +56,7 @@ export class Edition extends StandardErc1155<TokenERC1155> {
     TokenERC1155,
     (typeof Edition.contractRoles)[number]
   >;
-  public sales: ContractPrimarySale<TokenERC1155>;
+  public sales: ContractPrimarySale;
   public platformFees: ContractPlatformFee<TokenERC1155>;
   public encoder: ContractEncoder<TokenERC1155>;
   public estimator: GasCostEstimator<TokenERC1155>;

--- a/packages/sdk/src/evm/contracts/prebuilt-implementations/nft-collection.ts
+++ b/packages/sdk/src/evm/contracts/prebuilt-implementations/nft-collection.ts
@@ -58,7 +58,7 @@ export class NFTCollection extends StandardErc721<TokenERC721> {
   public encoder: ContractEncoder<TokenERC721>;
   public estimator: GasCostEstimator<TokenERC721>;
   public events: ContractEvents<TokenERC721>;
-  public sales: ContractPrimarySale<TokenERC721>;
+  public sales: ContractPrimarySale;
   public platformFees: ContractPlatformFee<TokenERC721>;
   /**
    * Configure royalties

--- a/packages/sdk/src/evm/contracts/prebuilt-implementations/nft-drop.ts
+++ b/packages/sdk/src/evm/contracts/prebuilt-implementations/nft-drop.ts
@@ -60,7 +60,7 @@ export class NFTDrop extends StandardErc721<PrebuiltNFTDrop> {
     typeof DropErc721ContractSchema
   >;
   public app: ContractAppURI<PrebuiltNFTDrop>;
-  public sales: ContractPrimarySale<PrebuiltNFTDrop>;
+  public sales: ContractPrimarySale;
   public platformFees: ContractPlatformFee<PrebuiltNFTDrop>;
   public events: ContractEvents<PrebuiltNFTDrop>;
   public roles: ContractRoles<

--- a/packages/sdk/src/evm/contracts/prebuilt-implementations/signature-drop.ts
+++ b/packages/sdk/src/evm/contracts/prebuilt-implementations/signature-drop.ts
@@ -65,7 +65,7 @@ export class SignatureDrop extends StandardErc721<SignatureDropContract> {
     typeof DropErc721ContractSchema
   >;
   public app: ContractAppURI<SignatureDropContract>;
-  public sales: ContractPrimarySale<SignatureDropContract>;
+  public sales: ContractPrimarySale;
   public platformFees: ContractPlatformFee<SignatureDropContract>;
   public events: ContractEvents<SignatureDropContract>;
   public roles: ContractRoles<

--- a/packages/sdk/src/evm/contracts/prebuilt-implementations/split.ts
+++ b/packages/sdk/src/evm/contracts/prebuilt-implementations/split.ts
@@ -1,3 +1,11 @@
+import type {
+  IERC20,
+  Split as SplitContract,
+} from "@thirdweb-dev/contracts-js";
+import ERC20Abi from "@thirdweb-dev/contracts-js/dist/abis/IERC20.json";
+import { ThirdwebStorage } from "@thirdweb-dev/storage";
+import { BigNumber, CallOverrides, Contract } from "ethers";
+import { fetchCurrencyValue } from "../../common/currency/fetchCurrencyValue";
 import { resolveAddress } from "../../common/ens/resolveAddress";
 import { buildTransactionFunction } from "../../common/transactions";
 import { ContractAppURI } from "../../core/classes/contract-appuri";
@@ -11,21 +19,13 @@ import { GasCostEstimator } from "../../core/classes/gas-cost-estimator";
 import { Transaction } from "../../core/classes/transactions";
 import { UpdateableNetwork } from "../../core/interfaces/contract";
 import { NetworkInput } from "../../core/types";
-import { AddressOrEns } from "../../schema/shared/AddressOrEnsSchema";
-import { Address } from "../../schema/shared/Address";
 import { Abi, AbiInput, AbiSchema } from "../../schema/contracts/custom";
 import { SplitsContractSchema } from "../../schema/contracts/splits";
 import { SDKOptions } from "../../schema/sdk-options";
+import { Address } from "../../schema/shared/Address";
+import { AddressOrEns } from "../../schema/shared/AddressOrEnsSchema";
 import { SplitRecipient } from "../../types/SplitRecipient";
 import { CurrencyValue } from "../../types/currency";
-import type {
-  IERC20,
-  Split as SplitContract,
-} from "@thirdweb-dev/contracts-js";
-import ERC20Abi from "@thirdweb-dev/contracts-js/dist/abis/IERC20.json";
-import { ThirdwebStorage } from "@thirdweb-dev/storage";
-import { BigNumber, CallOverrides, Contract } from "ethers";
-import { fetchCurrencyValue } from "../../common/currency/fetchCurrencyValue";
 import { ADMIN_ROLE } from "../contractRoles";
 
 /**

--- a/packages/sdk/src/evm/contracts/prebuilt-implementations/token-drop.ts
+++ b/packages/sdk/src/evm/contracts/prebuilt-implementations/token-drop.ts
@@ -54,7 +54,7 @@ export class TokenDrop extends StandardErc20<PrebuiltTokenDrop> {
   >;
   public encoder: ContractEncoder<PrebuiltTokenDrop>;
   public estimator: GasCostEstimator<PrebuiltTokenDrop>;
-  public sales: ContractPrimarySale<PrebuiltTokenDrop>;
+  public sales: ContractPrimarySale;
   public platformFees: ContractPlatformFee<PrebuiltTokenDrop>;
   public events: ContractEvents<PrebuiltTokenDrop>;
   /**

--- a/packages/sdk/src/evm/contracts/prebuilt-implementations/token.ts
+++ b/packages/sdk/src/evm/contracts/prebuilt-implementations/token.ts
@@ -58,7 +58,7 @@ export class Token extends StandardErc20<TokenERC20> {
   public history: TokenERC20History;
   public events: ContractEvents<TokenERC20>;
   public platformFees: ContractPlatformFee<TokenERC20>;
-  public sales: ContractPrimarySale<TokenERC20>;
+  public sales: ContractPrimarySale;
   /**
    * Signature Minting
    * @remarks Generate tokens that can be minted only with your own signature, attaching your own set of mint conditions.

--- a/packages/sdk/src/evm/contracts/prebuilt-implementations/vote.ts
+++ b/packages/sdk/src/evm/contracts/prebuilt-implementations/vote.ts
@@ -112,7 +112,7 @@ export class Vote implements UpdateableNetwork {
   }
 
   getAddress(): Address {
-    return this.contractWrapper.readContract.address;
+    return this.contractWrapper.address;
   }
 
   /** ******************************
@@ -151,7 +151,7 @@ export class Vote implements UpdateableNetwork {
    */
   public async getAll(): Promise<Proposal[]> {
     return Promise.all(
-      (await this.contractWrapper.readContract.getAllProposals()).map(
+      (await this.contractWrapper.read("getAllProposals", [])).map(
         async (data) => ({
           proposalId: data.proposalId,
           proposer: data.proposer,

--- a/packages/sdk/src/evm/contracts/smart-contract.ts
+++ b/packages/sdk/src/evm/contracts/smart-contract.ts
@@ -136,7 +136,7 @@ export class SmartContract<
   /**
    * Handle primary sales
    */
-  get sales(): ContractPrimarySale<IPrimarySale> {
+  get sales(): ContractPrimarySale {
     return assertEnabled(this.detectPrimarySales(), FEATURE_PRIMARY_SALE);
   }
 
@@ -317,7 +317,7 @@ export class SmartContract<
   get airdrop1155(): Airdrop1155<AirdropERC1155> {
     return assertEnabled(this.detectAirdrop1155(), FEATURE_AIRDROP_ERC1155);
   }
-    
+
   /**
    * Account Factory
    *
@@ -594,7 +594,10 @@ export class SmartContract<
 
   private detectAirdrop721() {
     if (
-      detectContractFeature<AirdropERC721>(this.contractWrapper, "AirdropERC721")
+      detectContractFeature<AirdropERC721>(
+        this.contractWrapper,
+        "AirdropERC721",
+      )
     ) {
       return new Airdrop721(this.contractWrapper);
     }
@@ -603,7 +606,10 @@ export class SmartContract<
 
   private detectAirdrop1155() {
     if (
-      detectContractFeature<AirdropERC1155>(this.contractWrapper, "AirdropERC1155")
+      detectContractFeature<AirdropERC1155>(
+        this.contractWrapper,
+        "AirdropERC1155",
+      )
     ) {
       return new Airdrop1155(this.contractWrapper);
     }

--- a/packages/sdk/src/evm/core/classes/account-permissions.ts
+++ b/packages/sdk/src/evm/core/classes/account-permissions.ts
@@ -1,30 +1,30 @@
+import { BigNumber, utils } from "ethers";
+import { FEATURE_ACCOUNT_PERMISSIONS } from "../../constants/thirdweb-features";
 import { DetectableFeature } from "../interfaces/DetectableFeature";
 import { ContractWrapper } from "./contract-wrapper";
-import { FEATURE_ACCOUNT_PERMISSIONS } from "../../constants/thirdweb-features";
-import { utils, BigNumber } from "ethers";
 import { Transaction } from "./transactions";
 
 import type {
   IAccountCore,
   IAccountPermissions,
 } from "@thirdweb-dev/contracts-js";
+import invariant from "tiny-invariant";
+import { resolveAddress } from "../../common";
+import { resolveOrGenerateId } from "../../common/signature-minting";
+import { buildTransactionFunction } from "../../common/transactions";
+import { AddressOrEns } from "../../schema";
 import {
+  PermissionSnapshotInput,
+  PermissionSnapshotOutput,
+  PermissionSnapshotSchema,
   SignedSignerPermissionsPayload,
-  SignerPermissionsOutput,
-  SignerWithPermissions,
+  SignerPermissionRequest,
   SignerPermissions,
   SignerPermissionsInput,
-  SignerPermissionRequest,
+  SignerPermissionsOutput,
   SignerPermissionsSchema,
-  PermissionSnapshotInput,
-  PermissionSnapshotSchema,
-  PermissionSnapshotOutput,
+  SignerWithPermissions,
 } from "../../types";
-import invariant from "tiny-invariant";
-import { buildTransactionFunction } from "../../common/transactions";
-import { resolveOrGenerateId } from "../../common/signature-minting";
-import { AddressOrEns } from "../../schema";
-import { resolveAddress } from "../../common";
 
 export class AccountPermissions implements DetectableFeature {
   featureName = FEATURE_ACCOUNT_PERMISSIONS.name;
@@ -91,11 +91,11 @@ export class AccountPermissions implements DetectableFeature {
       permissions,
     );
 
-    const { success } =
-      await this.contractWrapper.readContract.verifySignerPermissionRequest(
-        payload,
-        signature,
-      );
+    const [success] = await this.contractWrapper.read(
+      "verifySignerPermissionRequest",
+      [payload, signature],
+    );
+
     if (!success) {
       throw new Error(`Invalid signature.`);
     }

--- a/packages/sdk/src/evm/core/classes/contract-owner.ts
+++ b/packages/sdk/src/evm/core/classes/contract-owner.ts
@@ -1,3 +1,4 @@
+import type { Ownable } from "@thirdweb-dev/contracts-js";
 import { resolveAddress } from "../../common/ens/resolveAddress";
 import { buildTransactionFunction } from "../../common/transactions";
 import { FEATURE_OWNER } from "../../constants/thirdweb-features";
@@ -5,7 +6,6 @@ import { AddressOrEns } from "../../schema/shared/AddressOrEnsSchema";
 import { DetectableFeature } from "../interfaces/DetectableFeature";
 import { ContractWrapper } from "./contract-wrapper";
 import { Transaction } from "./transactions";
-import type { Ownable } from "@thirdweb-dev/contracts-js";
 
 /**
  * Encodes and decodes Contract functions

--- a/packages/sdk/src/evm/core/classes/contract-sales.ts
+++ b/packages/sdk/src/evm/core/classes/contract-sales.ts
@@ -38,7 +38,11 @@ export class ContractPrimarySale<TContract extends IPrimarySale>
    * @twfeature PrimarySale
    */
   public async getRecipient(): Promise<Address> {
-    return await this.contractWrapper.call("", []);
+    const result = await this.contractWrapper.read<
+      IPrimarySale,
+      "primarySaleRecipient"
+    >("primarySaleRecipient", []);
+    return result;
   }
 
   /**

--- a/packages/sdk/src/evm/core/classes/contract-sales.ts
+++ b/packages/sdk/src/evm/core/classes/contract-sales.ts
@@ -17,13 +17,11 @@ import { Transaction } from "./transactions";
  * ```
  * @public
  */
-export class ContractPrimarySale<TContract extends IPrimarySale>
-  implements DetectableFeature
-{
+export class ContractPrimarySale implements DetectableFeature {
   featureName = FEATURE_PRIMARY_SALE.name;
   private contractWrapper;
 
-  constructor(contractWrapper: ContractWrapper<TContract>) {
+  constructor(contractWrapper: ContractWrapper<IPrimarySale>) {
     this.contractWrapper = contractWrapper;
   }
 
@@ -38,10 +36,7 @@ export class ContractPrimarySale<TContract extends IPrimarySale>
    * @twfeature PrimarySale
    */
   public async getRecipient(): Promise<Address> {
-    const result = await this.contractWrapper.read<
-      IPrimarySale,
-      "primarySaleRecipient"
-    >("primarySaleRecipient", []);
+    const result = await this.contractWrapper.read("primarySaleRecipient", []);
     return result;
   }
 
@@ -58,7 +53,7 @@ export class ContractPrimarySale<TContract extends IPrimarySale>
   setRecipient = /* @__PURE__ */ buildTransactionFunction(
     async (recipient: string): Promise<Transaction> => {
       return Transaction.fromContractWrapper({
-        contractWrapper: this.contractWrapper as ContractWrapper<IPrimarySale>,
+        contractWrapper: this.contractWrapper,
         method: "setPrimarySaleRecipient",
         args: [recipient],
       });

--- a/packages/sdk/src/evm/core/classes/contract-sales.ts
+++ b/packages/sdk/src/evm/core/classes/contract-sales.ts
@@ -1,10 +1,10 @@
+import type { IPrimarySale } from "@thirdweb-dev/contracts-js";
 import { buildTransactionFunction } from "../../common/transactions";
 import { FEATURE_PRIMARY_SALE } from "../../constants/thirdweb-features";
 import { Address } from "../../schema/shared/Address";
 import { DetectableFeature } from "../interfaces/DetectableFeature";
 import { ContractWrapper } from "./contract-wrapper";
 import { Transaction } from "./transactions";
-import type { IPrimarySale } from "@thirdweb-dev/contracts-js";
 
 /**
  * Handle primary sales recipients
@@ -38,7 +38,7 @@ export class ContractPrimarySale<TContract extends IPrimarySale>
    * @twfeature PrimarySale
    */
   public async getRecipient(): Promise<Address> {
-    return await this.contractWrapper.readContract.primarySaleRecipient();
+    return await this.contractWrapper.call("", []);
   }
 
   /**

--- a/packages/sdk/src/evm/core/classes/contract-wrapper.ts
+++ b/packages/sdk/src/evm/core/classes/contract-wrapper.ts
@@ -324,7 +324,7 @@ export class ContractWrapper<
 
     if (!functions.length) {
       throw new Error(
-        `Function ${functionName} not found in contract. Check your dashboard for the list of functions available`,
+        `Function "${functionName}" not found in contract. Check your dashboard for the list of functions available`,
       );
     }
     const fn = functions.find(

--- a/packages/sdk/src/evm/core/classes/contract-wrapper.ts
+++ b/packages/sdk/src/evm/core/classes/contract-wrapper.ts
@@ -287,7 +287,11 @@ export class ContractWrapper<
   >(
     functionName: FnName,
     args: Param,
-  ): Promise<ReturnType<TContract["functions"][FnName]>> {
+  ): Promise<
+    Awaited<ReturnType<TContract["functions"][FnName]>> extends { length: 1 }
+      ? Awaited<ReturnType<TContract["functions"][FnName]>>[0]
+      : Awaited<ReturnType<TContract["functions"][FnName]>>
+  > {
     const fn = await this.readContract.functions[functionName as string];
     if (!fn) {
       throw new Error(
@@ -295,6 +299,9 @@ export class ContractWrapper<
       );
     }
     const result = await fn(...args);
+    if (Array.isArray(result) && result.length === 1) {
+      return result[0];
+    }
     return result;
   }
 

--- a/packages/sdk/src/evm/core/classes/contract-wrapper.ts
+++ b/packages/sdk/src/evm/core/classes/contract-wrapper.ts
@@ -288,7 +288,14 @@ export class ContractWrapper<
     functionName: FnName,
     args: Param,
   ): Promise<ReturnType<TContract["functions"][FnName]>> {
-    return this.readContract.functions[functionName as string]?.(...args);
+    const fn = await this.readContract.functions[functionName as string];
+    if (!fn) {
+      throw new Error(
+        `Function ${functionName.toString()} not found in contract. Check your dashboard for the list of functions available`,
+      );
+    }
+    const result = await fn(...args);
+    return result;
   }
 
   /**
@@ -310,7 +317,7 @@ export class ContractWrapper<
 
     if (!functions.length) {
       throw new Error(
-        `Function ${functionName.toString()} not found in contract. Check your dashboard for the list of functions available`,
+        `Function ${functionName} not found in contract. Check your dashboard for the list of functions available`,
       );
     }
     const fn = functions.find(
@@ -320,17 +327,11 @@ export class ContractWrapper<
     // TODO extract this and re-use for deploy function to check constructor args
     if (!fn) {
       throw new Error(
-        `Function "${functionName.toString()}" requires ${
-          functions[0].inputs.length
-        } arguments, but ${
-          args.length
-        } were provided.\nExpected function signature: ${
-          functions[0].signature
-        }`,
+        `Function "${functionName}" requires ${functions[0].inputs.length} arguments, but ${args.length} were provided.\nExpected function signature: ${functions[0].signature}`,
       );
     }
 
-    const ethersFnName = `${functionName.toString()}(${fn.inputs
+    const ethersFnName = `${functionName}(${fn.inputs
       .map((i) => i.type)
       .join()})`;
 

--- a/packages/sdk/src/evm/integrations/thirdweb-checkout.ts
+++ b/packages/sdk/src/evm/integrations/thirdweb-checkout.ts
@@ -1,8 +1,8 @@
+import { SignatureDrop } from "@thirdweb-dev/contracts-js/dist/declarations/src/SignatureDrop";
 import { ChainId } from "../constants/chains/ChainId";
 import { ContractWrapper } from "../core/classes/contract-wrapper";
 import { SignedPayload721WithQuantitySignature } from "../schema/contracts/common/signature";
 import { PrebuiltEditionDrop, PrebuiltNFTDrop } from "../types/eips";
-import { SignatureDrop } from "@thirdweb-dev/contracts-js/dist/declarations/src/SignatureDrop";
 // import fetch from "cross-fetch";
 import invariant from "tiny-invariant";
 
@@ -213,7 +213,7 @@ export class PaperCheckout<
 
   private async getCheckoutId(): Promise<string> {
     return fetchRegisteredCheckoutId(
-      this.contractWrapper.readContract.address,
+      this.contractWrapper.address,
       await this.contractWrapper.getChainID(),
     );
   }


### PR DESCRIPTION
## Problem solved

This PR introduces a basic pattern for centralizing contract reads within the SDK itself.

## Changes made

- [ ] Public API changes: `NONE`
- [ ] Internal API changes: Instead of calling `this.contractWrapper.readContract.fnName()`, we now call `this.contractWrapper.read("fnName", []);`

## How to test

- [ ] Automated tests: To be updated

##  Discussion

- Have a `call` function that already exists today. Is this something that we want to use?  (not typesafe auto completion though 😢 )
    - Not used anywhere. Seems to be exposed as an external API through the pre-built contracts.

## Notes

- We don't need things to be too clean. will be swapped out with viem items in a bit
- Typescript limitation means we have something like [contract-sales.ts](https://github.com/thirdweb-dev/js/pull/1520/files#diff-e9e0cc9e7ffcc3798766eeba7b78fa939dd0c53692ca0bcfd655d4dc043b318eR41) for generic `ContracttWrapper` (we cannot have partial inferred optional types. I might update the types as I centralize more of the reads, but I think this should tide us over for now till Viem in which case we probbaly have to write our own etherChain adapter or swap to abiType anyways.


