### PR TITLE
[RN] Show selectUI component when passing one supportedWallet

### DIFF
--- a/.changeset/wise-emus-cheer.md
+++ b/.changeset/wise-emus-cheer.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/react-native": patch
+---
+
+Fixes bug when passing only one wallet as a supportedWallet. The selectUI component must be displayed.

--- a/packages/react-native/src/evm/components/ConnectWalletFlow/ConnectWalletFlow.tsx
+++ b/packages/react-native/src/evm/components/ConnectWalletFlow/ConnectWalletFlow.tsx
@@ -74,13 +74,19 @@ export const ConnectWalletFlow = () => {
   useEffect(() => {
     // case when only one wallet is passed in supportedWallets
     if (walletConfig) {
-      if (walletConfig.connectUI) {
-        // if there's a connection UI, then show it
-        setActiveWallet(walletConfig);
-      } else {
-        // if there's no connection UI, then connect the wallet
-        onChooseWallet(walletConfig);
+      // if there's a selection UI, then continue with the flow
+      if (walletConfig.selectUI) {
+        return;
       }
+
+      if (walletConfig.connectUI) {
+        // if there's a connection UI and no selection UI, then show it
+        setActiveWallet(walletConfig);
+        return;
+      }
+
+      // if there's no connection UI or selectionUI, then automatically select it
+      onChooseWallet(walletConfig);
     }
   }, [onChooseWallet, walletConfig]);
 


### PR DESCRIPTION
## Problem solved

When a single wallet is passed as a `supportedWallet` we auto-connect the wallet to save users one interaction. In the case where wallets needed to show a UI before connection (like the input text to get the email for embeddedWallet), we were bypassing showing this UI.

Short description of the bug fixed or feature added

We now correctly check if the wallet has a `selectUI` or `connectUI` that needs to be shown before auto-connecting a single wallet.

## Changes made

- [ ] Public API changes: list the public API changes made if any
- [x] Internal API changes: explain the internal logic changes

## How to test

- [ ] Automated tests: link to unit test file
- [x] Manual tests: step by step instructions on how to test
Pass only one wallet with a selectUI as a supportedWallet: e.g. `embeddedWallet()`
