### PR TITLE
RPC Override Fix

### DIFF
--- a/.changeset/pretty-toys-yawn.md
+++ b/.changeset/pretty-toys-yawn.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/sdk": patch
+---
+
+Fix for RPC Override Implementation to get user provided Url and not default RPC Url for the chain

--- a/packages/sdk/src/evm/constants/urls.ts
+++ b/packages/sdk/src/evm/constants/urls.ts
@@ -44,7 +44,7 @@ export function getChainProvider(
     options.supportedChains = [
       // @ts-expect-error - we know this is a chain and it will work to build the map
       network,
-      ...options.supportedChains.filter((c) => c.chainId !== network.chainId),
+      ...options.supportedChains.filter((c) => c.chainId === network.chainId),
     ];
   }
 

--- a/packages/sdk/src/evm/core/sdk.ts
+++ b/packages/sdk/src/evm/core/sdk.ts
@@ -724,13 +724,10 @@ export class ThirdwebSDK extends RPCConnectionHandler {
       walletAddress,
     );
 
-    const chainMap = chains.reduce(
-      (acc, chain) => {
-        acc[chain.chainId] = chain;
-        return acc;
-      },
-      {} as Record<number, Chain>,
-    );
+    const chainMap = chains.reduce((acc, chain) => {
+      acc[chain.chainId] = chain;
+      return acc;
+    }, {} as Record<number, Chain>);
 
     const sdkMap: Record<number, ThirdwebSDK> = {};
 
@@ -890,7 +887,7 @@ function addChainToSupportedChains(
     options = {
       ...options,
       // @ts-expect-error - we know that the network is assignable despite the readonly mismatch
-      supportedChains: [...(options?.supportedChains || []), network],
+      supportedChains: [network, ...(options?.supportedChains || [])],
     };
   }
   return options;


### PR DESCRIPTION
## Problem solved

RPC Override logic on SDK was not using the user provided RPC Url.

## Changes made

- [ ] Sync the order of data in `supportedChains` [], i.e., [`provided_network_data`, `user_rpc_override_data`]. It was mixed earlier.
- [ ] Updated the `filter` to have `===` instead of `!==`

## How to test

- [ ] Run `hardhat` locally using docker. Change the port to `8000` instead of `8545`
- [ ] Pass in `supportedChain` data with the new `rpc` Url, i.e., `http://localhost:8000`
- [ ] Call `sdk.wallet.getBalance()` -> This should get you the balance

Supported Chain (RPC Override) Data:

```
[
  {
    "name": "Localhost",
    "chain": "ETH",
    "rpc": ["http://localhost:8000"],
    "nativeCurrency": {
      "name": "Ether",
      "symbol": "ETH",
      "decimals": 18
    },
    "chainId": 1337,
    "shortName": "local",
    "slug": "localhost"
  }
]
```
