### PR TITLE
Patch: missing data arg in isSmartWalletDeployed

### DIFF
--- a/.changeset/short-beds-hunt.md
+++ b/.changeset/short-beds-hunt.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/wallets": patch
+---
+
+Patch isSmartWalletDeployed

--- a/packages/wallets/src/evm/connectors/smart-wallet/utils.ts
+++ b/packages/wallets/src/evm/connectors/smart-wallet/utils.ts
@@ -86,6 +86,7 @@ export async function isSmartWalletDeployed(
   const factoryContract = await readOnlySDK.getContract(factoryAddress);
   const accountAddress = await factoryContract.call("getAddress", [
     personalWalletAddress,
+    "0x",
   ]);
   const isDeployed = await isContractDeployed(
     accountAddress,


### PR DESCRIPTION
## Problem solved

Added the missing empty data arg `0x` to `isSmartWalletDeployed` logic's call to `accountFactory.getAddress`

## Changes made

- [ ] Public API changes: list the public API changes made if any
- [ ] Internal API changes: explain the internal logic changes

## How to test

- [ ] Automated tests: link to unit test file
- [ ] Manual tests: step by step instructions on how to test
