### PR TITLE
[SDK] Dynamic gas fee estimation

### DIFF
--- a/.changeset/tidy-hairs-drive.md
+++ b/.changeset/tidy-hairs-drive.md
@@ -1,0 +1,6 @@
+---
+"@thirdweb-dev/wallets": patch
+"@thirdweb-dev/sdk": patch
+---
+
+Dynamic gas fee estimations

--- a/packages/sdk/src/evm/constants/chains/supportedChains.ts
+++ b/packages/sdk/src/evm/constants/chains/supportedChains.ts
@@ -30,12 +30,3 @@ export function setSupportedChains(chains: ChainInfo[] | undefined) {
 export function getSupportedChains() {
   return supportedChains;
 }
-
-export const OP_STACK_CHAINS = [
-  Optimism,
-  Base,
-  Zora,
-  OptimismGoerli,
-  BaseGoerli,
-  ZoraTestnet,
-];

--- a/packages/sdk/src/evm/constants/chains/supportedChains.ts
+++ b/packages/sdk/src/evm/constants/chains/supportedChains.ts
@@ -1,13 +1,5 @@
 import type { ChainInfo } from "../../schema/shared/ChainInfo";
-import {
-  Base,
-  BaseGoerli,
-  Optimism,
-  OptimismGoerli,
-  Zora,
-  ZoraTestnet,
-  defaultChains,
-} from "@thirdweb-dev/chains";
+import { defaultChains } from "@thirdweb-dev/chains";
 
 // @ts-expect-error - readonly vs not
 let supportedChains: ChainInfo[] = defaultChains;

--- a/packages/sdk/src/evm/core/classes/contract-wrapper.ts
+++ b/packages/sdk/src/evm/core/classes/contract-wrapper.ts
@@ -27,14 +27,12 @@ import {
   ForwardRequest,
   getAndIncrementNonce,
 } from "../../common/forwarder";
-import { getPolygonGasPriorityFee } from "../../common/gas-price";
+import { getDefaultGasOverrides } from "../../common/gas-price";
 import { fetchContractMetadataFromAddress } from "../../common/metadata-resolver";
 import { signEIP2612Permit } from "../../common/permit";
 import { signTypedDataInternal } from "../../common/sign";
-import { isBrowser } from "../../common/utils";
 import { CONTRACT_ADDRESSES } from "../../constants/addresses/CONTRACT_ADDRESSES";
 import { getContractAddressByChainId } from "../../constants/addresses/getContractAddressByChainId";
-import { ChainId } from "../../constants/chains/ChainId";
 import { EventType } from "../../constants/events";
 import { AbiSchema, ContractSource } from "../../schema/contracts/custom";
 import { SDKOptions } from "../../schema/sdk-options";
@@ -47,7 +45,6 @@ import {
   PermitRequestMessage,
 } from "../types";
 import { RPCConnectionHandler } from "./rpc-connection-handler";
-import { OP_STACK_CHAINS } from "../../constants";
 
 /**
  * @internal
@@ -134,88 +131,7 @@ export class ContractWrapper<
    * @internal
    */
   public async getCallOverrides(): Promise<CallOverrides> {
-    if (isBrowser()) {
-      // When running in the browser, let the wallet suggest gas estimates
-      // this means that the gas speed preferences set in the SDK options are ignored in a browser context
-      // but it also allows users to select their own gas speed prefs per tx from their wallet directly
-      return {};
-    }
-    const feeData = await this.getProvider().getFeeData();
-    const supports1559 = feeData.maxFeePerGas && feeData.maxPriorityFeePerGas;
-    if (supports1559) {
-      const chainId = await this.getChainID();
-      const block = await this.getProvider().getBlock("latest");
-      const baseBlockFee =
-        block && block.baseFeePerGas
-          ? block.baseFeePerGas
-          : utils.parseUnits("1", "gwei");
-      let defaultPriorityFee: BigNumber;
-      const opStackChainIds: number[] = OP_STACK_CHAINS.map((c) => c.chainId);
-      if (opStackChainIds.includes(chainId)) {
-        // for op stack chains lower the default fee
-        defaultPriorityFee = BigNumber.from(1000000); // 0.001 gwei
-      } else if (chainId === ChainId.Mumbai || chainId === ChainId.Polygon) {
-        // for polygon, get fee data from gas station
-        defaultPriorityFee = await getPolygonGasPriorityFee(chainId);
-      } else {
-        // otherwise get it from ethers
-        defaultPriorityFee = BigNumber.from(feeData.maxPriorityFeePerGas);
-      }
-      // then add additional fee based on user preferences
-      const maxPriorityFeePerGas =
-        this.getPreferredPriorityFee(defaultPriorityFee);
-      // See: https://eips.ethereum.org/EIPS/eip-1559 for formula
-      const baseMaxFeePerGas = baseBlockFee.mul(2);
-      const maxFeePerGas = baseMaxFeePerGas.add(maxPriorityFeePerGas);
-      return {
-        maxFeePerGas,
-        maxPriorityFeePerGas,
-      };
-    } else {
-      return {
-        gasPrice: await this.getPreferredGasPrice(),
-      };
-    }
-  }
-
-  /**
-   * Calculates the priority fee per gas according to user preferences
-   * @param defaultPriorityFeePerGas - the base priority fee
-   */
-  private getPreferredPriorityFee(
-    defaultPriorityFeePerGas: BigNumber,
-  ): BigNumber {
-    const extraTip = defaultPriorityFeePerGas.div(100).mul(10); // + 10%
-    const txGasPrice = defaultPriorityFeePerGas.add(extraTip);
-    return txGasPrice;
-  }
-
-  /**
-   * Calculates the gas price for transactions according to user preferences
-   */
-  public async getPreferredGasPrice(): Promise<BigNumber> {
-    const gasPrice = await this.getProvider().getGasPrice();
-    const speed = this.options.gasSettings.speed;
-    const maxGasPrice = this.options.gasSettings.maxPriceInGwei;
-    let txGasPrice = gasPrice;
-    let extraTip;
-    switch (speed) {
-      case "standard":
-        extraTip = BigNumber.from(1); // min 1 wei
-        break;
-      case "fast":
-        extraTip = gasPrice.div(100).mul(5); // + 5%
-        break;
-      case "fastest":
-        extraTip = gasPrice.div(100).mul(10); // + 10%
-        break;
-    }
-    txGasPrice = txGasPrice.add(extraTip);
-    const max = utils.parseUnits(maxGasPrice.toString(), "gwei");
-    if (txGasPrice.gt(max)) {
-      txGasPrice = max;
-    }
-    return txGasPrice;
+    return getDefaultGasOverrides(this.getProvider());
   }
 
   /**

--- a/packages/sdk/src/evm/core/classes/gas-cost-estimator.ts
+++ b/packages/sdk/src/evm/core/classes/gas-cost-estimator.ts
@@ -1,4 +1,3 @@
-import { getGasPrice } from "../../common";
 import { ContractWrapper } from "./contract-wrapper";
 import { BaseContract, BigNumber, utils } from "ethers";
 
@@ -36,7 +35,7 @@ export class GasCostEstimator<TContract extends BaseContract> {
     fn: keyof TContract["functions"] | (string & {}),
     args: Parameters<TContract["functions"][typeof fn]> | any[],
   ): Promise<string> {
-    const price = await getGasPrice(this.contractWrapper.getProvider());
+    const price = await this.contractWrapper.getProvider().getGasPrice();
     const gasUnits = await this.contractWrapper.estimateGas(fn, args);
     return utils.formatEther(gasUnits.mul(price));
   }

--- a/packages/sdk/src/evm/core/classes/gas-cost-estimator.ts
+++ b/packages/sdk/src/evm/core/classes/gas-cost-estimator.ts
@@ -1,3 +1,4 @@
+import { getGasPrice } from "../../common";
 import { ContractWrapper } from "./contract-wrapper";
 import { BaseContract, BigNumber, utils } from "ethers";
 
@@ -35,7 +36,7 @@ export class GasCostEstimator<TContract extends BaseContract> {
     fn: keyof TContract["functions"] | (string & {}),
     args: Parameters<TContract["functions"][typeof fn]> | any[],
   ): Promise<string> {
-    const price = await this.contractWrapper.getPreferredGasPrice();
+    const price = await getGasPrice(this.contractWrapper.getProvider());
     const gasUnits = await this.contractWrapper.estimateGas(fn, args);
     return utils.formatEther(gasUnits.mul(price));
   }

--- a/packages/sdk/src/evm/core/classes/transactions.ts
+++ b/packages/sdk/src/evm/core/classes/transactions.ts
@@ -1,10 +1,8 @@
 import { TransactionError, parseRevertReason } from "../../common/error";
-import { getPolygonGasPriorityFee } from "../../common/gas-price";
+import { getDefaultGasOverrides, getGasPrice } from "../../common/gas-price";
 import { fetchContractMetadataFromAddress } from "../../common/metadata-resolver";
 import { fetchSourceFilesFromMetadata } from "../../common/fetchSourceFilesFromMetadata";
 import { isRouterContract } from "../../common/plugin/isRouterContract";
-import { isBrowser } from "../../common/utils";
-import { ChainId } from "../../constants/chains/ChainId";
 import { ContractSource } from "../../schema/contracts/custom";
 import { SDKOptionsOutput } from "../../schema/sdk-options";
 import type {
@@ -48,7 +46,6 @@ import fetch from "cross-fetch";
 import { BytesLike } from "ethers";
 import { CONTRACT_ADDRESSES } from "../../constants/addresses/CONTRACT_ADDRESSES";
 import { getContractAddressByChainId } from "../../constants/addresses/getContractAddressByChainId";
-import { OP_STACK_CHAINS } from "../../constants/chains/supportedChains";
 
 abstract class TransactionContext {
   protected args: any[];
@@ -206,16 +203,7 @@ abstract class TransactionContext {
    * Calculates the gas price for transactions (adding a 10% tip buffer)
    */
   public async getGasPrice(): Promise<BigNumber> {
-    const gasPrice = await this.provider.getGasPrice();
-    const maxGasPrice = utils.parseUnits("300", "gwei"); // 300 gwei
-    const extraTip = gasPrice.div(100).mul(10); // + 10%
-    const txGasPrice = gasPrice.add(extraTip);
-
-    if (txGasPrice.gt(maxGasPrice)) {
-      return maxGasPrice;
-    }
-
-    return txGasPrice;
+    return getGasPrice(this.provider);
   }
 
   /**
@@ -229,47 +217,7 @@ abstract class TransactionContext {
    * Get gas overrides for the transaction
    */
   protected async getGasOverrides() {
-    // If we're running in the browser, let users configure gas price in their wallet UI
-    if (isBrowser()) {
-      return {};
-    }
-
-    const feeData = await this.provider.getFeeData();
-    const supports1559 = feeData.maxFeePerGas && feeData.maxPriorityFeePerGas;
-    if (supports1559) {
-      const chainId = (await this.provider.getNetwork()).chainId;
-      const block = await this.provider.getBlock("latest");
-      const baseBlockFee =
-        block && block.baseFeePerGas
-          ? block.baseFeePerGas
-          : utils.parseUnits("1", "gwei");
-      let defaultPriorityFee: BigNumber;
-      const opStackChainIds: number[] = OP_STACK_CHAINS.map((c) => c.chainId);
-      if (opStackChainIds.includes(chainId)) {
-        // for op stack chains lower the default fee
-        defaultPriorityFee = BigNumber.from(1000000); // 0.001 gwei
-      } else if (chainId === ChainId.Mumbai || chainId === ChainId.Polygon) {
-        // for polygon, get fee data from gas station
-        defaultPriorityFee = await getPolygonGasPriorityFee(chainId);
-      } else {
-        // otherwise get it from ethers
-        defaultPriorityFee = BigNumber.from(feeData.maxPriorityFeePerGas);
-      }
-      // then add additional fee based on user preferences
-      const maxPriorityFeePerGas =
-        this.getPreferredPriorityFee(defaultPriorityFee);
-      // See: https://eips.ethereum.org/EIPS/eip-1559 for formula
-      const baseMaxFeePerGas = baseBlockFee.mul(2);
-      const maxFeePerGas = baseMaxFeePerGas.add(maxPriorityFeePerGas);
-      return {
-        maxFeePerGas,
-        maxPriorityFeePerGas,
-      };
-    } else {
-      return {
-        gasPrice: await this.getGasPrice(),
-      };
-    }
+    return getDefaultGasOverrides(this.provider);
   }
 
   /**


### PR DESCRIPTION
## Problem solved

We were relying on hardcoded gas fees for most chains, this PR introduces a centralized method to compute gas fees and prioritizes `eth_maxPriorityFeePerGas` from the RPC directly to estimate fees accurately.

## Changes made

- [ ] Public API changes: none
- [ ] Internal API changes: internal changes to transaction fee calculation in SDK and bundler

## How to test

- [ ] Automated tests: none
- [ ] Manual tests: tested via scripts on multiple chains
