### PR TITLE
[Storage] Catch error when converting invalid IPFS URIs

### DIFF
--- a/.changeset/old-cycles-travel.md
+++ b/.changeset/old-cycles-travel.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/storage": patch
+---
+
+[storage] Catch issue when converting invalid IPFS CID to v1

--- a/.changeset/old-cycles-travel.md
+++ b/.changeset/old-cycles-travel.md
@@ -2,4 +2,4 @@
 "@thirdweb-dev/storage": patch
 ---
 
-[storage] Catch issue when converting invalid IPFS CID to v1
+Catch issue when converting invalid IPFS CID to v1

--- a/packages/storage/src/common/urls.ts
+++ b/packages/storage/src/common/urls.ts
@@ -163,7 +163,7 @@ export function convertCidToV1(cid: string) {
     const hash = cid.split("/")[0];
     normalized = CIDTool.base32(hash);
   } catch (e) {
-    throw new Error(`The IPFS uri: ${cid} is not valid.`);
+    throw new Error(`The CID ${cid} is not valid.`);
   }
   return normalized;
 }

--- a/packages/storage/src/common/urls.ts
+++ b/packages/storage/src/common/urls.ts
@@ -163,7 +163,7 @@ export function convertCidToV1(cid: string) {
     const hash = cid.split("/")[0];
     normalized = CIDTool.base32(hash);
   } catch (e) {
-    throw new Error(`The CID ${cid} is not valid.`);
+    throw new Error(`The IPFS uri: ${cid} is not valid.`);
   }
   return normalized;
 }

--- a/packages/storage/src/common/utils.ts
+++ b/packages/storage/src/common/utils.ts
@@ -162,7 +162,17 @@ export function replaceSchemeWithGatewayUrl(
   }
 
   const path = uri.replace(scheme, "");
-  return getGatewayUrlForCid(schemeGatewayUrls[index], path, clientId);
+  try {
+    const gatewayUrl = getGatewayUrlForCid(
+      schemeGatewayUrls[index],
+      path,
+      clientId,
+    );
+    return gatewayUrl;
+  } catch (err) {
+    console.warn(`The CID ${path} is not valid.`);
+    return undefined;
+  }
 }
 
 /**

--- a/packages/storage/src/common/utils.ts
+++ b/packages/storage/src/common/utils.ts
@@ -170,7 +170,7 @@ export function replaceSchemeWithGatewayUrl(
     );
     return gatewayUrl;
   } catch (err) {
-    console.warn(`The CID ${path} is not valid.`);
+    console.warn(`The IPFS uri: ${path} is not valid.`);
     return undefined;
   }
 }


### PR DESCRIPTION
## Problem solved

User recorded this error:
https://github.com/thirdweb-dev/js/assets/26052673/dfecb175-7b91-47b7-9e66-5153f5910b9d

This happens because they have an NFT with an invalid IPFS uri
![image](https://github.com/thirdweb-dev/js/assets/26052673/bcfe8bea-7b76-4ebf-872e-97ad2d193563)

So we need catch the error causing by `CIDTool.base32(hash)`

![image](https://github.com/thirdweb-dev/js/assets/26052673/f5082a42-bc88-4423-83d9-5faeac4cb368)


## Changes made

- [ ] Public API changes: list the public API changes made if any
- [x] Internal API changes: explain the internal logic changes

## How to test

- [ ] Automated tests: link to unit test file
- [x] Manual tests: step by step instructions on how to test
