### PR TITLE
feat(actions): sendAndConfirmTransaction

### DIFF
--- a/packages/thirdweb/src/exports/transaction.ts
+++ b/packages/thirdweb/src/exports/transaction.ts
@@ -30,6 +30,7 @@ export {
   sendTransaction,
   type SendTransactionOptions,
 } from "../transaction/actions/send-transaction.js";
+export { sendAndConfirmTransaction } from "../transaction/actions/send-and-confirm-transaction.js";
 export {
   sendBatchTransaction,
   type SendBatchTransactionOptions,

--- a/packages/thirdweb/src/transaction/actions/send-and-confirm-transaction.test.ts
+++ b/packages/thirdweb/src/transaction/actions/send-and-confirm-transaction.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach, afterAll } from "vitest";
+import { USDC_CONTRACT } from "../../../test/src/test-contracts.js";
+import { TEST_WALLET_A, TEST_WALLET_B } from "../../../test/src/addresses.js";
+import { transfer } from "../../extensions/erc20/write/transfer.js";
+import type { Account } from "../../wallets/interfaces/wallet.js";
+import * as waitForReceiptExports from "./wait-for-tx-receipt.js";
+import type { TransactionReceipt } from "../types.js";
+import { sendAndConfirmTransaction } from "./send-and-confirm-transaction.js";
+
+const MOCK_TX_HASH =
+  "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+
+const mockAccount = {
+  address: TEST_WALLET_A,
+  sendTransaction: vi.fn().mockResolvedValue({ transactionHash: MOCK_TX_HASH }),
+  signMessage: vi.fn().mockResolvedValue("0xabcdef1234567890"),
+  signTypedData: vi.fn().mockResolvedValue("0xabcdef1234567890"),
+} satisfies Account;
+
+const TRANSACTION = transfer({
+  to: TEST_WALLET_B,
+  amount: 100,
+  contract: USDC_CONTRACT,
+});
+
+const TX_RESULT = {
+  accessList: undefined,
+  chainId: 1,
+  data: "0xa9059cbb00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000005f5e100",
+  gas: 45134n,
+  nonce: 0,
+  to: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+  value: undefined,
+};
+
+const MOCK_SUCCESS_RECEIPT: TransactionReceipt = {
+  transactionHash: MOCK_TX_HASH,
+  blockNumber: 1234n,
+  status: "success",
+  blockHash: "0xabcdef1234567890",
+  contractAddress: "0x1234567890abcdef",
+  cumulativeGasUsed: 123456n,
+  from: "0xabcdef1234567890",
+  gasUsed: 123456n,
+  logs: [],
+  logsBloom: "0xabcdef1234567890",
+  to: "0x1234567890abcdef",
+  transactionIndex: 1234,
+  effectiveGasPrice: 123456n,
+  type: "legacy",
+  root: "0xabcdef1234567890",
+  blobGasPrice: 123456n,
+  blobGasUsed: 123456n,
+};
+
+vi.spyOn(waitForReceiptExports, "waitForReceipt").mockResolvedValueOnce(
+  MOCK_SUCCESS_RECEIPT,
+);
+
+describe("sendAndConfirmTransaction", () => {
+  afterAll(() => {
+    vi.restoreAllMocks();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should send transaction then wait for confirmation", async () => {
+    const res = sendAndConfirmTransaction({
+      account: mockAccount,
+      transaction: TRANSACTION,
+    });
+
+    await expect(res).resolves.toMatchObject(MOCK_SUCCESS_RECEIPT);
+    expect(mockAccount.sendTransaction).toHaveBeenCalledTimes(1);
+    expect(waitForReceiptExports.waitForReceipt).toHaveBeenCalledTimes(1);
+    expect(mockAccount.sendTransaction.mock.lastCall[0]).toMatchObject(
+      TX_RESULT,
+    );
+  });
+});

--- a/packages/thirdweb/src/transaction/actions/send-and-confirm-transaction.ts
+++ b/packages/thirdweb/src/transaction/actions/send-and-confirm-transaction.ts
@@ -1,0 +1,28 @@
+import { waitForReceipt } from "./wait-for-tx-receipt.js";
+import type { TransactionReceipt } from "../types.js";
+import {
+  sendTransaction,
+  type SendTransactionOptions,
+} from "./send-transaction.js";
+
+/**
+ * Sends a transaction using the provided wallet.
+ * @param options - The options for sending the transaction.
+ * @returns A promise that resolves to the confirmed transaction receipt.
+ * @throws An error if the wallet is not connected.
+ * @transaction
+ * @example
+ * ```ts
+ * import { sendAndConfirmTransaction } from "thirdweb";
+ * const transactionReceipt = await sendAndConfirmTransaction({
+ *  account,
+ *  transaction
+ * });
+ * ```
+ */
+export async function sendAndConfirmTransaction(
+  options: SendTransactionOptions,
+): Promise<TransactionReceipt> {
+  const submittedTx = await sendTransaction(options);
+  return waitForReceipt(submittedTx);
+}

--- a/packages/thirdweb/src/transaction/actions/send-and-confirm-transaction.ts
+++ b/packages/thirdweb/src/transaction/actions/send-and-confirm-transaction.ts
@@ -14,8 +14,9 @@ import {
  * @example
  * ```ts
  * import { sendAndConfirmTransaction } from "thirdweb";
+ *
  * const transactionReceipt = await sendAndConfirmTransaction({
- *  account,
+ *  wallet,
  *  transaction
  * });
  * ```


### PR DESCRIPTION
## Problem solved
Adds a waitForReceipt flag on sendTransaction allowing users to initiate a transaction and wait for its full execution in a single await.

## Changes made
  - [ ] Public API change: Users can call `sendAndConfirmTransaction` to bundle `sendTransaction` and `waitForReceipt`

## How to test
  - [ ] Automated tests: Test added to send-and-confirm-transaction.test.ts

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add a new function `sendAndConfirmTransaction` that sends a transaction and waits for confirmation.

### Detailed summary
- Added `sendAndConfirmTransaction` function to send and confirm transactions
- Added tests for `sendAndConfirmTransaction` functionality
- Introduced mock data for testing
- Updated imports and types for transaction handling

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->