### PR TITLE
[Storage] Up default download timeout to 60s, expose option to override it

### DIFF
--- a/.changeset/cuddly-peas-appear.md
+++ b/.changeset/cuddly-peas-appear.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/storage": patch
+---
+
+[Storage] Up default download timeout to 60s + expose option to override

--- a/packages/storage/src/core/downloaders/storage-downloader.ts
+++ b/packages/storage/src/core/downloaders/storage-downloader.ts
@@ -29,15 +29,18 @@ import pkg from "../../../package.json";
  * @public
  */
 export class StorageDownloader implements IStorageDownloader {
-  DEFAULT_TIMEOUT_IN_SECONDS = 30;
+  DEFAULT_TIMEOUT_IN_SECONDS = 60;
   DEFAULT_MAX_RETRIES = 3;
 
   private secretKey?: string;
   private clientId?: string;
+  private defaultTimeout: number;
 
   constructor(options: IpfsDownloaderOptions) {
     this.secretKey = options.secretKey;
     this.clientId = options.clientId;
+    this.defaultTimeout =
+      options.timeoutInSeconds || this.DEFAULT_TIMEOUT_IN_SECONDS;
   }
 
   async download(
@@ -104,8 +107,10 @@ export class StorageDownloader implements IStorageDownloader {
       ) {
         headers = {
           ...headers,
-          authorization: `Bearer ${(globalThis as any).TW_AUTH_TOKEN as string}`,
-          "x-authorize-wallet": 'true',
+          authorization: `Bearer ${
+            (globalThis as any).TW_AUTH_TOKEN as string
+          }`,
+          "x-authorize-wallet": "true",
         };
       }
 
@@ -124,8 +129,7 @@ export class StorageDownloader implements IStorageDownloader {
     }
 
     const controller = new AbortController();
-    const timeoutInSeconds =
-      options?.timeoutInSeconds || this.DEFAULT_TIMEOUT_IN_SECONDS;
+    const timeoutInSeconds = options?.timeoutInSeconds || this.defaultTimeout;
     const timeout = setTimeout(
       () => controller.abort(),
       timeoutInSeconds * 1000,

--- a/packages/storage/src/types/download.ts
+++ b/packages/storage/src/types/download.ts
@@ -31,6 +31,10 @@ export type IpfsDownloaderOptions = {
    * You can get a clientId here: https://thirdweb.com/create-api-key
    */
   clientId?: string;
+  /**
+   * Optional timeout in seconds for the download request, overrides the default timeout
+   */
+  timeoutInSeconds?: number;
 };
 
 export type SingleDownloadOptions = {


### PR DESCRIPTION
## Problem solved

Timeouts of 30s was getting hit in some legit cases, but global option to override wasn't exposed

## Changes made

- [ ] Public API changes: add `timeoutInSeconds` back to `StorageDownloader`
- [ ] Internal API changes: up the default timeout to 60s

## How to test

- [ ] Automated tests
- [ ] Manual tests: script test
