### PR TITLE
[Wallets] make accountInfo/factoryInfo internal props optional in SmartWalletConfig

### DIFF
--- a/.changeset/nervous-ladybugs-watch.md
+++ b/.changeset/nervous-ladybugs-watch.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/wallets": patch
+---
+
+Make accountInfo/factoryInfo internal props optional in SmartWalletConfig

--- a/packages/wallets/src/evm/connectors/smart-wallet/index.ts
+++ b/packages/wallets/src/evm/connectors/smart-wallet/index.ts
@@ -5,7 +5,9 @@ import { getVerifyingPaymaster } from "./lib/paymaster";
 import { create4337Provider } from "./lib/provider-utils";
 import {
   AccountContractInfo,
+  AccountContractInfoInternal,
   FactoryContractInfo,
+  FactoryContractInfoInternal,
   ProviderConfig,
   SmartWalletConfig,
   SmartWalletConnectionArgs,
@@ -71,8 +73,22 @@ export class SmartWalletConnector extends Connector<SmartWalletConnectionArgs> {
       gasless: config.gasless,
       factoryAddress: config.factoryAddress,
       accountAddress: params.accountAddress,
-      factoryInfo: config.factoryInfo || this.defaultFactoryInfo(),
-      accountInfo: config.accountInfo || this.defaultAccountInfo(),
+      factoryInfo: {
+        createAccount:
+          config.factoryInfo?.createAccount ||
+          this.defaultFactoryInfo().createAccount,
+        getAccountAddress:
+          config.factoryInfo?.getAccountAddress ||
+          this.defaultFactoryInfo().getAccountAddress,
+        abi: config.factoryInfo?.abi,
+      },
+      accountInfo: {
+        execute:
+          config.accountInfo?.execute || this.defaultAccountInfo().execute,
+        getNonce:
+          config.accountInfo?.getNonce || this.defaultAccountInfo().getNonce,
+        abi: config.accountInfo?.abi,
+      },
       clientId: config.clientId,
       secretKey: config.secretKey,
       erc20PaymasterAddress: config.erc20PaymasterAddress,
@@ -541,7 +557,7 @@ export class SmartWalletConnector extends Connector<SmartWalletConnectionArgs> {
     return sdk.getContract(this.config.factoryAddress);
   }
 
-  protected defaultFactoryInfo(): FactoryContractInfo {
+  protected defaultFactoryInfo(): FactoryContractInfoInternal {
     return {
       createAccount: async (factory, owner) => {
         return factory.prepare("createAccount", [
@@ -558,7 +574,7 @@ export class SmartWalletConnector extends Connector<SmartWalletConnectionArgs> {
     };
   }
 
-  protected defaultAccountInfo(): AccountContractInfo {
+  protected defaultAccountInfo(): AccountContractInfoInternal {
     return {
       execute: async (account, target, value, data) => {
         return account.prepare("execute", [target, value, data]);

--- a/packages/wallets/src/evm/connectors/smart-wallet/index.ts
+++ b/packages/wallets/src/evm/connectors/smart-wallet/index.ts
@@ -4,9 +4,7 @@ import { ERC4337EthersProvider } from "./lib/erc4337-provider";
 import { getVerifyingPaymaster } from "./lib/paymaster";
 import { create4337Provider } from "./lib/provider-utils";
 import {
-  AccountContractInfo,
   AccountContractInfoInternal,
-  FactoryContractInfo,
   FactoryContractInfoInternal,
   ProviderConfig,
   SmartWalletConfig,

--- a/packages/wallets/src/evm/connectors/smart-wallet/types.ts
+++ b/packages/wallets/src/evm/connectors/smart-wallet/types.ts
@@ -54,11 +54,14 @@ export type ContractInfoInput = {
 };
 
 export type ContractInfo = {
-  factoryInfo: FactoryContractInfo;
-  accountInfo: AccountContractInfo;
+  factoryInfo: FactoryContractInfoInternal;
+  accountInfo: AccountContractInfoInternal;
 };
 
-export type AccountContractInfo = {
+/**
+ * @internal
+ */
+export type AccountContractInfoInternal = {
   abi?: ContractInterface;
   getNonce: (account: SmartContract) => Promise<BigNumber>;
   execute: (
@@ -69,13 +72,39 @@ export type AccountContractInfo = {
   ) => Promise<Transaction>;
 };
 
-export type FactoryContractInfo = {
+/**
+ * @internal
+ */
+export type FactoryContractInfoInternal = {
   abi?: ContractInterface;
   createAccount: (
     factory: SmartContract,
     owner: string,
   ) => Promise<Transaction>;
   getAccountAddress: (factory: SmartContract, owner: string) => Promise<string>;
+};
+
+export type AccountContractInfo = {
+  abi?: ContractInterface;
+  getNonce?: (account: SmartContract) => Promise<BigNumber>;
+  execute?: (
+    account: SmartContract,
+    target: string,
+    value: BigNumberish,
+    data: string,
+  ) => Promise<Transaction>;
+};
+
+export type FactoryContractInfo = {
+  abi?: ContractInterface;
+  createAccount?: (
+    factory: SmartContract,
+    owner: string,
+  ) => Promise<Transaction>;
+  getAccountAddress?: (
+    factory: SmartContract,
+    owner: string,
+  ) => Promise<string>;
 };
 
 export type PaymasterResult = {

--- a/packages/wallets/src/evm/connectors/token-bound-smart-wallet/index.ts
+++ b/packages/wallets/src/evm/connectors/token-bound-smart-wallet/index.ts
@@ -1,7 +1,7 @@
 import { TokenBoundSmartWalletConfig } from "./types";
 import { ethers } from "ethers";
 import { SmartWalletConnector } from "../smart-wallet";
-import { FactoryContractInfo } from "../smart-wallet/types";
+import { FactoryContractInfoInternal } from "../smart-wallet/types";
 import { ERC6551_REGISTRY } from "../smart-wallet/lib/constants";
 
 export class TokenBoundSmartWalletConnector extends SmartWalletConnector {
@@ -16,7 +16,7 @@ export class TokenBoundSmartWalletConnector extends SmartWalletConnector {
     // TODO default account implementation address
   }
 
-  protected defaultFactoryInfo(): FactoryContractInfo {
+  protected defaultFactoryInfo(): FactoryContractInfoInternal {
     return {
       createAccount: async (factory) => {
         return factory.prepare("createAccount", [


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

## Changes made

- [ ] Public API changes: list the public API changes made if any
- [ ] Internal API changes: explain the internal logic changes

## How to test

- [ ] Automated tests: link to unit test file
- [ ] Manual tests: step by step instructions on how to test

## Contributor NFT

Paste in your wallet address below and we will airdrop you a special NFT when your pull request is merged. 

```Address: ```

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates `@thirdweb-dev/wallets` package to make internal props optional in `SmartWalletConfig`.

### Detailed summary
- Updated internal props to be optional in `SmartWalletConfig`
- Renamed `FactoryContractInfo` to `FactoryContractInfoInternal`
- Renamed `AccountContractInfo` to `AccountContractInfoInternal`
- Updated types and methods in `TokenBoundSmartWalletConnector` and `SmartWalletConnector`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->