### PR TITLE
[react] Remove unnecessary ConnectModal opening

### DIFF
--- a/.changeset/silly-moles-punch.md
+++ b/.changeset/silly-moles-punch.md
@@ -1,0 +1,7 @@
+---
+"@thirdweb-dev/react": patch
+---
+
+Remove unnecessary ConnectModal auto opening.
+
+This also fixes the issue where Connect Modal opens on page load when `ThirdwebProvider` is dynamically imported and rendered in the app.

--- a/packages/react/src/wallet/ConnectWallet/Modal/ConnectModal.tsx
+++ b/packages/react/src/wallet/ConnectWallet/Modal/ConnectModal.tsx
@@ -9,7 +9,6 @@ import {
   useDisconnect,
   useThirdwebAuthContext,
   useUser,
-  useWallet,
   useWalletContext,
   useWallets,
 } from "@thirdweb-dev/react-core";

--- a/packages/react/src/wallet/ConnectWallet/Modal/ConnectModal.tsx
+++ b/packages/react/src/wallet/ConnectWallet/Modal/ConnectModal.tsx
@@ -241,40 +241,7 @@ export const ConnectModal = () => {
     });
   }, [initialScreen, setIsWalletModalOpen, setScreen]);
 
-  const [prevConnectionStatus, setPrevConnectionStatus] =
-    useState(connectionStatus);
-
-  useEffect(() => {
-    setPrevConnectionStatus(connectionStatus);
-  }, [connectionStatus]);
-
   const disconnect = useDisconnect();
-
-  const wallet = useWallet();
-  const isWrapperConnected = !!wallet?.getPersonalWallet();
-
-  const isWrapperScreen =
-    typeof screen !== "string" && !!screen.personalWallets;
-
-  // reopen the screen to complete wrapper wallet's next step after connecting a personal wallet
-  useEffect(() => {
-    if (
-      !isWrapperConnected &&
-      isWrapperScreen &&
-      !isWalletModalOpen &&
-      connectionStatus === "connected" &&
-      prevConnectionStatus === "connecting"
-    ) {
-      setIsWalletModalOpen(true);
-    }
-  }, [
-    isWalletModalOpen,
-    connectionStatus,
-    setIsWalletModalOpen,
-    isWrapperScreen,
-    isWrapperConnected,
-    prevConnectionStatus,
-  ]);
 
   useEffect(() => {
     if (!isWalletModalOpen) {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR removes unnecessary auto opening of the ConnectModal in the `ConnectWallet` component to prevent it from opening on page load when `ThirdwebProvider` is dynamically imported.

### Detailed summary
- Removed auto opening of ConnectModal
- Fixed issue with Connect Modal opening on page load

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->