### PR TITLE
[Wallets] Fix executeBatch type mismatch

### DIFF
--- a/.changeset/empty-readers-grab.md
+++ b/.changeset/empty-readers-grab.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/wallets": patch
+---
+
+Fix executeBatch() type mismatches

--- a/packages/wallets/src/evm/connectors/smart-wallet/index.ts
+++ b/packages/wallets/src/evm/connectors/smart-wallet/index.ts
@@ -186,7 +186,9 @@ export class SmartWalletConnector extends Connector<SmartWalletConnectionArgs> {
    * @param transactions
    * @returns the transaction receipt
    */
-  async executeBatch(transactions: Transaction[]): Promise<TransactionResult> {
+  async executeBatch(
+    transactions: Transaction<any>[],
+  ): Promise<TransactionResult> {
     if (!this.accountApi) {
       throw new Error("Personal wallet not connected");
     }

--- a/packages/wallets/src/evm/wallets/smart-wallet.ts
+++ b/packages/wallets/src/evm/wallets/smart-wallet.ts
@@ -110,7 +110,9 @@ export class SmartWallet
    * @param transactions
    * @returns the transaction receipt
    */
-  async executeBatch(transactions: Transaction[]): Promise<TransactionResult> {
+  async executeBatch(
+    transactions: Transaction<any>[],
+  ): Promise<TransactionResult> {
     const connector = await this.getConnector();
     return connector.executeBatch(transactions);
   }


### PR DESCRIPTION
## Problem solved

You can get a type error if you try to match a erc721 claim with another regular tx because erc721 claim returns an array of tx responses, which breaks the type checking.

## Changes made

- [ ] Public API changes: none
- [ ] Internal API changes: loosen the type expectation for executeBatch

## How to test

- [ ] Automated tests: none
- [ ] Manual tests: tested via script
