### PR TITLE
Handle default gas values for raw transactions, expose from property for 1155 airdrops

### DIFF
--- a/.changeset/afraid-moons-travel.md
+++ b/.changeset/afraid-moons-travel.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/sdk": patch
+---
+
+Handle default gas values for `sdk.wallet.sendRawTransaction()`, expose `sdk.wallet.executeRawTransasction()` and expose `fromAddress` in `contract.erc1155.airdrop()`

--- a/packages/sdk/src/evm/common/gas-price.ts
+++ b/packages/sdk/src/evm/common/gas-price.ts
@@ -55,10 +55,6 @@ export async function getDynamicFeeData(
   if (chainId === Mumbai.chainId || chainId === Polygon.chainId) {
     // for polygon, get fee data from gas station
     maxPriorityFeePerGas = await getPolygonGasPriorityFee(chainId);
-    console.log(
-      "DYNAMIC: polygon fee",
-      utils.formatUnits(maxPriorityFeePerGas, "gwei"),
-    );
   } else if (eth_maxPriorityFeePerGas) {
     // prioritize fee from eth_maxPriorityFeePerGas
     maxPriorityFeePerGas = BigNumber.from(eth_maxPriorityFeePerGas);

--- a/packages/sdk/src/evm/core/classes/erc-1155-standard.ts
+++ b/packages/sdk/src/evm/core/classes/erc-1155-standard.ts
@@ -195,9 +195,15 @@ export class StandardErc1155<
     async (
       tokenId: BigNumberish,
       addresses: AirdropInput,
+      fromAddress?: AddressOrEns,
       data: BytesLike = [0],
     ) => {
-      return this.erc1155.airdrop.prepare(tokenId, addresses, data);
+      return this.erc1155.airdrop.prepare(
+        tokenId,
+        addresses,
+        fromAddress,
+        data,
+      );
     },
   );
 }

--- a/packages/sdk/src/evm/core/classes/erc-1155.ts
+++ b/packages/sdk/src/evm/core/classes/erc-1155.ts
@@ -353,9 +353,12 @@ export class Erc1155<
     async (
       tokenId: BigNumberish,
       addresses: AirdropInput,
+      fromAddress?: AddressOrEns,
       data: BytesLike = [0],
     ) => {
-      const from = await this.contractWrapper.getSignerAddress();
+      const from = fromAddress
+        ? await resolveAddress(fromAddress)
+        : await this.contractWrapper.getSignerAddress();
 
       const balanceOf = await this.balanceOf(from, tokenId);
 


### PR DESCRIPTION
## Problem solved

`sdk.wallet.sendRawTransaction()` was not handling gas values for networks like Polygon and OP chains.

## Changes made

- [x] Public API changes: sdk.wallet.sendRawTransaction() now only submits the tx. `sdk.wallet.executeRawTransasction()` submits and executes. added `fromAddress` to `contract.erc1155.airdrop()`
- [ ] Internal API changes: none

## How to test

- [ ] Automated tests: link to unit test file
- [ ] Manual tests: step by step instructions on how to test
