### PR TITLE
chore: update size benchmark

### DIFF
--- a/packages/thirdweb/benchmarks/README.md
+++ b/packages/thirdweb/benchmarks/README.md
@@ -8,8 +8,8 @@ Imported bundle size to make a basic RPC call:
 
 - thirdweb: 6.1 KB gzipped
     - `import { createThirdwebClient, getRpcClient, defineChain }`
-- viem: 35 KB gzipped
-    - `import { createPublicClient, http }`
+- viem: 3.78 KB gzipped
+    - `import { createClient, http }`
 - ethers: 88 KB gzipped
     - `import { getJsonRPCProvider }`
 


### PR DESCRIPTION
Reproduce with `bun run size` on Viem.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR optimizes the size of the `viem` package in the benchmarks folder by reducing its gzipped size from 35 KB to 3.78 KB. The `createPublicClient` function was replaced with `createClient`.

### Detailed summary
- Reduced `viem` package size from 35 KB to 3.78 KB
- Replaced `createPublicClient` with `createClient` in benchmarks README.md

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->