### PR TITLE
[Wallets] Enforce authenticated users when getting EW signers

### DIFF
--- a/.changeset/smart-ligers-relax.md
+++ b/.changeset/smart-ligers-relax.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/wallets": patch
+---
+
+Enforce authenticated users when getting embedded wallet signers

--- a/packages/wallets/src/evm/connectors/embedded-wallet/index.ts
+++ b/packages/wallets/src/evm/connectors/embedded-wallet/index.ts
@@ -184,7 +184,7 @@ export class EmbeddedWalletConnector extends Connector<EmbeddedWalletConnectionA
     if (
       !this.user ||
       !this.user.wallet ||
-      !this.user.wallet.getEthersJsSigner // when serializing, functions are lost
+      !this.user.wallet.getEthersJsSigner // when serializing, functions are lost, need to rehydrate
     ) {
       const embeddedWalletSdk = this.getEmbeddedWalletSDK();
       const user = await embeddedWalletSdk.getUser();
@@ -193,12 +193,13 @@ export class EmbeddedWalletConnector extends Connector<EmbeddedWalletConnectionA
           this.user = user;
           break;
         }
+        default: {
+          // if logged out or unitialized, we can't get a signer, so throw an error
+          throw new Error(
+            "Embedded Wallet is not authenticated, please authenticate first",
+          );
+        }
       }
-    }
-    if (!this.user) {
-      throw new Error(
-        "No user found, Embedded Wallet is not authenticated, please authenticate first",
-      );
     }
     return this.user;
   }


### PR DESCRIPTION
## Problem solved

throw when users are in logged out or uninitialized states and attempting to get a signer

## Changes made

- [ ] Public API changes: list the public API changes made if any
- [x] Internal API changes: explain the internal logic changes

## How to test

- [ ] Automated tests: link to unit test file
- [x] Manual tests: step by step instructions on how to test
