### PR TITLE
[SDK] make api match for checking and adding admin

### DIFF
--- a/.changeset/orange-countries-appear.md
+++ b/.changeset/orange-countries-appear.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/sdk": patch
+---
+
+Make API match for adding & removing admins from accounts

--- a/packages/sdk/src/evm/core/classes/account-permissions.ts
+++ b/packages/sdk/src/evm/core/classes/account-permissions.ts
@@ -649,7 +649,7 @@ export class AccountPermissions implements DetectableFeature {
       // Remove all existing admins not included in the passed snapshot.
       const allAdmins = await this.getAllAdmins();
       const allToMakeAdmin = resolvedSnapshot
-        .filter((item) => item.makeAdmin)
+        .filter((item) => item.isAdmin)
         .map((item) => item.signer);
       allAdmins.forEach((admin) => {
         if (!allToMakeAdmin.includes(admin)) {
@@ -666,7 +666,7 @@ export class AccountPermissions implements DetectableFeature {
       const allSigners = await this.getAllSigners();
       const allToMakeSigners = resolvedSnapshot
         .filter((item) => {
-          return !item.makeAdmin;
+          return !item.isAdmin;
         })
         .map((item) => item.signer);
       await Promise.all(
@@ -686,7 +686,7 @@ export class AccountPermissions implements DetectableFeature {
 
       for (const member of resolvedSnapshot) {
         // Add new admin
-        if (member.makeAdmin) {
+        if (member.isAdmin) {
           addAdminData.push(
             this.contractWrapper.writeContract.interface.encodeFunctionData(
               "setAdmin",

--- a/packages/sdk/src/evm/types/account.ts
+++ b/packages/sdk/src/evm/types/account.ts
@@ -31,7 +31,7 @@ export type SignerWithPermissions = {
 export const PermissionSnapshotSchema = /* @__PURE__ */ z.array(
   /* @__PURE__ */ z.object({
     signer: AddressOrEnsSchema,
-    makeAdmin: /* @__PURE__ */ z.boolean(),
+    isAdmin: /* @__PURE__ */ z.boolean(),
     permissions: SignerPermissionsSchema,
   }),
 );

--- a/packages/sdk/test/evm/account.test.ts
+++ b/packages/sdk/test/evm/account.test.ts
@@ -609,7 +609,7 @@ global.fetch = /* @__PURE__ */ require("cross-fetch");
 
       const restrictionsForAdmin = {
         signer: adminWallet.address,
-        makeAdmin: true,
+        isAdmin: true,
         permissions: { approvedCallTargets: [] },
       };
       signersWithRestrictions.push(restrictionsForAdmin);
@@ -617,7 +617,7 @@ global.fetch = /* @__PURE__ */ require("cross-fetch");
       // Adding a new admin: Signer3
       const restrictionsSigner3 = {
         signer: signer3Wallet.address,
-        makeAdmin: true,
+        isAdmin: true,
         permissions: { approvedCallTargets: [] },
       };
       signersWithRestrictions.push(restrictionsSigner3);
@@ -627,7 +627,7 @@ global.fetch = /* @__PURE__ */ require("cross-fetch");
 
       const restrictionsSigner4 = {
         signer: signer4Wallet.address,
-        makeAdmin: false,
+        isAdmin: false,
         permissions: { approvedCallTargets: [] },
       };
       signersWithRestrictions.push(restrictionsSigner4);
@@ -635,7 +635,7 @@ global.fetch = /* @__PURE__ */ require("cross-fetch");
       // Adding a new scoped signer
       const restrictionsSigner5 = {
         signer: signer5Wallet.address,
-        makeAdmin: false,
+        isAdmin: false,
         permissions: { approvedCallTargets: [adminWallet.address] },
       };
       signersWithRestrictions.push(restrictionsSigner5);
@@ -647,7 +647,7 @@ global.fetch = /* @__PURE__ */ require("cross-fetch");
 
       const restrictionsSigner6 = {
         signer: signer6Wallet.address,
-        makeAdmin: false,
+        isAdmin: false,
         permissions: { approvedCallTargets: [] },
       };
       signersWithRestrictions.push(restrictionsSigner6);
@@ -660,7 +660,7 @@ global.fetch = /* @__PURE__ */ require("cross-fetch");
 
       const restrictionsSigner7 = {
         signer: signer7Wallet.address,
-        makeAdmin: false,
+        isAdmin: false,
         permissions: { approvedCallTargets: [signer1Wallet.address] },
       };
       signersWithRestrictions.push(restrictionsSigner7);
@@ -670,7 +670,7 @@ global.fetch = /* @__PURE__ */ require("cross-fetch");
 
       const restrictionsSigner8 = {
         signer: signer8Wallet.address,
-        makeAdmin: false,
+        isAdmin: false,
         permissions: { approvedCallTargets: [adminWallet.address] },
       };
       signersWithRestrictions.push(restrictionsSigner8);
@@ -682,7 +682,7 @@ global.fetch = /* @__PURE__ */ require("cross-fetch");
 
       const restrictionsSigner9 = {
         signer: signer9Wallet.address,
-        makeAdmin: true,
+        isAdmin: true,
         permissions: { approvedCallTargets: [] },
       };
       signersWithRestrictions.push(restrictionsSigner9);


### PR DESCRIPTION
## Problem solved

Updated the API so that the API when reading the signers on an account match the API for setting the signers

## Changes made

- [ ] Public API changes: makeAdmin -> isAdmin for adding, removing & updating signers on accounts

