### PR TITLE
fix: try/catch logHttpRequest

### DIFF
--- a/packages/service-utils/src/cf-worker/index.ts
+++ b/packages/service-utils/src/cf-worker/index.ts
@@ -185,23 +185,27 @@ export async function logHttpRequest({
   isAuthed?: boolean;
   statusMessage?: Error | string;
 }) {
-  const authorizationData = await extractAuthorizationData({ req, clientId });
-  const headers = req.headers;
+  try {
+    const authorizationData = await extractAuthorizationData({ req, clientId });
+    const headers = req.headers;
 
-  console.log(
-    JSON.stringify({
-      source,
-      pathname: req.url,
-      hasSecretKey: !!authorizationData.secretKey,
-      hasClientId: !!authorizationData.clientId,
-      hasJwt: !!authorizationData.jwt,
-      clientId: authorizationData.clientId,
-      isAuthed: !!isAuthed ?? null,
-      status: res.status,
-      sdkName: headers.get("x-sdk-name") ?? "unknown",
-      sdkVersion: headers.get("x-sdk-version") ?? "unknown",
-      platform: headers.get("x-sdk-platform") ?? "unknown",
-    }),
-  );
-  console.log(`statusMessage=${statusMessage ?? res.statusText}`);
+    console.log(
+      JSON.stringify({
+        source,
+        pathname: req.url,
+        hasSecretKey: !!authorizationData.secretKey,
+        hasClientId: !!authorizationData.clientId,
+        hasJwt: !!authorizationData.jwt,
+        clientId: authorizationData.clientId,
+        isAuthed: !!isAuthed ?? null,
+        status: res.status,
+        sdkName: headers.get("x-sdk-name") ?? "unknown",
+        sdkVersion: headers.get("x-sdk-version") ?? "unknown",
+        platform: headers.get("x-sdk-platform") ?? "unknown",
+      }),
+    );
+    console.log(`statusMessage=${statusMessage ?? res.statusText}`);
+  } catch (err) {
+    console.error("Failed to log HTTP request:", err);
+  }
 }

--- a/packages/service-utils/src/node/index.ts
+++ b/packages/service-utils/src/node/index.ts
@@ -187,25 +187,29 @@ export function logHttpRequest({
   isAuthed?: boolean;
   statusMessage?: Error | string;
 }) {
-  const authorizationData = extractAuthorizationData({ req, clientId });
-  const headers = req.headers;
+  try {
+    const authorizationData = extractAuthorizationData({ req, clientId });
+    const headers = req.headers;
 
-  const _statusMessage = statusMessage ?? res.statusMessage;
-  console.log(
-    JSON.stringify({
-      source,
-      pathname: req.url,
-      hasSecretKey: !!authorizationData.secretKey,
-      hasClientId: !!authorizationData.clientId,
-      hasJwt: !!authorizationData.jwt,
-      clientId: authorizationData.clientId,
-      isAuthed: !!isAuthed ?? null,
-      status: res.statusCode,
-      statusMessage: _statusMessage,
-      sdkName: headers["x-sdk-name"] ?? "unknown",
-      sdkVersion: headers["x-sdk-version"] ?? "unknown",
-      platform: headers["x-sdk-platform"] ?? "unknown",
-    }),
-  );
-  console.log(`statusMessage=${_statusMessage}`);
+    const _statusMessage = statusMessage ?? res.statusMessage;
+    console.log(
+      JSON.stringify({
+        source,
+        pathname: req.url,
+        hasSecretKey: !!authorizationData.secretKey,
+        hasClientId: !!authorizationData.clientId,
+        hasJwt: !!authorizationData.jwt,
+        clientId: authorizationData.clientId,
+        isAuthed: !!isAuthed ?? null,
+        status: res.statusCode,
+        statusMessage: _statusMessage,
+        sdkName: headers["x-sdk-name"] ?? "unknown",
+        sdkVersion: headers["x-sdk-version"] ?? "unknown",
+        platform: headers["x-sdk-platform"] ?? "unknown",
+      }),
+    );
+    console.log(`statusMessage=${_statusMessage}`);
+  } catch (err) {
+    console.error("Failed to log HTTP request:", err);
+  }
 }


### PR DESCRIPTION
## Problem solved

Uncaught exceptions in logging may cause Express servers to crash.

## Changes made

- Add a try/catch to `logHttpRequest`. No user-facing impact.
