### PR TITLE
Use BigInt function instead of bigint primitive numbers

### DIFF
--- a/.changeset/tame-snakes-retire.md
+++ b/.changeset/tame-snakes-retire.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/wallets": patch
+---
+
+Use BigInt function instead of bigint primitive numbers to fix broken Vite templates

--- a/packages/wallets/src/evm/connectors/smart-wallet/lib/utils.ts
+++ b/packages/wallets/src/evm/connectors/smart-wallet/lib/utils.ts
@@ -85,11 +85,11 @@ const generateRandomUint192 = (): bigint => {
   const rand5 = BigInt(Math.floor(Math.random() * 0x100000000));
   const rand6 = BigInt(Math.floor(Math.random() * 0x100000000));
   return (
-    (rand1 << 160n) |
-    (rand2 << 128n) |
-    (rand3 << 96n) |
-    (rand4 << 64n) |
-    (rand5 << 32n) |
+    (rand1 << BigInt(160)) |
+    (rand2 << BigInt(128)) |
+    (rand3 << BigInt(96)) |
+    (rand4 << BigInt(64)) |
+    (rand5 << BigInt(32)) |
     rand6
   );
 };


### PR DESCRIPTION
## Problem solved

Fixes broken Vite templates

![image](https://github.com/thirdweb-dev/js/assets/22043396/d1ca6f74-fe16-4632-bffb-7e341d84e1bd)

