### PR TITLE
Update icon info about Arbitrum Sepolia

### DIFF
--- a/packages/chains/chains/11155420.ts
+++ b/packages/chains/chains/11155420.ts
@@ -18,6 +18,12 @@ export default {
   "faucets": [
     "https://app.optimism.io/faucet"
   ],
+  "icon": {
+    "url": "ipfs://QmcxZHpyJa8T4i63xqjPYrZ6tKrt55tZJpbXcjSDKuKaf9/optimism/512.png",
+    "width": 512,
+    "height": 512,
+    "format": "png"
+  },
   "infoURL": "https://optimism.io",
   "name": "OP Sepolia Testnet",
   "nativeCurrency": {

--- a/packages/chains/chains/421614.ts
+++ b/packages/chains/chains/421614.ts
@@ -10,6 +10,13 @@ export default {
     }
   ],
   "faucets": [],
+  "features": [],
+  "icon": {
+    "url": "ipfs://QmcxZHpyJa8T4i63xqjPYrZ6tKrt55tZJpbXcjSDKuKaf9/arbitrum/512.png",
+    "width": 512,
+    "height": 512,
+    "format": "png"
+  },
   "infoURL": "https://arbitrum.io",
   "name": "Arbitrum Sepolia",
   "nativeCurrency": {


### PR DESCRIPTION
## Problem solved

Unable to get Icon images for Arbitrum Sepolia utilizing @thirdweb-dev/chains

## Changes made

- [ ] Public API changes: list the public API changes made if any
- [ ] Internal API changes: explain the internal logic changes

## How to test

- [ ] Automated tests: link to unit test file
- [ ] Manual tests: step by step instructions on how to test
