### PR TITLE
Catch fail name/symbol on getContractMetadata

### DIFF
--- a/packages/thirdweb/src/extensions/common/read/getContractMetadata.ts
+++ b/packages/thirdweb/src/extensions/common/read/getContractMetadata.ts
@@ -34,8 +34,8 @@ export async function getContractMetadata(
         return null;
       })
       .catch(() => null),
-    name(options),
-    symbol(options),
+    name(options).catch(() => null),
+    symbol(options).catch(() => null),
   ]);
 
   // TODO: basic parsing?


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `getContractMetadata` function in `getContractMetadata.ts` to handle errors when fetching contract metadata.

### Detailed summary
- Updated `name` and `symbol` functions in `getContractMetadata` to handle errors
- Added error handling using `catch` method for both `name` and `symbol` functions

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->