### PR TITLE
refactor(any-evm-constants): Simplify matchError function

### DIFF
--- a/.changeset/young-cougars-serve.md
+++ b/.changeset/young-cougars-serve.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/sdk": patch
+---
+
+simplify matchError function

--- a/packages/sdk/src/evm/common/any-evm-constants.ts
+++ b/packages/sdk/src/evm/common/any-evm-constants.ts
@@ -76,21 +76,19 @@ export const CUSTOM_GAS_FOR_CHAIN: Record<number, CustomChain> = {
     gasLimit: 200000,
   },
 };
-/* eslint-enable no-useless-computed-key */
 
 export function matchError(error: string): boolean {
-  const errorIndex = ERROR_SUBSTRINGS.findIndex((substring) =>
+  const hasError = ERROR_SUBSTRINGS.some((substring) =>
     error.includes(substring),
   );
+  // can early exit if we find a match
+  if (hasError) {
+    return true;
+  }
 
-  const compositeErrorIndex = ERROR_SUBSTRINGS_COMPOSITE.findIndex((arr) => {
-    let foundError = true;
-    arr.forEach((substring) => {
-      foundError &&= error.includes(substring);
-    });
-
-    return foundError;
+  const hasCompositeError = ERROR_SUBSTRINGS_COMPOSITE.some((arr) => {
+    return arr.some((substring) => error.includes(substring));
   });
 
-  return errorIndex !== -1 || compositeErrorIndex !== -1;
+  return hasCompositeError;
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR simplifies the `matchError` function in `any-evm-constants.ts` for better readability and efficiency.

### Detailed summary
- Refactored the `matchError` function to use `some` instead of `findIndex`
- Added early exit condition if a match is found
- Improved handling of composite errors using `some` instead of `forEach`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->