### PR TITLE
Better UX for expired CLI tokens + Enrich auth errors for better error handling

### DIFF
--- a/.changeset/tasty-months-shake.md
+++ b/.changeset/tasty-months-shake.md
@@ -1,0 +1,6 @@
+---
+"@thirdweb-dev/auth": patch
+"thirdweb": patch
+---
+
+Improve error messages coming from the auth SDK

--- a/packages/auth/src/core/errors.ts
+++ b/packages/auth/src/core/errors.ts
@@ -53,8 +53,10 @@ export function createError<Variables = undefined>(
       this.innerError = innerError;
       this.variables = variables;
 
-      Error.stackTraceLimit !== 0 &&
-      Error.captureStackTrace(this, ThirdwebAuthError);
+      // @ts-ignore
+      if (Error.stackTraceLimit !== 0) {
+        Error.captureStackTrace(this, ThirdwebAuthError)
+      }
     }
   }
 

--- a/packages/auth/src/core/errors.ts
+++ b/packages/auth/src/core/errors.ts
@@ -8,6 +8,10 @@ export interface ThirdwebErrorConstructorArgs<Variables = undefined> {
   variables: Variables;
 }
 
+/**
+ * Replaces all instances of ${key} with the corresponding value in substitutions
+ * Eg: formatString("Hello ${name}", { name: "John" }) => "Hello John"
+ */
 function formatString(
   template: string,
   substitutions: { [key: string]: any }

--- a/packages/auth/src/core/errors.ts
+++ b/packages/auth/src/core/errors.ts
@@ -54,8 +54,9 @@ export function createThirdwebError<Variables = undefined>(
       this.variables = variables;
       this.statusCode = options.statusCode;
 
-      Error.stackTraceLimit !== 0 &&
-      Error.captureStackTrace(this, ThirdwebError);
+      if (Error.stackTraceLimit !== 0) {
+        Error.captureStackTrace(this, ThirdwebError)
+      }
     }
   }
 

--- a/packages/auth/src/core/errors.ts
+++ b/packages/auth/src/core/errors.ts
@@ -4,7 +4,7 @@ export interface ThirdwebErrorConstructorArgs<Variables = undefined> {
   code: string;
   message: string
   name?: string
-  cause?: Error;
+  innerError?: Error;
   variables: Variables;
 }
 
@@ -18,13 +18,13 @@ export function createError<Variables>(options: Omit<ThirdwebErrorConstructorArg
   class ThirdwebAuthError extends Error {
     public code: string;
     public message: string;
-    public cause: Error | null;
+    public innerError: Error | null;
     public variables: any;
 
     constructor(overrideOptions?: Partial<ThirdwebErrorConstructorArgs<Variables>>) {
       const code = overrideOptions?.code ?? options.code;
       const name = overrideOptions?.name ?? 'ThirdwebAuthError';
-      const cause = overrideOptions?.cause ?? null;
+      const innerError = overrideOptions?.innerError ?? null;
       const variables = overrideOptions?.variables ?? {}
 
       const unformattedMessage = overrideOptions?.message ?? options.message;
@@ -35,7 +35,7 @@ export function createError<Variables>(options: Omit<ThirdwebErrorConstructorArg
       this.code = code;
       this.message = message;
       this.name = name;
-      this.cause = cause;
+      this.innerError = innerError;
       this.variables = variables;
 
       Error.stackTraceLimit !== 0 && Error.captureStackTrace(this, ThirdwebAuthError)

--- a/packages/auth/src/core/errors.ts
+++ b/packages/auth/src/core/errors.ts
@@ -1,0 +1,92 @@
+import { format } from 'util';
+
+export interface ThirdwebErrorConstructorArgs<Variables = undefined> {
+  code: string;
+  message: string
+  name?: string
+  cause?: Error;
+  variables: Variables;
+}
+
+function formatString(template: string, substitutions: { [key: string]: any }): string {
+  return template.replace(/\$\{(\w+)\}/g, (_match, p1) => {
+    return substitutions[p1] !== undefined ? substitutions[p1] : _match;
+  });
+}
+
+export function createError<Variables>(options: Omit<ThirdwebErrorConstructorArgs<Variables>, 'variables'>) {
+  class ThirdwebAuthError extends Error {
+    public code: string;
+    public message: string;
+    public cause: Error | null;
+    public variables: any;
+
+    constructor(overrideOptions?: Partial<ThirdwebErrorConstructorArgs<Variables>>) {
+      const code = overrideOptions?.code ?? options.code;
+      const name = overrideOptions?.name ?? 'ThirdwebAuthError';
+      const cause = overrideOptions?.cause ?? null;
+      const variables = overrideOptions?.variables ?? {}
+
+      const unformattedMessage = overrideOptions?.message ?? options.message;
+      const message = formatString(unformattedMessage, variables);
+
+      super(message);
+
+      this.code = code;
+      this.message = message;
+      this.name = name;
+      this.cause = cause;
+      this.variables = variables;
+
+      Error.stackTraceLimit !== 0 && Error.captureStackTrace(this, ThirdwebAuthError)
+    }
+  }
+
+  return ThirdwebAuthError;
+}
+
+export const ThirdwebAuthErrors = {
+  InvalidTokenId: createError({
+    code: 'INVALID_TOKEN_ID',
+    message: 'The token ID is invalid.',
+  }),
+
+  InvalidTokenDomain: createError<{
+    expectedDomain: string;
+    actualDomain: string;
+  }>({
+    code: 'INVALID_TOKEN_DOMAIN',
+    message: "Expected token to be for the domain '${expectedDomain}', but found token with domain '${actualDomain}'.",
+  }),
+
+  InvalidTokenTimeBefore: createError<{
+    notBeforeTime: number;
+    currentTime: number;
+  }>({
+    code: 'INVALID_NOT_BEFORE_TIME',
+    message: "This token is invalid before epoch time '${nbf}', current epoch time is '${currentTime}'.",
+  }),
+
+  ExpiredToken: createError<{
+    expirationTime: number;
+    currentTime: number;
+  }> ({
+    code: 'EXPIRED_TOKEN',
+    message: "This token expired at epoch time '${expirationTime}', current epoch time is '${currentTime}'.",
+  }),
+
+  TokenIssuerMismatch: createError<{
+    expectedIssuer: string;
+    actualIssuer: string;
+  }> ({
+    code: 'TOKEN_ISSUER_MISMATCH',
+    message: "Expected token to be issued by '${expectedIssuer}', but found token issued by '${actualIssuer}'.",
+  }),
+
+  TokenInvalidSignature: createError<{
+    signerAddress: string;
+  }> ({
+    code: 'TOKEN_INVALID_SIGNATURE',
+    message: "The token was signed by '${signerAddress}', but the signature is invalid or missing.",
+  })
+}

--- a/packages/auth/test/evm.test.ts
+++ b/packages/auth/test/evm.test.ts
@@ -271,8 +271,8 @@ describe("Wallet Authentication - EVM", async () => {
       await auth.authenticate(token);
       expect.fail();
     } catch (err: any) {
-      expect(err.message).to.contain(
-        `The expected issuer address '${await signerWallet.getAddress()}' did not match the token issuer address '${await adminWallet.getAddress()}'`,
+      expect(err.code).to.equal(
+        'TOKEN_ISSUER_MISMATCH'
       );
     }
   });
@@ -314,7 +314,7 @@ describe("Wallet Authentication - EVM", async () => {
       });
       expect.fail();
     } catch (err: any) {
-      expect(err.message).to.contain("Token ID is invalid");
+      expect(err.code).to.equal('INVALID_TOKEN_ID');
     }
   });
 
@@ -362,7 +362,7 @@ describe("Wallet Authentication - EVM", async () => {
       await auth.authenticate(token);
       expect.fail();
     } catch (err: any) {
-      expect(err.message).to.contain("The expected issuer address");
+      expect(err.code).to.equal('TOKEN_ISSUER_MISMATCH');
     }
 
     const user = await auth.authenticate(token, {

--- a/packages/auth/test/solana.test.ts
+++ b/packages/auth/test/solana.test.ts
@@ -2,6 +2,7 @@ import { ThirdwebAuth } from "../src/core";
 import { Keypair } from "@solana/web3.js";
 import { KeypairWallet } from "@thirdweb-dev/wallets/solana/wallets/keypair";
 import { expect } from "chai";
+import {ThirdwebAuthError, ThirdwebAuthErrors} from "../src/core/errors";
 
 describe("Wallet Authentication - Solana", async () => {
   let adminWallet: any, signerWallet: any, attackerWallet: any;
@@ -222,9 +223,7 @@ describe("Wallet Authentication - Solana", async () => {
       await auth.authenticate(token, { domain: "test.thirdweb.com" });
       expect.fail();
     } catch (err: any) {
-      expect(err.message).to.contain(
-        "Expected token to be for the domain 'test.thirdweb.com', but found token with domain 'thirdweb.com'",
-      );
+      expect(err.code).to.equal('INVALID_TOKEN_DOMAIN');
     }
   });
 
@@ -271,8 +270,8 @@ describe("Wallet Authentication - Solana", async () => {
       await auth.authenticate(token);
       expect.fail();
     } catch (err: any) {
-      expect(err.message).to.contain(
-        `The expected issuer address '${await signerWallet.getAddress()}' did not match the token issuer address '${await adminWallet.getAddress()}'`,
+      expect(err.code).to.equal(
+        'TOKEN_ISSUER_MISMATCH',
       );
     }
   });
@@ -314,7 +313,7 @@ describe("Wallet Authentication - Solana", async () => {
       });
       expect.fail();
     } catch (err: any) {
-      expect(err.message).to.contain("Token ID is invalid");
+      expect(err.code).to.equal("INVALID_TOKEN_ID");
     }
   });
 

--- a/packages/cli/src/auth/index.ts
+++ b/packages/cli/src/auth/index.ts
@@ -59,17 +59,17 @@ export async function loginUser(
 export async function logoutUser({ credsConfigPath, tokenPath, cliWalletPath }: ConfigPaths, options?: { showLogs?: boolean }) {
   const showLogs = options?.showLogs ?? true;
   try {
-    showLogs && ora("Logging out...").start();
+    if (showLogs) ora("Logging out...").start();
     const dirExists = fs.existsSync(credsConfigPath) && fs.existsSync(tokenPath) && fs.existsSync(cliWalletPath);
     if (!dirExists) {
-      showLogs && ora().warn(chalk.yellow("You are already logged out, did you mean to login?"));
+      if (showLogs) ora().warn(chalk.yellow("You are already logged out, did you mean to login?"));
       return;
     }
     fs.unlinkSync(credsConfigPath);
     fs.unlinkSync(tokenPath);
     // TODO: We can consider not removing this on logout later, once we want to implement teams. For now this wallet will be ephemeral.
     fs.unlinkSync(cliWalletPath);
-    showLogs && ora().succeed(chalk.green("You have been logged out"));
+    if (showLogs) ora().succeed(chalk.green("You have been logged out"));
   } catch (error) {
     console.log(chalk.red("Something went wrong", error));
   }

--- a/packages/cli/src/auth/index.ts
+++ b/packages/cli/src/auth/index.ts
@@ -59,17 +59,23 @@ export async function loginUser(
 export async function logoutUser({ credsConfigPath, tokenPath, cliWalletPath }: ConfigPaths, options?: { showLogs?: boolean }) {
   const showLogs = options?.showLogs ?? true;
   try {
-    if (showLogs) ora("Logging out...").start();
+    if (showLogs) {
+      ora("Logging out...").start();
+    }
     const dirExists = fs.existsSync(credsConfigPath) && fs.existsSync(tokenPath) && fs.existsSync(cliWalletPath);
     if (!dirExists) {
-      if (showLogs) ora().warn(chalk.yellow("You are already logged out, did you mean to login?"));
+      if (showLogs) {
+        ora().warn(chalk.yellow("You are already logged out, did you mean to login?"));
+      }
       return;
     }
     fs.unlinkSync(credsConfigPath);
     fs.unlinkSync(tokenPath);
     // TODO: We can consider not removing this on logout later, once we want to implement teams. For now this wallet will be ephemeral.
     fs.unlinkSync(cliWalletPath);
-    if (showLogs) ora().succeed(chalk.green("You have been logged out"));
+    if (showLogs) {
+      ora().succeed(chalk.green("You have been logged out"));
+    }
   } catch (error) {
     console.log(chalk.red("Something went wrong", error));
   }

--- a/packages/cli/src/auth/index.ts
+++ b/packages/cli/src/auth/index.ts
@@ -56,22 +56,28 @@ export async function loginUser(
   }
 }
 
-export async function logoutUser(credsConfigPath: string, tokenPath: string, cliWalletPath: string) {
+export async function logoutUser({ credsConfigPath, tokenPath, cliWalletPath }: ConfigPaths, options?: { showLogs?: boolean }) {
+  const showLogs = options?.showLogs ?? true;
   try {
-    ora("Logging out...").start();
+    showLogs && ora("Logging out...").start();
     const dirExists = fs.existsSync(credsConfigPath) && fs.existsSync(tokenPath) && fs.existsSync(cliWalletPath);
     if (!dirExists) {
-      ora().warn(chalk.yellow("You are already logged out, did you mean to login?"));
+      showLogs && ora().warn(chalk.yellow("You are already logged out, did you mean to login?"));
       return;
     }
     fs.unlinkSync(credsConfigPath);
     fs.unlinkSync(tokenPath);
     // TODO: We can consider not removing this on logout later, once we want to implement teams. For now this wallet will be ephemeral.
     fs.unlinkSync(cliWalletPath);
-    ora().succeed(chalk.green("You have been logged out"));
+    showLogs && ora().succeed(chalk.green("You have been logged out"));
   } catch (error) {
     console.log(chalk.red("Something went wrong", error));
   }
+}
+
+export async function requireLogin(configPaths: ConfigPaths) {
+  await logoutUser(configPaths, { showLogs: false });
+  ora().info(chalk.yellow("You probably need to log in again. Run `npx thirdweb@latest login`"));
 }
 
 export async function getSession(tokenPath: string, configCredsPath: string) {


### PR DESCRIPTION
## Problem solved

### CLI authentication error UX
- This PR improves CLI: when the local wallet's token has expired, CLI will now re-ask the user to authenticate

### Standard Thirdweb error object
- Additionally, this PR sets us up for a standard error object throughout the thirdweb SDK
- Services like CLI do not have a granular understanding of why there are failures in auth flows
- This PR standardizes a format for errors

The big problem with JS errors is the lack of `code`, which would allow for duck typing on errors (and improving application behavior based on specific error codes.

This introduces `ThirdwebAuthError`. When the auth SDK throws an error, you'll get an error object with new properties:
- `code`: A hardcoded string that can be used for duck typing by upstream code
- `message`: Another hardcoded string, but unlike the regular `message` supplied by `Error`, you can use substitutions like `This error happened because of ${x}` and set the value of that
- `innerError`: This is a property that can be used to store an error that was encountered while throwing this one

## Changes made

- [ ] Public API changes: list the public API changes made if any
- [x] Internal API changes: explain the internal logic changes

## How to test

- [ ] Intentionally send an expired token from CLI (turn back the system clock). Notice CLI now has exposure to error codes and formatted messages
