### PR TITLE
[react] - Fix OTP input not working well with Japanese keyboard

### DIFF
--- a/.changeset/sixty-taxis-train.md
+++ b/.changeset/sixty-taxis-train.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/react": patch
+---
+
+Fix OTP input not working well with Japanese keyboard

--- a/packages/react/src/components/OTPInput.tsx
+++ b/packages/react/src/components/OTPInput.tsx
@@ -38,7 +38,9 @@ export function OTPInput(props: {
             key={i}
             value={otp[i] ?? ""}
             type="number"
+            pattern="[0-9]*"
             variant="outline"
+            inputMode="numeric"
             onPaste={(e) => {
               const pastedData = e.clipboardData.getData("text/plain");
               const newOTP = pastedData


### PR DESCRIPTION
## Problem solved

https://linear.app/thirdweb/issue/DEVX-1410/input-issues-for-otp-on-mobile
