### PR TITLE
[Wallets] Add support for signTransaction for smart wallets

### DIFF
--- a/.changeset/smooth-paws-cry.md
+++ b/.changeset/smooth-paws-cry.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/wallets": patch
+---
+
+Add support for signTransaction to smart wallets


### PR DESCRIPTION
Add support for `signTransactions` on `ERC4337Signer` so that users can store a signed user operation to broadcast later.