### PR TITLE
[SDK] handle estimateGasCost for OP chains

### DIFF
--- a/.changeset/tame-keys-pretend.md
+++ b/.changeset/tame-keys-pretend.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/sdk": patch
+---
+
+Handle L1 fees for OP chains in `estimateGasCost()`

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -134,6 +134,7 @@
     }
   },
   "dependencies": {
+    "@eth-optimism/sdk": "^3.2.1",
     "@thirdweb-dev/chains": "workspace:*",
     "@thirdweb-dev/contracts-js": "workspace:*",
     "@thirdweb-dev/crypto": "workspace:*",

--- a/packages/sdk/src/evm/common/gas-price.ts
+++ b/packages/sdk/src/evm/common/gas-price.ts
@@ -1,6 +1,17 @@
 import { ChainId } from "../constants/chains/ChainId";
 import { BigNumber, utils, providers } from "ethers";
-import { Mumbai, Polygon, Flag, FlagTestnet } from "@thirdweb-dev/chains";
+import {
+  Mumbai,
+  Polygon,
+  Flag,
+  FlagTestnet,
+  Optimism,
+  OpSepoliaTestnet,
+  Base,
+  BaseSepoliaTestnet,
+  Zora,
+  ZoraSepoliaTestnet,
+} from "@thirdweb-dev/chains";
 
 type FeeData = {
   maxFeePerGas: null | BigNumber;
@@ -97,6 +108,35 @@ export async function getGasPrice(
   }
 
   return txGasPrice;
+}
+
+export async function estimateTxCost(
+  provider: providers.Provider,
+  tx: providers.TransactionRequest,
+) {
+  const chainId = (await provider.getNetwork()).chainId;
+  if (isOpStackChain(chainId)) {
+    const { asL2Provider } = await import("@eth-optimism/sdk");
+    const l2RpcProvider = asL2Provider(provider);
+    const l2GasCost = await l2RpcProvider.estimateTotalGasCost(tx);
+    return l2GasCost;
+  } else {
+    const gasLimit = tx.gasLimit || (await provider.estimateGas(tx));
+    const gasPrice = await getGasPrice(provider);
+    const gasCost = BigNumber.from(gasLimit).mul(gasPrice);
+    return gasCost;
+  }
+}
+
+function isOpStackChain(chainId: number) {
+  return (
+    chainId === Optimism.chainId ||
+    chainId === OpSepoliaTestnet.chainId ||
+    chainId === Base.chainId ||
+    chainId === BaseSepoliaTestnet.chainId ||
+    chainId === Zora.chainId ||
+    chainId === ZoraSepoliaTestnet.chainId
+  );
 }
 
 /**

--- a/packages/sdk/src/evm/common/gas-price.ts
+++ b/packages/sdk/src/evm/common/gas-price.ts
@@ -110,7 +110,7 @@ export async function getGasPrice(
   return txGasPrice;
 }
 
-export async function estimateTxCost(
+export async function estimateTransactionCost(
   provider: providers.Provider,
   tx: providers.TransactionRequest,
 ) {

--- a/packages/sdk/src/evm/core/classes/gas-cost-estimator.ts
+++ b/packages/sdk/src/evm/core/classes/gas-cost-estimator.ts
@@ -36,11 +36,10 @@ export class GasCostEstimator<TContract extends BaseContract> {
     // eslint-disable-next-line @typescript-eslint/ban-types
     fn: keyof TContract["functions"] | (string & {}),
     args: Parameters<TContract["functions"][typeof fn]> | any[],
-    overrides?: CallOverrides,
   ): Promise<string> {
     const gasCost = await estimateTransactionCost(
       this.contractWrapper.getProvider(),
-      await this.contractWrapper.populateTx(fn, args, overrides),
+      await this.contractWrapper.populateTransaction(fn, args),
     );
     return toEther(gasCost);
   }

--- a/packages/sdk/src/evm/core/classes/gas-cost-estimator.ts
+++ b/packages/sdk/src/evm/core/classes/gas-cost-estimator.ts
@@ -1,5 +1,5 @@
 import { toEther } from "../../common/currency/toEther";
-import { estimateTxCost } from "../../common/gas-price";
+import { estimateTransactionCost } from "../../common/gas-price";
 import { ContractWrapper } from "./internal/contract-wrapper";
 import { BaseContract, BigNumber, CallOverrides, utils } from "ethers";
 
@@ -38,7 +38,7 @@ export class GasCostEstimator<TContract extends BaseContract> {
     args: Parameters<TContract["functions"][typeof fn]> | any[],
     overrides?: CallOverrides,
   ): Promise<string> {
-    const gasCost = await estimateTxCost(
+    const gasCost = await estimateTransactionCost(
       this.contractWrapper.getProvider(),
       await this.contractWrapper.populateTx(fn, args, overrides),
     );

--- a/packages/sdk/src/evm/core/classes/gas-cost-estimator.ts
+++ b/packages/sdk/src/evm/core/classes/gas-cost-estimator.ts
@@ -1,7 +1,7 @@
 import { toEther } from "../../common/currency/toEther";
 import { estimateTransactionCost } from "../../common/gas-price";
 import { ContractWrapper } from "./internal/contract-wrapper";
-import { BaseContract, BigNumber, CallOverrides, utils } from "ethers";
+import { BaseContract, BigNumber, utils } from "ethers";
 
 /**
  * Estimates the gas cost of Contract calls

--- a/packages/sdk/src/evm/core/classes/internal/contract-wrapper.ts
+++ b/packages/sdk/src/evm/core/classes/internal/contract-wrapper.ts
@@ -192,15 +192,11 @@ export class ContractWrapper<
     return this.writeContract.estimateGas[fn as string](...args);
   }
 
-  public async populateTx(
+  public async populateTransaction(
     fn: keyof TContract["functions"],
     args: any[],
-    overrides?: CallOverrides,
   ): Promise<providers.TransactionRequest> {
-    return this.writeContract.populateTransaction[fn as string](
-      ...args,
-      overrides,
-    );
+    return this.writeContract.populateTransaction[fn as string](...args);
   }
 
   /**

--- a/packages/sdk/src/evm/core/classes/internal/contract-wrapper.ts
+++ b/packages/sdk/src/evm/core/classes/internal/contract-wrapper.ts
@@ -192,6 +192,17 @@ export class ContractWrapper<
     return this.writeContract.estimateGas[fn as string](...args);
   }
 
+  public async populateTx(
+    fn: keyof TContract["functions"],
+    args: any[],
+    overrides?: CallOverrides,
+  ): Promise<providers.TransactionRequest> {
+    return this.writeContract.populateTransaction[fn as string](
+      ...args,
+      overrides,
+    );
+  }
+
   /**
    * @internal
    */

--- a/packages/sdk/src/evm/core/classes/transactions.ts
+++ b/packages/sdk/src/evm/core/classes/transactions.ts
@@ -1,6 +1,6 @@
 import { TransactionError, parseRevertReason } from "../../common/error";
 import {
-  estimateTxCost,
+  estimateTransactionCost,
   getDefaultGasOverrides,
   getGasPrice,
 } from "../../common/gas-price";
@@ -423,7 +423,7 @@ export class Transaction<
    * Estimate the total gas cost of this transaction (in both ether and wei)
    */
   public async estimateGasCost() {
-    const gasCost = await estimateTxCost(
+    const gasCost = await estimateTransactionCost(
       this.provider,
       await this.populateTransaction(),
     );
@@ -768,7 +768,7 @@ export class DeployTransaction extends TransactionContext {
       ...this.args,
       overrides,
     );
-    const gasCost = await estimateTxCost(this.provider, populatedTx);
+    const gasCost = await estimateTransactionCost(this.provider, populatedTx);
     return {
       ether: utils.formatEther(gasCost),
       wei: gasCost,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1090,6 +1090,9 @@ importers:
 
   packages/sdk:
     dependencies:
+      '@eth-optimism/sdk':
+        specifier: ^3.2.1
+        version: 3.2.1(ethers@5.7.2)
       '@thirdweb-dev/chains':
         specifier: workspace:*
         version: link:../chains
@@ -7536,8 +7539,27 @@ packages:
     resolution: {integrity: sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  /@eth-optimism/contracts-bedrock@0.17.1:
+    resolution: {integrity: sha512-Hc5peN5PM8kzl9dzqSD5jv6ED3QliO1DF0dXLRJxfrXR7/rmEeyuAYESUwUM0gdJZjkwRYiS5m230BI6bQmnlw==}
+    requiresBuild: true
+    dev: false
+
   /@eth-optimism/contracts@0.5.40(ethers@5.7.2):
     resolution: {integrity: sha512-MrzV0nvsymfO/fursTB7m/KunkPsCndltVgfdHaT1Aj5Vi6R/doKIGGkOofHX+8B6VMZpuZosKCMQ5lQuqjt8w==}
+    peerDependencies:
+      ethers: ^5
+    dependencies:
+      '@eth-optimism/core-utils': 0.12.0
+      '@ethersproject/abstract-provider': 5.7.0
+      '@ethersproject/abstract-signer': 5.7.0
+      ethers: 5.7.2
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: false
+
+  /@eth-optimism/contracts@0.6.0(ethers@5.7.2):
+    resolution: {integrity: sha512-vQ04wfG9kMf1Fwy3FEMqH2QZbgS0gldKhcBeBUPfO8zu68L61VI97UDXmsMQXzTsEAxK8HnokW3/gosl4/NW3w==}
     peerDependencies:
       ethers: ^5
     dependencies:
@@ -7571,6 +7593,50 @@ packages:
       chai: 4.3.7
     transitivePeerDependencies:
       - bufferutil
+      - utf-8-validate
+    dev: false
+
+  /@eth-optimism/core-utils@0.13.1:
+    resolution: {integrity: sha512-1FvzbUmCEy9zSKPG1QWg2VfA2Cy90xBA9Wkp11lXXrz91zUPCNCNSRTujXWYIC86ketNsZp7p4njSf6lTycHCw==}
+    requiresBuild: true
+    dependencies:
+      '@ethersproject/abi': 5.7.0
+      '@ethersproject/abstract-provider': 5.7.0
+      '@ethersproject/address': 5.7.0
+      '@ethersproject/bignumber': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/constants': 5.7.0
+      '@ethersproject/contracts': 5.7.0
+      '@ethersproject/keccak256': 5.7.0
+      '@ethersproject/properties': 5.7.0
+      '@ethersproject/rlp': 5.7.0
+      '@ethersproject/web': 5.7.1
+      chai: 4.4.1
+      ethers: 5.7.2
+      node-fetch: 2.6.12
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - utf-8-validate
+    dev: false
+
+  /@eth-optimism/sdk@3.2.1(ethers@5.7.2):
+    resolution: {integrity: sha512-COmnT2zRzFn2XhMW/OD1ML3gCrT6SO95YF3hV/Mx3G1G4Q6zOv09rwU1avH/OcqdDMBmZ/DTrZm+9OVmc+YPlQ==}
+    requiresBuild: true
+    peerDependencies:
+      ethers: ^5
+    dependencies:
+      '@eth-optimism/contracts': 0.6.0(ethers@5.7.2)
+      '@eth-optimism/contracts-bedrock': 0.17.1
+      '@eth-optimism/core-utils': 0.13.1
+      ethers: 5.7.2
+      lodash: 4.17.21
+      merkletreejs: 0.3.11
+      rlp: 2.2.7
+      semver: 7.6.0
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
       - utf-8-validate
     dev: false
 
@@ -15775,6 +15841,19 @@ packages:
       pathval: 1.1.1
       type-detect: 4.0.8
 
+  /chai@4.4.1:
+    resolution: {integrity: sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==}
+    engines: {node: '>=4'}
+    dependencies:
+      assertion-error: 1.1.0
+      check-error: 1.0.3
+      deep-eql: 4.1.3
+      get-func-name: 2.0.2
+      loupe: 2.3.6
+      pathval: 1.1.1
+      type-detect: 4.0.8
+    dev: false
+
   /chalk-template@0.4.0:
     resolution: {integrity: sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==}
     engines: {node: '>=12'}
@@ -15845,6 +15924,12 @@ packages:
 
   /check-error@1.0.2:
     resolution: {integrity: sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==}
+
+  /check-error@1.0.3:
+    resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
+    dependencies:
+      get-func-name: 2.0.2
+    dev: false
 
   /check-types@11.2.2:
     resolution: {integrity: sha512-HBiYvXvn9Z70Z88XKjz3AEKd4HJhBXsa3j7xFnITAzoS8+q6eIGi8qDB8FKPBAjtuxjI/zFpwuiCb8oDtKOYrA==}
@@ -16480,7 +16565,6 @@ packages:
 
   /crypto-js@4.2.0:
     resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
-    dev: true
 
   /crypto-random-string@1.0.0:
     resolution: {integrity: sha512-GsVpkFPlycH7/fRR7Dhcmnoii54gV1nz7y4CWyeFS14N+JVBBhY+r8amRHE4BwSYal7BPTDp8isvAlCxyFt3Hg==}
@@ -19938,6 +20022,10 @@ packages:
 
   /get-func-name@2.0.0:
     resolution: {integrity: sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==}
+
+  /get-func-name@2.0.2:
+    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
+    dev: false
 
   /get-intrinsic@1.2.0:
     resolution: {integrity: sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==}
@@ -23603,6 +23691,17 @@ packages:
   /merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  /merkletreejs@0.3.11:
+    resolution: {integrity: sha512-LJKTl4iVNTndhL+3Uz/tfkjD0klIWsHlUzgtuNnNrsf7bAlXR30m+xYB7lHr5Z/l6e/yAIsr26Dabx6Buo4VGQ==}
+    engines: {node: '>= 7.6.0'}
+    dependencies:
+      bignumber.js: 9.1.1
+      buffer-reverse: 1.0.1
+      crypto-js: 4.2.0
+      treeify: 1.1.0
+      web3-utils: 1.8.2
+    dev: false
 
   /methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
@@ -27974,6 +28073,14 @@ packages:
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
+
+  /semver@7.6.0:
+    resolution: {integrity: sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      lru-cache: 6.0.0
+    dev: false
 
   /send@0.18.0:
     resolution: {integrity: sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on handling L1 fees for OP chains in `estimateGasCost()`. 

### Detailed summary
- Added `estimateTransactionCost()` function to calculate gas cost
- Updated `populateTransaction()` method in `ContractWrapper`
- Modified gas cost calculation in `GasCostEstimator`
- Implemented `estimateGasCost()` method in `TransactionContext` and `DeployTransaction`
- Updated dependencies for OP chains and SDK

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->