### PR TITLE
feat: allow enabling/disabling gasless tx on demand

### DIFF
--- a/packages/wallets/src/evm/connectors/smart-wallet/lib/base-api.ts
+++ b/packages/wallets/src/evm/connectors/smart-wallet/lib/base-api.ts
@@ -14,7 +14,7 @@ import {
 } from "@thirdweb-dev/chains";
 import { Transaction, getDynamicFeeData } from "@thirdweb-dev/sdk";
 import { HttpRpcClient } from "./http-rpc-client";
-import type { BaseApiParams, BatchData, PaymasterAPI } from "../types";
+import type { BaseApiParams, PaymasterAPI, UserOpConfig } from "../types";
 
 const DUMMY_SIGNATURE =
   "0xfffffffffffffffffffffffffffffff0000000000000000000000000000000007aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1c";
@@ -40,8 +40,9 @@ export abstract class BaseAccountAPI {
 
   provider: providers.Provider;
   entryPointAddress: string;
+  paymasterAPI: PaymasterAPI;
   accountAddress?: string;
-  paymasterAPI?: PaymasterAPI;
+  gasless?: boolean;
 
   /**
    * base constructor.
@@ -170,12 +171,12 @@ export abstract class BaseAccountAPI {
   async createUnsignedUserOp(
     httpRpcClient: HttpRpcClient,
     info: TransactionDetailsForUserOp,
-    batchData?: BatchData,
+    config?: UserOpConfig,
   ): Promise<UserOperationStruct> {
     // construct the userOp without gasLimit or preVerifictaionGas
     const initCode = await this.getInitCode();
     const value = parseNumber(info.value) ?? BigNumber.from(0);
-    const callData = batchData
+    const callData = config?.batchData
       ? info.data
       : await this.prepareExecute(info.target, value, info.data).then((tx) =>
           tx.encode(),
@@ -226,7 +227,8 @@ export abstract class BaseAccountAPI {
     };
 
     // paymaster data + maybe used for estimation as well
-    if (this.paymasterAPI) {
+    const gasless = config?.gasless !== undefined ? config.gasless : this.gasless;
+    if (gasless) {
       const paymasterResult = await this.paymasterAPI.getPaymasterAndData(
         partialOp,
       );

--- a/packages/wallets/src/evm/connectors/smart-wallet/lib/base-api.ts
+++ b/packages/wallets/src/evm/connectors/smart-wallet/lib/base-api.ts
@@ -14,7 +14,7 @@ import {
 } from "@thirdweb-dev/chains";
 import { Transaction, getDynamicFeeData } from "@thirdweb-dev/sdk";
 import { HttpRpcClient } from "./http-rpc-client";
-import type { BaseApiParams, PaymasterAPI, UserOpConfig } from "../types";
+import type { BaseApiParams, PaymasterAPI, UserOpOptions } from "../types";
 
 const DUMMY_SIGNATURE =
   "0xfffffffffffffffffffffffffffffff0000000000000000000000000000000007aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1c";
@@ -171,12 +171,12 @@ export abstract class BaseAccountAPI {
   async createUnsignedUserOp(
     httpRpcClient: HttpRpcClient,
     info: TransactionDetailsForUserOp,
-    config?: UserOpConfig,
+    options?: UserOpOptions,
   ): Promise<UserOperationStruct> {
     // construct the userOp without gasLimit or preVerifictaionGas
     const initCode = await this.getInitCode();
     const value = parseNumber(info.value) ?? BigNumber.from(0);
-    const callData = config?.batchData
+    const callData = options?.batchData
       ? info.data
       : await this.prepareExecute(info.target, value, info.data).then((tx) =>
           tx.encode(),
@@ -227,7 +227,7 @@ export abstract class BaseAccountAPI {
     };
 
     // paymaster data + maybe used for estimation as well
-    const gasless = config?.gasless !== undefined ? config.gasless : this.gasless;
+    const gasless = options?.gasless !== undefined ? options.gasless : this.gasless;
     if (gasless) {
       const paymasterResult = await this.paymasterAPI.getPaymasterAndData(
         partialOp,

--- a/packages/wallets/src/evm/connectors/smart-wallet/lib/erc4337-signer.ts
+++ b/packages/wallets/src/evm/connectors/smart-wallet/lib/erc4337-signer.ts
@@ -5,7 +5,7 @@ import { BaseAccountAPI } from "./base-api";
 import type { ERC4337EthersProvider } from "./erc4337-provider";
 import { HttpRpcClient } from "./http-rpc-client";
 import { hexlifyUserOp, randomNonce } from "./utils";
-import { BatchData, ProviderConfig } from "../types";
+import { ProviderConfig, UserOpConfig } from "../types";
 
 export class ERC4337EthersSigner extends Signer {
   config: ProviderConfig;
@@ -36,7 +36,7 @@ export class ERC4337EthersSigner extends Signer {
   // This one is called by Contract. It signs the request and passes in to Provider to be sent.
   async sendTransaction(
     transaction: utils.Deferrable<providers.TransactionRequest>,
-    batchData?: BatchData,
+    config?: UserOpConfig,
   ): Promise<providers.TransactionResponse> {
     const tx = await ethers.utils.resolveProperties(transaction);
     await this.verifyAllNecessaryFields(tx);
@@ -53,7 +53,7 @@ export class ERC4337EthersSigner extends Signer {
         maxFeePerGas: tx.maxFeePerGas,
         maxPriorityFeePerGas: tx.maxPriorityFeePerGas,
       },
-      batchData,
+      config,
     );
     const userOperation = await this.smartAccountAPI.signUserOp(unsigned);
 
@@ -155,7 +155,7 @@ Code: ${errorCode}`;
 
   async signTransaction(
     transaction: utils.Deferrable<providers.TransactionRequest>,
-    batchData?: BatchData,
+    config?: UserOpConfig,
   ): Promise<string> {
     const tx = await ethers.utils.resolveProperties(transaction);
     await this.verifyAllNecessaryFields(tx);
@@ -170,7 +170,7 @@ Code: ${errorCode}`;
         gasLimit: tx.gasLimit,
         nonce: multidimensionalNonce,
       },
-      batchData,
+      config,
     );
     const userOperation = await this.smartAccountAPI.signUserOp(unsigned);
 

--- a/packages/wallets/src/evm/connectors/smart-wallet/lib/erc4337-signer.ts
+++ b/packages/wallets/src/evm/connectors/smart-wallet/lib/erc4337-signer.ts
@@ -5,7 +5,7 @@ import { BaseAccountAPI } from "./base-api";
 import type { ERC4337EthersProvider } from "./erc4337-provider";
 import { HttpRpcClient } from "./http-rpc-client";
 import { hexlifyUserOp, randomNonce } from "./utils";
-import { ProviderConfig, UserOpConfig } from "../types";
+import { ProviderConfig, UserOpOptions } from "../types";
 
 export class ERC4337EthersSigner extends Signer {
   config: ProviderConfig;
@@ -36,7 +36,7 @@ export class ERC4337EthersSigner extends Signer {
   // This one is called by Contract. It signs the request and passes in to Provider to be sent.
   async sendTransaction(
     transaction: utils.Deferrable<providers.TransactionRequest>,
-    config?: UserOpConfig,
+    options?: UserOpOptions,
   ): Promise<providers.TransactionResponse> {
     const tx = await ethers.utils.resolveProperties(transaction);
     await this.verifyAllNecessaryFields(tx);
@@ -53,7 +53,7 @@ export class ERC4337EthersSigner extends Signer {
         maxFeePerGas: tx.maxFeePerGas,
         maxPriorityFeePerGas: tx.maxPriorityFeePerGas,
       },
-      config,
+      options,
     );
     const userOperation = await this.smartAccountAPI.signUserOp(unsigned);
 
@@ -155,7 +155,7 @@ Code: ${errorCode}`;
 
   async signTransaction(
     transaction: utils.Deferrable<providers.TransactionRequest>,
-    config?: UserOpConfig,
+    options?: UserOpOptions,
   ): Promise<string> {
     const tx = await ethers.utils.resolveProperties(transaction);
     await this.verifyAllNecessaryFields(tx);
@@ -170,7 +170,7 @@ Code: ${errorCode}`;
         gasLimit: tx.gasLimit,
         nonce: multidimensionalNonce,
       },
-      config,
+      options,
     );
     const userOperation = await this.smartAccountAPI.signUserOp(unsigned);
 

--- a/packages/wallets/src/evm/connectors/smart-wallet/types.ts
+++ b/packages/wallets/src/evm/connectors/smart-wallet/types.ts
@@ -55,7 +55,8 @@ export interface ProviderConfig extends ContractInfo {
   bundlerUrl: string;
   factoryAddress: string;
   accountAddress?: string;
-  paymasterAPI?: PaymasterAPI;
+  paymasterAPI: PaymasterAPI;
+  gasless: boolean;
 }
 
 export type ContractInfoInput = {
@@ -110,6 +111,11 @@ export abstract class PaymasterAPI {
   ): Promise<PaymasterResult>;
 }
 
+export type UserOpConfig = {
+  gasless?: boolean;
+  batchData?: BatchData;
+};
+
 export type BatchData = {
   targets: (string | undefined)[];
   data: BytesLike[];
@@ -119,8 +125,8 @@ export type BatchData = {
 export interface BaseApiParams {
   provider: providers.Provider;
   entryPointAddress: string;
+  paymasterAPI: PaymasterAPI;
   accountAddress?: string;
-  paymasterAPI?: PaymasterAPI;
 }
 
 export interface UserOpResult {

--- a/packages/wallets/src/evm/connectors/smart-wallet/types.ts
+++ b/packages/wallets/src/evm/connectors/smart-wallet/types.ts
@@ -1,4 +1,4 @@
-import type {
+import {
   ChainOrRpcUrl,
   SmartContract,
   Transaction,
@@ -111,8 +111,11 @@ export abstract class PaymasterAPI {
   ): Promise<PaymasterResult>;
 }
 
-export type UserOpConfig = {
+export interface TransactionOptions {
   gasless?: boolean;
+};
+
+export interface UserOpOptions extends TransactionOptions {
   batchData?: BatchData;
 };
 

--- a/packages/wallets/src/evm/wallets/smart-wallet.ts
+++ b/packages/wallets/src/evm/wallets/smart-wallet.ts
@@ -4,6 +4,7 @@ import type { ConnectParams } from "../interfaces/connector";
 import type {
   SmartWalletConfig,
   SmartWalletConnectionArgs,
+  TransactionOptions,
 } from "../connectors/smart-wallet/types";
 import type { SmartWalletConnector as SmartWalletConnectorType } from "../connectors/smart-wallet";
 import {
@@ -153,169 +154,191 @@ export class SmartWallet extends AbstractClientWallet<
   /**
    * Send a single transaction without waiting for confirmations
    * @param transaction - the transaction to send
+   * @param options - optional transaction options
    * @returns The transaction result
    */
   async send(
     transaction: Transaction,
-    config?: { gasless?: boolean }
+    options?: TransactionOptions
   ): Promise<providers.TransactionResponse> {
     const connector = await this.getConnector();
-    return connector.send(transaction, config);
+    return connector.send(transaction, options);
   }
 
   /**
    * Execute a single transaction and wait for confirmations
    * @param transaction - the transaction to execute
+   * @param options - optional transaction options
    * @returns The transaction receipt
    */
   async execute(
     transaction: Transaction,
-    config?: { gasless?: boolean }
+    options?: TransactionOptions
   ): Promise<TransactionResult> {
     const connector = await this.getConnector();
-    return connector.execute(transaction, config);
+    return connector.execute(transaction, options);
   }
 
   /**
    * Send a multiple transaction in a batch without waiting for confirmations
    * @param transactions - the transactions to send
+   * @param options - optional transaction options
    * @returns The transaction result
    */
   async sendBatch(
     transactions: Transaction[],
-    config?: { gasless?: boolean }
+    options?: TransactionOptions
   ): Promise<providers.TransactionResponse> {
     const connector = await this.getConnector();
-    return connector.sendBatch(transactions, config);
+    return connector.sendBatch(transactions, options);
   }
 
   /**
    * Execute multiple transactions in a single batch and wait for confirmations
    * @param transactions - the transactions to execute
+   * @param options - optional transaction options
    * @returns The transaction receipt
    */
   async executeBatch(
     transactions: Transaction<any>[],
-    config?: { gasless?: boolean },
+    options?: TransactionOptions,
   ): Promise<TransactionResult> {
     const connector = await this.getConnector();
-    return connector.executeBatch(transactions, config);
+    return connector.executeBatch(transactions, options);
   }
 
   /**
    * Send a single raw transaction without waiting for confirmations
    * @param transaction - the transaction to send
+   * @param options - optional transaction options
    * @returns The transaction result
    */
   async sendRaw(
     transaction: utils.Deferrable<providers.TransactionRequest>,
-    config?: { gasless?: boolean }
+    options?: TransactionOptions
   ): Promise<providers.TransactionResponse> {
     const connector = await this.getConnector();
-    return connector.sendRaw(transaction, config);
+    return connector.sendRaw(transaction, options);
   }
 
   /**
    * Execute a single raw transaction and wait for confirmations
    * @param transaction - the transaction to execute
+   * @param options - optional transaction options
    * @returns The transaction receipt
    */
   async executeRaw(
     transaction: utils.Deferrable<providers.TransactionRequest>,
-    config?: { gasless?: boolean }
+    options?: TransactionOptions
   ): Promise<TransactionResult> {
     const connector = await this.getConnector();
-    return connector.executeRaw(transaction, config);
+    return connector.executeRaw(transaction, options);
   }
 
   /**
    * Estimate the gas cost of a single transaction
    * @param transaction - the transaction to estimate
+   * @param options - optional transaction options
    * @returns
    */
-  async estimate(transaction: Transaction<any>) {
+  async estimate(
+    transaction: Transaction<any>,
+    options?: TransactionOptions,
+  ) {
     const connector = await this.getConnector();
-    return connector.estimate(transaction);
+    return connector.estimate(transaction, options);
   }
 
   /**
    * Estimate the gas cost of a batch of transactions
    * @param transactions - the transactions to estimate
+   * @param options - optional transaction options
    * @returns
    */
-  async estimateBatch(transactions: Transaction<any>[]) {
+  async estimateBatch(
+    transactions: Transaction<any>[],
+    options?: TransactionOptions,
+  ) {
     const connector = await this.getConnector();
-    return connector.estimateBatch(transactions);
+    return connector.estimateBatch(transactions, options);
   }
 
   /**
    * Estimate the gas cost of a single raw transaction
    * @param transactions - the transactions to estimate
+   * @param options - optional transaction options
    * @returns
    */
   async estimateRaw(
     transactions: utils.Deferrable<providers.TransactionRequest>,
+    options?: TransactionOptions,
   ) {
     const connector = await this.getConnector();
-    return connector.estimateRaw(transactions);
+    return connector.estimateRaw(transactions, options);
   }
 
   /**
    * Estimate the gas cost of a batch of raw transactions
    * @param transactions - the transactions to estimate
+   * @param options - optional transaction options
    * @returns
    */
   async estimateBatchRaw(
     transactions: utils.Deferrable<providers.TransactionRequest>[],
+    options?: TransactionOptions,
   ) {
     const connector = await this.getConnector();
-    return connector.estimateBatchRaw(transactions);
+    return connector.estimateBatchRaw(transactions, options);
   }
 
   /**
    * Send multiple raw transaction in a batch without waiting for confirmations
    * @param transactions - the transactions to send
+   * @param options - optional transaction options
    * @returns The transaction result
    */
   async sendBatchRaw(
     transactions: utils.Deferrable<providers.TransactionRequest>[],
-    config?: { gasless?: boolean },
+    options?: TransactionOptions,
   ): Promise<providers.TransactionResponse> {
     const connector = await this.getConnector();
-    return connector.sendBatchRaw(transactions, config);
+    return connector.sendBatchRaw(transactions, options);
   }
 
   /**
    * Execute multiple raw transactions in a single batch and wait for confirmations
    * @param transactions - the transactions to execute
+   * @param options - optional transaction options
    * @returns The transaction receipt
    */
   async executeBatchRaw(
     transactions: utils.Deferrable<providers.TransactionRequest>[],
-    config?: { gasless?: boolean },
+    options?: TransactionOptions,
   ): Promise<TransactionResult> {
     const connector = await this.getConnector();
-    return connector.executeBatchRaw(transactions, config);
+    return connector.executeBatchRaw(transactions, options);
   }
 
   /**
    * Manually deploy the smart wallet contract. If already deployed this will throw an error.
    * Note that this is not necessary as the smart wallet will be deployed automatically on the first transaction the user makes.
+   * @param options - optional transaction options
    * @returns The transaction receipt
    */
-  async deploy(config?: { gasless?: boolean }): Promise<TransactionResult> {
+  async deploy(options?: TransactionOptions): Promise<TransactionResult> {
     const connector = await this.getConnector();
-    return connector.deploy(config);
+    return connector.deploy(options);
   }
 
   /**
    * Manually deploy the smart wallet contract. If already deployed this will do nothing.
    * Note that this is not necessary as the smart wallet will be deployed automatically on the first transaction the user makes.
+   * @param options - optional transaction options
    * @returns The transaction receipt
    */
-  async deployIfNeeded(config?: { gasless?: boolean }): Promise<void> {
+  async deployIfNeeded(options?: TransactionOptions): Promise<void> {
     const connector = await this.getConnector();
-    return connector.deployIfNeeded(config);
+    return connector.deployIfNeeded(options);
   }
 
   /**

--- a/packages/wallets/src/evm/wallets/smart-wallet.ts
+++ b/packages/wallets/src/evm/wallets/smart-wallet.ts
@@ -155,9 +155,12 @@ export class SmartWallet extends AbstractClientWallet<
    * @param transaction - the transaction to send
    * @returns The transaction result
    */
-  async send(transaction: Transaction): Promise<providers.TransactionResponse> {
+  async send(
+    transaction: Transaction,
+    config?: { gasless?: boolean }
+  ): Promise<providers.TransactionResponse> {
     const connector = await this.getConnector();
-    return connector.send(transaction);
+    return connector.send(transaction, config);
   }
 
   /**
@@ -165,9 +168,12 @@ export class SmartWallet extends AbstractClientWallet<
    * @param transaction - the transaction to execute
    * @returns The transaction receipt
    */
-  async execute(transaction: Transaction): Promise<TransactionResult> {
+  async execute(
+    transaction: Transaction,
+    config?: { gasless?: boolean }
+  ): Promise<TransactionResult> {
     const connector = await this.getConnector();
-    return connector.execute(transaction);
+    return connector.execute(transaction, config);
   }
 
   /**
@@ -177,9 +183,10 @@ export class SmartWallet extends AbstractClientWallet<
    */
   async sendBatch(
     transactions: Transaction[],
+    config?: { gasless?: boolean }
   ): Promise<providers.TransactionResponse> {
     const connector = await this.getConnector();
-    return connector.sendBatch(transactions);
+    return connector.sendBatch(transactions, config);
   }
 
   /**
@@ -189,9 +196,10 @@ export class SmartWallet extends AbstractClientWallet<
    */
   async executeBatch(
     transactions: Transaction<any>[],
+    config?: { gasless?: boolean },
   ): Promise<TransactionResult> {
     const connector = await this.getConnector();
-    return connector.executeBatch(transactions);
+    return connector.executeBatch(transactions, config);
   }
 
   /**
@@ -201,9 +209,10 @@ export class SmartWallet extends AbstractClientWallet<
    */
   async sendRaw(
     transaction: utils.Deferrable<providers.TransactionRequest>,
+    config?: { gasless?: boolean }
   ): Promise<providers.TransactionResponse> {
     const connector = await this.getConnector();
-    return connector.sendRaw(transaction);
+    return connector.sendRaw(transaction, config);
   }
 
   /**
@@ -213,9 +222,10 @@ export class SmartWallet extends AbstractClientWallet<
    */
   async executeRaw(
     transaction: utils.Deferrable<providers.TransactionRequest>,
+    config?: { gasless?: boolean }
   ): Promise<TransactionResult> {
     const connector = await this.getConnector();
-    return connector.executeRaw(transaction);
+    return connector.executeRaw(transaction, config);
   }
 
   /**
@@ -269,9 +279,10 @@ export class SmartWallet extends AbstractClientWallet<
    */
   async sendBatchRaw(
     transactions: utils.Deferrable<providers.TransactionRequest>[],
+    config?: { gasless?: boolean },
   ): Promise<providers.TransactionResponse> {
     const connector = await this.getConnector();
-    return connector.sendBatchRaw(transactions);
+    return connector.sendBatchRaw(transactions, config);
   }
 
   /**
@@ -281,9 +292,10 @@ export class SmartWallet extends AbstractClientWallet<
    */
   async executeBatchRaw(
     transactions: utils.Deferrable<providers.TransactionRequest>[],
+    config?: { gasless?: boolean },
   ): Promise<TransactionResult> {
     const connector = await this.getConnector();
-    return connector.executeBatchRaw(transactions);
+    return connector.executeBatchRaw(transactions, config);
   }
 
   /**
@@ -291,9 +303,9 @@ export class SmartWallet extends AbstractClientWallet<
    * Note that this is not necessary as the smart wallet will be deployed automatically on the first transaction the user makes.
    * @returns The transaction receipt
    */
-  async deploy(): Promise<TransactionResult> {
+  async deploy(config?: { gasless?: boolean }): Promise<TransactionResult> {
     const connector = await this.getConnector();
-    return connector.deploy();
+    return connector.deploy(config);
   }
 
   /**
@@ -301,9 +313,9 @@ export class SmartWallet extends AbstractClientWallet<
    * Note that this is not necessary as the smart wallet will be deployed automatically on the first transaction the user makes.
    * @returns The transaction receipt
    */
-  async deployIfNeeded(): Promise<void> {
+  async deployIfNeeded(config?: { gasless?: boolean }): Promise<void> {
     const connector = await this.getConnector();
-    return connector.deployIfNeeded();
+    return connector.deployIfNeeded(config);
   }
 
   /**


### PR DESCRIPTION
## Problem solved

Updates #2113

Allow enabling/disabling gasless tx on demand.

## Changes made

- [x] Added optional config to transaction calls - `execute`, `send`, `sendBatch`, `executeBatch`, `sendRaw`, `executeRaw`, `sendBatchRaw`, `executeBatchRaw` and `deploy`
- [x] Removed paymaster API flag initialization, which should always initialize the API now and change the condition in `createUnsignedUserOp` to use the `gasless` flag instead.

## How to test

- Initialize a smart wallet with gasless enabled or disabled
- Pass opposite `gasless` flag to transaction
