### PR TITLE
[SmartWallet] Improved `useSmartWallet` hook

### DIFF
--- a/.changeset/fair-ladybugs-rhyme.md
+++ b/.changeset/fair-ladybugs-rhyme.md
@@ -1,0 +1,58 @@
+---
+"@thirdweb-dev/react-native": patch
+"@thirdweb-dev/react": patch
+---
+
+Improved `useSmartWallet()` hook
+
+Example with metamask:
+
+```ts
+const { connect } = useSmartWallet(metamaskWallet(), {
+  factoryAddress: factoryAddress,
+  gasless: true,
+});
+
+const onClick = async () => {
+  // nothing to do here, all handled internally
+  await connect();
+};
+```
+
+```ts
+Example with localWallet:
+
+const { connect } = useSmartWallet(localWallet(), {
+    factoryAddress: factoryAddress,
+    gasless: true,
+});
+
+const onClick = async () => {
+    // function to 'load' the local wallet before using it
+    await connect({
+        connectPersonalWallet: async (w) => {
+            await w.generate();
+            await w.connect();
+        }
+    });
+}
+```
+
+```ts
+Example with embeddedWallet:
+
+const { connect } = useSmartWallet(embeddedWallet(), {
+    factoryAddress: factoryAddress,
+    gasless: true,
+});
+
+const onClick = async () => {
+    // function to 'auth' the embedded wallet before using it
+    await connect({
+        connectPersonalWallet: async (w) => {
+            const authResult = await w.authenticate({ strategy: "google" });
+            await w.connect({ authResult });
+        }
+    });
+}
+```

--- a/packages/react-native/src/evm/index.ts
+++ b/packages/react-native/src/evm/index.ts
@@ -32,6 +32,7 @@ export { useRainbowWallet } from "./wallets/hooks/useRainbowWallet";
 export { useTrustWallet } from "./wallets/hooks/useTrustWallet";
 export { useEmbeddedWallet } from "./wallets/hooks/useEmbeddedWallet";
 export { useSmartWallet } from "./wallets/hooks/useSmartWallet";
+export { useEmbeddedWalletSendVerificationEmail } from "./wallets/hooks/useEmbeddedWalletSendVerificationEmail";
 
 export {
   ConnectWallet,

--- a/packages/react-native/src/evm/index.ts
+++ b/packages/react-native/src/evm/index.ts
@@ -31,6 +31,7 @@ export { useMetaMaskWallet } from "./wallets/hooks/useMetaMaskWallet";
 export { useRainbowWallet } from "./wallets/hooks/useRainbowWallet";
 export { useTrustWallet } from "./wallets/hooks/useTrustWallet";
 export { useEmbeddedWallet } from "./wallets/hooks/useEmbeddedWallet";
+export { useSmartWallet } from "./wallets/hooks/useSmartWallet";
 
 export {
   ConnectWallet,

--- a/packages/react-native/src/evm/wallets/connectors/embedded-wallet/embedded-connector.ts
+++ b/packages/react-native/src/evm/wallets/connectors/embedded-wallet/embedded-connector.ts
@@ -59,6 +59,9 @@ export class EmbeddedWalletConnector extends Connector<EmbeddedWalletConnectionA
       await this.switchChain(options.chainId);
     }
 
+    if (this.email) {
+      saveConnectedEmail(this.email);
+    }
     return this.getAddress();
   }
 
@@ -144,7 +147,6 @@ export class EmbeddedWalletConnector extends Connector<EmbeddedWalletConnectionA
     email: string;
   }): Promise<SendEmailOtpReturnType> {
     this.email = options.email;
-    saveConnectedEmail(options.email);
     return sendVerificationEmail({
       email: options.email,
       clientId: this.options.clientId,

--- a/packages/react-native/src/evm/wallets/connectors/embedded-wallet/embedded-connector.ts
+++ b/packages/react-native/src/evm/wallets/connectors/embedded-wallet/embedded-connector.ts
@@ -67,6 +67,7 @@ export class EmbeddedWalletConnector extends Connector<EmbeddedWalletConnectionA
     switch (strategy) {
       case "email_verification": {
         return await this.validateEmailOTP({
+          email: params.email,
           otp: params.verificationCode,
           recoveryCode: params.recoveryCode,
         });
@@ -89,16 +90,13 @@ export class EmbeddedWalletConnector extends Connector<EmbeddedWalletConnectionA
   }
 
   private async validateEmailOTP(options: {
+    email: string;
     otp: string;
     recoveryCode?: string;
   }): Promise<AuthResult> {
-    if (!this.email) {
-      throw new Error("Email is required to connect");
-    }
-
     try {
       const { storedToken } = await validateEmailOTP({
-        email: this.email,
+        email: options.email,
         clientId: this.options.clientId,
         otp: options.otp,
         recoveryCode: options.recoveryCode,

--- a/packages/react-native/src/evm/wallets/hooks/useEmbeddedWalletSendVerificationEmail.ts
+++ b/packages/react-native/src/evm/wallets/hooks/useEmbeddedWalletSendVerificationEmail.ts
@@ -1,0 +1,22 @@
+import { useWalletContext } from "@thirdweb-dev/react-core";
+import { useCallback } from "react";
+import { EmbeddedWallet } from "../wallets/embedded/EmbeddedWallet";
+
+export const useEmbeddedWalletSendVerificationEmail = () => {
+  const context = useWalletContext();
+
+  const sendVerificationEmail = useCallback(
+    async (email: string) => {
+      if (!context.clientId) {
+        throw new Error("Please, provide a clientId in the ThirdwebProvider");
+      }
+      return EmbeddedWallet.sendVerificationEmail({
+        email,
+        clientId: context.clientId,
+      });
+    },
+    [context.clientId],
+  );
+
+  return sendVerificationEmail;
+};

--- a/packages/react-native/src/evm/wallets/hooks/useSmartWallet.ts
+++ b/packages/react-native/src/evm/wallets/hooks/useSmartWallet.ts
@@ -6,18 +6,18 @@ import {
   useSetConnectionStatus,
   useWalletContext,
 } from "@thirdweb-dev/react-core";
-import type { SmartWalletConfigOptions } from "../../../wallet/wallets/smartWallet/types";
 import {
   getSmartWalletAddress,
   type SmartWalletConnectionArgs,
 } from "@thirdweb-dev/wallets/evm/wallets/smart-wallet";
 import { useCallback } from "react";
 import type { BytesLike } from "ethers";
-import { EmbeddedWallet } from "@thirdweb-dev/wallets";
+import { SmartWalletConfig } from "../types/smart-wallet";
+import { EmbeddedWallet } from "../wallets/embedded/EmbeddedWallet";
 
 export function useSmartWallet<W extends WalletInstance>(
   personalWallet: WalletConfig<W>,
-  options: SmartWalletConfigOptions,
+  options: SmartWalletConfig,
 ) {
   const create = useCreateWalletInstance();
   const setStatus = useSetConnectionStatus();
@@ -41,9 +41,7 @@ export function useSmartWallet<W extends WalletInstance>(
       connectPersonalWallet?: (wallet: W) => Promise<void>;
       connectionArgs?: Omit<SmartWalletConnectionArgs, "personalWallet">;
     }) => {
-      const { smartWallet } = await import(
-        "../../../wallet/wallets/smartWallet/smartWallet"
-      );
+      const { smartWallet } = await import("../wallets/smart-wallet");
       setStatus("connecting");
       const pw = create(personalWallet);
       const sw = create(smartWallet(personalWallet, options));

--- a/packages/react/src/evm/hooks/useEmbeddedWalletSendVerificationEmail.ts
+++ b/packages/react/src/evm/hooks/useEmbeddedWalletSendVerificationEmail.ts
@@ -1,0 +1,22 @@
+import { useWalletContext } from "@thirdweb-dev/react-core";
+import { EmbeddedWallet } from "@thirdweb-dev/wallets";
+import { useCallback } from "react";
+
+export const useEmbeddedWalletSendVerificationEmail = () => {
+  const context = useWalletContext();
+
+  const sendVerificationEmail = useCallback(
+    async (email: string) => {
+      if (!context.clientId) {
+        throw new Error("Please, provide a clientId in the ThirdwebProvider");
+      }
+      return EmbeddedWallet.sendVerificationEmail({
+        email,
+        clientId: context.clientId,
+      });
+    },
+    [context.clientId],
+  );
+
+  return sendVerificationEmail;
+};

--- a/packages/react/src/evm/hooks/wallets/useSmartWallet.ts
+++ b/packages/react/src/evm/hooks/wallets/useSmartWallet.ts
@@ -5,6 +5,7 @@ import {
   useSetConnectedWallet,
   useSetConnectionStatus,
   useWalletContext,
+  useWallets,
 } from "@thirdweb-dev/react-core";
 import type { SmartWalletConfigOptions } from "../../../wallet/wallets/smartWallet/types";
 import {
@@ -13,7 +14,6 @@ import {
 } from "@thirdweb-dev/wallets/evm/wallets/smart-wallet";
 import { useCallback } from "react";
 import type { BytesLike } from "ethers";
-import { EmbeddedWallet } from "@thirdweb-dev/wallets";
 
 export function useSmartWallet<W extends WalletInstance>(
   personalWallet: WalletConfig<W>,
@@ -23,6 +23,7 @@ export function useSmartWallet<W extends WalletInstance>(
   const setStatus = useSetConnectionStatus();
   const setWallet = useSetConnectedWallet();
   const context = useWalletContext();
+  const supportedWallets = useWallets();
 
   const predictAddress = useCallback(
     async (args: { personalWalletAddress: string; data?: BytesLike }) => {
@@ -41,6 +42,11 @@ export function useSmartWallet<W extends WalletInstance>(
       connectPersonalWallet?: (wallet: W) => Promise<void>;
       connectionArgs?: Omit<SmartWalletConnectionArgs, "personalWallet">;
     }) => {
+      if (!supportedWallets.find((w) => w.id === personalWallet.id)) {
+        console.warn(
+          "Please, add your smart wallet to the supportedWallets prop of the ThirdwebProvider to enjoy auto-connecting to the wallet.",
+        );
+      }
       const { smartWallet } = await import(
         "../../../wallet/wallets/smartWallet/smartWallet"
       );
@@ -77,25 +83,12 @@ export function useSmartWallet<W extends WalletInstance>(
       personalWallet,
       setStatus,
       setWallet,
+      supportedWallets,
     ],
-  );
-
-  const sendVerificationEmail = useCallback(
-    async (email: string) => {
-      if (!context.clientId) {
-        throw new Error("Please, provide a clientId in the ThirdwebProvider");
-      }
-      return EmbeddedWallet.sendVerificationEmail({
-        email,
-        clientId: context.clientId,
-      });
-    },
-    [context.clientId],
   );
 
   return {
     connect,
     predictAddress,
-    sendVerificationEmail,
   };
 }

--- a/packages/react/src/evm/hooks/wallets/useSmartWallet.ts
+++ b/packages/react/src/evm/hooks/wallets/useSmartWallet.ts
@@ -1,20 +1,84 @@
-import { type WalletConfig, useConnect } from "@thirdweb-dev/react-core";
+import {
+  type WalletConfig,
+  WalletInstance,
+  useCreateWalletInstance,
+  useSetConnectedWallet,
+  useSetConnectionStatus,
+  useWalletContext,
+} from "@thirdweb-dev/react-core";
 import type { SmartWalletConfigOptions } from "../../../wallet/wallets/smartWallet/types";
-import type { SmartWalletConnectionArgs } from "@thirdweb-dev/wallets/evm/wallets/smart-wallet";
+import {
+  getSmartWalletAddress,
+  type SmartWalletConnectionArgs,
+} from "@thirdweb-dev/wallets/evm/wallets/smart-wallet";
 import { useCallback } from "react";
+import type { BytesLike } from "ethers";
 
-export function useSmartWallet() {
-  const connect = useConnect();
-  return useCallback(
-    async (
-      wallet: WalletConfig<any>,
-      options: SmartWalletConnectionArgs & SmartWalletConfigOptions,
-    ) => {
+export function useSmartWallet<W extends WalletInstance>(
+  personalWallet: WalletConfig<W>,
+  options: SmartWalletConfigOptions,
+) {
+  const create = useCreateWalletInstance();
+  const setStatus = useSetConnectionStatus();
+  const setWallet = useSetConnectedWallet();
+  const context = useWalletContext();
+
+  const predictAddress = useCallback(
+    async (args: { personalWalletAddress: string; data?: BytesLike }) => {
+      return getSmartWalletAddress(
+        context.activeChain,
+        options.factoryAddress,
+        args.personalWalletAddress,
+        args.data,
+      );
+    },
+    [context.activeChain, options.factoryAddress],
+  );
+
+  const connect = useCallback(
+    async (args?: {
+      connectPersonalWallet?: (wallet: W) => Promise<void>;
+      connectionArgs?: Omit<SmartWalletConnectionArgs, "personalWallet">;
+    }) => {
       const { smartWallet } = await import(
         "../../../wallet/wallets/smartWallet/smartWallet"
       );
-      return connect(smartWallet(wallet, options), options);
+      setStatus("connecting");
+      const pw = create(personalWallet);
+      const sw = create(smartWallet(personalWallet, options));
+      try {
+        if (args?.connectPersonalWallet) {
+          // if passed in, use custom function to connect personal wallet
+          await args.connectPersonalWallet(pw);
+        } else {
+          // otherwise default to auto-connecting personal wallet with chainId
+          await pw.connect({
+            chainId: context.activeChain.chainId,
+          });
+        }
+        await sw.connect({
+          ...args?.connectionArgs,
+          personalWallet: pw,
+        });
+        setStatus("connected");
+        setWallet(sw);
+      } catch (e) {
+        console.error("Error connecting to smart wallet", e);
+        setStatus("disconnected");
+      }
+      return sw;
     },
-    [connect],
+    [
+      context.activeChain.chainId,
+      create,
+      options,
+      personalWallet,
+      setStatus,
+      setWallet,
+    ],
   );
+  return {
+    connect,
+    predictAddress,
+  };
 }

--- a/packages/react/src/evm/index.ts
+++ b/packages/react/src/evm/index.ts
@@ -34,6 +34,7 @@ export { useCoinbaseWallet } from "./hooks/wallets/useCoinbaseWallet";
 export { useFrameWallet } from "./hooks/wallets/useFrame";
 export { useBloctoWallet } from "./hooks/wallets/useBloctoWallet";
 export { useEmbeddedWallet } from "./hooks/wallets/useEmbeddedWallet";
+export { useEmbeddedWalletSendVerificationEmail } from "./hooks/useEmbeddedWalletSendVerificationEmail";
 
 export {
   usePaperWalletUserEmail,


### PR DESCRIPTION
## Problem solved

New API for conveniently connecting smart wallets without UI components:

Example with metamask:

```tsx
const { connect } = useSmartWallet(metamaskWallet(), {
    factoryAddress: factoryAddress,
    gasless: true,
});

const onClick = async () => {
    // nothing to do here, all handled internally
    await connect(); 
}
```

Example with localWallet:

```tsx
const { connect } = useSmartWallet(localWallet(), {
    factoryAddress: factoryAddress,
    gasless: true,
});

const onClick = async () => {
    // function to 'load' the local wallet before using it
    await connect({
        connectPersonalWallet: async (w) => {
            await w.generate();
            await w.connect();
        }
    });
}
```

Example with embeddedWallet:

```tsx
const { connect } = useSmartWallet(embeddedWallet(), {
    factoryAddress: factoryAddress,
    gasless: true,
});

const onClick = async () => {
    // function to 'auth' the embedded wallet before using it
    await connect({
        connectPersonalWallet: async (w) => {
            const authResult = await w.authenticate({ strategy: "google" });
            await w.connect({ authResult });
        }
    });
}
```

## Changes made

- [ ] Public API changes: list the public API changes made if any
- [ ] Internal API changes: explain the internal logic changes

## How to test

- [ ] Automated tests: link to unit test file
- [ ] Manual tests: step by step instructions on how to test
