### PR TITLE
[AA] Option to not deploy SW on sign message

### DIFF
--- a/.changeset/cool-planets-help.md
+++ b/.changeset/cool-planets-help.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/wallets": patch
+---
+
+[AA] Option to not deploy SW on sign message

--- a/packages/unity-js-bridge/src/thirdweb-bridge.ts
+++ b/packages/unity-js-bridge/src/thirdweb-bridge.ts
@@ -229,6 +229,7 @@ class ThirdwebBridge implements TWBridge {
             paymasterUrl: sdkOptions.smartWalletConfig?.paymasterUrl,
             // paymasterAPI: sdkOptions.smartWalletConfig?.paymasterAPI,
             entryPointAddress: sdkOptions.smartWalletConfig?.entryPointAddress,
+            doNotDeployOnSignMessage: sdkOptions.smartWalletConfig?.doNotDeployOnSignMessage,
           };
           walletInstance = new SmartWallet(config);
           break;

--- a/packages/unity-js-bridge/src/thirdweb-bridge.ts
+++ b/packages/unity-js-bridge/src/thirdweb-bridge.ts
@@ -229,7 +229,7 @@ class ThirdwebBridge implements TWBridge {
             paymasterUrl: sdkOptions.smartWalletConfig?.paymasterUrl,
             // paymasterAPI: sdkOptions.smartWalletConfig?.paymasterAPI,
             entryPointAddress: sdkOptions.smartWalletConfig?.entryPointAddress,
-            doNotDeployOnSignMessage: sdkOptions.smartWalletConfig?.doNotDeployOnSignMessage,
+            deployOnSign: sdkOptions.smartWalletConfig?.deployOnSign,
           };
           walletInstance = new SmartWallet(config);
           break;

--- a/packages/wallets/src/evm/connectors/smart-wallet/index.ts
+++ b/packages/wallets/src/evm/connectors/smart-wallet/index.ts
@@ -54,7 +54,7 @@ export class SmartWalletConnector extends Connector<SmartWalletConnectionArgs> {
       this.config.paymasterUrl ||
       `https://${this.chainId}.bundler.thirdweb.com/v2`;
     const entryPointAddress = config.entryPointAddress || ENTRYPOINT_ADDRESS;
-    const doNotDeployOnSignMessage = config.doNotDeployOnSignMessage || false;
+    const deployOnSign = config.deployOnSign || true;
     const localSigner = await params.personalWallet.getSigner();
     const providerConfig: ProviderConfig = {
       chain: config.chain,
@@ -70,7 +70,7 @@ export class SmartWalletConnector extends Connector<SmartWalletConnectionArgs> {
             this.config.secretKey,
           ),
       gasless: config.gasless,
-      doNotDeployOnSignMessage: doNotDeployOnSignMessage,
+      deployOnSign: deployOnSign,
       factoryAddress: config.factoryAddress,
       accountAddress: params.accountAddress,
       factoryInfo: config.factoryInfo || this.defaultFactoryInfo(),

--- a/packages/wallets/src/evm/connectors/smart-wallet/index.ts
+++ b/packages/wallets/src/evm/connectors/smart-wallet/index.ts
@@ -54,6 +54,7 @@ export class SmartWalletConnector extends Connector<SmartWalletConnectionArgs> {
       this.config.paymasterUrl ||
       `https://${this.chainId}.bundler.thirdweb.com/v2`;
     const entryPointAddress = config.entryPointAddress || ENTRYPOINT_ADDRESS;
+    const doNotDeployOnSignMessage = config.doNotDeployOnSignMessage || false;
     const localSigner = await params.personalWallet.getSigner();
     const providerConfig: ProviderConfig = {
       chain: config.chain,
@@ -69,6 +70,7 @@ export class SmartWalletConnector extends Connector<SmartWalletConnectionArgs> {
             this.config.secretKey,
           ),
       gasless: config.gasless,
+      doNotDeployOnSignMessage: doNotDeployOnSignMessage,
       factoryAddress: config.factoryAddress,
       accountAddress: params.accountAddress,
       factoryInfo: config.factoryInfo || this.defaultFactoryInfo(),

--- a/packages/wallets/src/evm/connectors/smart-wallet/index.ts
+++ b/packages/wallets/src/evm/connectors/smart-wallet/index.ts
@@ -54,7 +54,7 @@ export class SmartWalletConnector extends Connector<SmartWalletConnectionArgs> {
       this.config.paymasterUrl ||
       `https://${this.chainId}.bundler.thirdweb.com/v2`;
     const entryPointAddress = config.entryPointAddress || ENTRYPOINT_ADDRESS;
-    const deployOnSign = config.deployOnSign || true;
+    const deployOnSign = config.deployOnSign ?? true;
     const localSigner = await params.personalWallet.getSigner();
     const providerConfig: ProviderConfig = {
       chain: config.chain,

--- a/packages/wallets/src/evm/connectors/smart-wallet/lib/erc4337-signer.ts
+++ b/packages/wallets/src/evm/connectors/smart-wallet/lib/erc4337-signer.ts
@@ -139,17 +139,18 @@ Code: ${errorCode}`;
   }
 
   async signMessage(message: Bytes | string): Promise<string> {
-    const isNotDeployed = await this.smartAccountAPI.checkAccountPhantom();
-    if (isNotDeployed) {
-      console.log(
-        "Account contract not deployed yet. Deploying account before signing message",
-      );
-      const tx = await this.sendTransaction({
-        to: await this.getAddress(),
-        data: "0x",
-      });
-      await tx.wait();
-    }
+      const isNotDeployed = await this.smartAccountAPI.checkAccountPhantom();
+      if (isNotDeployed && (this.config.doNotDeployOnSignMessage === undefined || this.config.doNotDeployOnSignMessage === false)) {
+        console.log(
+          "Account contract not deployed yet. Deploying account before signing message",
+        );
+        const tx = await this.sendTransaction({
+          to: await this.getAddress(),
+          data: "0x",
+        });
+        await tx.wait();
+      }
+    
     return await this.originalSigner.signMessage(message);
   }
 

--- a/packages/wallets/src/evm/connectors/smart-wallet/lib/erc4337-signer.ts
+++ b/packages/wallets/src/evm/connectors/smart-wallet/lib/erc4337-signer.ts
@@ -140,7 +140,7 @@ Code: ${errorCode}`;
 
   async signMessage(message: Bytes | string): Promise<string> {
       const isNotDeployed = await this.smartAccountAPI.checkAccountPhantom();
-      if (isNotDeployed && (this.config.doNotDeployOnSignMessage === undefined || this.config.doNotDeployOnSignMessage === false)) {
+      if (isNotDeployed && this.config.deployOnSign) {
         console.log(
           "Account contract not deployed yet. Deploying account before signing message",
         );

--- a/packages/wallets/src/evm/connectors/smart-wallet/types.ts
+++ b/packages/wallets/src/evm/connectors/smart-wallet/types.ts
@@ -22,7 +22,7 @@ export type SmartWalletConfig = {
   paymasterUrl?: string;
   paymasterAPI?: PaymasterAPI;
   entryPointAddress?: string;
-  doNotDeployOnSignMessage?: boolean;
+  deployOnSign?: boolean;
 } & ContractInfoInput &
   WalletConnectReceiverConfig;
 
@@ -43,7 +43,7 @@ export interface ProviderConfig extends ContractInfo {
   accountAddress?: string;
   paymasterAPI: PaymasterAPI;
   gasless: boolean;
-  doNotDeployOnSignMessage?: boolean;
+  deployOnSign?: boolean;
 }
 
 export type ContractInfoInput = {

--- a/packages/wallets/src/evm/connectors/smart-wallet/types.ts
+++ b/packages/wallets/src/evm/connectors/smart-wallet/types.ts
@@ -22,6 +22,7 @@ export type SmartWalletConfig = {
   paymasterUrl?: string;
   paymasterAPI?: PaymasterAPI;
   entryPointAddress?: string;
+  doNotDeployOnSignMessage?: boolean;
 } & ContractInfoInput &
   WalletConnectReceiverConfig;
 
@@ -42,6 +43,7 @@ export interface ProviderConfig extends ContractInfo {
   accountAddress?: string;
   paymasterAPI: PaymasterAPI;
   gasless: boolean;
+  doNotDeployOnSignMessage?: boolean;
 }
 
 export type ContractInfoInput = {


### PR DESCRIPTION
## Problem solved

Allow users to specify whether they want to force deploy smart wallets on sign, useful in cases where delayed deploy is needed and only write tx should trigger it, such as session key creation or just avoiding spam.

## Changes made

- [ ] Added `doNotDeployOnSignMessage` optional param to SmartWalletConfig
- [ ] Updated check in `signMessage`

## How to test

- [ ] Turn on and sign message or auth
