### PR TITLE
[Wallets] Fix potential embedded wallet autoconnect race condition

### DIFF
--- a/.changeset/real-bags-marry.md
+++ b/.changeset/real-bags-marry.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/wallets": patch
+---
+
+Fix potential auto connection race condition

--- a/packages/wallets/src/evm/connectors/embedded-wallet/types.ts
+++ b/packages/wallets/src/evm/connectors/embedded-wallet/types.ts
@@ -64,5 +64,4 @@ export type AuthResult = {
   user?: InitializedUser;
   isNewUser?: boolean;
   needsRecoveryCode?: boolean;
-  verifyOTP?: (otp: string, recoveryCode?: string) => Promise<AuthResult>;
 };


### PR DESCRIPTION
## Problem solved

There was a potential code path that would attempt to get the signer after autoconnect where the user is not in the initialized state, resulting in getAddress returning the last saved address but the signer failing to initialize. Fixed that by enforcing that getUser() always returns a initialized user or throw, and syncing the getAddress() and getSigner() calls.

## Changes made

- [ ] Public API changes: list the public API changes made if any
- [x] Internal API changes: explain the internal logic changes

## How to test

- [ ] Automated tests: link to unit test file
- [x] Manual tests: step by step instructions on how to test
