### PR TITLE
[SDK] Expose proxy resolver helper function

### DIFF
--- a/.changeset/brown-moose-sniff.md
+++ b/.changeset/brown-moose-sniff.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/sdk": patch
+---
+
+Expose proxy resolver helper function


### PR DESCRIPTION
## Problem solved

Expose `resolveImplementation()` helper function to resolve implementation address + bytecode of any proxy contract

## Changes made

- [x] Public API changes: return type now returns implementation address as well
- [ ] Internal API changes: explain the internal logic changes

## How to test

- [x] Automated tests: link to unit test file
- [x] Manual tests: step by step instructions on how to test
