### PR TITLE
fix: Typo on setting maxFeePerGas

### DIFF
--- a/.changeset/nine-queens-pay.md
+++ b/.changeset/nine-queens-pay.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/sdk": patch
+---
+
+Fixes maxFeePerGas value set incorrectly

--- a/packages/sdk/src/evm/common/gas-price.ts
+++ b/packages/sdk/src/evm/common/gas-price.ts
@@ -25,7 +25,7 @@ export async function getDefaultGasOverrides(provider: providers.Provider) {
   );
   if (feeData.maxFeePerGas && feeData.maxPriorityFeePerGas) {
     return {
-      maxFeePerGas: feeData.maxPriorityFeePerGas,
+      maxFeePerGas: feeData.maxFeePerGas,
       maxPriorityFeePerGas: feeData.maxPriorityFeePerGas,
     };
   } else {


### PR DESCRIPTION
## Problem solved
`getDefaultGasOverrides()` returning incorrect value.

## Changes made

- [ ] Typo that erroneously set maxFeePerGas to maxPriorityFeePerGas

## How to test

- [ ] Manually fix and confirm it returns values matching other gas stations.