### PR TITLE
[RN] Export WC modal component

### DIFF
--- a/.changeset/little-hats-hide.md
+++ b/.changeset/little-hats-hide.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/react-native": patch
+---
+
+Export WalletConnect modal component

--- a/packages/react-native/src/evm/components/ConnectWalletFlow/ConnectWalletFlow.tsx
+++ b/packages/react-native/src/evm/components/ConnectWalletFlow/ConnectWalletFlow.tsx
@@ -120,7 +120,7 @@ export const ConnectWalletFlow = () => {
           connected={handleClose}
           isOpen={modalVisible}
           show={onOpenModal}
-          hide={() => {}}
+          hide={handleClose}
           walletConfig={activeWallet}
           supportedWallets={supportedWallets}
           selectionData={selectionData}

--- a/packages/react-native/src/evm/components/ConnectWalletFlow/SmartWallet/SmartWalletFlow.tsx
+++ b/packages/react-native/src/evm/components/ConnectWalletFlow/SmartWallet/SmartWalletFlow.tsx
@@ -25,6 +25,7 @@ export const SmartWalletFlow = ({
   goBack,
   walletConfig,
   personalWalletConfig,
+  hide,
   ...props
 }: ConnectUIProps<SmartWallet> & { personalWalletConfig: WalletConfig }) => {
   const l = useLocale();
@@ -124,7 +125,7 @@ export const SmartWalletFlow = ({
         <PersonalWalletConfigUI
           {...props}
           connected={connected}
-          hide={connected}
+          hide={hide}
           goBack={goBack}
           walletConfig={personalWalletConfig}
           onLocallyConnected={onPersonalWalletConnected}

--- a/packages/react-native/src/evm/components/ConnectWalletFlow/SmartWallet/SmartWalletFlow.tsx
+++ b/packages/react-native/src/evm/components/ConnectWalletFlow/SmartWallet/SmartWalletFlow.tsx
@@ -124,6 +124,7 @@ export const SmartWalletFlow = ({
         <PersonalWalletConfigUI
           {...props}
           connected={connected}
+          hide={connected}
           goBack={goBack}
           walletConfig={personalWalletConfig}
           onLocallyConnected={onPersonalWalletConnected}

--- a/packages/react-native/src/evm/components/base/modal/TWModal.tsx
+++ b/packages/react-native/src/evm/components/base/modal/TWModal.tsx
@@ -14,6 +14,8 @@ export function TWModal(props: Partial<ModalProps>) {
       useNativeDriver
       hideModalContentWhileAnimating={true}
       style={{ maxWidth: MAX_WIDTH }}
+      animationIn="slideInUp" // Slide in from bottom
+      animationOut="slideOutDown" // Slide out to bottom
     >
       {props.children}
     </Modal>

--- a/packages/react-native/src/evm/index.ts
+++ b/packages/react-native/src/evm/index.ts
@@ -40,6 +40,8 @@ export {
 } from "./components/ConnectWallet";
 export { Web3Button, type ActionFn } from "./components/Web3Button";
 
+export { WalletConnectUI } from "./wallets/wallets/wallet-connect/WalletConnectUI";
+
 // utilities
 export * from "./utils/uri";
 export { createSyncStorage as createLocalStorage } from "../core/AsyncStorage";

--- a/packages/react-native/src/evm/wallets/wallets/wallet-connect/WalletConnectUI.tsx
+++ b/packages/react-native/src/evm/wallets/wallets/wallet-connect/WalletConnectUI.tsx
@@ -43,6 +43,7 @@ export function WalletConnectUI({
   walletConfig,
   projectId,
   goBack,
+  hide,
   supportedWallets,
   isVisible,
 }: Omit<
@@ -67,6 +68,9 @@ export function WalletConnectUI({
   const createWalletInstance = useCreateWalletInstance();
   const setConnectedWallet = useSetConnectedWallet();
   const setConnectionStatus = useSetConnectionStatus();
+  const [isVisibleInternal, setIsVisibleInternal] = useState<
+    boolean | undefined
+  >(isVisible);
 
   const onChangeText = useDebounceCallback({ callback: setSearch });
 
@@ -131,6 +135,10 @@ export function WalletConnectUI({
   }, [projectId]);
 
   useEffect(() => {
+    setIsVisibleInternal(isVisible);
+  }, [isVisible]);
+
+  useEffect(() => {
     if (wallets && search) {
       setSearchWallets(
         wallets.filter((w) => {
@@ -157,18 +165,24 @@ export function WalletConnectUI({
         console.error(`Error connecting with WalletConnect: ${e}`);
       })
       .finally(() => {
-        connected();
+        setIsVisibleInternal(false);
+        setTimeout(() => {
+          connected();
+        });
       });
   };
 
   const onClosePress = () => {
     setConnectionStatus("disconnected");
-    connected();
+    setIsVisibleInternal(false);
+    setTimeout(() => {
+      hide();
+    });
   };
 
   return (
     <TWModal
-      isVisible={isVisible ?? true}
+      isVisible={isVisibleInternal ?? true}
       onBackdropPress={onClosePress}
       backdropOpacity={0.7}
     >

--- a/packages/react-native/src/evm/wallets/wallets/wallet-connect/WalletConnectUI.tsx
+++ b/packages/react-native/src/evm/wallets/wallets/wallet-connect/WalletConnectUI.tsx
@@ -45,7 +45,18 @@ export function WalletConnectUI({
   goBack,
   supportedWallets,
   isVisible,
-}: ConnectUIProps<WalletConnect> & { projectId: string; isVisible?: boolean }) {
+}: Omit<
+  ConnectUIProps<WalletConnect>,
+  | "isOpen"
+  | "show"
+  | "theme"
+  | "selectionData"
+  | "setSelectionData"
+  | "modalSize"
+> & {
+  projectId: string;
+  isVisible?: boolean;
+}) {
   const l = useLocale();
   const theme = useGlobalTheme();
   const [wallets, setWallets] = useState<WCWallet[]>([]);

--- a/packages/react-native/src/evm/wallets/wallets/wallet-connect/WalletConnectUI.tsx
+++ b/packages/react-native/src/evm/wallets/wallets/wallet-connect/WalletConnectUI.tsx
@@ -44,7 +44,8 @@ export function WalletConnectUI({
   projectId,
   goBack,
   supportedWallets,
-}: ConnectUIProps<WalletConnect> & { projectId: string }) {
+  isVisible,
+}: ConnectUIProps<WalletConnect> & { projectId: string; isVisible?: boolean }) {
   const l = useLocale();
   const theme = useGlobalTheme();
   const [wallets, setWallets] = useState<WCWallet[]>([]);
@@ -156,7 +157,7 @@ export function WalletConnectUI({
 
   return (
     <TWModal
-      isVisible={true}
+      isVisible={isVisible ?? true}
       onBackdropPress={onClosePress}
       backdropOpacity={0.7}
     >


### PR DESCRIPTION
## Problem solved

You can now trigger the WC modal from your app without having to use the ConnectWallet button

```
import { WalletConnectUI } from "@thirdweb-dev/react-native";

<WalletConnectUI
        hide={() => setWCModalVisible(false)}
        connected={() => setWCModalVisible(false)}
        walletConfig={supportedWallets[0]}
        supportedWallets={supportedWallets}
        isVisible={wcModalVisible}
        projectId="your-wallet-connect-projectId"
      />
```

## Changes made

- [ ] Public API changes: list the public API changes made if any
- [ ] Internal API changes: explain the internal logic changes

## How to test

- [ ] Automated tests: link to unit test file
- [ ] Manual tests: step by step instructions on how to test
