### PR TITLE
[react] Fix onConnect called multiple times in EmbeddedWalletSocialLogin

### DIFF
--- a/.changeset/mean-baboons-trade.md
+++ b/.changeset/mean-baboons-trade.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/react": patch
+---
+
+Fix multiple renders of EmbeddedWallet social Login screen after connection

--- a/packages/react/src/wallet/wallets/embeddedWallet/EmbeddedWalletSocialLogin.tsx
+++ b/packages/react/src/wallet/wallets/embeddedWallet/EmbeddedWalletSocialLogin.tsx
@@ -3,7 +3,7 @@ import {
   EmbeddedWallet,
   EmbeddedWalletOauthStrategy,
 } from "@thirdweb-dev/wallets";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Spacer } from "../../../components/Spacer";
 import { Spinner } from "../../../components/Spinner";
 import { Container, ModalHeader } from "../../../components/basic";
@@ -33,7 +33,6 @@ export const EmbeddedWalletSocialLogin = (
 
   const socialLogin = async () => {
     try {
-      console.log("socialLogin");
       const embeddedWallet = createWalletInstance();
       setConnectionStatus("connecting");
       const socialWindow = openOauthSignInWindow(props.strategy, themeObj);
@@ -63,13 +62,19 @@ export const EmbeddedWalletSocialLogin = (
     }
   };
 
-  const closeModal = props.connected;
+  const onConnect = props.connected;
 
+  const onConnectCalled = useRef(false);
   useEffect(() => {
-    if (connectionStatus === "connected") {
-      closeModal();
+    if (onConnectCalled.current) {
+      return;
     }
-  }, [connectionStatus, closeModal]);
+
+    if (connectionStatus === "connected") {
+      onConnect();
+      onConnectCalled.current = true;
+    }
+  }, [connectionStatus, onConnect]);
 
   return (
     <Container animate="fadein" flex="column" fullHeight>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on fixing multiple renders of the EmbeddedWallet social Login screen after connection. 

### Detailed summary
- Updated `EmbeddedWalletSocialLogin.tsx` to fix multiple renders after connection
- Replaced `closeModal` with `onConnect` to handle connection status
- Added `onConnectCalled` ref to prevent multiple calls to `onConnect`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->