### PR TITLE
fix: Reuse response body in service utils helper

### DIFF
--- a/.changeset/rude-horses-shake.md
+++ b/.changeset/rude-horses-shake.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+Handle if error parsing JSON response in authorization helper

--- a/packages/service-utils/src/core/api.ts
+++ b/packages/service-utils/src/core/api.ts
@@ -109,17 +109,16 @@ export async function fetchAccountFromApi(
       authorization: `Bearer ${jwt}`,
     },
   });
-  let json: ApiAccountResponse;
+
+  let text = "";
   try {
-    json = await response.json();
+    text = await response.text();
+    return JSON.parse(text);
   } catch (e) {
     throw new Error(
-      `Error fetching account from API: ${response.status} - ${
-        response.statusText
-      } - ${await response.text()}`,
+      `Error fetching account from API: ${response.status} - ${text}`,
     );
   }
-  return json;
 }
 
 export async function updateRateLimitedAt(

--- a/packages/service-utils/src/core/api.ts
+++ b/packages/service-utils/src/core/api.ts
@@ -80,17 +80,16 @@ export async function fetchKeyMetadataFromApi(
       "content-type": "application/json",
     },
   });
-  let json: ApiResponse;
+
+  let text = "";
   try {
-    json = await response.json();
+    text = await response.text();
+    return JSON.parse(text);
   } catch (e) {
     throw new Error(
-      `Error fetching key metadata from API: ${response.status} - ${
-        response.statusText
-      } - ${await response.text()}`,
+      `Error fetching key metadata from API: ${response.status} - ${text}`,
     );
   }
-  return json;
 }
 
 export async function fetchAccountFromApi(


### PR DESCRIPTION
## Problem solved

Fixing a potential edge case where the response body is read twice, causing an unrelated throw:

```
Body has already been used. It can only be used once. Use tee() first if you need to read it twice.
```
