### PR TITLE
fix(sdk): dev deployments and bundleId=undefined query params

### DIFF
--- a/.changeset/polite-toes-retire.md
+++ b/.changeset/polite-toes-retire.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/chains": patch
+---
+
+do not append `?bundleId` query param to rpc url if the bundle id is undefined

--- a/.changeset/sour-candles-wave.md
+++ b/.changeset/sour-candles-wave.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/sdk": patch
+---
+
+do not overwrite chains in supportedChains computation

--- a/packages/chains/src/utils.ts
+++ b/packages/chains/src/utils.ts
@@ -99,7 +99,9 @@ export function getValidChainRPCs(
       if (clientId) {
         processedRPCs.push(
           rpc.replace("${THIRDWEB_API_KEY}", clientId) +
-            (typeof globalThis !== "undefined" && "APP_BUNDLE_ID" in globalThis
+            (typeof globalThis !== "undefined" &&
+            "APP_BUNDLE_ID" in globalThis &&
+            !!(globalThis as any).APP_BUNDLE_ID
               ? // @ts-ignore
                 `/?bundleId=${globalThis.APP_BUNDLE_ID}`
               : ""),

--- a/packages/sdk/src/evm/constants/urls.ts
+++ b/packages/sdk/src/evm/constants/urls.ts
@@ -17,7 +17,10 @@ import { setAnalyticsHeaders } from "../../core/utils/headers";
 function buildDefaultMap(options: SDKOptionsOutput) {
   return options.supportedChains.reduce(
     (previousValue, currentValue) => {
-      previousValue[currentValue.chainId] = currentValue;
+      // don't overwrite existing chains!
+      if (!previousValue[currentValue.chainId]) {
+        previousValue[currentValue.chainId] = currentValue;
+      }
       return previousValue;
     },
     {} as Record<number, ChainInfo>,


### PR DESCRIPTION
1. fix dev deployments by not overwriting existing chains
2. fix ?bundleId=undefined spam

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on preventing overwriting chains in supportedChains computation and avoiding appending `?bundleId` query param if bundle id is undefined.

### Detailed summary
- Prevent overwriting chains in supportedChains computation
- Avoid appending `?bundleId` query param if bundle id is undefined

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->