### PR TITLE
changing Avalanche tether USD address mapping

### DIFF
--- a/packages/react/src/wallet/ConnectWallet/defaultTokens.ts
+++ b/packages/react/src/wallet/ConnectWallet/defaultTokens.ts
@@ -255,7 +255,7 @@ export const defaultTokens: SupportedTokens = {
       icon: wrappedEthIcon,
     },
     {
-      address: "0xc7198437980c041c805A1EDcbA50c1Ce5db95118",
+      address: "0x9702230a8ea53601f5cd2dc00fdbc13d4df4a8c7",
       name: "Tether USD",
       symbol: "USDT",
       icon: tetherUsdIcon,


### PR DESCRIPTION
## Problem solved

Changed the mapping of Avalanche tether USD contract address

## Changes made

- [ ] Public API changes: list the public API changes made if any
- [x ] Internal API changes: explain the internal logic changes

No logic change, just changed address in the SupportedTokens data object

## How to test

- [ ] Automated tests: link to unit test file
- [x ] Manual tests: step by step instructions on how to test

Connect to Avalanche in Connect component, go to "send" and see that Tether USD shows balance from correct contract address