### PR TITLE
feat: ethers `skipFetchSetup` support

### DIFF
--- a/packages/sdk/src/evm/constants/urls.ts
+++ b/packages/sdk/src/evm/constants/urls.ts
@@ -286,12 +286,22 @@ export function getProviderFromRpcUrl(
           }
 
           // Otherwise, create a new provider on the specific network
+          let _skipFetchSetup = false;
+          if (
+            typeof globalThis !== "undefined" &&
+            "TW_SKIP_FETCH_SETUP" in globalThis &&
+            typeof (globalThis as any).TW_SKIP_FETCH_SETUP === "boolean"
+          ) {
+            _skipFetchSetup = (globalThis as any).TW_SKIP_FETCH_SETUP as boolean;
+          }
+
           const newProvider = chainId
             ? // If we know the chainId we should use the StaticJsonRpcBatchProvider
               new StaticJsonRpcBatchProvider(
                 {
                   url: rpcUrl,
                   headers,
+                  skipFetchSetup: _skipFetchSetup,
                 },
                 chainId,
               )
@@ -299,6 +309,7 @@ export function getProviderFromRpcUrl(
               new providers.JsonRpcBatchProvider({
                 url: rpcUrl,
                 headers,
+                skipFetchSetup: _skipFetchSetup,
               });
 
           // Save the provider in our cache

--- a/packages/sdk/src/evm/constants/urls.ts
+++ b/packages/sdk/src/evm/constants/urls.ts
@@ -284,8 +284,8 @@ export function getProviderFromRpcUrl(
           if (existingProvider) {
             return existingProvider;
           }
-
-          // Otherwise, create a new provider on the specific network
+          
+          // TODO: remove below `skipFetchSetup` logic when ethers.js v6 support arrives
           let _skipFetchSetup = false;
           if (
             typeof globalThis !== "undefined" &&
@@ -295,6 +295,7 @@ export function getProviderFromRpcUrl(
             _skipFetchSetup = (globalThis as any).TW_SKIP_FETCH_SETUP as boolean;
           }
 
+          // Otherwise, create a new provider on the specific network
           const newProvider = chainId
             ? // If we know the chainId we should use the StaticJsonRpcBatchProvider
               new StaticJsonRpcBatchProvider(


### PR DESCRIPTION
## Problem solved

This fixes https://github.com/thirdweb-dev/js/issues/2002

It may not be the clearest solution but the quick one. If the global environment variable `TW_SKIP_FETCH_SETUP ` is set, the Thirdweb SDK will assign the value of it to the `skipFetchSetup` option. When ethers.js v6 support arrives, we need to revert this commit. This is also commented on the source as a todo.

## Changes made

- [ ] Public API changes: list the public API changes made if any
- [x] Internal API changes: explain the internal logic changes

## How to test

- [ ] Automated tests: link to unit test file
- [x] Manual tests: set `TW_SKIP_FETCH_SETUP` to true and the issue explained in the related issue number #2002 will be gone
