### PR TITLE
[RN] Use regular import for coinbase connector

### DIFF
--- a/.changeset/fifty-radios-grin.md
+++ b/.changeset/fifty-radios-grin.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/react-native": patch
+---
+
+Use regular import for coinbase connector in React Native

--- a/packages/react-native/src/evm/wallets/wallets/coinbase-wallet.ts
+++ b/packages/react-native/src/evm/wallets/wallets/coinbase-wallet.ts
@@ -1,8 +1,9 @@
 import { noopStorage } from "../../../core/AsyncStorage";
 import type {
-  CoinbaseWalletConnector,
+  CoinbaseWalletConnector as CoinbaseWalletConnectorType,
   CoinbaseWalletConnectorOptions,
 } from "../connectors/coinbase-wallet";
+import { CoinbaseWalletConnector } from "../connectors/coinbase-wallet";
 import {
   AbstractClientWallet,
   Connector,
@@ -28,8 +29,8 @@ export class CoinbaseWallet extends AbstractClientWallet<CoinbaseWalletConnector
   };
 
   connector?: Connector;
-  coinbaseConnector?: CoinbaseWalletConnector;
-  provider?: CoinbaseWalletConnector["provider"];
+  coinbaseConnector?: CoinbaseWalletConnectorType;
+  provider?: CoinbaseWalletConnectorType["provider"];
 
   static id = walletIds.coinbase;
   public get walletName() {
@@ -50,11 +51,6 @@ export class CoinbaseWallet extends AbstractClientWallet<CoinbaseWalletConnector
 
   protected async getConnector(): Promise<Connector> {
     if (!this.connector) {
-      // import the connector dynamically
-      const { CoinbaseWalletConnector: CoinbaseWalletConnector } = await import(
-        "../connectors/coinbase-wallet"
-      );
-
       const cbConnector = new CoinbaseWalletConnector({
         chains: this.chains,
         options: {


### PR DESCRIPTION
## Problem solved

Some users where facing issues with their metro configurations and how we dynamically imported the coinbase connector. Since this didn't have any real utility for us since we already statically import the connector file, I'm making this a regular import.

## Changes made

- [ ] Public API changes: list the public API changes made if any
- [ ] Internal API changes: explain the internal logic changes

## How to test

- [ ] Automated tests: link to unit test file
- [x] Manual tests: step by step instructions on how to test
Will give them a test package to verify the issue is resolved
