### PR TITLE
[SDK] Better return type for getProofsForAllowListEntry

### DIFF
--- a/.changeset/tall-dolphins-march.md
+++ b/.changeset/tall-dolphins-march.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/sdk": patch
+---
+
+Better return type for getProofsForAllowListEntry

--- a/packages/sdk/src/evm/common/snapshots.ts
+++ b/packages/sdk/src/evm/common/snapshots.ts
@@ -91,9 +91,9 @@ export async function getProofsForAllowListEntry(
   tokenDecimals: number = 18,
   version: SnapshotFormatVersion = SnapshotFormatVersion.V1,
 ) {
-  return merkleTree.getProof(
-    hashAllowListEntry(snapshotEntry, tokenDecimals, version),
-  );
+  return merkleTree
+    .getProof(hashAllowListEntry(snapshotEntry, tokenDecimals, version))
+    .map((value) => "0x" + value.data.toString("hex"));
 }
 
 /**


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR improves the return type for `getProofsForAllowListEntry` in the SDK. 

### Detailed summary
- Updated return type to include hexadecimal conversion for proof values.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->