### PR TITLE
[SDK] Enforce minimum for maxPriorityFeePerGas

### DIFF
--- a/.changeset/gentle-foxes-reply.md
+++ b/.changeset/gentle-foxes-reply.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/sdk": patch
+---
+
+Min maxPriorityFeePerGas enforcement

--- a/packages/sdk/src/evm/common/gas-price.ts
+++ b/packages/sdk/src/evm/common/gas-price.ts
@@ -79,6 +79,12 @@ export async function getDynamicFeeData(
 
   // add 10% tip to maxPriorityFeePerGas for faster processing
   maxPriorityFeePerGas = getPreferredPriorityFee(maxPriorityFeePerGas);
+
+  // ensure maxPriorityFeePerGas is at least 0.001 gwei
+  // the value seems to be rejected by some nodes otherwise
+  if (maxPriorityFeePerGas.lt(1000000)) {
+    maxPriorityFeePerGas = BigNumber.from(1000000);
+  }
   // eip-1559 formula, doubling the base fee ensures that the tx can be included in the next 6 blocks no matter how busy the network is
   // good article on the subject: https://www.blocknative.com/blog/eip-1559-fees
   maxFeePerGas = baseBlockFee.mul(2).add(maxPriorityFeePerGas);


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enforcing a minimum value for `maxPriorityFeePerGas` to prevent rejection by some nodes.

### Detailed summary
- Added enforcement to ensure `maxPriorityFeePerGas` is at least 0.001 gwei
- Set `maxPriorityFeePerGas` to 1000000 if below the minimum value

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->