### PR TITLE
chore: Make accountId optional in usage event type

### DIFF
--- a/.changeset/old-students-work.md
+++ b/.changeset/old-students-work.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+Make accountId optional in publishUsageEvents. This will be hydrated internally.

--- a/packages/service-utils/src/cf-worker/usage.ts
+++ b/packages/service-utils/src/cf-worker/usage.ts
@@ -21,11 +21,16 @@ const usageEventSchema = z.object({
     "bundler",
     "paymaster",
     "relayer",
+    "connectWallet",
   ]),
   action: z.string(),
-  accountId: z.string(),
 
-  // Optional
+  /**
+   * The following fields are optional.
+   */
+
+  accountId: z.string().optional(),
+  isClientEvent: z.boolean().optional(),
   apiKeyId: z.string().optional(),
   creatorWalletAddress: z.string().optional(),
   clientId: z.string().optional(),


### PR DESCRIPTION
## Problem solved

Don't require account ID when publishing usage events. The internal analytics service will hydrate client ID -> account metadata.

## Changes made

- Make accountId optional when publishing usage events.

## How to test

- [ ] Manually emit events without account ID.
