### PR TITLE
Remove RN shims

### DIFF
--- a/packages/thirdweb/package.json
+++ b/packages/thirdweb/package.json
@@ -75,11 +75,6 @@
       "import": "./dist/esm/exports/rpc.js",
       "default": "./dist/cjs/exports/rpc.js"
     },
-    "./react-native-shims": {
-      "types": "./dist/types/exports/react-native-shims.d.ts",
-      "import": "./dist/esm/exports/react-native-shims.js",
-      "default": "./dist/cjs/exports/react-native-shims.js"
-    },
     "./storage": {
       "types": "./dist/types/exports/storage.d.ts",
       "import": "./dist/esm/exports/storage.js",
@@ -138,9 +133,6 @@
       ],
       "rpc": [
         "./dist/types/exports/rpc.d.ts"
-      ],
-      "react-native-shims": [
-        "./dist/types/exports/react-native-shims.d.ts"
       ],
       "storage": [
         "./dist/types/exports/storage.d.ts"

--- a/packages/thirdweb/src/exports/react-native-shims.ts
+++ b/packages/thirdweb/src/exports/react-native-shims.ts
@@ -1,1 +1,0 @@
-import "fast-text-encoding";


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

## Changes made

- [ ] Public API changes: list the public API changes made if any
- [ ] Internal API changes: explain the internal logic changes

## How to test

- [ ] Automated tests: link to unit test file
- [ ] Manual tests: step by step instructions on how to test

## Contributor NFT

Paste in your wallet address below and we will airdrop you a special NFT when your pull request is merged. 

```Address: ```


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on major version updates, new exports, and additions to various adapters, scripts, and types in the `thirdweb` package.

### Detailed summary
- Deleted test files and configurations for `vite-3`, `cra-5`, and `next-13`
- Added `version` export with value "0.0.0"
- Updated dependencies and scripts
- Added new exports for adapters, wallets, and extensions
- Added new scripts for generating ABIs
- Updated types and utilities in various files

> The following files were skipped due to too many changes: `packages/thirdweb/src/utils/text-decoder.ts`, `packages/thirdweb/src/utils/text-encoder.ts`, `packages/thirdweb/scripts/generate/abis/thirdweb/IThirdwebContract.json`, `packages/thirdweb/src/react/web/ui/components/Spacer.tsx`, `packages/thirdweb/src/auth/core/constants.ts`, `packages/thirdweb/scripts/typedoc.mjs`, `packages/thirdweb/src/transaction/utils.ts`, `packages/thirdweb/src/react/core/connectionManager.ts`, `packages/thirdweb/scripts/generate/abis/erc721/IERC721Enumerable.json`, `packages/thirdweb/scripts/generate/abis/erc20/IAirdropERC20Claimable.json`, `packages/thirdweb/src/react/web/ui/components/FadeIn.tsx`, `packages/thirdweb/src/react/web/wallets/embedded/socialIcons.ts`, `packages/thirdweb/scripts/generate/abis/erc721/INFTStake.json`, `packages/thirdweb/scripts/generate/abis/erc20/ITokenStake.json`, `packages/thirdweb/scripts/generate/abis/erc721/IAirdropERC721Claimable.json`, `packages/thirdweb/scripts/generate/abis/erc721/ILazyMint.json`, `packages/thirdweb/scripts/generate/abis/erc721/ISharedMetadata.json`, `packages/thirdweb/src/wallets/interfaces/listeners.ts`, `packages/thirdweb/scripts/generate/abis/erc1155/IEditionStake.json`, `packages/thirdweb/scripts/generate/abis/erc20/IERC20Permit.json`, `packages/thirdweb/tsconfig.build.json`, `packages/thirdweb/scripts/generate/abis/erc6551/IERC6551Account.json`, `packages/thirdweb/scripts/generate/abis/erc721/IDelayedReveal.json`, `packages/thirdweb/src/contract/deployment/types.ts`, `packages/thirdweb/scripts/generate/abis/common/IContractMetadata.json`, `packages/thirdweb/scripts/generate/abis/erc721/IAirdropERC721.json`, `packages/thirdweb/src/exports/pay.ts`, `packages/react-native/src/evm/hooks/useDebounceCallback.ts`, `packages/thirdweb/scripts/generate/abis/erc20/IAirdropERC20.json`, `packages/thirdweb/src/wallets/utils/defaultDappMetadata.ts`, `packages/thirdweb/src/constants/addresses.ts`, `packages/thirdweb/scripts/generate/abis/erc1155/IAirdropERC1155Claimable.json`, `packages/thirdweb/scripts/version.mjs`, `packages/thirdweb/scripts/generate/abis/erc721/IClaimableERC721.json`, `packages/thirdweb/tsconfig.json`, `packages/thirdweb/src/exports/wallets/coinbase.ts`, `packages/sdk/src/evm/lib/static-batch-rpc.ts`, `packages/thirdweb/src/utils/promise/wait.ts`, `packages/thirdweb/scripts/generate/abis/erc1155/IAirdropERC1155.json`, `packages/thirdweb/src/exports/storage.ts`, `packages/thirdweb/src/chains/chain-definitions/base.ts`, `packages/thirdweb/scripts/generate/abis/erc1155/IClaimableERC1155.json`, `packages/thirdweb/scripts/generate/abis/erc721/INFTMetadata.json`, `packages/thirdweb/scripts/generate/abis/erc1155/INFTMetadata.json`, `packages/thirdweb/src/utils/json.ts`, `packages/thirdweb/src/utils/text-decoder.test.ts`, `packages/thirdweb/src/utils/text-encoder.test.ts`, `packages/thirdweb/src/chains/chain-definitions/arbitrum.ts`, `packages/thirdweb/src/chains/chain-definitions/polygon.ts`, `packages/thirdweb/src/chains/chain-definitions/zora.ts`, `packages/thirdweb/src/wallets/embedded/implementations/interfaces/embedded-wallets/signer.ts`, `packages/thirdweb/src/chains/chain-definitions/avalanche.ts`, `packages/thirdweb/src/utils/uuid.ts`, `packages/thirdweb/src/react/web/utils/canFitWideModal.ts`, `packages/thirdweb/scripts/generate/abis/erc1155/IERC1155Receiver.json`, `packages/thirdweb/src/utils/promise/wait.test.ts`, `packages/thirdweb/src/chains/chain-definitions/ethereum.ts`, `packages/thirdweb/src/chains/chain-definitions/optimism.ts`, `packages/thirdweb/scripts/generate/abis/thirdweb/ISignatureAction.json`, `packages/thirdweb/src/chains/chain-definitions/sepolia.ts`, `packages/thirdweb/scripts/generate/abis/erc4337/IAccount.json`, `packages/thirdweb/test/src/addresses.ts`, `packages/thirdweb/scripts/generate/abis/common/IRoyaltyPayments.json`, `packages/thirdweb/src/react/native/wallets/defaultWallets.ts`, `packages/thirdweb/src/utils/any-evm/keccak-id.test.ts`, `packages/thirdweb/src/wallets/types.ts`, `packages/thirdweb/src/chains/chain-definitions/base-sepolia.ts`, `packages/thirdweb/src/gas/op-gas-fee-reducer.test.ts`, `packages/thirdweb/src/react/core/hooks/others/useInvalidateQueries.ts`, `packages/thirdweb/src/wallets/utils/normalizeChainId.ts`, `packages/thirdweb/src/react/web/providers/locale-provider.tsx`, `packages/thirdweb/src/react/native/providers/locale-provider.tsx`, `packages/thirdweb/src/chains/chain-definitions/avalanche-fuji.ts`, `packages/thirdweb/scripts/generate/abis/common/IPlatformFee.json`, `packages/thirdweb/src/utils/ens/encodeLabelToLabelhash.ts`, `packages/thirdweb/src/exports/wallets/embedded.ts`, `packages/thirdweb/src/chains/chain-definitions/arbitrum-sepolia.ts`, `packages/thirdweb/src/chains/chain-definitions/optimism-sepolia.ts`, `packages/thirdweb/src/chains/chain-definitions/zora-sepolia.ts`, `packages/thirdweb/src/react/core/utils/handleWCSessionRequest.ts`, `packages/thirdweb/src/react/core/providers/thirdweb-provider-ctx.tsx`, `packages/thirdweb/src/utils/units.bench.ts`, `packages/thirdweb/src/exports/wallets/local.ts`, `packages/thirdweb/src/utils/jwt/jwt-header.ts`, `packages/thirdweb/scripts/generate/abis/erc721/IERC721AQueryable.json`, `packages/thirdweb/src/extensions/ens/resolve-address.test.ts`, `packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/LazyConnectModal.tsx`, `packages/thirdweb/src/chains/chain-definitions/polygon-mumbai.ts`, `packages/thirdweb/src/react/web/wallets/local/utils/downloadTextFile.ts`, `packages/thirdweb/scripts/generate/abis/erc4337/IPaymaster.json`, `packages/cli/package.json`, `packages/thirdweb/src/react/web/ui/design-system/styles.tsx`, `packages/thirdweb/knip.json`, `packages/thirdweb/src/react/web/ui/design-system/animations.ts`, `packages/thirdweb/src/exports/event.ts`, `packages/thirdweb/src/react/web/ui/MediaRenderer/mime/mime.ts`, `packages/thirdweb/test/src/chains.ts`, `packages/thirdweb/src/utils/encoding/helpers/charcode-to-base-16.ts`, `packages/thirdweb/src/abi/decode.ts`, `packages/thirdweb/src/react/web/utils/resolveMimeType.ts`, `packages/thirdweb/src/utils/caching/lru.ts`, `packages/thirdweb/test/src/test-wallets.ts`, `packages/thirdweb/.size-limit.json`, `packages/react/src/wallet/wallets/localWallet/types.ts`, `packages/thirdweb/src/utils/any-evm/keccak-id.ts`, `packages/thirdweb/scripts/generate/abis/erc721/ISharedMetadataBatch.json`, `packages/thirdweb/src/pay/swap/utils/definitions.ts`, `packages/thirdweb/scripts/generate/abis/erc1155/IPackVRFDirect.json`, `packages/thirdweb/scripts/generate/abis/common/IClaimConditionsSinglePhase.json`, `packages/thirdweb/scripts/generate/abis/uniswap/IQuoter.json`, `packages/thirdweb/src/react/core/hooks/others/useThirdwebProviderProps.ts`, `packages/thirdweb/src/react/core/utils/asyncLocalStorage.ts`, `packages/thirdweb/src/react/web/ui/components/Overlay.tsx`, `packages/thirdweb/src/utils/promise/resolve-promised-value.ts`, `packages/thirdweb/src/utils/bigint.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/events/Paused.ts`, `packages/thirdweb/src/utils/encoding/helpers/byte-size.ts`, `packages/thirdweb/src/react/web/ui/hooks/useCopyClipboard.ts`, `packages/thirdweb/src/react/web/wallets/local/utils/useSavedLocalWalletDataQuery.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/INFTMetadata/events/MetadataFrozen.ts`, `packages/thirdweb/src/react/web/ui/ConnectWallet/constants.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/INFTMetadata/events/MetadataFrozen.ts`, `packages/thirdweb/src/extensions/common/read/getContractMetadata.test.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/events/BeforeExecution.ts`, `packages/wallets/src/evm/wallets/smart-wallet.ts`, `packages/thirdweb/scripts/generate/abis/erc721/IStaking721.json`, `packages/thirdweb/src/react/web/wallets/local/utils/usePassword.ts`, `packages/thirdweb/src/extensions/erc4906/__generated__/IERC4906/events/MetadataUpdate.ts`, `packages/thirdweb/scripts/generate/abis/common/IPermissions.json`, `packages/thirdweb/src/extensions/erc721/__generated__/INFTMetadata/events/MetadataUpdate.ts`, `packages/thirdweb/scripts/generate/abis/erc20/IERC20.json`, `packages/thirdweb/src/extensions/erc1155/__generated__/INFTMetadata/events/MetadataUpdate.ts`, `packages/thirdweb/src/transaction/prepare-contract-call.test.ts`, `packages/thirdweb/src/utils/client-id.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IAppURI/events/AppURIUpdated.ts`, `packages/thirdweb/src/react/web/wallets/embedded/types.ts`, `packages/thirdweb/src/auth/core/types.ts`, `packages/thirdweb/src/wallets/smart/lib/constants.ts`, `packages/thirdweb/src/react/web/wallets/local/LocalWalletConnectUI.tsx`, `packages/thirdweb/src/utils/any-evm/get-salt-hash.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IStaking20/events/UpdatedTimeUnit.ts`, `packages/thirdweb/src/utils/json.test.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IStaking721/events/UpdatedTimeUnit.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/IUniswapV3Factory/events/FeeAmountEnabled.ts`, `packages/thirdweb/src/rpc/actions/eth_getLogs.test.ts`, `packages/thirdweb/src/react/web/ui/design-system/elements.ts`, `packages/thirdweb/scripts/generate/abis/erc20/IVotes.json`, `packages/thirdweb/src/extensions/common/__generated__/IContractMetadata/events/ContractURIUpdated.ts`, `packages/thirdweb/src/react/core/storage.ts`, `packages/thirdweb/src/extensions/common/__generated__/IPlatformFee/events/PlatformFeeTypeUpdated.ts`, `packages/thirdweb/src/extensions/erc4906/__generated__/IERC4906/events/BatchMetadataUpdate.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/INFTMetadata/events/BatchMetadataUpdate.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/INFTMetadata/events/BatchMetadataUpdate.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IStaking20/events/UpdatedMinStakeAmount.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/events/PlatformFeeTypeUpdated.ts`, `packages/thirdweb/src/react/web/ui/ConnectWallet/PoweredByTW.tsx`, `packages/thirdweb/scripts/generate/abis/erc20/IStaking20.json`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/read/name.ts`, `packages/thirdweb/test/vitest.config.ts`, `packages/thirdweb/src/extensions/common/__generated__/IOwnable/read/owner.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IStaking1155/events/UpdatedDefaultTimeUnit.ts`, `packages/thirdweb/test/src/utils.ts`, `packages/thirdweb/src/extensions/common/__generated__/IContractMetadata/read/name.ts`, `packages/thirdweb/src/extensions/common/__generated__/IPlatformFee/events/FlatPlatformFeeUpdated.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/ITokenStake/events/RewardTokensDepositedByAdmin.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/ITokenStake/events/RewardTokensWithdrawnByAdmin.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/INFTStake/events/RewardTokensDepositedByAdmin.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/INFTStake/events/RewardTokensWithdrawnByAdmin.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/read/symbol.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/events/AuctionBuffersUpdated.ts`, `packages/thirdweb/src/extensions/erc6551/__generated__/IERC6551Account/read/state.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IAppURI/read/appURI.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IEditionStake/events/RewardTokensDepositedByAdmin.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IEditionStake/events/RewardTokensWithdrawnByAdmin.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IERC20/read/decimals.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/IUniswapV3Factory/read/owner.ts`, `packages/thirdweb/src/extensions/common/__generated__/IContractMetadata/read/symbol.ts`, `packages/thirdweb/src/rpc/actions/eth_gasPrice.ts`, `packages/thirdweb/scripts/generate/abis/common/IRoyalty.json`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/events/FlatPlatformFeeUpdated.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IStaking20/events/UpdatedRewardRatio.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IWETH/write/deposit.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ISharedMetadata/events/SharedMetadataUpdated.ts`, `.github/workflows/release-artifacts.yml`, `packages/thirdweb/src/chains/constants.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IERC20/read/totalSupply.ts`, `packages/thirdweb/scripts/generate/abis/thirdweb/ITWMultichainRegistry.json`, `packages/thirdweb/src/extensions/erc721/__generated__/IStaking721/events/UpdatedRewardsPerUnitTime.ts`, `packages/thirdweb/src/extensions/erc20/read/getBalance.test.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/read/totalSupply.ts`, `packages/thirdweb/src/utils/type-guards.ts`, `packages/thirdweb/src/react/web/ui/design-system/CustomThemeProvider.tsx`, `packages/thirdweb/src/storage/upload/types.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/read/startTokenId.ts`, `packages/thirdweb/src/extensions/common/__generated__/IContractMetadata/read/contractURI.ts`, `packages/thirdweb/src/utils/encoding/helpers/assert-size.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ISignatureDropERC721/read/totalMinted.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IThirdwebContract/read/contractURI.ts`, `packages/thirdweb/src/react/web/wallets/defaultWallets.ts`, `turbo.json`, `packages/thirdweb/src/extensions/erc20/__generated__/IStaking20/write/claimRewards.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/unlockStake.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/read/contractURI.ts`, `packages/thirdweb/src/transaction/actions/estimate-gas-cost.test.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IStaking721/write/claimRewards.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IThirdwebContract/read/contractType.ts`, `.github/workflows/release-beta.yml`, `packages/thirdweb/src/extensions/erc1822/__generated__/IERC1822Proxiable/read/proxiableUUID.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/read/contractType.ts`, `packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/asset.ts`, `.github/workflows/release-alpha.yml`, `packages/thirdweb/src/gas/op-gas-fee-reducer.ts`, `packages/thirdweb/scripts/generate/abis/erc4337/IAccountFactory.json`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/read/getAllAccounts.ts`, `packages/thirdweb/src/rpc/actions/eth_blockNumber.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IERC20Permit/read/DOMAIN_SEPARATOR.ts`, `packages/thirdweb/src/react/core/utils/isMobile.ts`, `packages/thirdweb/src/reactive/store.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/INFTMetadata/write/freezeMetadata.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/read/totalListings.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/INFTMetadata/write/freezeMetadata.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IThirdwebContract/read/contractVersion.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccountPermissions/read/getAllAdmins.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IDrop/read/nextTokenIdToClaim.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/read/contractVersion.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IStaking1155/events/UpdatedDefaultRewardsPerUnitTime.ts`, `packages/thirdweb/src/rpc/actions/eth_sendRawTransaction.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721Enumerable/read/nextTokenIdToMint.ts`, `packages/thirdweb/scripts/generate/abis/common/IPermissionsEnumerable.json`, `packages/thirdweb/src/utils/bytecode/prefix.ts`, `packages/thirdweb/src/crypto/aes/lib/universal-crypto.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155Enumerable/read/nextTokenIdToMint.ts`, `packages/thirdweb/src/extensions/common/__generated__/IPrimarySale/read/primarySaleRecipient.ts`, `packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/totalAssets.ts`, `packages/thirdweb/test/globalSetup.ts`, `packages/thirdweb/src/extensions/common/__generated__/IPlatformFee/read/getPlatformFeeInfo.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/read/accountImplementation.ts`, `packages/thirdweb/scripts/generate/abis/erc20/ISignatureMintERC20.json`, `packages/thirdweb/src/exports/auth.ts`, `packages/thirdweb/src/react/core/hooks/pay/useSwapRoute.ts`, `packages/thirdweb/src/extensions/common/__generated__/IRoyalty/read/getDefaultRoyaltyInfo.ts`, `packages/thirdweb/src/extensions/erc6551/__generated__/IERC6551Account/read/token.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/read/getPlatformFeeInfo.ts`, `packages/thirdweb/src/utils/ens/namehash.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IDrop/read/getActiveClaimConditionId.ts`, `packages/thirdweb/src/react/web/ui/components/Skeleton.tsx`, `packages/thirdweb/src/rpc/actions/eth_maxPriorityFeePerGas.ts`, `packages/thirdweb/src/react/web/ui/components/TextDivider.tsx`, `packages/thirdweb/src/react/web/ui/MediaRenderer/ModelViewer.tsx`, `packages/thirdweb/src/react/web/ui/components/CopyIcon.tsx`, `packages/thirdweb/src/utils/promise/resolve-promised-value.test.ts`, `packages/thirdweb/scripts/generate/abis/uniswap/ISwapRouter.json`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/read/getRulesEngineOverride.ts`, `packages/thirdweb/scripts/generate/abis/uniswap/IUniswapV3Factory.json`, `packages/thirdweb/src/react/core/utils/openWindow.ts`, `packages/thirdweb/scripts/generate/abis/erc1155/IPack.json`, `packages/thirdweb/src/exports/extensions/common.ts`, `packages/thirdweb/src/extensions/common/read/name.ts`, `packages/thirdweb/src/utils/function-id.test.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IDrop/events/ClaimConditionsUpdated.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IDropERC20/events/ClaimConditionsUpdated.ts`, `packages/thirdweb/scripts/generate/abis/erc20/IDropERC20.json`, `packages/thirdweb/src/extensions/common/read/symbol.ts`, `packages/thirdweb/src/transaction/actions/send-and-confirm-transaction.ts`, `packages/thirdweb/src/extensions/common/__generated__/IClaimConditionsSinglePhase/events/ClaimConditionUpdated.ts`, `packages/thirdweb/src/extensions/erc20/read/decimals.ts`, `packages/thirdweb/src/utils/encoding/helpers/is-hex.ts`, `packages/thirdweb/src/auth/core/sign-login-payload.ts`, `packages/thirdweb/src/transaction/actions/encode.ts`, `packages/thirdweb/src/react/core/hooks/contract/useEstimate.ts`, `packages/thirdweb/src/rpc/actions/eth_getCode.ts`, `packages/thirdweb/src/react/core/utils/applyOverrides.ts`, `packages/thirdweb/src/extensions/erc721/drops/read/getActiveClaimCondition.ts`, `packages/thirdweb/src/utils/function-id.ts`, `packages/thirdweb/src/contract/contract.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/events/URI.ts`, `packages/thirdweb/src/rpc/actions/eth_estimateGas.ts`, `packages/thirdweb/src/extensions/erc721/read/getTotalUnclaimedSupply.ts`, `packages/thirdweb/src/gas/get-gas-price.ts`, `packages/thirdweb/src/react/web/ui/components/Img.tsx`, `packages/thirdweb/src/reactive/effect.ts`, `packages/thirdweb/src/abi/encode.ts`, `packages/thirdweb/src/react/web/wallets/local/persist/create/LocalWallet_Persist_CreationFlow.tsx`, `packages/react-native/src/evm/wallets/connectors/embedded-wallet/embedded/helpers/wallet/encryption.ts`, `packages/thirdweb/src/auth/auth.ts`, `packages/thirdweb/src/rpc/actions/eth_getStorageAt.ts`, `packages/thirdweb/src/utils/base64/base64.test.ts`, `packages/thirdweb/src/utils/contract/fetchContractMetadata.ts`, `packages/thirdweb/src/extensions/ens/__generated__/AddressResolver/read/addr.ts`, `packages/thirdweb/scripts/generate/abis/thirdweb/IRulesEngine.json`, `packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/read/uri.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IPackVRFDirect/write/claimRewards.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/events/RuleDeleted.ts`, `packages/thirdweb/src/react/web/ui/ConnectWallet/icons/FundsIcon.tsx`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/events/Deposited.ts`, `packages/thirdweb/src/wallets/embedded/core/authentication/type.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IERC20Permit/read/nonces.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IStaking20/events/TokensStaked.ts`, `packages/thirdweb/scripts/generate/abis/erc721/ISignatureMintERC721.json`, `packages/thirdweb/src/react/web/ui/components/DynamicHeight.tsx`, `packages/thirdweb/src/extensions/erc20/__generated__/IBurnableERC20/write/burn.ts`, `packages/thirdweb/src/react/web/ui/ConnectWallet/screens/types.ts`, `packages/thirdweb/src/utils/any-evm/is-eip155-enforced.test.ts`, `packages/thirdweb/src/utils/hashing/sha256.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IStaking20/write/stake.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/events/Withdrawn.ts`, `packages/thirdweb/tsdoc.json`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccountPermissions/events/AdminUpdated.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IBurnableERC721/write/burn.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/read/ownerOf.ts`, `packages/thirdweb/src/react/web/ui/MediaRenderer/useResolvedMediaType.ts`, `packages/thirdweb/src/extensions/erc20/read/getCurrencyMetadata.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccountPermissions/read/isAdmin.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IMintableERC20/events/TokensMinted.ts`, `packages/thirdweb/src/exports/contract.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccountPermissions/read/getAllSigners.ts`, `packages/thirdweb/src/rpc/actions/eth_getBalance.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IPack/events/PackCreated.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IPack/events/PackUpdated.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IVotes/read/getVotes.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IStaking20/events/RewardsClaimed.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/events/StakeUnlocked.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/read/balanceOf.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/read/tokenURI.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IStaking721/events/RewardsClaimed.ts`, `packages/thirdweb/src/contract/actions/get-bytecode.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IWETH/write/withdraw.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IStaking721/write/stake.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IStaking20/events/TokensWithdrawn.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IVotes/read/delegates.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/read/totalSupply.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IStaking1155/events/RewardsClaimed.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/events/StakeLocked.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IERC20/read/balanceOf.ts`, `packages/thirdweb/scripts/generate/abis/erc1155/IStaking1155.json`, `packages/thirdweb/src/extensions/erc20/__generated__/IStaking20/write/withdraw.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IAppURI/write/setAppURI.ts`, `packages/thirdweb/src/utils/base64/base64.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/read/getAllRules.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/read/balanceOf.ts`, `packages/thirdweb/src/utils/hashing/keccak256.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/ITWMultichainRegistry/read/count.ts`, `packages/thirdweb/src/extensions/common/__generated__/IOwnable/write/setOwner.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IDelayedReveal/events/TokenURIRevealed.ts`, `packages/thirdweb/scripts/generate/abis/erc1155/IERC1155.json`, `packages/thirdweb/src/extensions/erc20/__generated__/IVotes/write/delegate.ts`, `packages/thirdweb/src/extensions/common/__generated__/IPermissions/read/getRoleAdmin.ts`, `packages/thirdweb/src/react/core/hooks/contract/useSend.ts`, `packages/thirdweb/scripts/generate/abis/erc1155/ISignatureMintERC1155.json`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/events/StakeWithdrawn.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/read/getApproved.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/depositTo.ts`, `packages/thirdweb/src/rpc/actions/eth_getTransactionByHash.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccountPermissions/read/getAllActiveSigners.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IStaking721/write/withdraw.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/IUniswapV3Factory/write/setOwner.ts`, `packages/thirdweb/src/extensions/erc721/drops/read/getActiveClaimCondition.test.ts`, `packages/thirdweb/src/extensions/common/__generated__/IPermissionsEnumerable/read/getRoleAdmin.ts`, `packages/thirdweb/src/storage/download.ts`, `packages/thirdweb/src/utils/jwt/decode-jwt.ts`, `packages/thirdweb/benchmarks/run.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721Enumerable/read/tokenByIndex.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/write/deleteRule.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ISharedMetadataBatch/events/SharedMetadataDeleted.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IERC20/events/Transfer.ts`, `packages/thirdweb/src/cli/bin.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721AQueryable/read/tokensOfOwner.ts`, `packages/thirdweb/src/extensions/erc721/read/getTotalClaimedSupply.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IStaking1155/events/UpdatedTimeUnit.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/read/getScore.ts`, `packages/thirdweb/src/extensions/erc1155/drops/read/getActiveClaimCondition.ts`, `packages/thirdweb/src/utils/jwt/refresh-jwt.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ISharedMetadataBatch/read/getAllSharedMetadata.ts`, `packages/thirdweb/src/utils/ens/packetToBytes.ts`, `packages/thirdweb/src/extensions/common/__generated__/IRoyalty/events/DefaultRoyalty.ts`, `packages/thirdweb/src/wallets/embedded/implementations/index.ts`, `packages/thirdweb/src/extensions/common/__generated__/IMulticall/write/multicall.ts`, `packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/TOS.tsx`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/incrementNonce.ts`, `packages/thirdweb/src/extensions/erc721/read/getOwnedNFTs.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccountPermissions/read/isActiveSigner.ts`, `packages/thirdweb/src/extensions/common/__generated__/IContractMetadata/write/setContractURI.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IStaking1155/write/claimRewards.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IOffers/write/acceptOffer.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IOffers/write/cancelOffer.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/addStake.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IPackVRFDirect/read/canClaimRewards.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IERC20/events/Approval.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IThirdwebContract/write/setContractURI.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/setContractURI.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/events/RulesEngineOverriden.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/events/RuleCreated.ts`, `packages/thirdweb/src/react/web/ui/ConnectWallet/icons/LockIcon.tsx`, `packages/thirdweb/src/extensions/erc20/__generated__/IVotes/events/DelegateVotesChanged.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ILazyMint/events/TokensLazyMinted.ts`, `packages/thirdweb/src/utils/any-evm/keyless-transaction.ts`, `packages/thirdweb/src/extensions/common/__generated__/IPermissionsEnumerable/read/getRoleMemberCount.ts`, `packages/thirdweb/src/contract/actions/compiler-metadata.ts`, `packages/thirdweb/src/client/client.test.ts`, `packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/maxMint.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/IUniswapV3Factory/read/feeAmountTickSpacing.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IStaking20/read/getStakeInfo.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/getSenderAddress.ts`, `packages/thirdweb/src/extensions/erc165/__generated__/IERC165/read/supportsInterface.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/events/SignerAdded.ts`, `packages/thirdweb/src/extensions/common/__generated__/IRoyalty/read/supportsInterface.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/cancelListing.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/cancelAuction.ts`, `packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/maxRedeem.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/INFTMetadata/read/supportsInterface.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IStaking721/read/getStakeInfo.ts`, `packages/thirdweb/src/extensions/uniswap/read/getUniswapV3Pools.test.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/INFTMetadata/read/supportsInterface.ts`, `packages/thirdweb/src/extensions/common/__generated__/IRoyaltyPayments/read/supportsInterface.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/read/isAuctionExpired.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IVotes/read/getPastTotalSupply.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IStaking721/events/TokensStaked.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/events/SignatureAggregatorChanged.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155Receiver/read/supportsInterface.ts`, `packages/thirdweb/src/extensions/erc2771/__generated__/IERC2771Context/read/isTrustedForwarder.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ISharedMetadataBatch/events/SharedMetadataUpdated.ts`, `packages/thirdweb/src/utils/bytecode/extractIPFS.test.ts`, `packages/thirdweb/src/extensions/erc721/read/getOwnedTokenIds.ts`, `packages/thirdweb/src/extensions/common/__generated__/IPrimarySale/events/PrimarySaleRecipientUpdated.ts`, `packages/thirdweb/src/utils/bigint.test.ts`, `packages/thirdweb/src/extensions/common/__generated__/IOwnable/events/OwnerUpdated.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/withdrawStake.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ISharedMetadataBatch/write/deleteSharedMetadata.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/ITokenStake/write/depositRewardTokens.ts`, `packages/thirdweb/src/extensions/erc7504/__generated__/IRouterState/read/getAllExtensions.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/INFTStake/write/depositRewardTokens.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/events/SignerRemoved.ts`, `packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/previewMint.ts`, `packages/thirdweb/src/contract/deployment/deploy-published.test.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IStaking1155/events/TokensStaked.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/events/PublisherProfileUpdated.ts`, `packages/thirdweb/src/react/web/ui/ConnectWallet/icons/PlayStoreIcon.tsx`, `packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/maxWithdraw.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/IUniswapV3Factory/events/OwnerChanged.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IEditionStake/write/depositRewardTokens.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IMintableERC20/write/mintTo.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/ITokenStake/write/withdrawRewardTokens.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/read/getAccountsOfSigner.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/INFTStake/write/withdrawRewardTokens.ts`, `packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/ConnectModalSkeleton.tsx`, `packages/thirdweb/src/extensions/ens/__generated__/UniversalResolver/read/resolve.ts`, `packages/thirdweb/src/extensions/common/__generated__/IPermissions/read/hasRole.ts`, `packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/maxDeposit.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/events/ApprovalForAll.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IEditionStake/write/withdrawRewardTokens.ts`, `packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/events/Deposit.ts`, `packages/thirdweb/src/react/core/hooks/others/useChainQuery.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IOffers/events/CancelledOffer.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/write/approve.ts`, `packages/thirdweb/src/extensions/common/__generated__/IPermissionsEnumerable/read/hasRole.ts`, `packages/thirdweb/src/extensions/common/__generated__/IPlatformFee/events/PlatformFeeInfoUpdated.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IMintableERC721/write/mintTo.ts`, `packages/thirdweb/src/rpc/actions/eth_getTransactionCount.ts`, `packages/thirdweb/src/extensions/erc1155/drops/read/getActiveClaimCondition.test.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IStaking721/events/TokensWithdrawn.ts`, `packages/thirdweb/src/wallets/smart/lib/utils.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IStaking1155/write/stake.ts`, `packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/previewRedeem.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/events/ApprovalForAll.ts`, `packages/thirdweb/src/transaction/actions/estimate-gas-cost.ts`, `packages/thirdweb/src/transaction/prepare-transaction.test.ts`, `packages/thirdweb/src/rpc/actions/eth_getTransactionReceipt.ts`, `packages/thirdweb/benchmarks/send-transaction.md`, `packages/thirdweb/src/gas/estimate-l1-fee.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IERC20/read/allowance.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IMintableERC721/events/TokensMinted.ts`, `packages/thirdweb/src/extensions/common/__generated__/IRoyalty/read/getRoyaltyInfoForToken.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/events/AccountCreated.ts`, `packages/thirdweb/src/react/core/hooks/others/useWalletBalance.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IAirdropERC20Claimable/events/TokensClaimed.ts`, `packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/previewDeposit.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IWETH/write/transfer.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/read/getNonce.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/events/PlatformFeeInfoUpdated.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IStaking1155/events/TokensWithdrawn.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IERC20/write/transfer.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/cancelDirectListing.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IAirdropERC721Claimable/events/TokensClaimed.ts`, `packages/thirdweb/src/wallets/embedded/implementations/interfaces/auth.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IStaking1155/events/UpdatedRewardsPerUnitTime.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IDrop1155/read/getActiveClaimConditionId.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/read/balanceOf.ts`, `packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/convertToAssets.ts`, `packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/convertToShares.ts`, `packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/previewWithdraw.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IStaking1155/read/getStakeInfo.ts`, `packages/thirdweb/src/extensions/erc1155/read/getNFT.test.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IClaimableERC721/write/claim.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/collectAuctionPayout.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/collectAuctionTokens.ts`, `packages/thirdweb/src/wallets/embedded/core/wallet/types.ts`, `packages/thirdweb/src/extensions/common/__generated__/IPermissions/write/grantRole.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IBurnableERC20/write/burnFrom.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IStaking1155/write/withdraw.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IERC20/write/approve.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/read/getPublisherProfileUri.ts`, `packages/thirdweb/src/react/web/wallets/local/LocalWallet_NoPersist.tsx`, `packages/thirdweb/src/extensions/common/__generated__/IRoyaltyPayments/write/setRoyaltyEngine.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IClaimableERC721/read/verifyClaim.ts`, `packages/thirdweb/src/wallets/embedded/implementations/constants/settings.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/events/Transfer.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/events/ListingRemoved.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/events/ListingUpdated.ts`, `packages/thirdweb/src/extensions/common/__generated__/IPermissions/write/revokeRole.ts`, `packages/thirdweb/src/extensions/common/__generated__/IPermissionsEnumerable/write/grantRole.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IMintableERC1155/events/TokensMinted.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/events/AccountDeployed.ts`, `packages/thirdweb/src/extensions/common/__generated__/IPermissionsEnumerable/write/revokeRole.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IDelayedReveal/read/encryptDecrypt.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/INFTMetadata/write/setTokenURI.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/read/getAddress.ts`, `packages/thirdweb/src/extensions/common/__generated__/IPermissionsEnumerable/read/getRoleMember.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/ITWMultichainRegistry/read/getAll.ts`, `packages/thirdweb/src/reactive/computedStore.ts`, `packages/thirdweb/src/extensions/common/__generated__/IRoyalty/events/RoyaltyForToken.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/INFTMetadata/write/setTokenURI.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/read/getWinningBid.ts`, `packages/thirdweb/src/utils/any-evm/get-init-bytecode-with-salt.ts`, `packages/thirdweb/src/extensions/common/__generated__/IPrimarySale/write/setPrimarySaleRecipient.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IPackVRFDirect/events/PackOpenRequested.ts`, `packages/thirdweb/src/extensions/common/__generated__/IPermissions/write/renounceRole.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IDelayedReveal/write/reveal.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/events/CancelledListing.ts`, `packages/thirdweb/src/utils/encoding/helpers/trim.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/events/Approval.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/events/CancelledAuction.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IPack/events/PackOpened.ts`, `packages/thirdweb/src/extensions/common/__generated__/IPermissionsEnumerable/write/renounceRole.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IVotes/read/getPastVotes.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/ITWFee/read/getFeeInfo.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/write/setRulesEngineOverride.ts`, `packages/thirdweb/src/react/core/hooks/contract/useWaitForReceipt.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IPackVRFDirect/events/PackRandomnessFulfilled.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/read/isApprovedForAll.ts`, `packages/thirdweb/src/extensions/common/__generated__/IPermissions/events/RoleGranted.ts`, `packages/thirdweb/src/extensions/common/__generated__/IPermissions/events/RoleRevoked.ts`, `packages/thirdweb/src/extensions/erc6551/__generated__/IERC6551Account/read/isValidSigner.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/read/isApprovedForAll.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/ISignatureAction/events/RequestExecuted.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/read/balanceOfBatch.ts`, `packages/thirdweb/src/extensions/erc1271/__generated__/isValidSignature/read/isValidSignature.ts`, `packages/thirdweb/src/exports/extensions/erc20.ts`, `packages/thirdweb/src/utils/domains.ts`, `packages/thirdweb/src/exports/chains.ts`, `packages/thirdweb/src/exports/rpc.ts`, `packages/thirdweb/src/extensions/common/__generated__/IPermissionsEnumerable/events/RoleGranted.ts`, `packages/thirdweb/src/extensions/common/__generated__/IPermissionsEnumerable/events/RoleRevoked.ts`, `packages/thirdweb/src/extensions/common/__generated__/IRoyaltyPayments/events/RoyaltyEngineUpdated.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/ITWMultichainRegistry/events/Deleted.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/ITWMultichainRegistry/events/Added.ts`, `packages/thirdweb/scripts/generate/abis/erc721/IDrop.json`, `packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/events/BuyerApprovedForListing.ts`, `packages/thirdweb/src/wallets/injected/types.ts`, `.github/workflows/build-test-lint.yml`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/write/createAccount.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721Enumerable/read/tokenOfOwnerByIndex.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/IUniswapV3Factory/write/enableFeeAmount.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/closeAuction.ts`, `packages/thirdweb/src/transaction/actions/estimate-gas.test.ts`, `packages/thirdweb/src/react/web/ui/components/Spinner.tsx`, `packages/thirdweb/src/transaction/actions/simulate.test.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/write/setApprovalForAll.ts`, `packages/thirdweb/src/extensions/common/__generated__/IRoyalty/read/royaltyInfo.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IBurnableERC1155/write/burn.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/bidInAuction.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/write/setApprovalForAll.ts`, `packages/thirdweb/src/transaction/read-contract.test.ts`, `packages/thirdweb/src/utils/type-utils.ts`, `packages/thirdweb/src/extensions/erc2981/__generated__/IERC2981/read/royaltyInfo.ts`, `packages/thirdweb/src/utils/bytecode/is-contract-deployed.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/read/isNewWinningBid.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/ITWMultichainRegistry/read/getMetadataUri.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/IQuoter/write/quoteExactInput.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/events/UserOperationRevertReason.ts`, `packages/thirdweb/scripts/generate/abis/erc1155/IDrop1155.json`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/withdrawTo.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/events/TransferBatch.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/events/TransferSingle.ts`, `packages/thirdweb/src/event/actions/parse-logs.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IDrop1155/events/ClaimConditionsUpdated.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/IQuoter/write/quoteExactOutput.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/events/CurrencyApprovedForListing.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/IUniswapV3Factory/read/getPool.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IClaimableERC1155/events/TokensClaimed.ts`, `packages/thirdweb/benchmarks/README.md`, `packages/thirdweb/src/extensions/uniswap/__generated__/IUniswapV3Factory/events/PoolCreated.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IAirdropERC1155Claimable/events/TokensClaimed.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/write/unpublishContract.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/events/NewSale.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IClaimableERC721/events/TokensClaimed.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/write/setPublisherProfileUri.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IAirdropERC20/events/AirdropFailed.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IVotes/events/DelegateChanged.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/read/getPublishedUriFromCompilerUri.ts`, `packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/events/Withdraw.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/read/getDepositInfo.ts`, `packages/thirdweb/src/extensions/common/read/getContractMetadata.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/events/NewOffer.ts`, `packages/thirdweb/src/wallets/injected/mipdStore.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IAirdropERC721/events/AirdropFailed.ts`, `packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/write/mint.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/events/ContractPublished.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IPaymaster/write/postOp.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721AQueryable/events/ConsecutiveTransfer.ts`, `packages/thirdweb/src/utils/ipfs.test.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/events/AuctionClosed.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IClaimableERC1155/write/claim.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/write/transferFrom.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IBurnableERC1155/write/burnBatch.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IDropERC20/events/TokensClaimed.ts`, `packages/thirdweb/src/wallets/local/utils.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IClaimableERC1155/read/verifyClaim.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IStaking1155/read/getStakeInfoForToken.ts`, `packages/thirdweb/src/utils/hashing/hashMessage.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IAirdropERC1155/events/AirdropFailed.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IERC20/write/transferFrom.ts`, `packages/thirdweb/src/extensions/common/__generated__/IPermissions/events/RoleAdminChanged.ts`, `packages/thirdweb/src/react/web/wallets/local/persist/LocalWallet_Persist.tsx`, `packages/thirdweb/src/rpc/actions/eth_blockNumber.test.ts`, `packages/thirdweb/src/extensions/common/__generated__/IPermissionsEnumerable/events/RoleAdminChanged.ts`, `packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/write/deposit.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IDrop/events/TokensClaimed.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/events/ContractUnpublished.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IDrop1155/events/TokensClaimed.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721AQueryable/read/tokensOfOwnerIn.ts`, `packages/thirdweb/src/transaction/actions/encode.bench.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/ITWMultichainRegistry/write/remove.ts`, `packages/thirdweb/src/utils/bytecode/extractIPFS.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/events/NewSale.ts`, `packages/thirdweb/src/extensions/erc1155/read/getNFT.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/write/safeTransferFrom.ts`, `packages/thirdweb/src/extensions/common/__generated__/IRoyalty/write/setDefaultRoyaltyInfo.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/IUniswapV3Factory/write/createPool.ts`, `packages/thirdweb/src/crypto/aes/encrypt.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/events/AuctionClosed.ts`, `packages/thirdweb/src/contract/verification/source-files.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IOffers/events/AcceptedOffer.ts`, `packages/thirdweb/src/extensions/common/__generated__/IPlatformFee/write/setPlatformFeeInfo.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/write/onSignerAdded.ts`, `packages/thirdweb/src/utils/nft/parseNft.ts`, `packages/thirdweb/src/auth/verifySignature.test.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/setPlatformFeeInfo.ts`, `packages/thirdweb/src/extensions/erc1155/read/getNFTs.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/events/UserOperationEvent.ts`, `packages/thirdweb/src/exports/extensions/erc1155.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/write/onSignerRemoved.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/ISignatureMintERC20/events/TokensMintedWithSignature.ts`, `packages/thirdweb/src/storage/uploadMobile.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ILazyMint/write/lazyMint.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IMintableERC1155/write/mintTo.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IPack/write/openPack.ts`, `packages/thirdweb/src/auth/core/generate-login-payload.ts`, `packages/thirdweb/src/rpc/actions/eth_getBlockByHash.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccountPermissions/read/getPermissionsForSigner.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IOffers/events/NewOffer.ts`, `packages/thirdweb/src/exports/react-native.ts`, `packages/thirdweb/src/extensions/common/__generated__/IRoyalty/write/setRoyaltyInfoForToken.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/read/getAllPublishedContracts.ts`, `packages/thirdweb/src/extensions/erc20/write/mintTo.ts`, `packages/thirdweb/src/extensions/common/__generated__/IRoyaltyPayments/write/getRoyalty.ts`, `packages/thirdweb/src/extensions/erc1271/checkContractWalletSignature.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ISharedMetadata/write/setSharedMetadata.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/approveBuyerForListing.ts`, `packages/thirdweb/src/exports/transaction.ts`, `packages/thirdweb/src/auth/core/create-login-message.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IOffers/read/getOffer.ts`, `packages/thirdweb/src/extensions/erc20/read/getBalance.ts`, `packages/thirdweb/src/contract/deployment/utils/infra.ts`, `packages/thirdweb/src/transaction/resolve-method.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/ITWMultichainRegistry/write/add.ts`, `packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/write/redeem.ts`, `packages/thirdweb/src/extensions/erc20/write/approve.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/ISwapRouter/write/exactInput.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/events/ListingAdded.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IContractFactory/write/deployProxyByImplementation.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccountPermissions/events/SignerPermissionsUpdated.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/events/NewListing.ts`, `packages/thirdweb/src/extensions/erc20/write/transfer.ts`, `packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/write/withdraw.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/ISwapRouter/write/exactOutput.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721Receiver/write/onERC721Received.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/events/NewBid.ts`, `packages/thirdweb/scripts/generate/abis/thirdweb/IContractPublisher.json`, `packages/thirdweb/src/extensions/erc721/__generated__/IDrop/read/getClaimConditionById.ts`, `packages/thirdweb/src/react/web/ui/components/modalElements.tsx`, `packages/thirdweb/src/extensions/erc20/__generated__/IAirdropERC20Claimable/write/claim.ts`, `packages/thirdweb/src/react/core/hooks/pay/useSwapStatus.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IPackVRFDirect/write/openPackAndClaimRewards.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IAirdropERC721Claimable/write/claim.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/acceptOffer.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/events/UpdatedListing.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/write/createRuleMultiplicative.ts`, `packages/thirdweb/scripts/generate/abis/erc721/IERC721A.json`, `packages/thirdweb/src/extensions/thirdweb/__generated__/ISignatureAction/read/verify.ts`, `packages/thirdweb/scripts/generate/abis/marketplace/IOffers.json`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/read/getPublishedContract.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/write/createRuleThreshold.ts`, `packages/thirdweb/src/react/web/ui/components/text.tsx`, `packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/events/NewAuction.ts`, `packages/thirdweb/src/event/prepare-event.test.ts`, `packages/thirdweb/src/extensions/uniswap/read/getUniswapV3Pools.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ISharedMetadataBatch/write/setSharedMetadata.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/approveCurrencyForListing.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IAirdropERC20/write/airdropERC20.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/read/getListing.ts`, `packages/thirdweb/src/react/web/wallets/shared/InjectedAndWCConnectUI.tsx`, `packages/thirdweb/src/extensions/erc721/__generated__/IAirdropERC721/write/airdropERC721.ts`, `packages/thirdweb/src/transaction/extract-error.ts`, `packages/thirdweb/src/exports/wallets/index.ts`, `packages/thirdweb/src/react/core/hooks/pay/useSendSwap.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ISignatureMintERC721/events/TokensMintedWithSignature.ts`, `packages/thirdweb/src/extensions/erc721/read/getNFT.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IOffers/write/makeOffer.ts`, `packages/thirdweb/src/contract/deployment/deploy-published.ts`, `packages/thirdweb/src/wallets/coinbase/coinbaseMetadata.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/write/safeTransferFrom.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/buy.ts`, `packages/thirdweb/src/react/web/wallets/shared/InjectedConnectUI.tsx`, `packages/thirdweb/src/extensions/erc1155/__generated__/ISignatureMintERC1155/events/TokensMintedWithSignature.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/read/getPublishedContractVersions.ts`, `packages/thirdweb/src/transaction/actions/to-serializable-transaction.ts`, `packages/thirdweb/src/react/web/ui/ConnectWallet/icons/ChromeIcon.tsx`, `packages/thirdweb/benchmarks/rpc.md`, `packages/thirdweb/src/extensions/marketplace/__generated__/IOffers/read/getAllOffers.ts`, `packages/thirdweb/src/utils/any-evm/compute-published-contract-address.ts`, `packages/thirdweb/src/cli/commands/generate/utils.ts`, `packages/thirdweb/src/utils/any-evm/compute-deployment-address.ts`, `packages/thirdweb/benchmarks/encode-tx.md`, `packages/thirdweb/benchmarks/read-contract.md`, `packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155Receiver/write/onERC1155Received.ts`, `packages/thirdweb/src/event/actions/get-events.test.ts`, `packages/thirdweb/src/react/web/ui/ConnectWallet/icons/AppleIcon.tsx`, `packages/thirdweb/src/react/core/utils/createQuery.ts`, `packages/thirdweb/src/wallets/embedded/implementations/utils/iFrameCommunication/EmbeddedWalletIframeCommunicator.ts`, `packages/thirdweb/src/react/core/hooks/rpc/useBlockNumber.ts`, `packages/thirdweb/src/utils/any-evm/fetch-published-contract.ts`, `packages/thirdweb/src/react/web/wallets/shared/ScanScreen.tsx`, `scripts/hotlink/changes.mjs`, `packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/write/safeBatchTransferFrom.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IOffers/read/getAllValidOffers.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IDrop1155/read/getClaimConditionById.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IAirdropERC1155/write/airdropERC1155.ts`, `packages/thirdweb/src/react/web/ui/components/Tooltip.tsx`, `packages/thirdweb/src/extensions/erc1155/__generated__/IAirdropERC1155Claimable/write/claim.ts`, `packages/thirdweb/src/react/web/wallets/local/persist/connectToSaved/overrideConfirmation.tsx`, `packages/thirdweb/src/extensions/erc20/__generated__/IVotes/write/delegateBySig.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/read/getAuction.ts`, `packages/thirdweb/src/react/web/ui/hooks/useSendToken.ts`, `packages/thirdweb/src/react/web/wallets/embedded/InputSelectionUI.tsx`, `packages/thirdweb/src/extensions/erc20/write/transferFrom.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155Receiver/write/onERC1155BatchReceived.ts`, `packages/thirdweb/src/auth/core/create-login-message.test.ts`, `packages/thirdweb/src/wallets/interfaces/wallet.ts`, `packages/thirdweb/src/chains/types.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/offer.ts`, `packages/thirdweb/src/wallets/utils/chains.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/read/getAllListings.ts`, `packages/thirdweb/scripts/generate/abis/erc4337/IAccountPermissions.json`, `packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/buyFromListing.ts`, `packages/thirdweb/src/utils/nft/fetchTokenMetadata.ts`, `packages/thirdweb/src/utils/abi/prepare-method.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IERC20Permit/write/permit.ts`, `packages/thirdweb/src/react/web/wallets/headlessConnectUI.tsx`, `packages/thirdweb/src/transaction/actions/send-transaction.ts`, `packages/thirdweb/src/react/web/ui/MediaRenderer/types.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/read/getAllValidListings.ts`, `packages/thirdweb/src/contract/deployment/deploy-with-abi.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/IQuoter/write/quoteExactInputSingle.ts`, `packages/thirdweb/test/src/test-contracts.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/ISwapRouter/write/exactInputSingle.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/createListing.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/IQuoter/write/quoteExactOutputSingle.ts`, `packages/thirdweb/src/react/web/wallets/local/persist/connectToSaved/LocalWallet_ConnectToSavedFlow.tsx`, `packages/thirdweb/src/utils/base58/encode.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/ISwapRouter/write/exactOutputSingle.ts`, `packages/thirdweb/src/utils/bytecode/detectExtension.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/read/getAllAuctions.ts`, `packages/thirdweb/src/pay/swap/actions/getStatus.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/ISignatureMintERC20/read/verify.ts`, `packages/thirdweb/src/adapters/ethers6.test.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/read/getAllValidAuctions.ts`, `packages/thirdweb/src/rpc/actions/eth_getBlockByNumber.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/createListing.ts`, `packages/thirdweb/src/react/web/ui/MediaRenderer/icons.tsx`, `packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/updateListing.ts`, `packages/thirdweb/src/utils/any-evm/compute-published-contract-deploy-info.ts`, `packages/thirdweb/benchmarks/send-transaction.ts`, `packages/thirdweb/src/pay/swap/actions/sendSwap.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/ISignatureMintERC20/write/mintWithSignature.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IDropERC20/write/claim.ts`, `packages/thirdweb/src/event/prepare-event.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/read/getUserOpHash.ts`, `packages/thirdweb/src/utils/detect-platform.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/createAuction.ts`, `packages/thirdweb/src/wallets/smart/lib/bundler.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/write/publishContract.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IDrop/write/setClaimConditions.ts`, `packages/thirdweb/src/utils/jwt/encode-jwt.ts`, `packages/thirdweb/src/react/web/wallets/embedded/openOauthSignInWindow.ts`, `packages/thirdweb/src/extensions/common/__generated__/IClaimConditionsSinglePhase/write/setClaimConditions.ts`, `packages/thirdweb/tsconfig.base.json`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/simulateValidation.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IDropERC20/write/setClaimConditions.ts`, `packages/thirdweb/src/transaction/actions/send-batch-transaction.ts`, `packages/thirdweb/src/extensions/erc721/write/mintTo.ts`, `packages/thirdweb/src/wallets/utils/getTokenBalance.ts`, `packages/thirdweb/src/exports/extensions/erc4626.ts`, `packages/thirdweb/src/extensions/erc1155/read/getOwnedNFTs.ts`, `packages/thirdweb/src/react/web/ui/ConnectWallet/screens/ReceiveFunds.tsx`, `packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/screen.tsx`, `packages/thirdweb/src/react/web/wallets/local/localWalletConfig.tsx`, `packages/thirdweb/src/react/web/ui/ConnectWallet/screens/ExportLocalWallet.tsx`, `packages/thirdweb/src/extensions/erc721/__generated__/ISignatureMintERC721/read/verify.ts`, `packages/thirdweb/src/extensions/erc721/read/getAllOwners.test.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/handleOps.ts`, `packages/thirdweb/src/utils/bytecode/extractMnimalProxyImplementationAddress.ts`, `packages/thirdweb/src/client/client.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IDrop/write/claim.ts`, `packages/thirdweb/src/react/web/wallets/shared/ConnectingScreen.tsx`, `packages/thirdweb/src/wallets/smart/lib/paymaster.ts`, `packages/thirdweb/src/storage/upload/node.ts`, `packages/thirdweb/src/transaction/prepare-transaction.ts`, `packages/thirdweb/src/transaction/types.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccountPermissions/write/setPermissionsForSigner.ts`, `packages/thirdweb/src/event/actions/watch-events.ts`, `packages/thirdweb/src/rpc/actions/eth_getLogs.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IDrop1155/write/setClaimConditions.ts`, `packages/thirdweb/src/wallets/smart/lib/receipts.ts`, `packages/thirdweb/src/wallets/injected/wallets/coinbase.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/ISignatureMintERC1155/read/verify.ts`, `packages/thirdweb/src/auth/verifyJWT.ts`, `packages/thirdweb/src/extensions/ens/resolve-address.ts`, `packages/thirdweb/src/crypto/aes/decrypt.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ISignatureMintERC721/write/mintWithSignature.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/updateListing.ts`, `packages/thirdweb/src/utils/signatures/resolve-signature.test.ts`, `packages/thirdweb/src/extensions/erc721/write/lazyMint.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccountPermissions/read/verifySignerPermissionRequest.ts`, `packages/thirdweb/src/transaction/actions/encode.test.ts`, `packages/thirdweb/src/rpc/actions/eth_call.ts`, `packages/thirdweb/src/react/web/ui/components/formFields.tsx`, `packages/thirdweb/src/extensions/erc1155/__generated__/IDrop1155/write/claim.ts`, `packages/thirdweb/src/auth/core/generate-login-payload.test.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/ISignatureMintERC1155/write/mintWithSignature.ts`, `packages/thirdweb/src/utils/promise/withCache.test.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/simulateHandleOp.ts`, `packages/thirdweb/src/wallets/smart/types.ts`, `packages/thirdweb/src/utils/promise/withCache.ts`, `packages/thirdweb/src/react/native/ui/locales/types.ts`, `packages/thirdweb/src/transaction/actions/send-and-confirm-transaction.test.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IPack/write/createPack.ts`, `packages/thirdweb/src/exports/extensions/uniswap.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccount/write/validateUserOp.ts`, `packages/thirdweb/src/extensions/erc721/drops/write/claimTo.ts`, `packages/thirdweb/src/wallets/storage/walletStorage.ts`, `packages/thirdweb/src/extensions/erc1155/drops/write/claimTo.ts`, `packages/thirdweb/scripts/generate/abis/marketplace/IMarketplace.json`, `packages/thirdweb/src/extensions/erc4337/__generated__/IPaymaster/write/validatePaymasterUserOp.ts`, `packages/thirdweb/benchmarks/rpc.ts`, `packages/thirdweb/src/wallets/embedded/implementations/utils/Storage/LocalStorage.ts`, `packages/thirdweb/src/contract/actions/resolve-abi.test.ts`, `packages/thirdweb/src/react/web/ui/components/OTPInput.tsx`, `packages/thirdweb/benchmarks/encode-tx.ts`, `packages/thirdweb/src/storage/upload.ts`, `packages/thirdweb/src/transaction/actions/simulate.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/handleAggregatedOps.ts`, `packages/thirdweb/src/react/web/ui/ConnectWallet/screens/WalletLogoSpinner.tsx`, `packages/thirdweb/src/extensions/erc721/read/getNFTs.ts`, `packages/thirdweb/.eslintrc.cjs`, `packages/thirdweb/src/extensions/erc721/read/getNFT.test.ts`, `packages/thirdweb/src/contract/deployment/deploy-via-autofactory.ts`, `packages/thirdweb/src/utils/address.ts`, `packages/thirdweb/src/extensions/erc721/read/getAllOwners.ts`, `packages/thirdweb/src/react/web/ui/components/formElements.tsx`, `packages/thirdweb/src/event/types.ts`, `packages/thirdweb/src/utils/any-evm/is-eip155-enforced.ts`, `packages/thirdweb/src/react/core/hooks/contract/useContractEvents.ts`, `packages/thirdweb/src/wallets/embedded/core/authentication/index.ts`, `packages/thirdweb/src/exports/wallets.ts`, `packages/thirdweb/src/rpc/actions/eth_getBalance.test.ts`, `packages/thirdweb/src/react/web/ui/components/QRCode/QRCodeRenderer.tsx`, `packages/thirdweb/src/react/web/ui/MediaRenderer/mime/types.ts`, `packages/thirdweb/src/wallets/embedded/implementations/lib/auth/abstract-login.ts`, `packages/thirdweb/scripts/generate/abis/marketplace/IEnglishAuctions.json`, `packages/thirdweb/src/react/web/wallets/zerion/zerionConfig.tsx`, `packages/thirdweb/scripts/generate/abis/marketplace/IDirectListings.json`, `packages/thirdweb/src/wallets/smart/lib/calls.ts`, `packages/thirdweb/src/react/web/ui/components/buttons.tsx`, `packages/thirdweb/src/react/web/wallets/rainbow/rainbowConfig.tsx`, `packages/thirdweb/src/react/web/ui/ConnectWallet/screens/StartScreen.tsx`, `packages/thirdweb/src/crypto/aes/utils/crypto-js-compat.ts`, `packages/thirdweb/src/exports/extensions/erc721.ts`, `packages/thirdweb/src/contract/deployment/deploy-from-uri.ts`, `packages/thirdweb/src/utils/address.test.ts`, `packages/thirdweb/src/react/web/wallets/metamask/metamaskConfig.tsx`, `packages/thirdweb/src/wallets/embedded/implementations/lib/embedded-wallet.ts`, `packages/thirdweb/src/wallets/injected/wallets/zerion.ts`, `package.json`, `packages/thirdweb/benchmarks/read-contract.ts`, `packages/thirdweb/src/react/web/ui/ConnectWallet/icons/twIcon.tsx`, `packages/thirdweb/src/react/web/ui/components/QRCode.tsx`, `packages/thirdweb/src/transaction/actions/wait-for-tx-receipt.test.ts`, `packages/thirdweb/src/exports/utils.ts`, `packages/thirdweb/src/utils/signatures/resolve-signature.ts`, `packages/thirdweb/src/transaction/actions/wait-for-tx-receipt.ts`, `packages/thirdweb/src/transaction/actions/send-transaction.test.ts`, `packages/thirdweb/src/transaction/actions/estimate-gas.ts`, `packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/ConnectModal.tsx`, `packages/thirdweb/src/react/web/wallets/shared/WalletConnectConnection.tsx`, `packages/thirdweb/src/auth/core/verify-login-payload.ts`, `packages/thirdweb/src/react/web/wallets/embedded/EmbeddedWalletSocialLogin.tsx`, `packages/thirdweb/src/auth/core/verify-login-payload.test.ts`, `packages/thirdweb/src/react/web/wallets/local/persist/create/ImportLocalWallet.tsx`, `packages/thirdweb/src/wallets/embedded/implementations/interfaces/embedded-wallets/embedded-wallets.ts`, `packages/thirdweb/README.md`, `packages/thirdweb/src/storage/upload/browser.ts`, `packages/thirdweb/src/wallets/private-key.ts`, `packages/thirdweb/src/react/web/wallets/local/persist/ExportSavedLocalWallet.tsx`, `packages/thirdweb/src/utils/fetch.ts`, `packages/thirdweb/src/utils/ipfs.ts`, `packages/thirdweb/src/event/actions/get-events.ts`, `packages/thirdweb/src/react/web/wallets/local/persist/create/LocalWallet_Persist_Create.tsx`, `packages/thirdweb/src/react/web/wallets/smartWallet/smartWalletConfig.tsx`, `packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/ConnectModalInline.tsx`, `packages/thirdweb/src/contract/verification/constructor-params.ts`, `packages/thirdweb/src/react/core/hooks/contract/useRead.ts`, `packages/thirdweb/src/react/web/wallets/local/persist/connectToSaved/LocalWallet_ConnectToSaved.tsx`, `packages/thirdweb/src/event/actions/parse-logs.test.ts`, `packages/thirdweb/src/auth/verifySignature.ts`, `packages/thirdweb/src/react/web/ui/components/basic.tsx`, `packages/thirdweb/scripts/generate/abis/erc4337/IEntryPoint.json`, `packages/thirdweb/src/exports/react.ts`, `packages/thirdweb/src/utils/promise/p-limit.ts`, `packages/thirdweb/src/utils/bytecode/resolveImplementation.ts`, `packages/thirdweb/src/react/web/ui/TransactionButton/index.tsx`, `packages/thirdweb/src/pay/swap/actions/getSwap.ts`, `packages/thirdweb/src/react/web/ui/components/Modal.tsx`, `packages/thirdweb/src/wallets/embedded/implementations/utils/iFrameCommunication/IframeCommunicator.ts`, `packages/thirdweb/src/utils/units.ts`, `packages/thirdweb/src/react/core/hooks/connection/useAutoConnect.ts`, `packages/thirdweb/src/react/web/ui/ConnectWallet/icons/ThirdwebTextIcon.tsx`, `packages/thirdweb/src/react/web/ui/components/DragNDrop.tsx`, `packages/thirdweb/src/react/native/ui/locales/ja.ts`, `packages/thirdweb/src/react/web/ui/components/ChainIcon.tsx`, `packages/thirdweb/src/rpc/watchBlockNumber.ts`, `packages/thirdweb/src/utils/any-evm/deploy-metadata.ts`, `packages/thirdweb/src/react/native/providers/thirdweb-provider.tsx`, `packages/thirdweb/src/utils/encoding/from-bytes.ts`, `packages/thirdweb/src/react/web/wallets/coinbase/coinbaseConfig.tsx`, `packages/thirdweb/src/transaction/read-contract.ts`, `packages/thirdweb/src/react/web/wallets/shared/GetStartedScreen.tsx`, `packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/ConnectModalContent.tsx`, `packages/thirdweb/src/utils/encoding/to-bytes.ts`, `packages/thirdweb/src/react/web/providers/thirdweb-provider.tsx`, `packages/thirdweb/src/react/core/types/wallets.ts`, `packages/thirdweb/src/utils/base58/encode.test.ts`, `packages/thirdweb/scripts/generate/abis/erc4626/IERC4626.json`, `packages/thirdweb/src/adapters/viem.ts`, `packages/thirdweb/src/wallets/embedded/implementations/lib/auth/base-login.ts`, `packages/thirdweb/src/react/native/ui/locales/en.ts`, `packages/thirdweb/src/react/native/ui/locales/tr.ts`, `packages/thirdweb/src/react/web/wallets/embedded/embeddedWalletConfig.tsx`, `packages/thirdweb/src/react/web/ui/locales/types.ts`, `packages/thirdweb/src/contract/verification/publisher.ts`, `packages/thirdweb/src/exports/thirdweb.ts`, `packages/thirdweb/src/react/web/ui/design-system/index.ts`, `packages/thirdweb/src/utils/uint8-array.ts`, `packages/thirdweb/src/react/native/ui/locales/es.ts`, `packages/thirdweb/src/react/native/ui/locales/tl.ts`, `packages/thirdweb/src/contract/verification/index.ts`, `packages/thirdweb/src/react/web/wallets/embedded/EmbeddedWalletFormUI.tsx`, `packages/thirdweb/src/react/core/providers/thirdweb-provider.tsx`, `packages/thirdweb/package.json`, `packages/thirdweb/src/contract/deployment/utils/create-2-factory.ts`, `packages/thirdweb/src/react/web/wallets/walletConnect/walletConnectConfig.tsx`, `packages/thirdweb/src/transaction/prepare-contract-call.ts`, `packages/thirdweb/src/wallets/wallet-connect/types.ts`, `packages/thirdweb/src/storage/upload/mobile.ts`, `packages/thirdweb/src/react/core/hooks/wallets/wallet-hooks.tsx`, `packages/thirdweb/src/storage/upload/helpers.ts`, `packages/thirdweb/src/wallets/manager/index.ts`, `packages/thirdweb/src/wallets/smart/lib/userop.ts`, `packages/thirdweb/src/react/web/wallets/smartWallet/SmartWalletConnectUI.tsx`, `packages/thirdweb/src/wallets/embedded/implementations/lib/auth/index.ts`, `packages/thirdweb/src/gas/fee-data.ts`, `packages/thirdweb/src/wallets/injected/wallets/rainbow.ts`, `packages/thirdweb/src/react/web/ui/ConnectWallet/ConnectWallet.tsx`, `packages/thirdweb/src/chains/utils.ts`, `packages/thirdweb/src/cli/commands/generate/generate.ts`, `packages/thirdweb/src/wallets/injected/wallets/metamask.ts`, `packages/thirdweb/test/src/abis/doodles.ts`, `packages/thirdweb/src/wallets/embedded/implementations/lib/core/embedded-wallet.ts`, `packages/thirdweb/src/react/web/wallets/embedded/EmbeddedWalletOTPLoginUI.tsx`, `packages/thirdweb/src/utils/abi/encodeAbiParameters.ts`, `packages/thirdweb/scripts/generate/generate.ts`, `packages/thirdweb/src/rpc/rpc.ts`, `packages/thirdweb/src/react/web/ui/locales/ja.ts`, `packages/thirdweb/src/wallets/embedded/core/wallet/index.ts`, `packages/thirdweb/src/utils/bytecode/cbor-decode.ts`, `packages/thirdweb/src/contract/actions/resolve-abi.ts`, `packages/thirdweb/src/react/web/ui/ConnectWallet/icons/dataUris.ts`, `packages/thirdweb/src/wallets/local/types.ts`, `packages/thirdweb/src/react/web/ui/locales/en.ts`, `packages/thirdweb/src/react/web/ui/MediaRenderer/MediaRenderer.tsx`, `packages/thirdweb/src/extensions/erc721/read/getNFTs.test.ts`, `packages/thirdweb/src/crypto/aes/lib/md5.ts`, `packages/thirdweb/src/react/web/ui/ConnectWallet/screens/SendFunds.tsx`, `packages/thirdweb/src/react/web/ui/locales/es.ts`, `packages/thirdweb/src/wallets/injected/index.ts`, `packages/thirdweb/src/react/web/ui/locales/tl.ts`, `packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/ConnectEmbed.tsx`, `packages/thirdweb/src/react/web/ui/ConnectWallet/WalletSelector.tsx`, `packages/thirdweb/src/adapters/ethers5.ts`, `packages/thirdweb/src/react/web/ui/ConnectWallet/icons/socialLogins.ts`, `packages/thirdweb/src/react/web/ui/ConnectWallet/ConnectWalletProps.ts`, `packages/thirdweb/src/utils/units.test.ts`, `packages/thirdweb/src/adapters/ethers6.ts`, `packages/thirdweb/src/react/web/providers/wallet-ui-states-provider.tsx`, `packages/thirdweb/src/utils/encoding/hex.ts`, `packages/thirdweb/src/wallets/coinbase/coinbaseSDKWallet.ts`, `packages/thirdweb/src/wallets/smart/index.ts`, `packages/thirdweb/test/src/abis/usdc.ts`, `packages/thirdweb/src/react/web/ui/ConnectWallet/NetworkSelector.tsx`, `packages/thirdweb/src/react/web/ui/ConnectWallet/Details.tsx`, `packages/thirdweb/src/wallets/wallet-connect/index.ts`, `packages/thirdweb/src/wallets/local/index.ts`, `packages/thirdweb/src/react/web/ui/ConnectWallet/defaultTokens.ts`, `packages/thirdweb/test/src/bytecode/doodles.bytecode`, `packages/thirdweb/src/react/web/ui/ConnectWallet/icons/GlobalIcon.tsx`, `pnpm-lock.yaml`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->