### PR TITLE
[Unity] Apple and Facebook logins

### DIFF
--- a/.changeset/nasty-pears-pay.md
+++ b/.changeset/nasty-pears-pay.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/unity-js-bridge": patch
+---
+
+[Unity] Added Facebook and Apple providers

--- a/packages/unity-js-bridge/src/thirdweb-bridge.ts
+++ b/packages/unity-js-bridge/src/thirdweb-bridge.ts
@@ -274,22 +274,38 @@ class ThirdwebBridge implements TWBridge {
             throw new Error("Email is required for EmbeddedWallet");
           }
           const authResult = await embeddedWallet.authenticate({
-            strategy: "iframe_email_verification",
+            strategy: "iframe_otp",
             email,
           });
           await embeddedWallet.connect({
             chainId: chainIdNumber,
             authResult,
           });
-        } else if (authOptionsParsed.authProvider === 1) {
-          // GoogleManaged
-          const googleWindow = this.openGoogleSignInWindow();
-          if (!googleWindow) {
-            throw new Error("Failed to open google login window");
+        } else if (authOptionsParsed.authProvider < 4) {
+          // OAuth
+          let authProvider;
+          switch (authOptionsParsed.authProvider) {
+            case 1:
+              authProvider = "google";
+              break;
+            case 2:
+              authProvider = "apple";
+              break;
+            case 3:
+              authProvider = "facebook";
+              break;
+            default:
+              throw new Error(
+                "Invalid auth provider: " + authOptionsParsed.authProvider,
+              );
+          }
+          const popupWindow = this.openPopupWindow();
+          if (!popupWindow) {
+            throw new Error("Failed to open login window");
           }
           const authResult = await embeddedWallet.authenticate({
-            strategy: "google",
-            openedWindow: googleWindow,
+            strategy: authProvider,
+            openedWindow: popupWindow,
             closeOpenedWindow: (openedWindow) => {
               openedWindow.close();
             },
@@ -298,7 +314,7 @@ class ThirdwebBridge implements TWBridge {
             chainId: chainIdNumber,
             authResult,
           });
-        } else if (authOptionsParsed.authProvider === 2) {
+        } else if (authOptionsParsed.authProvider === 4) {
           // CustomAuth
           const authResult = await embeddedWallet.authenticate({
             strategy: "jwt",
@@ -627,10 +643,10 @@ class ThirdwebBridge implements TWBridge {
     return localWallet;
   }
 
-  public openGoogleSignInWindow() {
+  public openPopupWindow() {
     const win = window.open("", undefined, "width=350, height=500");
     if (win) {
-      win.document.title = "Sign In - Google Accounts";
+      win.document.title = "Sign In - OAuth";
       win.document.body.innerHTML = `
       <svg class="loader" viewBox="0 0 50 50">
         <circle

--- a/packages/unity-js-bridge/src/thirdweb-bridge.ts
+++ b/packages/unity-js-bridge/src/thirdweb-bridge.ts
@@ -5,6 +5,7 @@ import { ThirdwebSDK, ChainIdOrName } from "@thirdweb-dev/sdk";
 import { ThirdwebStorage } from "@thirdweb-dev/storage";
 import {
   DAppMetaData,
+  EmbeddedWalletOauthStrategy,
   SmartWalletConfig,
   walletIds,
 } from "@thirdweb-dev/wallets";
@@ -274,7 +275,7 @@ class ThirdwebBridge implements TWBridge {
             throw new Error("Email is required for EmbeddedWallet");
           }
           const authResult = await embeddedWallet.authenticate({
-            strategy: "iframe_otp",
+            strategy: "iframe_email_verification",
             email,
           });
           await embeddedWallet.connect({
@@ -283,7 +284,7 @@ class ThirdwebBridge implements TWBridge {
           });
         } else if (authOptionsParsed.authProvider < 4) {
           // OAuth
-          let authProvider;
+          let authProvider: EmbeddedWalletOauthStrategy;
           switch (authOptionsParsed.authProvider) {
             case 1:
               authProvider = "google";


### PR DESCRIPTION
## Changes made

- Added Apple and Facebook login to Unity WebGL bridge
- Updated to match C# API

## How to test

- Set client id and build [this branch](https://github.com/thirdweb-dev/unity-sdk/pull/126) to WebGL
- Select one of the new social options
