### PR TITLE
fix condition, show new device detected

### DIFF
--- a/.changeset/chilly-foxes-beam.md
+++ b/.changeset/chilly-foxes-beam.md
@@ -1,0 +1,6 @@
+---
+"@thirdweb-dev/wallets": patch
+"@thirdweb-dev/react": patch
+---
+
+Fix Paper wallet issues

--- a/packages/react/src/wallet/wallets/paper/PaperOTPLoginUI.tsx
+++ b/packages/react/src/wallet/wallets/paper/PaperOTPLoginUI.tsx
@@ -38,6 +38,7 @@ export const PaperOTPLoginUI: React.FC<PaperOTPLoginUIProps> = (props) => {
   >(null);
 
   const recoveryCodeRequired = !!(
+    props.recoveryShareManagement !== "AWS_MANAGED" &&
     sentEmailInfo &&
     sentEmailInfo !== "error" &&
     sentEmailInfo.isNewDevice &&
@@ -58,8 +59,6 @@ export const PaperOTPLoginUI: React.FC<PaperOTPLoginUIProps> = (props) => {
         await _paperSDK.auth.sendPaperEmailLoginOtp({
           email: email,
         });
-
-      console.log({ isNewDevice, isNewUser });
 
       setSentEmailInfo({ isNewDevice, isNewUser });
     } catch (e) {

--- a/packages/react/src/wallet/wallets/paper/PaperOTPLoginUI.tsx
+++ b/packages/react/src/wallet/wallets/paper/PaperOTPLoginUI.tsx
@@ -38,7 +38,6 @@ export const PaperOTPLoginUI: React.FC<PaperOTPLoginUIProps> = (props) => {
   >(null);
 
   const recoveryCodeRequired = !!(
-    props.recoveryShareManagement !== "AWS_MANAGED" &&
     sentEmailInfo &&
     sentEmailInfo !== "error" &&
     sentEmailInfo.isNewDevice &&
@@ -59,6 +58,8 @@ export const PaperOTPLoginUI: React.FC<PaperOTPLoginUIProps> = (props) => {
         await _paperSDK.auth.sendPaperEmailLoginOtp({
           email: email,
         });
+
+      console.log({ isNewDevice, isNewUser });
 
       setSentEmailInfo({ isNewDevice, isNewUser });
     } catch (e) {

--- a/packages/wallets/src/evm/wallets/paper-wallet.ts
+++ b/packages/wallets/src/evm/wallets/paper-wallet.ts
@@ -49,10 +49,8 @@ export class PaperWallet extends AbstractClientWallet<
     ) {
       // checks to see if we are trying to use USER_MANAGED with thirdweb client ID. If so, we throw an error.
       if (
-        (options.clientId &&
-          !this.isClientIdLegacyPaper(options.clientId ?? "")) ||
-        (options.paperClientId &&
-          !this.isClientIdLegacyPaper(options.paperClientId))
+        options.paperClientId &&
+        !this.isClientIdLegacyPaper(options.paperClientId)
       ) {
         throw new Error(
           'RecoveryShareManagement option "USER_MANAGED" is not supported with thirdweb client ID',


### PR DESCRIPTION
## Problem solved

- PaperWallet throws error if both clientId and paperClientId is given
- ConnectWallet doesn't show "New Device Detected" if the user is on USER_MANAGED -

TODO: get the updated paper-sdk package which exposes which recovery the user is on, and use that instead of checking what the recovery the app is on