### PR TITLE
[RN/React] Remove signer as a prop

### DIFF
--- a/packages/react-native/src/evm/providers/thirdweb-provider.tsx
+++ b/packages/react-native/src/evm/providers/thirdweb-provider.tsx
@@ -20,7 +20,7 @@ import { ThirdwebStorage } from "../../core/storage/storage";
 interface ThirdwebProviderProps<TChains extends Chain[]>
   extends Omit<
     ThirdwebProviderCoreProps<TChains>,
-    "supportedWallets" | "secretKey"
+    "supportedWallets" | "secretKey" | "signer"
   > {
   /**
    * Wallets that will be supported by the dApp

--- a/packages/react/src/evm/providers/thirdweb-provider.tsx
+++ b/packages/react/src/evm/providers/thirdweb-provider.tsx
@@ -14,7 +14,7 @@ import { defaultWallets } from "../../wallet/wallets/defaultWallets";
 interface ThirdwebProviderProps<TChains extends Chain[]>
   extends Omit<
     ThirdwebProviderCoreProps<TChains>,
-    "createWalletStorage" | "supportedWallets"
+    "createWalletStorage" | "supportedWallets" | "signer"
   > {
   /**
    * Wallets supported by the dApp


### PR DESCRIPTION
## Problem solved

The idea of the React/RN `ThirdwebProvider` is to provider support for wallets. If devs want to pass their own signer they can directly use `ThirdwebSDKProvider`

## Changes made

- [x] Public API changes: list the public API changes made if any
Signer is no longer available in ThirdwebProvider (they were not being passed down anyways)
- [ ] Internal API changes: explain the internal logic changes

## How to test

- [ ] Automated tests: link to unit test file
- [x] Manual tests: step by step instructions on how to test
