### PR TITLE
[RN] Exports ConnectEmbed as a standalone component

### DIFF
--- a/.changeset/smart-ads-draw.md
+++ b/.changeset/smart-ads-draw.md
@@ -1,0 +1,24 @@
+---
+"@thirdweb-dev/react-native": patch
+---
+
+Exports standalone ConnectEmbed UI
+
+Devs can now show the Connect modal UI directly into their apps.
+This component will render the wallets defined in our ThirdwebProvider.
+
+```tsx
+<ConnectEmbed
+  modalTitleIconUrl="<my-icon-url>"
+  modalTitle="Sign In"
+  theme={"light"}
+  onConnect={() => {
+    console.log("wallet connected");
+  }}
+  container={{
+    paddingVertical: "md",
+    marginHorizontal: "md",
+    borderRadius: "md",
+  }}
+/>
+```

--- a/packages/react-native/src/evm/components/ConnectWalletFlow/ChooseWallet/ChooseWallet.tsx
+++ b/packages/react-native/src/evm/components/ConnectWalletFlow/ChooseWallet/ChooseWallet.tsx
@@ -23,7 +23,7 @@ export type ChooseWalletProps = {
   headerText?: ReactNode | string;
   subHeaderText?: ReactNode | string;
   onChooseWallet: (wallet: WalletConfig<any>, data?: any) => void;
-  onClose: () => void;
+  onClose?: () => void;
   wallets: WalletConfig<any>[];
   excludeWalletIds?: string[];
   modalTitleIconUrl?: string;

--- a/packages/react-native/src/evm/components/ConnectWalletFlow/ConnectWalletButton.tsx
+++ b/packages/react-native/src/evm/components/ConnectWalletFlow/ConnectWalletButton.tsx
@@ -1,6 +1,6 @@
 import { ActivityIndicator, StyleSheet } from "react-native";
 import { BaseButton, Text } from "../base";
-import { useConnectionStatus, useWallets } from "@thirdweb-dev/react-core";
+import { useConnectionStatus } from "@thirdweb-dev/react-core";
 import { useState, useEffect } from "react";
 import {
   useGlobalTheme,
@@ -53,7 +53,6 @@ export const ConnectWalletButton = ({
   const connectionStatus = useConnectionStatus();
   const isWalletConnecting = connectionStatus === "connecting";
 
-  const supportedWallets = useWallets();
   const [showButtonSpinner, setShowButtonSpinner] = useState(false);
   const { setModalState } = useModalState();
 
@@ -88,8 +87,6 @@ export const ConnectWalletButton = ({
         modalTitleIconUrl,
         termsOfServiceUrl,
         privacyPolicyUrl,
-        walletConfig:
-          supportedWallets.length === 1 ? supportedWallets[0] : undefined,
       },
       caller: "ConnectWallet",
     });

--- a/packages/react-native/src/evm/components/ConnectWalletFlow/ConnectingWallet/ConnectingWallet.tsx
+++ b/packages/react-native/src/evm/components/ConnectWalletFlow/ConnectingWallet/ConnectingWallet.tsx
@@ -11,7 +11,7 @@ export type ConnectingWalletProps = {
   subHeaderText?: string;
   footer?: ReactNode;
   content?: ReactNode;
-  onClose: () => void;
+  onClose?: () => void;
   onBackPress: () => void;
   wallet: WalletConfig<any>;
 };

--- a/packages/react-native/src/evm/components/ConnectWalletFlow/ConnectingWallet/ConnectingWalletHeader.tsx
+++ b/packages/react-native/src/evm/components/ConnectWalletFlow/ConnectingWallet/ConnectingWalletHeader.tsx
@@ -7,7 +7,7 @@ import Text from "../../base/Text";
 import { FlexAlignType, StyleSheet, View } from "react-native";
 
 interface ConnectWalletHeaderProps {
-  onClose: () => void;
+  onClose?: () => void;
   onBackPress?: () => void;
   middleContent?: React.ReactNode;
   headerText?: string;
@@ -46,13 +46,17 @@ export const ConnectWalletHeader = ({
           <View />
         )}
         {middleContent ? middleContent : null}
-        <Icon
-          type="close"
-          width={14}
-          height={14}
-          onPress={onClose}
-          color={theme.colors.iconPrimary}
-        />
+        {onClose ? (
+          <Icon
+            type="close"
+            width={14}
+            height={14}
+            onPress={onClose}
+            color={theme.colors.iconPrimary}
+          />
+        ) : (
+          <View />
+        )}
       </View>
       <View style={{ ...styles.headerContainer, alignItems: alignHeader }}>
         {headerText ? (

--- a/packages/react-native/src/evm/components/MainModal.tsx
+++ b/packages/react-native/src/evm/components/MainModal.tsx
@@ -2,7 +2,7 @@ import {
   useGlobalTheme,
   useModalState,
 } from "../providers/ui-context-provider";
-import { ConnectWalletFlow } from "./ConnectWalletFlow/ConnectWalletFlow";
+import { ConnectEmbedUI } from "./ConnectWalletFlow/ConnectEmbed";
 import { Dimensions, StyleSheet, View } from "react-native";
 import { useMemo } from "react";
 import { ThemeProvider } from "../styles/ThemeProvider";
@@ -10,6 +10,7 @@ import { SessionRequestModal } from "./ConnectWalletDetails/SessionRequestModal"
 import { SessionProposalModal } from "./ConnectWalletDetails/SessionProposalModal";
 import { TWModal } from "./base/modal/TWModal";
 import Box from "./base/Box";
+import { ConnectWalletFlowModal } from "../utils/modalTypes";
 
 const MODAL_HEIGHT = Dimensions.get("window").height * 0.7;
 const DEVICE_WIDTH = Dimensions.get("window").width;
@@ -23,7 +24,12 @@ export const MainModal = () => {
   const view = useMemo(() => {
     switch (modalState?.view) {
       case "ConnectWalletFlow":
-        return <ConnectWalletFlow />;
+        return (
+          <ConnectEmbedUI
+            {...(modalState as ConnectWalletFlowModal).data}
+            isModal={true}
+          />
+        );
       case "WalletConnectSessionRequestModal":
         return <SessionRequestModal />;
       case "WalletConnectSessionProposalModal":
@@ -31,7 +37,7 @@ export const MainModal = () => {
       default:
         return null;
     }
-  }, [modalState.view]);
+  }, [modalState]);
 
   return (
     <ThemeProvider theme={theme}>

--- a/packages/react-native/src/evm/components/base/WalletButton.tsx
+++ b/packages/react-native/src/evm/components/base/WalletButton.tsx
@@ -43,7 +43,6 @@ export const WalletButton = ({
       paddingHorizontal="md"
       paddingVertical="sm"
       borderRadius="sm"
-      backgroundColor="background"
       onPress={onPress}
       {...props}
     >

--- a/packages/react-native/src/evm/index.ts
+++ b/packages/react-native/src/evm/index.ts
@@ -38,6 +38,12 @@ export {
   ConnectWallet,
   type ConnectWalletProps,
 } from "./components/ConnectWallet";
+
+export {
+  ConnectEmbed,
+  type ConnectEmbedProps,
+} from "./components/ConnectWalletFlow/ConnectEmbed";
+
 export {
   Web3Button,
   type Web3ButtonProps,

--- a/packages/react-native/src/evm/providers/ui-context-provider.tsx
+++ b/packages/react-native/src/evm/providers/ui-context-provider.tsx
@@ -100,7 +100,7 @@ export const useGlobalTheme = (theme?: ThemeProviderProps["theme"]): Theme => {
   const resultTheme = useMemo(() => {
     const resp = getThemeObj(context.theme) || getThemeObj(theme) || appTheme;
     return resp;
-  }, [theme, context, appTheme]);
+  }, [theme, context.theme, appTheme]);
 
   return resultTheme;
 };

--- a/packages/react-native/src/evm/utils/modalTypes.ts
+++ b/packages/react-native/src/evm/utils/modalTypes.ts
@@ -1,4 +1,3 @@
-import { WalletConfig } from "@thirdweb-dev/react-core";
 import { WCProposal, WCRequest } from "@thirdweb-dev/wallets";
 
 export const CLOSE_MODAL_STATE = (caller: Caller): ModalState => {
@@ -50,17 +49,16 @@ export type ClosedModal = {
 } & SheetModal;
 
 // connect wallet flow
-export type ConnectWalletFlowData = {
+export type ConnectEmbedData = {
   modalTitle?: string;
   modalTitleIconUrl?: string;
   termsOfServiceUrl?: string;
   privacyPolicyUrl?: string;
-  walletConfig?: WalletConfig;
 };
 
 export type ConnectWalletFlowModal = {
   view: "ConnectWalletFlow";
-  data: ConnectWalletFlowData;
+  data: ConnectEmbedData;
 } & SheetModal;
 
 // wallet details


### PR DESCRIPTION
## Problem solved

Devs can now show the Connect modal UI directly into their apps.
This component will render the wallets defined in our ThirdwebProvider.

```tsx
<ConnectEmbed
  modalTitleIconUrl="<my-icon-url>"
  modalTitle="Sign In"
  theme={"light"}
  onConnect={() => {
    console.log("wallet connected");
  }}
  container={{
    paddingVertical: "md",
    marginHorizontal: "md",
    borderRadius: "md",
  }}
/>
```

## Changes made

- [ ] Public API changes: list the public API changes made if any
- [ ] Internal API changes: explain the internal logic changes

## How to test

- [ ] Automated tests: link to unit test file
- [ ] Manual tests: step by step instructions on how to test
