### PR TITLE
[sdk] Use default import for EventEmitter

### DIFF
--- a/.changeset/lazy-cougars-explode.md
+++ b/.changeset/lazy-cougars-explode.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/sdk": patch
+---
+
+Use default export for EventEmitter to fix issue with Nuxt/Vite

--- a/.changeset/lazy-cougars-explode.md
+++ b/.changeset/lazy-cougars-explode.md
@@ -2,4 +2,4 @@
 "@thirdweb-dev/sdk": patch
 ---
 
-Use default export for EventEmitter to fix issue with Nuxt/Vite
+Use default export for EventEmitter to fix issue with Nuxt/Vite + Yarn to fix the "Named export 'EventEmitter' not found" error

--- a/packages/sdk/.eslintrc.cjs
+++ b/packages/sdk/.eslintrc.cjs
@@ -14,6 +14,12 @@ module.exports = {
             message:
               "Do not import entire ethers object, Use named imports instead.",
           },
+          {
+            name: "eventemitter3",
+            importNames: ["EventEmitter"],
+            message:
+              "Do not use named import for importing EventEmitter, Use default import instead.",
+          },
         ],
       },
     ],

--- a/packages/sdk/src/evm/core/classes/contract-events.ts
+++ b/packages/sdk/src/evm/core/classes/contract-events.ts
@@ -2,7 +2,7 @@ import { EventType } from "../../constants/events";
 import type { ContractEvent, EventQueryOptions } from "../../types/events";
 import { ContractWrapper } from "./contract-wrapper";
 import type { BaseContract, Event, providers, utils } from "ethers";
-import type { EventEmitter } from "eventemitter3";
+import type EventEmitter from "eventemitter3";
 
 /**
  * Listen to Contract events in real time

--- a/packages/sdk/src/evm/core/classes/factory.ts
+++ b/packages/sdk/src/evm/core/classes/factory.ts
@@ -38,7 +38,7 @@ import {
   type ContractInterface,
   utils,
 } from "ethers";
-import { EventEmitter } from "eventemitter3";
+import EventEmitter from "eventemitter3";
 import invariant from "tiny-invariant";
 import { z } from "zod";
 import { getApprovedImplementation } from "../../constants/addresses/getApprovedImplementation";

--- a/packages/sdk/src/evm/core/sdk.ts
+++ b/packages/sdk/src/evm/core/sdk.ts
@@ -103,7 +103,7 @@ import {
   utils,
   ContractFactory as ethersContractFactory,
 } from "ethers";
-import { EventEmitter } from "eventemitter3";
+import EventEmitter from "eventemitter3";
 import invariant from "tiny-invariant";
 import { z } from "zod";
 import {

--- a/packages/wallets/.eslintrc.cjs
+++ b/packages/wallets/.eslintrc.cjs
@@ -4,5 +4,18 @@ module.exports = {
   plugins: ["better-tree-shaking"],
   rules: {
     "better-tree-shaking/no-top-level-side-effects": "error",
+    "no-restricted-imports": [
+      "error",
+      {
+        paths: [
+          {
+            name: "eventemitter3",
+            importNames: ["EventEmitter"],
+            message:
+              "Do not use named import for importing EventEmitter, Use default import instead.",
+          },
+        ],
+      },
+    ],
   },
 };


### PR DESCRIPTION
Fixes #1535 - Named export 'EventEmitter' not found in Nuxt/Vite with yarn 