### PR TITLE
[SDK] Support ERC20.Approve

### DIFF
--- a/packages/sdk/src/evm/core/classes/erc-20.ts
+++ b/packages/sdk/src/evm/core/classes/erc-20.ts
@@ -298,7 +298,7 @@ export class Erc20<
   );
 
   /**
-   * Set token allowance
+   * Increases or decreases token allowance to match passed amount
    * @remarks Allows the specified `spender` wallet to transfer the given `amount` of tokens to another wallet
    * @example
    * ```javascript
@@ -311,6 +311,32 @@ export class Erc20<
    * @twfeature ERC20
    */
   setAllowance = /* @__PURE__ */ buildTransactionFunction(
+    async (spender: AddressOrEns, amount: Amount) => {
+      return Transaction.fromContractWrapper({
+        contractWrapper: this.contractWrapper,
+        method: "approve",
+        args: await Promise.all([
+          resolveAddress(spender),
+          this.normalizeAmount(amount),
+        ]),
+      });
+    },
+  );
+
+  /**
+   * Sets exact token allowance
+   * @remarks Allows the specified `spender` wallet to transfer the given `amount` of tokens to another address
+   * @example
+   * ```javascript
+   * // Address of the wallet to allow transfers from
+   * const spenderAddress = "0x...";
+   * // The number of tokens to give as allowance
+   * const amount = 100
+   * await contract.erc20.approve(spenderAddress, amount);
+   * ```
+   * @twfeature ERC20
+   */
+  approve = /* @__PURE__ */ buildTransactionFunction(
     async (spender: AddressOrEns, amount: Amount) => {
       return Transaction.fromContractWrapper({
         contractWrapper: this.contractWrapper,

--- a/packages/sdk/src/evm/core/classes/internal/erc20/erc-20-standard.ts
+++ b/packages/sdk/src/evm/core/classes/internal/erc20/erc-20-standard.ts
@@ -232,6 +232,12 @@ export class StandardErc20<
     },
   );
 
+  approve = /* @__PURE__ */ buildTransactionFunction(
+    async (spender: AddressOrEns, amount: Amount): Promise<Transaction> => {
+      return this.erc20.approve.prepare(spender, amount);
+    },
+  );
+
   /**
    * Transfer Tokens To Many Wallets
    *


### PR DESCRIPTION
## Problem solved

In cases like Uniswap token or older tokens IncreaseAllowance and DecreaseAllowance may not exist Also, "approve" triggers custom UI on MetaMask which might be desireable Finally, wallet UI may also set the max according to the specific token as a failsafe, like in UNI's case, 96 bits is the max

## Changes made

- Public API changes: Added erc20.approve functionality

## How to test

- Call `await contract.erc20.approve(spender, amount);`
