### PR TITLE
[auth] update fastify login route response to match express/next

### DIFF
--- a/.changeset/eight-carrots-confess.md
+++ b/.changeset/eight-carrots-confess.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/auth": minor
+---
+
+Update Fastify login route response to match Express/Next

--- a/.changeset/eight-carrots-confess.md
+++ b/.changeset/eight-carrots-confess.md
@@ -1,5 +1,5 @@
 ---
-"@thirdweb-dev/auth": minor
+"@thirdweb-dev/auth": patch
 ---
 
 Update Fastify login route response to match Express/Next

--- a/packages/auth/src/fastify/routes/login.ts
+++ b/packages/auth/src/fastify/routes/login.ts
@@ -22,7 +22,9 @@ export const loginHandler = (
     schema: {
       body: LoginPayloadBodySchema,
       response: {
-        200: z.any(),
+        200: z.object({
+          token: z.string(),
+        }),
       },
     },
     handler: async (req, res) => {
@@ -104,7 +106,8 @@ export const loginHandler = (
         },
       );
 
-      return res.status(200).send({ success: true });
+      // Send token in body and as cookie for frontend and backend use cases
+      return res.status(200).send({ token });
     },
   });
 };


### PR DESCRIPTION
## Problem solved

The response payload for the `/login` route in the Fastify Auth package is missing the `token` field, which is included in the Express and Next versions. This makes it incompatible with the `useLogin` hook from the `react` package: https://github.com/thirdweb-dev/js/blob/main/packages/react-core/src/evm/hooks/auth/useLogin.ts#L77

## Changes made

- [X] Public API changes: list the public API changes made if any
- [ ] Internal API changes: explain the internal logic changes

1. Fastify `/login` response changed from `{ success: true }` to `{ token: ... }`

## How to test

- [ ] Automated tests: link to unit test file
- [X] Manual tests: step by step instructions on how to test

1. Create Fastify auth example project
2. Integrate `useLogin` on the frontend
3. Print response of `login` function call, should now include `token` result