### PR TITLE
feat(sdk): add support for overriding default admin

### DIFF
--- a/packages/sdk/src/evm/common/deploy.ts
+++ b/packages/sdk/src/evm/common/deploy.ts
@@ -33,8 +33,6 @@ import { overrideRecipientAddress } from "./override-recipient-address";
  * @returns
  * @internal
  */
-/* eslint-disable @typescript-eslint/no-unused-vars */
-// TODO: Update function interface: Remove unused param
 export async function getDeployArguments<
   TContractType extends PrebuiltContractType,
 >(
@@ -42,9 +40,8 @@ export async function getDeployArguments<
   metadata: z.input<DeploySchemaForPrebuiltContractType<TContractType>>,
   contractURI: string,
   signer: Signer,
-  storage: ThirdwebStorage,
 ): Promise<any[]> {
-  const signerAddress = await signer.getAddress();
+  const signerAddress = metadata.defaultAdmin || (await signer.getAddress());
   const trustedForwarders: string[] = [];
 
   // add any custom forwarders passed in

--- a/packages/sdk/src/evm/core/classes/internal/factory.ts
+++ b/packages/sdk/src/evm/core/classes/internal/factory.ts
@@ -88,9 +88,8 @@ export class ContractFactory extends ContractWrapper<TWFactory> {
       onExecute?: () => void,
     ): Promise<Transaction<Address>> => {
       const contract = PREBUILT_CONTRACTS_MAP[contractType];
-      const metadata = await contract.schema.deploy.parseAsync(
-        contractMetadata,
-      );
+      const metadata =
+        await contract.schema.deploy.parseAsync(contractMetadata);
 
       // TODO: is there any special pre-processing we need to do before uploading?
       const contractURI = await this.storage.upload(metadata);
@@ -119,7 +118,6 @@ export class ContractFactory extends ContractWrapper<TWFactory> {
         metadata,
         contractURI,
         signer,
-        this.storage,
       );
 
       const encodedFunc = Contract.getInterface(ABI).encodeFunctionData(
@@ -311,9 +309,8 @@ export class ContractFactory extends ContractWrapper<TWFactory> {
         ];
       case TokenDropInitializer.contractType:
       case TokenInitializer.contractType:
-        const erc20metadata = await TokenInitializer.schema.deploy.parseAsync(
-          metadata,
-        );
+        const erc20metadata =
+          await TokenInitializer.schema.deploy.parseAsync(metadata);
         return [
           signerAddress,
           erc20metadata.name,
@@ -331,9 +328,8 @@ export class ContractFactory extends ContractWrapper<TWFactory> {
           erc20metadata.platform_fee_basis_points,
         ];
       case VoteInitializer.contractType:
-        const voteMetadata = await VoteInitializer.schema.deploy.parseAsync(
-          metadata,
-        );
+        const voteMetadata =
+          await VoteInitializer.schema.deploy.parseAsync(metadata);
         return [
           voteMetadata.name,
           contractURI,
@@ -345,9 +341,8 @@ export class ContractFactory extends ContractWrapper<TWFactory> {
           voteMetadata.voting_quorum_fraction,
         ];
       case SplitInitializer.contractType:
-        const splitsMetadata = await SplitInitializer.schema.deploy.parseAsync(
-          metadata,
-        );
+        const splitsMetadata =
+          await SplitInitializer.schema.deploy.parseAsync(metadata);
         return [
           signerAddress,
           contractURI,
@@ -382,9 +377,8 @@ export class ContractFactory extends ContractWrapper<TWFactory> {
           marketplaceV3Metadata.platform_fee_basis_points,
         ];
       case PackInitializer.contractType:
-        const packsMetadata = await PackInitializer.schema.deploy.parseAsync(
-          metadata,
-        );
+        const packsMetadata =
+          await PackInitializer.schema.deploy.parseAsync(metadata);
         return [
           signerAddress,
           packsMetadata.name,

--- a/packages/sdk/src/evm/core/sdk.ts
+++ b/packages/sdk/src/evm/core/sdk.ts
@@ -1604,7 +1604,6 @@ export class ContractDeployer extends RPCConnectionHandler {
         parsedMetadata,
         contractURI,
         signer,
-        this.storage,
       );
 
       // fetch the publish URI from the ContractPublisher contract
@@ -1650,7 +1649,7 @@ export class ContractDeployer extends RPCConnectionHandler {
       publisherAddress: AddressOrEns,
       contractName: string,
       constructorParams: any[],
-      version: string = "latest",
+      version = "latest",
       options?: DeployOptions,
     ): Promise<DeployTransaction> => {
       const publishedContract = await this.fetchPublishedContractFromPolygon(
@@ -1688,7 +1687,7 @@ export class ContractDeployer extends RPCConnectionHandler {
     contractName: string,
     constructorParams: any[],
     publisherAddress: string = THIRDWEB_DEPLOYER,
-    contractVersion: string = "latest",
+    contractVersion = "latest",
     saltForCreate2?: string,
   ): Promise<string> {
     const signer = this.getSigner();
@@ -1719,7 +1718,7 @@ export class ContractDeployer extends RPCConnectionHandler {
     contractName: string,
     constructorParams: any[],
     publisherAddress: string = THIRDWEB_DEPLOYER,
-    contractVersion: string = "latest",
+    contractVersion = "latest",
     saltForCreate2?: string,
   ): Promise<string> {
     const provider = this.getProvider();

--- a/packages/sdk/src/evm/schema/contracts/common/index.ts
+++ b/packages/sdk/src/evm/schema/contracts/common/index.ts
@@ -18,6 +18,7 @@ export const CommonContractSchema = /* @__PURE__ */ (() =>
       external_link: z.string().optional(),
       app_uri: z.string().optional(),
       social_urls: z.record(z.string()).optional(),
+      defaultAdmin: AddressOrEnsSchema.optional(),
     })
     .catchall(z.unknown()))();
 

--- a/packages/sdk/src/evm/types/deploy/deploy-metadata.ts
+++ b/packages/sdk/src/evm/types/deploy/deploy-metadata.ts
@@ -57,6 +57,11 @@ export interface NFTContractDeployMetadata {
    * The default app for this contract
    */
   app_uri?: string;
+
+  /**
+   * The default admin for this contract
+   */
+  defaultAdmin?: AddressOrEns;
 }
 
 /**
@@ -104,6 +109,10 @@ export interface OpenEditionContractDeployMetadata {
    * The default app for this contract
    */
   app_uri?: string;
+  /**
+   * The default admin for this contract
+   */
+  defaultAdmin?: AddressOrEns;
 }
 
 /**
@@ -152,6 +161,10 @@ export interface TokenContractDeployMetadata {
    * The default app for this contract
    */
   app_uri?: string;
+  /**
+   * The default admin for this contract
+   */
+  defaultAdmin?: AddressOrEns;
 }
 
 /**
@@ -192,6 +205,10 @@ export interface MarketplaceContractDeployMetadata {
    * The default app for this contract
    */
   app_uri?: string;
+  /**
+   * The default admin for this contract
+   */
+  defaultAdmin?: AddressOrEns;
 }
 
 /**
@@ -231,6 +248,10 @@ export interface MarketplaceV3ContractDeployMetadata {
    * The default app for this contract
    */
   app_uri?: string;
+  /**
+   * The default admin for this contract
+   */
+  defaultAdmin?: AddressOrEns;
 }
 
 /**
@@ -284,6 +305,10 @@ export interface VoteContractDeployMetadata {
    * The default app for this contract
    */
   app_uri?: string;
+  /**
+   * The default admin for this contract
+   */
+  defaultAdmin?: AddressOrEns;
 }
 
 /**
@@ -333,6 +358,10 @@ export interface SplitContractDeployMetadata {
    * The default app for this contract
    */
   app_uri?: string;
+  /**
+   * The default admin for this contract
+   */
+  defaultAdmin?: AddressOrEns;
 }
 
 /**
@@ -376,6 +405,10 @@ export interface MultiwrapContractDeployMetadata {
    * The default app for this contract
    */
   app_uri?: string;
+  /**
+   * The default admin for this contract
+   */
+  defaultAdmin?: AddressOrEns;
 }
 
 /**
@@ -407,6 +440,10 @@ export interface AirdropContractDeployMetadata {
    * The default app for this contract
    */
   app_uri?: string;
+  /**
+   * The default admin for this contract
+   */
+  defaultAdmin?: AddressOrEns;
 }
 
 /**

--- a/packages/sdk/test/evm/nft.test.ts
+++ b/packages/sdk/test/evm/nft.test.ts
@@ -368,4 +368,18 @@ describe("NFT Contract", async () => {
     });
     expect(nfts).to.be.an("array").length(_tokenIds.length);
   });
+
+  it("allows overriding the default admin", async () => {
+    const address = await sdk.deployer.deployBuiltInContract(
+      NFTCollectionInitializer.contractType,
+      {
+        defaultAdmin: samWallet.address,
+      },
+    );
+
+    const contract = await sdk.getNFTCollection(address);
+
+    const admins = await contract.roles.get("admin");
+    expect(admins[0]).to.eq(samWallet.address);
+  });
 });

--- a/packages/sdk/test/evm/nft.test.ts
+++ b/packages/sdk/test/evm/nft.test.ts
@@ -373,6 +373,15 @@ describe("NFT Contract", async () => {
     const address = await sdk.deployer.deployBuiltInContract(
       NFTCollectionInitializer.contractType,
       {
+        name: "NFT Contract",
+        description: "Test NFT contract from tests",
+        image:
+          "https://pbs.twimg.com/profile_images/1433508973215367176/XBCfBn3g_400x400.jpg",
+        primary_sale_recipient: adminWallet.address,
+        seller_fee_basis_points: 1000,
+        fee_recipient: AddressZero,
+        platform_fee_basis_points: 10,
+        platform_fee_recipient: AddressZero,
         defaultAdmin: samWallet.address,
       },
     );


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to add a `defaultAdmin` field to contract deployment metadata and allow overriding the default admin in NFT contracts.

### Detailed summary
- Added `defaultAdmin` field to contract deployment metadata
- Updated contract deployment functions to handle `defaultAdmin`
- Added test for overriding default admin in NFT contracts

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->