### PR TITLE
[extensions/common] owner

### DIFF
--- a/packages/thirdweb/src/extensions/common/read/owner.macro.ts
+++ b/packages/thirdweb/src/extensions/common/read/owner.macro.ts
@@ -1,0 +1,25 @@
+import { readContract } from "../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../transaction/types.js";
+/**
+ * @macro delete-next-lines
+ */
+import { prepareMethod } from "../../../utils/abi/prepare-method.js";
+import { $run$ } from "@hazae41/saumon";
+
+/**
+ * Retrieves the owner of a contract.
+ * @param options - The transaction options.
+ * @returns A promise that resolves to the owner of the contract.
+ * @extension Ownable
+ * @example
+ * ```ts
+ * import { owner } from "thirdweb/extensions/commmon";
+ * const owner = await owner({ contract });
+ * ```
+ */
+export function owner(options: BaseTransactionOptions): Promise<string> {
+  return readContract({
+    ...options,
+    method: $run$(() => prepareMethod("function owner() returns (address)")),
+  });
+}

--- a/packages/thirdweb/src/extensions/common/read/owner.test.ts
+++ b/packages/thirdweb/src/extensions/common/read/owner.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { USDC_CONTRACT } from "~test/test-contracts.js";
+import { owner } from "./owner.js";
+
+const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+describe("shared.owner", () => {
+  afterEach(() => {
+    fetchSpy.mockClear();
+  });
+  it("should respond with the correct value", async () => {
+    const ownerAddress = await owner({
+      contract: USDC_CONTRACT,
+    });
+    expect(ownerAddress).toBe(`0xFcb19e6a322b27c06842A71e8c725399f049AE3a`);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/thirdweb/src/extensions/common/read/owner.ts
+++ b/packages/thirdweb/src/extensions/common/read/owner.ts
@@ -1,0 +1,27 @@
+import { readContract } from "../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../transaction/types.js";
+/**
+ * Retrieves the owner of a contract.
+ * @param options - The transaction options.
+ * @returns A promise that resolves to the owner of the contract.
+ * @extension Ownable
+ * @example
+ * ```ts
+ * import { owner } from "thirdweb/extensions/common";
+ * const owner = await owner({ contract });
+ * ```
+ */
+export function owner(options: BaseTransactionOptions): Promise<string> {
+  return readContract({
+    ...options,
+    method: [
+      "0x8da5cb5b",
+      [],
+      [
+        {
+          type: "address",
+        },
+      ],
+    ],
+  });
+}


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

## Changes made

- [ ] Public API changes: list the public API changes made if any
- [ ] Internal API changes: explain the internal logic changes

## How to test

- [ ] Automated tests: link to unit test file
- [ ] Manual tests: step by step instructions on how to test

## Contributor NFT

Paste in your wallet address below and we will airdrop you a special NFT when your pull request is merged. 

```Address: ```


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a `owner` function to retrieve the owner of a contract in the `thirdweb` extension.

### Detailed summary
- Added `owner` function in `owner.ts` to retrieve contract owner.
- Added test for `owner` function in `owner.test.ts`.
- Created a macro version of `owner` function in `owner.macro.ts`.
- Updated imports and added necessary dependencies.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->