### PR TITLE
[SDK] Add unit test for ERC721 allOwners()

### DIFF
--- a/.changeset/tall-balloons-breathe.md
+++ b/.changeset/tall-balloons-breathe.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/sdk": patch
+---
+
+Add unit test for getting all owners of ERC721 collection

--- a/packages/sdk/test/evm/nft.test.ts
+++ b/packages/sdk/test/evm/nft.test.ts
@@ -279,9 +279,12 @@ describe("NFT Contract", async () => {
     await nftContract.mintBatch(metadata);
 
     // Send one to AddressZero so that we can run the test
-    await nftContract.transfer(AddressZero, 0);
+    await nftContract.burn(0);
     const records = await nftContract.erc721.getAllOwners();
     const hasFaultyRecord = records.some((item) => item.owner === AddressZero);
     assert.strictEqual(hasFaultyRecord, false);
+    expect(records).to.be.an("array").length(2);
+    expect(records[0].tokenId).to.eq(1);
+    expect(records[1].tokenId).to.eq(2);
   });
 });

--- a/packages/sdk/test/evm/nft.test.ts
+++ b/packages/sdk/test/evm/nft.test.ts
@@ -273,4 +273,15 @@ describe("NFT Contract", async () => {
     });
     expect(tx.id.toNumber()).to.eq(0);
   });
+
+  it("allOwners() should not return AddressZero as one of the owners", async () => {
+    const metadata = [{ name: "Test1" }, { name: "Test2" }, { name: "Test3" }];
+    await nftContract.mintBatch(metadata);
+
+    // Send one to AddressZero so that we can run the test
+    await nftContract.transfer(AddressZero, 0);
+    const records = await nftContract.erc721.getAllOwners();
+    const hasFaultyRecord = records.some((item) => item.owner === AddressZero);
+    assert.strictEqual(hasFaultyRecord, false);
+  });
 });


### PR DESCRIPTION
## Problem solved

Add unit test for ERC721 allOwners() to ensure it does not return `AddressZero` as the owner
@jnsdls @joaquim-verges I'm practicing writing unit tests. Let me know whether this is encouraged or unecessary.


The function targeted for unit test:
path: `packages\sdk\src\evm\core\classes\erc-721-supply.ts`
```
  /**
   * Return all the owners of each token id in this contract
   * @returns
   */
  public async allOwners() {
    let totalCount: BigNumber;
    let startTokenId = BigNumber.from(0);
    if (hasFunction<OpenEditionERC721>("startTokenId", this.contractWrapper)) {
      startTokenId = await this.contractWrapper.read("startTokenId", []);
    }
    try {
      totalCount = await this.erc721.totalClaimedSupply();
    } catch (e) {
      totalCount = await this.totalCount();
    }

    totalCount = totalCount.add(startTokenId);

    // TODO use multicall3 if available
    // TODO can't call toNumber() here, this can be a very large number
    const arr = [...new Array(totalCount.toNumber()).keys()];
    const owners = await Promise.all(
      arr.map((i) => this.erc721.ownerOf(i).catch(() => constants.AddressZero)),
    );
    return arr
      .map((i) => ({
        tokenId: i,
        owner: owners[i],
      }))
      .filter((o) => o.owner !== constants.AddressZero); // <----------
  }
```
## Changes made

- [ ] Public API changes: list the public API changes made if any
- [x] Internal API changes: explain the internal logic changes

## How to test

- [x] Automated tests: link to unit test file
- [ ] Manual tests: step by step instructions on how to test
