### PR TITLE
Add useInvalidateContractQuery hook

### DIFF
--- a/packages/thirdweb/src/react/hooks/others/useInvalidateQueries.ts
+++ b/packages/thirdweb/src/react/hooks/others/useInvalidateQueries.ts
@@ -6,20 +6,15 @@ import { useQueryClient } from "@tanstack/react-query";
 export function useInvalidateContractQuery() {
   const queryClient = useQueryClient();
 
-  return (
-    chainId: number,
-    contractAddress: string,
-  ) => {
+  return ({
+    chainId,
+    contractAddress,
+  }: {
+    chainId: number;
+    contractAddress: string;
+  }) => {
     queryClient.invalidateQueries({
-      predicate: (query) => {
-        const [queryType, queriedChainId, queriedContractAddress] =
-          query.queryKey;
-        return (
-          queryType === "readContract" &&
-          queriedChainId === chainId &&
-          queriedContractAddress === contractAddress
-        );
-      },
+      queryKey: ["readContract", chainId, contractAddress],
     });
   };
 }

--- a/packages/thirdweb/src/react/hooks/others/useInvalidateQueries.ts
+++ b/packages/thirdweb/src/react/hooks/others/useInvalidateQueries.ts
@@ -1,0 +1,25 @@
+import { useQueryClient } from "@tanstack/react-query";
+
+/**
+ * @internal
+ */
+export function useInvalidateContractQuery(
+  chainId: number,
+  contractAddress: string,
+) {
+  const queryClient = useQueryClient();
+
+  return () => {
+    queryClient.invalidateQueries({
+      predicate: (query) => {
+        const [queryType, queriedChainId, queriedContractAddress] =
+          query.queryKey;
+        return (
+          queryType === "readContract" &&
+          queriedChainId === chainId &&
+          queriedContractAddress === contractAddress
+        );
+      },
+    });
+  };
+}

--- a/packages/thirdweb/src/react/hooks/others/useInvalidateQueries.ts
+++ b/packages/thirdweb/src/react/hooks/others/useInvalidateQueries.ts
@@ -3,13 +3,13 @@ import { useQueryClient } from "@tanstack/react-query";
 /**
  * @internal
  */
-export function useInvalidateContractQuery(
-  chainId: number,
-  contractAddress: string,
-) {
+export function useInvalidateContractQuery() {
   const queryClient = useQueryClient();
 
-  return () => {
+  return (
+    chainId: number,
+    contractAddress: string,
+  ) => {
     queryClient.invalidateQueries({
       predicate: (query) => {
         const [queryType, queriedChainId, queriedContractAddress] =


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a new internal hook `useInvalidateContractQuery` to invalidate specific queries based on chain ID and contract address.

### Detailed summary
- Added new internal hook `useInvalidateContractQuery`
- Uses `useQueryClient` from "@tanstack/react-query"
- Invalidates queries based on chain ID and contract address

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->