### PR TITLE
[React-core] Fix caching issue with useTotalCirculatingSupply

### DIFF
--- a/.changeset/healthy-trains-deny.md
+++ b/.changeset/healthy-trains-deny.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/react-core": patch
+---
+
+Fix caching issue with useTotalCirculatingSupply

--- a/packages/react-core/src/evm/hooks/async/nft.ts
+++ b/packages/react-core/src/evm/hooks/async/nft.ts
@@ -195,7 +195,7 @@ export function useTotalCirculatingSupply(
   return useQueryWithNetwork<BigNumber>(
     cacheKeys.contract.nft.query.totalCirculatingSupply(
       contractAddress,
-      tokenId,
+      tokenId ?? undefined,
     ),
     async () => {
       requiredParamInvariant(contract, "No Contract instance provided");

--- a/packages/react-core/src/evm/hooks/async/nft.ts
+++ b/packages/react-core/src/evm/hooks/async/nft.ts
@@ -193,7 +193,10 @@ export function useTotalCirculatingSupply(
   const { erc721, erc1155 } = getErcs(contract);
 
   return useQueryWithNetwork<BigNumber>(
-    cacheKeys.contract.nft.query.totalCirculatingSupply(contractAddress),
+    cacheKeys.contract.nft.query.totalCirculatingSupply(
+      contractAddress,
+      tokenId,
+    ),
     async () => {
       requiredParamInvariant(contract, "No Contract instance provided");
 

--- a/packages/react-core/src/evm/utils/cache-keys.ts
+++ b/packages/react-core/src/evm/utils/cache-keys.ts
@@ -182,12 +182,12 @@ export const cacheKeys = {
           ),
         totalCirculatingSupply: (
           contractAddress: RequiredParam<ContractAddress>,
-          tokenId?: RequiredParam<BigNumberish>,
+          tokenId?: BigNumberish,
         ) =>
           createContractCacheKey(contractAddress, [
             "query",
             "totalCirculatingSupply",
-            tokenId ?? "erc721",
+            tokenId ?? "0",
           ]),
         totalCount: (contractAddress: RequiredParam<ContractAddress>) =>
           createContractCacheKey(contractAddress, ["query", "totalCount"]),

--- a/packages/react-core/src/evm/utils/cache-keys.ts
+++ b/packages/react-core/src/evm/utils/cache-keys.ts
@@ -182,10 +182,12 @@ export const cacheKeys = {
           ),
         totalCirculatingSupply: (
           contractAddress: RequiredParam<ContractAddress>,
+          tokenId?: RequiredParam<BigNumberish>,
         ) =>
           createContractCacheKey(contractAddress, [
             "query",
             "totalCirculatingSupply",
+            tokenId ?? "erc721",
           ]),
         totalCount: (contractAddress: RequiredParam<ContractAddress>) =>
           createContractCacheKey(contractAddress, ["query", "totalCount"]),


### PR DESCRIPTION
## Problem solved
The code below doesn't work beecause currently they all share the same cacheKey, so as the result all of them will return the cached data from the first `useTotal...` (tokenId #0)

This fix adds the `tokenId` as the extra cacheKey
```
const { contract: nftContract } = useContract(
  "0x8a41F6......9829659526"
);
const { data: token0 } = useTotalCirculatingSupply(nftContract, 0);
const { data: token1 } = useTotalCirculatingSupply(nftContract, 1);
const { data: token2 } = useTotalCirculatingSupply(nftContract, 2);
const { data: token3 } = useTotalCirculatingSupply(nftContract, 3);

console.log({
  token0: token0?.toString(),
  token1: token1?.toString(),
  token2: token2?.toString(),
  token3: token3?.toString(),
});
```

## Changes made

- [ ] Public API changes: list the public API changes made if any
- [x] Internal API changes: explain the internal logic changes

## How to test

- [x] Automated tests: link to unit test file
- [ ] Manual tests: step by step instructions on how to test
