### PR TITLE
[SDK] Fix error waiting for transaction after gasless tx

### DIFF
--- a/.changeset/five-mice-complain.md
+++ b/.changeset/five-mice-complain.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/sdk": patch
+---
+
+Fix error on waiting for receipt after gasless tx for certain chains

--- a/packages/sdk/src/evm/core/classes/transactions.ts
+++ b/packages/sdk/src/evm/core/classes/transactions.ts
@@ -515,8 +515,11 @@ export class Transaction<
     let sentTx;
     let iteration = 1;
     while (!sentTx) {
-      sentTx = await this.provider.getTransaction(txHash);
-
+      try {
+        sentTx = await this.provider.getTransaction(txHash);
+      } catch (err) {
+        // some providers can throw an error if the tx is very recent
+      }
       // Exponential (ish) backoff for polling
       if (!sentTx) {
         await new Promise((resolve) =>


### PR DESCRIPTION
## Problem solved

On certain RPC providers, checking for tx receipt right after a gasless call would throw, then eventually resolve. Added a try catch in the exponential retry loop.

## Changes made

- [ ] Public API changes: none
- [ ] Internal API changes: try/catch

## How to test

- [ ] Automated tests: link to unit test file
- [x] Manual tests: tested via script
