### PR TITLE
[Smart Wallet] Do not deploy to sign typed data, allow presigned deploy+session key

### DIFF
--- a/.changeset/clean-bugs-drum.md
+++ b/.changeset/clean-bugs-drum.md
@@ -1,0 +1,7 @@
+---
+"@thirdweb-dev/unity-js-bridge": patch
+"@thirdweb-dev/wallets": patch
+"@thirdweb-dev/sdk": patch
+---
+
+[Smart Wallet] Do not deploy to sign typed data, allow presigned deploy+session key

--- a/packages/sdk/test/evm/account.test.ts
+++ b/packages/sdk/test/evm/account.test.ts
@@ -143,8 +143,9 @@ describe("Accounts with account factory", function () {
         "Correct admin for account.",
       );
 
-      const associatedAccounts =
-        await accountFactory.getAssociatedAccounts(admin);
+      const associatedAccounts = await accountFactory.getAssociatedAccounts(
+        admin,
+      );
 
       assert.isTrue(
         associatedAccounts.length === 1,
@@ -187,7 +188,6 @@ describe("Accounts with account factory", function () {
       );
 
       account = (await sdk.getContract(accountAddress)).account;
-      await account.sign("0x1234"); // force deploy
     });
 
     it("Should be able to add another admin to the account.", async () => {

--- a/packages/sdk/test/evm/account.test.ts
+++ b/packages/sdk/test/evm/account.test.ts
@@ -360,18 +360,38 @@ describe("Accounts with account factory", function () {
       );
     });
 
-    it("Should not be able to grant restricted access to a signer who already has access.", async () => {
+    it("Should be able to update permissions by granting restricted access to a signer who already has access.", async () => {
       // Grant access to signer1
       await account.grantPermissions(signer1Wallet.address, {
         nativeTokenLimitPerTransaction: "1",
         approvedCallTargets: [adminWallet.address],
       });
 
+      // Store permissions
+      const signersWithRestrictions = await account.getAllSigners();
+      const restrictions = signersWithRestrictions.find(
+        (result) =>
+          utils.getAddress(result.signer) ===
+          utils.getAddress(signer1Wallet.address),
+      )?.permissions as SignerPermissions;
+
       // Try granting access to signer1 again
       await account.grantPermissions(signer1Wallet.address, {
-        approvedCallTargets: [adminWallet.address],
+        approvedCallTargets: [adminWallet.address, signer2Wallet.address],
       });
-      expect.fail();
+
+      const newSignersWithRestrictions = await account.getAllSigners();
+      const newRestrictions = newSignersWithRestrictions.find(
+        (result) =>
+          utils.getAddress(result.signer) ===
+          utils.getAddress(signer1Wallet.address),
+      )?.permissions as SignerPermissions;
+
+      assert.strictEqual(
+        newRestrictions.approvedCallTargets.length,
+        2,
+        "New signer1 should have two approved call targets.",
+      );
     });
 
     it("Should be able to revoke restricted access from an authorized signer.", async () => {
@@ -411,7 +431,7 @@ describe("Accounts with account factory", function () {
       );
     });
 
-    it("Should not be able to revoke restricted access from a signer who doesn't have access.", async () => {
+    it("Should be able to revoke restricted access from a signer who doesn't have access with no effect.", async () => {
       const signersWithRestrictions = await account.getAllSigners();
       assert.isFalse(
         signersWithRestrictions
@@ -422,7 +442,14 @@ describe("Accounts with account factory", function () {
 
       // Try revoking access from signer1
       await account.revokeAccess(signer1Wallet.address);
-      expect.fail();
+
+      const newSignersWithRestrictions = await account.getAllSigners();
+      assert.isFalse(
+        newSignersWithRestrictions
+          .map((result) => utils.getAddress(result.signer))
+          .includes(signer1Wallet.address),
+        "New signer should not have access to the account.",
+      );
     });
 
     it("Should be able to update access of an authorized signer.", async () => {

--- a/packages/sdk/test/evm/account.test.ts
+++ b/packages/sdk/test/evm/account.test.ts
@@ -143,9 +143,8 @@ describe("Accounts with account factory", function () {
         "Correct admin for account.",
       );
 
-      const associatedAccounts = await accountFactory.getAssociatedAccounts(
-        admin,
-      );
+      const associatedAccounts =
+        await accountFactory.getAssociatedAccounts(admin);
 
       assert.isTrue(
         associatedAccounts.length === 1,
@@ -188,6 +187,7 @@ describe("Accounts with account factory", function () {
       );
 
       account = (await sdk.getContract(accountAddress)).account;
+      await account.sign("0x1234"); // force deploy
     });
 
     it("Should be able to add another admin to the account.", async () => {

--- a/packages/sdk/test/evm/account.test.ts
+++ b/packages/sdk/test/evm/account.test.ts
@@ -143,9 +143,8 @@ describe("Accounts with account factory", function () {
         "Correct admin for account.",
       );
 
-      const associatedAccounts = await accountFactory.getAssociatedAccounts(
-        admin,
-      );
+      const associatedAccounts =
+        await accountFactory.getAssociatedAccounts(admin);
 
       assert.isTrue(
         associatedAccounts.length === 1,
@@ -369,16 +368,10 @@ describe("Accounts with account factory", function () {
       });
 
       // Try granting access to signer1 again
-      try {
-        await account.grantPermissions(signer1Wallet.address, {
-          approvedCallTargets: [adminWallet.address],
-        });
-        expect.fail();
-      } catch (err: any) {
-        expect(err.message).to.equal(
-          "Signer already has permissions. Cannot grant permissions to an existing signer. You can update permissions using `updatePermissions`.",
-        );
-      }
+      await account.grantPermissions(signer1Wallet.address, {
+        approvedCallTargets: [adminWallet.address],
+      });
+      expect.fail();
     });
 
     it("Should be able to revoke restricted access from an authorized signer.", async () => {
@@ -428,14 +421,8 @@ describe("Accounts with account factory", function () {
       );
 
       // Try revoking access from signer1
-      try {
-        await account.revokeAccess(signer1Wallet.address);
-        expect.fail();
-      } catch (err: any) {
-        expect(err.message).to.equal(
-          "Signer does not already have permissions. You can grant permissions using `grantPermissions`.",
-        );
-      }
+      await account.revokeAccess(signer1Wallet.address);
+      expect.fail();
     });
 
     it("Should be able to update access of an authorized signer.", async () => {

--- a/packages/unity-js-bridge/src/thirdweb-bridge.ts
+++ b/packages/unity-js-bridge/src/thirdweb-bridge.ts
@@ -144,7 +144,7 @@ class ThirdwebBridge implements TWBridge {
       }
       (globalThis as any).X_SDK_NAME = "UnitySDK_WebGL";
       (globalThis as any).X_SDK_PLATFORM = "unity";
-      (globalThis as any).X_SDK_VERSION = "4.7.2";
+      (globalThis as any).X_SDK_VERSION = "4.7.3";
       (globalThis as any).X_SDK_OS = browser?.os ?? "unknown";
     }
     this.initializedChain = chain;

--- a/packages/unity-js-bridge/src/thirdweb-bridge.ts
+++ b/packages/unity-js-bridge/src/thirdweb-bridge.ts
@@ -381,6 +381,7 @@ class ThirdwebBridge implements TWBridge {
           personalWallet,
           authOptions,
         );
+        await this.switchNetwork(chainId); // workaround for polygon/mumbai
         if (this.activeWallet) {
           // Pass EOA and reconnect to initialize smart wallet
           await this.initializeSmartWallet(
@@ -513,7 +514,10 @@ class ThirdwebBridge implements TWBridge {
           // ccipReadEnabled: txInput.ccipReadEnabled,
         });
 
-        if (routeArgs[2].includes("send")) {
+        if (routeArgs[2].includes("sign")) {
+          const result = await tx.sign();
+          return JSON.stringify({ result: result }, bigNumberReplacer);
+        } else if (routeArgs[2].includes("send")) {
           tx.setGaslessOptions(
             routeArgs[2] === "sendGasless"
               ? this.activeSDK.options.gasless

--- a/packages/unity-js-bridge/src/thirdweb-bridge.ts
+++ b/packages/unity-js-bridge/src/thirdweb-bridge.ts
@@ -144,7 +144,7 @@ class ThirdwebBridge implements TWBridge {
       }
       (globalThis as any).X_SDK_NAME = "UnitySDK_WebGL";
       (globalThis as any).X_SDK_PLATFORM = "unity";
-      (globalThis as any).X_SDK_VERSION = "4.7.3";
+      (globalThis as any).X_SDK_VERSION = "4.7.4";
       (globalThis as any).X_SDK_OS = browser?.os ?? "unknown";
     }
     this.initializedChain = chain;

--- a/packages/unity-js-bridge/src/thirdweb-bridge.ts
+++ b/packages/unity-js-bridge/src/thirdweb-bridge.ts
@@ -144,7 +144,7 @@ class ThirdwebBridge implements TWBridge {
       }
       (globalThis as any).X_SDK_NAME = "UnitySDK_WebGL";
       (globalThis as any).X_SDK_PLATFORM = "unity";
-      (globalThis as any).X_SDK_VERSION = "4.7.1";
+      (globalThis as any).X_SDK_VERSION = "4.7.2";
       (globalThis as any).X_SDK_OS = browser?.os ?? "unknown";
     }
     this.initializedChain = chain;

--- a/packages/wallets/src/evm/connectors/smart-wallet/index.ts
+++ b/packages/wallets/src/evm/connectors/smart-wallet/index.ts
@@ -12,7 +12,7 @@ import {
   TransactionOptions,
   UserOpOptions,
 } from "./types";
-import { ENTRYPOINT_ADDRESS } from "./lib/constants";
+import { ACCOUNT_CORE_ABI, ENTRYPOINT_ADDRESS } from "./lib/constants";
 import { EVMWallet } from "../../interfaces";
 import { ERC4337EthersSigner } from "./lib/erc4337-signer";
 import { BigNumber, constants, ethers, providers, utils } from "ethers";
@@ -448,25 +448,21 @@ export class SmartWalletConnector extends Connector<SmartWalletConnectionArgs> {
     target: string,
     permissions: SignerPermissionsInput,
   ): Promise<TransactionResult> {
-    await this.deployIfNeeded();
     const accountContract = await this.getAccountContract();
     return accountContract.account.grantPermissions(target, permissions);
   }
 
   async revokePermissions(target: string): Promise<TransactionResult> {
-    await this.deployIfNeeded();
     const accountContract = await this.getAccountContract();
     return accountContract.account.revokeAccess(target);
   }
 
   async addAdmin(target: string): Promise<TransactionResult> {
-    await this.deployIfNeeded();
     const accountContract = await this.getAccountContract();
     return accountContract.account.grantAdminPermissions(target);
   }
 
   async removeAdmin(target: string): Promise<TransactionResult> {
-    await this.deployIfNeeded();
     const accountContract = await this.getAccountContract();
     return accountContract.account.revokeAdminPermissions(target);
   }
@@ -501,12 +497,6 @@ export class SmartWalletConnector extends Connector<SmartWalletConnectionArgs> {
    * @returns The account contract of the smart wallet.
    */
   async getAccountContract(): Promise<SmartContract> {
-    const isDeployed = await this.isDeployed();
-    if (!isDeployed) {
-      throw new Error(
-        "Account contract is not deployed yet. You can deploy it manually using SmartWallet.deploy(), or by executing a transaction from this wallet.",
-      );
-    }
     // getting a new instance everytime
     // to avoid caching issues pre/post deployment
     const sdk = ThirdwebSDK.fromSigner(
@@ -523,7 +513,7 @@ export class SmartWalletConnector extends Connector<SmartWalletConnectionArgs> {
         this.config.accountInfo.abi,
       );
     } else {
-      return sdk.getContract(await this.getAddress());
+      return sdk.getContract(await this.getAddress(), ACCOUNT_CORE_ABI);
     }
   }
 


### PR DESCRIPTION
## Problem solved

Related https://github.com/thirdweb-dev/unity-sdk/pull/154

## Changes made

- [ ] Public API changes: list the public API changes made if any
- [ ] Internal API changes: explain the internal logic changes

## How to test

- [ ] Automated tests: link to unit test file
- [ ] Manual tests: step by step instructions on how to test

## Contributor NFT

Paste in your wallet address below and we will airdrop you a special NFT when your pull request is merged. 

```Address: ```

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `UnitySDK_WebGL` version, enhances smart wallet features, and improves permissions handling for signers.

### Detailed summary
- Updated `UnitySDK_WebGL` version to `4.7.4`
- Improved smart wallet deployment and session key handling
- Enhanced signer permissions and access management

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->