### PR TITLE
[SmartWallet] Expose new estimation functions for smart wallet transactions

### DIFF
--- a/.changeset/cuddly-kings-listen.md
+++ b/.changeset/cuddly-kings-listen.md
@@ -1,0 +1,17 @@
+---
+"@thirdweb-dev/wallets": patch
+---
+
+Expose function to estimate SmartWallet transactions, handling pre and post deployment state
+
+```ts
+const cost = smartWallet.estimate(preparedTx);
+const costBatch = smartWallet.estimateBatch(preparedTxs);
+```
+
+Also works with raw transactions
+
+```ts
+const cost = smartWallet.estimateRaw(rawTx);
+const costBatch = smartWallet.estimateBatchRaw(rawTxs);
+```

--- a/packages/wallets/src/evm/connectors/smart-wallet/lib/account.ts
+++ b/packages/wallets/src/evm/connectors/smart-wallet/lib/account.ts
@@ -1,4 +1,9 @@
-import { LOCAL_NODE_PKEY, SmartContract, ThirdwebSDK } from "@thirdweb-dev/sdk";
+import {
+  LOCAL_NODE_PKEY,
+  SmartContract,
+  ThirdwebSDK,
+  Transaction,
+} from "@thirdweb-dev/sdk";
 import { BigNumberish, BigNumber, ethers, utils, BytesLike } from "ethers";
 import { AccountApiParams } from "../types";
 import { BaseAccountAPI } from "./base-api";
@@ -103,33 +108,27 @@ export class AccountAPI extends BaseAccountAPI {
     return this.params.accountInfo.getNonce(accountContract);
   }
 
-  async encodeExecute(
+  async prepareExecute(
     target: string,
     value: BigNumberish,
     data: string,
-  ): Promise<string> {
+  ): Promise<Transaction<any>> {
     const accountContract = await this.getAccountContract();
-    const tx = await this.params.accountInfo.execute(
+    return this.params.accountInfo.execute(
       accountContract,
       target,
       value,
       data,
     );
-    return tx.encode();
   }
 
-  async encodeExecuteBatch(
+  async prepareExecuteBatch(
     targets: string[],
     values: BigNumberish[],
     datas: BytesLike[],
-  ): Promise<string> {
+  ): Promise<Transaction<any>> {
     const accountContract = await this.getAccountContract();
-    const tx = accountContract.prepare("executeBatch", [
-      targets,
-      values,
-      datas,
-    ]);
-    return tx.encode();
+    return accountContract.prepare("executeBatch", [targets, values, datas]);
   }
 
   async signUserOpHash(userOpHash: string): Promise<string> {

--- a/packages/wallets/src/evm/connectors/smart-wallet/lib/base-api.ts
+++ b/packages/wallets/src/evm/connectors/smart-wallet/lib/base-api.ts
@@ -1,4 +1,11 @@
-import { ethers, BigNumber, BigNumberish, providers, utils } from "ethers";
+import {
+  ethers,
+  BigNumber,
+  BigNumberish,
+  providers,
+  utils,
+  BytesLike,
+} from "ethers";
 import {
   EntryPoint,
   EntryPoint__factory,
@@ -20,6 +27,11 @@ import {
   Celo,
 } from "@thirdweb-dev/chains";
 import { Transaction, getDynamicFeeData } from "@thirdweb-dev/sdk";
+
+export type BatchData = {
+  targets: (string | undefined)[];
+  data: BytesLike[];
+};
 
 export interface BaseApiParams {
   provider: providers.Provider;
@@ -186,10 +198,10 @@ export abstract class BaseAccountAPI {
 
   async encodeUserOpCallDataAndGasLimit(
     detailsForUserOp: TransactionDetailsForUserOp,
-    batched: boolean,
+    batchData?: BatchData,
   ): Promise<{ callData: string; callGasLimit: BigNumber }> {
     const value = parseNumber(detailsForUserOp.value) ?? BigNumber.from(0);
-    const callData = batched
+    const callData = batchData
       ? detailsForUserOp.data
       : await this.prepareExecute(
           detailsForUserOp.target,
@@ -197,16 +209,29 @@ export abstract class BaseAccountAPI {
           detailsForUserOp.data,
         ).then((tx) => tx.encode());
 
-    let callGasLimit;
+    let callGasLimit: BigNumber;
     const isPhantom = await this.checkAccountPhantom();
     if (isPhantom) {
       // when the account is not deployed yet, we simulate the call to the target contract directly
-      callGasLimit = await this.provider.estimateGas({
-        from: this.getAccountAddress(),
-        to: detailsForUserOp.target,
-        data: detailsForUserOp.data,
-      });
-      console.log("estimated gas limit", callGasLimit.toString());
+      if (batchData) {
+        const limits = await Promise.all(
+          batchData.targets.map((_, i) =>
+            this.provider.estimateGas({
+              from: this.getAccountAddress(),
+              to: batchData.targets[i],
+              data: batchData.data[i],
+            }),
+          ),
+        );
+        callGasLimit = limits.reduce((a, b) => a.add(b), BigNumber.from(0));
+      } else {
+        callGasLimit = await this.provider.estimateGas({
+          from: this.getAccountAddress(),
+          to: detailsForUserOp.target,
+          data: detailsForUserOp.data,
+        });
+      }
+
       // add 20% overhead for entrypoint checks
       callGasLimit = callGasLimit.mul(120).div(100);
       // if the estimation is too low, we use a fixed value of 500k
@@ -274,10 +299,10 @@ export abstract class BaseAccountAPI {
    */
   async createUnsignedUserOp(
     info: TransactionDetailsForUserOp,
-    batched: boolean,
+    batchData?: BatchData,
   ): Promise<UserOperationStruct> {
     const { callData, callGasLimit } =
-      await this.encodeUserOpCallDataAndGasLimit(info, batched);
+      await this.encodeUserOpCallDataAndGasLimit(info, batchData);
     const initCode = await this.getInitCode();
 
     const initGas = await this.estimateCreationGas(initCode);
@@ -391,10 +416,10 @@ export abstract class BaseAccountAPI {
    */
   async createSignedUserOp(
     info: TransactionDetailsForUserOp,
-    batched: boolean,
+    batchData?: BatchData,
   ): Promise<UserOperationStruct> {
     return await this.signUserOp(
-      await this.createUnsignedUserOp(info, batched),
+      await this.createUnsignedUserOp(info, batchData),
     );
   }
 

--- a/packages/wallets/src/evm/connectors/smart-wallet/lib/erc4337-provider.ts
+++ b/packages/wallets/src/evm/connectors/smart-wallet/lib/erc4337-provider.ts
@@ -62,15 +62,12 @@ export class ERC4337EthersProvider extends providers.BaseProvider {
     if (method === "estimateGas") {
       // hijack this to estimate gas from the entrypoint instead
       const { callGasLimit } =
-        await this.smartAccountAPI.encodeUserOpCallDataAndGasLimit(
-          {
-            target: params.transaction.to,
-            data: params.transaction.data,
-            value: params.transaction.value,
-            gasLimit: params.transaction.gasLimit,
-          },
-          false, // TODO check this
-        );
+        await this.smartAccountAPI.encodeUserOpCallDataAndGasLimit({
+          target: params.transaction.to,
+          data: params.transaction.data,
+          value: params.transaction.value,
+          gasLimit: params.transaction.gasLimit,
+        });
       return callGasLimit;
     }
     return await this.originalProvider.perform(method, params);

--- a/packages/wallets/src/evm/connectors/smart-wallet/lib/erc4337-signer.ts
+++ b/packages/wallets/src/evm/connectors/smart-wallet/lib/erc4337-signer.ts
@@ -2,7 +2,7 @@ import { ethers, providers, utils } from "ethers";
 
 import { Bytes, Signer } from "ethers";
 import { ClientConfig } from "@account-abstraction/sdk";
-import { BaseAccountAPI } from "./base-api";
+import { BaseAccountAPI, BatchData } from "./base-api";
 import type { ERC4337EthersProvider } from "./erc4337-provider";
 import { HttpRpcClient } from "./http-rpc-client";
 import { randomNonce } from "./utils";
@@ -36,7 +36,7 @@ export class ERC4337EthersSigner extends Signer {
   // This one is called by Contract. It signs the request and passes in to Provider to be sent.
   async sendTransaction(
     transaction: utils.Deferrable<providers.TransactionRequest>,
-    batched: boolean = false,
+    batchData?: BatchData,
   ): Promise<providers.TransactionResponse> {
     const tx = await ethers.utils.resolveProperties(transaction);
     await this.verifyAllNecessaryFields(tx);
@@ -50,7 +50,7 @@ export class ERC4337EthersSigner extends Signer {
         gasLimit: tx.gasLimit,
         nonce: multidimensionalNonce,
       },
-      batched,
+      batchData,
     );
 
     const transactionResponse =

--- a/packages/wallets/src/evm/wallets/smart-wallet.ts
+++ b/packages/wallets/src/evm/wallets/smart-wallet.ts
@@ -181,6 +181,30 @@ export class SmartWallet
     return connector.executeRaw(transaction);
   }
 
+  async estimate(transaction: Transaction<any>) {
+    const connector = await this.getConnector();
+    return connector.estimate(transaction);
+  }
+
+  async estimateBatch(transactions: Transaction<any>[]) {
+    const connector = await this.getConnector();
+    return connector.estimateBatch(transactions);
+  }
+
+  async estimateRaw(
+    transactions: utils.Deferrable<providers.TransactionRequest>,
+  ) {
+    const connector = await this.getConnector();
+    return connector.estimateRaw(transactions);
+  }
+
+  async estimateBatchRaw(
+    transactions: utils.Deferrable<providers.TransactionRequest>[],
+  ) {
+    const connector = await this.getConnector();
+    return connector.estimateBatchRaw(transactions);
+  }
+
   /**
    * Send multiple raw transaction in a batch without waiting for confirmations
    * @param transaction

--- a/packages/wallets/src/evm/wallets/smart-wallet.ts
+++ b/packages/wallets/src/evm/wallets/smart-wallet.ts
@@ -181,16 +181,31 @@ export class SmartWallet
     return connector.executeRaw(transaction);
   }
 
+  /**
+   * Estimate the gas cost of a single transaction
+   * @param transaction
+   * @returns
+   */
   async estimate(transaction: Transaction<any>) {
     const connector = await this.getConnector();
     return connector.estimate(transaction);
   }
 
+  /**
+   * Estimate the gas cost of a batch of transactions
+   * @param transaction
+   * @returns
+   */
   async estimateBatch(transactions: Transaction<any>[]) {
     const connector = await this.getConnector();
     return connector.estimateBatch(transactions);
   }
 
+  /**
+   * Estimate the gas cost of a single raw transaction
+   * @param transaction
+   * @returns
+   */
   async estimateRaw(
     transactions: utils.Deferrable<providers.TransactionRequest>,
   ) {
@@ -198,6 +213,11 @@ export class SmartWallet
     return connector.estimateRaw(transactions);
   }
 
+  /**
+   * Estimate the gas cost of a batch of raw transactions
+   * @param transaction
+   * @returns
+   */
   async estimateBatchRaw(
     transactions: utils.Deferrable<providers.TransactionRequest>[],
   ) {


### PR DESCRIPTION
## Problem solved

Expose function to estimate SmartWallet transactions, handling pre and post deployment state

```ts
const cost = smartWallet.estimate(preparedTx);
const costBatch = smartWallet.estimateBatch(preparedTxs);
```

Also works with raw transactions

```ts
const cost = smartWallet.estimateRaw(rawTx);
const costBatch = smartWallet.estimateBatchRaw(rawTxs);
```

returns:

```ts
batch {
  ether: '0.0000000000122901',
  wei: BigNumber { _hex: '0xbb8834', _isBigNumber: true },
  details: {
    deployGasLimit: BigNumber { _hex: '0x0421b6', _isBigNumber: true },
    transactionGasLimit: BigNumber { _hex: '0x053eb3', _isBigNumber: true },
    gasPrice: BigNumber { _hex: '0x14', _isBigNumber: true },
    transactionCost: BigNumber { _hex: '0x68e5fc', _isBigNumber: true },
    deployCost: BigNumber { _hex: '0x52a238', _isBigNumber: true },
    totalCost: BigNumber { _hex: '0xbb8834', _isBigNumber: true }
  }
}
```

## Changes made

- [x] Public API changes: list the public API changes made if any
- [x] Internal API changes: explain the internal logic changes

## How to test

- [ ] Automated tests: link to unit test file
- [x] Manual tests: step by step instructions on how to test
