### PR TITLE
[SDK] Fix double trailing slash when downloading merkle data

### DIFF
--- a/.changeset/metal-moles-press.md
+++ b/.changeset/metal-moles-press.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/sdk": patch
+---
+
+Fix double trailing slash when downloading merkle data

--- a/packages/sdk/src/evm/common/sharded-merkle-tree.ts
+++ b/packages/sdk/src/evm/common/sharded-merkle-tree.ts
@@ -234,10 +234,11 @@ export class ShardedMerkleTree {
     const currencyDecimalMap: Record<string, number> = {};
     if (shard === undefined) {
       try {
+        const uri = this.baseUri.endsWith("/")
+          ? this.baseUri
+          : `${this.baseUri}/`;
         shard = this.shards[shardId] =
-          await this.storage.downloadJSON<ShardData>(
-            `${this.baseUri}/${shardId}.json`,
-          );
+          await this.storage.downloadJSON<ShardData>(`${uri}${shardId}.json`);
         const hashedEntries = await Promise.all(
           shard.entries.map(async (entry) => {
             // cache decimals for each currency to avoid refetching for every address


### PR DESCRIPTION
## Problem solved

clean up the base URI if it has a trailing slash

## Changes made

- [ ] Public API changes: list the public API changes made if any
- [ ] Internal API changes: explain the internal logic changes

## How to test

- [ ] Automated tests: link to unit test file
- [ ] Manual tests: step by step instructions on how to test
