### PR TITLE
chore: add evmMethod to usage traacker body

### DIFF
--- a/packages/service-utils/src/cf-worker/usage.ts
+++ b/packages/service-utils/src/cf-worker/usage.ts
@@ -15,7 +15,7 @@ function getAws(options: ConstructorParameters<typeof AwsClient>[0]) {
  */
 const usageEventSchema = z.object({
   source: z.enum([
-    "wallet",
+    "embeddedWallets",
     "rpc",
     "storage",
     "bundler",
@@ -35,10 +35,11 @@ const usageEventSchema = z.object({
   mimeType: z.string().optional(),
   fileSize: z.number().int().nonnegative().optional(),
   fileCid: z.string().optional(),
-  transactionHash: z.string().optional(),
+  evmMethod: z.string().optional(),
+  userOpHash: z.string().optional(),
   gasLimit: z.number().nonnegative().optional(),
   gasPricePerUnit: z.string().optional(),
-  userOpHash: z.string().optional(),
+  transactionHash: z.string().optional(),
 });
 export type UsageEvent = z.infer<typeof usageEventSchema>;
 


### PR DESCRIPTION
## Problem solved

evmMethod is useful metadata to track for certain services like RPC.
Method arguments are not tracked.
