### PR TITLE
handle l2 estimations when forcing gasLimit

### DIFF
--- a/.changeset/happy-foxes-destroy.md
+++ b/.changeset/happy-foxes-destroy.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/sdk": patch
+---
+
+Handle l2 gas estimations when forcing gasLimit

--- a/packages/sdk/src/evm/common/gas-price.ts
+++ b/packages/sdk/src/evm/common/gas-price.ts
@@ -115,17 +115,16 @@ export async function estimateTransactionCost(
   tx: providers.TransactionRequest,
 ) {
   const chainId = (await provider.getNetwork()).chainId;
+  let l1GasCost = BigNumber.from(0);
   if (isOpStackChain(chainId)) {
     const { asL2Provider } = await import("@eth-optimism/sdk");
     const l2RpcProvider = asL2Provider(provider);
-    const l2GasCost = await l2RpcProvider.estimateTotalGasCost(tx);
-    return l2GasCost;
-  } else {
-    const gasLimit = tx.gasLimit || (await provider.estimateGas(tx));
-    const gasPrice = await getGasPrice(provider);
-    const gasCost = BigNumber.from(gasLimit).mul(gasPrice);
-    return gasCost;
+    l1GasCost = await l2RpcProvider.estimateL1GasCost(tx);
   }
+  const gasLimit = tx.gasLimit || (await provider.estimateGas(tx));
+  const gasPrice = await getGasPrice(provider);
+  const gasCost = BigNumber.from(gasLimit).mul(gasPrice);
+  return gasCost.add(l1GasCost);
 }
 
 function isOpStackChain(chainId: number) {

--- a/packages/sdk/src/evm/core/classes/transactions.ts
+++ b/packages/sdk/src/evm/core/classes/transactions.ts
@@ -666,7 +666,6 @@ export class Transaction<
     const reason = parseRevertReason(error);
 
     // Get contract sources for stack trace
-    let sources: ContractSource[] | undefined = undefined;
     let contractName: string | undefined = undefined;
     try {
       const chainId = (await provider.getNetwork()).chainId;
@@ -677,10 +676,6 @@ export class Transaction<
 
       if (metadata?.name) {
         contractName = metadata.name;
-      }
-
-      if (metadata?.metadata.sources) {
-        sources = await fetchSourceFilesFromMetadata(metadata, this.storage);
       }
     } catch (err) {
       // no-op
@@ -698,7 +693,6 @@ export class Transaction<
         value,
         hash,
         contractName,
-        sources,
       },
       error,
     );

--- a/packages/sdk/src/evm/core/classes/transactions.ts
+++ b/packages/sdk/src/evm/core/classes/transactions.ts
@@ -8,8 +8,6 @@ import {
   fetchContractMetadataFromAddress,
   getContractMetadataFromCache,
 } from "../../common/metadata-resolver";
-import { fetchSourceFilesFromMetadata } from "../../common/fetchSourceFilesFromMetadata";
-import { ContractSource } from "../../schema/contracts/custom";
 import { SDKOptionsOutput } from "../../schema/sdk-options";
 import type {
   DeployTransactionOptions,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on handling gas estimations for L2 transactions when forcing gasLimit.

### Detailed summary
- Updated gas estimation logic for L1 and L2 transactions
- Removed unnecessary imports in transaction class
- Refactored contract source retrieval in transactions class

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->