### PR TITLE
[react-core] Fix auto-connecting a personal wallet for smart/safe wallet

### DIFF
--- a/.changeset/wild-tigers-design.md
+++ b/.changeset/wild-tigers-design.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/react-core": patch
+---
+
+Fix auto-connecting a personal wallet for smart/safe wallet

--- a/packages/react-core/src/core/providers/thirdweb-wallet-provider.tsx
+++ b/packages/react-core/src/core/providers/thirdweb-wallet-provider.tsx
@@ -383,6 +383,7 @@ export function ThirdwebWalletProvider(
             (w) => w.id === walletInfo.walletId,
           );
           if (!walletObj) {
+            setConnectionStatus("disconnected");
             return;
           }
         }

--- a/packages/react-core/src/core/providers/thirdweb-wallet-provider.tsx
+++ b/packages/react-core/src/core/providers/thirdweb-wallet-provider.tsx
@@ -303,7 +303,7 @@ export function ThirdwebWalletProvider(
         return;
       }
 
-      const walletObj = props.supportedWallets.find(
+      let walletObj = props.supportedWallets.find(
         (W) => W.id === walletInfo.walletId,
       );
 
@@ -373,6 +373,18 @@ export function ThirdwebWalletProvider(
           // last used personal wallet is no longer present in the supported wallets
           setConnectionStatus("disconnected");
           return;
+        }
+      } else {
+        // if walletObj requires a personal wallet, but the saved data does not have it
+        // connect to personal wallet only ( this happens when user switches to personal wallet and reloads the page )
+        if (walletObj.personalWallets) {
+          // connect the personal wallet instead
+          walletObj = walletObj.personalWallets.find(
+            (w) => w.id === walletInfo.walletId,
+          );
+          if (!walletObj) {
+            return;
+          }
         }
       }
 


### PR DESCRIPTION
## Problem solved

* Connect a smart / safe wallet
* click on switch to personal wallet in the ConnectWallet dropdown
* reload the page
* expect to be connected to the last connected wallet ( personal wallet )
* problem: autoconnection fails because given personal wallet can not be found in the list of supported wallets in thirdweb provider

## Solution
* if the last connected wallet is a personal wallet, get the personal wallet from smart wallet / safe wallet's personalWallets array and connect to it 