### PR TITLE
fix(react): show recovery password modal for `USER_MANAGED` in `paperWallet`

### DIFF
--- a/.changeset/strange-planets-nail.md
+++ b/.changeset/strange-planets-nail.md
@@ -1,0 +1,6 @@
+---
+"@thirdweb-dev/wallets": patch
+"@thirdweb-dev/react": patch
+---
+
+fix(wallets/react): Show recovery modal for `USER_MANAGED` wallets in `paperWallet` implementation

--- a/packages/react/src/wallet/wallets/paper/PaperOTPLoginUI.tsx
+++ b/packages/react/src/wallet/wallets/paper/PaperOTPLoginUI.tsx
@@ -1,5 +1,6 @@
-import { PaperWallet } from "@thirdweb-dev/wallets";
+import styled from "@emotion/styled";
 import { ConnectUIProps, useWalletContext } from "@thirdweb-dev/react-core";
+import { PaperWallet } from "@thirdweb-dev/wallets";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { FadeIn } from "../../../components/FadeIn";
 import { OTPInput } from "../../../components/OTPInput";
@@ -10,7 +11,6 @@ import { Button } from "../../../components/buttons";
 import { Input } from "../../../components/formElements";
 import { Text } from "../../../components/text";
 import { Theme, fontSize } from "../../../design-system";
-import styled from "@emotion/styled";
 import { RecoveryShareManagement } from "./types";
 
 type PaperOTPLoginUIProps = ConnectUIProps<PaperWallet> & {
@@ -19,6 +19,7 @@ type PaperOTPLoginUIProps = ConnectUIProps<PaperWallet> & {
 type SentEmailInfo = {
   isNewDevice: boolean;
   isNewUser: boolean;
+  recoveryShareManagement: RecoveryShareManagement;
 };
 export const PaperOTPLoginUI: React.FC<PaperOTPLoginUIProps> = (props) => {
   const email = props.selectionData;
@@ -38,9 +39,9 @@ export const PaperOTPLoginUI: React.FC<PaperOTPLoginUIProps> = (props) => {
   >(null);
 
   const recoveryCodeRequired = !!(
-    props.recoveryShareManagement !== "AWS_MANAGED" &&
     sentEmailInfo &&
     sentEmailInfo !== "error" &&
+    sentEmailInfo.recoveryShareManagement !== "AWS_MANAGED" &&
     sentEmailInfo.isNewDevice &&
     !sentEmailInfo.isNewUser
   );
@@ -55,12 +56,12 @@ export const PaperOTPLoginUI: React.FC<PaperOTPLoginUIProps> = (props) => {
       setWallet(_wallet);
       const _paperSDK = await _wallet.getPaperSDK();
 
-      const { isNewDevice, isNewUser } =
+      const { isNewDevice, isNewUser, recoveryShareManagement } =
         await _paperSDK.auth.sendPaperEmailLoginOtp({
           email: email,
         });
 
-      setSentEmailInfo({ isNewDevice, isNewUser });
+      setSentEmailInfo({ isNewDevice, isNewUser, recoveryShareManagement });
     } catch (e) {
       console.error(e);
       setVerifyStatus("idle");

--- a/packages/wallets/package.json
+++ b/packages/wallets/package.json
@@ -390,7 +390,7 @@
     "@magic-ext/connect": "^6.7.2",
     "@magic-ext/oauth": "^7.6.2",
     "@magic-sdk/provider": "^13.6.2",
-    "@paperxyz/embedded-wallet-service-sdk": "^1.2.3",
+    "@paperxyz/embedded-wallet-service-sdk": "^1.2.4",
     "@paperxyz/sdk-common-utilities": "^0.1.0",
     "@safe-global/safe-core-sdk": "^3.3.4",
     "@safe-global/safe-ethers-adapters": "0.1.0-alpha.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1344,8 +1344,8 @@ importers:
         specifier: ^13.6.2
         version: 13.6.2(localforage@1.10.0)
       '@paperxyz/embedded-wallet-service-sdk':
-        specifier: ^1.2.3
-        version: 1.2.3
+        specifier: ^1.2.4
+        version: 1.2.4
       '@paperxyz/sdk-common-utilities':
         specifier: ^0.1.0
         version: 0.1.0
@@ -7153,8 +7153,8 @@ packages:
     resolution: {integrity: sha512-003xWiCuvePbLaPHT+CRuaV4GlyCAVm6XYSbBZDHoWZGn1mNkVKFaDbGJjjxmEFvizUwlCoM6O18FCBMMky2zQ==}
     dev: true
 
-  /@paperxyz/embedded-wallet-service-sdk@1.2.3:
-    resolution: {integrity: sha512-RePDyRqOb9Pmk8MzAg70keCxHjWdqzsEkLY4tK0Sxy5F4TDbjMkevXCV94Jt2mfL4A6b7Rvd8OOvSPnTdUf03w==}
+  /@paperxyz/embedded-wallet-service-sdk@1.2.4:
+    resolution: {integrity: sha512-yCOvGB6aEQB06UWowBgu0+thXOwxcHLF3j+e0YgiWtvEpZ8EgbfqbuL9NHN0zJJsTNjF05T39haDQMOBgrMpYA==}
     dependencies:
       '@ethersproject/abstract-signer': 5.7.0
       '@ethersproject/bytes': 5.7.0


### PR DESCRIPTION
## Problem solved

Previous implementation does not show the recovery screen modal for `USER_MANAGED` wallets in the headless flow

## Changes made

- [ ] Public API changes: NONE
- [ ] Internal API changes: NONE

## How to test

- [ ] Automated tests: NONE
- [ ] Manual tests: Instal on test app
