### PR TITLE
[SmartWallets] Fix gas estimation for first SW transaction

### DIFF
--- a/.changeset/calm-comics-wash.md
+++ b/.changeset/calm-comics-wash.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/sdk": patch
+---
+
+Fix error handling when wallets have no funds

--- a/.changeset/unlucky-hornets-ring.md
+++ b/.changeset/unlucky-hornets-ring.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/wallets": patch
+---
+
+Fix gas estimation for first smart wallet transaction

--- a/packages/sdk/src/evm/core/classes/contract-wrapper.ts
+++ b/packages/sdk/src/evm/core/classes/contract-wrapper.ts
@@ -412,21 +412,6 @@ export class ContractWrapper<
     try {
       return await func(...args, callOverrides);
     } catch (err) {
-      const from = await (callOverrides.from || this.getSignerAddress());
-      const value = await (callOverrides.value ? callOverrides.value : 0);
-      const balance = await this.getProvider().getBalance(from);
-
-      if (balance.eq(0) || (value && balance.lt(value))) {
-        throw await this.formatError(
-          new Error(
-            "You have insufficient funds in your account to execute this transaction.",
-          ),
-          fn,
-          args,
-          callOverrides,
-        );
-      }
-
       throw await this.formatError(err, fn, args, callOverrides);
     }
   }

--- a/packages/wallets/src/evm/connectors/smart-wallet/lib/base-api.ts
+++ b/packages/wallets/src/evm/connectors/smart-wallet/lib/base-api.ts
@@ -213,6 +213,8 @@ export abstract class BaseAccountAPI {
         to: detailsForUserOp.target,
         data: detailsForUserOp.data,
       });
+      // add 20% overhead for entrypoint checks
+      callGasLimit = callGasLimit.mul(120).div(100);
       // if the estimation is too low, we use a fixed value of 500k
       if (callGasLimit.lt(30000)) {
         callGasLimit = BigNumber.from(500000);
@@ -366,9 +368,8 @@ export abstract class BaseAccountAPI {
         ...userOp,
         paymasterAndData: "0x",
       };
-      modifiedOp.preVerificationGas = await this.getPreVerificationGas(
-        modifiedOp,
-      );
+      modifiedOp.preVerificationGas =
+        await this.getPreVerificationGas(modifiedOp);
       return {
         ...modifiedOp,
         signature: "",


### PR DESCRIPTION
## Problem solved

first SW transaction can run out of gas due to how we estimate gas for non deployed accounts. Added a 20% buffer to remediate, can probably be more accurate but this will help for now.

## Changes made

- [ ] Public API changes: none
- [ ] Internal API changes: fix error swallowing when account has no balance, add 20% gas limit overhead

## How to test

- [ ] Automated tests: link to unit test file
- [ ] Manual tests: script, cat attack
