### PR TITLE
[Smart Wallet] Always force deploy on sign/auth, support 1271

### DIFF
--- a/.changeset/good-ways-listen.md
+++ b/.changeset/good-ways-listen.md
@@ -1,6 +1,6 @@
 ---
 "@thirdweb-dev/unity-js-bridge": minor
-"@thirdweb-dev/wallets": minor
+"@thirdweb-dev/wallets": patch
 ---
 
-[Smart Wallet] Always force deploy on sign/auth, remove legacy signing, always use 1271
+[Smart Wallet] Always force deploy on sign/auth, use 712 with 1271 where possible

--- a/.changeset/good-ways-listen.md
+++ b/.changeset/good-ways-listen.md
@@ -1,0 +1,6 @@
+---
+"@thirdweb-dev/unity-js-bridge": minor
+"@thirdweb-dev/wallets": minor
+---
+
+[Smart Wallet] Always force deploy on sign/auth, remove legacy signing, always use 1271

--- a/packages/unity-js-bridge/src/thirdweb-bridge.ts
+++ b/packages/unity-js-bridge/src/thirdweb-bridge.ts
@@ -244,7 +244,6 @@ class ThirdwebBridge implements TWBridge {
             paymasterUrl: sdkOptions.smartWalletConfig?.paymasterUrl,
             // paymasterAPI: sdkOptions.smartWalletConfig?.paymasterAPI,
             entryPointAddress: sdkOptions.smartWalletConfig?.entryPointAddress,
-            deployOnSign: sdkOptions.smartWalletConfig?.deployOnSign,
           };
           walletInstance = new SmartWallet(config);
           break;

--- a/packages/unity-js-bridge/src/thirdweb-bridge.ts
+++ b/packages/unity-js-bridge/src/thirdweb-bridge.ts
@@ -144,7 +144,7 @@ class ThirdwebBridge implements TWBridge {
       }
       (globalThis as any).X_SDK_NAME = "UnitySDK_WebGL";
       (globalThis as any).X_SDK_PLATFORM = "unity";
-      (globalThis as any).X_SDK_VERSION = "4.6.4";
+      (globalThis as any).X_SDK_VERSION = "4.7.0";
       (globalThis as any).X_SDK_OS = browser?.os ?? "unknown";
     }
     this.initializedChain = chain;
@@ -812,18 +812,19 @@ class ThirdwebBridge implements TWBridge {
     if (!this.activeWallet) {
       throw new Error("No wallet connected");
     }
-    try{
+    try {
       const smartWallet = this.activeWallet as SmartWallet;
       const signer = await smartWallet.getPersonalWallet()?.getSigner();
       const res = await signer?.getAddress();
       return JSON.stringify({ result: res }, bigNumberReplacer);
     } catch {
-      console.debug("Could not find a smart wallet, defaulting to normal signer");
+      console.debug(
+        "Could not find a smart wallet, defaulting to normal signer",
+      );
       const signer = await this.activeWallet.getSigner();
       const res = await signer.getAddress();
       return JSON.stringify({ result: res }, bigNumberReplacer);
     }
-    
   }
 
   public openPopupWindow() {

--- a/packages/wallets/src/evm/connectors/smart-wallet/index.ts
+++ b/packages/wallets/src/evm/connectors/smart-wallet/index.ts
@@ -54,7 +54,6 @@ export class SmartWalletConnector extends Connector<SmartWalletConnectionArgs> {
       this.config.paymasterUrl ||
       `https://${this.chainId}.bundler.thirdweb.com/v2`;
     const entryPointAddress = config.entryPointAddress || ENTRYPOINT_ADDRESS;
-    const deployOnSign = config.deployOnSign ?? true;
     const localSigner = await params.personalWallet.getSigner();
     const providerConfig: ProviderConfig = {
       chain: config.chain,
@@ -70,7 +69,6 @@ export class SmartWalletConnector extends Connector<SmartWalletConnectionArgs> {
             this.config.secretKey,
           ),
       gasless: config.gasless,
-      deployOnSign: deployOnSign,
       factoryAddress: config.factoryAddress,
       accountAddress: params.accountAddress,
       factoryInfo: config.factoryInfo || this.defaultFactoryInfo(),
@@ -316,8 +314,8 @@ export class SmartWalletConnector extends Connector<SmartWalletConnectionArgs> {
         value: await transaction.getValue(),
         gasLimit: await transaction.getOverrides().gasLimit,
         maxFeePerGas: await transaction.getOverrides().maxFeePerGas,
-        maxPriorityFeePerGas: await transaction.getOverrides()
-          .maxPriorityFeePerGas,
+        maxPriorityFeePerGas:
+          await transaction.getOverrides().maxPriorityFeePerGas,
         nonce: await transaction.getOverrides().nonce,
       },
       options,

--- a/packages/wallets/src/evm/connectors/smart-wallet/lib/erc4337-signer.ts
+++ b/packages/wallets/src/evm/connectors/smart-wallet/lib/erc4337-signer.ts
@@ -160,8 +160,10 @@ Code: ${errorCode}`;
       await tx.wait();
     }
 
-    const chainId = await this.getChainId();
-    const address = await this.getAddress();
+    const [chainId, address] = await Promise.all([
+      this.getChainId(),
+      this.getAddress(),
+    ]);
     const originalMsgHash = utils.hashMessage(message);
 
     let factorySupports712: boolean;

--- a/packages/wallets/src/evm/connectors/smart-wallet/lib/erc4337-signer.ts
+++ b/packages/wallets/src/evm/connectors/smart-wallet/lib/erc4337-signer.ts
@@ -175,7 +175,9 @@ Code: ${errorCode}`;
 
       const walletContract = new Contract(
         address,
-        "function getMessageHash(bytes32 _hash) public view returns (bytes32)",
+        [
+          "function getMessageHash(bytes32 _hash) public view returns (bytes32)",
+        ],
         provider,
       );
 

--- a/packages/wallets/src/evm/connectors/smart-wallet/lib/erc4337-signer.ts
+++ b/packages/wallets/src/evm/connectors/smart-wallet/lib/erc4337-signer.ts
@@ -169,23 +169,24 @@ Code: ${errorCode}`;
      */
     try {
       const provider = new providers.JsonRpcProvider({
-        url: chainIdToThirdwebRpc(chainId),
+        url: chainIdToThirdwebRpc(chainId, this.config.clientId),
         skipFetchSetup: false,
       });
       const walletContract = new Contract(
         address,
-        "function getMessageHash(bytes memory message) public view returns (bytes32)",
+        "function getMessageHash(bytes32 _hash) public view returns (bytes32)",
         provider,
       );
 
+      const hash = utils.hashMessage(message);
+
       // if this doesn't fail, it's a post 1271 + typehash account
-      await walletContract.getMessageHash(message);
+      await walletContract.getMessageHash(hash);
 
       console.log(
         "Signing with EIP-712 typed data and verifying with EIP-1271...",
       );
 
-      const hash = utils.hashMessage(message);
       const result = await signTypedDataInternal(
         this,
         {

--- a/packages/wallets/src/evm/connectors/smart-wallet/lib/erc4337-signer.ts
+++ b/packages/wallets/src/evm/connectors/smart-wallet/lib/erc4337-signer.ts
@@ -139,18 +139,18 @@ Code: ${errorCode}`;
   }
 
   async signMessage(message: Bytes | string): Promise<string> {
-      const isNotDeployed = await this.smartAccountAPI.checkAccountPhantom();
-      if (isNotDeployed && this.config.deployOnSign) {
-        console.log(
-          "Account contract not deployed yet. Deploying account before signing message",
-        );
-        const tx = await this.sendTransaction({
-          to: await this.getAddress(),
-          data: "0x",
-        });
-        await tx.wait();
-      }
-    
+    const isNotDeployed = await this.smartAccountAPI.checkAccountPhantom();
+    if (isNotDeployed) {
+      console.log(
+        "Account contract not deployed yet. Deploying account before signing message",
+      );
+      const tx = await this.sendTransaction({
+        to: await this.getAddress(),
+        data: "0x",
+      });
+      await tx.wait();
+    }
+
     return await this.originalSigner.signMessage(message);
   }
 

--- a/packages/wallets/src/evm/connectors/smart-wallet/lib/erc4337-signer.ts
+++ b/packages/wallets/src/evm/connectors/smart-wallet/lib/erc4337-signer.ts
@@ -201,7 +201,7 @@ Code: ${errorCode}`;
       );
 
       const isValid = await checkContractWalletSignature(
-        hash,
+        message as string,
         result.signature,
         address,
         chainId,

--- a/packages/wallets/src/evm/connectors/smart-wallet/lib/erc4337-signer.ts
+++ b/packages/wallets/src/evm/connectors/smart-wallet/lib/erc4337-signer.ts
@@ -194,7 +194,7 @@ Code: ${errorCode}`;
           chainId,
           verifyingContract: address,
         },
-        { AccountMessage: [{ name: "message", type: "bytes32" }] },
+        { AccountMessage: [{ name: "message", type: "bytes" }] },
         {
           message: utils.defaultAbiCoder.encode(["bytes32"], [hash]),
         },

--- a/packages/wallets/src/evm/connectors/smart-wallet/types.ts
+++ b/packages/wallets/src/evm/connectors/smart-wallet/types.ts
@@ -22,7 +22,6 @@ export type SmartWalletConfig = {
   paymasterUrl?: string;
   paymasterAPI?: PaymasterAPI;
   entryPointAddress?: string;
-  deployOnSign?: boolean;
 } & ContractInfoInput &
   WalletConnectReceiverConfig;
 
@@ -43,7 +42,6 @@ export interface ProviderConfig extends ContractInfo {
   accountAddress?: string;
   paymasterAPI: PaymasterAPI;
   gasless: boolean;
-  deployOnSign?: boolean;
 }
 
 export type ContractInfoInput = {

--- a/packages/wallets/src/evm/wallets/abstract.ts
+++ b/packages/wallets/src/evm/wallets/abstract.ts
@@ -15,7 +15,7 @@ import {
 import { createErc20 } from "../utils/currency";
 
 // TODO improve this
-function chainIdToThirdwebRpc(chainId: number, clientId?: string) {
+export function chainIdToThirdwebRpc(chainId: number, clientId?: string) {
   return `https://${chainId}.rpc.thirdweb.com${clientId ? `/${clientId}` : ""}${
     typeof globalThis !== "undefined" && "APP_BUNDLE_ID" in globalThis
       ? `?bundleId=${(globalThis as any).APP_BUNDLE_ID as string}`

--- a/packages/wallets/src/evm/wallets/abstract.ts
+++ b/packages/wallets/src/evm/wallets/abstract.ts
@@ -45,7 +45,7 @@ const EIP1271_ABI = [
 const EIP1271_MAGICVALUE = "0x1626ba7e";
 
 export async function checkContractWalletSignature(
-  message: string,
+  hash: string,
   signature: string,
   address: string,
   chainId: number,
@@ -66,9 +66,8 @@ export async function checkContractWalletSignature(
     skipFetchSetup: _skipFetchSetup,
   });
   const walletContract = new Contract(address, EIP1271_ABI, provider);
-  const _hashMessage = utils.hashMessage(message);
   try {
-    const res = await walletContract.isValidSignature(_hashMessage, signature);
+    const res = await walletContract.isValidSignature(hash, signature);
     return res === EIP1271_MAGICVALUE;
   } catch {
     return false;

--- a/packages/wallets/src/evm/wallets/abstract.ts
+++ b/packages/wallets/src/evm/wallets/abstract.ts
@@ -45,7 +45,7 @@ const EIP1271_ABI = [
 const EIP1271_MAGICVALUE = "0x1626ba7e";
 
 export async function checkContractWalletSignature(
-  hash: string,
+  message: string,
   signature: string,
   address: string,
   chainId: number,
@@ -67,7 +67,10 @@ export async function checkContractWalletSignature(
   });
   const walletContract = new Contract(address, EIP1271_ABI, provider);
   try {
-    const res = await walletContract.isValidSignature(hash, signature);
+    const res = await walletContract.isValidSignature(
+      utils.hashMessage(message),
+      signature,
+    );
     return res === EIP1271_MAGICVALUE;
   } catch {
     return false;

--- a/packages/wallets/src/evm/wallets/smart-wallet.ts
+++ b/packages/wallets/src/evm/wallets/smart-wallet.ts
@@ -15,8 +15,7 @@ import {
 } from "@thirdweb-dev/sdk";
 import { walletIds } from "../constants/walletIds";
 import { getValidChainRPCs } from "@thirdweb-dev/chains";
-import { providers, utils, Bytes, Signer } from "ethers";
-import { signTypedDataInternal } from "@thirdweb-dev/sdk";
+import { providers, utils } from "ethers";
 
 // export types and utils for convenience
 export type * from "../connectors/smart-wallet/types";

--- a/packages/wallets/src/evm/wallets/smart-wallet.ts
+++ b/packages/wallets/src/evm/wallets/smart-wallet.ts
@@ -1,5 +1,4 @@
 import { AbstractClientWallet, WalletOptions } from "./base";
-import { checkContractWalletSignature } from "./abstract";
 import type { ConnectParams } from "../interfaces/connector";
 import type {
   SmartWalletConfig,
@@ -314,66 +313,6 @@ export class SmartWallet extends AbstractClientWallet<
    */
   getPersonalWallet() {
     return this.connector?.personalWallet;
-  }
-
-  /**
-   * Sign a message and return the signature
-   */
-  public async signMessage(message: Bytes | string): Promise<string> {
-    // Deploy smart wallet if needed
-    const connector = await this.getConnector();
-    await connector.deployIfNeeded();
-
-    const erc4337Signer = await this.getSigner();
-    const chainId = await erc4337Signer.getChainId();
-    const address = await connector.getAddress();
-
-    /**
-     * We first try to sign the EIP-712 typed data i.e. the message mixed with the smart wallet's domain separator.
-     * If this fails, we fallback to the legacy signing method.
-     */
-    try {
-      const hash = utils.hashMessage(message);
-      const result = await signTypedDataInternal(
-        erc4337Signer,
-        {
-          name: "Account",
-          version: "1",
-          chainId,
-          verifyingContract: address,
-        },
-        { AccountMessage: [{ name: "hash", type: "bytes32" }] },
-        {
-          message: utils.defaultAbiCoder.encode(["bytes32"], [hash]),
-        },
-      );
-
-      const isValid = await checkContractWalletSignature(
-        hash,
-        result.signature,
-        address,
-        chainId,
-      );
-
-      if (!isValid) {
-        throw new Error("Invalid signature");
-      }
-
-      return result.signature;
-    } catch {
-      return await this.signMessageLegacy(erc4337Signer, message);
-    }
-  }
-
-  /**
-   * This is only for for legacy EIP-1271 signature verification
-   * Sign a message and return the signature
-   */
-  private async signMessageLegacy(
-    signer: Signer,
-    message: Bytes | string,
-  ): Promise<string> {
-    return await signer.signMessage(message);
   }
 
   /**

--- a/packages/wallets/src/evm/wallets/smart-wallet.ts
+++ b/packages/wallets/src/evm/wallets/smart-wallet.ts
@@ -328,37 +328,52 @@ export class SmartWallet extends AbstractClientWallet<
     const chainId = await erc4337Signer.getChainId();
     const address = await connector.getAddress();
 
-    const result = await signTypedDataInternal(
-      erc4337Signer,
-      {
-        name: "Account",
-        version: "1",
-        chainId,
-        verifyingContract: address,
-      },
-      { AccountMessage: [{ name: "message", type: "bytes" }] },
-      {
-        message: utils.defaultAbiCoder.encode(
-          ["bytes32"],
-          [utils.hashMessage(message)],
-        ),
-      },
-    );
-
-    const isValid = await checkContractWalletSignature(
-      message as string,
-      result.signature,
-      address,
-      chainId,
-    );
-
-    if (!isValid) {
-      throw new Error(
-        "Unable to verify signature on smart account, please make sure the smart account is deployed and the signature is valid.",
+    /**
+     * We first try to sign the EIP-712 typed data i.e. the message mixed with the smart wallet's domain separator.
+     * If this fails, we fallback to the legacy signing method.
+     */
+    try {
+      const hash = utils.hashMessage(message);
+      const result = await signTypedDataInternal(
+        erc4337Signer,
+        {
+          name: "Account",
+          version: "1",
+          chainId,
+          verifyingContract: address,
+        },
+        { AccountMessage: [{ name: "hash", type: "bytes32" }] },
+        {
+          message: utils.defaultAbiCoder.encode(["bytes32"], [hash]),
+        },
       );
-    }
 
-    return result.signature;
+      const isValid = await checkContractWalletSignature(
+        hash,
+        result.signature,
+        address,
+        chainId,
+      );
+
+      if (!isValid) {
+        throw new Error("Invalid signature");
+      }
+
+      return result.signature;
+    } catch {
+      return await this.signMessageLegacy(erc4337Signer, message);
+    }
+  }
+
+  /**
+   * This is only for for legacy EIP-1271 signature verification
+   * Sign a message and return the signature
+   */
+  private async signMessageLegacy(
+    signer: Signer,
+    message: Bytes | string,
+  ): Promise<string> {
+    return await signer.signMessage(message);
   }
 
   /**


### PR DESCRIPTION
## Problem solved

Support 712 based smart wallet signing and 1271 verification for new factories.
Remove optional deployment option.
Move smart-wallet signing functionality to erc4337-signer, all flows except user op signing should go through this.

## Changes made

- [ ] Public API changes: `deployOnSign` Smart Wallet option is no longer available.
- [ ] Internal API changes: `signMessageLegacy` is now removed.

## How to test

- [ ] Automated tests: link to unit test file
- [ ] Manual tests: step by step instructions on how to test

## Contributor NFT

Paste in your wallet address below and we will airdrop you a special NFT when your pull request is merged. 

```Address: ```
