### PR TITLE
[Wallets] Add AsyncWallet

### DIFF
--- a/.changeset/nervous-students-warn.md
+++ b/.changeset/nervous-students-warn.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/wallets": patch
+---
+
+Add AsyncWallet

--- a/packages/wallets/evm/wallets/async/package.json
+++ b/packages/wallets/evm/wallets/async/package.json
@@ -1,0 +1,7 @@
+{
+  "main": "dist/thirdweb-dev-wallets-evm-wallets-async.cjs.js",
+  "module": "dist/thirdweb-dev-wallets-evm-wallets-async.esm.js",
+  "browser": {
+    "./dist/thirdweb-dev-wallets-evm-wallets-async.esm.js": "./dist/thirdweb-dev-wallets-evm-wallets-async.browser.esm.js"
+  }
+}

--- a/packages/wallets/package.json
+++ b/packages/wallets/package.json
@@ -36,6 +36,13 @@
       },
       "default": "./evm/wallets/safe/dist/thirdweb-dev-wallets-evm-wallets-safe.cjs.js"
     },
+    "./evm/wallets/async": {
+      "module": {
+        "browser": "./evm/wallets/async/dist/thirdweb-dev-wallets-evm-wallets-async.browser.esm.js",
+        "default": "./evm/wallets/async/dist/thirdweb-dev-wallets-evm-wallets-async.esm.js"
+      },
+      "default": "./evm/wallets/async/dist/thirdweb-dev-wallets-evm-wallets-async.cjs.js"
+    },
     "./evm/wallets/frame": {
       "module": {
         "browser": "./evm/wallets/frame/dist/thirdweb-dev-wallets-evm-wallets-frame.browser.esm.js",

--- a/packages/wallets/src/evm/wallets/async.ts
+++ b/packages/wallets/src/evm/wallets/async.ts
@@ -1,0 +1,25 @@
+import { Signer } from "ethers";
+import { AbstractWallet } from "./abstract";
+
+export interface AsyncWalletOptions {
+  getSigner: () => Promise<Signer>;
+  cacheSigner: boolean;
+}
+
+export class AsyncWallet extends AbstractWallet {
+  #signer?: Signer;
+  #options: AsyncWalletOptions;
+
+  constructor(options: AsyncWalletOptions) {
+    super();
+    this.#options = options;
+  }
+
+  async getSigner(): Promise<Signer> {
+    if (!this.#signer || !this.#options.cacheSigner) {
+      this.#signer = await this.#options.getSigner();
+    }
+
+    return this.#signer;
+  }
+}


### PR DESCRIPTION
- Adds an `AsyncWallet` class that allows you to pass in a `getSigner` function that will get called when signer is actually needed.
- We need this in engine since the admin wallet can get created during runtime.
- You can configure `cacheSigner` to set whether the signer get's cached after the first use or not.