### PR TITLE
Show sign in button if user address and active wallet address are mis-matched

### DIFF
--- a/.changeset/smart-pens-tap.md
+++ b/.changeset/smart-pens-tap.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/react": patch
+---
+
+Fix for user address and active wallet address out of sync

--- a/packages/react/src/wallet/ConnectWallet/ConnectWallet.tsx
+++ b/packages/react/src/wallet/ConnectWallet/ConnectWallet.tsx
@@ -169,9 +169,12 @@ export const ConnectWallet: React.FC<ConnectWalletProps> = (props) => {
   const { user } = useUser();
   const disconnect = useDisconnect();
 
+  const shouldSignIn = !!authConfig?.authUrl && !!address && !user?.address;
+  const addressAndUserAddressMismatched = address !== user?.address;
+
   const requiresSignIn = props.auth?.loginOptional
     ? false
-    : !!authConfig?.authUrl && !!address && !user?.address;
+    : shouldSignIn || addressAndUserAddressMismatched;
 
   const supportedTokens = useMemo(() => {
     if (!props.supportedTokens) {
@@ -192,10 +195,10 @@ export const ConnectWallet: React.FC<ConnectWalletProps> = (props) => {
 
   // if wallet gets disconnected, close the signature modal
   useEffect(() => {
-    if (!activeWallet) {
+    if (!activeWallet && !addressAndUserAddressMismatched) {
       setShowSignatureModal(false);
     }
-  }, [activeWallet]);
+  }, [activeWallet, addressAndUserAddressMismatched]);
 
   return (
     <CustomThemeProvider theme={theme}>


### PR DESCRIPTION
## Problem solved

It is possible for the user address and the active wallet address to be mismatched in ConnectWallet. This will cause the auth login endpoint will never be called, and result in bad auth behavior in the developer's application.

Examples of how this can happen:
 - Create local wallet, then reload. The local wallet will still exist in storage (and recognized in useUser) but not recognized in useAddress.

## Changes made

- Force show the Sign In button if addresses are out of sync

## How to test
- [x] Manual tests: create local wallet, refresh, create a new local wallet, observe if sign in shows up.