### PR TITLE
[React] expose useUpdateNFTMetadata hook

### DIFF
--- a/.changeset/tricky-shrimps-grow.md
+++ b/.changeset/tricky-shrimps-grow.md
@@ -1,0 +1,6 @@
+---
+"@thirdweb-dev/react-core": patch
+"@thirdweb-dev/sdk": patch
+---
+
+Added useUpdateNFTMetadata hook

--- a/packages/react-core/src/evm/hooks/async/nft.ts
+++ b/packages/react-core/src/evm/hooks/async/nft.ts
@@ -1,4 +1,8 @@
-import type { BasicNFTInput } from "@thirdweb-dev/sdk";
+import type {
+  BasicNFTInput,
+  NFTMetadata,
+  NFTMetadataOrUri,
+} from "@thirdweb-dev/sdk";
 import {
   requiredParamInvariant,
   RequiredParam,
@@ -335,7 +339,7 @@ export function useTotalCirculatingSupply(
  * @param ownerWalletAddress -
  * The wallet address to get owned tokens for. Likely, you will want to view the connected wallet’s NFTs. use the `useAddress` hook to get this value.
  *
- * @param queryParams - 
+ * @param queryParams -
  * Paginate the results by providing a `queryParams` object as an argument.
  *
  * ```jsx
@@ -354,7 +358,7 @@ export function useTotalCirculatingSupply(
  *   );
  * }
  * ```
- * 
+ *
  * @returns Query result object that includes the list of owned `NFT` objects
  *
  * @twfeature ERC721Enumerable | ERC1155Enumerable | ERC721Supply
@@ -1039,6 +1043,44 @@ export function useSetSharedMetadata<TContract extends NFTContract>(
     async (data: BasicNFTInput) => {
       if (erc721) {
         return await erc721.sharedMetadata.set(data);
+      }
+      invariant(false, "Unknown NFT type");
+    },
+    {
+      onSettled: () =>
+        invalidateContractAndBalances(
+          queryClient,
+          contractAddress,
+          activeChainId,
+        ),
+    },
+  );
+}
+
+/**
+ * Update nft metadata
+ * @param contract - Instance of a `NFTContract`
+ * @param tokenId - The token ID of the NFT you want to fetch.
+ * @public
+ * @twfeature ERC721UpdatableMetadata | ERC1155UpdatableMetadata
+ * @nft
+ */
+export function useUpdateNFTMetadata<TContract extends NFTContract>(
+  contract: RequiredParam<TContract>,
+) {
+  const activeChainId = useSDKChainId();
+  const contractAddress = contract?.getAddress();
+  const queryClient = useQueryClient();
+  const { erc721, erc1155 } = getErcs(contract);
+
+  return useMutation(
+    async (data: { tokenId: BigNumberish; metadata: NFTMetadata }) => {
+      const { tokenId, metadata } = data;
+      if (erc721) {
+        return await erc721.updateMetadata(tokenId, metadata);
+      }
+      if (erc1155) {
+        return await erc1155.updateMetadata(tokenId, metadata);
       }
       invariant(false, "Unknown NFT type");
     },

--- a/packages/react-core/src/evm/hooks/async/nft.ts
+++ b/packages/react-core/src/evm/hooks/async/nft.ts
@@ -1,8 +1,4 @@
-import type {
-  BasicNFTInput,
-  NFTMetadata,
-  NFTMetadataInput,
-} from "@thirdweb-dev/sdk";
+import type { BasicNFTInput, NFTMetadataInput } from "@thirdweb-dev/sdk";
 import {
   requiredParamInvariant,
   RequiredParam,

--- a/packages/react-core/src/evm/hooks/async/nft.ts
+++ b/packages/react-core/src/evm/hooks/async/nft.ts
@@ -1,4 +1,8 @@
-import type { BasicNFTInput, NFTMetadata } from "@thirdweb-dev/sdk";
+import type {
+  BasicNFTInput,
+  NFTMetadata,
+  NFTMetadataInput,
+} from "@thirdweb-dev/sdk";
 import {
   requiredParamInvariant,
   RequiredParam,
@@ -1070,7 +1074,7 @@ export function useUpdateNFTMetadata<TContract extends NFTContract>(
   const { erc721, erc1155 } = getErcs(contract);
 
   return useMutation(
-    async (data: { tokenId: BigNumberish; metadata: NFTMetadata }) => {
+    async (data: { tokenId: BigNumberish; metadata: NFTMetadataInput }) => {
       const { tokenId, metadata } = data;
       if (erc721) {
         return await erc721.updateMetadata(tokenId, metadata);

--- a/packages/react-core/src/evm/hooks/async/nft.ts
+++ b/packages/react-core/src/evm/hooks/async/nft.ts
@@ -1,8 +1,4 @@
-import type {
-  BasicNFTInput,
-  NFTMetadata,
-  NFTMetadataOrUri,
-} from "@thirdweb-dev/sdk";
+import type { BasicNFTInput, NFTMetadata } from "@thirdweb-dev/sdk";
 import {
   requiredParamInvariant,
   RequiredParam,

--- a/packages/react-core/src/evm/index.ts
+++ b/packages/react-core/src/evm/index.ts
@@ -173,6 +173,7 @@ export {
   useBurnNFT,
   useSharedMetadata,
   useSetSharedMetadata,
+  useUpdateNFTMetadata,
 } from "./hooks/async/nft";
 
 // roles

--- a/packages/sdk/src/evm/core/classes/erc-721.ts
+++ b/packages/sdk/src/evm/core/classes/erc-721.ts
@@ -749,7 +749,7 @@ export class Erc721<
    * ```
    * @twfeature ERC721UpdatableMetadata
    */
-  update = /* @__PURE__ */ buildTransactionFunction(
+  updateMetadata = /* @__PURE__ */ buildTransactionFunction(
     async (tokenId: BigNumberish, metadata: NFTMetadataOrUri) => {
       return assertEnabled(
         this.updatableMetadata,
@@ -757,6 +757,11 @@ export class Erc721<
       ).update.prepare(tokenId, metadata);
     },
   );
+
+  // alias for backwards compat
+  async update(tokenId: BigNumberish, metadata: NFTMetadataOrUri) {
+    return this.updateMetadata(tokenId, metadata);
+  }
 
   ////// ERC721 Claimable Extension //////
 


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

## Changes made

- [ ] Public API changes: list the public API changes made if any
- [ ] Internal API changes: explain the internal logic changes

## How to test

- [ ] Automated tests: link to unit test file
- [ ] Manual tests: step by step instructions on how to test

## Contributor NFT

Paste in your wallet address below and we will airdrop you a special NFT when your pull request is merged. 

```Address: ```

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to introduce a new hook `useUpdateNFTMetadata` in the `react-core` package for updating NFT metadata.

### Detailed summary
- Added `useUpdateNFTMetadata` hook in `react-core`
- Updated `update` method to `updateMetadata` in `erc-721.ts`
- Added alias for `update` method for backward compatibility
- Imported types and made adjustments in `nft.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->