### PR TITLE
Use `private` for private members in classes instead of `#`

### DIFF
--- a/.changeset/tiny-forks-help.md
+++ b/.changeset/tiny-forks-help.md
@@ -1,0 +1,9 @@
+---
+"@thirdweb-dev/wallets": patch
+"@thirdweb-dev/crypto": patch
+"thirdweb": patch
+"@thirdweb-dev/pay": patch
+"@thirdweb-dev/sdk": patch
+---
+
+Use `private foo` instead of `#foo` for making the members private in classes

--- a/packages/cli/src/core/helpers/logger.ts
+++ b/packages/cli/src/core/helpers/logger.ts
@@ -12,39 +12,39 @@ function shouldLog(minLevel: LogLevel, currentLevel: LogLevel): boolean {
 }
 
 class BasicLogger {
-  #minLevel: LogLevel = "info";
+  private _minLevel: LogLevel = "info";
   constructor(params?: BasicLoggerConstructorParams) {
     if (params?.minLevel) {
-      this.#minLevel = params.minLevel;
+      this._minLevel = params.minLevel;
     }
   }
 
   setSettings(params: BasicLoggerConstructorParams) {
     if (params.minLevel) {
-      this.#minLevel = params.minLevel;
+      this._minLevel = params.minLevel;
     }
   }
 
   debug(...args: any[]) {
-    if (shouldLog(this.#minLevel, "debug")) {
+    if (shouldLog(this._minLevel, "debug")) {
       console.info(...args);
     }
   }
 
   info(...args: any[]) {
-    if (shouldLog(this.#minLevel, "info")) {
+    if (shouldLog(this._minLevel, "info")) {
       console.info(...args);
     }
   }
 
   warn(...args: any[]) {
-    if (shouldLog(this.#minLevel, "warn")) {
+    if (shouldLog(this._minLevel, "warn")) {
       console.warn(...args);
     }
   }
 
   error(...args: any[]) {
-    if (shouldLog(this.#minLevel, "error")) {
+    if (shouldLog(this._minLevel, "error")) {
       console.error(...args);
     }
   }

--- a/packages/crypto/src/utils/cache.ts
+++ b/packages/crypto/src/utils/cache.ts
@@ -1,19 +1,19 @@
 class TextProcessorCache {
-  #encoder: TextEncoder | undefined;
-  #decoder: TextDecoder | undefined;
+  private _encoder: TextEncoder | undefined;
+  private _decoder: TextDecoder | undefined;
 
   get encoder(): TextEncoder {
-    if (!this.#encoder) {
-      this.#encoder = new TextEncoder();
+    if (!this._encoder) {
+      this._encoder = new TextEncoder();
     }
-    return this.#encoder;
+    return this._encoder;
   }
 
   get decoder(): TextDecoder {
-    if (!this.#decoder) {
-      this.#decoder = new TextDecoder();
+    if (!this._decoder) {
+      this._decoder = new TextDecoder();
     }
-    return this.#decoder;
+    return this._decoder;
   }
 }
 

--- a/packages/pay/src/integrations/coinbase/index.ts
+++ b/packages/pay/src/integrations/coinbase/index.ts
@@ -16,9 +16,9 @@ export type FundWalletOptions = {
 };
 
 export class CoinbasePayIntegration {
-  #appId: string;
+  private _appId: string;
   constructor(options: CoinbasePayOptions) {
-    this.#appId = options.appId;
+    this._appId = options.appId;
   }
 
   async fundWallet(opts: FundWalletOptions): Promise<void> {
@@ -27,7 +27,7 @@ export class CoinbasePayIntegration {
     return new Promise((res, rej) => {
       initOnRamp(
         {
-          appId: this.#appId,
+          appId: this._appId,
           widgetParameters: {
             destinationWallets: [
               {

--- a/packages/sdk/src/evm/common/error.ts
+++ b/packages/sdk/src/evm/common/error.ts
@@ -284,9 +284,9 @@ export type TransactionErrorInfo = {
  * @public
  */
 export class TransactionError extends Error {
-  #reason: string;
-  #info: TransactionErrorInfo;
-  #raw: any;
+  private _reason: string;
+  private _info: TransactionErrorInfo;
+  private _raw: any;
 
   constructor(info: TransactionErrorInfo, raw: any) {
     let errorMessage = `\n\n\n╔═══════════════════╗\n║ TRANSACTION ERROR ║\n╚═══════════════════╝\n\n`;
@@ -363,22 +363,22 @@ export class TransactionError extends Error {
 
     super(errorMessage);
 
-    this.#reason = info.reason;
-    this.#info = info;
-    this.#raw = raw;
+    this._reason = info.reason;
+    this._info = info;
+    this._raw = raw;
   }
 
   // Keep reason here for backwards compatibility
   get reason(): string {
-    return this.#reason;
+    return this._reason;
   }
 
   get raw(): any {
-    return this.#raw;
+    return this._raw;
   }
 
   get info(): TransactionErrorInfo {
-    return this.#info;
+    return this._info;
   }
 }
 

--- a/packages/wallets/src/evm/connectors/embedded-wallet/index.ts
+++ b/packages/wallets/src/evm/connectors/embedded-wallet/index.ts
@@ -26,10 +26,9 @@ export class EmbeddedWalletConnector extends Connector<EmbeddedWalletConnectionA
   ready = true;
 
   private user: InitializedUser | null = null;
-  #embeddedWalletSdk?: EmbeddedWalletSdk;
+  private _embeddedWalletSdk?: EmbeddedWalletSdk;
   private options: EmbeddedWalletConnectorOptions;
-
-  #signer?: Signer;
+  private _signer?: Signer;
 
   constructor(options: EmbeddedWalletConnectorOptions) {
     super();
@@ -37,14 +36,14 @@ export class EmbeddedWalletConnector extends Connector<EmbeddedWalletConnectionA
   }
 
   getEmbeddedWalletSDK(): EmbeddedWalletSdk {
-    if (!this.#embeddedWalletSdk) {
-      this.#embeddedWalletSdk = new EmbeddedWalletSdk({
+    if (!this._embeddedWalletSdk) {
+      this._embeddedWalletSdk = new EmbeddedWalletSdk({
         clientId: this.options.clientId,
         chain: "Ethereum",
         onAuthSuccess: this.options.onAuthSuccess,
       });
     }
-    return this.#embeddedWalletSdk;
+    return this._embeddedWalletSdk;
   }
 
   async connect(args?: EmbeddedWalletConnectionArgs): Promise<string> {
@@ -78,10 +77,10 @@ export class EmbeddedWalletConnector extends Connector<EmbeddedWalletConnectionA
   }
 
   async disconnect(): Promise<void> {
-    const paper = this.#embeddedWalletSdk;
+    const paper = this._embeddedWalletSdk;
     await paper?.auth.logout();
-    this.#signer = undefined;
-    this.#embeddedWalletSdk = undefined;
+    this._signer = undefined;
+    this._embeddedWalletSdk = undefined;
     this.user = null;
   }
 
@@ -110,8 +109,8 @@ export class EmbeddedWalletConnector extends Connector<EmbeddedWalletConnectionA
   }
 
   public async getSigner(): Promise<Signer> {
-    if (this.#signer) {
-      return this.#signer;
+    if (this._signer) {
+      return this._signer;
     }
 
     const user = await this.getUser();
@@ -123,7 +122,7 @@ export class EmbeddedWalletConnector extends Connector<EmbeddedWalletConnectionA
       throw new Error("Signer not found");
     }
 
-    this.#signer = signer;
+    this._signer = signer;
 
     return signer;
   }
@@ -142,7 +141,7 @@ export class EmbeddedWalletConnector extends Connector<EmbeddedWalletConnectionA
       // update chain in wallet
       await this.user?.wallet.setChain({ chain: "Ethereum" }); // just pass Ethereum no matter what chain we are going to connect
       // update signer
-      this.#signer = await this.user?.wallet.getEthersJsSigner({
+      this._signer = await this.user?.wallet.getEthersJsSigner({
         rpcEndpoint: chain.rpc[0] || "",
       });
       this.emit("change", { chain: { id: chainId, unsupported: false } });

--- a/packages/wallets/src/evm/connectors/frame/index.ts
+++ b/packages/wallets/src/evm/connectors/frame/index.ts
@@ -43,7 +43,7 @@ export class FrameConnector extends WagmiConnector<
   readonly ready = true;
   protected shimDisconnectKey = `${this.id}.shimDisconnect`;
 
-  #provider?: Provider | Ethereum;
+  private _provider?: Provider | Ethereum;
   connectorStorage: AsyncStorage;
 
   constructor({
@@ -148,10 +148,10 @@ export class FrameConnector extends WagmiConnector<
   }
 
   async getProvider() {
-    this.#provider = this.isInjected()
+    this._provider = this.isInjected()
       ? this.injectedProvider()
       : await this.createProvider();
-    return this.#provider;
+    return this._provider;
   }
 
   /**

--- a/packages/wallets/src/evm/connectors/injected/index.ts
+++ b/packages/wallets/src/evm/connectors/injected/index.ts
@@ -69,7 +69,7 @@ export class InjectedConnector extends WagmiConnector<
    */
   readonly ready: boolean;
 
-  #provider?: Ethereum;
+  private _provider?: Ethereum;
   connectorStorage: AsyncStorage;
 
   protected shimDisconnectKey = "injected.shimDisconnect";
@@ -246,10 +246,10 @@ export class InjectedConnector extends WagmiConnector<
   async getProvider() {
     const provider = this.options.getProvider();
     if (provider) {
-      this.#provider = provider;
+      this._provider = provider;
       // setting listeners
     }
-    return this.#provider as Ethereum;
+    return this._provider as Ethereum;
   }
 
   /**

--- a/packages/wallets/src/evm/connectors/local-wallet/index.ts
+++ b/packages/wallets/src/evm/connectors/local-wallet/index.ts
@@ -21,8 +21,8 @@ export class LocalWalletConnector extends Connector<LocalWalletConnectionArgs> {
   readonly name: string = "Local Wallet";
   options: LocalWalletConnectorOptions;
 
-  #provider?: providers.Provider;
-  #signer?: Signer;
+  private _provider?: providers.Provider;
+  private _signer?: Signer;
 
   protected shimDisconnectKey = "localWallet.shimDisconnect";
 
@@ -42,8 +42,8 @@ export class LocalWalletConnector extends Connector<LocalWalletConnectionArgs> {
   }
 
   async disconnect() {
-    this.#provider = undefined;
-    this.#signer = undefined;
+    this._provider = undefined;
+    this._signer = undefined;
   }
 
   async getAddress(): Promise<string> {
@@ -64,24 +64,24 @@ export class LocalWalletConnector extends Connector<LocalWalletConnectionArgs> {
   }
 
   async getProvider() {
-    if (!this.#provider) {
-      this.#provider = getChainProvider(this.options.chain, {
+    if (!this._provider) {
+      this._provider = getChainProvider(this.options.chain, {
         clientId: this.options.clientId,
         secretKey: this.options.secretKey,
       });
     }
-    return this.#provider;
+    return this._provider;
   }
 
   async getSigner() {
-    if (!this.#signer) {
+    if (!this._signer) {
       const provider = await this.getProvider();
-      this.#signer = getSignerFromEthersWallet(
+      this._signer = getSignerFromEthersWallet(
         this.options.ethersWallet,
         provider,
       );
     }
-    return this.#signer;
+    return this._signer;
   }
 
   async switchChain(chainId: number): Promise<void> {
@@ -92,13 +92,13 @@ export class LocalWalletConnector extends Connector<LocalWalletConnectionArgs> {
       );
     }
 
-    this.#provider = getChainProvider(chain, {
+    this._provider = getChainProvider(chain, {
       clientId: this.options.clientId,
       secretKey: this.options.secretKey,
     });
-    this.#signer = getSignerFromEthersWallet(
+    this._signer = getSignerFromEthersWallet(
       this.options.ethersWallet,
-      this.#provider,
+      this._provider,
     );
     this.onChainChanged(chainId);
   }

--- a/packages/wallets/src/evm/connectors/magic/index.ts
+++ b/packages/wallets/src/evm/connectors/magic/index.ts
@@ -129,8 +129,8 @@ export class MagicAuthConnector extends MagicBaseConnector {
     string,
     MagicSDKExtensionsOption<OAuthExtension["name"]>
   >;
-  #connectedChainId?: number;
-  #type?: "connect" | "auth";
+  private _connectedChainId?: number;
+  private _type?: "connect" | "auth";
 
   oauthProviders: OAuthProvider[];
   oauthRedirectURI?: string;
@@ -138,7 +138,7 @@ export class MagicAuthConnector extends MagicBaseConnector {
   constructor(config: { chains?: Chain[]; options: MagicAuthOptions }) {
     super(config);
     this.magicSdkConfiguration = config.options.magicSdkConfiguration;
-    this.#type = config.options.type;
+    this._type = config.options.type;
     this.oauthProviders = config.options.oauthOptions?.providers || [];
     this.oauthRedirectURI = config.options.oauthOptions?.redirectURI;
   }
@@ -166,7 +166,7 @@ export class MagicAuthConnector extends MagicBaseConnector {
         chainId = 0;
       }
 
-      this.#connectedChainId = chainId;
+      this._connectedChainId = chainId;
 
       // if there is a user logged in, return the user
       if (isAuthenticated) {
@@ -182,7 +182,7 @@ export class MagicAuthConnector extends MagicBaseConnector {
 
       const magic = this.getMagicSDK();
 
-      if (this.#type === "connect") {
+      if (this._type === "connect") {
         if ("email" in options || "phoneNumber" in options) {
           console.warn(
             "Passing email or phoneNumber is not required for Magic Connect",
@@ -298,7 +298,7 @@ export class MagicAuthConnector extends MagicBaseConnector {
       throw new Error("Chain not found");
     }
 
-    if (this.#connectedChainId !== chainId) {
+    if (this._connectedChainId !== chainId) {
       this.initializeMagicSDK({ chainId });
     }
 

--- a/packages/wallets/src/evm/connectors/metamask/index.ts
+++ b/packages/wallets/src/evm/connectors/metamask/index.ts
@@ -29,7 +29,7 @@ type MetamaskConnectorConstructorArg = {
 
 export class MetaMaskConnector extends InjectedConnector {
   readonly id = walletIds.metamask;
-  #UNSTABLE_shimOnConnectSelectAccount: MetaMaskConnectorOptions["UNSTABLE_shimOnConnectSelectAccount"];
+  private _UNSTABLE_shimOnConnectSelectAccount: MetaMaskConnectorOptions["UNSTABLE_shimOnConnectSelectAccount"];
 
   constructor(arg: MetamaskConnectorConstructorArg) {
     const defaultOptions = {
@@ -50,7 +50,7 @@ export class MetaMaskConnector extends InjectedConnector {
       connectorStorage: arg.connectorStorage,
     });
 
-    this.#UNSTABLE_shimOnConnectSelectAccount =
+    this._UNSTABLE_shimOnConnectSelectAccount =
       options.UNSTABLE_shimOnConnectSelectAccount;
   }
 
@@ -73,7 +73,7 @@ export class MetaMaskConnector extends InjectedConnector {
       // `shimDisconnect` is active and account is in disconnected state (flag in storage)
       let account: string | null = null;
       if (
-        this.#UNSTABLE_shimOnConnectSelectAccount &&
+        this._UNSTABLE_shimOnConnectSelectAccount &&
         this.options?.shimDisconnect &&
         !Boolean(this.connectorStorage.getItem(this.shimDisconnectKey))
       ) {

--- a/packages/wallets/src/evm/connectors/paper/index.ts
+++ b/packages/wallets/src/evm/connectors/paper/index.ts
@@ -27,7 +27,7 @@ export class PaperWalletConnector extends Connector<Record<string, never>> {
   paper?: Promise<PaperEmbeddedWalletSdk>;
   private options: PaperWalletConnectorOptions;
 
-  #signer?: Signer;
+  private _signer?: Signer;
 
   constructor(options: PaperWalletConnectorOptions) {
     super();
@@ -149,7 +149,7 @@ export class PaperWalletConnector extends Connector<Record<string, never>> {
   async disconnect(): Promise<void> {
     const paper = await this.paper;
     await paper?.auth.logout();
-    this.#signer = undefined;
+    this._signer = undefined;
     this.user = null;
   }
 
@@ -176,8 +176,8 @@ export class PaperWalletConnector extends Connector<Record<string, never>> {
   }
 
   public async getSigner(): Promise<Signer> {
-    if (this.#signer) {
-      return this.#signer;
+    if (this._signer) {
+      return this._signer;
     }
 
     if (!this.user) {
@@ -199,7 +199,7 @@ export class PaperWalletConnector extends Connector<Record<string, never>> {
       throw new Error("Signer not found");
     }
 
-    this.#signer = signer;
+    this._signer = signer;
 
     return signer;
   }
@@ -218,7 +218,7 @@ export class PaperWalletConnector extends Connector<Record<string, never>> {
     await this.user?.wallet.setChain({ chain: "Ethereum" }); // just pass Ethereum no matter what chain we are going to connect
 
     // update signer
-    this.#signer = await this.user?.wallet.getEthersJsSigner({
+    this._signer = await this.user?.wallet.getEthersJsSigner({
       rpcEndpoint: chain.rpc[0] || "", // TODO: handle chain.rpc being empty array
     });
 

--- a/packages/wallets/src/evm/connectors/phantom/index.ts
+++ b/packages/wallets/src/evm/connectors/phantom/index.ts
@@ -29,7 +29,7 @@ type PhantomConnectorConstructorArg = {
 
 export class PhantomConnector extends InjectedConnector {
   readonly id = walletIds.phantom;
-  #UNSTABLE_shimOnConnectSelectAccount: PhantomConnectorOptions["UNSTABLE_shimOnConnectSelectAccount"];
+  private _UNSTABLE_shimOnConnectSelectAccount: PhantomConnectorOptions["UNSTABLE_shimOnConnectSelectAccount"];
 
   constructor(arg: PhantomConnectorConstructorArg) {
     const defaultOptions = {
@@ -50,7 +50,7 @@ export class PhantomConnector extends InjectedConnector {
       connectorStorage: arg.connectorStorage,
     });
 
-    this.#UNSTABLE_shimOnConnectSelectAccount =
+    this._UNSTABLE_shimOnConnectSelectAccount =
       options.UNSTABLE_shimOnConnectSelectAccount;
   }
 
@@ -73,7 +73,7 @@ export class PhantomConnector extends InjectedConnector {
       // `shimDisconnect` is active and account is in disconnected state (flag in storage)
       let account: string | null = null;
       if (
-        this.#UNSTABLE_shimOnConnectSelectAccount &&
+        this._UNSTABLE_shimOnConnectSelectAccount &&
         this.options?.shimDisconnect &&
         !Boolean(this.connectorStorage.getItem(this.shimDisconnectKey))
       ) {

--- a/packages/wallets/src/evm/connectors/rainbow/index.ts
+++ b/packages/wallets/src/evm/connectors/rainbow/index.ts
@@ -29,7 +29,7 @@ type RainbowConnectorConstructorArg = {
 
 export class RainbowConnector extends InjectedConnector {
   readonly id = walletIds.rainbow;
-  #UNSTABLE_shimOnConnectSelectAccount: RainbowConnectorOptions["UNSTABLE_shimOnConnectSelectAccount"];
+  private _UNSTABLE_shimOnConnectSelectAccount: RainbowConnectorOptions["UNSTABLE_shimOnConnectSelectAccount"];
 
   constructor(arg: RainbowConnectorConstructorArg) {
     const defaultOptions = {
@@ -50,7 +50,7 @@ export class RainbowConnector extends InjectedConnector {
       connectorStorage: arg.connectorStorage,
     });
 
-    this.#UNSTABLE_shimOnConnectSelectAccount =
+    this._UNSTABLE_shimOnConnectSelectAccount =
       options.UNSTABLE_shimOnConnectSelectAccount;
   }
 
@@ -73,7 +73,7 @@ export class RainbowConnector extends InjectedConnector {
       // `shimDisconnect` is active and account is in disconnected state (flag in storage)
       let account: string | null = null;
       if (
-        this.#UNSTABLE_shimOnConnectSelectAccount &&
+        this._UNSTABLE_shimOnConnectSelectAccount &&
         this.options?.shimDisconnect &&
         !Boolean(this.connectorStorage.getItem(this.shimDisconnectKey))
       ) {

--- a/packages/wallets/src/evm/connectors/signer/index.ts
+++ b/packages/wallets/src/evm/connectors/signer/index.ts
@@ -16,8 +16,8 @@ export type SignerWalletConnectorOptions = {
 
 export class SignerConnector extends Connector<LocalWalletConnectionArgs> {
   options: SignerWalletConnectorOptions;
-  #provider?: providers.Provider;
-  #signer?: Signer;
+  private _provider?: providers.Provider;
+  private _signer?: Signer;
 
   constructor(options: SignerWalletConnectorOptions) {
     super();
@@ -34,8 +34,8 @@ export class SignerConnector extends Connector<LocalWalletConnectionArgs> {
   }
 
   async disconnect() {
-    this.#provider = undefined;
-    this.#signer = undefined;
+    this._provider = undefined;
+    this._signer = undefined;
   }
 
   async getAddress(): Promise<string> {
@@ -56,21 +56,21 @@ export class SignerConnector extends Connector<LocalWalletConnectionArgs> {
   }
 
   async getProvider() {
-    if (!this.#provider) {
-      this.#provider = getChainProvider(this.options.chain, {
+    if (!this._provider) {
+      this._provider = getChainProvider(this.options.chain, {
         clientId: this.options.clientId,
         secretKey: this.options.secretKey,
       });
     }
-    return this.#provider;
+    return this._provider;
   }
 
   async getSigner() {
-    if (!this.#signer) {
+    if (!this._signer) {
       const provider = await this.getProvider();
-      this.#signer = getUpdatedSigner(this.options.signer, provider);
+      this._signer = getUpdatedSigner(this.options.signer, provider);
     }
-    return this.#signer;
+    return this._signer;
   }
 
   async switchChain(chainId: number): Promise<void> {
@@ -82,12 +82,12 @@ export class SignerConnector extends Connector<LocalWalletConnectionArgs> {
       );
     }
 
-    this.#provider = getChainProvider(chain, {
+    this._provider = getChainProvider(chain, {
       clientId: this.options.clientId,
       secretKey: this.options.secretKey,
     });
 
-    this.#signer = getUpdatedSigner(this.options.signer, this.#provider);
+    this._signer = getUpdatedSigner(this.options.signer, this._provider);
 
     this.onChainChanged(chainId);
   }

--- a/packages/wallets/src/evm/wallets/async.ts
+++ b/packages/wallets/src/evm/wallets/async.ts
@@ -10,19 +10,19 @@ export interface AsyncWalletOptions {
  * @internal
  */
 export class AsyncWallet extends AbstractWallet {
-  #signer?: Signer;
-  #options: AsyncWalletOptions;
+  private _signer?: Signer;
+  private _options: AsyncWalletOptions;
 
   constructor(options: AsyncWalletOptions) {
     super();
-    this.#options = options;
+    this._options = options;
   }
 
   async getSigner(): Promise<Signer> {
-    if (!this.#signer || !this.#options.cacheSigner) {
-      this.#signer = await this.#options.getSigner();
+    if (!this._signer || !this._options.cacheSigner) {
+      this._signer = await this._options.getSigner();
     }
 
-    return this.#signer;
+    return this._signer;
   }
 }

--- a/packages/wallets/src/evm/wallets/aws-kms.ts
+++ b/packages/wallets/src/evm/wallets/aws-kms.ts
@@ -23,8 +23,8 @@ import type { AwsKmsSignerCredentials } from "ethers-aws-kms-signer";
  * @wallet
  */
 export class AwsKmsWallet extends AbstractWallet {
-  #signer?: Promise<Signer>;
-  #options: AwsKmsSignerCredentials;
+  private _signer?: Promise<Signer>;
+  private _options: AwsKmsSignerCredentials;
 
   /**
    * Create instance of `AwsKmsWallet`
@@ -33,18 +33,18 @@ export class AwsKmsWallet extends AbstractWallet {
    */
   constructor(options: AwsKmsSignerCredentials) {
     super();
-    this.#options = options;
+    this._options = options;
   }
 
   /**
    * Get [ethers signer](https://docs.ethers.io/v5/api/signer/) of the connected wallet
    */
   async getSigner(): Promise<Signer> {
-    if (!this.#signer) {
-      this.#signer = new Promise(async (resolve, reject) => {
+    if (!this._signer) {
+      this._signer = new Promise(async (resolve, reject) => {
         try {
           const { AwsKmsSigner } = await import("ethers-aws-kms-signer");
-          const signer = new AwsKmsSigner(this.#options);
+          const signer = new AwsKmsSigner(this._options);
 
           // Need to add this because ethers-aws-kms-signer doesn't support
           (signer as any)._signTypedData = async function (
@@ -63,11 +63,11 @@ export class AwsKmsWallet extends AbstractWallet {
           resolve(signer);
         } catch (err) {
           // remove the cached promise so we can try again
-          this.#signer = undefined;
+          this._signer = undefined;
           reject(err);
         }
       });
     }
-    return this.#signer;
+    return this._signer;
   }
 }

--- a/packages/wallets/src/evm/wallets/engine.ts
+++ b/packages/wallets/src/evm/wallets/engine.ts
@@ -9,14 +9,14 @@ import { AbstractWallet } from "./abstract";
  * @wallet
  */
 export class EngineWallet extends AbstractWallet {
-  #signer: EngineSigner;
+  private _signer: EngineSigner;
 
   constructor(config: EngineSignerConfiguration) {
     super();
-    this.#signer = new EngineSigner(config);
+    this._signer = new EngineSigner(config);
   }
 
   async getSigner(): Promise<Signer> {
-    return this.#signer;
+    return this._signer;
   }
 }

--- a/packages/wallets/src/evm/wallets/ethers.ts
+++ b/packages/wallets/src/evm/wallets/ethers.ts
@@ -19,7 +19,7 @@ import { ethers } from "ethers";
  * @wallet
  */
 export class EthersWallet extends AbstractWallet {
-  #signer: ethers.Signer;
+  private _signer: ethers.Signer;
 
   /**
    * Create instance of `EthersWallet`
@@ -27,13 +27,13 @@ export class EthersWallet extends AbstractWallet {
    */
   constructor(signer: ethers.Signer) {
     super();
-    this.#signer = signer;
+    this._signer = signer;
   }
 
   /**
    * Returns [ethers signer](https://docs.ethers.org/v5/api/signer/) object used by the wallet
    */
   async getSigner(): Promise<ethers.Signer> {
-    return this.#signer;
+    return this._signer;
   }
 }

--- a/packages/wallets/src/evm/wallets/gcp-kms.ts
+++ b/packages/wallets/src/evm/wallets/gcp-kms.ts
@@ -9,14 +9,14 @@ import {
  * @wallet
  */
 export class GcpKmsWallet extends AbstractWallet {
-  #options: GcpKmsSignerCredentials;
+  private _options: GcpKmsSignerCredentials;
 
   constructor(options: GcpKmsSignerCredentials) {
     super();
-    this.#options = options;
+    this._options = options;
   }
 
   async getSigner(): Promise<Signer> {
-    return new GcpKmsSigner(this.#options);
+    return new GcpKmsSigner(this._options);
   }
 }

--- a/packages/wallets/src/evm/wallets/local-wallet.ts
+++ b/packages/wallets/src/evm/wallets/local-wallet.ts
@@ -176,7 +176,7 @@ export class LocalWallet extends AbstractClientWallet<
   /**
    * @internal
    */
-  #storage: AsyncStorage;
+  private _storage: AsyncStorage;
 
   /**
    * @internal
@@ -257,7 +257,7 @@ export class LocalWallet extends AbstractClientWallet<
 
     this.options = options || {};
 
-    this.#storage =
+    this._storage =
       options?.storage || createAsyncLocalStorage(walletIds.localWallet);
   }
 
@@ -562,7 +562,7 @@ export class LocalWallet extends AbstractClientWallet<
         },
       });
 
-      await this.#saveData(
+      await this._saveData(
         {
           address: wallet.address,
           data: encryptedData,
@@ -578,7 +578,7 @@ export class LocalWallet extends AbstractClientWallet<
         wallet.privateKey,
       );
 
-      await this.#saveData(
+      await this._saveData(
         {
           address: wallet.address,
           data: privateKey,
@@ -599,7 +599,7 @@ export class LocalWallet extends AbstractClientWallet<
       const mnemonic = await getEncryptor(options.encryption)(
         wallet.mnemonic.phrase,
       );
-      await this.#saveData(
+      await this._saveData(
         {
           address: wallet.address,
           data: mnemonic,
@@ -638,7 +638,7 @@ export class LocalWallet extends AbstractClientWallet<
    * ```
    */
   async deleteSaved() {
-    await this.#storage.removeItem(STORAGE_KEY_WALLET_DATA);
+    await this._storage.removeItem(STORAGE_KEY_WALLET_DATA);
   }
 
   /**
@@ -734,7 +734,7 @@ export class LocalWallet extends AbstractClientWallet<
    * ```
    */
   async getSavedData(storage?: AsyncStorage): Promise<WalletData | null> {
-    const _storage = storage || this.#storage;
+    const _storage = storage || this._storage;
 
     try {
       const savedDataStr = await _storage.getItem(STORAGE_KEY_WALLET_DATA);
@@ -756,8 +756,8 @@ export class LocalWallet extends AbstractClientWallet<
   /**
    * store the wallet data to storage
    */
-  async #saveData(data: WalletData, storage?: AsyncStorage) {
-    const _storage = storage || this.#storage;
+  private async _saveData(data: WalletData, storage?: AsyncStorage) {
+    const _storage = storage || this._storage;
     await _storage.setItem(STORAGE_KEY_WALLET_DATA, JSON.stringify(data));
   }
 

--- a/packages/wallets/src/evm/wallets/private-key.ts
+++ b/packages/wallets/src/evm/wallets/private-key.ts
@@ -17,7 +17,7 @@ import { ChainOrRpcUrl, getChainProvider } from "@thirdweb-dev/sdk";
  * @wallet
  */
 export class PrivateKeyWallet extends AbstractWallet {
-  #signer: ethers.Signer;
+  private _signer: ethers.Signer;
 
   /**
    * Create instance of `PrivateKeyWallet`
@@ -34,7 +34,7 @@ export class PrivateKeyWallet extends AbstractWallet {
   constructor(privateKey: string, chain?: ChainOrRpcUrl, secretKey?: string) {
     super();
 
-    this.#signer = new ethers.Wallet(
+    this._signer = new ethers.Wallet(
       privateKey,
       chain
         ? getChainProvider(chain, {
@@ -48,6 +48,6 @@ export class PrivateKeyWallet extends AbstractWallet {
    * Get the [ethers.js signer](https://docs.ethers.io/v5/api/signer/) object used by the wallet
    */
   async getSigner(): Promise<ethers.Signer> {
-    return this.#signer;
+    return this._signer;
   }
 }

--- a/packages/wallets/src/evm/wallets/signer.ts
+++ b/packages/wallets/src/evm/wallets/signer.ts
@@ -30,7 +30,7 @@ export class SignerWallet extends AbstractClientWallet<
   connector?: Connector;
   options: WalletOptions<SignerWalletAdditionalOptions>;
   signer?: Signer;
-  #storage: AsyncStorage;
+  private _storage: AsyncStorage;
 
   constructor(options: WalletOptions<SignerWalletAdditionalOptions>) {
     super("signerWallet", options);
@@ -41,7 +41,7 @@ export class SignerWallet extends AbstractClientWallet<
 
     this.options = options;
     this.signer = options.signer;
-    this.#storage =
+    this._storage =
       options?.storage || createAsyncLocalStorage(walletIds.localWallet);
   }
 

--- a/packages/wallets/src/evm/wallets/wallet-connect.ts
+++ b/packages/wallets/src/evm/wallets/wallet-connect.ts
@@ -51,8 +51,8 @@ export type WalletConnectOptions = {
  * @wallet
  */
 export class WalletConnect extends AbstractClientWallet<WalletConnectOptions> {
-  #walletConnectConnector?: WalletConnectConnector;
-  #provider?: WalletConnectProvider;
+  private _walletConnectConnector?: WalletConnectConnector;
+  private _provider?: WalletConnectProvider;
 
   connector?: Connector;
 
@@ -140,7 +140,7 @@ export class WalletConnect extends AbstractClientWallet<WalletConnectOptions> {
         "../connectors/wallet-connect"
       );
 
-      this.#walletConnectConnector = new WalletConnectConnector({
+      this._walletConnectConnector = new WalletConnectConnector({
         chains: this.chains,
         options: {
           qrcode: this.qrcode,
@@ -150,31 +150,31 @@ export class WalletConnect extends AbstractClientWallet<WalletConnectOptions> {
           qrModalOptions: this.options?.qrModalOptions,
         },
       });
-      this.connector = new WagmiAdapter(this.#walletConnectConnector);
-      this.#provider = await this.#walletConnectConnector.getProvider();
-      this.#setupListeners();
+      this.connector = new WagmiAdapter(this._walletConnectConnector);
+      this._provider = await this._walletConnectConnector.getProvider();
+      this._setupListeners();
     }
     return this.connector;
   }
 
-  #maybeThrowError = (error: any) => {
+  private _maybeThrowError = (error: any) => {
     if (error) {
       throw error;
     }
   };
 
-  #onConnect = (data: WagmiConnectorData<WalletConnectProvider>) => {
-    this.#provider = data.provider;
-    if (!this.#provider) {
+  private _onConnect = (data: WagmiConnectorData<WalletConnectProvider>) => {
+    this._provider = data.provider;
+    if (!this._provider) {
       throw new Error("WalletConnect provider not found after connecting.");
     }
   };
 
-  #onDisconnect = () => {
-    this.#removeListeners();
+  private _onDisconnect = () => {
+    this._removeListeners();
   };
 
-  #onChange = async (payload: any) => {
+  private _onChange = async (payload: any) => {
     if (payload.chain) {
       // chain changed
     } else if (payload.account) {
@@ -182,7 +182,7 @@ export class WalletConnect extends AbstractClientWallet<WalletConnectOptions> {
     }
   };
 
-  #onMessage = (payload: any) => {
+  private _onMessage = (payload: any) => {
     switch (payload.type) {
       case "display_uri":
         this.emit("display_uri", payload.data);
@@ -190,39 +190,39 @@ export class WalletConnect extends AbstractClientWallet<WalletConnectOptions> {
     }
   };
 
-  #onSessionRequestSent = () => {
+  private _onSessionRequestSent = () => {
     this.emit("wc_session_request_sent");
   };
 
-  #setupListeners() {
-    if (!this.#walletConnectConnector) {
+  private _setupListeners() {
+    if (!this._walletConnectConnector) {
       return;
     }
-    this.#removeListeners();
-    this.#walletConnectConnector.on("connect", this.#onConnect);
-    this.#walletConnectConnector.on("disconnect", this.#onDisconnect);
-    this.#walletConnectConnector.on("change", this.#onChange);
-    this.#walletConnectConnector.on("message", this.#onMessage);
-    this.#provider?.signer.client.on(
+    this._removeListeners();
+    this._walletConnectConnector.on("connect", this._onConnect);
+    this._walletConnectConnector.on("disconnect", this._onDisconnect);
+    this._walletConnectConnector.on("change", this._onChange);
+    this._walletConnectConnector.on("message", this._onMessage);
+    this._provider?.signer.client.on(
       "session_request_sent",
-      this.#onSessionRequestSent,
+      this._onSessionRequestSent,
     );
   }
 
-  #removeListeners() {
-    if (!this.#walletConnectConnector) {
+  private _removeListeners() {
+    if (!this._walletConnectConnector) {
       return;
     }
-    this.#walletConnectConnector.removeListener("connect", this.#onConnect);
-    this.#walletConnectConnector.removeListener(
+    this._walletConnectConnector.removeListener("connect", this._onConnect);
+    this._walletConnectConnector.removeListener(
       "disconnect",
-      this.#onDisconnect,
+      this._onDisconnect,
     );
-    this.#walletConnectConnector.removeListener("change", this.#onChange);
-    this.#walletConnectConnector.removeListener("message", this.#onMessage);
-    this.#provider?.signer.client.removeListener(
+    this._walletConnectConnector.removeListener("change", this._onChange);
+    this._walletConnectConnector.removeListener("message", this._onMessage);
+    this._provider?.signer.client.removeListener(
       "session_request_sent",
-      this.#onSessionRequestSent,
+      this._onSessionRequestSent,
     );
   }
 
@@ -257,7 +257,7 @@ export class WalletConnect extends AbstractClientWallet<WalletConnectOptions> {
    */
   async connectWithQrCode(options: ConnectWithQrCodeArgs) {
     await this.getConnector();
-    const wcConnector = this.#walletConnectConnector;
+    const wcConnector = this._walletConnectConnector;
 
     if (!wcConnector) {
       throw new Error("WalletConnect connector not found");
@@ -280,7 +280,7 @@ export class WalletConnect extends AbstractClientWallet<WalletConnectOptions> {
    */
   async connectWithModal(options?: { chainId?: number }) {
     await this.getConnector();
-    const wcConnector = this.#walletConnectConnector;
+    const wcConnector = this._walletConnectConnector;
 
     if (!wcConnector) {
       throw new Error("WalletConnect connector not found");


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates code across multiple packages to replace `#` with `private` for private members in classes.

### Detailed summary
- Replaced `#` with `private` for private members in classes across various files
- Updated classes: `EngineWallet`, `GcpKmsWallet`, `CoinbasePayIntegration`, `SignerWallet`, `FrameConnector`, `InjectedConnector`, `EthersWallet`, `Cache`, `AsyncWallet`, `PrivateKeyWallet`, `TransactionError`, `BasicLogger`, `PhantomConnector`, `RainbowConnector`, `MetaMaskConnector`, `AwsKmsWallet`

> The following files were skipped due to too many changes: `packages/wallets/src/evm/wallets/aws-kms.ts`, `packages/wallets/src/evm/connectors/paper/index.ts`, `packages/wallets/src/evm/connectors/magic/index.ts`, `packages/wallets/src/evm/connectors/local-wallet/index.ts`, `packages/wallets/src/evm/connectors/signer/index.ts`, `packages/wallets/src/evm/wallets/local-wallet.ts`, `packages/wallets/src/evm/connectors/embedded-wallet/index.ts`, `packages/wallets/src/evm/wallets/base.ts`, `packages/wallets/src/evm/wallets/aws-secrets-manager.ts`, `packages/wallets/src/evm/connectors/coinbase-wallet/index.ts`, `packages/wallets/src/evm/connectors/blocto/index.ts`, `packages/wallets/src/evm/wallets/wallet-connect.ts`, `packages/wallets/src/core/WalletConnect/WalletConnectV2Handler.ts`, `packages/wallets/src/evm/connectors/wallet-connect/index.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->