### PR TITLE
[RN] Adds hideSendButtonand hideReceiveButton to ConnectWallet

### DIFF
--- a/.changeset/dull-pumpkins-provide.md
+++ b/.changeset/dull-pumpkins-provide.md
@@ -1,0 +1,11 @@
+---
+"@thirdweb-dev/react-native": patch
+---
+
+Adds `hideSendButton` and `hideReceiveButton` to the ConnectWallet component.
+
+Both props default to `false`.
+
+```js
+<ConnectWallet hideReceiveButton={true} hideSendButton={true} />
+```

--- a/packages/react-native/src/evm/components/ConnectWallet.tsx
+++ b/packages/react-native/src/evm/components/ConnectWallet.tsx
@@ -24,14 +24,28 @@ import { SupportedTokens, defaultTokens } from "./SendFunds/defaultTokens";
 
 export type ConnectWalletProps = {
   /**
-   * render a custom button to display the connected wallet details instead of the default button
+   * Renders a custom button to display the connected wallet details instead of the default button
    */
   detailsButton?: ConnectWalletDetailsProps["detailsButton"];
 
   /**
-   * render custom rows in the Connect Wallet Details modal
+   * Renders custom rows in the Connect Wallet Details modal
    */
   extraRows?: ConnectWalletDetailsProps["extraRows"];
+
+  /**
+   * Option to hide the Send button in the wallet details modal.
+   *
+   * The default is `false`
+   */
+  hideSendButton?: boolean;
+
+  /**
+   * Option to hide the Receive button in the wallet details modal.
+   *
+   * The default is `false`
+   */
+  hideReceiveButton?: boolean;
 
   /**
    * Hide option to request testnet funds for testnets in dropdown
@@ -84,6 +98,8 @@ export const ConnectWallet = ({
   buttonTitle,
   modalTitle,
   modalTitleIconUrl,
+  hideReceiveButton,
+  hideSendButton,
   extraRows,
   hideTestnetFaucet,
   displayBalanceToken,
@@ -169,6 +185,8 @@ export const ConnectWallet = ({
               detailsButton={detailsButton}
               extraRows={extraRows}
               hideTestnetFaucet={hideTestnetFaucet}
+              hideReceiveButton={hideReceiveButton}
+              hideSendButton={hideSendButton}
               supportedTokens={supportedTokensMemo}
               displayBalanceToken={displayBalanceToken}
               hideSwitchToPersonalWallet={hideSwitchToPersonalWallet}

--- a/packages/react-native/src/evm/components/ConnectWalletDetails/ConnectWalletDetailsModal.tsx
+++ b/packages/react-native/src/evm/components/ConnectWalletDetails/ConnectWalletDetailsModal.tsx
@@ -45,6 +45,8 @@ export const ConnectWalletDetailsModal = ({
   supportedTokens,
   displayBalanceToken,
   hideSwitchToPersonalWallet,
+  hideReceiveButton,
+  hideSendButton,
 }: {
   isVisible: boolean;
   onClosePress: () => void;
@@ -54,6 +56,8 @@ export const ConnectWalletDetailsModal = ({
   supportedTokens: SupportedTokens;
   displayBalanceToken?: Record<number, string>;
   hideSwitchToPersonalWallet?: boolean;
+  hideReceiveButton?: boolean;
+  hideSendButton?: boolean;
 }) => {
   const l = useLocale();
   const [isExportModalVisible, setIsExportModalVisible] = useState(false);
@@ -143,7 +147,7 @@ export const ConnectWalletDetailsModal = ({
     if (activeWallet?.walletId === walletIds.localWallet) {
       return (
         <>
-          <View style={styles.currentNetwork}>
+          <View style={styles.additionalActions}>
             <Text variant="bodySmallSecondary">
               {l.connect_wallet_details.additional_actions}
             </Text>
@@ -267,14 +271,19 @@ export const ConnectWalletDetailsModal = ({
                 </Text>
               </Box>
             ) : null}
-            <Box
-              flexDirection="row"
-              justifyContent="space-evenly"
-              marginVertical="md"
-            >
-              <SendButton supportedTokens={supportedTokens} />
-              <ReceiveButton />
-            </Box>
+            {hideReceiveButton && hideSendButton ? null : (
+              <Box
+                flexDirection="row"
+                justifyContent="space-evenly"
+                gap="xs"
+                marginTop="md"
+              >
+                {hideSendButton ? null : (
+                  <SendButton supportedTokens={supportedTokens} />
+                )}
+                {hideReceiveButton ? null : <ReceiveButton />}
+              </Box>
+            )}
             <View style={styles.currentNetwork}>
               <Text variant="bodySmallSecondary">
                 {l.connect_wallet_details.current_network}
@@ -353,6 +362,15 @@ const styles = StyleSheet.create({
     minWidth: 200,
   },
   currentNetwork: {
+    display: "flex",
+    flexDirection: "column",
+    alignContent: "flex-start",
+    alignItems: "flex-start",
+    justifyContent: "flex-start",
+    marginBottom: 8,
+    marginTop: 28,
+  },
+  additionalActions: {
     display: "flex",
     flexDirection: "column",
     alignContent: "flex-start",

--- a/packages/react-native/src/evm/components/ConnectWalletDetails/WalletDetailsButton.tsx
+++ b/packages/react-native/src/evm/components/ConnectWalletDetails/WalletDetailsButton.tsx
@@ -42,6 +42,20 @@ export type ConnectWalletDetailsProps = {
    * The default is `false`
    */
   hideSwitchToPersonalWallet?: boolean;
+
+  /**
+   * Option to hide the Send button in the wallet details modal.
+   *
+   * The default is `false`
+   */
+  hideSendButton?: boolean;
+
+  /**
+   * Option to hide the Receive button in the wallet details modal.
+   *
+   * The default is `false`
+   */
+  hideReceiveButton?: boolean;
 };
 
 export const WalletDetailsButton = ({
@@ -49,6 +63,8 @@ export const WalletDetailsButton = ({
   detailsButton,
   extraRows,
   hideTestnetFaucet,
+  hideReceiveButton,
+  hideSendButton,
   supportedTokens,
   displayBalanceToken,
   hideSwitchToPersonalWallet,
@@ -84,6 +100,8 @@ export const WalletDetailsButton = ({
         supportedTokens={supportedTokens}
         displayBalanceToken={displayBalanceToken}
         hideSwitchToPersonalWallet={hideSwitchToPersonalWallet}
+        hideReceiveButton={hideReceiveButton}
+        hideSendButton={hideSendButton}
       />
       {detailsButton ? (
         detailsButton({ onPress })

--- a/packages/react-native/src/evm/components/ReceiveButton.tsx
+++ b/packages/react-native/src/evm/components/ReceiveButton.tsx
@@ -33,7 +33,6 @@ export const ReceiveButton = () => {
     <>
       <IconTextButton
         flex={1}
-        ml="xs"
         text={l.common.receive}
         justifyContent="center"
         icon={


### PR DESCRIPTION
## Problem solved

Devs are now able to hide the Send and/or Receive buttons:

Both props default to `false`.

```js
<ConnectWallet hideReceiveButton={true} hideSendButton={true} />
```

Devs can alternatively change the text of the buttons by customizing the locale object for the modal component:

```javascript
import { en, ThirdwebProvider } from '@thirdweb-dev/react-native';

<ThirdwebProvider
      locale={en({
        common: {
          send: 'Deliver',
          receive: 'Receive',
        },
      })}
...
```

Short description of the bug fixed or feature added

## Changes made

- [ ] Public API changes: list the public API changes made if any
- [ ] Internal API changes: explain the internal logic changes

## How to test

- [ ] Automated tests: link to unit test file
- [ ] Manual tests: step by step instructions on how to test
