### PR TITLE
[react] Make OTPInput numeric ( EmbeddedWallet UI )

### DIFF
--- a/.changeset/quiet-sloths-hammer.md
+++ b/.changeset/quiet-sloths-hammer.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/react": patch
+---
+
+Make OTPInput used in EmbeddedWallet numeric

--- a/packages/react/src/components/OTPInput.tsx
+++ b/packages/react/src/components/OTPInput.tsx
@@ -12,9 +12,9 @@ export function OTPInput(props: {
   setValue: (value: string) => void;
   onEnter?: () => void;
 }) {
-  const otp = props.value.split("");
+  const otp = props.value.split("").map(Number);
 
-  const setOTP = (newOTP: string[]) => {
+  const setOTP = (newOTP: number[]) => {
     props.setValue(newOTP.join(""));
   };
 
@@ -38,13 +38,18 @@ export function OTPInput(props: {
             ref={(e) => (boxEls.current[i] = e)}
             key={i}
             value={otp[i] ?? ""}
-            type="text"
-            pattern="[a-zA-Z0-9]*"
+            type="number"
+            pattern="[0-9]*"
             variant="outline"
-            inputMode="text"
+            inputMode="numeric"
             onPaste={(e) => {
               const pastedData = e.clipboardData.getData("text/plain");
-              const newOTP = pastedData.slice(0, props.digits).split("");
+              const newOTP = pastedData
+                .slice(0, props.digits)
+                .split("")
+                .filter((n) => /\d/.test(n))
+                .map(Number);
+
               setOTP(newOTP);
               e.preventDefault();
             }}
@@ -106,7 +111,7 @@ export function OTPInput(props: {
               const newOTP = [...otp];
               const index = i > inputToFocusIndex - 1 ? inputToFocusIndex : i;
 
-              newOTP[index] = value;
+              newOTP[index] = Number(value);
               setOTP(newOTP);
             }}
           />


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `OTPInput` component in `@thirdweb-dev/react` to ensure it accepts and handles numeric values correctly.

### Detailed summary
- Converted OTP values to numbers for consistency
- Updated input type to `number` and `inputMode` to `numeric`
- Filtered and mapped pasted data to ensure only numeric values are accepted

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->