### PR TITLE
[RN] Hide back button in WC modal when WC is the only supportedWallet

### DIFF
--- a/.changeset/swift-rockets-brake.md
+++ b/.changeset/swift-rockets-brake.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/react-native": patch
+---
+
+Hide WC modal back button when only WC is defined as a supportedWallet

--- a/packages/react-native/src/evm/wallets/wallets/wallet-connect/WalletConnectUI.tsx
+++ b/packages/react-native/src/evm/wallets/wallets/wallet-connect/WalletConnectUI.tsx
@@ -41,8 +41,9 @@ const MODAL_HEIGHT = Dimensions.get("window").height * 0.5;
 export function WalletConnectUI({
   connected,
   walletConfig,
-  goBack,
   projectId,
+  goBack,
+  supportedWallets,
 }: ConnectUIProps<WalletConnect> & { projectId: string }) {
   const l = useLocale();
   const theme = useGlobalTheme();
@@ -163,7 +164,7 @@ export function WalletConnectUI({
         style={[styles.modal, { backgroundColor: theme.colors.background }]}
       >
         <ModalHeaderTextClose
-          onBackPress={goBack}
+          onBackPress={supportedWallets.length === 1 ? undefined : goBack}
           headerText="WalletConnect"
           onClose={onClosePress}
           paddingHorizontal="md"


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

## Changes made

- [ ] Public API changes: list the public API changes made if any
- [ ] Internal API changes: explain the internal logic changes

## How to test

- [ ] Automated tests: link to unit test file
- [ ] Manual tests: step by step instructions on how to test
