### PR TITLE
Export invalidate queries hook

### DIFF
--- a/packages/thirdweb/src/exports/react.ts
+++ b/packages/thirdweb/src/exports/react.ts
@@ -56,6 +56,7 @@ export {
 
 // utils
 export { createContractQuery } from "../react/utils/createQuery.js";
+export { useInvalidateContractQuery } from "../react/hooks/others/useInvalidateQueries.js";
 
 // wallets
 export {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds the `useInvalidateContractQuery` hook to the `react` exports in `thirdweb`.

### Detailed summary
- Added `useInvalidateContractQuery` hook to `react` exports.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->