### PR TITLE
[SDK] Custom jwt for embedded wallets

### DIFF
--- a/.changeset/proud-buses-matter.md
+++ b/.changeset/proud-buses-matter.md
@@ -2,4 +2,19 @@
 "@thirdweb-dev/wallets": minor
 ---
 
-feat(wallets): Enable custom jwt auth forembedded wallets
+feat(wallets): Enable custom jwt auth for embedded wallets
+
+Usage:
+
+```typescript
+const embeddedWalletConnector = new EmbeddedWalletConnecter({
+  clientId: "Thirdweb client id",
+  chains: [Optimism, Goerli, Ethereum],
+  chain: Optimism,
+});
+embeddedWalletConnector.connect({
+  loginType: "custom_jwt_auth",
+  jwt: "Your jwt here",
+  encryptionKey: "Super strong encryption key",
+});
+```

--- a/.changeset/proud-buses-matter.md
+++ b/.changeset/proud-buses-matter.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/wallets": minor
+---
+
+feat(wallets): Enable custom jwt auth forembedded wallets

--- a/packages/wallets/src/evm/connectors/embedded-wallet/implementations/lib/auth/abstract-login.ts
+++ b/packages/wallets/src/evm/connectors/embedded-wallet/implementations/lib/auth/abstract-login.ts
@@ -9,7 +9,7 @@ import type {
 import type { EmbeddedWalletIframeCommunicator } from "../../utils/iFrameCommunication/EmbeddedWalletIframeCommunicator";
 
 export type LoginQuerierTypes = {
-  loginWithJwtAuthCallback: { token: string; recoveryCode: string };
+  loginWithCustomJwt: { jwt: string; encryptionKey: string };
   loginWithThirdwebModal: undefined | { email: string };
   sendThirdwebEmailLoginOtp: { email: string };
   verifyThirdwebEmailLoginOtp: {
@@ -59,9 +59,9 @@ export abstract class AbstractLogin<
     this.clientId = clientId;
   }
 
-  abstract loginWithJwtToken(args: {
-    token: string;
-    recoveryCode: string;
+  abstract loginWithCustomJwt(args: {
+    jwt: string;
+    encryptionKey: string;
   }): Promise<AuthLoginReturnType>;
   abstract loginWithModal(args?: MODAL): Promise<AuthLoginReturnType>;
   abstract loginWithEmailOtp(args: EMAIL_MODAL): Promise<AuthLoginReturnType>;

--- a/packages/wallets/src/evm/connectors/embedded-wallet/implementations/lib/auth/base-login.ts
+++ b/packages/wallets/src/evm/connectors/embedded-wallet/implementations/lib/auth/base-login.ts
@@ -161,13 +161,13 @@ export class BaseLogin extends AbstractLogin<
     });
   }
 
-  override async loginWithJwtToken({
-    recoveryCode,
-    token,
-  }: LoginQuerierTypes["loginWithJwtAuthCallback"]): Promise<AuthLoginReturnType> {
+  override async loginWithCustomJwt({
+    encryptionKey,
+    jwt,
+  }: LoginQuerierTypes["loginWithCustomJwt"]): Promise<AuthLoginReturnType> {
     const result = await this.LoginQuerier.call<AuthAndWalletRpcReturnType>({
-      procedureName: "loginWithJwtAuthCallback",
-      params: { recoveryCode, token },
+      procedureName: "loginWithCustomJwt",
+      params: { encryptionKey, jwt },
     });
     return this.postLogin(result);
   }

--- a/packages/wallets/src/evm/connectors/embedded-wallet/implementations/lib/auth/index.ts
+++ b/packages/wallets/src/evm/connectors/embedded-wallet/implementations/lib/auth/index.ts
@@ -129,6 +129,12 @@ export class Auth {
     return this.BaseLogin.loginWithEmailOtp(args);
   }
 
+  async loginWithCustomJwt(
+    args: Parameters<BaseLogin["loginWithCustomJwt"]>[0],
+  ): Promise<AuthLoginReturnType> {
+    return this.BaseLogin.loginWithCustomJwt(args);
+  }
+
   async loginWithGoogle(
     args?: Parameters<BaseLogin["loginWithGoogle"]>[0],
   ): Promise<AuthLoginReturnType> {

--- a/packages/wallets/src/evm/connectors/embedded-wallet/index.ts
+++ b/packages/wallets/src/evm/connectors/embedded-wallet/index.ts
@@ -80,6 +80,13 @@ export class EmbeddedWalletConnector extends Connector<EmbeddedWalletConnectionA
         });
         break;
       }
+      case "custom_jwt_auth": {
+        authResult = await thirdwebSDK.auth.loginWithCustomJwt({
+          jwt: options.jwt,
+          encryptionKey: options.encryptionKey,
+        });
+        break;
+      }
       default: {
         authResult = await thirdwebSDK.auth.loginWithModal();
         break;

--- a/packages/wallets/src/evm/connectors/embedded-wallet/types.ts
+++ b/packages/wallets/src/evm/connectors/embedded-wallet/types.ts
@@ -32,4 +32,9 @@ export type EmbeddedWalletConnectionArgs = {
       loginType: "ui_email_otp";
       email: string;
     }
+  | {
+      loginType: "custom_jwt_auth";
+      jwt: string;
+      encryptionKey: string;
+    }
 );


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

## Changes made

- [ ] Public API changes: 

```
const embeddedWalletConnector = new EmbeddedWalletConnecter({
  clientId: "Thirdweb client id",
  chains: [Optimism, Goerli, Ethereum],
  chain: Optimism,
});
embeddedWalletConnector.connect({
  loginType: "custom_jwt_auth",
  jwt: "Your jwt here",
  encryptionKey: "Super strong encryption key",
});
```
- [ ] Internal API changes: None

## How to test

- [ ] Automated tests: None
- [ ] Manual tests: publish dev build an attempt to run connector in demo app
