### PR TITLE
Set activeChain in Provider state and created useSwitchActiveChain hook

### DIFF
--- a/packages/react-core/src/core/hooks/wallet-hooks.ts
+++ b/packages/react-core/src/core/hooks/wallet-hooks.ts
@@ -187,6 +187,20 @@ export function useSwitchChain() {
 
 /**
  *
+ * @returns a method to connect the wallet to network/chain with given chainId and also change the activeChain in the <ThirdwebProvider/>
+ *
+ */
+export function useSwitchActiveChainForProvider() {
+  const context = useWalletContext();
+  invariant(
+    context,
+    "useSwitchActiveChainForProvider() must be used within a <ThirdwebProvider/>",
+  );
+  return context.switchActiveChainForProvider;
+}
+
+/**
+ *
  * @returns a method to set a connected wallet instance
  */
 export function useSetConnectedWallet() {

--- a/packages/react-core/src/core/providers/thirdweb-wallet-provider.tsx
+++ b/packages/react-core/src/core/providers/thirdweb-wallet-provider.tsx
@@ -92,6 +92,7 @@ type ThirdwebWalletContextData = {
   getWalletConfig: (walletInstance: WalletInstance) => WalletConfig | undefined;
   activeChainSetExplicitly: boolean;
   clientId?: string;
+  switchActiveChainForProvider: (chain: number) => Promise<void>;
 };
 
 const ThirdwebWalletContext = /* @__PURE__ */ createContext<
@@ -116,6 +117,8 @@ export function ThirdwebWalletProvider(
   const [signer, setSigner] = useState<Signer | undefined>(undefined);
   const [connectionStatus, setConnectionStatus] =
     useState<ConnectionStatus>("unknown");
+
+  const [activeChain, setActiveChain] = useState<Chain>(props.activeChain);
 
   const autoConnectTimeout = props.autoConnectTimeout || 15000;
 
@@ -261,6 +264,14 @@ export function ThirdwebWalletProvider(
       setSigner(_signer);
     },
     [activeWallet, storeLastActiveChainId],
+  );
+
+  const switchActiveChainForProvider = useCallback(
+    async (chainId: number) => {
+      await switchChain(chainId);
+      setActiveChain(chainId);
+    },
+    [switchChain],
   );
 
   const autoConnectTriggered = useRef(false);
@@ -513,13 +524,14 @@ export function ThirdwebWalletProvider(
         createWalletStorage: props.createWalletStorage,
         switchChain,
         setConnectedWallet: setConnectedWallet,
-        activeChain: props.activeChain,
+        activeChain: activeChain,
         chainToConnect,
         getWalletConfig: (walletInstance: WalletInstance) => {
           return walletInstanceToConfig.get(walletInstance);
         },
         activeChainSetExplicitly: props.activeChainSetExplicitly,
         clientId: props.clientId,
+        switchActiveChainForProvider,
       }}
     >
       {props.children}


### PR DESCRIPTION
## Problem solved
- Added `const [activeChain, setActiveChain] = useState<Chain>(props.activeChain)` to `ThirdwebWalletProvider` and consume the activeChain value from local state instead of `props.activeChain` 
- Created `useSwitchActiveChain` to be able to switch the Provider `activeChain`

## Changes made

- [x] Public API changes: list the public API changes made if any
- [ ] Internal API changes: explain the internal logic changes

## How to test
Using the pr to publish an npm package to test the chanes

- [ ] Automated tests: link to unit test file
- [ ] Manual tests: step by step instructions on how to test


#1868 