### PR TITLE
fix(auth): Next.js App Router handler return type

### DIFF
--- a/.changeset/healthy-horses-pull.md
+++ b/.changeset/healthy-horses-pull.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/auth": patch
+---
+
+fix(auth): Next.js App Router handler return type

--- a/packages/auth/src/next/router-app/index.ts
+++ b/packages/auth/src/next/router-app/index.ts
@@ -58,13 +58,8 @@ export function ThirdwebAuth<
     auth: new ThirdwebAuthSDK(cfg.wallet, cfg.domain),
   };
 
-  async function ThirdwebAuthHandler(...args: [] | [NextRequest, ThirdwebNextContext]) {
-    if (args.length === 0) {
-      return async (req: NextRequest, ctx: ThirdwebNextContext): Promise<void | Response> =>
-        await ThirdwebAuthRouter(req, ctx, authCtx as ThirdwebAuthContext);
-    }
-
-    return ThirdwebAuthRouter(args[0], args[1], authCtx as ThirdwebAuthContext);
+  async function ThirdwebAuthHandler(req: NextRequest, ctx: ThirdwebNextContext) {
+    return await ThirdwebAuthRouter(req, ctx, authCtx as ThirdwebAuthContext);
   }
 
   return {


### PR DESCRIPTION
## Problem solved

I just realized that when running the Next.js `build` script the below TS error is thrown. Next.js does not like the return type of the async handler function (the handler in which no arguments are passed).

And I think in the App Router there is no need for the handler with zero arguments. It seems that the below lines only make sense in Pages Router.
https://github.com/thirdweb-dev/js/blob/bdf60e98900cd08df0e28d5f4a624a1154f786a3/packages/auth/src/next/router-app/index.ts#L62-L65

```
frontend:build:  ✓ Compiled successfully
   Linting and checking validity of types  ..Failed to compile.
frontend:build: 
frontend:build: app/api/auth/[...thirdweb]/route.ts
frontend:build: Type error: Route "app/api/auth/[...thirdweb]/route.ts" has an invalid export:
frontend:build:   "Promise<Response | ((req: NextRequest, ctx: ThirdwebNextContext) => Promise<void | Response>)>" is not a valid GET return type:
frontend:build:     Expected "void | Response | Promise<void | Response>", got "Promise<Response | ((req: NextRequest, ctx: ThirdwebNextContext) => Promise<void | Response>)>".
frontend:build:       Expected "Promise<void | Response>", got "Promise<Response | ((req: NextRequest, ctx: ThirdwebNextContext) => Promise<void | Response>)>".
frontend:build:         Expected "void | Response", got "Response | ((req: NextRequest, ctx: ThirdwebNextContext) => Promise<void | Response>)".
frontend:build:           Expected "void | Response", got "(req: NextRequest, ctx: ThirdwebNextContext) => Promise<void | Response>".
frontend:build: 
frontend:build:  ELIFECYCLE  Command failed with exit code 1.
```

## Changes made

- [ ] Public API changes: list the public API changes made if any
- [x] Internal API changes: explain the internal logic changes

## How to test

- [ ] Automated tests: link to unit test file
- [x] Manual tests: step by step instructions on how to test

## Contributor NFT

Paste in your wallet address below and we will airdrop you a special NFT when your pull request is merged. 

```Address: 0x706df41aBc8830Fb7866d04cd703813Ef43a4e53```
