### PR TITLE
[Unity] Expose SW isDeployed

### DIFF
--- a/.changeset/tiny-eagles-applaud.md
+++ b/.changeset/tiny-eagles-applaud.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/unity-js-bridge": patch
+---
+
+[unity] expose sw isdeployed

--- a/packages/unity-js-bridge/src/thirdweb-bridge.ts
+++ b/packages/unity-js-bridge/src/thirdweb-bridge.ts
@@ -101,6 +101,7 @@ interface TWBridge {
   getBlockWithTransactions: (blockNumber: string) => Promise<string>;
   getEmail: () => Promise<string>;
   getSignerAddress: () => Promise<string>;
+  smartWalletIsDeployed: () => Promise<string>;
 }
 
 const w = window;
@@ -144,7 +145,7 @@ class ThirdwebBridge implements TWBridge {
       }
       (globalThis as any).X_SDK_NAME = "UnitySDK_WebGL";
       (globalThis as any).X_SDK_PLATFORM = "unity";
-      (globalThis as any).X_SDK_VERSION = "4.7.7";
+      (globalThis as any).X_SDK_VERSION = "4.7.8";
       (globalThis as any).X_SDK_OS = browser?.os ?? "unknown";
     }
     this.initializedChain = chain;
@@ -815,6 +816,15 @@ class ThirdwebBridge implements TWBridge {
       const res = await signer.getAddress();
       return JSON.stringify({ result: res }, bigNumberReplacer);
     }
+  }
+
+  public async smartWalletIsDeployed() {
+    if (!this.activeWallet) {
+      throw new Error("No wallet connected");
+    }
+    const smartWallet = this.activeWallet as SmartWallet;
+    const res = await smartWallet.isDeployed();
+    return JSON.stringify({ result: res }, bigNumberReplacer);
   }
 
   public openPopupWindow() {


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

## Changes made

- [ ] Public API changes: list the public API changes made if any
- [ ] Internal API changes: explain the internal logic changes

## How to test

- [ ] Automated tests: link to unit test file
- [ ] Manual tests: step by step instructions on how to test

## Contributor NFT

Paste in your wallet address below and we will airdrop you a special NFT when your pull request is merged. 

```Address: ```


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to expose a new method `smartWalletIsDeployed` in the `ThirdwebBridge` class of the `unity-js-bridge` package.

### Detailed summary
- Added `smartWalletIsDeployed` method to check if smart wallet is deployed
- Updated `X_SDK_VERSION` to "4.7.8"
- Implemented logic to handle smart wallet deployment status

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->