### PR TITLE
[SDK] [Bug] Always update network if configured in fromSigner

### DIFF
--- a/.changeset/red-years-clean.md
+++ b/.changeset/red-years-clean.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/sdk": patch
+---
+
+fromSigner should respect network if possible

--- a/packages/sdk/src/evm/core/sdk.ts
+++ b/packages/sdk/src/evm/core/sdk.ts
@@ -186,8 +186,12 @@ export class ThirdwebSDK extends RPCConnectionHandler {
   ): ThirdwebSDK {
     let signerWithProvider = signer;
     if (network) {
-      const provider = getChainProvider(network, options);
-      signerWithProvider = signer.connect(provider);
+      try {
+        const provider = getChainProvider(network, options);
+        signerWithProvider = signer.connect(provider);
+      } catch {
+        // We have to catch here because browser wallets throw when trying to override provider
+      }
     }
 
     const sdk = new ThirdwebSDK(

--- a/packages/sdk/src/evm/core/sdk.ts
+++ b/packages/sdk/src/evm/core/sdk.ts
@@ -185,7 +185,7 @@ export class ThirdwebSDK extends RPCConnectionHandler {
     storage?: ThirdwebStorage,
   ): ThirdwebSDK {
     let signerWithProvider = signer;
-    if (network && !signer.provider) {
+    if (network) {
       const provider = getChainProvider(network, options);
       signerWithProvider = signer.connect(provider);
     }


### PR DESCRIPTION
## Problem solved

- If you pass `network` to `ThirdwebSDK.fromSigner` it should always overwrite the network of the SDK and signer.
- Previously, if you pass `network` to `fromSigner`, but the `signer` passed in already has a configured `provider`, we wouldn't overwrite the network.
- Now we properly overwrite the network here.
