### PR TITLE
[Wallets] Respect `value` in smart wallet gas estimations + add `getUserOpReceipt` utility function

### DIFF
--- a/.changeset/spotty-lizards-yawn.md
+++ b/.changeset/spotty-lizards-yawn.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/wallets": patch
+---
+
+Respect `value` in smart wallet gas estimations + add `getUserOpReceipt` utility function

--- a/packages/wallets/src/evm/connectors/smart-wallet/index.ts
+++ b/packages/wallets/src/evm/connectors/smart-wallet/index.ts
@@ -359,6 +359,7 @@ export class SmartWalletConnector extends Connector<SmartWalletConnectionArgs> {
       {
         targets: [],
         data: [],
+        values: [],
       }, // batched tx flag to avoid hitting the Router fallback method
     );
     const receipt = await tx.wait();
@@ -590,6 +591,7 @@ export class SmartWalletConnector extends Connector<SmartWalletConnectionArgs> {
       batchData: {
         targets,
         data,
+        values,
       },
     };
   }
@@ -606,6 +608,7 @@ export class SmartWalletConnector extends Connector<SmartWalletConnectionArgs> {
       batchData: {
         targets,
         data,
+        values,
       },
     };
   }

--- a/packages/wallets/src/evm/connectors/smart-wallet/lib/base-api.ts
+++ b/packages/wallets/src/evm/connectors/smart-wallet/lib/base-api.ts
@@ -31,6 +31,7 @@ import { Transaction, getDynamicFeeData } from "@thirdweb-dev/sdk";
 export type BatchData = {
   targets: (string | undefined)[];
   data: BytesLike[];
+  values: BigNumberish[];
 };
 
 export interface BaseApiParams {
@@ -201,6 +202,7 @@ export abstract class BaseAccountAPI {
               from: this.getAccountAddress(),
               to: batchData.targets[i],
               data: batchData.data[i],
+              value: batchData.values[i],
             }),
           ),
         );
@@ -210,6 +212,7 @@ export abstract class BaseAccountAPI {
           from: this.getAccountAddress(),
           to: detailsForUserOp.target,
           data: detailsForUserOp.data,
+          value: detailsForUserOp.value,
         });
       }
 
@@ -226,12 +229,9 @@ export abstract class BaseAccountAPI {
           from: this.entryPointAddress,
           to: this.getAccountAddress(),
           data: callData,
+          value: detailsForUserOp.value,
         }));
     }
-
-    // callGasLimit = callGasLimit.mul(10); // add 100k for entrypoint checks
-
-    console.log("callGasLimit", callGasLimit.toString());
 
     return {
       callData,
@@ -419,7 +419,7 @@ export abstract class BaseAccountAPI {
   async getUserOpReceipt(
     userOpHash: string,
     timeout = 30000,
-    interval = 5000,
+    interval = 2000,
   ): Promise<string | null> {
     const endtime = Date.now() + timeout;
     while (Date.now() < endtime) {


### PR DESCRIPTION
## Problem solved

- respect `value` when doing tx estimations
- add `getUserOpReceipt` utility function to get trasaction hashes from a userOp hash

## Changes made

- [ ] Public API changes: list the public API changes made if any
- [ ] Internal API changes: explain the internal logic changes

## How to test

- [ ] Automated tests: link to unit test file
- [ ] Manual tests: step by step instructions on how to test
