### PR TITLE
add generated encode and decode functions for extensions

### DIFF
--- a/packages/thirdweb/src/extensions/common/__generated__/IClaimConditionsSinglePhase/write/setClaimConditions.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IClaimConditionsSinglePhase/write/setClaimConditions.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "setClaimConditions" function.
@@ -34,6 +35,76 @@ export type SetClaimConditionsParams = Prettify<
       asyncParams: () => Promise<SetClaimConditionsParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x426cfaf3" as const;
+const FN_INPUTS = [
+  {
+    type: "tuple",
+    name: "phase",
+    components: [
+      {
+        type: "uint256",
+        name: "startTimestamp",
+      },
+      {
+        type: "uint256",
+        name: "maxClaimableSupply",
+      },
+      {
+        type: "uint256",
+        name: "supplyClaimed",
+      },
+      {
+        type: "uint256",
+        name: "quantityLimitPerWallet",
+      },
+      {
+        type: "bytes32",
+        name: "merkleRoot",
+      },
+      {
+        type: "uint256",
+        name: "pricePerToken",
+      },
+      {
+        type: "address",
+        name: "currency",
+      },
+      {
+        type: "string",
+        name: "metadata",
+      },
+    ],
+  },
+  {
+    type: "bool",
+    name: "resetClaimEligibility",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "setClaimConditions" function.
+ * @param options - The options for the setClaimConditions function.
+ * @returns The encoded ABI parameters.
+ * @extension COMMON
+ * @example
+ * ```
+ * import { encodeSetClaimConditionsParams } "thirdweb/extensions/common";
+ * const result = encodeSetClaimConditionsParams({
+ *  phase: ...,
+ *  resetClaimEligibility: ...,
+ * });
+ * ```
+ */
+export function encodeSetClaimConditionsParams(
+  options: SetClaimConditionsParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.phase,
+    options.resetClaimEligibility,
+  ]);
+}
+
 /**
  * Calls the "setClaimConditions" function on the contract.
  * @param options - The options for the "setClaimConditions" function.
@@ -58,54 +129,7 @@ export function setClaimConditions(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x426cfaf3",
-      [
-        {
-          type: "tuple",
-          name: "phase",
-          components: [
-            {
-              type: "uint256",
-              name: "startTimestamp",
-            },
-            {
-              type: "uint256",
-              name: "maxClaimableSupply",
-            },
-            {
-              type: "uint256",
-              name: "supplyClaimed",
-            },
-            {
-              type: "uint256",
-              name: "quantityLimitPerWallet",
-            },
-            {
-              type: "bytes32",
-              name: "merkleRoot",
-            },
-            {
-              type: "uint256",
-              name: "pricePerToken",
-            },
-            {
-              type: "address",
-              name: "currency",
-            },
-            {
-              type: "string",
-              name: "metadata",
-            },
-          ],
-        },
-        {
-          type: "bool",
-          name: "resetClaimEligibility",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/common/__generated__/IContractMetadata/read/contractURI.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IContractMetadata/read/contractURI.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0xe8a3d485" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "string",
+  },
+] as const;
+
+/**
+ * Decodes the result of the contractURI function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension COMMON
+ * @example
+ * ```
+ * import { decodeContractURIResult } from "thirdweb/extensions/common";
+ * const result = decodeContractURIResult("...");
+ * ```
+ */
+export function decodeContractURIResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "contractURI" function on the contract.
  * @param options - The options for the contractURI function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function contractURI(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xe8a3d485",
-      [],
-      [
-        {
-          type: "string",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/common/__generated__/IContractMetadata/read/name.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IContractMetadata/read/name.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x06fdde03" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "string",
+  },
+] as const;
+
+/**
+ * Decodes the result of the name function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension COMMON
+ * @example
+ * ```
+ * import { decodeNameResult } from "thirdweb/extensions/common";
+ * const result = decodeNameResult("...");
+ * ```
+ */
+export function decodeNameResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "name" function on the contract.
  * @param options - The options for the name function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function name(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x06fdde03",
-      [],
-      [
-        {
-          type: "string",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/common/__generated__/IContractMetadata/read/symbol.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IContractMetadata/read/symbol.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x95d89b41" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "string",
+  },
+] as const;
+
+/**
+ * Decodes the result of the symbol function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension COMMON
+ * @example
+ * ```
+ * import { decodeSymbolResult } from "thirdweb/extensions/common";
+ * const result = decodeSymbolResult("...");
+ * ```
+ */
+export function decodeSymbolResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "symbol" function on the contract.
  * @param options - The options for the symbol function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function symbol(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x95d89b41",
-      [],
-      [
-        {
-          type: "string",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/common/__generated__/IContractMetadata/write/setContractURI.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IContractMetadata/write/setContractURI.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "setContractURI" function.
@@ -17,6 +18,34 @@ export type SetContractURIParams = Prettify<
       asyncParams: () => Promise<SetContractURIParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x938e3d7b" as const;
+const FN_INPUTS = [
+  {
+    type: "string",
+    name: "_uri",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "setContractURI" function.
+ * @param options - The options for the setContractURI function.
+ * @returns The encoded ABI parameters.
+ * @extension COMMON
+ * @example
+ * ```
+ * import { encodeSetContractURIParams } "thirdweb/extensions/common";
+ * const result = encodeSetContractURIParams({
+ *  uri: ...,
+ * });
+ * ```
+ */
+export function encodeSetContractURIParams(
+  options: SetContractURIParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.uri]);
+}
+
 /**
  * Calls the "setContractURI" function on the contract.
  * @param options - The options for the "setContractURI" function.
@@ -40,16 +69,7 @@ export function setContractURI(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x938e3d7b",
-      [
-        {
-          type: "string",
-          name: "_uri",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/common/__generated__/IMulticall/write/multicall.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IMulticall/write/multicall.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "multicall" function.
@@ -17,6 +18,37 @@ export type MulticallParams = Prettify<
       asyncParams: () => Promise<MulticallParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xac9650d8" as const;
+const FN_INPUTS = [
+  {
+    type: "bytes[]",
+    name: "data",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bytes[]",
+    name: "results",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "multicall" function.
+ * @param options - The options for the multicall function.
+ * @returns The encoded ABI parameters.
+ * @extension COMMON
+ * @example
+ * ```
+ * import { encodeMulticallParams } "thirdweb/extensions/common";
+ * const result = encodeMulticallParams({
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeMulticallParams(options: MulticallParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.data]);
+}
+
 /**
  * Calls the "multicall" function on the contract.
  * @param options - The options for the "multicall" function.
@@ -38,21 +70,7 @@ export type MulticallParams = Prettify<
 export function multicall(options: BaseTransactionOptions<MulticallParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xac9650d8",
-      [
-        {
-          type: "bytes[]",
-          name: "data",
-        },
-      ],
-      [
-        {
-          type: "bytes[]",
-          name: "results",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/common/__generated__/IOwnable/read/owner.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IOwnable/read/owner.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x8da5cb5b" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "address",
+  },
+] as const;
+
+/**
+ * Decodes the result of the owner function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension COMMON
+ * @example
+ * ```
+ * import { decodeOwnerResult } from "thirdweb/extensions/common";
+ * const result = decodeOwnerResult("...");
+ * ```
+ */
+export function decodeOwnerResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "owner" function on the contract.
  * @param options - The options for the owner function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function owner(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x8da5cb5b",
-      [],
-      [
-        {
-          type: "address",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/common/__generated__/IOwnable/write/setOwner.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IOwnable/write/setOwner.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "setOwner" function.
@@ -17,6 +18,32 @@ export type SetOwnerParams = Prettify<
       asyncParams: () => Promise<SetOwnerParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x13af4035" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "_newOwner",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "setOwner" function.
+ * @param options - The options for the setOwner function.
+ * @returns The encoded ABI parameters.
+ * @extension COMMON
+ * @example
+ * ```
+ * import { encodeSetOwnerParams } "thirdweb/extensions/common";
+ * const result = encodeSetOwnerParams({
+ *  newOwner: ...,
+ * });
+ * ```
+ */
+export function encodeSetOwnerParams(options: SetOwnerParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.newOwner]);
+}
+
 /**
  * Calls the "setOwner" function on the contract.
  * @param options - The options for the "setOwner" function.
@@ -38,16 +65,7 @@ export type SetOwnerParams = Prettify<
 export function setOwner(options: BaseTransactionOptions<SetOwnerParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x13af4035",
-      [
-        {
-          type: "address",
-          name: "_newOwner",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/common/__generated__/IPermissions/read/getRoleAdmin.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IPermissions/read/getRoleAdmin.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "getRoleAdmin" function.
@@ -8,6 +11,51 @@ import type { AbiParameterToPrimitiveType } from "abitype";
 export type GetRoleAdminParams = {
   role: AbiParameterToPrimitiveType<{ type: "bytes32"; name: "role" }>;
 };
+
+const FN_SELECTOR = "0x248a9ca3" as const;
+const FN_INPUTS = [
+  {
+    type: "bytes32",
+    name: "role",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bytes32",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getRoleAdmin" function.
+ * @param options - The options for the getRoleAdmin function.
+ * @returns The encoded ABI parameters.
+ * @extension COMMON
+ * @example
+ * ```
+ * import { encodeGetRoleAdminParams } "thirdweb/extensions/common";
+ * const result = encodeGetRoleAdminParams({
+ *  role: ...,
+ * });
+ * ```
+ */
+export function encodeGetRoleAdminParams(options: GetRoleAdminParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.role]);
+}
+
+/**
+ * Decodes the result of the getRoleAdmin function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension COMMON
+ * @example
+ * ```
+ * import { decodeGetRoleAdminResult } from "thirdweb/extensions/common";
+ * const result = decodeGetRoleAdminResult("...");
+ * ```
+ */
+export function decodeGetRoleAdminResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "getRoleAdmin" function on the contract.
@@ -29,20 +77,7 @@ export async function getRoleAdmin(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x248a9ca3",
-      [
-        {
-          type: "bytes32",
-          name: "role",
-        },
-      ],
-      [
-        {
-          type: "bytes32",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.role],
   });
 }

--- a/packages/thirdweb/src/extensions/common/__generated__/IPermissions/read/hasRole.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IPermissions/read/hasRole.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "hasRole" function.
@@ -9,6 +12,56 @@ export type HasRoleParams = {
   role: AbiParameterToPrimitiveType<{ type: "bytes32"; name: "role" }>;
   account: AbiParameterToPrimitiveType<{ type: "address"; name: "account" }>;
 };
+
+const FN_SELECTOR = "0x91d14854" as const;
+const FN_INPUTS = [
+  {
+    type: "bytes32",
+    name: "role",
+  },
+  {
+    type: "address",
+    name: "account",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bool",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "hasRole" function.
+ * @param options - The options for the hasRole function.
+ * @returns The encoded ABI parameters.
+ * @extension COMMON
+ * @example
+ * ```
+ * import { encodeHasRoleParams } "thirdweb/extensions/common";
+ * const result = encodeHasRoleParams({
+ *  role: ...,
+ *  account: ...,
+ * });
+ * ```
+ */
+export function encodeHasRoleParams(options: HasRoleParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.role, options.account]);
+}
+
+/**
+ * Decodes the result of the hasRole function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension COMMON
+ * @example
+ * ```
+ * import { decodeHasRoleResult } from "thirdweb/extensions/common";
+ * const result = decodeHasRoleResult("...");
+ * ```
+ */
+export function decodeHasRoleResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "hasRole" function on the contract.
@@ -29,24 +82,7 @@ export type HasRoleParams = {
 export async function hasRole(options: BaseTransactionOptions<HasRoleParams>) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x91d14854",
-      [
-        {
-          type: "bytes32",
-          name: "role",
-        },
-        {
-          type: "address",
-          name: "account",
-        },
-      ],
-      [
-        {
-          type: "bool",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.role, options.account],
   });
 }

--- a/packages/thirdweb/src/extensions/common/__generated__/IPermissions/write/grantRole.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IPermissions/write/grantRole.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "grantRole" function.
@@ -18,6 +19,37 @@ export type GrantRoleParams = Prettify<
       asyncParams: () => Promise<GrantRoleParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x2f2ff15d" as const;
+const FN_INPUTS = [
+  {
+    type: "bytes32",
+    name: "role",
+  },
+  {
+    type: "address",
+    name: "account",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "grantRole" function.
+ * @param options - The options for the grantRole function.
+ * @returns The encoded ABI parameters.
+ * @extension COMMON
+ * @example
+ * ```
+ * import { encodeGrantRoleParams } "thirdweb/extensions/common";
+ * const result = encodeGrantRoleParams({
+ *  role: ...,
+ *  account: ...,
+ * });
+ * ```
+ */
+export function encodeGrantRoleParams(options: GrantRoleParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.role, options.account]);
+}
+
 /**
  * Calls the "grantRole" function on the contract.
  * @param options - The options for the "grantRole" function.
@@ -40,20 +72,7 @@ export type GrantRoleParams = Prettify<
 export function grantRole(options: BaseTransactionOptions<GrantRoleParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x2f2ff15d",
-      [
-        {
-          type: "bytes32",
-          name: "role",
-        },
-        {
-          type: "address",
-          name: "account",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/common/__generated__/IPermissions/write/renounceRole.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IPermissions/write/renounceRole.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "renounceRole" function.
@@ -18,6 +19,37 @@ export type RenounceRoleParams = Prettify<
       asyncParams: () => Promise<RenounceRoleParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x36568abe" as const;
+const FN_INPUTS = [
+  {
+    type: "bytes32",
+    name: "role",
+  },
+  {
+    type: "address",
+    name: "account",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "renounceRole" function.
+ * @param options - The options for the renounceRole function.
+ * @returns The encoded ABI parameters.
+ * @extension COMMON
+ * @example
+ * ```
+ * import { encodeRenounceRoleParams } "thirdweb/extensions/common";
+ * const result = encodeRenounceRoleParams({
+ *  role: ...,
+ *  account: ...,
+ * });
+ * ```
+ */
+export function encodeRenounceRoleParams(options: RenounceRoleParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.role, options.account]);
+}
+
 /**
  * Calls the "renounceRole" function on the contract.
  * @param options - The options for the "renounceRole" function.
@@ -42,20 +74,7 @@ export function renounceRole(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x36568abe",
-      [
-        {
-          type: "bytes32",
-          name: "role",
-        },
-        {
-          type: "address",
-          name: "account",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/common/__generated__/IPermissions/write/revokeRole.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IPermissions/write/revokeRole.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "revokeRole" function.
@@ -18,6 +19,37 @@ export type RevokeRoleParams = Prettify<
       asyncParams: () => Promise<RevokeRoleParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xd547741f" as const;
+const FN_INPUTS = [
+  {
+    type: "bytes32",
+    name: "role",
+  },
+  {
+    type: "address",
+    name: "account",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "revokeRole" function.
+ * @param options - The options for the revokeRole function.
+ * @returns The encoded ABI parameters.
+ * @extension COMMON
+ * @example
+ * ```
+ * import { encodeRevokeRoleParams } "thirdweb/extensions/common";
+ * const result = encodeRevokeRoleParams({
+ *  role: ...,
+ *  account: ...,
+ * });
+ * ```
+ */
+export function encodeRevokeRoleParams(options: RevokeRoleParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.role, options.account]);
+}
+
 /**
  * Calls the "revokeRole" function on the contract.
  * @param options - The options for the "revokeRole" function.
@@ -40,20 +72,7 @@ export type RevokeRoleParams = Prettify<
 export function revokeRole(options: BaseTransactionOptions<RevokeRoleParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xd547741f",
-      [
-        {
-          type: "bytes32",
-          name: "role",
-        },
-        {
-          type: "address",
-          name: "account",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/common/__generated__/IPermissionsEnumerable/read/getRoleAdmin.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IPermissionsEnumerable/read/getRoleAdmin.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "getRoleAdmin" function.
@@ -8,6 +11,51 @@ import type { AbiParameterToPrimitiveType } from "abitype";
 export type GetRoleAdminParams = {
   role: AbiParameterToPrimitiveType<{ type: "bytes32"; name: "role" }>;
 };
+
+const FN_SELECTOR = "0x248a9ca3" as const;
+const FN_INPUTS = [
+  {
+    type: "bytes32",
+    name: "role",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bytes32",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getRoleAdmin" function.
+ * @param options - The options for the getRoleAdmin function.
+ * @returns The encoded ABI parameters.
+ * @extension COMMON
+ * @example
+ * ```
+ * import { encodeGetRoleAdminParams } "thirdweb/extensions/common";
+ * const result = encodeGetRoleAdminParams({
+ *  role: ...,
+ * });
+ * ```
+ */
+export function encodeGetRoleAdminParams(options: GetRoleAdminParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.role]);
+}
+
+/**
+ * Decodes the result of the getRoleAdmin function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension COMMON
+ * @example
+ * ```
+ * import { decodeGetRoleAdminResult } from "thirdweb/extensions/common";
+ * const result = decodeGetRoleAdminResult("...");
+ * ```
+ */
+export function decodeGetRoleAdminResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "getRoleAdmin" function on the contract.
@@ -29,20 +77,7 @@ export async function getRoleAdmin(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x248a9ca3",
-      [
-        {
-          type: "bytes32",
-          name: "role",
-        },
-      ],
-      [
-        {
-          type: "bytes32",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.role],
   });
 }

--- a/packages/thirdweb/src/extensions/common/__generated__/IPermissionsEnumerable/read/getRoleMember.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IPermissionsEnumerable/read/getRoleMember.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "getRoleMember" function.
@@ -9,6 +12,56 @@ export type GetRoleMemberParams = {
   role: AbiParameterToPrimitiveType<{ type: "bytes32"; name: "role" }>;
   index: AbiParameterToPrimitiveType<{ type: "uint256"; name: "index" }>;
 };
+
+const FN_SELECTOR = "0x9010d07c" as const;
+const FN_INPUTS = [
+  {
+    type: "bytes32",
+    name: "role",
+  },
+  {
+    type: "uint256",
+    name: "index",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "address",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getRoleMember" function.
+ * @param options - The options for the getRoleMember function.
+ * @returns The encoded ABI parameters.
+ * @extension COMMON
+ * @example
+ * ```
+ * import { encodeGetRoleMemberParams } "thirdweb/extensions/common";
+ * const result = encodeGetRoleMemberParams({
+ *  role: ...,
+ *  index: ...,
+ * });
+ * ```
+ */
+export function encodeGetRoleMemberParams(options: GetRoleMemberParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.role, options.index]);
+}
+
+/**
+ * Decodes the result of the getRoleMember function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension COMMON
+ * @example
+ * ```
+ * import { decodeGetRoleMemberResult } from "thirdweb/extensions/common";
+ * const result = decodeGetRoleMemberResult("...");
+ * ```
+ */
+export function decodeGetRoleMemberResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "getRoleMember" function on the contract.
@@ -31,24 +84,7 @@ export async function getRoleMember(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x9010d07c",
-      [
-        {
-          type: "bytes32",
-          name: "role",
-        },
-        {
-          type: "uint256",
-          name: "index",
-        },
-      ],
-      [
-        {
-          type: "address",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.role, options.index],
   });
 }

--- a/packages/thirdweb/src/extensions/common/__generated__/IPermissionsEnumerable/read/getRoleMemberCount.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IPermissionsEnumerable/read/getRoleMemberCount.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "getRoleMemberCount" function.
@@ -8,6 +11,53 @@ import type { AbiParameterToPrimitiveType } from "abitype";
 export type GetRoleMemberCountParams = {
   role: AbiParameterToPrimitiveType<{ type: "bytes32"; name: "role" }>;
 };
+
+const FN_SELECTOR = "0xca15c873" as const;
+const FN_INPUTS = [
+  {
+    type: "bytes32",
+    name: "role",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getRoleMemberCount" function.
+ * @param options - The options for the getRoleMemberCount function.
+ * @returns The encoded ABI parameters.
+ * @extension COMMON
+ * @example
+ * ```
+ * import { encodeGetRoleMemberCountParams } "thirdweb/extensions/common";
+ * const result = encodeGetRoleMemberCountParams({
+ *  role: ...,
+ * });
+ * ```
+ */
+export function encodeGetRoleMemberCountParams(
+  options: GetRoleMemberCountParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.role]);
+}
+
+/**
+ * Decodes the result of the getRoleMemberCount function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension COMMON
+ * @example
+ * ```
+ * import { decodeGetRoleMemberCountResult } from "thirdweb/extensions/common";
+ * const result = decodeGetRoleMemberCountResult("...");
+ * ```
+ */
+export function decodeGetRoleMemberCountResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "getRoleMemberCount" function on the contract.
@@ -29,20 +79,7 @@ export async function getRoleMemberCount(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xca15c873",
-      [
-        {
-          type: "bytes32",
-          name: "role",
-        },
-      ],
-      [
-        {
-          type: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.role],
   });
 }

--- a/packages/thirdweb/src/extensions/common/__generated__/IPermissionsEnumerable/read/hasRole.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IPermissionsEnumerable/read/hasRole.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "hasRole" function.
@@ -9,6 +12,56 @@ export type HasRoleParams = {
   role: AbiParameterToPrimitiveType<{ type: "bytes32"; name: "role" }>;
   account: AbiParameterToPrimitiveType<{ type: "address"; name: "account" }>;
 };
+
+const FN_SELECTOR = "0x91d14854" as const;
+const FN_INPUTS = [
+  {
+    type: "bytes32",
+    name: "role",
+  },
+  {
+    type: "address",
+    name: "account",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bool",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "hasRole" function.
+ * @param options - The options for the hasRole function.
+ * @returns The encoded ABI parameters.
+ * @extension COMMON
+ * @example
+ * ```
+ * import { encodeHasRoleParams } "thirdweb/extensions/common";
+ * const result = encodeHasRoleParams({
+ *  role: ...,
+ *  account: ...,
+ * });
+ * ```
+ */
+export function encodeHasRoleParams(options: HasRoleParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.role, options.account]);
+}
+
+/**
+ * Decodes the result of the hasRole function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension COMMON
+ * @example
+ * ```
+ * import { decodeHasRoleResult } from "thirdweb/extensions/common";
+ * const result = decodeHasRoleResult("...");
+ * ```
+ */
+export function decodeHasRoleResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "hasRole" function on the contract.
@@ -29,24 +82,7 @@ export type HasRoleParams = {
 export async function hasRole(options: BaseTransactionOptions<HasRoleParams>) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x91d14854",
-      [
-        {
-          type: "bytes32",
-          name: "role",
-        },
-        {
-          type: "address",
-          name: "account",
-        },
-      ],
-      [
-        {
-          type: "bool",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.role, options.account],
   });
 }

--- a/packages/thirdweb/src/extensions/common/__generated__/IPermissionsEnumerable/write/grantRole.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IPermissionsEnumerable/write/grantRole.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "grantRole" function.
@@ -18,6 +19,37 @@ export type GrantRoleParams = Prettify<
       asyncParams: () => Promise<GrantRoleParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x2f2ff15d" as const;
+const FN_INPUTS = [
+  {
+    type: "bytes32",
+    name: "role",
+  },
+  {
+    type: "address",
+    name: "account",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "grantRole" function.
+ * @param options - The options for the grantRole function.
+ * @returns The encoded ABI parameters.
+ * @extension COMMON
+ * @example
+ * ```
+ * import { encodeGrantRoleParams } "thirdweb/extensions/common";
+ * const result = encodeGrantRoleParams({
+ *  role: ...,
+ *  account: ...,
+ * });
+ * ```
+ */
+export function encodeGrantRoleParams(options: GrantRoleParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.role, options.account]);
+}
+
 /**
  * Calls the "grantRole" function on the contract.
  * @param options - The options for the "grantRole" function.
@@ -40,20 +72,7 @@ export type GrantRoleParams = Prettify<
 export function grantRole(options: BaseTransactionOptions<GrantRoleParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x2f2ff15d",
-      [
-        {
-          type: "bytes32",
-          name: "role",
-        },
-        {
-          type: "address",
-          name: "account",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/common/__generated__/IPermissionsEnumerable/write/renounceRole.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IPermissionsEnumerable/write/renounceRole.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "renounceRole" function.
@@ -18,6 +19,37 @@ export type RenounceRoleParams = Prettify<
       asyncParams: () => Promise<RenounceRoleParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x36568abe" as const;
+const FN_INPUTS = [
+  {
+    type: "bytes32",
+    name: "role",
+  },
+  {
+    type: "address",
+    name: "account",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "renounceRole" function.
+ * @param options - The options for the renounceRole function.
+ * @returns The encoded ABI parameters.
+ * @extension COMMON
+ * @example
+ * ```
+ * import { encodeRenounceRoleParams } "thirdweb/extensions/common";
+ * const result = encodeRenounceRoleParams({
+ *  role: ...,
+ *  account: ...,
+ * });
+ * ```
+ */
+export function encodeRenounceRoleParams(options: RenounceRoleParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.role, options.account]);
+}
+
 /**
  * Calls the "renounceRole" function on the contract.
  * @param options - The options for the "renounceRole" function.
@@ -42,20 +74,7 @@ export function renounceRole(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x36568abe",
-      [
-        {
-          type: "bytes32",
-          name: "role",
-        },
-        {
-          type: "address",
-          name: "account",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/common/__generated__/IPermissionsEnumerable/write/revokeRole.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IPermissionsEnumerable/write/revokeRole.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "revokeRole" function.
@@ -18,6 +19,37 @@ export type RevokeRoleParams = Prettify<
       asyncParams: () => Promise<RevokeRoleParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xd547741f" as const;
+const FN_INPUTS = [
+  {
+    type: "bytes32",
+    name: "role",
+  },
+  {
+    type: "address",
+    name: "account",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "revokeRole" function.
+ * @param options - The options for the revokeRole function.
+ * @returns The encoded ABI parameters.
+ * @extension COMMON
+ * @example
+ * ```
+ * import { encodeRevokeRoleParams } "thirdweb/extensions/common";
+ * const result = encodeRevokeRoleParams({
+ *  role: ...,
+ *  account: ...,
+ * });
+ * ```
+ */
+export function encodeRevokeRoleParams(options: RevokeRoleParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.role, options.account]);
+}
+
 /**
  * Calls the "revokeRole" function on the contract.
  * @param options - The options for the "revokeRole" function.
@@ -40,20 +72,7 @@ export type RevokeRoleParams = Prettify<
 export function revokeRole(options: BaseTransactionOptions<RevokeRoleParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xd547741f",
-      [
-        {
-          type: "bytes32",
-          name: "role",
-        },
-        {
-          type: "address",
-          name: "account",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/common/__generated__/IPlatformFee/read/getPlatformFeeInfo.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IPlatformFee/read/getPlatformFeeInfo.ts
@@ -1,6 +1,35 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0xd45573f6" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "address",
+  },
+  {
+    type: "uint16",
+  },
+] as const;
+
+/**
+ * Decodes the result of the getPlatformFeeInfo function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension COMMON
+ * @example
+ * ```
+ * import { decodeGetPlatformFeeInfoResult } from "thirdweb/extensions/common";
+ * const result = decodeGetPlatformFeeInfoResult("...");
+ * ```
+ */
+export function decodeGetPlatformFeeInfoResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result);
+}
+
 /**
  * Calls the "getPlatformFeeInfo" function on the contract.
  * @param options - The options for the getPlatformFeeInfo function.
@@ -17,18 +46,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function getPlatformFeeInfo(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xd45573f6",
-      [],
-      [
-        {
-          type: "address",
-        },
-        {
-          type: "uint16",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/common/__generated__/IPlatformFee/write/setPlatformFeeInfo.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IPlatformFee/write/setPlatformFeeInfo.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "setPlatformFeeInfo" function.
@@ -24,6 +25,42 @@ export type SetPlatformFeeInfoParams = Prettify<
       asyncParams: () => Promise<SetPlatformFeeInfoParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x1e7ac488" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "_platformFeeRecipient",
+  },
+  {
+    type: "uint256",
+    name: "_platformFeeBps",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "setPlatformFeeInfo" function.
+ * @param options - The options for the setPlatformFeeInfo function.
+ * @returns The encoded ABI parameters.
+ * @extension COMMON
+ * @example
+ * ```
+ * import { encodeSetPlatformFeeInfoParams } "thirdweb/extensions/common";
+ * const result = encodeSetPlatformFeeInfoParams({
+ *  platformFeeRecipient: ...,
+ *  platformFeeBps: ...,
+ * });
+ * ```
+ */
+export function encodeSetPlatformFeeInfoParams(
+  options: SetPlatformFeeInfoParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.platformFeeRecipient,
+    options.platformFeeBps,
+  ]);
+}
+
 /**
  * Calls the "setPlatformFeeInfo" function on the contract.
  * @param options - The options for the "setPlatformFeeInfo" function.
@@ -48,20 +85,7 @@ export function setPlatformFeeInfo(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x1e7ac488",
-      [
-        {
-          type: "address",
-          name: "_platformFeeRecipient",
-        },
-        {
-          type: "uint256",
-          name: "_platformFeeBps",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/common/__generated__/IPrimarySale/read/primarySaleRecipient.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IPrimarySale/read/primarySaleRecipient.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x079fe40e" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "address",
+  },
+] as const;
+
+/**
+ * Decodes the result of the primarySaleRecipient function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension COMMON
+ * @example
+ * ```
+ * import { decodePrimarySaleRecipientResult } from "thirdweb/extensions/common";
+ * const result = decodePrimarySaleRecipientResult("...");
+ * ```
+ */
+export function decodePrimarySaleRecipientResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "primarySaleRecipient" function on the contract.
  * @param options - The options for the primarySaleRecipient function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function primarySaleRecipient(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x079fe40e",
-      [],
-      [
-        {
-          type: "address",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/common/__generated__/IPrimarySale/write/setPrimarySaleRecipient.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IPrimarySale/write/setPrimarySaleRecipient.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "setPrimarySaleRecipient" function.
@@ -20,6 +21,34 @@ export type SetPrimarySaleRecipientParams = Prettify<
       asyncParams: () => Promise<SetPrimarySaleRecipientParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x6f4f2837" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "_saleRecipient",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "setPrimarySaleRecipient" function.
+ * @param options - The options for the setPrimarySaleRecipient function.
+ * @returns The encoded ABI parameters.
+ * @extension COMMON
+ * @example
+ * ```
+ * import { encodeSetPrimarySaleRecipientParams } "thirdweb/extensions/common";
+ * const result = encodeSetPrimarySaleRecipientParams({
+ *  saleRecipient: ...,
+ * });
+ * ```
+ */
+export function encodeSetPrimarySaleRecipientParams(
+  options: SetPrimarySaleRecipientParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.saleRecipient]);
+}
+
 /**
  * Calls the "setPrimarySaleRecipient" function on the contract.
  * @param options - The options for the "setPrimarySaleRecipient" function.
@@ -43,16 +72,7 @@ export function setPrimarySaleRecipient(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x6f4f2837",
-      [
-        {
-          type: "address",
-          name: "_saleRecipient",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/common/__generated__/IRoyalty/read/getDefaultRoyaltyInfo.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IRoyalty/read/getDefaultRoyaltyInfo.ts
@@ -1,6 +1,35 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0xb24f2d39" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "address",
+  },
+  {
+    type: "uint16",
+  },
+] as const;
+
+/**
+ * Decodes the result of the getDefaultRoyaltyInfo function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension COMMON
+ * @example
+ * ```
+ * import { decodeGetDefaultRoyaltyInfoResult } from "thirdweb/extensions/common";
+ * const result = decodeGetDefaultRoyaltyInfoResult("...");
+ * ```
+ */
+export function decodeGetDefaultRoyaltyInfoResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result);
+}
+
 /**
  * Calls the "getDefaultRoyaltyInfo" function on the contract.
  * @param options - The options for the getDefaultRoyaltyInfo function.
@@ -17,18 +46,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function getDefaultRoyaltyInfo(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xb24f2d39",
-      [],
-      [
-        {
-          type: "address",
-        },
-        {
-          type: "uint16",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/common/__generated__/IRoyalty/read/getRoyaltyInfoForToken.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IRoyalty/read/getRoyaltyInfoForToken.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "getRoyaltyInfoForToken" function.
@@ -8,6 +11,56 @@ import type { AbiParameterToPrimitiveType } from "abitype";
 export type GetRoyaltyInfoForTokenParams = {
   tokenId: AbiParameterToPrimitiveType<{ type: "uint256"; name: "tokenId" }>;
 };
+
+const FN_SELECTOR = "0x4cc157df" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "tokenId",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "address",
+  },
+  {
+    type: "uint16",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getRoyaltyInfoForToken" function.
+ * @param options - The options for the getRoyaltyInfoForToken function.
+ * @returns The encoded ABI parameters.
+ * @extension COMMON
+ * @example
+ * ```
+ * import { encodeGetRoyaltyInfoForTokenParams } "thirdweb/extensions/common";
+ * const result = encodeGetRoyaltyInfoForTokenParams({
+ *  tokenId: ...,
+ * });
+ * ```
+ */
+export function encodeGetRoyaltyInfoForTokenParams(
+  options: GetRoyaltyInfoForTokenParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.tokenId]);
+}
+
+/**
+ * Decodes the result of the getRoyaltyInfoForToken function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension COMMON
+ * @example
+ * ```
+ * import { decodeGetRoyaltyInfoForTokenResult } from "thirdweb/extensions/common";
+ * const result = decodeGetRoyaltyInfoForTokenResult("...");
+ * ```
+ */
+export function decodeGetRoyaltyInfoForTokenResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result);
+}
 
 /**
  * Calls the "getRoyaltyInfoForToken" function on the contract.
@@ -29,23 +82,7 @@ export async function getRoyaltyInfoForToken(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x4cc157df",
-      [
-        {
-          type: "uint256",
-          name: "tokenId",
-        },
-      ],
-      [
-        {
-          type: "address",
-        },
-        {
-          type: "uint16",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.tokenId],
   });
 }

--- a/packages/thirdweb/src/extensions/common/__generated__/IRoyalty/read/royaltyInfo.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IRoyalty/read/royaltyInfo.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "royaltyInfo" function.
@@ -12,6 +15,61 @@ export type RoyaltyInfoParams = {
     name: "salePrice";
   }>;
 };
+
+const FN_SELECTOR = "0x2a55205a" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "tokenId",
+  },
+  {
+    type: "uint256",
+    name: "salePrice",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "address",
+    name: "receiver",
+  },
+  {
+    type: "uint256",
+    name: "royaltyAmount",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "royaltyInfo" function.
+ * @param options - The options for the royaltyInfo function.
+ * @returns The encoded ABI parameters.
+ * @extension COMMON
+ * @example
+ * ```
+ * import { encodeRoyaltyInfoParams } "thirdweb/extensions/common";
+ * const result = encodeRoyaltyInfoParams({
+ *  tokenId: ...,
+ *  salePrice: ...,
+ * });
+ * ```
+ */
+export function encodeRoyaltyInfoParams(options: RoyaltyInfoParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.tokenId, options.salePrice]);
+}
+
+/**
+ * Decodes the result of the royaltyInfo function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension COMMON
+ * @example
+ * ```
+ * import { decodeRoyaltyInfoResult } from "thirdweb/extensions/common";
+ * const result = decodeRoyaltyInfoResult("...");
+ * ```
+ */
+export function decodeRoyaltyInfoResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result);
+}
 
 /**
  * Calls the "royaltyInfo" function on the contract.
@@ -34,29 +92,7 @@ export async function royaltyInfo(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x2a55205a",
-      [
-        {
-          type: "uint256",
-          name: "tokenId",
-        },
-        {
-          type: "uint256",
-          name: "salePrice",
-        },
-      ],
-      [
-        {
-          type: "address",
-          name: "receiver",
-        },
-        {
-          type: "uint256",
-          name: "royaltyAmount",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.tokenId, options.salePrice],
   });
 }

--- a/packages/thirdweb/src/extensions/common/__generated__/IRoyalty/read/supportsInterface.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IRoyalty/read/supportsInterface.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "supportsInterface" function.
@@ -11,6 +14,53 @@ export type SupportsInterfaceParams = {
     name: "interfaceId";
   }>;
 };
+
+const FN_SELECTOR = "0x01ffc9a7" as const;
+const FN_INPUTS = [
+  {
+    type: "bytes4",
+    name: "interfaceId",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bool",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "supportsInterface" function.
+ * @param options - The options for the supportsInterface function.
+ * @returns The encoded ABI parameters.
+ * @extension COMMON
+ * @example
+ * ```
+ * import { encodeSupportsInterfaceParams } "thirdweb/extensions/common";
+ * const result = encodeSupportsInterfaceParams({
+ *  interfaceId: ...,
+ * });
+ * ```
+ */
+export function encodeSupportsInterfaceParams(
+  options: SupportsInterfaceParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.interfaceId]);
+}
+
+/**
+ * Decodes the result of the supportsInterface function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension COMMON
+ * @example
+ * ```
+ * import { decodeSupportsInterfaceResult } from "thirdweb/extensions/common";
+ * const result = decodeSupportsInterfaceResult("...");
+ * ```
+ */
+export function decodeSupportsInterfaceResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "supportsInterface" function on the contract.
@@ -32,20 +82,7 @@ export async function supportsInterface(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x01ffc9a7",
-      [
-        {
-          type: "bytes4",
-          name: "interfaceId",
-        },
-      ],
-      [
-        {
-          type: "bool",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.interfaceId],
   });
 }

--- a/packages/thirdweb/src/extensions/common/__generated__/IRoyalty/write/setDefaultRoyaltyInfo.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IRoyalty/write/setDefaultRoyaltyInfo.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "setDefaultRoyaltyInfo" function.
@@ -24,6 +25,42 @@ export type SetDefaultRoyaltyInfoParams = Prettify<
       asyncParams: () => Promise<SetDefaultRoyaltyInfoParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x600dd5ea" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "_royaltyRecipient",
+  },
+  {
+    type: "uint256",
+    name: "_royaltyBps",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "setDefaultRoyaltyInfo" function.
+ * @param options - The options for the setDefaultRoyaltyInfo function.
+ * @returns The encoded ABI parameters.
+ * @extension COMMON
+ * @example
+ * ```
+ * import { encodeSetDefaultRoyaltyInfoParams } "thirdweb/extensions/common";
+ * const result = encodeSetDefaultRoyaltyInfoParams({
+ *  royaltyRecipient: ...,
+ *  royaltyBps: ...,
+ * });
+ * ```
+ */
+export function encodeSetDefaultRoyaltyInfoParams(
+  options: SetDefaultRoyaltyInfoParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.royaltyRecipient,
+    options.royaltyBps,
+  ]);
+}
+
 /**
  * Calls the "setDefaultRoyaltyInfo" function on the contract.
  * @param options - The options for the "setDefaultRoyaltyInfo" function.
@@ -48,20 +85,7 @@ export function setDefaultRoyaltyInfo(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x600dd5ea",
-      [
-        {
-          type: "address",
-          name: "_royaltyRecipient",
-        },
-        {
-          type: "uint256",
-          name: "_royaltyBps",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/common/__generated__/IRoyalty/write/setRoyaltyInfoForToken.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IRoyalty/write/setRoyaltyInfoForToken.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "setRoyaltyInfoForToken" function.
@@ -22,6 +23,48 @@ export type SetRoyaltyInfoForTokenParams = Prettify<
       asyncParams: () => Promise<SetRoyaltyInfoForTokenParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x9bcf7a15" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "tokenId",
+  },
+  {
+    type: "address",
+    name: "recipient",
+  },
+  {
+    type: "uint256",
+    name: "bps",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "setRoyaltyInfoForToken" function.
+ * @param options - The options for the setRoyaltyInfoForToken function.
+ * @returns The encoded ABI parameters.
+ * @extension COMMON
+ * @example
+ * ```
+ * import { encodeSetRoyaltyInfoForTokenParams } "thirdweb/extensions/common";
+ * const result = encodeSetRoyaltyInfoForTokenParams({
+ *  tokenId: ...,
+ *  recipient: ...,
+ *  bps: ...,
+ * });
+ * ```
+ */
+export function encodeSetRoyaltyInfoForTokenParams(
+  options: SetRoyaltyInfoForTokenParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.tokenId,
+    options.recipient,
+    options.bps,
+  ]);
+}
+
 /**
  * Calls the "setRoyaltyInfoForToken" function on the contract.
  * @param options - The options for the "setRoyaltyInfoForToken" function.
@@ -47,24 +90,7 @@ export function setRoyaltyInfoForToken(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x9bcf7a15",
-      [
-        {
-          type: "uint256",
-          name: "tokenId",
-        },
-        {
-          type: "address",
-          name: "recipient",
-        },
-        {
-          type: "uint256",
-          name: "bps",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/common/__generated__/IRoyaltyPayments/read/supportsInterface.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IRoyaltyPayments/read/supportsInterface.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "supportsInterface" function.
@@ -11,6 +14,53 @@ export type SupportsInterfaceParams = {
     name: "interfaceId";
   }>;
 };
+
+const FN_SELECTOR = "0x01ffc9a7" as const;
+const FN_INPUTS = [
+  {
+    type: "bytes4",
+    name: "interfaceId",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bool",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "supportsInterface" function.
+ * @param options - The options for the supportsInterface function.
+ * @returns The encoded ABI parameters.
+ * @extension COMMON
+ * @example
+ * ```
+ * import { encodeSupportsInterfaceParams } "thirdweb/extensions/common";
+ * const result = encodeSupportsInterfaceParams({
+ *  interfaceId: ...,
+ * });
+ * ```
+ */
+export function encodeSupportsInterfaceParams(
+  options: SupportsInterfaceParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.interfaceId]);
+}
+
+/**
+ * Decodes the result of the supportsInterface function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension COMMON
+ * @example
+ * ```
+ * import { decodeSupportsInterfaceResult } from "thirdweb/extensions/common";
+ * const result = decodeSupportsInterfaceResult("...");
+ * ```
+ */
+export function decodeSupportsInterfaceResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "supportsInterface" function on the contract.
@@ -32,20 +82,7 @@ export async function supportsInterface(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x01ffc9a7",
-      [
-        {
-          type: "bytes4",
-          name: "interfaceId",
-        },
-      ],
-      [
-        {
-          type: "bool",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.interfaceId],
   });
 }

--- a/packages/thirdweb/src/extensions/common/__generated__/IRoyaltyPayments/write/getRoyalty.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IRoyaltyPayments/write/getRoyalty.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "getRoyalty" function.
@@ -22,6 +23,55 @@ export type GetRoyaltyParams = Prettify<
       asyncParams: () => Promise<GetRoyaltyParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xf533b802" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "tokenAddress",
+  },
+  {
+    type: "uint256",
+    name: "tokenId",
+  },
+  {
+    type: "uint256",
+    name: "value",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "address[]",
+    name: "recipients",
+  },
+  {
+    type: "uint256[]",
+    name: "amounts",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getRoyalty" function.
+ * @param options - The options for the getRoyalty function.
+ * @returns The encoded ABI parameters.
+ * @extension COMMON
+ * @example
+ * ```
+ * import { encodeGetRoyaltyParams } "thirdweb/extensions/common";
+ * const result = encodeGetRoyaltyParams({
+ *  tokenAddress: ...,
+ *  tokenId: ...,
+ *  value: ...,
+ * });
+ * ```
+ */
+export function encodeGetRoyaltyParams(options: GetRoyaltyParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.tokenAddress,
+    options.tokenId,
+    options.value,
+  ]);
+}
+
 /**
  * Calls the "getRoyalty" function on the contract.
  * @param options - The options for the "getRoyalty" function.
@@ -45,33 +95,7 @@ export type GetRoyaltyParams = Prettify<
 export function getRoyalty(options: BaseTransactionOptions<GetRoyaltyParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xf533b802",
-      [
-        {
-          type: "address",
-          name: "tokenAddress",
-        },
-        {
-          type: "uint256",
-          name: "tokenId",
-        },
-        {
-          type: "uint256",
-          name: "value",
-        },
-      ],
-      [
-        {
-          type: "address[]",
-          name: "recipients",
-        },
-        {
-          type: "uint256[]",
-          name: "amounts",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/common/__generated__/IRoyaltyPayments/write/setRoyaltyEngine.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IRoyaltyPayments/write/setRoyaltyEngine.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "setRoyaltyEngine" function.
@@ -20,6 +21,34 @@ export type SetRoyaltyEngineParams = Prettify<
       asyncParams: () => Promise<SetRoyaltyEngineParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x21ede032" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "_royaltyEngineAddress",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "setRoyaltyEngine" function.
+ * @param options - The options for the setRoyaltyEngine function.
+ * @returns The encoded ABI parameters.
+ * @extension COMMON
+ * @example
+ * ```
+ * import { encodeSetRoyaltyEngineParams } "thirdweb/extensions/common";
+ * const result = encodeSetRoyaltyEngineParams({
+ *  royaltyEngineAddress: ...,
+ * });
+ * ```
+ */
+export function encodeSetRoyaltyEngineParams(
+  options: SetRoyaltyEngineParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.royaltyEngineAddress]);
+}
+
 /**
  * Calls the "setRoyaltyEngine" function on the contract.
  * @param options - The options for the "setRoyaltyEngine" function.
@@ -43,16 +72,7 @@ export function setRoyaltyEngine(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x21ede032",
-      [
-        {
-          type: "address",
-          name: "_royaltyEngineAddress",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/ens/__generated__/AddressResolver/read/addr.ts
+++ b/packages/thirdweb/src/extensions/ens/__generated__/AddressResolver/read/addr.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "addr" function.
@@ -8,6 +11,51 @@ import type { AbiParameterToPrimitiveType } from "abitype";
 export type AddrParams = {
   name: AbiParameterToPrimitiveType<{ type: "bytes32"; name: "name" }>;
 };
+
+const FN_SELECTOR = "0x3b3b57de" as const;
+const FN_INPUTS = [
+  {
+    type: "bytes32",
+    name: "name",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "address",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "addr" function.
+ * @param options - The options for the addr function.
+ * @returns The encoded ABI parameters.
+ * @extension ENS
+ * @example
+ * ```
+ * import { encodeAddrParams } "thirdweb/extensions/ens";
+ * const result = encodeAddrParams({
+ *  name: ...,
+ * });
+ * ```
+ */
+export function encodeAddrParams(options: AddrParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.name]);
+}
+
+/**
+ * Decodes the result of the addr function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ENS
+ * @example
+ * ```
+ * import { decodeAddrResult } from "thirdweb/extensions/ens";
+ * const result = decodeAddrResult("...");
+ * ```
+ */
+export function decodeAddrResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "addr" function on the contract.
@@ -27,20 +75,7 @@ export type AddrParams = {
 export async function addr(options: BaseTransactionOptions<AddrParams>) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x3b3b57de",
-      [
-        {
-          type: "bytes32",
-          name: "name",
-        },
-      ],
-      [
-        {
-          type: "address",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.name],
   });
 }

--- a/packages/thirdweb/src/extensions/ens/__generated__/UniversalResolver/read/resolve.ts
+++ b/packages/thirdweb/src/extensions/ens/__generated__/UniversalResolver/read/resolve.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "resolve" function.
@@ -9,6 +12,59 @@ export type ResolveParams = {
   name: AbiParameterToPrimitiveType<{ type: "bytes"; name: "name" }>;
   data: AbiParameterToPrimitiveType<{ type: "bytes"; name: "data" }>;
 };
+
+const FN_SELECTOR = "0x9061b923" as const;
+const FN_INPUTS = [
+  {
+    type: "bytes",
+    name: "name",
+  },
+  {
+    type: "bytes",
+    name: "data",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bytes",
+  },
+  {
+    type: "address",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "resolve" function.
+ * @param options - The options for the resolve function.
+ * @returns The encoded ABI parameters.
+ * @extension ENS
+ * @example
+ * ```
+ * import { encodeResolveParams } "thirdweb/extensions/ens";
+ * const result = encodeResolveParams({
+ *  name: ...,
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeResolveParams(options: ResolveParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.name, options.data]);
+}
+
+/**
+ * Decodes the result of the resolve function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ENS
+ * @example
+ * ```
+ * import { decodeResolveResult } from "thirdweb/extensions/ens";
+ * const result = decodeResolveResult("...");
+ * ```
+ */
+export function decodeResolveResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result);
+}
 
 /**
  * Calls the "resolve" function on the contract.
@@ -29,27 +85,7 @@ export type ResolveParams = {
 export async function resolve(options: BaseTransactionOptions<ResolveParams>) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x9061b923",
-      [
-        {
-          type: "bytes",
-          name: "name",
-        },
-        {
-          type: "bytes",
-          name: "data",
-        },
-      ],
-      [
-        {
-          type: "bytes",
-        },
-        {
-          type: "address",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.name, options.data],
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IAirdropERC1155/write/airdropERC1155.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IAirdropERC1155/write/airdropERC1155.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "airdropERC1155" function.
@@ -33,6 +34,62 @@ export type AirdropERC1155Params = Prettify<
       asyncParams: () => Promise<AirdropERC1155ParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x41444690" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "tokenAddress",
+  },
+  {
+    type: "address",
+    name: "tokenOwner",
+  },
+  {
+    type: "tuple[]",
+    name: "contents",
+    components: [
+      {
+        type: "address",
+        name: "recipient",
+      },
+      {
+        type: "uint256",
+        name: "tokenId",
+      },
+      {
+        type: "uint256",
+        name: "amount",
+      },
+    ],
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "airdropERC1155" function.
+ * @param options - The options for the airdropERC1155 function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { encodeAirdropERC1155Params } "thirdweb/extensions/erc1155";
+ * const result = encodeAirdropERC1155Params({
+ *  tokenAddress: ...,
+ *  tokenOwner: ...,
+ *  contents: ...,
+ * });
+ * ```
+ */
+export function encodeAirdropERC1155Params(
+  options: AirdropERC1155ParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.tokenAddress,
+    options.tokenOwner,
+    options.contents,
+  ]);
+}
+
 /**
  * Calls the "airdropERC1155" function on the contract.
  * @param options - The options for the "airdropERC1155" function.
@@ -58,38 +115,7 @@ export function airdropERC1155(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x41444690",
-      [
-        {
-          type: "address",
-          name: "tokenAddress",
-        },
-        {
-          type: "address",
-          name: "tokenOwner",
-        },
-        {
-          type: "tuple[]",
-          name: "contents",
-          components: [
-            {
-              type: "address",
-              name: "recipient",
-            },
-            {
-              type: "uint256",
-              name: "tokenId",
-            },
-            {
-              type: "uint256",
-              name: "amount",
-            },
-          ],
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IAirdropERC1155Claimable/write/claim.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IAirdropERC1155Claimable/write/claim.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "claim" function.
@@ -24,6 +25,58 @@ export type ClaimParams = Prettify<
       asyncParams: () => Promise<ClaimParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x38524a10" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "receiver",
+  },
+  {
+    type: "uint256",
+    name: "quantity",
+  },
+  {
+    type: "uint256",
+    name: "tokenId",
+  },
+  {
+    type: "bytes32[]",
+    name: "proofs",
+  },
+  {
+    type: "uint256",
+    name: "proofMaxQuantityForWallet",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "claim" function.
+ * @param options - The options for the claim function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { encodeClaimParams } "thirdweb/extensions/erc1155";
+ * const result = encodeClaimParams({
+ *  receiver: ...,
+ *  quantity: ...,
+ *  tokenId: ...,
+ *  proofs: ...,
+ *  proofMaxQuantityForWallet: ...,
+ * });
+ * ```
+ */
+export function encodeClaimParams(options: ClaimParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.receiver,
+    options.quantity,
+    options.tokenId,
+    options.proofs,
+    options.proofMaxQuantityForWallet,
+  ]);
+}
+
 /**
  * Calls the "claim" function on the contract.
  * @param options - The options for the "claim" function.
@@ -49,32 +102,7 @@ export type ClaimParams = Prettify<
 export function claim(options: BaseTransactionOptions<ClaimParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x38524a10",
-      [
-        {
-          type: "address",
-          name: "receiver",
-        },
-        {
-          type: "uint256",
-          name: "quantity",
-        },
-        {
-          type: "uint256",
-          name: "tokenId",
-        },
-        {
-          type: "bytes32[]",
-          name: "proofs",
-        },
-        {
-          type: "uint256",
-          name: "proofMaxQuantityForWallet",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IBurnableERC1155/write/burn.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IBurnableERC1155/write/burn.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "burn" function.
@@ -19,6 +20,46 @@ export type BurnParams = Prettify<
       asyncParams: () => Promise<BurnParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xf5298aca" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "account",
+  },
+  {
+    type: "uint256",
+    name: "id",
+  },
+  {
+    type: "uint256",
+    name: "value",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "burn" function.
+ * @param options - The options for the burn function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { encodeBurnParams } "thirdweb/extensions/erc1155";
+ * const result = encodeBurnParams({
+ *  account: ...,
+ *  id: ...,
+ *  value: ...,
+ * });
+ * ```
+ */
+export function encodeBurnParams(options: BurnParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.account,
+    options.id,
+    options.value,
+  ]);
+}
+
 /**
  * Calls the "burn" function on the contract.
  * @param options - The options for the "burn" function.
@@ -42,24 +83,7 @@ export type BurnParams = Prettify<
 export function burn(options: BaseTransactionOptions<BurnParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xf5298aca",
-      [
-        {
-          type: "address",
-          name: "account",
-        },
-        {
-          type: "uint256",
-          name: "id",
-        },
-        {
-          type: "uint256",
-          name: "value",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IBurnableERC1155/write/burnBatch.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IBurnableERC1155/write/burnBatch.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "burnBatch" function.
@@ -19,6 +20,46 @@ export type BurnBatchParams = Prettify<
       asyncParams: () => Promise<BurnBatchParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x6b20c454" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "account",
+  },
+  {
+    type: "uint256[]",
+    name: "ids",
+  },
+  {
+    type: "uint256[]",
+    name: "values",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "burnBatch" function.
+ * @param options - The options for the burnBatch function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { encodeBurnBatchParams } "thirdweb/extensions/erc1155";
+ * const result = encodeBurnBatchParams({
+ *  account: ...,
+ *  ids: ...,
+ *  values: ...,
+ * });
+ * ```
+ */
+export function encodeBurnBatchParams(options: BurnBatchParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.account,
+    options.ids,
+    options.values,
+  ]);
+}
+
 /**
  * Calls the "burnBatch" function on the contract.
  * @param options - The options for the "burnBatch" function.
@@ -42,24 +83,7 @@ export type BurnBatchParams = Prettify<
 export function burnBatch(options: BaseTransactionOptions<BurnBatchParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x6b20c454",
-      [
-        {
-          type: "address",
-          name: "account",
-        },
-        {
-          type: "uint256[]",
-          name: "ids",
-        },
-        {
-          type: "uint256[]",
-          name: "values",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IClaimableERC1155/read/verifyClaim.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IClaimableERC1155/read/verifyClaim.ts
@@ -1,6 +1,7 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "verifyClaim" function.
@@ -10,6 +11,46 @@ export type VerifyClaimParams = {
   tokenId: AbiParameterToPrimitiveType<{ type: "uint256"; name: "_tokenId" }>;
   quantity: AbiParameterToPrimitiveType<{ type: "uint256"; name: "_quantity" }>;
 };
+
+const FN_SELECTOR = "0x4bbb1abf" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "_claimer",
+  },
+  {
+    type: "uint256",
+    name: "_tokenId",
+  },
+  {
+    type: "uint256",
+    name: "_quantity",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "verifyClaim" function.
+ * @param options - The options for the verifyClaim function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { encodeVerifyClaimParams } "thirdweb/extensions/erc1155";
+ * const result = encodeVerifyClaimParams({
+ *  claimer: ...,
+ *  tokenId: ...,
+ *  quantity: ...,
+ * });
+ * ```
+ */
+export function encodeVerifyClaimParams(options: VerifyClaimParams) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.claimer,
+    options.tokenId,
+    options.quantity,
+  ]);
+}
 
 /**
  * Calls the "verifyClaim" function on the contract.
@@ -33,24 +74,7 @@ export async function verifyClaim(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x4bbb1abf",
-      [
-        {
-          type: "address",
-          name: "_claimer",
-        },
-        {
-          type: "uint256",
-          name: "_tokenId",
-        },
-        {
-          type: "uint256",
-          name: "_quantity",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.claimer, options.tokenId, options.quantity],
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IClaimableERC1155/write/claim.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IClaimableERC1155/write/claim.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "claim" function.
@@ -19,6 +20,46 @@ export type ClaimParams = Prettify<
       asyncParams: () => Promise<ClaimParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x2bc43fd9" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "_receiver",
+  },
+  {
+    type: "uint256",
+    name: "_tokenId",
+  },
+  {
+    type: "uint256",
+    name: "_quantity",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "claim" function.
+ * @param options - The options for the claim function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { encodeClaimParams } "thirdweb/extensions/erc1155";
+ * const result = encodeClaimParams({
+ *  receiver: ...,
+ *  tokenId: ...,
+ *  quantity: ...,
+ * });
+ * ```
+ */
+export function encodeClaimParams(options: ClaimParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.receiver,
+    options.tokenId,
+    options.quantity,
+  ]);
+}
+
 /**
  * Calls the "claim" function on the contract.
  * @param options - The options for the "claim" function.
@@ -42,24 +83,7 @@ export type ClaimParams = Prettify<
 export function claim(options: BaseTransactionOptions<ClaimParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x2bc43fd9",
-      [
-        {
-          type: "address",
-          name: "_receiver",
-        },
-        {
-          type: "uint256",
-          name: "_tokenId",
-        },
-        {
-          type: "uint256",
-          name: "_quantity",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IDrop1155/read/getActiveClaimConditionId.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IDrop1155/read/getActiveClaimConditionId.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "getActiveClaimConditionId" function.
@@ -8,6 +11,53 @@ import type { AbiParameterToPrimitiveType } from "abitype";
 export type GetActiveClaimConditionIdParams = {
   tokenId: AbiParameterToPrimitiveType<{ type: "uint256"; name: "_tokenId" }>;
 };
+
+const FN_SELECTOR = "0x5ab063e8" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_tokenId",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getActiveClaimConditionId" function.
+ * @param options - The options for the getActiveClaimConditionId function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { encodeGetActiveClaimConditionIdParams } "thirdweb/extensions/erc1155";
+ * const result = encodeGetActiveClaimConditionIdParams({
+ *  tokenId: ...,
+ * });
+ * ```
+ */
+export function encodeGetActiveClaimConditionIdParams(
+  options: GetActiveClaimConditionIdParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.tokenId]);
+}
+
+/**
+ * Decodes the result of the getActiveClaimConditionId function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { decodeGetActiveClaimConditionIdResult } from "thirdweb/extensions/erc1155";
+ * const result = decodeGetActiveClaimConditionIdResult("...");
+ * ```
+ */
+export function decodeGetActiveClaimConditionIdResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "getActiveClaimConditionId" function on the contract.
@@ -29,20 +79,7 @@ export async function getActiveClaimConditionId(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x5ab063e8",
-      [
-        {
-          type: "uint256",
-          name: "_tokenId",
-        },
-      ],
-      [
-        {
-          type: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.tokenId],
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IDrop1155/read/getClaimConditionById.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IDrop1155/read/getClaimConditionById.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "getClaimConditionById" function.
@@ -12,6 +15,93 @@ export type GetClaimConditionByIdParams = {
     name: "_conditionId";
   }>;
 };
+
+const FN_SELECTOR = "0xd45b28d7" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_tokenId",
+  },
+  {
+    type: "uint256",
+    name: "_conditionId",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "tuple",
+    name: "condition",
+    components: [
+      {
+        type: "uint256",
+        name: "startTimestamp",
+      },
+      {
+        type: "uint256",
+        name: "maxClaimableSupply",
+      },
+      {
+        type: "uint256",
+        name: "supplyClaimed",
+      },
+      {
+        type: "uint256",
+        name: "quantityLimitPerWallet",
+      },
+      {
+        type: "bytes32",
+        name: "merkleRoot",
+      },
+      {
+        type: "uint256",
+        name: "pricePerToken",
+      },
+      {
+        type: "address",
+        name: "currency",
+      },
+      {
+        type: "string",
+        name: "metadata",
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getClaimConditionById" function.
+ * @param options - The options for the getClaimConditionById function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { encodeGetClaimConditionByIdParams } "thirdweb/extensions/erc1155";
+ * const result = encodeGetClaimConditionByIdParams({
+ *  tokenId: ...,
+ *  conditionId: ...,
+ * });
+ * ```
+ */
+export function encodeGetClaimConditionByIdParams(
+  options: GetClaimConditionByIdParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.tokenId, options.conditionId]);
+}
+
+/**
+ * Decodes the result of the getClaimConditionById function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { decodeGetClaimConditionByIdResult } from "thirdweb/extensions/erc1155";
+ * const result = decodeGetClaimConditionByIdResult("...");
+ * ```
+ */
+export function decodeGetClaimConditionByIdResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "getClaimConditionById" function on the contract.
@@ -34,59 +124,7 @@ export async function getClaimConditionById(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xd45b28d7",
-      [
-        {
-          type: "uint256",
-          name: "_tokenId",
-        },
-        {
-          type: "uint256",
-          name: "_conditionId",
-        },
-      ],
-      [
-        {
-          type: "tuple",
-          name: "condition",
-          components: [
-            {
-              type: "uint256",
-              name: "startTimestamp",
-            },
-            {
-              type: "uint256",
-              name: "maxClaimableSupply",
-            },
-            {
-              type: "uint256",
-              name: "supplyClaimed",
-            },
-            {
-              type: "uint256",
-              name: "quantityLimitPerWallet",
-            },
-            {
-              type: "bytes32",
-              name: "merkleRoot",
-            },
-            {
-              type: "uint256",
-              name: "pricePerToken",
-            },
-            {
-              type: "address",
-              name: "currency",
-            },
-            {
-              type: "string",
-              name: "metadata",
-            },
-          ],
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.tokenId, options.conditionId],
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IDrop1155/write/claim.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IDrop1155/write/claim.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "claim" function.
@@ -35,6 +36,88 @@ export type ClaimParams = Prettify<
       asyncParams: () => Promise<ClaimParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x57bc3d78" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "receiver",
+  },
+  {
+    type: "uint256",
+    name: "tokenId",
+  },
+  {
+    type: "uint256",
+    name: "quantity",
+  },
+  {
+    type: "address",
+    name: "currency",
+  },
+  {
+    type: "uint256",
+    name: "pricePerToken",
+  },
+  {
+    type: "tuple",
+    name: "allowlistProof",
+    components: [
+      {
+        type: "bytes32[]",
+        name: "proof",
+      },
+      {
+        type: "uint256",
+        name: "quantityLimitPerWallet",
+      },
+      {
+        type: "uint256",
+        name: "pricePerToken",
+      },
+      {
+        type: "address",
+        name: "currency",
+      },
+    ],
+  },
+  {
+    type: "bytes",
+    name: "data",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "claim" function.
+ * @param options - The options for the claim function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { encodeClaimParams } "thirdweb/extensions/erc1155";
+ * const result = encodeClaimParams({
+ *  receiver: ...,
+ *  tokenId: ...,
+ *  quantity: ...,
+ *  currency: ...,
+ *  pricePerToken: ...,
+ *  allowlistProof: ...,
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeClaimParams(options: ClaimParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.receiver,
+    options.tokenId,
+    options.quantity,
+    options.currency,
+    options.pricePerToken,
+    options.allowlistProof,
+    options.data,
+  ]);
+}
+
 /**
  * Calls the "claim" function on the contract.
  * @param options - The options for the "claim" function.
@@ -62,58 +145,7 @@ export type ClaimParams = Prettify<
 export function claim(options: BaseTransactionOptions<ClaimParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x57bc3d78",
-      [
-        {
-          type: "address",
-          name: "receiver",
-        },
-        {
-          type: "uint256",
-          name: "tokenId",
-        },
-        {
-          type: "uint256",
-          name: "quantity",
-        },
-        {
-          type: "address",
-          name: "currency",
-        },
-        {
-          type: "uint256",
-          name: "pricePerToken",
-        },
-        {
-          type: "tuple",
-          name: "allowlistProof",
-          components: [
-            {
-              type: "bytes32[]",
-              name: "proof",
-            },
-            {
-              type: "uint256",
-              name: "quantityLimitPerWallet",
-            },
-            {
-              type: "uint256",
-              name: "pricePerToken",
-            },
-            {
-              type: "address",
-              name: "currency",
-            },
-          ],
-        },
-        {
-          type: "bytes",
-          name: "data",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IDrop1155/write/setClaimConditions.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IDrop1155/write/setClaimConditions.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "setClaimConditions" function.
@@ -35,6 +36,82 @@ export type SetClaimConditionsParams = Prettify<
       asyncParams: () => Promise<SetClaimConditionsParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x183718d1" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "tokenId",
+  },
+  {
+    type: "tuple[]",
+    name: "phases",
+    components: [
+      {
+        type: "uint256",
+        name: "startTimestamp",
+      },
+      {
+        type: "uint256",
+        name: "maxClaimableSupply",
+      },
+      {
+        type: "uint256",
+        name: "supplyClaimed",
+      },
+      {
+        type: "uint256",
+        name: "quantityLimitPerWallet",
+      },
+      {
+        type: "bytes32",
+        name: "merkleRoot",
+      },
+      {
+        type: "uint256",
+        name: "pricePerToken",
+      },
+      {
+        type: "address",
+        name: "currency",
+      },
+      {
+        type: "string",
+        name: "metadata",
+      },
+    ],
+  },
+  {
+    type: "bool",
+    name: "resetClaimEligibility",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "setClaimConditions" function.
+ * @param options - The options for the setClaimConditions function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { encodeSetClaimConditionsParams } "thirdweb/extensions/erc1155";
+ * const result = encodeSetClaimConditionsParams({
+ *  tokenId: ...,
+ *  phases: ...,
+ *  resetClaimEligibility: ...,
+ * });
+ * ```
+ */
+export function encodeSetClaimConditionsParams(
+  options: SetClaimConditionsParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.tokenId,
+    options.phases,
+    options.resetClaimEligibility,
+  ]);
+}
+
 /**
  * Calls the "setClaimConditions" function on the contract.
  * @param options - The options for the "setClaimConditions" function.
@@ -60,58 +137,7 @@ export function setClaimConditions(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x183718d1",
-      [
-        {
-          type: "uint256",
-          name: "tokenId",
-        },
-        {
-          type: "tuple[]",
-          name: "phases",
-          components: [
-            {
-              type: "uint256",
-              name: "startTimestamp",
-            },
-            {
-              type: "uint256",
-              name: "maxClaimableSupply",
-            },
-            {
-              type: "uint256",
-              name: "supplyClaimed",
-            },
-            {
-              type: "uint256",
-              name: "quantityLimitPerWallet",
-            },
-            {
-              type: "bytes32",
-              name: "merkleRoot",
-            },
-            {
-              type: "uint256",
-              name: "pricePerToken",
-            },
-            {
-              type: "address",
-              name: "currency",
-            },
-            {
-              type: "string",
-              name: "metadata",
-            },
-          ],
-        },
-        {
-          type: "bool",
-          name: "resetClaimEligibility",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/read/balanceOf.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/read/balanceOf.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "balanceOf" function.
@@ -9,6 +12,56 @@ export type BalanceOfParams = {
   owner: AbiParameterToPrimitiveType<{ type: "address"; name: "_owner" }>;
   tokenId: AbiParameterToPrimitiveType<{ type: "uint256"; name: "tokenId" }>;
 };
+
+const FN_SELECTOR = "0x00fdd58e" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "_owner",
+  },
+  {
+    type: "uint256",
+    name: "tokenId",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "balanceOf" function.
+ * @param options - The options for the balanceOf function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { encodeBalanceOfParams } "thirdweb/extensions/erc1155";
+ * const result = encodeBalanceOfParams({
+ *  owner: ...,
+ *  tokenId: ...,
+ * });
+ * ```
+ */
+export function encodeBalanceOfParams(options: BalanceOfParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.owner, options.tokenId]);
+}
+
+/**
+ * Decodes the result of the balanceOf function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { decodeBalanceOfResult } from "thirdweb/extensions/erc1155";
+ * const result = decodeBalanceOfResult("...");
+ * ```
+ */
+export function decodeBalanceOfResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "balanceOf" function on the contract.
@@ -31,24 +84,7 @@ export async function balanceOf(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x00fdd58e",
-      [
-        {
-          type: "address",
-          name: "_owner",
-        },
-        {
-          type: "uint256",
-          name: "tokenId",
-        },
-      ],
-      [
-        {
-          type: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.owner, options.tokenId],
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/read/balanceOfBatch.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/read/balanceOfBatch.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "balanceOfBatch" function.
@@ -12,6 +15,56 @@ export type BalanceOfBatchParams = {
     name: "tokenIds";
   }>;
 };
+
+const FN_SELECTOR = "0x4e1273f4" as const;
+const FN_INPUTS = [
+  {
+    type: "address[]",
+    name: "_owners",
+  },
+  {
+    type: "uint256[]",
+    name: "tokenIds",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256[]",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "balanceOfBatch" function.
+ * @param options - The options for the balanceOfBatch function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { encodeBalanceOfBatchParams } "thirdweb/extensions/erc1155";
+ * const result = encodeBalanceOfBatchParams({
+ *  owners: ...,
+ *  tokenIds: ...,
+ * });
+ * ```
+ */
+export function encodeBalanceOfBatchParams(options: BalanceOfBatchParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.owners, options.tokenIds]);
+}
+
+/**
+ * Decodes the result of the balanceOfBatch function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { decodeBalanceOfBatchResult } from "thirdweb/extensions/erc1155";
+ * const result = decodeBalanceOfBatchResult("...");
+ * ```
+ */
+export function decodeBalanceOfBatchResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "balanceOfBatch" function on the contract.
@@ -34,24 +87,7 @@ export async function balanceOfBatch(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x4e1273f4",
-      [
-        {
-          type: "address[]",
-          name: "_owners",
-        },
-        {
-          type: "uint256[]",
-          name: "tokenIds",
-        },
-      ],
-      [
-        {
-          type: "uint256[]",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.owners, options.tokenIds],
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/read/isApprovedForAll.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/read/isApprovedForAll.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "isApprovedForAll" function.
@@ -9,6 +12,56 @@ export type IsApprovedForAllParams = {
   owner: AbiParameterToPrimitiveType<{ type: "address"; name: "_owner" }>;
   operator: AbiParameterToPrimitiveType<{ type: "address"; name: "_operator" }>;
 };
+
+const FN_SELECTOR = "0xe985e9c5" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "_owner",
+  },
+  {
+    type: "address",
+    name: "_operator",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bool",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "isApprovedForAll" function.
+ * @param options - The options for the isApprovedForAll function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { encodeIsApprovedForAllParams } "thirdweb/extensions/erc1155";
+ * const result = encodeIsApprovedForAllParams({
+ *  owner: ...,
+ *  operator: ...,
+ * });
+ * ```
+ */
+export function encodeIsApprovedForAllParams(options: IsApprovedForAllParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.owner, options.operator]);
+}
+
+/**
+ * Decodes the result of the isApprovedForAll function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { decodeIsApprovedForAllResult } from "thirdweb/extensions/erc1155";
+ * const result = decodeIsApprovedForAllResult("...");
+ * ```
+ */
+export function decodeIsApprovedForAllResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "isApprovedForAll" function on the contract.
@@ -31,24 +84,7 @@ export async function isApprovedForAll(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xe985e9c5",
-      [
-        {
-          type: "address",
-          name: "_owner",
-        },
-        {
-          type: "address",
-          name: "_operator",
-        },
-      ],
-      [
-        {
-          type: "bool",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.owner, options.operator],
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/read/totalSupply.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/read/totalSupply.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "totalSupply" function.
@@ -8,6 +11,51 @@ import type { AbiParameterToPrimitiveType } from "abitype";
 export type TotalSupplyParams = {
   id: AbiParameterToPrimitiveType<{ type: "uint256"; name: "id" }>;
 };
+
+const FN_SELECTOR = "0xbd85b039" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "id",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "totalSupply" function.
+ * @param options - The options for the totalSupply function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { encodeTotalSupplyParams } "thirdweb/extensions/erc1155";
+ * const result = encodeTotalSupplyParams({
+ *  id: ...,
+ * });
+ * ```
+ */
+export function encodeTotalSupplyParams(options: TotalSupplyParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.id]);
+}
+
+/**
+ * Decodes the result of the totalSupply function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { decodeTotalSupplyResult } from "thirdweb/extensions/erc1155";
+ * const result = decodeTotalSupplyResult("...");
+ * ```
+ */
+export function decodeTotalSupplyResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "totalSupply" function on the contract.
@@ -29,20 +77,7 @@ export async function totalSupply(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xbd85b039",
-      [
-        {
-          type: "uint256",
-          name: "id",
-        },
-      ],
-      [
-        {
-          type: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.id],
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/read/uri.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/read/uri.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "uri" function.
@@ -8,6 +11,51 @@ import type { AbiParameterToPrimitiveType } from "abitype";
 export type UriParams = {
   tokenId: AbiParameterToPrimitiveType<{ type: "uint256"; name: "tokenId" }>;
 };
+
+const FN_SELECTOR = "0x0e89341c" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "tokenId",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "string",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "uri" function.
+ * @param options - The options for the uri function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { encodeUriParams } "thirdweb/extensions/erc1155";
+ * const result = encodeUriParams({
+ *  tokenId: ...,
+ * });
+ * ```
+ */
+export function encodeUriParams(options: UriParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.tokenId]);
+}
+
+/**
+ * Decodes the result of the uri function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { decodeUriResult } from "thirdweb/extensions/erc1155";
+ * const result = decodeUriResult("...");
+ * ```
+ */
+export function decodeUriResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "uri" function on the contract.
@@ -27,20 +75,7 @@ export type UriParams = {
 export async function uri(options: BaseTransactionOptions<UriParams>) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x0e89341c",
-      [
-        {
-          type: "uint256",
-          name: "tokenId",
-        },
-      ],
-      [
-        {
-          type: "string",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.tokenId],
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/write/safeBatchTransferFrom.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/write/safeBatchTransferFrom.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "safeBatchTransferFrom" function.
@@ -24,6 +25,60 @@ export type SafeBatchTransferFromParams = Prettify<
       asyncParams: () => Promise<SafeBatchTransferFromParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x2eb2c2d6" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "_from",
+  },
+  {
+    type: "address",
+    name: "_to",
+  },
+  {
+    type: "uint256[]",
+    name: "tokenIds",
+  },
+  {
+    type: "uint256[]",
+    name: "_values",
+  },
+  {
+    type: "bytes",
+    name: "_data",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "safeBatchTransferFrom" function.
+ * @param options - The options for the safeBatchTransferFrom function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { encodeSafeBatchTransferFromParams } "thirdweb/extensions/erc1155";
+ * const result = encodeSafeBatchTransferFromParams({
+ *  from: ...,
+ *  to: ...,
+ *  tokenIds: ...,
+ *  values: ...,
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeSafeBatchTransferFromParams(
+  options: SafeBatchTransferFromParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.from,
+    options.to,
+    options.tokenIds,
+    options.values,
+    options.data,
+  ]);
+}
+
 /**
  * Calls the "safeBatchTransferFrom" function on the contract.
  * @param options - The options for the "safeBatchTransferFrom" function.
@@ -51,32 +106,7 @@ export function safeBatchTransferFrom(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x2eb2c2d6",
-      [
-        {
-          type: "address",
-          name: "_from",
-        },
-        {
-          type: "address",
-          name: "_to",
-        },
-        {
-          type: "uint256[]",
-          name: "tokenIds",
-        },
-        {
-          type: "uint256[]",
-          name: "_values",
-        },
-        {
-          type: "bytes",
-          name: "_data",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/write/safeTransferFrom.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/write/safeTransferFrom.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "safeTransferFrom" function.
@@ -21,6 +22,60 @@ export type SafeTransferFromParams = Prettify<
       asyncParams: () => Promise<SafeTransferFromParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xf242432a" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "_from",
+  },
+  {
+    type: "address",
+    name: "_to",
+  },
+  {
+    type: "uint256",
+    name: "tokenId",
+  },
+  {
+    type: "uint256",
+    name: "_value",
+  },
+  {
+    type: "bytes",
+    name: "_data",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "safeTransferFrom" function.
+ * @param options - The options for the safeTransferFrom function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { encodeSafeTransferFromParams } "thirdweb/extensions/erc1155";
+ * const result = encodeSafeTransferFromParams({
+ *  from: ...,
+ *  to: ...,
+ *  tokenId: ...,
+ *  value: ...,
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeSafeTransferFromParams(
+  options: SafeTransferFromParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.from,
+    options.to,
+    options.tokenId,
+    options.value,
+    options.data,
+  ]);
+}
+
 /**
  * Calls the "safeTransferFrom" function on the contract.
  * @param options - The options for the "safeTransferFrom" function.
@@ -48,32 +103,7 @@ export function safeTransferFrom(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xf242432a",
-      [
-        {
-          type: "address",
-          name: "_from",
-        },
-        {
-          type: "address",
-          name: "_to",
-        },
-        {
-          type: "uint256",
-          name: "tokenId",
-        },
-        {
-          type: "uint256",
-          name: "_value",
-        },
-        {
-          type: "bytes",
-          name: "_data",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/write/setApprovalForAll.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/write/setApprovalForAll.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "setApprovalForAll" function.
@@ -18,6 +19,39 @@ export type SetApprovalForAllParams = Prettify<
       asyncParams: () => Promise<SetApprovalForAllParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xa22cb465" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "_operator",
+  },
+  {
+    type: "bool",
+    name: "_approved",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "setApprovalForAll" function.
+ * @param options - The options for the setApprovalForAll function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { encodeSetApprovalForAllParams } "thirdweb/extensions/erc1155";
+ * const result = encodeSetApprovalForAllParams({
+ *  operator: ...,
+ *  approved: ...,
+ * });
+ * ```
+ */
+export function encodeSetApprovalForAllParams(
+  options: SetApprovalForAllParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.operator, options.approved]);
+}
+
 /**
  * Calls the "setApprovalForAll" function on the contract.
  * @param options - The options for the "setApprovalForAll" function.
@@ -42,20 +76,7 @@ export function setApprovalForAll(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xa22cb465",
-      [
-        {
-          type: "address",
-          name: "_operator",
-        },
-        {
-          type: "bool",
-          name: "_approved",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155Enumerable/read/nextTokenIdToMint.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155Enumerable/read/nextTokenIdToMint.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x3b1475a7" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the nextTokenIdToMint function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { decodeNextTokenIdToMintResult } from "thirdweb/extensions/erc1155";
+ * const result = decodeNextTokenIdToMintResult("...");
+ * ```
+ */
+export function decodeNextTokenIdToMintResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "nextTokenIdToMint" function on the contract.
  * @param options - The options for the nextTokenIdToMint function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function nextTokenIdToMint(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x3b1475a7",
-      [],
-      [
-        {
-          type: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155Receiver/read/supportsInterface.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155Receiver/read/supportsInterface.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "supportsInterface" function.
@@ -11,6 +14,53 @@ export type SupportsInterfaceParams = {
     name: "interfaceId";
   }>;
 };
+
+const FN_SELECTOR = "0x01ffc9a7" as const;
+const FN_INPUTS = [
+  {
+    type: "bytes4",
+    name: "interfaceId",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bool",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "supportsInterface" function.
+ * @param options - The options for the supportsInterface function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { encodeSupportsInterfaceParams } "thirdweb/extensions/erc1155";
+ * const result = encodeSupportsInterfaceParams({
+ *  interfaceId: ...,
+ * });
+ * ```
+ */
+export function encodeSupportsInterfaceParams(
+  options: SupportsInterfaceParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.interfaceId]);
+}
+
+/**
+ * Decodes the result of the supportsInterface function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { decodeSupportsInterfaceResult } from "thirdweb/extensions/erc1155";
+ * const result = decodeSupportsInterfaceResult("...");
+ * ```
+ */
+export function decodeSupportsInterfaceResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "supportsInterface" function on the contract.
@@ -32,20 +82,7 @@ export async function supportsInterface(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x01ffc9a7",
-      [
-        {
-          type: "bytes4",
-          name: "interfaceId",
-        },
-      ],
-      [
-        {
-          type: "bool",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.interfaceId],
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155Receiver/write/onERC1155BatchReceived.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155Receiver/write/onERC1155BatchReceived.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "onERC1155BatchReceived" function.
@@ -21,6 +22,64 @@ export type OnERC1155BatchReceivedParams = Prettify<
       asyncParams: () => Promise<OnERC1155BatchReceivedParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xbc197c81" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "operator",
+  },
+  {
+    type: "address",
+    name: "from",
+  },
+  {
+    type: "uint256[]",
+    name: "ids",
+  },
+  {
+    type: "uint256[]",
+    name: "values",
+  },
+  {
+    type: "bytes",
+    name: "data",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bytes4",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "onERC1155BatchReceived" function.
+ * @param options - The options for the onERC1155BatchReceived function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { encodeOnERC1155BatchReceivedParams } "thirdweb/extensions/erc1155";
+ * const result = encodeOnERC1155BatchReceivedParams({
+ *  operator: ...,
+ *  from: ...,
+ *  ids: ...,
+ *  values: ...,
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeOnERC1155BatchReceivedParams(
+  options: OnERC1155BatchReceivedParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.operator,
+    options.from,
+    options.ids,
+    options.values,
+    options.data,
+  ]);
+}
+
 /**
  * Calls the "onERC1155BatchReceived" function on the contract.
  * @param options - The options for the "onERC1155BatchReceived" function.
@@ -48,36 +107,7 @@ export function onERC1155BatchReceived(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xbc197c81",
-      [
-        {
-          type: "address",
-          name: "operator",
-        },
-        {
-          type: "address",
-          name: "from",
-        },
-        {
-          type: "uint256[]",
-          name: "ids",
-        },
-        {
-          type: "uint256[]",
-          name: "values",
-        },
-        {
-          type: "bytes",
-          name: "data",
-        },
-      ],
-      [
-        {
-          type: "bytes4",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155Receiver/write/onERC1155Received.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155Receiver/write/onERC1155Received.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "onERC1155Received" function.
@@ -21,6 +22,64 @@ export type OnERC1155ReceivedParams = Prettify<
       asyncParams: () => Promise<OnERC1155ReceivedParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xf23a6e61" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "operator",
+  },
+  {
+    type: "address",
+    name: "from",
+  },
+  {
+    type: "uint256",
+    name: "id",
+  },
+  {
+    type: "uint256",
+    name: "value",
+  },
+  {
+    type: "bytes",
+    name: "data",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bytes4",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "onERC1155Received" function.
+ * @param options - The options for the onERC1155Received function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { encodeOnERC1155ReceivedParams } "thirdweb/extensions/erc1155";
+ * const result = encodeOnERC1155ReceivedParams({
+ *  operator: ...,
+ *  from: ...,
+ *  id: ...,
+ *  value: ...,
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeOnERC1155ReceivedParams(
+  options: OnERC1155ReceivedParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.operator,
+    options.from,
+    options.id,
+    options.value,
+    options.data,
+  ]);
+}
+
 /**
  * Calls the "onERC1155Received" function on the contract.
  * @param options - The options for the "onERC1155Received" function.
@@ -48,36 +107,7 @@ export function onERC1155Received(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xf23a6e61",
-      [
-        {
-          type: "address",
-          name: "operator",
-        },
-        {
-          type: "address",
-          name: "from",
-        },
-        {
-          type: "uint256",
-          name: "id",
-        },
-        {
-          type: "uint256",
-          name: "value",
-        },
-        {
-          type: "bytes",
-          name: "data",
-        },
-      ],
-      [
-        {
-          type: "bytes4",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IEditionStake/write/depositRewardTokens.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IEditionStake/write/depositRewardTokens.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "depositRewardTokens" function.
@@ -17,6 +18,34 @@ export type DepositRewardTokensParams = Prettify<
       asyncParams: () => Promise<DepositRewardTokensParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x16c621e0" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_amount",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "depositRewardTokens" function.
+ * @param options - The options for the depositRewardTokens function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { encodeDepositRewardTokensParams } "thirdweb/extensions/erc1155";
+ * const result = encodeDepositRewardTokensParams({
+ *  amount: ...,
+ * });
+ * ```
+ */
+export function encodeDepositRewardTokensParams(
+  options: DepositRewardTokensParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.amount]);
+}
+
 /**
  * Calls the "depositRewardTokens" function on the contract.
  * @param options - The options for the "depositRewardTokens" function.
@@ -40,16 +69,7 @@ export function depositRewardTokens(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x16c621e0",
-      [
-        {
-          type: "uint256",
-          name: "_amount",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IEditionStake/write/withdrawRewardTokens.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IEditionStake/write/withdrawRewardTokens.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "withdrawRewardTokens" function.
@@ -17,6 +18,34 @@ export type WithdrawRewardTokensParams = Prettify<
       asyncParams: () => Promise<WithdrawRewardTokensParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xcb43b2dd" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_amount",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "withdrawRewardTokens" function.
+ * @param options - The options for the withdrawRewardTokens function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { encodeWithdrawRewardTokensParams } "thirdweb/extensions/erc1155";
+ * const result = encodeWithdrawRewardTokensParams({
+ *  amount: ...,
+ * });
+ * ```
+ */
+export function encodeWithdrawRewardTokensParams(
+  options: WithdrawRewardTokensParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.amount]);
+}
+
 /**
  * Calls the "withdrawRewardTokens" function on the contract.
  * @param options - The options for the "withdrawRewardTokens" function.
@@ -40,16 +69,7 @@ export function withdrawRewardTokens(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xcb43b2dd",
-      [
-        {
-          type: "uint256",
-          name: "_amount",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IMintableERC1155/write/mintTo.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IMintableERC1155/write/mintTo.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "mintTo" function.
@@ -20,6 +21,52 @@ export type MintToParams = Prettify<
       asyncParams: () => Promise<MintToParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xb03f4528" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "to",
+  },
+  {
+    type: "uint256",
+    name: "tokenId",
+  },
+  {
+    type: "string",
+    name: "uri",
+  },
+  {
+    type: "uint256",
+    name: "amount",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "mintTo" function.
+ * @param options - The options for the mintTo function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { encodeMintToParams } "thirdweb/extensions/erc1155";
+ * const result = encodeMintToParams({
+ *  to: ...,
+ *  tokenId: ...,
+ *  uri: ...,
+ *  amount: ...,
+ * });
+ * ```
+ */
+export function encodeMintToParams(options: MintToParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.to,
+    options.tokenId,
+    options.uri,
+    options.amount,
+  ]);
+}
+
 /**
  * Calls the "mintTo" function on the contract.
  * @param options - The options for the "mintTo" function.
@@ -44,28 +91,7 @@ export type MintToParams = Prettify<
 export function mintTo(options: BaseTransactionOptions<MintToParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xb03f4528",
-      [
-        {
-          type: "address",
-          name: "to",
-        },
-        {
-          type: "uint256",
-          name: "tokenId",
-        },
-        {
-          type: "string",
-          name: "uri",
-        },
-        {
-          type: "uint256",
-          name: "amount",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/INFTMetadata/read/supportsInterface.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/INFTMetadata/read/supportsInterface.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "supportsInterface" function.
@@ -11,6 +14,53 @@ export type SupportsInterfaceParams = {
     name: "interfaceId";
   }>;
 };
+
+const FN_SELECTOR = "0x01ffc9a7" as const;
+const FN_INPUTS = [
+  {
+    type: "bytes4",
+    name: "interfaceId",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bool",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "supportsInterface" function.
+ * @param options - The options for the supportsInterface function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { encodeSupportsInterfaceParams } "thirdweb/extensions/erc1155";
+ * const result = encodeSupportsInterfaceParams({
+ *  interfaceId: ...,
+ * });
+ * ```
+ */
+export function encodeSupportsInterfaceParams(
+  options: SupportsInterfaceParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.interfaceId]);
+}
+
+/**
+ * Decodes the result of the supportsInterface function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { decodeSupportsInterfaceResult } from "thirdweb/extensions/erc1155";
+ * const result = decodeSupportsInterfaceResult("...");
+ * ```
+ */
+export function decodeSupportsInterfaceResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "supportsInterface" function on the contract.
@@ -32,20 +82,7 @@ export async function supportsInterface(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x01ffc9a7",
-      [
-        {
-          type: "bytes4",
-          name: "interfaceId",
-        },
-      ],
-      [
-        {
-          type: "bool",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.interfaceId],
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/INFTMetadata/write/freezeMetadata.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/INFTMetadata/write/freezeMetadata.ts
@@ -1,6 +1,10 @@
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
 
+const FN_SELECTOR = "0xd111515d" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [] as const;
+
 /**
  * Calls the "freezeMetadata" function on the contract.
  * @param options - The options for the "freezeMetadata" function.
@@ -20,6 +24,6 @@ import { prepareContractCall } from "../../../../../transaction/prepare-contract
 export function freezeMetadata(options: BaseTransactionOptions) {
   return prepareContractCall({
     contract: options.contract,
-    method: ["0xd111515d", [], []],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/INFTMetadata/write/setTokenURI.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/INFTMetadata/write/setTokenURI.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "setTokenURI" function.
@@ -18,6 +19,37 @@ export type SetTokenURIParams = Prettify<
       asyncParams: () => Promise<SetTokenURIParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x162094c4" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_tokenId",
+  },
+  {
+    type: "string",
+    name: "_uri",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "setTokenURI" function.
+ * @param options - The options for the setTokenURI function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { encodeSetTokenURIParams } "thirdweb/extensions/erc1155";
+ * const result = encodeSetTokenURIParams({
+ *  tokenId: ...,
+ *  uri: ...,
+ * });
+ * ```
+ */
+export function encodeSetTokenURIParams(options: SetTokenURIParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.tokenId, options.uri]);
+}
+
 /**
  * Calls the "setTokenURI" function on the contract.
  * @param options - The options for the "setTokenURI" function.
@@ -42,20 +74,7 @@ export function setTokenURI(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x162094c4",
-      [
-        {
-          type: "uint256",
-          name: "_tokenId",
-        },
-        {
-          type: "string",
-          name: "_uri",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IPack/write/createPack.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IPack/write/createPack.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "createPack" function.
@@ -43,6 +44,91 @@ export type CreatePackParams = Prettify<
       asyncParams: () => Promise<CreatePackParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x092e6075" as const;
+const FN_INPUTS = [
+  {
+    type: "tuple[]",
+    name: "contents",
+    components: [
+      {
+        type: "address",
+        name: "assetContract",
+      },
+      {
+        type: "uint8",
+        name: "tokenType",
+      },
+      {
+        type: "uint256",
+        name: "tokenId",
+      },
+      {
+        type: "uint256",
+        name: "totalAmount",
+      },
+    ],
+  },
+  {
+    type: "uint256[]",
+    name: "numOfRewardUnits",
+  },
+  {
+    type: "string",
+    name: "packUri",
+  },
+  {
+    type: "uint128",
+    name: "openStartTimestamp",
+  },
+  {
+    type: "uint128",
+    name: "amountDistributedPerOpen",
+  },
+  {
+    type: "address",
+    name: "recipient",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+    name: "packId",
+  },
+  {
+    type: "uint256",
+    name: "packTotalSupply",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "createPack" function.
+ * @param options - The options for the createPack function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { encodeCreatePackParams } "thirdweb/extensions/erc1155";
+ * const result = encodeCreatePackParams({
+ *  contents: ...,
+ *  numOfRewardUnits: ...,
+ *  packUri: ...,
+ *  openStartTimestamp: ...,
+ *  amountDistributedPerOpen: ...,
+ *  recipient: ...,
+ * });
+ * ```
+ */
+export function encodeCreatePackParams(options: CreatePackParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.contents,
+    options.numOfRewardUnits,
+    options.packUri,
+    options.openStartTimestamp,
+    options.amountDistributedPerOpen,
+    options.recipient,
+  ]);
+}
+
 /**
  * Calls the "createPack" function on the contract.
  * @param options - The options for the "createPack" function.
@@ -69,63 +155,7 @@ export type CreatePackParams = Prettify<
 export function createPack(options: BaseTransactionOptions<CreatePackParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x092e6075",
-      [
-        {
-          type: "tuple[]",
-          name: "contents",
-          components: [
-            {
-              type: "address",
-              name: "assetContract",
-            },
-            {
-              type: "uint8",
-              name: "tokenType",
-            },
-            {
-              type: "uint256",
-              name: "tokenId",
-            },
-            {
-              type: "uint256",
-              name: "totalAmount",
-            },
-          ],
-        },
-        {
-          type: "uint256[]",
-          name: "numOfRewardUnits",
-        },
-        {
-          type: "string",
-          name: "packUri",
-        },
-        {
-          type: "uint128",
-          name: "openStartTimestamp",
-        },
-        {
-          type: "uint128",
-          name: "amountDistributedPerOpen",
-        },
-        {
-          type: "address",
-          name: "recipient",
-        },
-      ],
-      [
-        {
-          type: "uint256",
-          name: "packId",
-        },
-        {
-          type: "uint256",
-          name: "packTotalSupply",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IPack/write/openPack.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IPack/write/openPack.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "openPack" function.
@@ -21,6 +22,59 @@ export type OpenPackParams = Prettify<
       asyncParams: () => Promise<OpenPackParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x914e126a" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "packId",
+  },
+  {
+    type: "uint256",
+    name: "amountToOpen",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "tuple[]",
+    components: [
+      {
+        type: "address",
+        name: "assetContract",
+      },
+      {
+        type: "uint8",
+        name: "tokenType",
+      },
+      {
+        type: "uint256",
+        name: "tokenId",
+      },
+      {
+        type: "uint256",
+        name: "totalAmount",
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "openPack" function.
+ * @param options - The options for the openPack function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { encodeOpenPackParams } "thirdweb/extensions/erc1155";
+ * const result = encodeOpenPackParams({
+ *  packId: ...,
+ *  amountToOpen: ...,
+ * });
+ * ```
+ */
+export function encodeOpenPackParams(options: OpenPackParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.packId, options.amountToOpen]);
+}
+
 /**
  * Calls the "openPack" function on the contract.
  * @param options - The options for the "openPack" function.
@@ -43,42 +97,7 @@ export type OpenPackParams = Prettify<
 export function openPack(options: BaseTransactionOptions<OpenPackParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x914e126a",
-      [
-        {
-          type: "uint256",
-          name: "packId",
-        },
-        {
-          type: "uint256",
-          name: "amountToOpen",
-        },
-      ],
-      [
-        {
-          type: "tuple[]",
-          components: [
-            {
-              type: "address",
-              name: "assetContract",
-            },
-            {
-              type: "uint8",
-              name: "tokenType",
-            },
-            {
-              type: "uint256",
-              name: "tokenId",
-            },
-            {
-              type: "uint256",
-              name: "totalAmount",
-            },
-          ],
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IPackVRFDirect/read/canClaimRewards.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IPackVRFDirect/read/canClaimRewards.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "canClaimRewards" function.
@@ -8,6 +11,51 @@ import type { AbiParameterToPrimitiveType } from "abitype";
 export type CanClaimRewardsParams = {
   opener: AbiParameterToPrimitiveType<{ type: "address"; name: "_opener" }>;
 };
+
+const FN_SELECTOR = "0xa9b47a66" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "_opener",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bool",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "canClaimRewards" function.
+ * @param options - The options for the canClaimRewards function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { encodeCanClaimRewardsParams } "thirdweb/extensions/erc1155";
+ * const result = encodeCanClaimRewardsParams({
+ *  opener: ...,
+ * });
+ * ```
+ */
+export function encodeCanClaimRewardsParams(options: CanClaimRewardsParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.opener]);
+}
+
+/**
+ * Decodes the result of the canClaimRewards function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { decodeCanClaimRewardsResult } from "thirdweb/extensions/erc1155";
+ * const result = decodeCanClaimRewardsResult("...");
+ * ```
+ */
+export function decodeCanClaimRewardsResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "canClaimRewards" function on the contract.
@@ -29,20 +77,7 @@ export async function canClaimRewards(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xa9b47a66",
-      [
-        {
-          type: "address",
-          name: "_opener",
-        },
-      ],
-      [
-        {
-          type: "bool",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.opener],
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IPackVRFDirect/write/claimRewards.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IPackVRFDirect/write/claimRewards.ts
@@ -1,6 +1,33 @@
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
 
+const FN_SELECTOR = "0x372500ab" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "tuple[]",
+    name: "rewardUnits",
+    components: [
+      {
+        type: "address",
+        name: "assetContract",
+      },
+      {
+        type: "uint8",
+        name: "tokenType",
+      },
+      {
+        type: "uint256",
+        name: "tokenId",
+      },
+      {
+        type: "uint256",
+        name: "totalAmount",
+      },
+    ],
+  },
+] as const;
+
 /**
  * Calls the "claimRewards" function on the contract.
  * @param options - The options for the "claimRewards" function.
@@ -20,33 +47,6 @@ import { prepareContractCall } from "../../../../../transaction/prepare-contract
 export function claimRewards(options: BaseTransactionOptions) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x372500ab",
-      [],
-      [
-        {
-          type: "tuple[]",
-          name: "rewardUnits",
-          components: [
-            {
-              type: "address",
-              name: "assetContract",
-            },
-            {
-              type: "uint8",
-              name: "tokenType",
-            },
-            {
-              type: "uint256",
-              name: "tokenId",
-            },
-            {
-              type: "uint256",
-              name: "totalAmount",
-            },
-          ],
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IPackVRFDirect/write/openPackAndClaimRewards.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IPackVRFDirect/write/openPackAndClaimRewards.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "openPackAndClaimRewards" function.
@@ -25,6 +26,52 @@ export type OpenPackAndClaimRewardsParams = Prettify<
       asyncParams: () => Promise<OpenPackAndClaimRewardsParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xac296b3f" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_packId",
+  },
+  {
+    type: "uint256",
+    name: "_amountToOpen",
+  },
+  {
+    type: "uint32",
+    name: "_callBackGasLimit",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "openPackAndClaimRewards" function.
+ * @param options - The options for the openPackAndClaimRewards function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { encodeOpenPackAndClaimRewardsParams } "thirdweb/extensions/erc1155";
+ * const result = encodeOpenPackAndClaimRewardsParams({
+ *  packId: ...,
+ *  amountToOpen: ...,
+ *  callBackGasLimit: ...,
+ * });
+ * ```
+ */
+export function encodeOpenPackAndClaimRewardsParams(
+  options: OpenPackAndClaimRewardsParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.packId,
+    options.amountToOpen,
+    options.callBackGasLimit,
+  ]);
+}
+
 /**
  * Calls the "openPackAndClaimRewards" function on the contract.
  * @param options - The options for the "openPackAndClaimRewards" function.
@@ -50,28 +97,7 @@ export function openPackAndClaimRewards(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xac296b3f",
-      [
-        {
-          type: "uint256",
-          name: "_packId",
-        },
-        {
-          type: "uint256",
-          name: "_amountToOpen",
-        },
-        {
-          type: "uint32",
-          name: "_callBackGasLimit",
-        },
-      ],
-      [
-        {
-          type: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/ISignatureMintERC1155/read/verify.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/ISignatureMintERC1155/read/verify.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "verify" function.
@@ -27,6 +30,111 @@ export type VerifyParams = {
   signature: AbiParameterToPrimitiveType<{ type: "bytes"; name: "signature" }>;
 };
 
+const FN_SELECTOR = "0xb17cd86f" as const;
+const FN_INPUTS = [
+  {
+    type: "tuple",
+    name: "req",
+    components: [
+      {
+        type: "address",
+        name: "to",
+      },
+      {
+        type: "address",
+        name: "royaltyRecipient",
+      },
+      {
+        type: "uint256",
+        name: "royaltyBps",
+      },
+      {
+        type: "address",
+        name: "primarySaleRecipient",
+      },
+      {
+        type: "uint256",
+        name: "tokenId",
+      },
+      {
+        type: "string",
+        name: "uri",
+      },
+      {
+        type: "uint256",
+        name: "quantity",
+      },
+      {
+        type: "uint256",
+        name: "pricePerToken",
+      },
+      {
+        type: "address",
+        name: "currency",
+      },
+      {
+        type: "uint128",
+        name: "validityStartTimestamp",
+      },
+      {
+        type: "uint128",
+        name: "validityEndTimestamp",
+      },
+      {
+        type: "bytes32",
+        name: "uid",
+      },
+    ],
+  },
+  {
+    type: "bytes",
+    name: "signature",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bool",
+    name: "success",
+  },
+  {
+    type: "address",
+    name: "signer",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "verify" function.
+ * @param options - The options for the verify function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { encodeVerifyParams } "thirdweb/extensions/erc1155";
+ * const result = encodeVerifyParams({
+ *  req: ...,
+ *  signature: ...,
+ * });
+ * ```
+ */
+export function encodeVerifyParams(options: VerifyParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.req, options.signature]);
+}
+
+/**
+ * Decodes the result of the verify function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { decodeVerifyResult } from "thirdweb/extensions/erc1155";
+ * const result = decodeVerifyResult("...");
+ * ```
+ */
+export function decodeVerifyResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result);
+}
+
 /**
  * Calls the "verify" function on the contract.
  * @param options - The options for the verify function.
@@ -46,79 +154,7 @@ export type VerifyParams = {
 export async function verify(options: BaseTransactionOptions<VerifyParams>) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xb17cd86f",
-      [
-        {
-          type: "tuple",
-          name: "req",
-          components: [
-            {
-              type: "address",
-              name: "to",
-            },
-            {
-              type: "address",
-              name: "royaltyRecipient",
-            },
-            {
-              type: "uint256",
-              name: "royaltyBps",
-            },
-            {
-              type: "address",
-              name: "primarySaleRecipient",
-            },
-            {
-              type: "uint256",
-              name: "tokenId",
-            },
-            {
-              type: "string",
-              name: "uri",
-            },
-            {
-              type: "uint256",
-              name: "quantity",
-            },
-            {
-              type: "uint256",
-              name: "pricePerToken",
-            },
-            {
-              type: "address",
-              name: "currency",
-            },
-            {
-              type: "uint128",
-              name: "validityStartTimestamp",
-            },
-            {
-              type: "uint128",
-              name: "validityEndTimestamp",
-            },
-            {
-              type: "bytes32",
-              name: "uid",
-            },
-          ],
-        },
-        {
-          type: "bytes",
-          name: "signature",
-        },
-      ],
-      [
-        {
-          type: "bool",
-          name: "success",
-        },
-        {
-          type: "address",
-          name: "signer",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.req, options.signature],
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/ISignatureMintERC1155/write/mintWithSignature.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/ISignatureMintERC1155/write/mintWithSignature.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "mintWithSignature" function.
@@ -35,6 +36,94 @@ export type MintWithSignatureParams = Prettify<
       asyncParams: () => Promise<MintWithSignatureParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x98a6e993" as const;
+const FN_INPUTS = [
+  {
+    type: "tuple",
+    name: "req",
+    components: [
+      {
+        type: "address",
+        name: "to",
+      },
+      {
+        type: "address",
+        name: "royaltyRecipient",
+      },
+      {
+        type: "uint256",
+        name: "royaltyBps",
+      },
+      {
+        type: "address",
+        name: "primarySaleRecipient",
+      },
+      {
+        type: "uint256",
+        name: "tokenId",
+      },
+      {
+        type: "string",
+        name: "uri",
+      },
+      {
+        type: "uint256",
+        name: "quantity",
+      },
+      {
+        type: "uint256",
+        name: "pricePerToken",
+      },
+      {
+        type: "address",
+        name: "currency",
+      },
+      {
+        type: "uint128",
+        name: "validityStartTimestamp",
+      },
+      {
+        type: "uint128",
+        name: "validityEndTimestamp",
+      },
+      {
+        type: "bytes32",
+        name: "uid",
+      },
+    ],
+  },
+  {
+    type: "bytes",
+    name: "signature",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "address",
+    name: "signer",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "mintWithSignature" function.
+ * @param options - The options for the mintWithSignature function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { encodeMintWithSignatureParams } "thirdweb/extensions/erc1155";
+ * const result = encodeMintWithSignatureParams({
+ *  req: ...,
+ *  signature: ...,
+ * });
+ * ```
+ */
+export function encodeMintWithSignatureParams(
+  options: MintWithSignatureParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.req, options.signature]);
+}
+
 /**
  * Calls the "mintWithSignature" function on the contract.
  * @param options - The options for the "mintWithSignature" function.
@@ -59,75 +148,7 @@ export function mintWithSignature(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x98a6e993",
-      [
-        {
-          type: "tuple",
-          name: "req",
-          components: [
-            {
-              type: "address",
-              name: "to",
-            },
-            {
-              type: "address",
-              name: "royaltyRecipient",
-            },
-            {
-              type: "uint256",
-              name: "royaltyBps",
-            },
-            {
-              type: "address",
-              name: "primarySaleRecipient",
-            },
-            {
-              type: "uint256",
-              name: "tokenId",
-            },
-            {
-              type: "string",
-              name: "uri",
-            },
-            {
-              type: "uint256",
-              name: "quantity",
-            },
-            {
-              type: "uint256",
-              name: "pricePerToken",
-            },
-            {
-              type: "address",
-              name: "currency",
-            },
-            {
-              type: "uint128",
-              name: "validityStartTimestamp",
-            },
-            {
-              type: "uint128",
-              name: "validityEndTimestamp",
-            },
-            {
-              type: "bytes32",
-              name: "uid",
-            },
-          ],
-        },
-        {
-          type: "bytes",
-          name: "signature",
-        },
-      ],
-      [
-        {
-          type: "address",
-          name: "signer",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IStaking1155/read/getStakeInfo.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IStaking1155/read/getStakeInfo.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "getStakeInfo" function.
@@ -8,6 +11,60 @@ import type { AbiParameterToPrimitiveType } from "abitype";
 export type GetStakeInfoParams = {
   staker: AbiParameterToPrimitiveType<{ type: "address"; name: "staker" }>;
 };
+
+const FN_SELECTOR = "0xc3453153" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "staker",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256[]",
+    name: "_tokensStaked",
+  },
+  {
+    type: "uint256[]",
+    name: "_tokenAmounts",
+  },
+  {
+    type: "uint256",
+    name: "_totalRewards",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getStakeInfo" function.
+ * @param options - The options for the getStakeInfo function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { encodeGetStakeInfoParams } "thirdweb/extensions/erc1155";
+ * const result = encodeGetStakeInfoParams({
+ *  staker: ...,
+ * });
+ * ```
+ */
+export function encodeGetStakeInfoParams(options: GetStakeInfoParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.staker]);
+}
+
+/**
+ * Decodes the result of the getStakeInfo function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { decodeGetStakeInfoResult } from "thirdweb/extensions/erc1155";
+ * const result = decodeGetStakeInfoResult("...");
+ * ```
+ */
+export function decodeGetStakeInfoResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result);
+}
 
 /**
  * Calls the "getStakeInfo" function on the contract.
@@ -29,29 +86,7 @@ export async function getStakeInfo(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xc3453153",
-      [
-        {
-          type: "address",
-          name: "staker",
-        },
-      ],
-      [
-        {
-          type: "uint256[]",
-          name: "_tokensStaked",
-        },
-        {
-          type: "uint256[]",
-          name: "_tokenAmounts",
-        },
-        {
-          type: "uint256",
-          name: "_totalRewards",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.staker],
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IStaking1155/read/getStakeInfoForToken.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IStaking1155/read/getStakeInfoForToken.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "getStakeInfoForToken" function.
@@ -9,6 +12,63 @@ export type GetStakeInfoForTokenParams = {
   tokenId: AbiParameterToPrimitiveType<{ type: "uint256"; name: "tokenId" }>;
   staker: AbiParameterToPrimitiveType<{ type: "address"; name: "staker" }>;
 };
+
+const FN_SELECTOR = "0x168fb5c5" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "tokenId",
+  },
+  {
+    type: "address",
+    name: "staker",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+    name: "_tokensStaked",
+  },
+  {
+    type: "uint256",
+    name: "_rewards",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getStakeInfoForToken" function.
+ * @param options - The options for the getStakeInfoForToken function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { encodeGetStakeInfoForTokenParams } "thirdweb/extensions/erc1155";
+ * const result = encodeGetStakeInfoForTokenParams({
+ *  tokenId: ...,
+ *  staker: ...,
+ * });
+ * ```
+ */
+export function encodeGetStakeInfoForTokenParams(
+  options: GetStakeInfoForTokenParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.tokenId, options.staker]);
+}
+
+/**
+ * Decodes the result of the getStakeInfoForToken function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { decodeGetStakeInfoForTokenResult } from "thirdweb/extensions/erc1155";
+ * const result = decodeGetStakeInfoForTokenResult("...");
+ * ```
+ */
+export function decodeGetStakeInfoForTokenResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result);
+}
 
 /**
  * Calls the "getStakeInfoForToken" function on the contract.
@@ -31,29 +91,7 @@ export async function getStakeInfoForToken(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x168fb5c5",
-      [
-        {
-          type: "uint256",
-          name: "tokenId",
-        },
-        {
-          type: "address",
-          name: "staker",
-        },
-      ],
-      [
-        {
-          type: "uint256",
-          name: "_tokensStaked",
-        },
-        {
-          type: "uint256",
-          name: "_rewards",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.tokenId, options.staker],
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IStaking1155/write/claimRewards.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IStaking1155/write/claimRewards.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "claimRewards" function.
@@ -17,6 +18,32 @@ export type ClaimRewardsParams = Prettify<
       asyncParams: () => Promise<ClaimRewardsParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x0962ef79" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "tokenId",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "claimRewards" function.
+ * @param options - The options for the claimRewards function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { encodeClaimRewardsParams } "thirdweb/extensions/erc1155";
+ * const result = encodeClaimRewardsParams({
+ *  tokenId: ...,
+ * });
+ * ```
+ */
+export function encodeClaimRewardsParams(options: ClaimRewardsParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.tokenId]);
+}
+
 /**
  * Calls the "claimRewards" function on the contract.
  * @param options - The options for the "claimRewards" function.
@@ -40,16 +67,7 @@ export function claimRewards(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x0962ef79",
-      [
-        {
-          type: "uint256",
-          name: "tokenId",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IStaking1155/write/stake.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IStaking1155/write/stake.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "stake" function.
@@ -18,6 +19,37 @@ export type StakeParams = Prettify<
       asyncParams: () => Promise<StakeParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x952e68cf" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "tokenId",
+  },
+  {
+    type: "uint64",
+    name: "amount",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "stake" function.
+ * @param options - The options for the stake function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { encodeStakeParams } "thirdweb/extensions/erc1155";
+ * const result = encodeStakeParams({
+ *  tokenId: ...,
+ *  amount: ...,
+ * });
+ * ```
+ */
+export function encodeStakeParams(options: StakeParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.tokenId, options.amount]);
+}
+
 /**
  * Calls the "stake" function on the contract.
  * @param options - The options for the "stake" function.
@@ -40,20 +72,7 @@ export type StakeParams = Prettify<
 export function stake(options: BaseTransactionOptions<StakeParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x952e68cf",
-      [
-        {
-          type: "uint256",
-          name: "tokenId",
-        },
-        {
-          type: "uint64",
-          name: "amount",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IStaking1155/write/withdraw.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IStaking1155/write/withdraw.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "withdraw" function.
@@ -18,6 +19,37 @@ export type WithdrawParams = Prettify<
       asyncParams: () => Promise<WithdrawParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xc434dcfe" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "tokenId",
+  },
+  {
+    type: "uint64",
+    name: "amount",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "withdraw" function.
+ * @param options - The options for the withdraw function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC1155
+ * @example
+ * ```
+ * import { encodeWithdrawParams } "thirdweb/extensions/erc1155";
+ * const result = encodeWithdrawParams({
+ *  tokenId: ...,
+ *  amount: ...,
+ * });
+ * ```
+ */
+export function encodeWithdrawParams(options: WithdrawParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.tokenId, options.amount]);
+}
+
 /**
  * Calls the "withdraw" function on the contract.
  * @param options - The options for the "withdraw" function.
@@ -40,20 +72,7 @@ export type WithdrawParams = Prettify<
 export function withdraw(options: BaseTransactionOptions<WithdrawParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xc434dcfe",
-      [
-        {
-          type: "uint256",
-          name: "tokenId",
-        },
-        {
-          type: "uint64",
-          name: "amount",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc1271/__generated__/isValidSignature/read/isValidSignature.ts
+++ b/packages/thirdweb/src/extensions/erc1271/__generated__/isValidSignature/read/isValidSignature.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "isValidSignature" function.
@@ -9,6 +12,56 @@ export type IsValidSignatureParams = {
   hash: AbiParameterToPrimitiveType<{ type: "bytes32"; name: "hash" }>;
   signature: AbiParameterToPrimitiveType<{ type: "bytes"; name: "signature" }>;
 };
+
+const FN_SELECTOR = "0x1626ba7e" as const;
+const FN_INPUTS = [
+  {
+    type: "bytes32",
+    name: "hash",
+  },
+  {
+    type: "bytes",
+    name: "signature",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bytes4",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "isValidSignature" function.
+ * @param options - The options for the isValidSignature function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC1271
+ * @example
+ * ```
+ * import { encodeIsValidSignatureParams } "thirdweb/extensions/erc1271";
+ * const result = encodeIsValidSignatureParams({
+ *  hash: ...,
+ *  signature: ...,
+ * });
+ * ```
+ */
+export function encodeIsValidSignatureParams(options: IsValidSignatureParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.hash, options.signature]);
+}
+
+/**
+ * Decodes the result of the isValidSignature function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC1271
+ * @example
+ * ```
+ * import { decodeIsValidSignatureResult } from "thirdweb/extensions/erc1271";
+ * const result = decodeIsValidSignatureResult("...");
+ * ```
+ */
+export function decodeIsValidSignatureResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "isValidSignature" function on the contract.
@@ -31,24 +84,7 @@ export async function isValidSignature(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x1626ba7e",
-      [
-        {
-          type: "bytes32",
-          name: "hash",
-        },
-        {
-          type: "bytes",
-          name: "signature",
-        },
-      ],
-      [
-        {
-          type: "bytes4",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.hash, options.signature],
   });
 }

--- a/packages/thirdweb/src/extensions/erc165/__generated__/IERC165/read/supportsInterface.ts
+++ b/packages/thirdweb/src/extensions/erc165/__generated__/IERC165/read/supportsInterface.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "supportsInterface" function.
@@ -11,6 +14,53 @@ export type SupportsInterfaceParams = {
     name: "interfaceId";
   }>;
 };
+
+const FN_SELECTOR = "0x01ffc9a7" as const;
+const FN_INPUTS = [
+  {
+    type: "bytes4",
+    name: "interfaceId",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bool",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "supportsInterface" function.
+ * @param options - The options for the supportsInterface function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC165
+ * @example
+ * ```
+ * import { encodeSupportsInterfaceParams } "thirdweb/extensions/erc165";
+ * const result = encodeSupportsInterfaceParams({
+ *  interfaceId: ...,
+ * });
+ * ```
+ */
+export function encodeSupportsInterfaceParams(
+  options: SupportsInterfaceParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.interfaceId]);
+}
+
+/**
+ * Decodes the result of the supportsInterface function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC165
+ * @example
+ * ```
+ * import { decodeSupportsInterfaceResult } from "thirdweb/extensions/erc165";
+ * const result = decodeSupportsInterfaceResult("...");
+ * ```
+ */
+export function decodeSupportsInterfaceResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "supportsInterface" function on the contract.
@@ -32,20 +82,7 @@ export async function supportsInterface(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x01ffc9a7",
-      [
-        {
-          type: "bytes4",
-          name: "interfaceId",
-        },
-      ],
-      [
-        {
-          type: "bool",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.interfaceId],
   });
 }

--- a/packages/thirdweb/src/extensions/erc1822/__generated__/IERC1822Proxiable/read/proxiableUUID.ts
+++ b/packages/thirdweb/src/extensions/erc1822/__generated__/IERC1822Proxiable/read/proxiableUUID.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x52d1902d" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bytes32",
+  },
+] as const;
+
+/**
+ * Decodes the result of the proxiableUUID function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC1822
+ * @example
+ * ```
+ * import { decodeProxiableUUIDResult } from "thirdweb/extensions/erc1822";
+ * const result = decodeProxiableUUIDResult("...");
+ * ```
+ */
+export function decodeProxiableUUIDResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "proxiableUUID" function on the contract.
  * @param options - The options for the proxiableUUID function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function proxiableUUID(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x52d1902d",
-      [],
-      [
-        {
-          type: "bytes32",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IAirdropERC20/write/airdropERC20.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IAirdropERC20/write/airdropERC20.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "airdropERC20" function.
@@ -32,6 +33,56 @@ export type AirdropERC20Params = Prettify<
       asyncParams: () => Promise<AirdropERC20ParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x0670b2b3" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "tokenAddress",
+  },
+  {
+    type: "address",
+    name: "tokenOwner",
+  },
+  {
+    type: "tuple[]",
+    name: "contents",
+    components: [
+      {
+        type: "address",
+        name: "recipient",
+      },
+      {
+        type: "uint256",
+        name: "amount",
+      },
+    ],
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "airdropERC20" function.
+ * @param options - The options for the airdropERC20 function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC20
+ * @example
+ * ```
+ * import { encodeAirdropERC20Params } "thirdweb/extensions/erc20";
+ * const result = encodeAirdropERC20Params({
+ *  tokenAddress: ...,
+ *  tokenOwner: ...,
+ *  contents: ...,
+ * });
+ * ```
+ */
+export function encodeAirdropERC20Params(options: AirdropERC20ParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.tokenAddress,
+    options.tokenOwner,
+    options.contents,
+  ]);
+}
+
 /**
  * Calls the "airdropERC20" function on the contract.
  * @param options - The options for the "airdropERC20" function.
@@ -57,34 +108,7 @@ export function airdropERC20(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x0670b2b3",
-      [
-        {
-          type: "address",
-          name: "tokenAddress",
-        },
-        {
-          type: "address",
-          name: "tokenOwner",
-        },
-        {
-          type: "tuple[]",
-          name: "contents",
-          components: [
-            {
-              type: "address",
-              name: "recipient",
-            },
-            {
-              type: "uint256",
-              name: "amount",
-            },
-          ],
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IAirdropERC20Claimable/write/claim.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IAirdropERC20Claimable/write/claim.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "claim" function.
@@ -23,6 +24,52 @@ export type ClaimParams = Prettify<
       asyncParams: () => Promise<ClaimParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x3b4b57b0" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "receiver",
+  },
+  {
+    type: "uint256",
+    name: "quantity",
+  },
+  {
+    type: "bytes32[]",
+    name: "proofs",
+  },
+  {
+    type: "uint256",
+    name: "proofMaxQuantityForWallet",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "claim" function.
+ * @param options - The options for the claim function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC20
+ * @example
+ * ```
+ * import { encodeClaimParams } "thirdweb/extensions/erc20";
+ * const result = encodeClaimParams({
+ *  receiver: ...,
+ *  quantity: ...,
+ *  proofs: ...,
+ *  proofMaxQuantityForWallet: ...,
+ * });
+ * ```
+ */
+export function encodeClaimParams(options: ClaimParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.receiver,
+    options.quantity,
+    options.proofs,
+    options.proofMaxQuantityForWallet,
+  ]);
+}
+
 /**
  * Calls the "claim" function on the contract.
  * @param options - The options for the "claim" function.
@@ -47,28 +94,7 @@ export type ClaimParams = Prettify<
 export function claim(options: BaseTransactionOptions<ClaimParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x3b4b57b0",
-      [
-        {
-          type: "address",
-          name: "receiver",
-        },
-        {
-          type: "uint256",
-          name: "quantity",
-        },
-        {
-          type: "bytes32[]",
-          name: "proofs",
-        },
-        {
-          type: "uint256",
-          name: "proofMaxQuantityForWallet",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IBurnableERC20/write/burn.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IBurnableERC20/write/burn.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "burn" function.
@@ -17,6 +18,32 @@ export type BurnParams = Prettify<
       asyncParams: () => Promise<BurnParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x42966c68" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "amount",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "burn" function.
+ * @param options - The options for the burn function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC20
+ * @example
+ * ```
+ * import { encodeBurnParams } "thirdweb/extensions/erc20";
+ * const result = encodeBurnParams({
+ *  amount: ...,
+ * });
+ * ```
+ */
+export function encodeBurnParams(options: BurnParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.amount]);
+}
+
 /**
  * Calls the "burn" function on the contract.
  * @param options - The options for the "burn" function.
@@ -38,16 +65,7 @@ export type BurnParams = Prettify<
 export function burn(options: BaseTransactionOptions<BurnParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x42966c68",
-      [
-        {
-          type: "uint256",
-          name: "amount",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IBurnableERC20/write/burnFrom.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IBurnableERC20/write/burnFrom.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "burnFrom" function.
@@ -18,6 +19,37 @@ export type BurnFromParams = Prettify<
       asyncParams: () => Promise<BurnFromParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x79cc6790" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "account",
+  },
+  {
+    type: "uint256",
+    name: "amount",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "burnFrom" function.
+ * @param options - The options for the burnFrom function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC20
+ * @example
+ * ```
+ * import { encodeBurnFromParams } "thirdweb/extensions/erc20";
+ * const result = encodeBurnFromParams({
+ *  account: ...,
+ *  amount: ...,
+ * });
+ * ```
+ */
+export function encodeBurnFromParams(options: BurnFromParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.account, options.amount]);
+}
+
 /**
  * Calls the "burnFrom" function on the contract.
  * @param options - The options for the "burnFrom" function.
@@ -40,20 +72,7 @@ export type BurnFromParams = Prettify<
 export function burnFrom(options: BaseTransactionOptions<BurnFromParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x79cc6790",
-      [
-        {
-          type: "address",
-          name: "account",
-        },
-        {
-          type: "uint256",
-          name: "amount",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IDropERC20/write/claim.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IDropERC20/write/claim.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "claim" function.
@@ -32,6 +33,74 @@ export type ClaimParams = Prettify<
       asyncParams: () => Promise<ClaimParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x5ab31c1a" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "receiver",
+  },
+  {
+    type: "uint256",
+    name: "quantity",
+  },
+  {
+    type: "address",
+    name: "currency",
+  },
+  {
+    type: "uint256",
+    name: "pricePerToken",
+  },
+  {
+    type: "tuple",
+    name: "allowlistProof",
+    components: [
+      {
+        type: "bytes32[]",
+        name: "proof",
+      },
+      {
+        type: "uint256",
+        name: "maxQuantityInAllowlist",
+      },
+    ],
+  },
+  {
+    type: "bytes",
+    name: "data",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "claim" function.
+ * @param options - The options for the claim function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC20
+ * @example
+ * ```
+ * import { encodeClaimParams } "thirdweb/extensions/erc20";
+ * const result = encodeClaimParams({
+ *  receiver: ...,
+ *  quantity: ...,
+ *  currency: ...,
+ *  pricePerToken: ...,
+ *  allowlistProof: ...,
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeClaimParams(options: ClaimParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.receiver,
+    options.quantity,
+    options.currency,
+    options.pricePerToken,
+    options.allowlistProof,
+    options.data,
+  ]);
+}
+
 /**
  * Calls the "claim" function on the contract.
  * @param options - The options for the "claim" function.
@@ -58,46 +127,7 @@ export type ClaimParams = Prettify<
 export function claim(options: BaseTransactionOptions<ClaimParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x5ab31c1a",
-      [
-        {
-          type: "address",
-          name: "receiver",
-        },
-        {
-          type: "uint256",
-          name: "quantity",
-        },
-        {
-          type: "address",
-          name: "currency",
-        },
-        {
-          type: "uint256",
-          name: "pricePerToken",
-        },
-        {
-          type: "tuple",
-          name: "allowlistProof",
-          components: [
-            {
-              type: "bytes32[]",
-              name: "proof",
-            },
-            {
-              type: "uint256",
-              name: "maxQuantityInAllowlist",
-            },
-          ],
-        },
-        {
-          type: "bytes",
-          name: "data",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IDropERC20/write/setClaimConditions.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IDropERC20/write/setClaimConditions.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "setClaimConditions" function.
@@ -34,6 +35,76 @@ export type SetClaimConditionsParams = Prettify<
       asyncParams: () => Promise<SetClaimConditionsParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xe23b8164" as const;
+const FN_INPUTS = [
+  {
+    type: "tuple[]",
+    name: "phases",
+    components: [
+      {
+        type: "uint256",
+        name: "startTimestamp",
+      },
+      {
+        type: "uint256",
+        name: "maxClaimableSupply",
+      },
+      {
+        type: "uint256",
+        name: "supplyClaimed",
+      },
+      {
+        type: "uint256",
+        name: "quantityLimitPerWallet",
+      },
+      {
+        type: "uint256",
+        name: "waitTimeInSecondsBetweenClaims",
+      },
+      {
+        type: "bytes32",
+        name: "merkleRoot",
+      },
+      {
+        type: "uint256",
+        name: "pricePerToken",
+      },
+      {
+        type: "address",
+        name: "currency",
+      },
+    ],
+  },
+  {
+    type: "bool",
+    name: "resetClaimEligibility",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "setClaimConditions" function.
+ * @param options - The options for the setClaimConditions function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC20
+ * @example
+ * ```
+ * import { encodeSetClaimConditionsParams } "thirdweb/extensions/erc20";
+ * const result = encodeSetClaimConditionsParams({
+ *  phases: ...,
+ *  resetClaimEligibility: ...,
+ * });
+ * ```
+ */
+export function encodeSetClaimConditionsParams(
+  options: SetClaimConditionsParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.phases,
+    options.resetClaimEligibility,
+  ]);
+}
+
 /**
  * Calls the "setClaimConditions" function on the contract.
  * @param options - The options for the "setClaimConditions" function.
@@ -58,54 +129,7 @@ export function setClaimConditions(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xe23b8164",
-      [
-        {
-          type: "tuple[]",
-          name: "phases",
-          components: [
-            {
-              type: "uint256",
-              name: "startTimestamp",
-            },
-            {
-              type: "uint256",
-              name: "maxClaimableSupply",
-            },
-            {
-              type: "uint256",
-              name: "supplyClaimed",
-            },
-            {
-              type: "uint256",
-              name: "quantityLimitPerWallet",
-            },
-            {
-              type: "uint256",
-              name: "waitTimeInSecondsBetweenClaims",
-            },
-            {
-              type: "bytes32",
-              name: "merkleRoot",
-            },
-            {
-              type: "uint256",
-              name: "pricePerToken",
-            },
-            {
-              type: "address",
-              name: "currency",
-            },
-          ],
-        },
-        {
-          type: "bool",
-          name: "resetClaimEligibility",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IERC20/read/allowance.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IERC20/read/allowance.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "allowance" function.
@@ -9,6 +12,56 @@ export type AllowanceParams = {
   owner: AbiParameterToPrimitiveType<{ type: "address"; name: "owner" }>;
   spender: AbiParameterToPrimitiveType<{ type: "address"; name: "spender" }>;
 };
+
+const FN_SELECTOR = "0xdd62ed3e" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "owner",
+  },
+  {
+    type: "address",
+    name: "spender",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "allowance" function.
+ * @param options - The options for the allowance function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC20
+ * @example
+ * ```
+ * import { encodeAllowanceParams } "thirdweb/extensions/erc20";
+ * const result = encodeAllowanceParams({
+ *  owner: ...,
+ *  spender: ...,
+ * });
+ * ```
+ */
+export function encodeAllowanceParams(options: AllowanceParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.owner, options.spender]);
+}
+
+/**
+ * Decodes the result of the allowance function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC20
+ * @example
+ * ```
+ * import { decodeAllowanceResult } from "thirdweb/extensions/erc20";
+ * const result = decodeAllowanceResult("...");
+ * ```
+ */
+export function decodeAllowanceResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "allowance" function on the contract.
@@ -31,24 +84,7 @@ export async function allowance(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xdd62ed3e",
-      [
-        {
-          type: "address",
-          name: "owner",
-        },
-        {
-          type: "address",
-          name: "spender",
-        },
-      ],
-      [
-        {
-          type: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.owner, options.spender],
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IERC20/read/balanceOf.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IERC20/read/balanceOf.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "balanceOf" function.
@@ -8,6 +11,51 @@ import type { AbiParameterToPrimitiveType } from "abitype";
 export type BalanceOfParams = {
   address: AbiParameterToPrimitiveType<{ type: "address"; name: "_address" }>;
 };
+
+const FN_SELECTOR = "0x70a08231" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "_address",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "balanceOf" function.
+ * @param options - The options for the balanceOf function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC20
+ * @example
+ * ```
+ * import { encodeBalanceOfParams } "thirdweb/extensions/erc20";
+ * const result = encodeBalanceOfParams({
+ *  address: ...,
+ * });
+ * ```
+ */
+export function encodeBalanceOfParams(options: BalanceOfParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.address]);
+}
+
+/**
+ * Decodes the result of the balanceOf function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC20
+ * @example
+ * ```
+ * import { decodeBalanceOfResult } from "thirdweb/extensions/erc20";
+ * const result = decodeBalanceOfResult("...");
+ * ```
+ */
+export function decodeBalanceOfResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "balanceOf" function on the contract.
@@ -29,20 +77,7 @@ export async function balanceOf(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x70a08231",
-      [
-        {
-          type: "address",
-          name: "_address",
-        },
-      ],
-      [
-        {
-          type: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.address],
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IERC20/read/decimals.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IERC20/read/decimals.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x313ce567" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint8",
+  },
+] as const;
+
+/**
+ * Decodes the result of the decimals function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC20
+ * @example
+ * ```
+ * import { decodeDecimalsResult } from "thirdweb/extensions/erc20";
+ * const result = decodeDecimalsResult("...");
+ * ```
+ */
+export function decodeDecimalsResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "decimals" function on the contract.
  * @param options - The options for the decimals function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function decimals(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x313ce567",
-      [],
-      [
-        {
-          type: "uint8",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IERC20/read/totalSupply.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IERC20/read/totalSupply.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x18160ddd" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the totalSupply function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC20
+ * @example
+ * ```
+ * import { decodeTotalSupplyResult } from "thirdweb/extensions/erc20";
+ * const result = decodeTotalSupplyResult("...");
+ * ```
+ */
+export function decodeTotalSupplyResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "totalSupply" function on the contract.
  * @param options - The options for the totalSupply function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function totalSupply(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x18160ddd",
-      [],
-      [
-        {
-          type: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IERC20/write/approve.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IERC20/write/approve.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "approve" function.
@@ -18,6 +19,41 @@ export type ApproveParams = Prettify<
       asyncParams: () => Promise<ApproveParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x095ea7b3" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "spender",
+  },
+  {
+    type: "uint256",
+    name: "value",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bool",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "approve" function.
+ * @param options - The options for the approve function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC20
+ * @example
+ * ```
+ * import { encodeApproveParams } "thirdweb/extensions/erc20";
+ * const result = encodeApproveParams({
+ *  spender: ...,
+ *  value: ...,
+ * });
+ * ```
+ */
+export function encodeApproveParams(options: ApproveParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.spender, options.value]);
+}
+
 /**
  * Calls the "approve" function on the contract.
  * @param options - The options for the "approve" function.
@@ -40,24 +76,7 @@ export type ApproveParams = Prettify<
 export function approve(options: BaseTransactionOptions<ApproveParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x095ea7b3",
-      [
-        {
-          type: "address",
-          name: "spender",
-        },
-        {
-          type: "uint256",
-          name: "value",
-        },
-      ],
-      [
-        {
-          type: "bool",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IERC20/write/transfer.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IERC20/write/transfer.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "transfer" function.
@@ -18,6 +19,41 @@ export type TransferParams = Prettify<
       asyncParams: () => Promise<TransferParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xa9059cbb" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "to",
+  },
+  {
+    type: "uint256",
+    name: "value",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bool",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "transfer" function.
+ * @param options - The options for the transfer function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC20
+ * @example
+ * ```
+ * import { encodeTransferParams } "thirdweb/extensions/erc20";
+ * const result = encodeTransferParams({
+ *  to: ...,
+ *  value: ...,
+ * });
+ * ```
+ */
+export function encodeTransferParams(options: TransferParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.to, options.value]);
+}
+
 /**
  * Calls the "transfer" function on the contract.
  * @param options - The options for the "transfer" function.
@@ -40,24 +76,7 @@ export type TransferParams = Prettify<
 export function transfer(options: BaseTransactionOptions<TransferParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xa9059cbb",
-      [
-        {
-          type: "address",
-          name: "to",
-        },
-        {
-          type: "uint256",
-          name: "value",
-        },
-      ],
-      [
-        {
-          type: "bool",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IERC20/write/transferFrom.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IERC20/write/transferFrom.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "transferFrom" function.
@@ -19,6 +20,50 @@ export type TransferFromParams = Prettify<
       asyncParams: () => Promise<TransferFromParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x23b872dd" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "from",
+  },
+  {
+    type: "address",
+    name: "to",
+  },
+  {
+    type: "uint256",
+    name: "value",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bool",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "transferFrom" function.
+ * @param options - The options for the transferFrom function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC20
+ * @example
+ * ```
+ * import { encodeTransferFromParams } "thirdweb/extensions/erc20";
+ * const result = encodeTransferFromParams({
+ *  from: ...,
+ *  to: ...,
+ *  value: ...,
+ * });
+ * ```
+ */
+export function encodeTransferFromParams(options: TransferFromParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.from,
+    options.to,
+    options.value,
+  ]);
+}
+
 /**
  * Calls the "transferFrom" function on the contract.
  * @param options - The options for the "transferFrom" function.
@@ -44,28 +89,7 @@ export function transferFrom(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x23b872dd",
-      [
-        {
-          type: "address",
-          name: "from",
-        },
-        {
-          type: "address",
-          name: "to",
-        },
-        {
-          type: "uint256",
-          name: "value",
-        },
-      ],
-      [
-        {
-          type: "bool",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IERC20Permit/read/DOMAIN_SEPARATOR.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IERC20Permit/read/DOMAIN_SEPARATOR.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x3644e515" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bytes32",
+  },
+] as const;
+
+/**
+ * Decodes the result of the DOMAIN_SEPARATOR function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC20
+ * @example
+ * ```
+ * import { decodeDOMAIN_SEPARATORResult } from "thirdweb/extensions/erc20";
+ * const result = decodeDOMAIN_SEPARATORResult("...");
+ * ```
+ */
+export function decodeDOMAIN_SEPARATORResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "DOMAIN_SEPARATOR" function on the contract.
  * @param options - The options for the DOMAIN_SEPARATOR function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function DOMAIN_SEPARATOR(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x3644e515",
-      [],
-      [
-        {
-          type: "bytes32",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IERC20Permit/read/nonces.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IERC20Permit/read/nonces.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "nonces" function.
@@ -8,6 +11,51 @@ import type { AbiParameterToPrimitiveType } from "abitype";
 export type NoncesParams = {
   owner: AbiParameterToPrimitiveType<{ type: "address"; name: "owner" }>;
 };
+
+const FN_SELECTOR = "0x7ecebe00" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "owner",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "nonces" function.
+ * @param options - The options for the nonces function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC20
+ * @example
+ * ```
+ * import { encodeNoncesParams } "thirdweb/extensions/erc20";
+ * const result = encodeNoncesParams({
+ *  owner: ...,
+ * });
+ * ```
+ */
+export function encodeNoncesParams(options: NoncesParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.owner]);
+}
+
+/**
+ * Decodes the result of the nonces function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC20
+ * @example
+ * ```
+ * import { decodeNoncesResult } from "thirdweb/extensions/erc20";
+ * const result = decodeNoncesResult("...");
+ * ```
+ */
+export function decodeNoncesResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "nonces" function on the contract.
@@ -27,20 +75,7 @@ export type NoncesParams = {
 export async function nonces(options: BaseTransactionOptions<NoncesParams>) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x7ecebe00",
-      [
-        {
-          type: "address",
-          name: "owner",
-        },
-      ],
-      [
-        {
-          type: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.owner],
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IERC20Permit/write/permit.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IERC20Permit/write/permit.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "permit" function.
@@ -23,6 +24,70 @@ export type PermitParams = Prettify<
       asyncParams: () => Promise<PermitParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xd505accf" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "owner",
+  },
+  {
+    type: "address",
+    name: "spender",
+  },
+  {
+    type: "uint256",
+    name: "value",
+  },
+  {
+    type: "uint256",
+    name: "deadline",
+  },
+  {
+    type: "uint8",
+    name: "v",
+  },
+  {
+    type: "bytes32",
+    name: "r",
+  },
+  {
+    type: "bytes32",
+    name: "s",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "permit" function.
+ * @param options - The options for the permit function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC20
+ * @example
+ * ```
+ * import { encodePermitParams } "thirdweb/extensions/erc20";
+ * const result = encodePermitParams({
+ *  owner: ...,
+ *  spender: ...,
+ *  value: ...,
+ *  deadline: ...,
+ *  v: ...,
+ *  r: ...,
+ *  s: ...,
+ * });
+ * ```
+ */
+export function encodePermitParams(options: PermitParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.owner,
+    options.spender,
+    options.value,
+    options.deadline,
+    options.v,
+    options.r,
+    options.s,
+  ]);
+}
+
 /**
  * Calls the "permit" function on the contract.
  * @param options - The options for the "permit" function.
@@ -50,40 +115,7 @@ export type PermitParams = Prettify<
 export function permit(options: BaseTransactionOptions<PermitParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xd505accf",
-      [
-        {
-          type: "address",
-          name: "owner",
-        },
-        {
-          type: "address",
-          name: "spender",
-        },
-        {
-          type: "uint256",
-          name: "value",
-        },
-        {
-          type: "uint256",
-          name: "deadline",
-        },
-        {
-          type: "uint8",
-          name: "v",
-        },
-        {
-          type: "bytes32",
-          name: "r",
-        },
-        {
-          type: "bytes32",
-          name: "s",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IMintableERC20/write/mintTo.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IMintableERC20/write/mintTo.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "mintTo" function.
@@ -18,6 +19,37 @@ export type MintToParams = Prettify<
       asyncParams: () => Promise<MintToParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x449a52f8" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "to",
+  },
+  {
+    type: "uint256",
+    name: "amount",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "mintTo" function.
+ * @param options - The options for the mintTo function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC20
+ * @example
+ * ```
+ * import { encodeMintToParams } "thirdweb/extensions/erc20";
+ * const result = encodeMintToParams({
+ *  to: ...,
+ *  amount: ...,
+ * });
+ * ```
+ */
+export function encodeMintToParams(options: MintToParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.to, options.amount]);
+}
+
 /**
  * Calls the "mintTo" function on the contract.
  * @param options - The options for the "mintTo" function.
@@ -40,20 +72,7 @@ export type MintToParams = Prettify<
 export function mintTo(options: BaseTransactionOptions<MintToParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x449a52f8",
-      [
-        {
-          type: "address",
-          name: "to",
-        },
-        {
-          type: "uint256",
-          name: "amount",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc20/__generated__/ISignatureMintERC20/read/verify.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/ISignatureMintERC20/read/verify.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "verify" function.
@@ -23,6 +26,95 @@ export type VerifyParams = {
   signature: AbiParameterToPrimitiveType<{ type: "bytes"; name: "signature" }>;
 };
 
+const FN_SELECTOR = "0xc1b606e2" as const;
+const FN_INPUTS = [
+  {
+    type: "tuple",
+    name: "req",
+    components: [
+      {
+        type: "address",
+        name: "to",
+      },
+      {
+        type: "address",
+        name: "primarySaleRecipient",
+      },
+      {
+        type: "uint256",
+        name: "quantity",
+      },
+      {
+        type: "uint256",
+        name: "price",
+      },
+      {
+        type: "address",
+        name: "currency",
+      },
+      {
+        type: "uint128",
+        name: "validityStartTimestamp",
+      },
+      {
+        type: "uint128",
+        name: "validityEndTimestamp",
+      },
+      {
+        type: "bytes32",
+        name: "uid",
+      },
+    ],
+  },
+  {
+    type: "bytes",
+    name: "signature",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bool",
+    name: "success",
+  },
+  {
+    type: "address",
+    name: "signer",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "verify" function.
+ * @param options - The options for the verify function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC20
+ * @example
+ * ```
+ * import { encodeVerifyParams } "thirdweb/extensions/erc20";
+ * const result = encodeVerifyParams({
+ *  req: ...,
+ *  signature: ...,
+ * });
+ * ```
+ */
+export function encodeVerifyParams(options: VerifyParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.req, options.signature]);
+}
+
+/**
+ * Decodes the result of the verify function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC20
+ * @example
+ * ```
+ * import { decodeVerifyResult } from "thirdweb/extensions/erc20";
+ * const result = decodeVerifyResult("...");
+ * ```
+ */
+export function decodeVerifyResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result);
+}
+
 /**
  * Calls the "verify" function on the contract.
  * @param options - The options for the verify function.
@@ -42,63 +134,7 @@ export type VerifyParams = {
 export async function verify(options: BaseTransactionOptions<VerifyParams>) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xc1b606e2",
-      [
-        {
-          type: "tuple",
-          name: "req",
-          components: [
-            {
-              type: "address",
-              name: "to",
-            },
-            {
-              type: "address",
-              name: "primarySaleRecipient",
-            },
-            {
-              type: "uint256",
-              name: "quantity",
-            },
-            {
-              type: "uint256",
-              name: "price",
-            },
-            {
-              type: "address",
-              name: "currency",
-            },
-            {
-              type: "uint128",
-              name: "validityStartTimestamp",
-            },
-            {
-              type: "uint128",
-              name: "validityEndTimestamp",
-            },
-            {
-              type: "bytes32",
-              name: "uid",
-            },
-          ],
-        },
-        {
-          type: "bytes",
-          name: "signature",
-        },
-      ],
-      [
-        {
-          type: "bool",
-          name: "success",
-        },
-        {
-          type: "address",
-          name: "signer",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.req, options.signature],
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/ISignatureMintERC20/write/mintWithSignature.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/ISignatureMintERC20/write/mintWithSignature.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "mintWithSignature" function.
@@ -31,6 +32,78 @@ export type MintWithSignatureParams = Prettify<
       asyncParams: () => Promise<MintWithSignatureParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x8f0fefbb" as const;
+const FN_INPUTS = [
+  {
+    type: "tuple",
+    name: "req",
+    components: [
+      {
+        type: "address",
+        name: "to",
+      },
+      {
+        type: "address",
+        name: "primarySaleRecipient",
+      },
+      {
+        type: "uint256",
+        name: "quantity",
+      },
+      {
+        type: "uint256",
+        name: "price",
+      },
+      {
+        type: "address",
+        name: "currency",
+      },
+      {
+        type: "uint128",
+        name: "validityStartTimestamp",
+      },
+      {
+        type: "uint128",
+        name: "validityEndTimestamp",
+      },
+      {
+        type: "bytes32",
+        name: "uid",
+      },
+    ],
+  },
+  {
+    type: "bytes",
+    name: "signature",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "address",
+    name: "signer",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "mintWithSignature" function.
+ * @param options - The options for the mintWithSignature function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC20
+ * @example
+ * ```
+ * import { encodeMintWithSignatureParams } "thirdweb/extensions/erc20";
+ * const result = encodeMintWithSignatureParams({
+ *  req: ...,
+ *  signature: ...,
+ * });
+ * ```
+ */
+export function encodeMintWithSignatureParams(
+  options: MintWithSignatureParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.req, options.signature]);
+}
+
 /**
  * Calls the "mintWithSignature" function on the contract.
  * @param options - The options for the "mintWithSignature" function.
@@ -55,59 +128,7 @@ export function mintWithSignature(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x8f0fefbb",
-      [
-        {
-          type: "tuple",
-          name: "req",
-          components: [
-            {
-              type: "address",
-              name: "to",
-            },
-            {
-              type: "address",
-              name: "primarySaleRecipient",
-            },
-            {
-              type: "uint256",
-              name: "quantity",
-            },
-            {
-              type: "uint256",
-              name: "price",
-            },
-            {
-              type: "address",
-              name: "currency",
-            },
-            {
-              type: "uint128",
-              name: "validityStartTimestamp",
-            },
-            {
-              type: "uint128",
-              name: "validityEndTimestamp",
-            },
-            {
-              type: "bytes32",
-              name: "uid",
-            },
-          ],
-        },
-        {
-          type: "bytes",
-          name: "signature",
-        },
-      ],
-      [
-        {
-          type: "address",
-          name: "signer",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IStaking20/read/getStakeInfo.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IStaking20/read/getStakeInfo.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "getStakeInfo" function.
@@ -8,6 +11,56 @@ import type { AbiParameterToPrimitiveType } from "abitype";
 export type GetStakeInfoParams = {
   staker: AbiParameterToPrimitiveType<{ type: "address"; name: "staker" }>;
 };
+
+const FN_SELECTOR = "0xc3453153" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "staker",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+    name: "_tokensStaked",
+  },
+  {
+    type: "uint256",
+    name: "_rewards",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getStakeInfo" function.
+ * @param options - The options for the getStakeInfo function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC20
+ * @example
+ * ```
+ * import { encodeGetStakeInfoParams } "thirdweb/extensions/erc20";
+ * const result = encodeGetStakeInfoParams({
+ *  staker: ...,
+ * });
+ * ```
+ */
+export function encodeGetStakeInfoParams(options: GetStakeInfoParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.staker]);
+}
+
+/**
+ * Decodes the result of the getStakeInfo function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC20
+ * @example
+ * ```
+ * import { decodeGetStakeInfoResult } from "thirdweb/extensions/erc20";
+ * const result = decodeGetStakeInfoResult("...");
+ * ```
+ */
+export function decodeGetStakeInfoResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result);
+}
 
 /**
  * Calls the "getStakeInfo" function on the contract.
@@ -29,25 +82,7 @@ export async function getStakeInfo(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xc3453153",
-      [
-        {
-          type: "address",
-          name: "staker",
-        },
-      ],
-      [
-        {
-          type: "uint256",
-          name: "_tokensStaked",
-        },
-        {
-          type: "uint256",
-          name: "_rewards",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.staker],
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IStaking20/write/claimRewards.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IStaking20/write/claimRewards.ts
@@ -1,6 +1,10 @@
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
 
+const FN_SELECTOR = "0x372500ab" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [] as const;
+
 /**
  * Calls the "claimRewards" function on the contract.
  * @param options - The options for the "claimRewards" function.
@@ -20,6 +24,6 @@ import { prepareContractCall } from "../../../../../transaction/prepare-contract
 export function claimRewards(options: BaseTransactionOptions) {
   return prepareContractCall({
     contract: options.contract,
-    method: ["0x372500ab", [], []],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IStaking20/write/stake.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IStaking20/write/stake.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "stake" function.
@@ -17,6 +18,32 @@ export type StakeParams = Prettify<
       asyncParams: () => Promise<StakeParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xa694fc3a" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "amount",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "stake" function.
+ * @param options - The options for the stake function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC20
+ * @example
+ * ```
+ * import { encodeStakeParams } "thirdweb/extensions/erc20";
+ * const result = encodeStakeParams({
+ *  amount: ...,
+ * });
+ * ```
+ */
+export function encodeStakeParams(options: StakeParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.amount]);
+}
+
 /**
  * Calls the "stake" function on the contract.
  * @param options - The options for the "stake" function.
@@ -38,16 +65,7 @@ export type StakeParams = Prettify<
 export function stake(options: BaseTransactionOptions<StakeParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xa694fc3a",
-      [
-        {
-          type: "uint256",
-          name: "amount",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IStaking20/write/withdraw.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IStaking20/write/withdraw.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "withdraw" function.
@@ -17,6 +18,32 @@ export type WithdrawParams = Prettify<
       asyncParams: () => Promise<WithdrawParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x2e1a7d4d" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "amount",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "withdraw" function.
+ * @param options - The options for the withdraw function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC20
+ * @example
+ * ```
+ * import { encodeWithdrawParams } "thirdweb/extensions/erc20";
+ * const result = encodeWithdrawParams({
+ *  amount: ...,
+ * });
+ * ```
+ */
+export function encodeWithdrawParams(options: WithdrawParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.amount]);
+}
+
 /**
  * Calls the "withdraw" function on the contract.
  * @param options - The options for the "withdraw" function.
@@ -38,16 +65,7 @@ export type WithdrawParams = Prettify<
 export function withdraw(options: BaseTransactionOptions<WithdrawParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x2e1a7d4d",
-      [
-        {
-          type: "uint256",
-          name: "amount",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc20/__generated__/ITokenStake/write/depositRewardTokens.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/ITokenStake/write/depositRewardTokens.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "depositRewardTokens" function.
@@ -17,6 +18,34 @@ export type DepositRewardTokensParams = Prettify<
       asyncParams: () => Promise<DepositRewardTokensParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x16c621e0" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_amount",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "depositRewardTokens" function.
+ * @param options - The options for the depositRewardTokens function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC20
+ * @example
+ * ```
+ * import { encodeDepositRewardTokensParams } "thirdweb/extensions/erc20";
+ * const result = encodeDepositRewardTokensParams({
+ *  amount: ...,
+ * });
+ * ```
+ */
+export function encodeDepositRewardTokensParams(
+  options: DepositRewardTokensParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.amount]);
+}
+
 /**
  * Calls the "depositRewardTokens" function on the contract.
  * @param options - The options for the "depositRewardTokens" function.
@@ -40,16 +69,7 @@ export function depositRewardTokens(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x16c621e0",
-      [
-        {
-          type: "uint256",
-          name: "_amount",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc20/__generated__/ITokenStake/write/withdrawRewardTokens.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/ITokenStake/write/withdrawRewardTokens.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "withdrawRewardTokens" function.
@@ -17,6 +18,34 @@ export type WithdrawRewardTokensParams = Prettify<
       asyncParams: () => Promise<WithdrawRewardTokensParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xcb43b2dd" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_amount",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "withdrawRewardTokens" function.
+ * @param options - The options for the withdrawRewardTokens function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC20
+ * @example
+ * ```
+ * import { encodeWithdrawRewardTokensParams } "thirdweb/extensions/erc20";
+ * const result = encodeWithdrawRewardTokensParams({
+ *  amount: ...,
+ * });
+ * ```
+ */
+export function encodeWithdrawRewardTokensParams(
+  options: WithdrawRewardTokensParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.amount]);
+}
+
 /**
  * Calls the "withdrawRewardTokens" function on the contract.
  * @param options - The options for the "withdrawRewardTokens" function.
@@ -40,16 +69,7 @@ export function withdrawRewardTokens(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xcb43b2dd",
-      [
-        {
-          type: "uint256",
-          name: "_amount",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IVotes/read/delegates.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IVotes/read/delegates.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "delegates" function.
@@ -8,6 +11,51 @@ import type { AbiParameterToPrimitiveType } from "abitype";
 export type DelegatesParams = {
   account: AbiParameterToPrimitiveType<{ type: "address"; name: "account" }>;
 };
+
+const FN_SELECTOR = "0x587cde1e" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "account",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "address",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "delegates" function.
+ * @param options - The options for the delegates function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC20
+ * @example
+ * ```
+ * import { encodeDelegatesParams } "thirdweb/extensions/erc20";
+ * const result = encodeDelegatesParams({
+ *  account: ...,
+ * });
+ * ```
+ */
+export function encodeDelegatesParams(options: DelegatesParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.account]);
+}
+
+/**
+ * Decodes the result of the delegates function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC20
+ * @example
+ * ```
+ * import { decodeDelegatesResult } from "thirdweb/extensions/erc20";
+ * const result = decodeDelegatesResult("...");
+ * ```
+ */
+export function decodeDelegatesResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "delegates" function on the contract.
@@ -29,20 +77,7 @@ export async function delegates(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x587cde1e",
-      [
-        {
-          type: "address",
-          name: "account",
-        },
-      ],
-      [
-        {
-          type: "address",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.account],
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IVotes/read/getPastTotalSupply.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IVotes/read/getPastTotalSupply.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "getPastTotalSupply" function.
@@ -11,6 +14,53 @@ export type GetPastTotalSupplyParams = {
     name: "blockNumber";
   }>;
 };
+
+const FN_SELECTOR = "0x8e539e8c" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "blockNumber",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getPastTotalSupply" function.
+ * @param options - The options for the getPastTotalSupply function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC20
+ * @example
+ * ```
+ * import { encodeGetPastTotalSupplyParams } "thirdweb/extensions/erc20";
+ * const result = encodeGetPastTotalSupplyParams({
+ *  blockNumber: ...,
+ * });
+ * ```
+ */
+export function encodeGetPastTotalSupplyParams(
+  options: GetPastTotalSupplyParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.blockNumber]);
+}
+
+/**
+ * Decodes the result of the getPastTotalSupply function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC20
+ * @example
+ * ```
+ * import { decodeGetPastTotalSupplyResult } from "thirdweb/extensions/erc20";
+ * const result = decodeGetPastTotalSupplyResult("...");
+ * ```
+ */
+export function decodeGetPastTotalSupplyResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "getPastTotalSupply" function on the contract.
@@ -32,20 +82,7 @@ export async function getPastTotalSupply(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x8e539e8c",
-      [
-        {
-          type: "uint256",
-          name: "blockNumber",
-        },
-      ],
-      [
-        {
-          type: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.blockNumber],
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IVotes/read/getPastVotes.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IVotes/read/getPastVotes.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "getPastVotes" function.
@@ -12,6 +15,56 @@ export type GetPastVotesParams = {
     name: "blockNumber";
   }>;
 };
+
+const FN_SELECTOR = "0x3a46b1a8" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "account",
+  },
+  {
+    type: "uint256",
+    name: "blockNumber",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getPastVotes" function.
+ * @param options - The options for the getPastVotes function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC20
+ * @example
+ * ```
+ * import { encodeGetPastVotesParams } "thirdweb/extensions/erc20";
+ * const result = encodeGetPastVotesParams({
+ *  account: ...,
+ *  blockNumber: ...,
+ * });
+ * ```
+ */
+export function encodeGetPastVotesParams(options: GetPastVotesParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.account, options.blockNumber]);
+}
+
+/**
+ * Decodes the result of the getPastVotes function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC20
+ * @example
+ * ```
+ * import { decodeGetPastVotesResult } from "thirdweb/extensions/erc20";
+ * const result = decodeGetPastVotesResult("...");
+ * ```
+ */
+export function decodeGetPastVotesResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "getPastVotes" function on the contract.
@@ -34,24 +87,7 @@ export async function getPastVotes(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x3a46b1a8",
-      [
-        {
-          type: "address",
-          name: "account",
-        },
-        {
-          type: "uint256",
-          name: "blockNumber",
-        },
-      ],
-      [
-        {
-          type: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.account, options.blockNumber],
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IVotes/read/getVotes.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IVotes/read/getVotes.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "getVotes" function.
@@ -8,6 +11,51 @@ import type { AbiParameterToPrimitiveType } from "abitype";
 export type GetVotesParams = {
   account: AbiParameterToPrimitiveType<{ type: "address"; name: "account" }>;
 };
+
+const FN_SELECTOR = "0x9ab24eb0" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "account",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getVotes" function.
+ * @param options - The options for the getVotes function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC20
+ * @example
+ * ```
+ * import { encodeGetVotesParams } "thirdweb/extensions/erc20";
+ * const result = encodeGetVotesParams({
+ *  account: ...,
+ * });
+ * ```
+ */
+export function encodeGetVotesParams(options: GetVotesParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.account]);
+}
+
+/**
+ * Decodes the result of the getVotes function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC20
+ * @example
+ * ```
+ * import { decodeGetVotesResult } from "thirdweb/extensions/erc20";
+ * const result = decodeGetVotesResult("...");
+ * ```
+ */
+export function decodeGetVotesResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "getVotes" function on the contract.
@@ -29,20 +77,7 @@ export async function getVotes(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x9ab24eb0",
-      [
-        {
-          type: "address",
-          name: "account",
-        },
-      ],
-      [
-        {
-          type: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.account],
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IVotes/write/delegate.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IVotes/write/delegate.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "delegate" function.
@@ -20,6 +21,32 @@ export type DelegateParams = Prettify<
       asyncParams: () => Promise<DelegateParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x5c19a95c" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "delegatee",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "delegate" function.
+ * @param options - The options for the delegate function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC20
+ * @example
+ * ```
+ * import { encodeDelegateParams } "thirdweb/extensions/erc20";
+ * const result = encodeDelegateParams({
+ *  delegatee: ...,
+ * });
+ * ```
+ */
+export function encodeDelegateParams(options: DelegateParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.delegatee]);
+}
+
 /**
  * Calls the "delegate" function on the contract.
  * @param options - The options for the "delegate" function.
@@ -41,16 +68,7 @@ export type DelegateParams = Prettify<
 export function delegate(options: BaseTransactionOptions<DelegateParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x5c19a95c",
-      [
-        {
-          type: "address",
-          name: "delegatee",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IVotes/write/delegateBySig.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IVotes/write/delegateBySig.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "delegateBySig" function.
@@ -25,6 +26,66 @@ export type DelegateBySigParams = Prettify<
       asyncParams: () => Promise<DelegateBySigParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xc3cda520" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "delegatee",
+  },
+  {
+    type: "uint256",
+    name: "nonce",
+  },
+  {
+    type: "uint256",
+    name: "expiry",
+  },
+  {
+    type: "uint8",
+    name: "v",
+  },
+  {
+    type: "bytes32",
+    name: "r",
+  },
+  {
+    type: "bytes32",
+    name: "s",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "delegateBySig" function.
+ * @param options - The options for the delegateBySig function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC20
+ * @example
+ * ```
+ * import { encodeDelegateBySigParams } "thirdweb/extensions/erc20";
+ * const result = encodeDelegateBySigParams({
+ *  delegatee: ...,
+ *  nonce: ...,
+ *  expiry: ...,
+ *  v: ...,
+ *  r: ...,
+ *  s: ...,
+ * });
+ * ```
+ */
+export function encodeDelegateBySigParams(
+  options: DelegateBySigParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.delegatee,
+    options.nonce,
+    options.expiry,
+    options.v,
+    options.r,
+    options.s,
+  ]);
+}
+
 /**
  * Calls the "delegateBySig" function on the contract.
  * @param options - The options for the "delegateBySig" function.
@@ -53,36 +114,7 @@ export function delegateBySig(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xc3cda520",
-      [
-        {
-          type: "address",
-          name: "delegatee",
-        },
-        {
-          type: "uint256",
-          name: "nonce",
-        },
-        {
-          type: "uint256",
-          name: "expiry",
-        },
-        {
-          type: "uint8",
-          name: "v",
-        },
-        {
-          type: "bytes32",
-          name: "r",
-        },
-        {
-          type: "bytes32",
-          name: "s",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IWETH/write/deposit.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IWETH/write/deposit.ts
@@ -1,6 +1,10 @@
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
 
+const FN_SELECTOR = "0xd0e30db0" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [] as const;
+
 /**
  * Calls the "deposit" function on the contract.
  * @param options - The options for the "deposit" function.
@@ -20,6 +24,6 @@ import { prepareContractCall } from "../../../../../transaction/prepare-contract
 export function deposit(options: BaseTransactionOptions) {
   return prepareContractCall({
     contract: options.contract,
-    method: ["0xd0e30db0", [], []],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IWETH/write/transfer.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IWETH/write/transfer.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "transfer" function.
@@ -18,6 +19,41 @@ export type TransferParams = Prettify<
       asyncParams: () => Promise<TransferParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xa9059cbb" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "to",
+  },
+  {
+    type: "uint256",
+    name: "value",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bool",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "transfer" function.
+ * @param options - The options for the transfer function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC20
+ * @example
+ * ```
+ * import { encodeTransferParams } "thirdweb/extensions/erc20";
+ * const result = encodeTransferParams({
+ *  to: ...,
+ *  value: ...,
+ * });
+ * ```
+ */
+export function encodeTransferParams(options: TransferParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.to, options.value]);
+}
+
 /**
  * Calls the "transfer" function on the contract.
  * @param options - The options for the "transfer" function.
@@ -40,24 +76,7 @@ export type TransferParams = Prettify<
 export function transfer(options: BaseTransactionOptions<TransferParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xa9059cbb",
-      [
-        {
-          type: "address",
-          name: "to",
-        },
-        {
-          type: "uint256",
-          name: "value",
-        },
-      ],
-      [
-        {
-          type: "bool",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IWETH/write/withdraw.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IWETH/write/withdraw.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "withdraw" function.
@@ -17,6 +18,32 @@ export type WithdrawParams = Prettify<
       asyncParams: () => Promise<WithdrawParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x2e1a7d4d" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "amount",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "withdraw" function.
+ * @param options - The options for the withdraw function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC20
+ * @example
+ * ```
+ * import { encodeWithdrawParams } "thirdweb/extensions/erc20";
+ * const result = encodeWithdrawParams({
+ *  amount: ...,
+ * });
+ * ```
+ */
+export function encodeWithdrawParams(options: WithdrawParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.amount]);
+}
+
 /**
  * Calls the "withdraw" function on the contract.
  * @param options - The options for the "withdraw" function.
@@ -38,16 +65,7 @@ export type WithdrawParams = Prettify<
 export function withdraw(options: BaseTransactionOptions<WithdrawParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x2e1a7d4d",
-      [
-        {
-          type: "uint256",
-          name: "amount",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc2771/__generated__/IERC2771Context/read/isTrustedForwarder.ts
+++ b/packages/thirdweb/src/extensions/erc2771/__generated__/IERC2771Context/read/isTrustedForwarder.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "isTrustedForwarder" function.
@@ -11,6 +14,53 @@ export type IsTrustedForwarderParams = {
     name: "forwarder";
   }>;
 };
+
+const FN_SELECTOR = "0x572b6c05" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "forwarder",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bool",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "isTrustedForwarder" function.
+ * @param options - The options for the isTrustedForwarder function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC2771
+ * @example
+ * ```
+ * import { encodeIsTrustedForwarderParams } "thirdweb/extensions/erc2771";
+ * const result = encodeIsTrustedForwarderParams({
+ *  forwarder: ...,
+ * });
+ * ```
+ */
+export function encodeIsTrustedForwarderParams(
+  options: IsTrustedForwarderParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.forwarder]);
+}
+
+/**
+ * Decodes the result of the isTrustedForwarder function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC2771
+ * @example
+ * ```
+ * import { decodeIsTrustedForwarderResult } from "thirdweb/extensions/erc2771";
+ * const result = decodeIsTrustedForwarderResult("...");
+ * ```
+ */
+export function decodeIsTrustedForwarderResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "isTrustedForwarder" function on the contract.
@@ -32,20 +82,7 @@ export async function isTrustedForwarder(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x572b6c05",
-      [
-        {
-          type: "address",
-          name: "forwarder",
-        },
-      ],
-      [
-        {
-          type: "bool",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.forwarder],
   });
 }

--- a/packages/thirdweb/src/extensions/erc2981/__generated__/IERC2981/read/royaltyInfo.ts
+++ b/packages/thirdweb/src/extensions/erc2981/__generated__/IERC2981/read/royaltyInfo.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "royaltyInfo" function.
@@ -12,6 +15,61 @@ export type RoyaltyInfoParams = {
     name: "salePrice";
   }>;
 };
+
+const FN_SELECTOR = "0x2a55205a" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "tokenId",
+  },
+  {
+    type: "uint256",
+    name: "salePrice",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "address",
+    name: "receiver",
+  },
+  {
+    type: "uint256",
+    name: "royaltyAmount",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "royaltyInfo" function.
+ * @param options - The options for the royaltyInfo function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC2981
+ * @example
+ * ```
+ * import { encodeRoyaltyInfoParams } "thirdweb/extensions/erc2981";
+ * const result = encodeRoyaltyInfoParams({
+ *  tokenId: ...,
+ *  salePrice: ...,
+ * });
+ * ```
+ */
+export function encodeRoyaltyInfoParams(options: RoyaltyInfoParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.tokenId, options.salePrice]);
+}
+
+/**
+ * Decodes the result of the royaltyInfo function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC2981
+ * @example
+ * ```
+ * import { decodeRoyaltyInfoResult } from "thirdweb/extensions/erc2981";
+ * const result = decodeRoyaltyInfoResult("...");
+ * ```
+ */
+export function decodeRoyaltyInfoResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result);
+}
 
 /**
  * Calls the "royaltyInfo" function on the contract.
@@ -34,29 +92,7 @@ export async function royaltyInfo(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x2a55205a",
-      [
-        {
-          type: "uint256",
-          name: "tokenId",
-        },
-        {
-          type: "uint256",
-          name: "salePrice",
-        },
-      ],
-      [
-        {
-          type: "address",
-          name: "receiver",
-        },
-        {
-          type: "uint256",
-          name: "royaltyAmount",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.tokenId, options.salePrice],
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IAccount/write/validateUserOp.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IAccount/write/validateUserOp.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "validateUserOp" function.
@@ -41,6 +42,99 @@ export type ValidateUserOpParams = Prettify<
       asyncParams: () => Promise<ValidateUserOpParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x3a871cdd" as const;
+const FN_INPUTS = [
+  {
+    type: "tuple",
+    name: "userOp",
+    components: [
+      {
+        type: "address",
+        name: "sender",
+      },
+      {
+        type: "uint256",
+        name: "nonce",
+      },
+      {
+        type: "bytes",
+        name: "initCode",
+      },
+      {
+        type: "bytes",
+        name: "callData",
+      },
+      {
+        type: "uint256",
+        name: "callGasLimit",
+      },
+      {
+        type: "uint256",
+        name: "verificationGasLimit",
+      },
+      {
+        type: "uint256",
+        name: "preVerificationGas",
+      },
+      {
+        type: "uint256",
+        name: "maxFeePerGas",
+      },
+      {
+        type: "uint256",
+        name: "maxPriorityFeePerGas",
+      },
+      {
+        type: "bytes",
+        name: "paymasterAndData",
+      },
+      {
+        type: "bytes",
+        name: "signature",
+      },
+    ],
+  },
+  {
+    type: "bytes32",
+    name: "userOpHash",
+  },
+  {
+    type: "uint256",
+    name: "missingAccountFunds",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+    name: "validationData",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "validateUserOp" function.
+ * @param options - The options for the validateUserOp function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC4337
+ * @example
+ * ```
+ * import { encodeValidateUserOpParams } "thirdweb/extensions/erc4337";
+ * const result = encodeValidateUserOpParams({
+ *  userOp: ...,
+ *  userOpHash: ...,
+ *  missingAccountFunds: ...,
+ * });
+ * ```
+ */
+export function encodeValidateUserOpParams(
+  options: ValidateUserOpParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.userOp,
+    options.userOpHash,
+    options.missingAccountFunds,
+  ]);
+}
+
 /**
  * Calls the "validateUserOp" function on the contract.
  * @param options - The options for the "validateUserOp" function.
@@ -66,75 +160,7 @@ export function validateUserOp(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x3a871cdd",
-      [
-        {
-          type: "tuple",
-          name: "userOp",
-          components: [
-            {
-              type: "address",
-              name: "sender",
-            },
-            {
-              type: "uint256",
-              name: "nonce",
-            },
-            {
-              type: "bytes",
-              name: "initCode",
-            },
-            {
-              type: "bytes",
-              name: "callData",
-            },
-            {
-              type: "uint256",
-              name: "callGasLimit",
-            },
-            {
-              type: "uint256",
-              name: "verificationGasLimit",
-            },
-            {
-              type: "uint256",
-              name: "preVerificationGas",
-            },
-            {
-              type: "uint256",
-              name: "maxFeePerGas",
-            },
-            {
-              type: "uint256",
-              name: "maxPriorityFeePerGas",
-            },
-            {
-              type: "bytes",
-              name: "paymasterAndData",
-            },
-            {
-              type: "bytes",
-              name: "signature",
-            },
-          ],
-        },
-        {
-          type: "bytes32",
-          name: "userOpHash",
-        },
-        {
-          type: "uint256",
-          name: "missingAccountFunds",
-        },
-      ],
-      [
-        {
-          type: "uint256",
-          name: "validationData",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/read/accountImplementation.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/read/accountImplementation.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x11464fbe" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "address",
+  },
+] as const;
+
+/**
+ * Decodes the result of the accountImplementation function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC4337
+ * @example
+ * ```
+ * import { decodeAccountImplementationResult } from "thirdweb/extensions/erc4337";
+ * const result = decodeAccountImplementationResult("...");
+ * ```
+ */
+export function decodeAccountImplementationResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "accountImplementation" function on the contract.
  * @param options - The options for the accountImplementation function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function accountImplementation(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x11464fbe",
-      [],
-      [
-        {
-          type: "address",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/read/getAccountsOfSigner.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/read/getAccountsOfSigner.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "getAccountsOfSigner" function.
@@ -8,6 +11,54 @@ import type { AbiParameterToPrimitiveType } from "abitype";
 export type GetAccountsOfSignerParams = {
   signer: AbiParameterToPrimitiveType<{ type: "address"; name: "signer" }>;
 };
+
+const FN_SELECTOR = "0x0e6254fd" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "signer",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "address[]",
+    name: "accounts",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getAccountsOfSigner" function.
+ * @param options - The options for the getAccountsOfSigner function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC4337
+ * @example
+ * ```
+ * import { encodeGetAccountsOfSignerParams } "thirdweb/extensions/erc4337";
+ * const result = encodeGetAccountsOfSignerParams({
+ *  signer: ...,
+ * });
+ * ```
+ */
+export function encodeGetAccountsOfSignerParams(
+  options: GetAccountsOfSignerParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.signer]);
+}
+
+/**
+ * Decodes the result of the getAccountsOfSigner function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC4337
+ * @example
+ * ```
+ * import { decodeGetAccountsOfSignerResult } from "thirdweb/extensions/erc4337";
+ * const result = decodeGetAccountsOfSignerResult("...");
+ * ```
+ */
+export function decodeGetAccountsOfSignerResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "getAccountsOfSigner" function on the contract.
@@ -29,21 +80,7 @@ export async function getAccountsOfSigner(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x0e6254fd",
-      [
-        {
-          type: "address",
-          name: "signer",
-        },
-      ],
-      [
-        {
-          type: "address[]",
-          name: "accounts",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.signer],
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/read/getAddress.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/read/getAddress.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "getAddress" function.
@@ -12,6 +15,56 @@ export type GetAddressParams = {
   }>;
   data: AbiParameterToPrimitiveType<{ type: "bytes"; name: "data" }>;
 };
+
+const FN_SELECTOR = "0x8878ed33" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "adminSigner",
+  },
+  {
+    type: "bytes",
+    name: "data",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "address",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getAddress" function.
+ * @param options - The options for the getAddress function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC4337
+ * @example
+ * ```
+ * import { encodeGetAddressParams } "thirdweb/extensions/erc4337";
+ * const result = encodeGetAddressParams({
+ *  adminSigner: ...,
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeGetAddressParams(options: GetAddressParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.adminSigner, options.data]);
+}
+
+/**
+ * Decodes the result of the getAddress function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC4337
+ * @example
+ * ```
+ * import { decodeGetAddressResult } from "thirdweb/extensions/erc4337";
+ * const result = decodeGetAddressResult("...");
+ * ```
+ */
+export function decodeGetAddressResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "getAddress" function on the contract.
@@ -34,24 +87,7 @@ export async function getAddress(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x8878ed33",
-      [
-        {
-          type: "address",
-          name: "adminSigner",
-        },
-        {
-          type: "bytes",
-          name: "data",
-        },
-      ],
-      [
-        {
-          type: "address",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.adminSigner, options.data],
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/read/getAllAccounts.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/read/getAllAccounts.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x08e93d0a" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "address[]",
+  },
+] as const;
+
+/**
+ * Decodes the result of the getAllAccounts function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC4337
+ * @example
+ * ```
+ * import { decodeGetAllAccountsResult } from "thirdweb/extensions/erc4337";
+ * const result = decodeGetAllAccountsResult("...");
+ * ```
+ */
+export function decodeGetAllAccountsResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "getAllAccounts" function on the contract.
  * @param options - The options for the getAllAccounts function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function getAllAccounts(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x08e93d0a",
-      [],
-      [
-        {
-          type: "address[]",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/write/createAccount.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/write/createAccount.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "createAccount" function.
@@ -18,6 +19,44 @@ export type CreateAccountParams = Prettify<
       asyncParams: () => Promise<CreateAccountParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xd8fd8f44" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "admin",
+  },
+  {
+    type: "bytes",
+    name: "_data",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "address",
+    name: "account",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "createAccount" function.
+ * @param options - The options for the createAccount function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC4337
+ * @example
+ * ```
+ * import { encodeCreateAccountParams } "thirdweb/extensions/erc4337";
+ * const result = encodeCreateAccountParams({
+ *  admin: ...,
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeCreateAccountParams(
+  options: CreateAccountParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.admin, options.data]);
+}
+
 /**
  * Calls the "createAccount" function on the contract.
  * @param options - The options for the "createAccount" function.
@@ -42,25 +81,7 @@ export function createAccount(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xd8fd8f44",
-      [
-        {
-          type: "address",
-          name: "admin",
-        },
-        {
-          type: "bytes",
-          name: "_data",
-        },
-      ],
-      [
-        {
-          type: "address",
-          name: "account",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/write/onSignerAdded.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/write/onSignerAdded.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "onSignerAdded" function.
@@ -22,6 +23,48 @@ export type OnSignerAddedParams = Prettify<
       asyncParams: () => Promise<OnSignerAddedParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x9ddbb9d8" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "signer",
+  },
+  {
+    type: "address",
+    name: "creatorAdmin",
+  },
+  {
+    type: "bytes",
+    name: "data",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "onSignerAdded" function.
+ * @param options - The options for the onSignerAdded function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC4337
+ * @example
+ * ```
+ * import { encodeOnSignerAddedParams } "thirdweb/extensions/erc4337";
+ * const result = encodeOnSignerAddedParams({
+ *  signer: ...,
+ *  creatorAdmin: ...,
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeOnSignerAddedParams(
+  options: OnSignerAddedParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.signer,
+    options.creatorAdmin,
+    options.data,
+  ]);
+}
+
 /**
  * Calls the "onSignerAdded" function on the contract.
  * @param options - The options for the "onSignerAdded" function.
@@ -47,24 +90,7 @@ export function onSignerAdded(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x9ddbb9d8",
-      [
-        {
-          type: "address",
-          name: "signer",
-        },
-        {
-          type: "address",
-          name: "creatorAdmin",
-        },
-        {
-          type: "bytes",
-          name: "data",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/write/onSignerRemoved.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/write/onSignerRemoved.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "onSignerRemoved" function.
@@ -22,6 +23,48 @@ export type OnSignerRemovedParams = Prettify<
       asyncParams: () => Promise<OnSignerRemovedParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x0db33003" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "signer",
+  },
+  {
+    type: "address",
+    name: "creatorAdmin",
+  },
+  {
+    type: "bytes",
+    name: "data",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "onSignerRemoved" function.
+ * @param options - The options for the onSignerRemoved function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC4337
+ * @example
+ * ```
+ * import { encodeOnSignerRemovedParams } "thirdweb/extensions/erc4337";
+ * const result = encodeOnSignerRemovedParams({
+ *  signer: ...,
+ *  creatorAdmin: ...,
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeOnSignerRemovedParams(
+  options: OnSignerRemovedParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.signer,
+    options.creatorAdmin,
+    options.data,
+  ]);
+}
+
 /**
  * Calls the "onSignerRemoved" function on the contract.
  * @param options - The options for the "onSignerRemoved" function.
@@ -47,24 +90,7 @@ export function onSignerRemoved(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x0db33003",
-      [
-        {
-          type: "address",
-          name: "signer",
-        },
-        {
-          type: "address",
-          name: "creatorAdmin",
-        },
-        {
-          type: "bytes",
-          name: "data",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountPermissions/read/getAllActiveSigners.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountPermissions/read/getAllActiveSigners.ts
@@ -1,6 +1,55 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x8b52d723" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "tuple[]",
+    name: "signers",
+    components: [
+      {
+        type: "address",
+        name: "signer",
+      },
+      {
+        type: "address[]",
+        name: "approvedTargets",
+      },
+      {
+        type: "uint256",
+        name: "nativeTokenLimitPerTransaction",
+      },
+      {
+        type: "uint128",
+        name: "startTimestamp",
+      },
+      {
+        type: "uint128",
+        name: "endTimestamp",
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Decodes the result of the getAllActiveSigners function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC4337
+ * @example
+ * ```
+ * import { decodeGetAllActiveSignersResult } from "thirdweb/extensions/erc4337";
+ * const result = decodeGetAllActiveSignersResult("...");
+ * ```
+ */
+export function decodeGetAllActiveSignersResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "getAllActiveSigners" function on the contract.
  * @param options - The options for the getAllActiveSigners function.
@@ -17,38 +66,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function getAllActiveSigners(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x8b52d723",
-      [],
-      [
-        {
-          type: "tuple[]",
-          name: "signers",
-          components: [
-            {
-              type: "address",
-              name: "signer",
-            },
-            {
-              type: "address[]",
-              name: "approvedTargets",
-            },
-            {
-              type: "uint256",
-              name: "nativeTokenLimitPerTransaction",
-            },
-            {
-              type: "uint128",
-              name: "startTimestamp",
-            },
-            {
-              type: "uint128",
-              name: "endTimestamp",
-            },
-          ],
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountPermissions/read/getAllAdmins.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountPermissions/read/getAllAdmins.ts
@@ -1,6 +1,33 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0xe9523c97" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "address[]",
+    name: "admins",
+  },
+] as const;
+
+/**
+ * Decodes the result of the getAllAdmins function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC4337
+ * @example
+ * ```
+ * import { decodeGetAllAdminsResult } from "thirdweb/extensions/erc4337";
+ * const result = decodeGetAllAdminsResult("...");
+ * ```
+ */
+export function decodeGetAllAdminsResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "getAllAdmins" function on the contract.
  * @param options - The options for the getAllAdmins function.
@@ -17,16 +44,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function getAllAdmins(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xe9523c97",
-      [],
-      [
-        {
-          type: "address[]",
-          name: "admins",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountPermissions/read/getAllSigners.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountPermissions/read/getAllSigners.ts
@@ -1,6 +1,55 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0xd42f2f35" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "tuple[]",
+    name: "signers",
+    components: [
+      {
+        type: "address",
+        name: "signer",
+      },
+      {
+        type: "address[]",
+        name: "approvedTargets",
+      },
+      {
+        type: "uint256",
+        name: "nativeTokenLimitPerTransaction",
+      },
+      {
+        type: "uint128",
+        name: "startTimestamp",
+      },
+      {
+        type: "uint128",
+        name: "endTimestamp",
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Decodes the result of the getAllSigners function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC4337
+ * @example
+ * ```
+ * import { decodeGetAllSignersResult } from "thirdweb/extensions/erc4337";
+ * const result = decodeGetAllSignersResult("...");
+ * ```
+ */
+export function decodeGetAllSignersResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "getAllSigners" function on the contract.
  * @param options - The options for the getAllSigners function.
@@ -17,38 +66,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function getAllSigners(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xd42f2f35",
-      [],
-      [
-        {
-          type: "tuple[]",
-          name: "signers",
-          components: [
-            {
-              type: "address",
-              name: "signer",
-            },
-            {
-              type: "address[]",
-              name: "approvedTargets",
-            },
-            {
-              type: "uint256",
-              name: "nativeTokenLimitPerTransaction",
-            },
-            {
-              type: "uint128",
-              name: "startTimestamp",
-            },
-            {
-              type: "uint128",
-              name: "endTimestamp",
-            },
-          ],
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountPermissions/read/getPermissionsForSigner.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountPermissions/read/getPermissionsForSigner.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "getPermissionsForSigner" function.
@@ -8,6 +11,76 @@ import type { AbiParameterToPrimitiveType } from "abitype";
 export type GetPermissionsForSignerParams = {
   signer: AbiParameterToPrimitiveType<{ type: "address"; name: "signer" }>;
 };
+
+const FN_SELECTOR = "0xf15d424e" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "signer",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "tuple",
+    name: "permissions",
+    components: [
+      {
+        type: "address",
+        name: "signer",
+      },
+      {
+        type: "address[]",
+        name: "approvedTargets",
+      },
+      {
+        type: "uint256",
+        name: "nativeTokenLimitPerTransaction",
+      },
+      {
+        type: "uint128",
+        name: "startTimestamp",
+      },
+      {
+        type: "uint128",
+        name: "endTimestamp",
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getPermissionsForSigner" function.
+ * @param options - The options for the getPermissionsForSigner function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC4337
+ * @example
+ * ```
+ * import { encodeGetPermissionsForSignerParams } "thirdweb/extensions/erc4337";
+ * const result = encodeGetPermissionsForSignerParams({
+ *  signer: ...,
+ * });
+ * ```
+ */
+export function encodeGetPermissionsForSignerParams(
+  options: GetPermissionsForSignerParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.signer]);
+}
+
+/**
+ * Decodes the result of the getPermissionsForSigner function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC4337
+ * @example
+ * ```
+ * import { decodeGetPermissionsForSignerResult } from "thirdweb/extensions/erc4337";
+ * const result = decodeGetPermissionsForSignerResult("...");
+ * ```
+ */
+export function decodeGetPermissionsForSignerResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "getPermissionsForSigner" function on the contract.
@@ -29,43 +102,7 @@ export async function getPermissionsForSigner(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xf15d424e",
-      [
-        {
-          type: "address",
-          name: "signer",
-        },
-      ],
-      [
-        {
-          type: "tuple",
-          name: "permissions",
-          components: [
-            {
-              type: "address",
-              name: "signer",
-            },
-            {
-              type: "address[]",
-              name: "approvedTargets",
-            },
-            {
-              type: "uint256",
-              name: "nativeTokenLimitPerTransaction",
-            },
-            {
-              type: "uint128",
-              name: "startTimestamp",
-            },
-            {
-              type: "uint128",
-              name: "endTimestamp",
-            },
-          ],
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.signer],
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountPermissions/read/isActiveSigner.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountPermissions/read/isActiveSigner.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "isActiveSigner" function.
@@ -8,6 +11,51 @@ import type { AbiParameterToPrimitiveType } from "abitype";
 export type IsActiveSignerParams = {
   signer: AbiParameterToPrimitiveType<{ type: "address"; name: "signer" }>;
 };
+
+const FN_SELECTOR = "0x7dff5a79" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "signer",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bool",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "isActiveSigner" function.
+ * @param options - The options for the isActiveSigner function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC4337
+ * @example
+ * ```
+ * import { encodeIsActiveSignerParams } "thirdweb/extensions/erc4337";
+ * const result = encodeIsActiveSignerParams({
+ *  signer: ...,
+ * });
+ * ```
+ */
+export function encodeIsActiveSignerParams(options: IsActiveSignerParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.signer]);
+}
+
+/**
+ * Decodes the result of the isActiveSigner function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC4337
+ * @example
+ * ```
+ * import { decodeIsActiveSignerResult } from "thirdweb/extensions/erc4337";
+ * const result = decodeIsActiveSignerResult("...");
+ * ```
+ */
+export function decodeIsActiveSignerResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "isActiveSigner" function on the contract.
@@ -29,20 +77,7 @@ export async function isActiveSigner(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x7dff5a79",
-      [
-        {
-          type: "address",
-          name: "signer",
-        },
-      ],
-      [
-        {
-          type: "bool",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.signer],
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountPermissions/read/isAdmin.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountPermissions/read/isAdmin.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "isAdmin" function.
@@ -8,6 +11,51 @@ import type { AbiParameterToPrimitiveType } from "abitype";
 export type IsAdminParams = {
   signer: AbiParameterToPrimitiveType<{ type: "address"; name: "signer" }>;
 };
+
+const FN_SELECTOR = "0x24d7806c" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "signer",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bool",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "isAdmin" function.
+ * @param options - The options for the isAdmin function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC4337
+ * @example
+ * ```
+ * import { encodeIsAdminParams } "thirdweb/extensions/erc4337";
+ * const result = encodeIsAdminParams({
+ *  signer: ...,
+ * });
+ * ```
+ */
+export function encodeIsAdminParams(options: IsAdminParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.signer]);
+}
+
+/**
+ * Decodes the result of the isAdmin function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC4337
+ * @example
+ * ```
+ * import { decodeIsAdminResult } from "thirdweb/extensions/erc4337";
+ * const result = decodeIsAdminResult("...");
+ * ```
+ */
+export function decodeIsAdminResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "isAdmin" function on the contract.
@@ -27,20 +75,7 @@ export type IsAdminParams = {
 export async function isAdmin(options: BaseTransactionOptions<IsAdminParams>) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x24d7806c",
-      [
-        {
-          type: "address",
-          name: "signer",
-        },
-      ],
-      [
-        {
-          type: "bool",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.signer],
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountPermissions/read/verifySignerPermissionRequest.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountPermissions/read/verifySignerPermissionRequest.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "verifySignerPermissionRequest" function.
@@ -24,6 +27,101 @@ export type VerifySignerPermissionRequestParams = {
   signature: AbiParameterToPrimitiveType<{ type: "bytes"; name: "signature" }>;
 };
 
+const FN_SELECTOR = "0xa9082d84" as const;
+const FN_INPUTS = [
+  {
+    type: "tuple",
+    name: "req",
+    components: [
+      {
+        type: "address",
+        name: "signer",
+      },
+      {
+        type: "uint8",
+        name: "isAdmin",
+      },
+      {
+        type: "address[]",
+        name: "approvedTargets",
+      },
+      {
+        type: "uint256",
+        name: "nativeTokenLimitPerTransaction",
+      },
+      {
+        type: "uint128",
+        name: "permissionStartTimestamp",
+      },
+      {
+        type: "uint128",
+        name: "permissionEndTimestamp",
+      },
+      {
+        type: "uint128",
+        name: "reqValidityStartTimestamp",
+      },
+      {
+        type: "uint128",
+        name: "reqValidityEndTimestamp",
+      },
+      {
+        type: "bytes32",
+        name: "uid",
+      },
+    ],
+  },
+  {
+    type: "bytes",
+    name: "signature",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bool",
+    name: "success",
+  },
+  {
+    type: "address",
+    name: "signer",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "verifySignerPermissionRequest" function.
+ * @param options - The options for the verifySignerPermissionRequest function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC4337
+ * @example
+ * ```
+ * import { encodeVerifySignerPermissionRequestParams } "thirdweb/extensions/erc4337";
+ * const result = encodeVerifySignerPermissionRequestParams({
+ *  req: ...,
+ *  signature: ...,
+ * });
+ * ```
+ */
+export function encodeVerifySignerPermissionRequestParams(
+  options: VerifySignerPermissionRequestParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.req, options.signature]);
+}
+
+/**
+ * Decodes the result of the verifySignerPermissionRequest function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC4337
+ * @example
+ * ```
+ * import { decodeVerifySignerPermissionRequestResult } from "thirdweb/extensions/erc4337";
+ * const result = decodeVerifySignerPermissionRequestResult("...");
+ * ```
+ */
+export function decodeVerifySignerPermissionRequestResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result);
+}
+
 /**
  * Calls the "verifySignerPermissionRequest" function on the contract.
  * @param options - The options for the verifySignerPermissionRequest function.
@@ -45,67 +143,7 @@ export async function verifySignerPermissionRequest(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xa9082d84",
-      [
-        {
-          type: "tuple",
-          name: "req",
-          components: [
-            {
-              type: "address",
-              name: "signer",
-            },
-            {
-              type: "uint8",
-              name: "isAdmin",
-            },
-            {
-              type: "address[]",
-              name: "approvedTargets",
-            },
-            {
-              type: "uint256",
-              name: "nativeTokenLimitPerTransaction",
-            },
-            {
-              type: "uint128",
-              name: "permissionStartTimestamp",
-            },
-            {
-              type: "uint128",
-              name: "permissionEndTimestamp",
-            },
-            {
-              type: "uint128",
-              name: "reqValidityStartTimestamp",
-            },
-            {
-              type: "uint128",
-              name: "reqValidityEndTimestamp",
-            },
-            {
-              type: "bytes32",
-              name: "uid",
-            },
-          ],
-        },
-        {
-          type: "bytes",
-          name: "signature",
-        },
-      ],
-      [
-        {
-          type: "bool",
-          name: "success",
-        },
-        {
-          type: "address",
-          name: "signer",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.req, options.signature],
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountPermissions/write/setPermissionsForSigner.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountPermissions/write/setPermissionsForSigner.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "setPermissionsForSigner" function.
@@ -32,6 +33,77 @@ export type SetPermissionsForSignerParams = Prettify<
       asyncParams: () => Promise<SetPermissionsForSignerParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x5892e236" as const;
+const FN_INPUTS = [
+  {
+    type: "tuple",
+    name: "req",
+    components: [
+      {
+        type: "address",
+        name: "signer",
+      },
+      {
+        type: "uint8",
+        name: "isAdmin",
+      },
+      {
+        type: "address[]",
+        name: "approvedTargets",
+      },
+      {
+        type: "uint256",
+        name: "nativeTokenLimitPerTransaction",
+      },
+      {
+        type: "uint128",
+        name: "permissionStartTimestamp",
+      },
+      {
+        type: "uint128",
+        name: "permissionEndTimestamp",
+      },
+      {
+        type: "uint128",
+        name: "reqValidityStartTimestamp",
+      },
+      {
+        type: "uint128",
+        name: "reqValidityEndTimestamp",
+      },
+      {
+        type: "bytes32",
+        name: "uid",
+      },
+    ],
+  },
+  {
+    type: "bytes",
+    name: "signature",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "setPermissionsForSigner" function.
+ * @param options - The options for the setPermissionsForSigner function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC4337
+ * @example
+ * ```
+ * import { encodeSetPermissionsForSignerParams } "thirdweb/extensions/erc4337";
+ * const result = encodeSetPermissionsForSignerParams({
+ *  req: ...,
+ *  signature: ...,
+ * });
+ * ```
+ */
+export function encodeSetPermissionsForSignerParams(
+  options: SetPermissionsForSignerParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.req, options.signature]);
+}
+
 /**
  * Calls the "setPermissionsForSigner" function on the contract.
  * @param options - The options for the "setPermissionsForSigner" function.
@@ -56,58 +128,7 @@ export function setPermissionsForSigner(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x5892e236",
-      [
-        {
-          type: "tuple",
-          name: "req",
-          components: [
-            {
-              type: "address",
-              name: "signer",
-            },
-            {
-              type: "uint8",
-              name: "isAdmin",
-            },
-            {
-              type: "address[]",
-              name: "approvedTargets",
-            },
-            {
-              type: "uint256",
-              name: "nativeTokenLimitPerTransaction",
-            },
-            {
-              type: "uint128",
-              name: "permissionStartTimestamp",
-            },
-            {
-              type: "uint128",
-              name: "permissionEndTimestamp",
-            },
-            {
-              type: "uint128",
-              name: "reqValidityStartTimestamp",
-            },
-            {
-              type: "uint128",
-              name: "reqValidityEndTimestamp",
-            },
-            {
-              type: "bytes32",
-              name: "uid",
-            },
-          ],
-        },
-        {
-          type: "bytes",
-          name: "signature",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/read/balanceOf.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/read/balanceOf.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "balanceOf" function.
@@ -8,6 +11,51 @@ import type { AbiParameterToPrimitiveType } from "abitype";
 export type BalanceOfParams = {
   account: AbiParameterToPrimitiveType<{ type: "address"; name: "account" }>;
 };
+
+const FN_SELECTOR = "0x70a08231" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "account",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "balanceOf" function.
+ * @param options - The options for the balanceOf function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC4337
+ * @example
+ * ```
+ * import { encodeBalanceOfParams } "thirdweb/extensions/erc4337";
+ * const result = encodeBalanceOfParams({
+ *  account: ...,
+ * });
+ * ```
+ */
+export function encodeBalanceOfParams(options: BalanceOfParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.account]);
+}
+
+/**
+ * Decodes the result of the balanceOf function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC4337
+ * @example
+ * ```
+ * import { decodeBalanceOfResult } from "thirdweb/extensions/erc4337";
+ * const result = decodeBalanceOfResult("...");
+ * ```
+ */
+export function decodeBalanceOfResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "balanceOf" function on the contract.
@@ -29,20 +77,7 @@ export async function balanceOf(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x70a08231",
-      [
-        {
-          type: "address",
-          name: "account",
-        },
-      ],
-      [
-        {
-          type: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.account],
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/read/getDepositInfo.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/read/getDepositInfo.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "getDepositInfo" function.
@@ -8,6 +11,74 @@ import type { AbiParameterToPrimitiveType } from "abitype";
 export type GetDepositInfoParams = {
   account: AbiParameterToPrimitiveType<{ type: "address"; name: "account" }>;
 };
+
+const FN_SELECTOR = "0x5287ce12" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "account",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "tuple",
+    name: "info",
+    components: [
+      {
+        type: "uint112",
+        name: "deposit",
+      },
+      {
+        type: "bool",
+        name: "staked",
+      },
+      {
+        type: "uint112",
+        name: "stake",
+      },
+      {
+        type: "uint32",
+        name: "unstakeDelaySec",
+      },
+      {
+        type: "uint48",
+        name: "withdrawTime",
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getDepositInfo" function.
+ * @param options - The options for the getDepositInfo function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC4337
+ * @example
+ * ```
+ * import { encodeGetDepositInfoParams } "thirdweb/extensions/erc4337";
+ * const result = encodeGetDepositInfoParams({
+ *  account: ...,
+ * });
+ * ```
+ */
+export function encodeGetDepositInfoParams(options: GetDepositInfoParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.account]);
+}
+
+/**
+ * Decodes the result of the getDepositInfo function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC4337
+ * @example
+ * ```
+ * import { decodeGetDepositInfoResult } from "thirdweb/extensions/erc4337";
+ * const result = decodeGetDepositInfoResult("...");
+ * ```
+ */
+export function decodeGetDepositInfoResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "getDepositInfo" function on the contract.
@@ -29,43 +100,7 @@ export async function getDepositInfo(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x5287ce12",
-      [
-        {
-          type: "address",
-          name: "account",
-        },
-      ],
-      [
-        {
-          type: "tuple",
-          name: "info",
-          components: [
-            {
-              type: "uint112",
-              name: "deposit",
-            },
-            {
-              type: "bool",
-              name: "staked",
-            },
-            {
-              type: "uint112",
-              name: "stake",
-            },
-            {
-              type: "uint32",
-              name: "unstakeDelaySec",
-            },
-            {
-              type: "uint48",
-              name: "withdrawTime",
-            },
-          ],
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.account],
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/read/getNonce.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/read/getNonce.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "getNonce" function.
@@ -9,6 +12,57 @@ export type GetNonceParams = {
   sender: AbiParameterToPrimitiveType<{ type: "address"; name: "sender" }>;
   key: AbiParameterToPrimitiveType<{ type: "uint192"; name: "key" }>;
 };
+
+const FN_SELECTOR = "0x35567e1a" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "sender",
+  },
+  {
+    type: "uint192",
+    name: "key",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+    name: "nonce",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getNonce" function.
+ * @param options - The options for the getNonce function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC4337
+ * @example
+ * ```
+ * import { encodeGetNonceParams } "thirdweb/extensions/erc4337";
+ * const result = encodeGetNonceParams({
+ *  sender: ...,
+ *  key: ...,
+ * });
+ * ```
+ */
+export function encodeGetNonceParams(options: GetNonceParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.sender, options.key]);
+}
+
+/**
+ * Decodes the result of the getNonce function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC4337
+ * @example
+ * ```
+ * import { decodeGetNonceResult } from "thirdweb/extensions/erc4337";
+ * const result = decodeGetNonceResult("...");
+ * ```
+ */
+export function decodeGetNonceResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "getNonce" function on the contract.
@@ -31,25 +85,7 @@ export async function getNonce(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x35567e1a",
-      [
-        {
-          type: "address",
-          name: "sender",
-        },
-        {
-          type: "uint192",
-          name: "key",
-        },
-      ],
-      [
-        {
-          type: "uint256",
-          name: "nonce",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.sender, options.key],
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/read/getUserOpHash.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/read/getUserOpHash.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "getUserOpHash" function.
@@ -25,6 +28,97 @@ export type GetUserOpHashParams = {
   }>;
 };
 
+const FN_SELECTOR = "0xa6193531" as const;
+const FN_INPUTS = [
+  {
+    type: "tuple",
+    name: "userOp",
+    components: [
+      {
+        type: "address",
+        name: "sender",
+      },
+      {
+        type: "uint256",
+        name: "nonce",
+      },
+      {
+        type: "bytes",
+        name: "initCode",
+      },
+      {
+        type: "bytes",
+        name: "callData",
+      },
+      {
+        type: "uint256",
+        name: "callGasLimit",
+      },
+      {
+        type: "uint256",
+        name: "verificationGasLimit",
+      },
+      {
+        type: "uint256",
+        name: "preVerificationGas",
+      },
+      {
+        type: "uint256",
+        name: "maxFeePerGas",
+      },
+      {
+        type: "uint256",
+        name: "maxPriorityFeePerGas",
+      },
+      {
+        type: "bytes",
+        name: "paymasterAndData",
+      },
+      {
+        type: "bytes",
+        name: "signature",
+      },
+    ],
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bytes32",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getUserOpHash" function.
+ * @param options - The options for the getUserOpHash function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC4337
+ * @example
+ * ```
+ * import { encodeGetUserOpHashParams } "thirdweb/extensions/erc4337";
+ * const result = encodeGetUserOpHashParams({
+ *  userOp: ...,
+ * });
+ * ```
+ */
+export function encodeGetUserOpHashParams(options: GetUserOpHashParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.userOp]);
+}
+
+/**
+ * Decodes the result of the getUserOpHash function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC4337
+ * @example
+ * ```
+ * import { decodeGetUserOpHashResult } from "thirdweb/extensions/erc4337";
+ * const result = decodeGetUserOpHashResult("...");
+ * ```
+ */
+export function decodeGetUserOpHashResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "getUserOpHash" function on the contract.
  * @param options - The options for the getUserOpHash function.
@@ -45,66 +139,7 @@ export async function getUserOpHash(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xa6193531",
-      [
-        {
-          type: "tuple",
-          name: "userOp",
-          components: [
-            {
-              type: "address",
-              name: "sender",
-            },
-            {
-              type: "uint256",
-              name: "nonce",
-            },
-            {
-              type: "bytes",
-              name: "initCode",
-            },
-            {
-              type: "bytes",
-              name: "callData",
-            },
-            {
-              type: "uint256",
-              name: "callGasLimit",
-            },
-            {
-              type: "uint256",
-              name: "verificationGasLimit",
-            },
-            {
-              type: "uint256",
-              name: "preVerificationGas",
-            },
-            {
-              type: "uint256",
-              name: "maxFeePerGas",
-            },
-            {
-              type: "uint256",
-              name: "maxPriorityFeePerGas",
-            },
-            {
-              type: "bytes",
-              name: "paymasterAndData",
-            },
-            {
-              type: "bytes",
-              name: "signature",
-            },
-          ],
-        },
-      ],
-      [
-        {
-          type: "bytes32",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.userOp],
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/addStake.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/addStake.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "addStake" function.
@@ -20,6 +21,32 @@ export type AddStakeParams = Prettify<
       asyncParams: () => Promise<AddStakeParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x0396cb60" as const;
+const FN_INPUTS = [
+  {
+    type: "uint32",
+    name: "_unstakeDelaySec",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "addStake" function.
+ * @param options - The options for the addStake function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC4337
+ * @example
+ * ```
+ * import { encodeAddStakeParams } "thirdweb/extensions/erc4337";
+ * const result = encodeAddStakeParams({
+ *  unstakeDelaySec: ...,
+ * });
+ * ```
+ */
+export function encodeAddStakeParams(options: AddStakeParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.unstakeDelaySec]);
+}
+
 /**
  * Calls the "addStake" function on the contract.
  * @param options - The options for the "addStake" function.
@@ -41,16 +68,7 @@ export type AddStakeParams = Prettify<
 export function addStake(options: BaseTransactionOptions<AddStakeParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x0396cb60",
-      [
-        {
-          type: "uint32",
-          name: "_unstakeDelaySec",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/depositTo.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/depositTo.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "depositTo" function.
@@ -17,6 +18,32 @@ export type DepositToParams = Prettify<
       asyncParams: () => Promise<DepositToParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xb760faf9" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "account",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "depositTo" function.
+ * @param options - The options for the depositTo function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC4337
+ * @example
+ * ```
+ * import { encodeDepositToParams } "thirdweb/extensions/erc4337";
+ * const result = encodeDepositToParams({
+ *  account: ...,
+ * });
+ * ```
+ */
+export function encodeDepositToParams(options: DepositToParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.account]);
+}
+
 /**
  * Calls the "depositTo" function on the contract.
  * @param options - The options for the "depositTo" function.
@@ -38,16 +65,7 @@ export type DepositToParams = Prettify<
 export function depositTo(options: BaseTransactionOptions<DepositToParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xb760faf9",
-      [
-        {
-          type: "address",
-          name: "account",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/getSenderAddress.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/getSenderAddress.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "getSenderAddress" function.
@@ -17,6 +18,34 @@ export type GetSenderAddressParams = Prettify<
       asyncParams: () => Promise<GetSenderAddressParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x9b249f69" as const;
+const FN_INPUTS = [
+  {
+    type: "bytes",
+    name: "initCode",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "getSenderAddress" function.
+ * @param options - The options for the getSenderAddress function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC4337
+ * @example
+ * ```
+ * import { encodeGetSenderAddressParams } "thirdweb/extensions/erc4337";
+ * const result = encodeGetSenderAddressParams({
+ *  initCode: ...,
+ * });
+ * ```
+ */
+export function encodeGetSenderAddressParams(
+  options: GetSenderAddressParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.initCode]);
+}
+
 /**
  * Calls the "getSenderAddress" function on the contract.
  * @param options - The options for the "getSenderAddress" function.
@@ -40,16 +69,7 @@ export function getSenderAddress(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x9b249f69",
-      [
-        {
-          type: "bytes",
-          name: "initCode",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/handleAggregatedOps.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/handleAggregatedOps.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "handleAggregatedOps" function.
@@ -45,6 +46,102 @@ export type HandleAggregatedOpsParams = Prettify<
       asyncParams: () => Promise<HandleAggregatedOpsParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x4b1d7cf5" as const;
+const FN_INPUTS = [
+  {
+    type: "tuple[]",
+    name: "opsPerAggregator",
+    components: [
+      {
+        type: "tuple[]",
+        name: "userOps",
+        components: [
+          {
+            type: "address",
+            name: "sender",
+          },
+          {
+            type: "uint256",
+            name: "nonce",
+          },
+          {
+            type: "bytes",
+            name: "initCode",
+          },
+          {
+            type: "bytes",
+            name: "callData",
+          },
+          {
+            type: "uint256",
+            name: "callGasLimit",
+          },
+          {
+            type: "uint256",
+            name: "verificationGasLimit",
+          },
+          {
+            type: "uint256",
+            name: "preVerificationGas",
+          },
+          {
+            type: "uint256",
+            name: "maxFeePerGas",
+          },
+          {
+            type: "uint256",
+            name: "maxPriorityFeePerGas",
+          },
+          {
+            type: "bytes",
+            name: "paymasterAndData",
+          },
+          {
+            type: "bytes",
+            name: "signature",
+          },
+        ],
+      },
+      {
+        type: "address",
+        name: "aggregator",
+      },
+      {
+        type: "bytes",
+        name: "signature",
+      },
+    ],
+  },
+  {
+    type: "address",
+    name: "beneficiary",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "handleAggregatedOps" function.
+ * @param options - The options for the handleAggregatedOps function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC4337
+ * @example
+ * ```
+ * import { encodeHandleAggregatedOpsParams } "thirdweb/extensions/erc4337";
+ * const result = encodeHandleAggregatedOpsParams({
+ *  opsPerAggregator: ...,
+ *  beneficiary: ...,
+ * });
+ * ```
+ */
+export function encodeHandleAggregatedOpsParams(
+  options: HandleAggregatedOpsParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.opsPerAggregator,
+    options.beneficiary,
+  ]);
+}
+
 /**
  * Calls the "handleAggregatedOps" function on the contract.
  * @param options - The options for the "handleAggregatedOps" function.
@@ -69,80 +166,7 @@ export function handleAggregatedOps(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x4b1d7cf5",
-      [
-        {
-          type: "tuple[]",
-          name: "opsPerAggregator",
-          components: [
-            {
-              type: "tuple[]",
-              name: "userOps",
-              components: [
-                {
-                  type: "address",
-                  name: "sender",
-                },
-                {
-                  type: "uint256",
-                  name: "nonce",
-                },
-                {
-                  type: "bytes",
-                  name: "initCode",
-                },
-                {
-                  type: "bytes",
-                  name: "callData",
-                },
-                {
-                  type: "uint256",
-                  name: "callGasLimit",
-                },
-                {
-                  type: "uint256",
-                  name: "verificationGasLimit",
-                },
-                {
-                  type: "uint256",
-                  name: "preVerificationGas",
-                },
-                {
-                  type: "uint256",
-                  name: "maxFeePerGas",
-                },
-                {
-                  type: "uint256",
-                  name: "maxPriorityFeePerGas",
-                },
-                {
-                  type: "bytes",
-                  name: "paymasterAndData",
-                },
-                {
-                  type: "bytes",
-                  name: "signature",
-                },
-              ],
-            },
-            {
-              type: "address",
-              name: "aggregator",
-            },
-            {
-              type: "bytes",
-              name: "signature",
-            },
-          ],
-        },
-        {
-          type: "address",
-          name: "beneficiary",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/handleOps.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/handleOps.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "handleOps" function.
@@ -37,6 +38,83 @@ export type HandleOpsParams = Prettify<
       asyncParams: () => Promise<HandleOpsParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x1fad948c" as const;
+const FN_INPUTS = [
+  {
+    type: "tuple[]",
+    name: "ops",
+    components: [
+      {
+        type: "address",
+        name: "sender",
+      },
+      {
+        type: "uint256",
+        name: "nonce",
+      },
+      {
+        type: "bytes",
+        name: "initCode",
+      },
+      {
+        type: "bytes",
+        name: "callData",
+      },
+      {
+        type: "uint256",
+        name: "callGasLimit",
+      },
+      {
+        type: "uint256",
+        name: "verificationGasLimit",
+      },
+      {
+        type: "uint256",
+        name: "preVerificationGas",
+      },
+      {
+        type: "uint256",
+        name: "maxFeePerGas",
+      },
+      {
+        type: "uint256",
+        name: "maxPriorityFeePerGas",
+      },
+      {
+        type: "bytes",
+        name: "paymasterAndData",
+      },
+      {
+        type: "bytes",
+        name: "signature",
+      },
+    ],
+  },
+  {
+    type: "address",
+    name: "beneficiary",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "handleOps" function.
+ * @param options - The options for the handleOps function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC4337
+ * @example
+ * ```
+ * import { encodeHandleOpsParams } "thirdweb/extensions/erc4337";
+ * const result = encodeHandleOpsParams({
+ *  ops: ...,
+ *  beneficiary: ...,
+ * });
+ * ```
+ */
+export function encodeHandleOpsParams(options: HandleOpsParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.ops, options.beneficiary]);
+}
+
 /**
  * Calls the "handleOps" function on the contract.
  * @param options - The options for the "handleOps" function.
@@ -59,66 +137,7 @@ export type HandleOpsParams = Prettify<
 export function handleOps(options: BaseTransactionOptions<HandleOpsParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x1fad948c",
-      [
-        {
-          type: "tuple[]",
-          name: "ops",
-          components: [
-            {
-              type: "address",
-              name: "sender",
-            },
-            {
-              type: "uint256",
-              name: "nonce",
-            },
-            {
-              type: "bytes",
-              name: "initCode",
-            },
-            {
-              type: "bytes",
-              name: "callData",
-            },
-            {
-              type: "uint256",
-              name: "callGasLimit",
-            },
-            {
-              type: "uint256",
-              name: "verificationGasLimit",
-            },
-            {
-              type: "uint256",
-              name: "preVerificationGas",
-            },
-            {
-              type: "uint256",
-              name: "maxFeePerGas",
-            },
-            {
-              type: "uint256",
-              name: "maxPriorityFeePerGas",
-            },
-            {
-              type: "bytes",
-              name: "paymasterAndData",
-            },
-            {
-              type: "bytes",
-              name: "signature",
-            },
-          ],
-        },
-        {
-          type: "address",
-          name: "beneficiary",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/incrementNonce.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/incrementNonce.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "incrementNonce" function.
@@ -17,6 +18,34 @@ export type IncrementNonceParams = Prettify<
       asyncParams: () => Promise<IncrementNonceParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x0bd28e3b" as const;
+const FN_INPUTS = [
+  {
+    type: "uint192",
+    name: "key",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "incrementNonce" function.
+ * @param options - The options for the incrementNonce function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC4337
+ * @example
+ * ```
+ * import { encodeIncrementNonceParams } "thirdweb/extensions/erc4337";
+ * const result = encodeIncrementNonceParams({
+ *  key: ...,
+ * });
+ * ```
+ */
+export function encodeIncrementNonceParams(
+  options: IncrementNonceParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.key]);
+}
+
 /**
  * Calls the "incrementNonce" function on the contract.
  * @param options - The options for the "incrementNonce" function.
@@ -40,16 +69,7 @@ export function incrementNonce(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x0bd28e3b",
-      [
-        {
-          type: "uint192",
-          name: "key",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/simulateHandleOp.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/simulateHandleOp.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "simulateHandleOp" function.
@@ -38,6 +39,94 @@ export type SimulateHandleOpParams = Prettify<
       asyncParams: () => Promise<SimulateHandleOpParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xd6383f94" as const;
+const FN_INPUTS = [
+  {
+    type: "tuple",
+    name: "op",
+    components: [
+      {
+        type: "address",
+        name: "sender",
+      },
+      {
+        type: "uint256",
+        name: "nonce",
+      },
+      {
+        type: "bytes",
+        name: "initCode",
+      },
+      {
+        type: "bytes",
+        name: "callData",
+      },
+      {
+        type: "uint256",
+        name: "callGasLimit",
+      },
+      {
+        type: "uint256",
+        name: "verificationGasLimit",
+      },
+      {
+        type: "uint256",
+        name: "preVerificationGas",
+      },
+      {
+        type: "uint256",
+        name: "maxFeePerGas",
+      },
+      {
+        type: "uint256",
+        name: "maxPriorityFeePerGas",
+      },
+      {
+        type: "bytes",
+        name: "paymasterAndData",
+      },
+      {
+        type: "bytes",
+        name: "signature",
+      },
+    ],
+  },
+  {
+    type: "address",
+    name: "target",
+  },
+  {
+    type: "bytes",
+    name: "targetCallData",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "simulateHandleOp" function.
+ * @param options - The options for the simulateHandleOp function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC4337
+ * @example
+ * ```
+ * import { encodeSimulateHandleOpParams } "thirdweb/extensions/erc4337";
+ * const result = encodeSimulateHandleOpParams({
+ *  op: ...,
+ *  target: ...,
+ *  targetCallData: ...,
+ * });
+ * ```
+ */
+export function encodeSimulateHandleOpParams(
+  options: SimulateHandleOpParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.op,
+    options.target,
+    options.targetCallData,
+  ]);
+}
+
 /**
  * Calls the "simulateHandleOp" function on the contract.
  * @param options - The options for the "simulateHandleOp" function.
@@ -63,70 +152,7 @@ export function simulateHandleOp(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xd6383f94",
-      [
-        {
-          type: "tuple",
-          name: "op",
-          components: [
-            {
-              type: "address",
-              name: "sender",
-            },
-            {
-              type: "uint256",
-              name: "nonce",
-            },
-            {
-              type: "bytes",
-              name: "initCode",
-            },
-            {
-              type: "bytes",
-              name: "callData",
-            },
-            {
-              type: "uint256",
-              name: "callGasLimit",
-            },
-            {
-              type: "uint256",
-              name: "verificationGasLimit",
-            },
-            {
-              type: "uint256",
-              name: "preVerificationGas",
-            },
-            {
-              type: "uint256",
-              name: "maxFeePerGas",
-            },
-            {
-              type: "uint256",
-              name: "maxPriorityFeePerGas",
-            },
-            {
-              type: "bytes",
-              name: "paymasterAndData",
-            },
-            {
-              type: "bytes",
-              name: "signature",
-            },
-          ],
-        },
-        {
-          type: "address",
-          name: "target",
-        },
-        {
-          type: "bytes",
-          name: "targetCallData",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/simulateValidation.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/simulateValidation.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "simulateValidation" function.
@@ -33,6 +34,80 @@ export type SimulateValidationParams = Prettify<
       asyncParams: () => Promise<SimulateValidationParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xee219423" as const;
+const FN_INPUTS = [
+  {
+    type: "tuple",
+    name: "userOp",
+    components: [
+      {
+        type: "address",
+        name: "sender",
+      },
+      {
+        type: "uint256",
+        name: "nonce",
+      },
+      {
+        type: "bytes",
+        name: "initCode",
+      },
+      {
+        type: "bytes",
+        name: "callData",
+      },
+      {
+        type: "uint256",
+        name: "callGasLimit",
+      },
+      {
+        type: "uint256",
+        name: "verificationGasLimit",
+      },
+      {
+        type: "uint256",
+        name: "preVerificationGas",
+      },
+      {
+        type: "uint256",
+        name: "maxFeePerGas",
+      },
+      {
+        type: "uint256",
+        name: "maxPriorityFeePerGas",
+      },
+      {
+        type: "bytes",
+        name: "paymasterAndData",
+      },
+      {
+        type: "bytes",
+        name: "signature",
+      },
+    ],
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "simulateValidation" function.
+ * @param options - The options for the simulateValidation function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC4337
+ * @example
+ * ```
+ * import { encodeSimulateValidationParams } "thirdweb/extensions/erc4337";
+ * const result = encodeSimulateValidationParams({
+ *  userOp: ...,
+ * });
+ * ```
+ */
+export function encodeSimulateValidationParams(
+  options: SimulateValidationParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.userOp]);
+}
+
 /**
  * Calls the "simulateValidation" function on the contract.
  * @param options - The options for the "simulateValidation" function.
@@ -56,62 +131,7 @@ export function simulateValidation(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xee219423",
-      [
-        {
-          type: "tuple",
-          name: "userOp",
-          components: [
-            {
-              type: "address",
-              name: "sender",
-            },
-            {
-              type: "uint256",
-              name: "nonce",
-            },
-            {
-              type: "bytes",
-              name: "initCode",
-            },
-            {
-              type: "bytes",
-              name: "callData",
-            },
-            {
-              type: "uint256",
-              name: "callGasLimit",
-            },
-            {
-              type: "uint256",
-              name: "verificationGasLimit",
-            },
-            {
-              type: "uint256",
-              name: "preVerificationGas",
-            },
-            {
-              type: "uint256",
-              name: "maxFeePerGas",
-            },
-            {
-              type: "uint256",
-              name: "maxPriorityFeePerGas",
-            },
-            {
-              type: "bytes",
-              name: "paymasterAndData",
-            },
-            {
-              type: "bytes",
-              name: "signature",
-            },
-          ],
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/unlockStake.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/unlockStake.ts
@@ -1,6 +1,10 @@
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
 
+const FN_SELECTOR = "0xbb9fe6bf" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [] as const;
+
 /**
  * Calls the "unlockStake" function on the contract.
  * @param options - The options for the "unlockStake" function.
@@ -20,6 +24,6 @@ import { prepareContractCall } from "../../../../../transaction/prepare-contract
 export function unlockStake(options: BaseTransactionOptions) {
   return prepareContractCall({
     contract: options.contract,
-    method: ["0xbb9fe6bf", [], []],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/withdrawStake.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/withdrawStake.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "withdrawStake" function.
@@ -20,6 +21,34 @@ export type WithdrawStakeParams = Prettify<
       asyncParams: () => Promise<WithdrawStakeParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xc23a5cea" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "withdrawAddress",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "withdrawStake" function.
+ * @param options - The options for the withdrawStake function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC4337
+ * @example
+ * ```
+ * import { encodeWithdrawStakeParams } "thirdweb/extensions/erc4337";
+ * const result = encodeWithdrawStakeParams({
+ *  withdrawAddress: ...,
+ * });
+ * ```
+ */
+export function encodeWithdrawStakeParams(
+  options: WithdrawStakeParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.withdrawAddress]);
+}
+
 /**
  * Calls the "withdrawStake" function on the contract.
  * @param options - The options for the "withdrawStake" function.
@@ -43,16 +72,7 @@ export function withdrawStake(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xc23a5cea",
-      [
-        {
-          type: "address",
-          name: "withdrawAddress",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/withdrawTo.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/withdrawTo.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "withdrawTo" function.
@@ -24,6 +25,40 @@ export type WithdrawToParams = Prettify<
       asyncParams: () => Promise<WithdrawToParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x205c2878" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "withdrawAddress",
+  },
+  {
+    type: "uint256",
+    name: "withdrawAmount",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "withdrawTo" function.
+ * @param options - The options for the withdrawTo function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC4337
+ * @example
+ * ```
+ * import { encodeWithdrawToParams } "thirdweb/extensions/erc4337";
+ * const result = encodeWithdrawToParams({
+ *  withdrawAddress: ...,
+ *  withdrawAmount: ...,
+ * });
+ * ```
+ */
+export function encodeWithdrawToParams(options: WithdrawToParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.withdrawAddress,
+    options.withdrawAmount,
+  ]);
+}
+
 /**
  * Calls the "withdrawTo" function on the contract.
  * @param options - The options for the "withdrawTo" function.
@@ -46,20 +81,7 @@ export type WithdrawToParams = Prettify<
 export function withdrawTo(options: BaseTransactionOptions<WithdrawToParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x205c2878",
-      [
-        {
-          type: "address",
-          name: "withdrawAddress",
-        },
-        {
-          type: "uint256",
-          name: "withdrawAmount",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IPaymaster/write/postOp.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IPaymaster/write/postOp.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "postOp" function.
@@ -22,6 +23,46 @@ export type PostOpParams = Prettify<
       asyncParams: () => Promise<PostOpParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xa9a23409" as const;
+const FN_INPUTS = [
+  {
+    type: "uint8",
+    name: "mode",
+  },
+  {
+    type: "bytes",
+    name: "context",
+  },
+  {
+    type: "uint256",
+    name: "actualGasCost",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "postOp" function.
+ * @param options - The options for the postOp function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC4337
+ * @example
+ * ```
+ * import { encodePostOpParams } "thirdweb/extensions/erc4337";
+ * const result = encodePostOpParams({
+ *  mode: ...,
+ *  context: ...,
+ *  actualGasCost: ...,
+ * });
+ * ```
+ */
+export function encodePostOpParams(options: PostOpParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.mode,
+    options.context,
+    options.actualGasCost,
+  ]);
+}
+
 /**
  * Calls the "postOp" function on the contract.
  * @param options - The options for the "postOp" function.
@@ -45,24 +86,7 @@ export type PostOpParams = Prettify<
 export function postOp(options: BaseTransactionOptions<PostOpParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xa9a23409",
-      [
-        {
-          type: "uint8",
-          name: "mode",
-        },
-        {
-          type: "bytes",
-          name: "context",
-        },
-        {
-          type: "uint256",
-          name: "actualGasCost",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IPaymaster/write/validatePaymasterUserOp.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IPaymaster/write/validatePaymasterUserOp.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "validatePaymasterUserOp" function.
@@ -38,6 +39,103 @@ export type ValidatePaymasterUserOpParams = Prettify<
       asyncParams: () => Promise<ValidatePaymasterUserOpParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xf465c77e" as const;
+const FN_INPUTS = [
+  {
+    type: "tuple",
+    name: "userOp",
+    components: [
+      {
+        type: "address",
+        name: "sender",
+      },
+      {
+        type: "uint256",
+        name: "nonce",
+      },
+      {
+        type: "bytes",
+        name: "initCode",
+      },
+      {
+        type: "bytes",
+        name: "callData",
+      },
+      {
+        type: "uint256",
+        name: "callGasLimit",
+      },
+      {
+        type: "uint256",
+        name: "verificationGasLimit",
+      },
+      {
+        type: "uint256",
+        name: "preVerificationGas",
+      },
+      {
+        type: "uint256",
+        name: "maxFeePerGas",
+      },
+      {
+        type: "uint256",
+        name: "maxPriorityFeePerGas",
+      },
+      {
+        type: "bytes",
+        name: "paymasterAndData",
+      },
+      {
+        type: "bytes",
+        name: "signature",
+      },
+    ],
+  },
+  {
+    type: "bytes32",
+    name: "userOpHash",
+  },
+  {
+    type: "uint256",
+    name: "maxCost",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bytes",
+    name: "context",
+  },
+  {
+    type: "uint256",
+    name: "validationData",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "validatePaymasterUserOp" function.
+ * @param options - The options for the validatePaymasterUserOp function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC4337
+ * @example
+ * ```
+ * import { encodeValidatePaymasterUserOpParams } "thirdweb/extensions/erc4337";
+ * const result = encodeValidatePaymasterUserOpParams({
+ *  userOp: ...,
+ *  userOpHash: ...,
+ *  maxCost: ...,
+ * });
+ * ```
+ */
+export function encodeValidatePaymasterUserOpParams(
+  options: ValidatePaymasterUserOpParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.userOp,
+    options.userOpHash,
+    options.maxCost,
+  ]);
+}
+
 /**
  * Calls the "validatePaymasterUserOp" function on the contract.
  * @param options - The options for the "validatePaymasterUserOp" function.
@@ -63,79 +161,7 @@ export function validatePaymasterUserOp(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xf465c77e",
-      [
-        {
-          type: "tuple",
-          name: "userOp",
-          components: [
-            {
-              type: "address",
-              name: "sender",
-            },
-            {
-              type: "uint256",
-              name: "nonce",
-            },
-            {
-              type: "bytes",
-              name: "initCode",
-            },
-            {
-              type: "bytes",
-              name: "callData",
-            },
-            {
-              type: "uint256",
-              name: "callGasLimit",
-            },
-            {
-              type: "uint256",
-              name: "verificationGasLimit",
-            },
-            {
-              type: "uint256",
-              name: "preVerificationGas",
-            },
-            {
-              type: "uint256",
-              name: "maxFeePerGas",
-            },
-            {
-              type: "uint256",
-              name: "maxPriorityFeePerGas",
-            },
-            {
-              type: "bytes",
-              name: "paymasterAndData",
-            },
-            {
-              type: "bytes",
-              name: "signature",
-            },
-          ],
-        },
-        {
-          type: "bytes32",
-          name: "userOpHash",
-        },
-        {
-          type: "uint256",
-          name: "maxCost",
-        },
-      ],
-      [
-        {
-          type: "bytes",
-          name: "context",
-        },
-        {
-          type: "uint256",
-          name: "validationData",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/asset.ts
+++ b/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/asset.ts
@@ -1,6 +1,34 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x38d52e0f" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "assetTokenAddress",
+    type: "address",
+    internalType: "contract ERC20",
+  },
+] as const;
+
+/**
+ * Decodes the result of the asset function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC4626
+ * @example
+ * ```
+ * import { decodeAssetResult } from "thirdweb/extensions/erc4626";
+ * const result = decodeAssetResult("...");
+ * ```
+ */
+export function decodeAssetResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "asset" function on the contract.
  * @param options - The options for the asset function.
@@ -17,17 +45,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function asset(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x38d52e0f",
-      [],
-      [
-        {
-          name: "assetTokenAddress",
-          type: "address",
-          internalType: "contract ERC20",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/convertToAssets.ts
+++ b/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/convertToAssets.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "convertToAssets" function.
@@ -12,6 +15,54 @@ export type ConvertToAssetsParams = {
     internalType: "uint256";
   }>;
 };
+
+const FN_SELECTOR = "0x07a2d13a" as const;
+const FN_INPUTS = [
+  {
+    name: "shares",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "assets",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "convertToAssets" function.
+ * @param options - The options for the convertToAssets function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC4626
+ * @example
+ * ```
+ * import { encodeConvertToAssetsParams } "thirdweb/extensions/erc4626";
+ * const result = encodeConvertToAssetsParams({
+ *  shares: ...,
+ * });
+ * ```
+ */
+export function encodeConvertToAssetsParams(options: ConvertToAssetsParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.shares]);
+}
+
+/**
+ * Decodes the result of the convertToAssets function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC4626
+ * @example
+ * ```
+ * import { decodeConvertToAssetsResult } from "thirdweb/extensions/erc4626";
+ * const result = decodeConvertToAssetsResult("...");
+ * ```
+ */
+export function decodeConvertToAssetsResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "convertToAssets" function on the contract.
@@ -33,23 +84,7 @@ export async function convertToAssets(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x07a2d13a",
-      [
-        {
-          name: "shares",
-          type: "uint256",
-          internalType: "uint256",
-        },
-      ],
-      [
-        {
-          name: "assets",
-          type: "uint256",
-          internalType: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.shares],
   });
 }

--- a/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/convertToShares.ts
+++ b/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/convertToShares.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "convertToShares" function.
@@ -12,6 +15,54 @@ export type ConvertToSharesParams = {
     internalType: "uint256";
   }>;
 };
+
+const FN_SELECTOR = "0xc6e6f592" as const;
+const FN_INPUTS = [
+  {
+    name: "assets",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "shares",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "convertToShares" function.
+ * @param options - The options for the convertToShares function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC4626
+ * @example
+ * ```
+ * import { encodeConvertToSharesParams } "thirdweb/extensions/erc4626";
+ * const result = encodeConvertToSharesParams({
+ *  assets: ...,
+ * });
+ * ```
+ */
+export function encodeConvertToSharesParams(options: ConvertToSharesParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.assets]);
+}
+
+/**
+ * Decodes the result of the convertToShares function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC4626
+ * @example
+ * ```
+ * import { decodeConvertToSharesResult } from "thirdweb/extensions/erc4626";
+ * const result = decodeConvertToSharesResult("...");
+ * ```
+ */
+export function decodeConvertToSharesResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "convertToShares" function on the contract.
@@ -33,23 +84,7 @@ export async function convertToShares(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xc6e6f592",
-      [
-        {
-          name: "assets",
-          type: "uint256",
-          internalType: "uint256",
-        },
-      ],
-      [
-        {
-          name: "shares",
-          type: "uint256",
-          internalType: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.assets],
   });
 }

--- a/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/maxDeposit.ts
+++ b/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/maxDeposit.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "maxDeposit" function.
@@ -12,6 +15,54 @@ export type MaxDepositParams = {
     internalType: "address";
   }>;
 };
+
+const FN_SELECTOR = "0x402d267d" as const;
+const FN_INPUTS = [
+  {
+    name: "receiver",
+    type: "address",
+    internalType: "address",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "maxAssets",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "maxDeposit" function.
+ * @param options - The options for the maxDeposit function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC4626
+ * @example
+ * ```
+ * import { encodeMaxDepositParams } "thirdweb/extensions/erc4626";
+ * const result = encodeMaxDepositParams({
+ *  receiver: ...,
+ * });
+ * ```
+ */
+export function encodeMaxDepositParams(options: MaxDepositParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.receiver]);
+}
+
+/**
+ * Decodes the result of the maxDeposit function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC4626
+ * @example
+ * ```
+ * import { decodeMaxDepositResult } from "thirdweb/extensions/erc4626";
+ * const result = decodeMaxDepositResult("...");
+ * ```
+ */
+export function decodeMaxDepositResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "maxDeposit" function on the contract.
@@ -33,23 +84,7 @@ export async function maxDeposit(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x402d267d",
-      [
-        {
-          name: "receiver",
-          type: "address",
-          internalType: "address",
-        },
-      ],
-      [
-        {
-          name: "maxAssets",
-          type: "uint256",
-          internalType: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.receiver],
   });
 }

--- a/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/maxMint.ts
+++ b/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/maxMint.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "maxMint" function.
@@ -12,6 +15,54 @@ export type MaxMintParams = {
     internalType: "address";
   }>;
 };
+
+const FN_SELECTOR = "0xc63d75b6" as const;
+const FN_INPUTS = [
+  {
+    name: "receiver",
+    type: "address",
+    internalType: "address",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "maxShares",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "maxMint" function.
+ * @param options - The options for the maxMint function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC4626
+ * @example
+ * ```
+ * import { encodeMaxMintParams } "thirdweb/extensions/erc4626";
+ * const result = encodeMaxMintParams({
+ *  receiver: ...,
+ * });
+ * ```
+ */
+export function encodeMaxMintParams(options: MaxMintParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.receiver]);
+}
+
+/**
+ * Decodes the result of the maxMint function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC4626
+ * @example
+ * ```
+ * import { decodeMaxMintResult } from "thirdweb/extensions/erc4626";
+ * const result = decodeMaxMintResult("...");
+ * ```
+ */
+export function decodeMaxMintResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "maxMint" function on the contract.
@@ -31,23 +82,7 @@ export type MaxMintParams = {
 export async function maxMint(options: BaseTransactionOptions<MaxMintParams>) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xc63d75b6",
-      [
-        {
-          name: "receiver",
-          type: "address",
-          internalType: "address",
-        },
-      ],
-      [
-        {
-          name: "maxShares",
-          type: "uint256",
-          internalType: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.receiver],
   });
 }

--- a/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/maxRedeem.ts
+++ b/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/maxRedeem.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "maxRedeem" function.
@@ -12,6 +15,54 @@ export type MaxRedeemParams = {
     internalType: "address";
   }>;
 };
+
+const FN_SELECTOR = "0xd905777e" as const;
+const FN_INPUTS = [
+  {
+    name: "owner",
+    type: "address",
+    internalType: "address",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "maxShares",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "maxRedeem" function.
+ * @param options - The options for the maxRedeem function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC4626
+ * @example
+ * ```
+ * import { encodeMaxRedeemParams } "thirdweb/extensions/erc4626";
+ * const result = encodeMaxRedeemParams({
+ *  owner: ...,
+ * });
+ * ```
+ */
+export function encodeMaxRedeemParams(options: MaxRedeemParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.owner]);
+}
+
+/**
+ * Decodes the result of the maxRedeem function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC4626
+ * @example
+ * ```
+ * import { decodeMaxRedeemResult } from "thirdweb/extensions/erc4626";
+ * const result = decodeMaxRedeemResult("...");
+ * ```
+ */
+export function decodeMaxRedeemResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "maxRedeem" function on the contract.
@@ -33,23 +84,7 @@ export async function maxRedeem(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xd905777e",
-      [
-        {
-          name: "owner",
-          type: "address",
-          internalType: "address",
-        },
-      ],
-      [
-        {
-          name: "maxShares",
-          type: "uint256",
-          internalType: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.owner],
   });
 }

--- a/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/maxWithdraw.ts
+++ b/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/maxWithdraw.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "maxWithdraw" function.
@@ -12,6 +15,54 @@ export type MaxWithdrawParams = {
     internalType: "address";
   }>;
 };
+
+const FN_SELECTOR = "0xce96cb77" as const;
+const FN_INPUTS = [
+  {
+    name: "owner",
+    type: "address",
+    internalType: "address",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "maxAssets",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "maxWithdraw" function.
+ * @param options - The options for the maxWithdraw function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC4626
+ * @example
+ * ```
+ * import { encodeMaxWithdrawParams } "thirdweb/extensions/erc4626";
+ * const result = encodeMaxWithdrawParams({
+ *  owner: ...,
+ * });
+ * ```
+ */
+export function encodeMaxWithdrawParams(options: MaxWithdrawParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.owner]);
+}
+
+/**
+ * Decodes the result of the maxWithdraw function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC4626
+ * @example
+ * ```
+ * import { decodeMaxWithdrawResult } from "thirdweb/extensions/erc4626";
+ * const result = decodeMaxWithdrawResult("...");
+ * ```
+ */
+export function decodeMaxWithdrawResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "maxWithdraw" function on the contract.
@@ -33,23 +84,7 @@ export async function maxWithdraw(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xce96cb77",
-      [
-        {
-          name: "owner",
-          type: "address",
-          internalType: "address",
-        },
-      ],
-      [
-        {
-          name: "maxAssets",
-          type: "uint256",
-          internalType: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.owner],
   });
 }

--- a/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/previewDeposit.ts
+++ b/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/previewDeposit.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "previewDeposit" function.
@@ -12,6 +15,54 @@ export type PreviewDepositParams = {
     internalType: "uint256";
   }>;
 };
+
+const FN_SELECTOR = "0xef8b30f7" as const;
+const FN_INPUTS = [
+  {
+    name: "assets",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "shares",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "previewDeposit" function.
+ * @param options - The options for the previewDeposit function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC4626
+ * @example
+ * ```
+ * import { encodePreviewDepositParams } "thirdweb/extensions/erc4626";
+ * const result = encodePreviewDepositParams({
+ *  assets: ...,
+ * });
+ * ```
+ */
+export function encodePreviewDepositParams(options: PreviewDepositParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.assets]);
+}
+
+/**
+ * Decodes the result of the previewDeposit function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC4626
+ * @example
+ * ```
+ * import { decodePreviewDepositResult } from "thirdweb/extensions/erc4626";
+ * const result = decodePreviewDepositResult("...");
+ * ```
+ */
+export function decodePreviewDepositResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "previewDeposit" function on the contract.
@@ -33,23 +84,7 @@ export async function previewDeposit(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xef8b30f7",
-      [
-        {
-          name: "assets",
-          type: "uint256",
-          internalType: "uint256",
-        },
-      ],
-      [
-        {
-          name: "shares",
-          type: "uint256",
-          internalType: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.assets],
   });
 }

--- a/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/previewMint.ts
+++ b/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/previewMint.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "previewMint" function.
@@ -12,6 +15,54 @@ export type PreviewMintParams = {
     internalType: "uint256";
   }>;
 };
+
+const FN_SELECTOR = "0xb3d7f6b9" as const;
+const FN_INPUTS = [
+  {
+    name: "shares",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "previewMint" function.
+ * @param options - The options for the previewMint function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC4626
+ * @example
+ * ```
+ * import { encodePreviewMintParams } "thirdweb/extensions/erc4626";
+ * const result = encodePreviewMintParams({
+ *  shares: ...,
+ * });
+ * ```
+ */
+export function encodePreviewMintParams(options: PreviewMintParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.shares]);
+}
+
+/**
+ * Decodes the result of the previewMint function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC4626
+ * @example
+ * ```
+ * import { decodePreviewMintResult } from "thirdweb/extensions/erc4626";
+ * const result = decodePreviewMintResult("...");
+ * ```
+ */
+export function decodePreviewMintResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "previewMint" function on the contract.
@@ -33,23 +84,7 @@ export async function previewMint(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xb3d7f6b9",
-      [
-        {
-          name: "shares",
-          type: "uint256",
-          internalType: "uint256",
-        },
-      ],
-      [
-        {
-          name: "",
-          type: "uint256",
-          internalType: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.shares],
   });
 }

--- a/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/previewRedeem.ts
+++ b/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/previewRedeem.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "previewRedeem" function.
@@ -12,6 +15,54 @@ export type PreviewRedeemParams = {
     internalType: "uint256";
   }>;
 };
+
+const FN_SELECTOR = "0x4cdad506" as const;
+const FN_INPUTS = [
+  {
+    name: "shares",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "assets",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "previewRedeem" function.
+ * @param options - The options for the previewRedeem function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC4626
+ * @example
+ * ```
+ * import { encodePreviewRedeemParams } "thirdweb/extensions/erc4626";
+ * const result = encodePreviewRedeemParams({
+ *  shares: ...,
+ * });
+ * ```
+ */
+export function encodePreviewRedeemParams(options: PreviewRedeemParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.shares]);
+}
+
+/**
+ * Decodes the result of the previewRedeem function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC4626
+ * @example
+ * ```
+ * import { decodePreviewRedeemResult } from "thirdweb/extensions/erc4626";
+ * const result = decodePreviewRedeemResult("...");
+ * ```
+ */
+export function decodePreviewRedeemResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "previewRedeem" function on the contract.
@@ -33,23 +84,7 @@ export async function previewRedeem(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x4cdad506",
-      [
-        {
-          name: "shares",
-          type: "uint256",
-          internalType: "uint256",
-        },
-      ],
-      [
-        {
-          name: "assets",
-          type: "uint256",
-          internalType: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.shares],
   });
 }

--- a/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/previewWithdraw.ts
+++ b/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/previewWithdraw.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "previewWithdraw" function.
@@ -12,6 +15,54 @@ export type PreviewWithdrawParams = {
     internalType: "uint256";
   }>;
 };
+
+const FN_SELECTOR = "0x0a28a477" as const;
+const FN_INPUTS = [
+  {
+    name: "assets",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "shares",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "previewWithdraw" function.
+ * @param options - The options for the previewWithdraw function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC4626
+ * @example
+ * ```
+ * import { encodePreviewWithdrawParams } "thirdweb/extensions/erc4626";
+ * const result = encodePreviewWithdrawParams({
+ *  assets: ...,
+ * });
+ * ```
+ */
+export function encodePreviewWithdrawParams(options: PreviewWithdrawParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.assets]);
+}
+
+/**
+ * Decodes the result of the previewWithdraw function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC4626
+ * @example
+ * ```
+ * import { decodePreviewWithdrawResult } from "thirdweb/extensions/erc4626";
+ * const result = decodePreviewWithdrawResult("...");
+ * ```
+ */
+export function decodePreviewWithdrawResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "previewWithdraw" function on the contract.
@@ -33,23 +84,7 @@ export async function previewWithdraw(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x0a28a477",
-      [
-        {
-          name: "assets",
-          type: "uint256",
-          internalType: "uint256",
-        },
-      ],
-      [
-        {
-          name: "shares",
-          type: "uint256",
-          internalType: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.assets],
   });
 }

--- a/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/totalAssets.ts
+++ b/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/totalAssets.ts
@@ -1,6 +1,34 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x01e1d114" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "totalManagedAssets",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the totalAssets function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC4626
+ * @example
+ * ```
+ * import { decodeTotalAssetsResult } from "thirdweb/extensions/erc4626";
+ * const result = decodeTotalAssetsResult("...");
+ * ```
+ */
+export function decodeTotalAssetsResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "totalAssets" function on the contract.
  * @param options - The options for the totalAssets function.
@@ -17,17 +45,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function totalAssets(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x01e1d114",
-      [],
-      [
-        {
-          name: "totalManagedAssets",
-          type: "uint256",
-          internalType: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/write/deposit.ts
+++ b/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/write/deposit.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "deposit" function.
@@ -26,6 +27,45 @@ export type DepositParams = Prettify<
       asyncParams: () => Promise<DepositParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x6e553f65" as const;
+const FN_INPUTS = [
+  {
+    name: "assets",
+    type: "uint256",
+    internalType: "uint256",
+  },
+  {
+    name: "receiver",
+    type: "address",
+    internalType: "address",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "shares",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "deposit" function.
+ * @param options - The options for the deposit function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC4626
+ * @example
+ * ```
+ * import { encodeDepositParams } "thirdweb/extensions/erc4626";
+ * const result = encodeDepositParams({
+ *  assets: ...,
+ *  receiver: ...,
+ * });
+ * ```
+ */
+export function encodeDepositParams(options: DepositParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.assets, options.receiver]);
+}
+
 /**
  * Calls the "deposit" function on the contract.
  * @param options - The options for the "deposit" function.
@@ -48,28 +88,7 @@ export type DepositParams = Prettify<
 export function deposit(options: BaseTransactionOptions<DepositParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x6e553f65",
-      [
-        {
-          name: "assets",
-          type: "uint256",
-          internalType: "uint256",
-        },
-        {
-          name: "receiver",
-          type: "address",
-          internalType: "address",
-        },
-      ],
-      [
-        {
-          name: "shares",
-          type: "uint256",
-          internalType: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/write/mint.ts
+++ b/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/write/mint.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "mint" function.
@@ -26,6 +27,45 @@ export type MintParams = Prettify<
       asyncParams: () => Promise<MintParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x94bf804d" as const;
+const FN_INPUTS = [
+  {
+    name: "shares",
+    type: "uint256",
+    internalType: "uint256",
+  },
+  {
+    name: "receiver",
+    type: "address",
+    internalType: "address",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "assets",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "mint" function.
+ * @param options - The options for the mint function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC4626
+ * @example
+ * ```
+ * import { encodeMintParams } "thirdweb/extensions/erc4626";
+ * const result = encodeMintParams({
+ *  shares: ...,
+ *  receiver: ...,
+ * });
+ * ```
+ */
+export function encodeMintParams(options: MintParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.shares, options.receiver]);
+}
+
 /**
  * Calls the "mint" function on the contract.
  * @param options - The options for the "mint" function.
@@ -48,28 +88,7 @@ export type MintParams = Prettify<
 export function mint(options: BaseTransactionOptions<MintParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x94bf804d",
-      [
-        {
-          name: "shares",
-          type: "uint256",
-          internalType: "uint256",
-        },
-        {
-          name: "receiver",
-          type: "address",
-          internalType: "address",
-        },
-      ],
-      [
-        {
-          name: "assets",
-          type: "uint256",
-          internalType: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/write/redeem.ts
+++ b/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/write/redeem.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "redeem" function.
@@ -31,6 +32,55 @@ export type RedeemParams = Prettify<
       asyncParams: () => Promise<RedeemParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xba087652" as const;
+const FN_INPUTS = [
+  {
+    name: "shares",
+    type: "uint256",
+    internalType: "uint256",
+  },
+  {
+    name: "receiver",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "owner",
+    type: "address",
+    internalType: "address",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "assets",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "redeem" function.
+ * @param options - The options for the redeem function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC4626
+ * @example
+ * ```
+ * import { encodeRedeemParams } "thirdweb/extensions/erc4626";
+ * const result = encodeRedeemParams({
+ *  shares: ...,
+ *  receiver: ...,
+ *  owner: ...,
+ * });
+ * ```
+ */
+export function encodeRedeemParams(options: RedeemParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.shares,
+    options.receiver,
+    options.owner,
+  ]);
+}
+
 /**
  * Calls the "redeem" function on the contract.
  * @param options - The options for the "redeem" function.
@@ -54,33 +104,7 @@ export type RedeemParams = Prettify<
 export function redeem(options: BaseTransactionOptions<RedeemParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xba087652",
-      [
-        {
-          name: "shares",
-          type: "uint256",
-          internalType: "uint256",
-        },
-        {
-          name: "receiver",
-          type: "address",
-          internalType: "address",
-        },
-        {
-          name: "owner",
-          type: "address",
-          internalType: "address",
-        },
-      ],
-      [
-        {
-          name: "assets",
-          type: "uint256",
-          internalType: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/write/withdraw.ts
+++ b/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/write/withdraw.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "withdraw" function.
@@ -31,6 +32,55 @@ export type WithdrawParams = Prettify<
       asyncParams: () => Promise<WithdrawParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xb460af94" as const;
+const FN_INPUTS = [
+  {
+    name: "assets",
+    type: "uint256",
+    internalType: "uint256",
+  },
+  {
+    name: "receiver",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "owner",
+    type: "address",
+    internalType: "address",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "shares",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "withdraw" function.
+ * @param options - The options for the withdraw function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC4626
+ * @example
+ * ```
+ * import { encodeWithdrawParams } "thirdweb/extensions/erc4626";
+ * const result = encodeWithdrawParams({
+ *  assets: ...,
+ *  receiver: ...,
+ *  owner: ...,
+ * });
+ * ```
+ */
+export function encodeWithdrawParams(options: WithdrawParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.assets,
+    options.receiver,
+    options.owner,
+  ]);
+}
+
 /**
  * Calls the "withdraw" function on the contract.
  * @param options - The options for the "withdraw" function.
@@ -54,33 +104,7 @@ export type WithdrawParams = Prettify<
 export function withdraw(options: BaseTransactionOptions<WithdrawParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xb460af94",
-      [
-        {
-          name: "assets",
-          type: "uint256",
-          internalType: "uint256",
-        },
-        {
-          name: "receiver",
-          type: "address",
-          internalType: "address",
-        },
-        {
-          name: "owner",
-          type: "address",
-          internalType: "address",
-        },
-      ],
-      [
-        {
-          name: "shares",
-          type: "uint256",
-          internalType: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc6551/__generated__/IERC6551Account/read/isValidSigner.ts
+++ b/packages/thirdweb/src/extensions/erc6551/__generated__/IERC6551Account/read/isValidSigner.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "isValidSigner" function.
@@ -9,6 +12,57 @@ export type IsValidSignerParams = {
   signer: AbiParameterToPrimitiveType<{ type: "address"; name: "signer" }>;
   context: AbiParameterToPrimitiveType<{ type: "bytes"; name: "context" }>;
 };
+
+const FN_SELECTOR = "0x523e3260" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "signer",
+  },
+  {
+    type: "bytes",
+    name: "context",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bytes4",
+    name: "magicValue",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "isValidSigner" function.
+ * @param options - The options for the isValidSigner function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC6551
+ * @example
+ * ```
+ * import { encodeIsValidSignerParams } "thirdweb/extensions/erc6551";
+ * const result = encodeIsValidSignerParams({
+ *  signer: ...,
+ *  context: ...,
+ * });
+ * ```
+ */
+export function encodeIsValidSignerParams(options: IsValidSignerParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.signer, options.context]);
+}
+
+/**
+ * Decodes the result of the isValidSigner function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC6551
+ * @example
+ * ```
+ * import { decodeIsValidSignerResult } from "thirdweb/extensions/erc6551";
+ * const result = decodeIsValidSignerResult("...");
+ * ```
+ */
+export function decodeIsValidSignerResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "isValidSigner" function on the contract.
@@ -31,25 +85,7 @@ export async function isValidSigner(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x523e3260",
-      [
-        {
-          type: "address",
-          name: "signer",
-        },
-        {
-          type: "bytes",
-          name: "context",
-        },
-      ],
-      [
-        {
-          type: "bytes4",
-          name: "magicValue",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.signer, options.context],
   });
 }

--- a/packages/thirdweb/src/extensions/erc6551/__generated__/IERC6551Account/read/state.ts
+++ b/packages/thirdweb/src/extensions/erc6551/__generated__/IERC6551Account/read/state.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0xc19d93fb" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the state function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC6551
+ * @example
+ * ```
+ * import { decodeStateResult } from "thirdweb/extensions/erc6551";
+ * const result = decodeStateResult("...");
+ * ```
+ */
+export function decodeStateResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "state" function on the contract.
  * @param options - The options for the state function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function state(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xc19d93fb",
-      [],
-      [
-        {
-          type: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/erc6551/__generated__/IERC6551Account/read/token.ts
+++ b/packages/thirdweb/src/extensions/erc6551/__generated__/IERC6551Account/read/token.ts
@@ -1,6 +1,41 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0xfc0c546a" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+    name: "chainId",
+  },
+  {
+    type: "address",
+    name: "tokenContract",
+  },
+  {
+    type: "uint256",
+    name: "tokenId",
+  },
+] as const;
+
+/**
+ * Decodes the result of the token function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC6551
+ * @example
+ * ```
+ * import { decodeTokenResult } from "thirdweb/extensions/erc6551";
+ * const result = decodeTokenResult("...");
+ * ```
+ */
+export function decodeTokenResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result);
+}
+
 /**
  * Calls the "token" function on the contract.
  * @param options - The options for the token function.
@@ -17,24 +52,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function token(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xfc0c546a",
-      [],
-      [
-        {
-          type: "uint256",
-          name: "chainId",
-        },
-        {
-          type: "address",
-          name: "tokenContract",
-        },
-        {
-          type: "uint256",
-          name: "tokenId",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IAirdropERC721/write/airdropERC721.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IAirdropERC721/write/airdropERC721.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "airdropERC721" function.
@@ -32,6 +33,58 @@ export type AirdropERC721Params = Prettify<
       asyncParams: () => Promise<AirdropERC721ParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x7c2c059d" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "tokenAddress",
+  },
+  {
+    type: "address",
+    name: "tokenOwner",
+  },
+  {
+    type: "tuple[]",
+    name: "contents",
+    components: [
+      {
+        type: "address",
+        name: "recipient",
+      },
+      {
+        type: "uint256",
+        name: "tokenId",
+      },
+    ],
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "airdropERC721" function.
+ * @param options - The options for the airdropERC721 function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { encodeAirdropERC721Params } "thirdweb/extensions/erc721";
+ * const result = encodeAirdropERC721Params({
+ *  tokenAddress: ...,
+ *  tokenOwner: ...,
+ *  contents: ...,
+ * });
+ * ```
+ */
+export function encodeAirdropERC721Params(
+  options: AirdropERC721ParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.tokenAddress,
+    options.tokenOwner,
+    options.contents,
+  ]);
+}
+
 /**
  * Calls the "airdropERC721" function on the contract.
  * @param options - The options for the "airdropERC721" function.
@@ -57,34 +110,7 @@ export function airdropERC721(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x7c2c059d",
-      [
-        {
-          type: "address",
-          name: "tokenAddress",
-        },
-        {
-          type: "address",
-          name: "tokenOwner",
-        },
-        {
-          type: "tuple[]",
-          name: "contents",
-          components: [
-            {
-              type: "address",
-              name: "recipient",
-            },
-            {
-              type: "uint256",
-              name: "tokenId",
-            },
-          ],
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IAirdropERC721Claimable/write/claim.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IAirdropERC721Claimable/write/claim.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "claim" function.
@@ -23,6 +24,52 @@ export type ClaimParams = Prettify<
       asyncParams: () => Promise<ClaimParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x3b4b57b0" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "receiver",
+  },
+  {
+    type: "uint256",
+    name: "quantity",
+  },
+  {
+    type: "bytes32[]",
+    name: "proofs",
+  },
+  {
+    type: "uint256",
+    name: "proofMaxQuantityForWallet",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "claim" function.
+ * @param options - The options for the claim function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { encodeClaimParams } "thirdweb/extensions/erc721";
+ * const result = encodeClaimParams({
+ *  receiver: ...,
+ *  quantity: ...,
+ *  proofs: ...,
+ *  proofMaxQuantityForWallet: ...,
+ * });
+ * ```
+ */
+export function encodeClaimParams(options: ClaimParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.receiver,
+    options.quantity,
+    options.proofs,
+    options.proofMaxQuantityForWallet,
+  ]);
+}
+
 /**
  * Calls the "claim" function on the contract.
  * @param options - The options for the "claim" function.
@@ -47,28 +94,7 @@ export type ClaimParams = Prettify<
 export function claim(options: BaseTransactionOptions<ClaimParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x3b4b57b0",
-      [
-        {
-          type: "address",
-          name: "receiver",
-        },
-        {
-          type: "uint256",
-          name: "quantity",
-        },
-        {
-          type: "bytes32[]",
-          name: "proofs",
-        },
-        {
-          type: "uint256",
-          name: "proofMaxQuantityForWallet",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IBurnableERC721/write/burn.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IBurnableERC721/write/burn.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "burn" function.
@@ -17,6 +18,32 @@ export type BurnParams = Prettify<
       asyncParams: () => Promise<BurnParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x42966c68" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "tokenId",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "burn" function.
+ * @param options - The options for the burn function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { encodeBurnParams } "thirdweb/extensions/erc721";
+ * const result = encodeBurnParams({
+ *  tokenId: ...,
+ * });
+ * ```
+ */
+export function encodeBurnParams(options: BurnParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.tokenId]);
+}
+
 /**
  * Calls the "burn" function on the contract.
  * @param options - The options for the "burn" function.
@@ -38,16 +65,7 @@ export type BurnParams = Prettify<
 export function burn(options: BaseTransactionOptions<BurnParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x42966c68",
-      [
-        {
-          type: "uint256",
-          name: "tokenId",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IClaimableERC721/read/verifyClaim.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IClaimableERC721/read/verifyClaim.ts
@@ -1,6 +1,7 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "verifyClaim" function.
@@ -9,6 +10,37 @@ export type VerifyClaimParams = {
   claimer: AbiParameterToPrimitiveType<{ type: "address"; name: "_claimer" }>;
   quantity: AbiParameterToPrimitiveType<{ type: "uint256"; name: "_quantity" }>;
 };
+
+const FN_SELECTOR = "0x2f92023a" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "_claimer",
+  },
+  {
+    type: "uint256",
+    name: "_quantity",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "verifyClaim" function.
+ * @param options - The options for the verifyClaim function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { encodeVerifyClaimParams } "thirdweb/extensions/erc721";
+ * const result = encodeVerifyClaimParams({
+ *  claimer: ...,
+ *  quantity: ...,
+ * });
+ * ```
+ */
+export function encodeVerifyClaimParams(options: VerifyClaimParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.claimer, options.quantity]);
+}
 
 /**
  * Calls the "verifyClaim" function on the contract.
@@ -31,20 +63,7 @@ export async function verifyClaim(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x2f92023a",
-      [
-        {
-          type: "address",
-          name: "_claimer",
-        },
-        {
-          type: "uint256",
-          name: "_quantity",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.claimer, options.quantity],
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IClaimableERC721/write/claim.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IClaimableERC721/write/claim.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "claim" function.
@@ -18,6 +19,37 @@ export type ClaimParams = Prettify<
       asyncParams: () => Promise<ClaimParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xaad3ec96" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "_receiver",
+  },
+  {
+    type: "uint256",
+    name: "_quantity",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "claim" function.
+ * @param options - The options for the claim function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { encodeClaimParams } "thirdweb/extensions/erc721";
+ * const result = encodeClaimParams({
+ *  receiver: ...,
+ *  quantity: ...,
+ * });
+ * ```
+ */
+export function encodeClaimParams(options: ClaimParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.receiver, options.quantity]);
+}
+
 /**
  * Calls the "claim" function on the contract.
  * @param options - The options for the "claim" function.
@@ -40,20 +72,7 @@ export type ClaimParams = Prettify<
 export function claim(options: BaseTransactionOptions<ClaimParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xaad3ec96",
-      [
-        {
-          type: "address",
-          name: "_receiver",
-        },
-        {
-          type: "uint256",
-          name: "_quantity",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IDelayedReveal/read/encryptDecrypt.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IDelayedReveal/read/encryptDecrypt.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "encryptDecrypt" function.
@@ -9,6 +12,57 @@ export type EncryptDecryptParams = {
   data: AbiParameterToPrimitiveType<{ type: "bytes"; name: "data" }>;
   key: AbiParameterToPrimitiveType<{ type: "bytes"; name: "key" }>;
 };
+
+const FN_SELECTOR = "0xe7150322" as const;
+const FN_INPUTS = [
+  {
+    type: "bytes",
+    name: "data",
+  },
+  {
+    type: "bytes",
+    name: "key",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bytes",
+    name: "result",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "encryptDecrypt" function.
+ * @param options - The options for the encryptDecrypt function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { encodeEncryptDecryptParams } "thirdweb/extensions/erc721";
+ * const result = encodeEncryptDecryptParams({
+ *  data: ...,
+ *  key: ...,
+ * });
+ * ```
+ */
+export function encodeEncryptDecryptParams(options: EncryptDecryptParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.data, options.key]);
+}
+
+/**
+ * Decodes the result of the encryptDecrypt function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { decodeEncryptDecryptResult } from "thirdweb/extensions/erc721";
+ * const result = decodeEncryptDecryptResult("...");
+ * ```
+ */
+export function decodeEncryptDecryptResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "encryptDecrypt" function on the contract.
@@ -31,25 +85,7 @@ export async function encryptDecrypt(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xe7150322",
-      [
-        {
-          type: "bytes",
-          name: "data",
-        },
-        {
-          type: "bytes",
-          name: "key",
-        },
-      ],
-      [
-        {
-          type: "bytes",
-          name: "result",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.data, options.key],
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IDelayedReveal/write/reveal.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IDelayedReveal/write/reveal.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "reveal" function.
@@ -21,6 +22,42 @@ export type RevealParams = Prettify<
       asyncParams: () => Promise<RevealParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xce805642" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "identifier",
+  },
+  {
+    type: "bytes",
+    name: "key",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "string",
+    name: "revealedURI",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "reveal" function.
+ * @param options - The options for the reveal function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { encodeRevealParams } "thirdweb/extensions/erc721";
+ * const result = encodeRevealParams({
+ *  identifier: ...,
+ *  key: ...,
+ * });
+ * ```
+ */
+export function encodeRevealParams(options: RevealParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.identifier, options.key]);
+}
+
 /**
  * Calls the "reveal" function on the contract.
  * @param options - The options for the "reveal" function.
@@ -43,25 +80,7 @@ export type RevealParams = Prettify<
 export function reveal(options: BaseTransactionOptions<RevealParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xce805642",
-      [
-        {
-          type: "uint256",
-          name: "identifier",
-        },
-        {
-          type: "bytes",
-          name: "key",
-        },
-      ],
-      [
-        {
-          type: "string",
-          name: "revealedURI",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IDrop/read/getActiveClaimConditionId.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IDrop/read/getActiveClaimConditionId.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0xc68907de" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the getActiveClaimConditionId function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { decodeGetActiveClaimConditionIdResult } from "thirdweb/extensions/erc721";
+ * const result = decodeGetActiveClaimConditionIdResult("...");
+ * ```
+ */
+export function decodeGetActiveClaimConditionIdResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "getActiveClaimConditionId" function on the contract.
  * @param options - The options for the getActiveClaimConditionId function.
@@ -19,15 +45,7 @@ export async function getActiveClaimConditionId(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xc68907de",
-      [],
-      [
-        {
-          type: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IDrop/read/getClaimConditionById.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IDrop/read/getClaimConditionById.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "getClaimConditionById" function.
@@ -11,6 +14,88 @@ export type GetClaimConditionByIdParams = {
     name: "_conditionId";
   }>;
 };
+
+const FN_SELECTOR = "0x6f8934f4" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_conditionId",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "tuple",
+    name: "condition",
+    components: [
+      {
+        type: "uint256",
+        name: "startTimestamp",
+      },
+      {
+        type: "uint256",
+        name: "maxClaimableSupply",
+      },
+      {
+        type: "uint256",
+        name: "supplyClaimed",
+      },
+      {
+        type: "uint256",
+        name: "quantityLimitPerWallet",
+      },
+      {
+        type: "bytes32",
+        name: "merkleRoot",
+      },
+      {
+        type: "uint256",
+        name: "pricePerToken",
+      },
+      {
+        type: "address",
+        name: "currency",
+      },
+      {
+        type: "string",
+        name: "metadata",
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getClaimConditionById" function.
+ * @param options - The options for the getClaimConditionById function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { encodeGetClaimConditionByIdParams } "thirdweb/extensions/erc721";
+ * const result = encodeGetClaimConditionByIdParams({
+ *  conditionId: ...,
+ * });
+ * ```
+ */
+export function encodeGetClaimConditionByIdParams(
+  options: GetClaimConditionByIdParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.conditionId]);
+}
+
+/**
+ * Decodes the result of the getClaimConditionById function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { decodeGetClaimConditionByIdResult } from "thirdweb/extensions/erc721";
+ * const result = decodeGetClaimConditionByIdResult("...");
+ * ```
+ */
+export function decodeGetClaimConditionByIdResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "getClaimConditionById" function on the contract.
@@ -32,55 +117,7 @@ export async function getClaimConditionById(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x6f8934f4",
-      [
-        {
-          type: "uint256",
-          name: "_conditionId",
-        },
-      ],
-      [
-        {
-          type: "tuple",
-          name: "condition",
-          components: [
-            {
-              type: "uint256",
-              name: "startTimestamp",
-            },
-            {
-              type: "uint256",
-              name: "maxClaimableSupply",
-            },
-            {
-              type: "uint256",
-              name: "supplyClaimed",
-            },
-            {
-              type: "uint256",
-              name: "quantityLimitPerWallet",
-            },
-            {
-              type: "bytes32",
-              name: "merkleRoot",
-            },
-            {
-              type: "uint256",
-              name: "pricePerToken",
-            },
-            {
-              type: "address",
-              name: "currency",
-            },
-            {
-              type: "string",
-              name: "metadata",
-            },
-          ],
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.conditionId],
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IDrop/read/nextTokenIdToClaim.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IDrop/read/nextTokenIdToClaim.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0xacd083f8" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the nextTokenIdToClaim function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { decodeNextTokenIdToClaimResult } from "thirdweb/extensions/erc721";
+ * const result = decodeNextTokenIdToClaimResult("...");
+ * ```
+ */
+export function decodeNextTokenIdToClaimResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "nextTokenIdToClaim" function on the contract.
  * @param options - The options for the nextTokenIdToClaim function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function nextTokenIdToClaim(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xacd083f8",
-      [],
-      [
-        {
-          type: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IDrop/write/claim.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IDrop/write/claim.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "claim" function.
@@ -34,6 +35,82 @@ export type ClaimParams = Prettify<
       asyncParams: () => Promise<ClaimParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x84bb1e42" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "receiver",
+  },
+  {
+    type: "uint256",
+    name: "quantity",
+  },
+  {
+    type: "address",
+    name: "currency",
+  },
+  {
+    type: "uint256",
+    name: "pricePerToken",
+  },
+  {
+    type: "tuple",
+    name: "allowlistProof",
+    components: [
+      {
+        type: "bytes32[]",
+        name: "proof",
+      },
+      {
+        type: "uint256",
+        name: "quantityLimitPerWallet",
+      },
+      {
+        type: "uint256",
+        name: "pricePerToken",
+      },
+      {
+        type: "address",
+        name: "currency",
+      },
+    ],
+  },
+  {
+    type: "bytes",
+    name: "data",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "claim" function.
+ * @param options - The options for the claim function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { encodeClaimParams } "thirdweb/extensions/erc721";
+ * const result = encodeClaimParams({
+ *  receiver: ...,
+ *  quantity: ...,
+ *  currency: ...,
+ *  pricePerToken: ...,
+ *  allowlistProof: ...,
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeClaimParams(options: ClaimParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.receiver,
+    options.quantity,
+    options.currency,
+    options.pricePerToken,
+    options.allowlistProof,
+    options.data,
+  ]);
+}
+
 /**
  * Calls the "claim" function on the contract.
  * @param options - The options for the "claim" function.
@@ -60,54 +137,7 @@ export type ClaimParams = Prettify<
 export function claim(options: BaseTransactionOptions<ClaimParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x84bb1e42",
-      [
-        {
-          type: "address",
-          name: "receiver",
-        },
-        {
-          type: "uint256",
-          name: "quantity",
-        },
-        {
-          type: "address",
-          name: "currency",
-        },
-        {
-          type: "uint256",
-          name: "pricePerToken",
-        },
-        {
-          type: "tuple",
-          name: "allowlistProof",
-          components: [
-            {
-              type: "bytes32[]",
-              name: "proof",
-            },
-            {
-              type: "uint256",
-              name: "quantityLimitPerWallet",
-            },
-            {
-              type: "uint256",
-              name: "pricePerToken",
-            },
-            {
-              type: "address",
-              name: "currency",
-            },
-          ],
-        },
-        {
-          type: "bytes",
-          name: "data",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IDrop/write/setClaimConditions.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IDrop/write/setClaimConditions.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "setClaimConditions" function.
@@ -34,6 +35,76 @@ export type SetClaimConditionsParams = Prettify<
       asyncParams: () => Promise<SetClaimConditionsParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x74bc7db7" as const;
+const FN_INPUTS = [
+  {
+    type: "tuple[]",
+    name: "phases",
+    components: [
+      {
+        type: "uint256",
+        name: "startTimestamp",
+      },
+      {
+        type: "uint256",
+        name: "maxClaimableSupply",
+      },
+      {
+        type: "uint256",
+        name: "supplyClaimed",
+      },
+      {
+        type: "uint256",
+        name: "quantityLimitPerWallet",
+      },
+      {
+        type: "bytes32",
+        name: "merkleRoot",
+      },
+      {
+        type: "uint256",
+        name: "pricePerToken",
+      },
+      {
+        type: "address",
+        name: "currency",
+      },
+      {
+        type: "string",
+        name: "metadata",
+      },
+    ],
+  },
+  {
+    type: "bool",
+    name: "resetClaimEligibility",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "setClaimConditions" function.
+ * @param options - The options for the setClaimConditions function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { encodeSetClaimConditionsParams } "thirdweb/extensions/erc721";
+ * const result = encodeSetClaimConditionsParams({
+ *  phases: ...,
+ *  resetClaimEligibility: ...,
+ * });
+ * ```
+ */
+export function encodeSetClaimConditionsParams(
+  options: SetClaimConditionsParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.phases,
+    options.resetClaimEligibility,
+  ]);
+}
+
 /**
  * Calls the "setClaimConditions" function on the contract.
  * @param options - The options for the "setClaimConditions" function.
@@ -58,54 +129,7 @@ export function setClaimConditions(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x74bc7db7",
-      [
-        {
-          type: "tuple[]",
-          name: "phases",
-          components: [
-            {
-              type: "uint256",
-              name: "startTimestamp",
-            },
-            {
-              type: "uint256",
-              name: "maxClaimableSupply",
-            },
-            {
-              type: "uint256",
-              name: "supplyClaimed",
-            },
-            {
-              type: "uint256",
-              name: "quantityLimitPerWallet",
-            },
-            {
-              type: "bytes32",
-              name: "merkleRoot",
-            },
-            {
-              type: "uint256",
-              name: "pricePerToken",
-            },
-            {
-              type: "address",
-              name: "currency",
-            },
-            {
-              type: "string",
-              name: "metadata",
-            },
-          ],
-        },
-        {
-          type: "bool",
-          name: "resetClaimEligibility",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/read/balanceOf.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/read/balanceOf.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "balanceOf" function.
@@ -8,6 +11,51 @@ import type { AbiParameterToPrimitiveType } from "abitype";
 export type BalanceOfParams = {
   owner: AbiParameterToPrimitiveType<{ type: "address"; name: "owner" }>;
 };
+
+const FN_SELECTOR = "0x70a08231" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "owner",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "balanceOf" function.
+ * @param options - The options for the balanceOf function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { encodeBalanceOfParams } "thirdweb/extensions/erc721";
+ * const result = encodeBalanceOfParams({
+ *  owner: ...,
+ * });
+ * ```
+ */
+export function encodeBalanceOfParams(options: BalanceOfParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.owner]);
+}
+
+/**
+ * Decodes the result of the balanceOf function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { decodeBalanceOfResult } from "thirdweb/extensions/erc721";
+ * const result = decodeBalanceOfResult("...");
+ * ```
+ */
+export function decodeBalanceOfResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "balanceOf" function on the contract.
@@ -29,20 +77,7 @@ export async function balanceOf(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x70a08231",
-      [
-        {
-          type: "address",
-          name: "owner",
-        },
-      ],
-      [
-        {
-          type: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.owner],
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/read/getApproved.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/read/getApproved.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "getApproved" function.
@@ -8,6 +11,51 @@ import type { AbiParameterToPrimitiveType } from "abitype";
 export type GetApprovedParams = {
   tokenId: AbiParameterToPrimitiveType<{ type: "uint256"; name: "tokenId" }>;
 };
+
+const FN_SELECTOR = "0x081812fc" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "tokenId",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "address",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getApproved" function.
+ * @param options - The options for the getApproved function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { encodeGetApprovedParams } "thirdweb/extensions/erc721";
+ * const result = encodeGetApprovedParams({
+ *  tokenId: ...,
+ * });
+ * ```
+ */
+export function encodeGetApprovedParams(options: GetApprovedParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.tokenId]);
+}
+
+/**
+ * Decodes the result of the getApproved function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { decodeGetApprovedResult } from "thirdweb/extensions/erc721";
+ * const result = decodeGetApprovedResult("...");
+ * ```
+ */
+export function decodeGetApprovedResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "getApproved" function on the contract.
@@ -29,20 +77,7 @@ export async function getApproved(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x081812fc",
-      [
-        {
-          type: "uint256",
-          name: "tokenId",
-        },
-      ],
-      [
-        {
-          type: "address",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.tokenId],
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/read/isApprovedForAll.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/read/isApprovedForAll.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "isApprovedForAll" function.
@@ -9,6 +12,56 @@ export type IsApprovedForAllParams = {
   owner: AbiParameterToPrimitiveType<{ type: "address"; name: "owner" }>;
   operator: AbiParameterToPrimitiveType<{ type: "address"; name: "operator" }>;
 };
+
+const FN_SELECTOR = "0xe985e9c5" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "owner",
+  },
+  {
+    type: "address",
+    name: "operator",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bool",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "isApprovedForAll" function.
+ * @param options - The options for the isApprovedForAll function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { encodeIsApprovedForAllParams } "thirdweb/extensions/erc721";
+ * const result = encodeIsApprovedForAllParams({
+ *  owner: ...,
+ *  operator: ...,
+ * });
+ * ```
+ */
+export function encodeIsApprovedForAllParams(options: IsApprovedForAllParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.owner, options.operator]);
+}
+
+/**
+ * Decodes the result of the isApprovedForAll function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { decodeIsApprovedForAllResult } from "thirdweb/extensions/erc721";
+ * const result = decodeIsApprovedForAllResult("...");
+ * ```
+ */
+export function decodeIsApprovedForAllResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "isApprovedForAll" function on the contract.
@@ -31,24 +84,7 @@ export async function isApprovedForAll(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xe985e9c5",
-      [
-        {
-          type: "address",
-          name: "owner",
-        },
-        {
-          type: "address",
-          name: "operator",
-        },
-      ],
-      [
-        {
-          type: "bool",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.owner, options.operator],
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/read/name.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/read/name.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x06fdde03" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "string",
+  },
+] as const;
+
+/**
+ * Decodes the result of the name function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { decodeNameResult } from "thirdweb/extensions/erc721";
+ * const result = decodeNameResult("...");
+ * ```
+ */
+export function decodeNameResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "name" function on the contract.
  * @param options - The options for the name function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function name(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x06fdde03",
-      [],
-      [
-        {
-          type: "string",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/read/ownerOf.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/read/ownerOf.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "ownerOf" function.
@@ -8,6 +11,51 @@ import type { AbiParameterToPrimitiveType } from "abitype";
 export type OwnerOfParams = {
   tokenId: AbiParameterToPrimitiveType<{ type: "uint256"; name: "tokenId" }>;
 };
+
+const FN_SELECTOR = "0x6352211e" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "tokenId",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "address",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "ownerOf" function.
+ * @param options - The options for the ownerOf function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { encodeOwnerOfParams } "thirdweb/extensions/erc721";
+ * const result = encodeOwnerOfParams({
+ *  tokenId: ...,
+ * });
+ * ```
+ */
+export function encodeOwnerOfParams(options: OwnerOfParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.tokenId]);
+}
+
+/**
+ * Decodes the result of the ownerOf function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { decodeOwnerOfResult } from "thirdweb/extensions/erc721";
+ * const result = decodeOwnerOfResult("...");
+ * ```
+ */
+export function decodeOwnerOfResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "ownerOf" function on the contract.
@@ -27,20 +75,7 @@ export type OwnerOfParams = {
 export async function ownerOf(options: BaseTransactionOptions<OwnerOfParams>) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x6352211e",
-      [
-        {
-          type: "uint256",
-          name: "tokenId",
-        },
-      ],
-      [
-        {
-          type: "address",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.tokenId],
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/read/startTokenId.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/read/startTokenId.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0xe6798baa" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the startTokenId function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { decodeStartTokenIdResult } from "thirdweb/extensions/erc721";
+ * const result = decodeStartTokenIdResult("...");
+ * ```
+ */
+export function decodeStartTokenIdResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "startTokenId" function on the contract.
  * @param options - The options for the startTokenId function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function startTokenId(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xe6798baa",
-      [],
-      [
-        {
-          type: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/read/symbol.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/read/symbol.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x95d89b41" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "string",
+  },
+] as const;
+
+/**
+ * Decodes the result of the symbol function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { decodeSymbolResult } from "thirdweb/extensions/erc721";
+ * const result = decodeSymbolResult("...");
+ * ```
+ */
+export function decodeSymbolResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "symbol" function on the contract.
  * @param options - The options for the symbol function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function symbol(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x95d89b41",
-      [],
-      [
-        {
-          type: "string",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/read/tokenURI.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/read/tokenURI.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "tokenURI" function.
@@ -8,6 +11,51 @@ import type { AbiParameterToPrimitiveType } from "abitype";
 export type TokenURIParams = {
   tokenId: AbiParameterToPrimitiveType<{ type: "uint256"; name: "_tokenId" }>;
 };
+
+const FN_SELECTOR = "0xc87b56dd" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_tokenId",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "string",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "tokenURI" function.
+ * @param options - The options for the tokenURI function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { encodeTokenURIParams } "thirdweb/extensions/erc721";
+ * const result = encodeTokenURIParams({
+ *  tokenId: ...,
+ * });
+ * ```
+ */
+export function encodeTokenURIParams(options: TokenURIParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.tokenId]);
+}
+
+/**
+ * Decodes the result of the tokenURI function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { decodeTokenURIResult } from "thirdweb/extensions/erc721";
+ * const result = decodeTokenURIResult("...");
+ * ```
+ */
+export function decodeTokenURIResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "tokenURI" function on the contract.
@@ -29,20 +77,7 @@ export async function tokenURI(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xc87b56dd",
-      [
-        {
-          type: "uint256",
-          name: "_tokenId",
-        },
-      ],
-      [
-        {
-          type: "string",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.tokenId],
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/read/totalSupply.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/read/totalSupply.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x18160ddd" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the totalSupply function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { decodeTotalSupplyResult } from "thirdweb/extensions/erc721";
+ * const result = decodeTotalSupplyResult("...");
+ * ```
+ */
+export function decodeTotalSupplyResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "totalSupply" function on the contract.
  * @param options - The options for the totalSupply function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function totalSupply(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x18160ddd",
-      [],
-      [
-        {
-          type: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/write/approve.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/write/approve.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "approve" function.
@@ -18,6 +19,37 @@ export type ApproveParams = Prettify<
       asyncParams: () => Promise<ApproveParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x095ea7b3" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "to",
+  },
+  {
+    type: "uint256",
+    name: "tokenId",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "approve" function.
+ * @param options - The options for the approve function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { encodeApproveParams } "thirdweb/extensions/erc721";
+ * const result = encodeApproveParams({
+ *  to: ...,
+ *  tokenId: ...,
+ * });
+ * ```
+ */
+export function encodeApproveParams(options: ApproveParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.to, options.tokenId]);
+}
+
 /**
  * Calls the "approve" function on the contract.
  * @param options - The options for the "approve" function.
@@ -40,20 +72,7 @@ export type ApproveParams = Prettify<
 export function approve(options: BaseTransactionOptions<ApproveParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x095ea7b3",
-      [
-        {
-          type: "address",
-          name: "to",
-        },
-        {
-          type: "uint256",
-          name: "tokenId",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/write/safeTransferFrom.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/write/safeTransferFrom.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "safeTransferFrom" function.
@@ -19,6 +20,48 @@ export type SafeTransferFromParams = Prettify<
       asyncParams: () => Promise<SafeTransferFromParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x42842e0e" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "from",
+  },
+  {
+    type: "address",
+    name: "to",
+  },
+  {
+    type: "uint256",
+    name: "tokenId",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "safeTransferFrom" function.
+ * @param options - The options for the safeTransferFrom function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { encodeSafeTransferFromParams } "thirdweb/extensions/erc721";
+ * const result = encodeSafeTransferFromParams({
+ *  from: ...,
+ *  to: ...,
+ *  tokenId: ...,
+ * });
+ * ```
+ */
+export function encodeSafeTransferFromParams(
+  options: SafeTransferFromParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.from,
+    options.to,
+    options.tokenId,
+  ]);
+}
+
 /**
  * Calls the "safeTransferFrom" function on the contract.
  * @param options - The options for the "safeTransferFrom" function.
@@ -44,24 +87,7 @@ export function safeTransferFrom(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x42842e0e",
-      [
-        {
-          type: "address",
-          name: "from",
-        },
-        {
-          type: "address",
-          name: "to",
-        },
-        {
-          type: "uint256",
-          name: "tokenId",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/write/setApprovalForAll.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/write/setApprovalForAll.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "setApprovalForAll" function.
@@ -18,6 +19,39 @@ export type SetApprovalForAllParams = Prettify<
       asyncParams: () => Promise<SetApprovalForAllParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xa22cb465" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "operator",
+  },
+  {
+    type: "bool",
+    name: "_approved",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "setApprovalForAll" function.
+ * @param options - The options for the setApprovalForAll function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { encodeSetApprovalForAllParams } "thirdweb/extensions/erc721";
+ * const result = encodeSetApprovalForAllParams({
+ *  operator: ...,
+ *  approved: ...,
+ * });
+ * ```
+ */
+export function encodeSetApprovalForAllParams(
+  options: SetApprovalForAllParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.operator, options.approved]);
+}
+
 /**
  * Calls the "setApprovalForAll" function on the contract.
  * @param options - The options for the "setApprovalForAll" function.
@@ -42,20 +76,7 @@ export function setApprovalForAll(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xa22cb465",
-      [
-        {
-          type: "address",
-          name: "operator",
-        },
-        {
-          type: "bool",
-          name: "_approved",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/write/transferFrom.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/write/transferFrom.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "transferFrom" function.
@@ -19,6 +20,46 @@ export type TransferFromParams = Prettify<
       asyncParams: () => Promise<TransferFromParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x23b872dd" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "from",
+  },
+  {
+    type: "address",
+    name: "to",
+  },
+  {
+    type: "uint256",
+    name: "tokenId",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "transferFrom" function.
+ * @param options - The options for the transferFrom function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { encodeTransferFromParams } "thirdweb/extensions/erc721";
+ * const result = encodeTransferFromParams({
+ *  from: ...,
+ *  to: ...,
+ *  tokenId: ...,
+ * });
+ * ```
+ */
+export function encodeTransferFromParams(options: TransferFromParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.from,
+    options.to,
+    options.tokenId,
+  ]);
+}
+
 /**
  * Calls the "transferFrom" function on the contract.
  * @param options - The options for the "transferFrom" function.
@@ -44,24 +85,7 @@ export function transferFrom(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x23b872dd",
-      [
-        {
-          type: "address",
-          name: "from",
-        },
-        {
-          type: "address",
-          name: "to",
-        },
-        {
-          type: "uint256",
-          name: "tokenId",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IERC721AQueryable/read/tokensOfOwner.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IERC721AQueryable/read/tokensOfOwner.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "tokensOfOwner" function.
@@ -8,6 +11,51 @@ import type { AbiParameterToPrimitiveType } from "abitype";
 export type TokensOfOwnerParams = {
   owner: AbiParameterToPrimitiveType<{ type: "address"; name: "owner" }>;
 };
+
+const FN_SELECTOR = "0x8462151c" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "owner",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256[]",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "tokensOfOwner" function.
+ * @param options - The options for the tokensOfOwner function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { encodeTokensOfOwnerParams } "thirdweb/extensions/erc721";
+ * const result = encodeTokensOfOwnerParams({
+ *  owner: ...,
+ * });
+ * ```
+ */
+export function encodeTokensOfOwnerParams(options: TokensOfOwnerParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.owner]);
+}
+
+/**
+ * Decodes the result of the tokensOfOwner function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { decodeTokensOfOwnerResult } from "thirdweb/extensions/erc721";
+ * const result = decodeTokensOfOwnerResult("...");
+ * ```
+ */
+export function decodeTokensOfOwnerResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "tokensOfOwner" function on the contract.
@@ -29,20 +77,7 @@ export async function tokensOfOwner(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x8462151c",
-      [
-        {
-          type: "address",
-          name: "owner",
-        },
-      ],
-      [
-        {
-          type: "uint256[]",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.owner],
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IERC721AQueryable/read/tokensOfOwnerIn.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IERC721AQueryable/read/tokensOfOwnerIn.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "tokensOfOwnerIn" function.
@@ -10,6 +13,65 @@ export type TokensOfOwnerInParams = {
   start: AbiParameterToPrimitiveType<{ type: "uint256"; name: "start" }>;
   stop: AbiParameterToPrimitiveType<{ type: "uint256"; name: "stop" }>;
 };
+
+const FN_SELECTOR = "0x99a2557a" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "owner",
+  },
+  {
+    type: "uint256",
+    name: "start",
+  },
+  {
+    type: "uint256",
+    name: "stop",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256[]",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "tokensOfOwnerIn" function.
+ * @param options - The options for the tokensOfOwnerIn function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { encodeTokensOfOwnerInParams } "thirdweb/extensions/erc721";
+ * const result = encodeTokensOfOwnerInParams({
+ *  owner: ...,
+ *  start: ...,
+ *  stop: ...,
+ * });
+ * ```
+ */
+export function encodeTokensOfOwnerInParams(options: TokensOfOwnerInParams) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.owner,
+    options.start,
+    options.stop,
+  ]);
+}
+
+/**
+ * Decodes the result of the tokensOfOwnerIn function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { decodeTokensOfOwnerInResult } from "thirdweb/extensions/erc721";
+ * const result = decodeTokensOfOwnerInResult("...");
+ * ```
+ */
+export function decodeTokensOfOwnerInResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "tokensOfOwnerIn" function on the contract.
@@ -33,28 +95,7 @@ export async function tokensOfOwnerIn(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x99a2557a",
-      [
-        {
-          type: "address",
-          name: "owner",
-        },
-        {
-          type: "uint256",
-          name: "start",
-        },
-        {
-          type: "uint256",
-          name: "stop",
-        },
-      ],
-      [
-        {
-          type: "uint256[]",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.owner, options.start, options.stop],
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IERC721Enumerable/read/nextTokenIdToMint.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IERC721Enumerable/read/nextTokenIdToMint.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x3b1475a7" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the nextTokenIdToMint function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { decodeNextTokenIdToMintResult } from "thirdweb/extensions/erc721";
+ * const result = decodeNextTokenIdToMintResult("...");
+ * ```
+ */
+export function decodeNextTokenIdToMintResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "nextTokenIdToMint" function on the contract.
  * @param options - The options for the nextTokenIdToMint function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function nextTokenIdToMint(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x3b1475a7",
-      [],
-      [
-        {
-          type: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IERC721Enumerable/read/tokenByIndex.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IERC721Enumerable/read/tokenByIndex.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "tokenByIndex" function.
@@ -8,6 +11,51 @@ import type { AbiParameterToPrimitiveType } from "abitype";
 export type TokenByIndexParams = {
   index: AbiParameterToPrimitiveType<{ type: "uint256"; name: "_index" }>;
 };
+
+const FN_SELECTOR = "0x4f6ccce7" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_index",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "tokenByIndex" function.
+ * @param options - The options for the tokenByIndex function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { encodeTokenByIndexParams } "thirdweb/extensions/erc721";
+ * const result = encodeTokenByIndexParams({
+ *  index: ...,
+ * });
+ * ```
+ */
+export function encodeTokenByIndexParams(options: TokenByIndexParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.index]);
+}
+
+/**
+ * Decodes the result of the tokenByIndex function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { decodeTokenByIndexResult } from "thirdweb/extensions/erc721";
+ * const result = decodeTokenByIndexResult("...");
+ * ```
+ */
+export function decodeTokenByIndexResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "tokenByIndex" function on the contract.
@@ -29,20 +77,7 @@ export async function tokenByIndex(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x4f6ccce7",
-      [
-        {
-          type: "uint256",
-          name: "_index",
-        },
-      ],
-      [
-        {
-          type: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.index],
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IERC721Enumerable/read/tokenOfOwnerByIndex.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IERC721Enumerable/read/tokenOfOwnerByIndex.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "tokenOfOwnerByIndex" function.
@@ -9,6 +12,58 @@ export type TokenOfOwnerByIndexParams = {
   owner: AbiParameterToPrimitiveType<{ type: "address"; name: "_owner" }>;
   index: AbiParameterToPrimitiveType<{ type: "uint256"; name: "_index" }>;
 };
+
+const FN_SELECTOR = "0x2f745c59" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "_owner",
+  },
+  {
+    type: "uint256",
+    name: "_index",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "tokenOfOwnerByIndex" function.
+ * @param options - The options for the tokenOfOwnerByIndex function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { encodeTokenOfOwnerByIndexParams } "thirdweb/extensions/erc721";
+ * const result = encodeTokenOfOwnerByIndexParams({
+ *  owner: ...,
+ *  index: ...,
+ * });
+ * ```
+ */
+export function encodeTokenOfOwnerByIndexParams(
+  options: TokenOfOwnerByIndexParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.owner, options.index]);
+}
+
+/**
+ * Decodes the result of the tokenOfOwnerByIndex function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { decodeTokenOfOwnerByIndexResult } from "thirdweb/extensions/erc721";
+ * const result = decodeTokenOfOwnerByIndexResult("...");
+ * ```
+ */
+export function decodeTokenOfOwnerByIndexResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "tokenOfOwnerByIndex" function on the contract.
@@ -31,24 +86,7 @@ export async function tokenOfOwnerByIndex(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x2f745c59",
-      [
-        {
-          type: "address",
-          name: "_owner",
-        },
-        {
-          type: "uint256",
-          name: "_index",
-        },
-      ],
-      [
-        {
-          type: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.owner, options.index],
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IERC721Receiver/write/onERC721Received.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IERC721Receiver/write/onERC721Received.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "onERC721Received" function.
@@ -20,6 +21,58 @@ export type OnERC721ReceivedParams = Prettify<
       asyncParams: () => Promise<OnERC721ReceivedParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x150b7a02" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "operator",
+  },
+  {
+    type: "address",
+    name: "from",
+  },
+  {
+    type: "uint256",
+    name: "tokenId",
+  },
+  {
+    type: "bytes",
+    name: "data",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bytes4",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "onERC721Received" function.
+ * @param options - The options for the onERC721Received function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { encodeOnERC721ReceivedParams } "thirdweb/extensions/erc721";
+ * const result = encodeOnERC721ReceivedParams({
+ *  operator: ...,
+ *  from: ...,
+ *  tokenId: ...,
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeOnERC721ReceivedParams(
+  options: OnERC721ReceivedParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.operator,
+    options.from,
+    options.tokenId,
+    options.data,
+  ]);
+}
+
 /**
  * Calls the "onERC721Received" function on the contract.
  * @param options - The options for the "onERC721Received" function.
@@ -46,32 +99,7 @@ export function onERC721Received(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x150b7a02",
-      [
-        {
-          type: "address",
-          name: "operator",
-        },
-        {
-          type: "address",
-          name: "from",
-        },
-        {
-          type: "uint256",
-          name: "tokenId",
-        },
-        {
-          type: "bytes",
-          name: "data",
-        },
-      ],
-      [
-        {
-          type: "bytes4",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ILazyMint/write/lazyMint.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ILazyMint/write/lazyMint.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "lazyMint" function.
@@ -22,6 +23,51 @@ export type LazyMintParams = Prettify<
       asyncParams: () => Promise<LazyMintParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xd37c353b" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "amount",
+  },
+  {
+    type: "string",
+    name: "baseURIForTokens",
+  },
+  {
+    type: "bytes",
+    name: "extraData",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+    name: "batchId",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "lazyMint" function.
+ * @param options - The options for the lazyMint function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { encodeLazyMintParams } "thirdweb/extensions/erc721";
+ * const result = encodeLazyMintParams({
+ *  amount: ...,
+ *  baseURIForTokens: ...,
+ *  extraData: ...,
+ * });
+ * ```
+ */
+export function encodeLazyMintParams(options: LazyMintParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.amount,
+    options.baseURIForTokens,
+    options.extraData,
+  ]);
+}
+
 /**
  * Calls the "lazyMint" function on the contract.
  * @param options - The options for the "lazyMint" function.
@@ -45,29 +91,7 @@ export type LazyMintParams = Prettify<
 export function lazyMint(options: BaseTransactionOptions<LazyMintParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xd37c353b",
-      [
-        {
-          type: "uint256",
-          name: "amount",
-        },
-        {
-          type: "string",
-          name: "baseURIForTokens",
-        },
-        {
-          type: "bytes",
-          name: "extraData",
-        },
-      ],
-      [
-        {
-          type: "uint256",
-          name: "batchId",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IMintableERC721/write/mintTo.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IMintableERC721/write/mintTo.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "mintTo" function.
@@ -18,6 +19,41 @@ export type MintToParams = Prettify<
       asyncParams: () => Promise<MintToParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x0075a317" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "to",
+  },
+  {
+    type: "string",
+    name: "uri",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "mintTo" function.
+ * @param options - The options for the mintTo function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { encodeMintToParams } "thirdweb/extensions/erc721";
+ * const result = encodeMintToParams({
+ *  to: ...,
+ *  uri: ...,
+ * });
+ * ```
+ */
+export function encodeMintToParams(options: MintToParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.to, options.uri]);
+}
+
 /**
  * Calls the "mintTo" function on the contract.
  * @param options - The options for the "mintTo" function.
@@ -40,24 +76,7 @@ export type MintToParams = Prettify<
 export function mintTo(options: BaseTransactionOptions<MintToParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x0075a317",
-      [
-        {
-          type: "address",
-          name: "to",
-        },
-        {
-          type: "string",
-          name: "uri",
-        },
-      ],
-      [
-        {
-          type: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc721/__generated__/INFTMetadata/read/supportsInterface.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/INFTMetadata/read/supportsInterface.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "supportsInterface" function.
@@ -11,6 +14,53 @@ export type SupportsInterfaceParams = {
     name: "interfaceId";
   }>;
 };
+
+const FN_SELECTOR = "0x01ffc9a7" as const;
+const FN_INPUTS = [
+  {
+    type: "bytes4",
+    name: "interfaceId",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bool",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "supportsInterface" function.
+ * @param options - The options for the supportsInterface function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { encodeSupportsInterfaceParams } "thirdweb/extensions/erc721";
+ * const result = encodeSupportsInterfaceParams({
+ *  interfaceId: ...,
+ * });
+ * ```
+ */
+export function encodeSupportsInterfaceParams(
+  options: SupportsInterfaceParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.interfaceId]);
+}
+
+/**
+ * Decodes the result of the supportsInterface function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { decodeSupportsInterfaceResult } from "thirdweb/extensions/erc721";
+ * const result = decodeSupportsInterfaceResult("...");
+ * ```
+ */
+export function decodeSupportsInterfaceResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "supportsInterface" function on the contract.
@@ -32,20 +82,7 @@ export async function supportsInterface(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x01ffc9a7",
-      [
-        {
-          type: "bytes4",
-          name: "interfaceId",
-        },
-      ],
-      [
-        {
-          type: "bool",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.interfaceId],
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/INFTMetadata/write/freezeMetadata.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/INFTMetadata/write/freezeMetadata.ts
@@ -1,6 +1,10 @@
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
 
+const FN_SELECTOR = "0xd111515d" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [] as const;
+
 /**
  * Calls the "freezeMetadata" function on the contract.
  * @param options - The options for the "freezeMetadata" function.
@@ -20,6 +24,6 @@ import { prepareContractCall } from "../../../../../transaction/prepare-contract
 export function freezeMetadata(options: BaseTransactionOptions) {
   return prepareContractCall({
     contract: options.contract,
-    method: ["0xd111515d", [], []],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/INFTMetadata/write/setTokenURI.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/INFTMetadata/write/setTokenURI.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "setTokenURI" function.
@@ -18,6 +19,37 @@ export type SetTokenURIParams = Prettify<
       asyncParams: () => Promise<SetTokenURIParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x162094c4" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_tokenId",
+  },
+  {
+    type: "string",
+    name: "_uri",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "setTokenURI" function.
+ * @param options - The options for the setTokenURI function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { encodeSetTokenURIParams } "thirdweb/extensions/erc721";
+ * const result = encodeSetTokenURIParams({
+ *  tokenId: ...,
+ *  uri: ...,
+ * });
+ * ```
+ */
+export function encodeSetTokenURIParams(options: SetTokenURIParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.tokenId, options.uri]);
+}
+
 /**
  * Calls the "setTokenURI" function on the contract.
  * @param options - The options for the "setTokenURI" function.
@@ -42,20 +74,7 @@ export function setTokenURI(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x162094c4",
-      [
-        {
-          type: "uint256",
-          name: "_tokenId",
-        },
-        {
-          type: "string",
-          name: "_uri",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc721/__generated__/INFTStake/write/depositRewardTokens.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/INFTStake/write/depositRewardTokens.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "depositRewardTokens" function.
@@ -17,6 +18,34 @@ export type DepositRewardTokensParams = Prettify<
       asyncParams: () => Promise<DepositRewardTokensParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x16c621e0" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_amount",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "depositRewardTokens" function.
+ * @param options - The options for the depositRewardTokens function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { encodeDepositRewardTokensParams } "thirdweb/extensions/erc721";
+ * const result = encodeDepositRewardTokensParams({
+ *  amount: ...,
+ * });
+ * ```
+ */
+export function encodeDepositRewardTokensParams(
+  options: DepositRewardTokensParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.amount]);
+}
+
 /**
  * Calls the "depositRewardTokens" function on the contract.
  * @param options - The options for the "depositRewardTokens" function.
@@ -40,16 +69,7 @@ export function depositRewardTokens(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x16c621e0",
-      [
-        {
-          type: "uint256",
-          name: "_amount",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc721/__generated__/INFTStake/write/withdrawRewardTokens.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/INFTStake/write/withdrawRewardTokens.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "withdrawRewardTokens" function.
@@ -17,6 +18,34 @@ export type WithdrawRewardTokensParams = Prettify<
       asyncParams: () => Promise<WithdrawRewardTokensParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xcb43b2dd" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_amount",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "withdrawRewardTokens" function.
+ * @param options - The options for the withdrawRewardTokens function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { encodeWithdrawRewardTokensParams } "thirdweb/extensions/erc721";
+ * const result = encodeWithdrawRewardTokensParams({
+ *  amount: ...,
+ * });
+ * ```
+ */
+export function encodeWithdrawRewardTokensParams(
+  options: WithdrawRewardTokensParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.amount]);
+}
+
 /**
  * Calls the "withdrawRewardTokens" function on the contract.
  * @param options - The options for the "withdrawRewardTokens" function.
@@ -40,16 +69,7 @@ export function withdrawRewardTokens(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xcb43b2dd",
-      [
-        {
-          type: "uint256",
-          name: "_amount",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ISharedMetadata/write/setSharedMetadata.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ISharedMetadata/write/setSharedMetadata.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "setSharedMetadata" function.
@@ -26,6 +27,52 @@ export type SetSharedMetadataParams = Prettify<
       asyncParams: () => Promise<SetSharedMetadataParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xa7d27d9d" as const;
+const FN_INPUTS = [
+  {
+    type: "tuple",
+    name: "_metadata",
+    components: [
+      {
+        type: "string",
+        name: "name",
+      },
+      {
+        type: "string",
+        name: "description",
+      },
+      {
+        type: "string",
+        name: "imageURI",
+      },
+      {
+        type: "string",
+        name: "animationURI",
+      },
+    ],
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "setSharedMetadata" function.
+ * @param options - The options for the setSharedMetadata function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { encodeSetSharedMetadataParams } "thirdweb/extensions/erc721";
+ * const result = encodeSetSharedMetadataParams({
+ *  metadata: ...,
+ * });
+ * ```
+ */
+export function encodeSetSharedMetadataParams(
+  options: SetSharedMetadataParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.metadata]);
+}
+
 /**
  * Calls the "setSharedMetadata" function on the contract.
  * @param options - The options for the "setSharedMetadata" function.
@@ -49,34 +96,7 @@ export function setSharedMetadata(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xa7d27d9d",
-      [
-        {
-          type: "tuple",
-          name: "_metadata",
-          components: [
-            {
-              type: "string",
-              name: "name",
-            },
-            {
-              type: "string",
-              name: "description",
-            },
-            {
-              type: "string",
-              name: "imageURI",
-            },
-            {
-              type: "string",
-              name: "animationURI",
-            },
-          ],
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ISharedMetadataBatch/read/getAllSharedMetadata.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ISharedMetadataBatch/read/getAllSharedMetadata.ts
@@ -1,6 +1,61 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0xfc3c2a73" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "tuple[]",
+    name: "metadata",
+    components: [
+      {
+        type: "bytes32",
+        name: "id",
+      },
+      {
+        type: "tuple",
+        name: "metadata",
+        components: [
+          {
+            type: "string",
+            name: "name",
+          },
+          {
+            type: "string",
+            name: "description",
+          },
+          {
+            type: "string",
+            name: "imageURI",
+          },
+          {
+            type: "string",
+            name: "animationURI",
+          },
+        ],
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Decodes the result of the getAllSharedMetadata function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { decodeGetAllSharedMetadataResult } from "thirdweb/extensions/erc721";
+ * const result = decodeGetAllSharedMetadataResult("...");
+ * ```
+ */
+export function decodeGetAllSharedMetadataResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "getAllSharedMetadata" function on the contract.
  * @param options - The options for the getAllSharedMetadata function.
@@ -17,44 +72,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function getAllSharedMetadata(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xfc3c2a73",
-      [],
-      [
-        {
-          type: "tuple[]",
-          name: "metadata",
-          components: [
-            {
-              type: "bytes32",
-              name: "id",
-            },
-            {
-              type: "tuple",
-              name: "metadata",
-              components: [
-                {
-                  type: "string",
-                  name: "name",
-                },
-                {
-                  type: "string",
-                  name: "description",
-                },
-                {
-                  type: "string",
-                  name: "imageURI",
-                },
-                {
-                  type: "string",
-                  name: "animationURI",
-                },
-              ],
-            },
-          ],
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ISharedMetadataBatch/write/deleteSharedMetadata.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ISharedMetadataBatch/write/deleteSharedMetadata.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "deleteSharedMetadata" function.
@@ -17,6 +18,34 @@ export type DeleteSharedMetadataParams = Prettify<
       asyncParams: () => Promise<DeleteSharedMetadataParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x1ebb2422" as const;
+const FN_INPUTS = [
+  {
+    type: "bytes32",
+    name: "id",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "deleteSharedMetadata" function.
+ * @param options - The options for the deleteSharedMetadata function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { encodeDeleteSharedMetadataParams } "thirdweb/extensions/erc721";
+ * const result = encodeDeleteSharedMetadataParams({
+ *  id: ...,
+ * });
+ * ```
+ */
+export function encodeDeleteSharedMetadataParams(
+  options: DeleteSharedMetadataParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.id]);
+}
+
 /**
  * Calls the "deleteSharedMetadata" function on the contract.
  * @param options - The options for the "deleteSharedMetadata" function.
@@ -40,16 +69,7 @@ export function deleteSharedMetadata(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x1ebb2422",
-      [
-        {
-          type: "bytes32",
-          name: "id",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ISharedMetadataBatch/write/setSharedMetadata.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ISharedMetadataBatch/write/setSharedMetadata.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "setSharedMetadata" function.
@@ -27,6 +28,57 @@ export type SetSharedMetadataParams = Prettify<
       asyncParams: () => Promise<SetSharedMetadataParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x696b0c1a" as const;
+const FN_INPUTS = [
+  {
+    type: "tuple",
+    name: "metadata",
+    components: [
+      {
+        type: "string",
+        name: "name",
+      },
+      {
+        type: "string",
+        name: "description",
+      },
+      {
+        type: "string",
+        name: "imageURI",
+      },
+      {
+        type: "string",
+        name: "animationURI",
+      },
+    ],
+  },
+  {
+    type: "bytes32",
+    name: "id",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "setSharedMetadata" function.
+ * @param options - The options for the setSharedMetadata function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { encodeSetSharedMetadataParams } "thirdweb/extensions/erc721";
+ * const result = encodeSetSharedMetadataParams({
+ *  metadata: ...,
+ *  id: ...,
+ * });
+ * ```
+ */
+export function encodeSetSharedMetadataParams(
+  options: SetSharedMetadataParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.metadata, options.id]);
+}
+
 /**
  * Calls the "setSharedMetadata" function on the contract.
  * @param options - The options for the "setSharedMetadata" function.
@@ -51,38 +103,7 @@ export function setSharedMetadata(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x696b0c1a",
-      [
-        {
-          type: "tuple",
-          name: "metadata",
-          components: [
-            {
-              type: "string",
-              name: "name",
-            },
-            {
-              type: "string",
-              name: "description",
-            },
-            {
-              type: "string",
-              name: "imageURI",
-            },
-            {
-              type: "string",
-              name: "animationURI",
-            },
-          ],
-        },
-        {
-          type: "bytes32",
-          name: "id",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ISignatureDropERC721/read/totalMinted.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ISignatureDropERC721/read/totalMinted.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0xa2309ff8" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the totalMinted function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { decodeTotalMintedResult } from "thirdweb/extensions/erc721";
+ * const result = decodeTotalMintedResult("...");
+ * ```
+ */
+export function decodeTotalMintedResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "totalMinted" function on the contract.
  * @param options - The options for the totalMinted function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function totalMinted(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xa2309ff8",
-      [],
-      [
-        {
-          type: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ISignatureMintERC721/read/verify.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ISignatureMintERC721/read/verify.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "verify" function.
@@ -26,6 +29,107 @@ export type VerifyParams = {
   signature: AbiParameterToPrimitiveType<{ type: "bytes"; name: "signature" }>;
 };
 
+const FN_SELECTOR = "0x252e82e8" as const;
+const FN_INPUTS = [
+  {
+    type: "tuple",
+    name: "req",
+    components: [
+      {
+        type: "address",
+        name: "to",
+      },
+      {
+        type: "address",
+        name: "royaltyRecipient",
+      },
+      {
+        type: "uint256",
+        name: "royaltyBps",
+      },
+      {
+        type: "address",
+        name: "primarySaleRecipient",
+      },
+      {
+        type: "string",
+        name: "uri",
+      },
+      {
+        type: "uint256",
+        name: "quantity",
+      },
+      {
+        type: "uint256",
+        name: "pricePerToken",
+      },
+      {
+        type: "address",
+        name: "currency",
+      },
+      {
+        type: "uint128",
+        name: "validityStartTimestamp",
+      },
+      {
+        type: "uint128",
+        name: "validityEndTimestamp",
+      },
+      {
+        type: "bytes32",
+        name: "uid",
+      },
+    ],
+  },
+  {
+    type: "bytes",
+    name: "signature",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bool",
+    name: "success",
+  },
+  {
+    type: "address",
+    name: "signer",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "verify" function.
+ * @param options - The options for the verify function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { encodeVerifyParams } "thirdweb/extensions/erc721";
+ * const result = encodeVerifyParams({
+ *  req: ...,
+ *  signature: ...,
+ * });
+ * ```
+ */
+export function encodeVerifyParams(options: VerifyParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.req, options.signature]);
+}
+
+/**
+ * Decodes the result of the verify function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { decodeVerifyResult } from "thirdweb/extensions/erc721";
+ * const result = decodeVerifyResult("...");
+ * ```
+ */
+export function decodeVerifyResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result);
+}
+
 /**
  * Calls the "verify" function on the contract.
  * @param options - The options for the verify function.
@@ -45,75 +149,7 @@ export type VerifyParams = {
 export async function verify(options: BaseTransactionOptions<VerifyParams>) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x252e82e8",
-      [
-        {
-          type: "tuple",
-          name: "req",
-          components: [
-            {
-              type: "address",
-              name: "to",
-            },
-            {
-              type: "address",
-              name: "royaltyRecipient",
-            },
-            {
-              type: "uint256",
-              name: "royaltyBps",
-            },
-            {
-              type: "address",
-              name: "primarySaleRecipient",
-            },
-            {
-              type: "string",
-              name: "uri",
-            },
-            {
-              type: "uint256",
-              name: "quantity",
-            },
-            {
-              type: "uint256",
-              name: "pricePerToken",
-            },
-            {
-              type: "address",
-              name: "currency",
-            },
-            {
-              type: "uint128",
-              name: "validityStartTimestamp",
-            },
-            {
-              type: "uint128",
-              name: "validityEndTimestamp",
-            },
-            {
-              type: "bytes32",
-              name: "uid",
-            },
-          ],
-        },
-        {
-          type: "bytes",
-          name: "signature",
-        },
-      ],
-      [
-        {
-          type: "bool",
-          name: "success",
-        },
-        {
-          type: "address",
-          name: "signer",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.req, options.signature],
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ISignatureMintERC721/write/mintWithSignature.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ISignatureMintERC721/write/mintWithSignature.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "mintWithSignature" function.
@@ -34,6 +35,90 @@ export type MintWithSignatureParams = Prettify<
       asyncParams: () => Promise<MintWithSignatureParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x439c7be5" as const;
+const FN_INPUTS = [
+  {
+    type: "tuple",
+    name: "req",
+    components: [
+      {
+        type: "address",
+        name: "to",
+      },
+      {
+        type: "address",
+        name: "royaltyRecipient",
+      },
+      {
+        type: "uint256",
+        name: "royaltyBps",
+      },
+      {
+        type: "address",
+        name: "primarySaleRecipient",
+      },
+      {
+        type: "string",
+        name: "uri",
+      },
+      {
+        type: "uint256",
+        name: "quantity",
+      },
+      {
+        type: "uint256",
+        name: "pricePerToken",
+      },
+      {
+        type: "address",
+        name: "currency",
+      },
+      {
+        type: "uint128",
+        name: "validityStartTimestamp",
+      },
+      {
+        type: "uint128",
+        name: "validityEndTimestamp",
+      },
+      {
+        type: "bytes32",
+        name: "uid",
+      },
+    ],
+  },
+  {
+    type: "bytes",
+    name: "signature",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "address",
+    name: "signer",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "mintWithSignature" function.
+ * @param options - The options for the mintWithSignature function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { encodeMintWithSignatureParams } "thirdweb/extensions/erc721";
+ * const result = encodeMintWithSignatureParams({
+ *  req: ...,
+ *  signature: ...,
+ * });
+ * ```
+ */
+export function encodeMintWithSignatureParams(
+  options: MintWithSignatureParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.req, options.signature]);
+}
+
 /**
  * Calls the "mintWithSignature" function on the contract.
  * @param options - The options for the "mintWithSignature" function.
@@ -58,71 +143,7 @@ export function mintWithSignature(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x439c7be5",
-      [
-        {
-          type: "tuple",
-          name: "req",
-          components: [
-            {
-              type: "address",
-              name: "to",
-            },
-            {
-              type: "address",
-              name: "royaltyRecipient",
-            },
-            {
-              type: "uint256",
-              name: "royaltyBps",
-            },
-            {
-              type: "address",
-              name: "primarySaleRecipient",
-            },
-            {
-              type: "string",
-              name: "uri",
-            },
-            {
-              type: "uint256",
-              name: "quantity",
-            },
-            {
-              type: "uint256",
-              name: "pricePerToken",
-            },
-            {
-              type: "address",
-              name: "currency",
-            },
-            {
-              type: "uint128",
-              name: "validityStartTimestamp",
-            },
-            {
-              type: "uint128",
-              name: "validityEndTimestamp",
-            },
-            {
-              type: "bytes32",
-              name: "uid",
-            },
-          ],
-        },
-        {
-          type: "bytes",
-          name: "signature",
-        },
-      ],
-      [
-        {
-          type: "address",
-          name: "signer",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IStaking721/read/getStakeInfo.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IStaking721/read/getStakeInfo.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "getStakeInfo" function.
@@ -8,6 +11,56 @@ import type { AbiParameterToPrimitiveType } from "abitype";
 export type GetStakeInfoParams = {
   staker: AbiParameterToPrimitiveType<{ type: "address"; name: "staker" }>;
 };
+
+const FN_SELECTOR = "0xc3453153" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "staker",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256[]",
+    name: "_tokensStaked",
+  },
+  {
+    type: "uint256",
+    name: "_rewards",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getStakeInfo" function.
+ * @param options - The options for the getStakeInfo function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { encodeGetStakeInfoParams } "thirdweb/extensions/erc721";
+ * const result = encodeGetStakeInfoParams({
+ *  staker: ...,
+ * });
+ * ```
+ */
+export function encodeGetStakeInfoParams(options: GetStakeInfoParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.staker]);
+}
+
+/**
+ * Decodes the result of the getStakeInfo function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { decodeGetStakeInfoResult } from "thirdweb/extensions/erc721";
+ * const result = decodeGetStakeInfoResult("...");
+ * ```
+ */
+export function decodeGetStakeInfoResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result);
+}
 
 /**
  * Calls the "getStakeInfo" function on the contract.
@@ -29,25 +82,7 @@ export async function getStakeInfo(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xc3453153",
-      [
-        {
-          type: "address",
-          name: "staker",
-        },
-      ],
-      [
-        {
-          type: "uint256[]",
-          name: "_tokensStaked",
-        },
-        {
-          type: "uint256",
-          name: "_rewards",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.staker],
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IStaking721/write/claimRewards.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IStaking721/write/claimRewards.ts
@@ -1,6 +1,10 @@
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
 
+const FN_SELECTOR = "0x372500ab" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [] as const;
+
 /**
  * Calls the "claimRewards" function on the contract.
  * @param options - The options for the "claimRewards" function.
@@ -20,6 +24,6 @@ import { prepareContractCall } from "../../../../../transaction/prepare-contract
 export function claimRewards(options: BaseTransactionOptions) {
   return prepareContractCall({
     contract: options.contract,
-    method: ["0x372500ab", [], []],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IStaking721/write/stake.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IStaking721/write/stake.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "stake" function.
@@ -20,6 +21,32 @@ export type StakeParams = Prettify<
       asyncParams: () => Promise<StakeParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x0fbf0a93" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256[]",
+    name: "tokenIds",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "stake" function.
+ * @param options - The options for the stake function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { encodeStakeParams } "thirdweb/extensions/erc721";
+ * const result = encodeStakeParams({
+ *  tokenIds: ...,
+ * });
+ * ```
+ */
+export function encodeStakeParams(options: StakeParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.tokenIds]);
+}
+
 /**
  * Calls the "stake" function on the contract.
  * @param options - The options for the "stake" function.
@@ -41,16 +68,7 @@ export type StakeParams = Prettify<
 export function stake(options: BaseTransactionOptions<StakeParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x0fbf0a93",
-      [
-        {
-          type: "uint256[]",
-          name: "tokenIds",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IStaking721/write/withdraw.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IStaking721/write/withdraw.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "withdraw" function.
@@ -20,6 +21,32 @@ export type WithdrawParams = Prettify<
       asyncParams: () => Promise<WithdrawParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x983d95ce" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256[]",
+    name: "tokenIds",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "withdraw" function.
+ * @param options - The options for the withdraw function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```
+ * import { encodeWithdrawParams } "thirdweb/extensions/erc721";
+ * const result = encodeWithdrawParams({
+ *  tokenIds: ...,
+ * });
+ * ```
+ */
+export function encodeWithdrawParams(options: WithdrawParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.tokenIds]);
+}
+
 /**
  * Calls the "withdraw" function on the contract.
  * @param options - The options for the "withdraw" function.
@@ -41,16 +68,7 @@ export type WithdrawParams = Prettify<
 export function withdraw(options: BaseTransactionOptions<WithdrawParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x983d95ce",
-      [
-        {
-          type: "uint256[]",
-          name: "tokenIds",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/erc7504/__generated__/IRouterState/read/getAllExtensions.ts
+++ b/packages/thirdweb/src/extensions/erc7504/__generated__/IRouterState/read/getAllExtensions.ts
@@ -1,6 +1,67 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x4a00cc48" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "tuple[]",
+    name: "allExtensions",
+    components: [
+      {
+        type: "tuple",
+        name: "metadata",
+        components: [
+          {
+            type: "string",
+            name: "name",
+          },
+          {
+            type: "string",
+            name: "metadataURI",
+          },
+          {
+            type: "address",
+            name: "implementation",
+          },
+        ],
+      },
+      {
+        type: "tuple[]",
+        name: "functions",
+        components: [
+          {
+            type: "bytes4",
+            name: "functionSelector",
+          },
+          {
+            type: "string",
+            name: "functionSignature",
+          },
+        ],
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Decodes the result of the getAllExtensions function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC7504
+ * @example
+ * ```
+ * import { decodeGetAllExtensionsResult } from "thirdweb/extensions/erc7504";
+ * const result = decodeGetAllExtensionsResult("...");
+ * ```
+ */
+export function decodeGetAllExtensionsResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "getAllExtensions" function on the contract.
  * @param options - The options for the getAllExtensions function.
@@ -17,50 +78,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function getAllExtensions(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x4a00cc48",
-      [],
-      [
-        {
-          type: "tuple[]",
-          name: "allExtensions",
-          components: [
-            {
-              type: "tuple",
-              name: "metadata",
-              components: [
-                {
-                  type: "string",
-                  name: "name",
-                },
-                {
-                  type: "string",
-                  name: "metadataURI",
-                },
-                {
-                  type: "address",
-                  name: "implementation",
-                },
-              ],
-            },
-            {
-              type: "tuple[]",
-              name: "functions",
-              components: [
-                {
-                  type: "bytes4",
-                  name: "functionSelector",
-                },
-                {
-                  type: "string",
-                  name: "functionSignature",
-                },
-              ],
-            },
-          ],
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IBundler/read/idGateway.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IBundler/read/idGateway.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x4b57a600" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "address",
+  },
+] as const;
+
+/**
+ * Decodes the result of the idGateway function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { decodeIdGatewayResult } from "thirdweb/extensions/farcaster";
+ * const result = decodeIdGatewayResult("...");
+ * ```
+ */
+export function decodeIdGatewayResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "idGateway" function on the contract.
  * @param options - The options for the idGateway function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function idGateway(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x4b57a600",
-      [],
-      [
-        {
-          type: "address",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IBundler/read/keyGateway.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IBundler/read/keyGateway.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x80334737" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "address",
+  },
+] as const;
+
+/**
+ * Decodes the result of the keyGateway function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { decodeKeyGatewayResult } from "thirdweb/extensions/farcaster";
+ * const result = decodeKeyGatewayResult("...");
+ * ```
+ */
+export function decodeKeyGatewayResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "keyGateway" function on the contract.
  * @param options - The options for the keyGateway function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function keyGateway(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x80334737",
-      [],
-      [
-        {
-          type: "address",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IBundler/read/price.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IBundler/read/price.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "price" function.
@@ -11,6 +14,51 @@ export type PriceParams = {
     name: "extraStorage";
   }>;
 };
+
+const FN_SELECTOR = "0x26a49e37" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "extraStorage",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "price" function.
+ * @param options - The options for the price function.
+ * @returns The encoded ABI parameters.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { encodePriceParams } "thirdweb/extensions/farcaster";
+ * const result = encodePriceParams({
+ *  extraStorage: ...,
+ * });
+ * ```
+ */
+export function encodePriceParams(options: PriceParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.extraStorage]);
+}
+
+/**
+ * Decodes the result of the price function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { decodePriceResult } from "thirdweb/extensions/farcaster";
+ * const result = decodePriceResult("...");
+ * ```
+ */
+export function decodePriceResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "price" function on the contract.
@@ -30,20 +78,7 @@ export type PriceParams = {
 export async function price(options: BaseTransactionOptions<PriceParams>) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x26a49e37",
-      [
-        {
-          type: "uint256",
-          name: "extraStorage",
-        },
-      ],
-      [
-        {
-          type: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.extraStorage],
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IBundler/write/register.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IBundler/write/register.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "register" function.
@@ -42,6 +43,95 @@ export type RegisterParams = Prettify<
       asyncParams: () => Promise<RegisterParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xa44c9ce7" as const;
+const FN_INPUTS = [
+  {
+    type: "tuple",
+    name: "registerParams",
+    components: [
+      {
+        type: "address",
+        name: "to",
+      },
+      {
+        type: "address",
+        name: "recovery",
+      },
+      {
+        type: "uint256",
+        name: "deadline",
+      },
+      {
+        type: "bytes",
+        name: "sig",
+      },
+    ],
+  },
+  {
+    type: "tuple[]",
+    name: "signerParams",
+    components: [
+      {
+        type: "uint32",
+        name: "keyType",
+      },
+      {
+        type: "bytes",
+        name: "key",
+      },
+      {
+        type: "uint8",
+        name: "metadataType",
+      },
+      {
+        type: "bytes",
+        name: "metadata",
+      },
+      {
+        type: "uint256",
+        name: "deadline",
+      },
+      {
+        type: "bytes",
+        name: "sig",
+      },
+    ],
+  },
+  {
+    type: "uint256",
+    name: "extraStorage",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+    name: "fid",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "register" function.
+ * @param options - The options for the register function.
+ * @returns The encoded ABI parameters.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { encodeRegisterParams } "thirdweb/extensions/farcaster";
+ * const result = encodeRegisterParams({
+ *  registerParams: ...,
+ *  signerParams: ...,
+ *  extraStorage: ...,
+ * });
+ * ```
+ */
+export function encodeRegisterParams(options: RegisterParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.registerParams,
+    options.signerParams,
+    options.extraStorage,
+  ]);
+}
+
 /**
  * Calls the "register" function on the contract.
  * @param options - The options for the "register" function.
@@ -65,73 +155,7 @@ export type RegisterParams = Prettify<
 export function register(options: BaseTransactionOptions<RegisterParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xa44c9ce7",
-      [
-        {
-          type: "tuple",
-          name: "registerParams",
-          components: [
-            {
-              type: "address",
-              name: "to",
-            },
-            {
-              type: "address",
-              name: "recovery",
-            },
-            {
-              type: "uint256",
-              name: "deadline",
-            },
-            {
-              type: "bytes",
-              name: "sig",
-            },
-          ],
-        },
-        {
-          type: "tuple[]",
-          name: "signerParams",
-          components: [
-            {
-              type: "uint32",
-              name: "keyType",
-            },
-            {
-              type: "bytes",
-              name: "key",
-            },
-            {
-              type: "uint8",
-              name: "metadataType",
-            },
-            {
-              type: "bytes",
-              name: "metadata",
-            },
-            {
-              type: "uint256",
-              name: "deadline",
-            },
-            {
-              type: "bytes",
-              name: "sig",
-            },
-          ],
-        },
-        {
-          type: "uint256",
-          name: "extraStorage",
-        },
-      ],
-      [
-        {
-          type: "uint256",
-          name: "fid",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IIdGateway/read/REGISTER_TYPEHASH.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IIdGateway/read/REGISTER_TYPEHASH.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x6a5306a3" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bytes32",
+  },
+] as const;
+
+/**
+ * Decodes the result of the REGISTER_TYPEHASH function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { decodeREGISTER_TYPEHASHResult } from "thirdweb/extensions/farcaster";
+ * const result = decodeREGISTER_TYPEHASHResult("...");
+ * ```
+ */
+export function decodeREGISTER_TYPEHASHResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "REGISTER_TYPEHASH" function on the contract.
  * @param options - The options for the REGISTER_TYPEHASH function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function REGISTER_TYPEHASH(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x6a5306a3",
-      [],
-      [
-        {
-          type: "bytes32",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IIdGateway/read/idRegistry.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IIdGateway/read/idRegistry.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x0aa13b8c" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "address",
+  },
+] as const;
+
+/**
+ * Decodes the result of the idRegistry function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { decodeIdRegistryResult } from "thirdweb/extensions/farcaster";
+ * const result = decodeIdRegistryResult("...");
+ * ```
+ */
+export function decodeIdRegistryResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "idRegistry" function on the contract.
  * @param options - The options for the idRegistry function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function idRegistry(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x0aa13b8c",
-      [],
-      [
-        {
-          type: "address",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IIdGateway/read/price.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IIdGateway/read/price.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "price" function.
@@ -11,6 +14,51 @@ export type PriceParams = {
     name: "extraStorage";
   }>;
 };
+
+const FN_SELECTOR = "0x26a49e37" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "extraStorage",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "price" function.
+ * @param options - The options for the price function.
+ * @returns The encoded ABI parameters.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { encodePriceParams } "thirdweb/extensions/farcaster";
+ * const result = encodePriceParams({
+ *  extraStorage: ...,
+ * });
+ * ```
+ */
+export function encodePriceParams(options: PriceParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.extraStorage]);
+}
+
+/**
+ * Decodes the result of the price function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { decodePriceResult } from "thirdweb/extensions/farcaster";
+ * const result = decodePriceResult("...");
+ * ```
+ */
+export function decodePriceResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "price" function on the contract.
@@ -30,20 +78,7 @@ export type PriceParams = {
 export async function price(options: BaseTransactionOptions<PriceParams>) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x26a49e37",
-      [
-        {
-          type: "uint256",
-          name: "extraStorage",
-        },
-      ],
-      [
-        {
-          type: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.extraStorage],
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IIdGateway/read/storageRegistry.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IIdGateway/read/storageRegistry.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x4ec77b45" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "address",
+  },
+] as const;
+
+/**
+ * Decodes the result of the storageRegistry function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { decodeStorageRegistryResult } from "thirdweb/extensions/farcaster";
+ * const result = decodeStorageRegistryResult("...");
+ * ```
+ */
+export function decodeStorageRegistryResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "storageRegistry" function on the contract.
  * @param options - The options for the storageRegistry function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function storageRegistry(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x4ec77b45",
-      [],
-      [
-        {
-          type: "address",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IIdGateway/write/register.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IIdGateway/write/register.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "register" function.
@@ -21,6 +22,49 @@ export type RegisterParams = Prettify<
       asyncParams: () => Promise<RegisterParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x6d705ebb" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "recovery",
+  },
+  {
+    type: "uint256",
+    name: "extraStorage",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+    name: "fid",
+  },
+  {
+    type: "uint256",
+    name: "overpayment",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "register" function.
+ * @param options - The options for the register function.
+ * @returns The encoded ABI parameters.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { encodeRegisterParams } "thirdweb/extensions/farcaster";
+ * const result = encodeRegisterParams({
+ *  recovery: ...,
+ *  extraStorage: ...,
+ * });
+ * ```
+ */
+export function encodeRegisterParams(options: RegisterParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.recovery,
+    options.extraStorage,
+  ]);
+}
+
 /**
  * Calls the "register" function on the contract.
  * @param options - The options for the "register" function.
@@ -43,29 +87,7 @@ export type RegisterParams = Prettify<
 export function register(options: BaseTransactionOptions<RegisterParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x6d705ebb",
-      [
-        {
-          type: "address",
-          name: "recovery",
-        },
-        {
-          type: "uint256",
-          name: "extraStorage",
-        },
-      ],
-      [
-        {
-          type: "uint256",
-          name: "fid",
-        },
-        {
-          type: "uint256",
-          name: "overpayment",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IIdGateway/write/registerFor.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IIdGateway/write/registerFor.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "registerFor" function.
@@ -24,6 +25,67 @@ export type RegisterForParams = Prettify<
       asyncParams: () => Promise<RegisterForParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xa0c7529c" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "to",
+  },
+  {
+    type: "address",
+    name: "recovery",
+  },
+  {
+    type: "uint256",
+    name: "deadline",
+  },
+  {
+    type: "bytes",
+    name: "sig",
+  },
+  {
+    type: "uint256",
+    name: "extraStorage",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+    name: "fid",
+  },
+  {
+    type: "uint256",
+    name: "overpayment",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "registerFor" function.
+ * @param options - The options for the registerFor function.
+ * @returns The encoded ABI parameters.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { encodeRegisterForParams } "thirdweb/extensions/farcaster";
+ * const result = encodeRegisterForParams({
+ *  to: ...,
+ *  recovery: ...,
+ *  deadline: ...,
+ *  sig: ...,
+ *  extraStorage: ...,
+ * });
+ * ```
+ */
+export function encodeRegisterForParams(options: RegisterForParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.to,
+    options.recovery,
+    options.deadline,
+    options.sig,
+    options.extraStorage,
+  ]);
+}
+
 /**
  * Calls the "registerFor" function on the contract.
  * @param options - The options for the "registerFor" function.
@@ -51,41 +113,7 @@ export function registerFor(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xa0c7529c",
-      [
-        {
-          type: "address",
-          name: "to",
-        },
-        {
-          type: "address",
-          name: "recovery",
-        },
-        {
-          type: "uint256",
-          name: "deadline",
-        },
-        {
-          type: "bytes",
-          name: "sig",
-        },
-        {
-          type: "uint256",
-          name: "extraStorage",
-        },
-      ],
-      [
-        {
-          type: "uint256",
-          name: "fid",
-        },
-        {
-          type: "uint256",
-          name: "overpayment",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/read/CHANGE_RECOVERY_ADDRESS_TYPEHASH.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/read/CHANGE_RECOVERY_ADDRESS_TYPEHASH.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0xd5bac7f3" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bytes32",
+  },
+] as const;
+
+/**
+ * Decodes the result of the CHANGE_RECOVERY_ADDRESS_TYPEHASH function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { decodeCHANGE_RECOVERY_ADDRESS_TYPEHASHResult } from "thirdweb/extensions/farcaster";
+ * const result = decodeCHANGE_RECOVERY_ADDRESS_TYPEHASHResult("...");
+ * ```
+ */
+export function decodeCHANGE_RECOVERY_ADDRESS_TYPEHASHResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "CHANGE_RECOVERY_ADDRESS_TYPEHASH" function on the contract.
  * @param options - The options for the CHANGE_RECOVERY_ADDRESS_TYPEHASH function.
@@ -19,15 +45,7 @@ export async function CHANGE_RECOVERY_ADDRESS_TYPEHASH(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xd5bac7f3",
-      [],
-      [
-        {
-          type: "bytes32",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/read/TRANSFER_AND_CHANGE_RECOVERY_TYPEHASH.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/read/TRANSFER_AND_CHANGE_RECOVERY_TYPEHASH.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0xea2bbb83" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bytes32",
+  },
+] as const;
+
+/**
+ * Decodes the result of the TRANSFER_AND_CHANGE_RECOVERY_TYPEHASH function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { decodeTRANSFER_AND_CHANGE_RECOVERY_TYPEHASHResult } from "thirdweb/extensions/farcaster";
+ * const result = decodeTRANSFER_AND_CHANGE_RECOVERY_TYPEHASHResult("...");
+ * ```
+ */
+export function decodeTRANSFER_AND_CHANGE_RECOVERY_TYPEHASHResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "TRANSFER_AND_CHANGE_RECOVERY_TYPEHASH" function on the contract.
  * @param options - The options for the TRANSFER_AND_CHANGE_RECOVERY_TYPEHASH function.
@@ -19,15 +45,7 @@ export async function TRANSFER_AND_CHANGE_RECOVERY_TYPEHASH(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xea2bbb83",
-      [],
-      [
-        {
-          type: "bytes32",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/read/TRANSFER_TYPEHASH.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/read/TRANSFER_TYPEHASH.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x00bf26f4" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bytes32",
+  },
+] as const;
+
+/**
+ * Decodes the result of the TRANSFER_TYPEHASH function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { decodeTRANSFER_TYPEHASHResult } from "thirdweb/extensions/farcaster";
+ * const result = decodeTRANSFER_TYPEHASHResult("...");
+ * ```
+ */
+export function decodeTRANSFER_TYPEHASHResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "TRANSFER_TYPEHASH" function on the contract.
  * @param options - The options for the TRANSFER_TYPEHASH function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function TRANSFER_TYPEHASH(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x00bf26f4",
-      [],
-      [
-        {
-          type: "bytes32",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/read/custodyOf.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/read/custodyOf.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "custodyOf" function.
@@ -8,6 +11,52 @@ import type { AbiParameterToPrimitiveType } from "abitype";
 export type CustodyOfParams = {
   fid: AbiParameterToPrimitiveType<{ type: "uint256"; name: "fid" }>;
 };
+
+const FN_SELECTOR = "0x65269e47" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "fid",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "address",
+    name: "owner",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "custodyOf" function.
+ * @param options - The options for the custodyOf function.
+ * @returns The encoded ABI parameters.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { encodeCustodyOfParams } "thirdweb/extensions/farcaster";
+ * const result = encodeCustodyOfParams({
+ *  fid: ...,
+ * });
+ * ```
+ */
+export function encodeCustodyOfParams(options: CustodyOfParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.fid]);
+}
+
+/**
+ * Decodes the result of the custodyOf function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { decodeCustodyOfResult } from "thirdweb/extensions/farcaster";
+ * const result = decodeCustodyOfResult("...");
+ * ```
+ */
+export function decodeCustodyOfResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "custodyOf" function on the contract.
@@ -29,21 +78,7 @@ export async function custodyOf(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x65269e47",
-      [
-        {
-          type: "uint256",
-          name: "fid",
-        },
-      ],
-      [
-        {
-          type: "address",
-          name: "owner",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.fid],
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/read/gatewayFrozen.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/read/gatewayFrozen.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x95e7549f" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bool",
+  },
+] as const;
+
+/**
+ * Decodes the result of the gatewayFrozen function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { decodeGatewayFrozenResult } from "thirdweb/extensions/farcaster";
+ * const result = decodeGatewayFrozenResult("...");
+ * ```
+ */
+export function decodeGatewayFrozenResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "gatewayFrozen" function on the contract.
  * @param options - The options for the gatewayFrozen function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function gatewayFrozen(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x95e7549f",
-      [],
-      [
-        {
-          type: "bool",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/read/idCounter.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/read/idCounter.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0xeb08ab28" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the idCounter function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { decodeIdCounterResult } from "thirdweb/extensions/farcaster";
+ * const result = decodeIdCounterResult("...");
+ * ```
+ */
+export function decodeIdCounterResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "idCounter" function on the contract.
  * @param options - The options for the idCounter function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function idCounter(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xeb08ab28",
-      [],
-      [
-        {
-          type: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/read/idGateway.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/read/idGateway.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x4b57a600" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "address",
+  },
+] as const;
+
+/**
+ * Decodes the result of the idGateway function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { decodeIdGatewayResult } from "thirdweb/extensions/farcaster";
+ * const result = decodeIdGatewayResult("...");
+ * ```
+ */
+export function decodeIdGatewayResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "idGateway" function on the contract.
  * @param options - The options for the idGateway function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function idGateway(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x4b57a600",
-      [],
-      [
-        {
-          type: "address",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/read/idOf.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/read/idOf.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "idOf" function.
@@ -8,6 +11,52 @@ import type { AbiParameterToPrimitiveType } from "abitype";
 export type IdOfParams = {
   owner: AbiParameterToPrimitiveType<{ type: "address"; name: "owner" }>;
 };
+
+const FN_SELECTOR = "0xd94fe832" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "owner",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+    name: "fid",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "idOf" function.
+ * @param options - The options for the idOf function.
+ * @returns The encoded ABI parameters.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { encodeIdOfParams } "thirdweb/extensions/farcaster";
+ * const result = encodeIdOfParams({
+ *  owner: ...,
+ * });
+ * ```
+ */
+export function encodeIdOfParams(options: IdOfParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.owner]);
+}
+
+/**
+ * Decodes the result of the idOf function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { decodeIdOfResult } from "thirdweb/extensions/farcaster";
+ * const result = decodeIdOfResult("...");
+ * ```
+ */
+export function decodeIdOfResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "idOf" function on the contract.
@@ -27,21 +76,7 @@ export type IdOfParams = {
 export async function idOf(options: BaseTransactionOptions<IdOfParams>) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xd94fe832",
-      [
-        {
-          type: "address",
-          name: "owner",
-        },
-      ],
-      [
-        {
-          type: "uint256",
-          name: "fid",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.owner],
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/read/recoveryOf.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/read/recoveryOf.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "recoveryOf" function.
@@ -8,6 +11,52 @@ import type { AbiParameterToPrimitiveType } from "abitype";
 export type RecoveryOfParams = {
   fid: AbiParameterToPrimitiveType<{ type: "uint256"; name: "fid" }>;
 };
+
+const FN_SELECTOR = "0xfa1a1b25" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "fid",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "address",
+    name: "recovery",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "recoveryOf" function.
+ * @param options - The options for the recoveryOf function.
+ * @returns The encoded ABI parameters.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { encodeRecoveryOfParams } "thirdweb/extensions/farcaster";
+ * const result = encodeRecoveryOfParams({
+ *  fid: ...,
+ * });
+ * ```
+ */
+export function encodeRecoveryOfParams(options: RecoveryOfParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.fid]);
+}
+
+/**
+ * Decodes the result of the recoveryOf function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { decodeRecoveryOfResult } from "thirdweb/extensions/farcaster";
+ * const result = decodeRecoveryOfResult("...");
+ * ```
+ */
+export function decodeRecoveryOfResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "recoveryOf" function on the contract.
@@ -29,21 +78,7 @@ export async function recoveryOf(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xfa1a1b25",
-      [
-        {
-          type: "uint256",
-          name: "fid",
-        },
-      ],
-      [
-        {
-          type: "address",
-          name: "recovery",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.fid],
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/read/verifyFidSignature.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/read/verifyFidSignature.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "verifyFidSignature" function.
@@ -14,6 +17,74 @@ export type VerifyFidSignatureParams = {
   digest: AbiParameterToPrimitiveType<{ type: "bytes32"; name: "digest" }>;
   sig: AbiParameterToPrimitiveType<{ type: "bytes"; name: "sig" }>;
 };
+
+const FN_SELECTOR = "0x32faac70" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "custodyAddress",
+  },
+  {
+    type: "uint256",
+    name: "fid",
+  },
+  {
+    type: "bytes32",
+    name: "digest",
+  },
+  {
+    type: "bytes",
+    name: "sig",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bool",
+    name: "isValid",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "verifyFidSignature" function.
+ * @param options - The options for the verifyFidSignature function.
+ * @returns The encoded ABI parameters.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { encodeVerifyFidSignatureParams } "thirdweb/extensions/farcaster";
+ * const result = encodeVerifyFidSignatureParams({
+ *  custodyAddress: ...,
+ *  fid: ...,
+ *  digest: ...,
+ *  sig: ...,
+ * });
+ * ```
+ */
+export function encodeVerifyFidSignatureParams(
+  options: VerifyFidSignatureParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.custodyAddress,
+    options.fid,
+    options.digest,
+    options.sig,
+  ]);
+}
+
+/**
+ * Decodes the result of the verifyFidSignature function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { decodeVerifyFidSignatureResult } from "thirdweb/extensions/farcaster";
+ * const result = decodeVerifyFidSignatureResult("...");
+ * ```
+ */
+export function decodeVerifyFidSignatureResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "verifyFidSignature" function on the contract.
@@ -38,33 +109,7 @@ export async function verifyFidSignature(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x32faac70",
-      [
-        {
-          type: "address",
-          name: "custodyAddress",
-        },
-        {
-          type: "uint256",
-          name: "fid",
-        },
-        {
-          type: "bytes32",
-          name: "digest",
-        },
-        {
-          type: "bytes",
-          name: "sig",
-        },
-      ],
-      [
-        {
-          type: "bool",
-          name: "isValid",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.custodyAddress, options.fid, options.digest, options.sig],
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/changeRecoveryAddress.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/changeRecoveryAddress.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "changeRecoveryAddress" function.
@@ -17,6 +18,34 @@ export type ChangeRecoveryAddressParams = Prettify<
       asyncParams: () => Promise<ChangeRecoveryAddressParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xf1f0b224" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "recovery",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "changeRecoveryAddress" function.
+ * @param options - The options for the changeRecoveryAddress function.
+ * @returns The encoded ABI parameters.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { encodeChangeRecoveryAddressParams } "thirdweb/extensions/farcaster";
+ * const result = encodeChangeRecoveryAddressParams({
+ *  recovery: ...,
+ * });
+ * ```
+ */
+export function encodeChangeRecoveryAddressParams(
+  options: ChangeRecoveryAddressParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.recovery]);
+}
+
 /**
  * Calls the "changeRecoveryAddress" function on the contract.
  * @param options - The options for the "changeRecoveryAddress" function.
@@ -40,16 +69,7 @@ export function changeRecoveryAddress(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xf1f0b224",
-      [
-        {
-          type: "address",
-          name: "recovery",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/changeRecoveryAddressFor.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/changeRecoveryAddressFor.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "changeRecoveryAddressFor" function.
@@ -20,6 +21,54 @@ export type ChangeRecoveryAddressForParams = Prettify<
       asyncParams: () => Promise<ChangeRecoveryAddressForParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x9cbef8dc" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "owner",
+  },
+  {
+    type: "address",
+    name: "recovery",
+  },
+  {
+    type: "uint256",
+    name: "deadline",
+  },
+  {
+    type: "bytes",
+    name: "sig",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "changeRecoveryAddressFor" function.
+ * @param options - The options for the changeRecoveryAddressFor function.
+ * @returns The encoded ABI parameters.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { encodeChangeRecoveryAddressForParams } "thirdweb/extensions/farcaster";
+ * const result = encodeChangeRecoveryAddressForParams({
+ *  owner: ...,
+ *  recovery: ...,
+ *  deadline: ...,
+ *  sig: ...,
+ * });
+ * ```
+ */
+export function encodeChangeRecoveryAddressForParams(
+  options: ChangeRecoveryAddressForParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.owner,
+    options.recovery,
+    options.deadline,
+    options.sig,
+  ]);
+}
+
 /**
  * Calls the "changeRecoveryAddressFor" function on the contract.
  * @param options - The options for the "changeRecoveryAddressFor" function.
@@ -46,28 +95,7 @@ export function changeRecoveryAddressFor(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x9cbef8dc",
-      [
-        {
-          type: "address",
-          name: "owner",
-        },
-        {
-          type: "address",
-          name: "recovery",
-        },
-        {
-          type: "uint256",
-          name: "deadline",
-        },
-        {
-          type: "bytes",
-          name: "sig",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/recover.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/recover.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "recover" function.
@@ -20,6 +21,52 @@ export type RecoverParams = Prettify<
       asyncParams: () => Promise<RecoverParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x2a42ede3" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "from",
+  },
+  {
+    type: "address",
+    name: "to",
+  },
+  {
+    type: "uint256",
+    name: "deadline",
+  },
+  {
+    type: "bytes",
+    name: "sig",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "recover" function.
+ * @param options - The options for the recover function.
+ * @returns The encoded ABI parameters.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { encodeRecoverParams } "thirdweb/extensions/farcaster";
+ * const result = encodeRecoverParams({
+ *  from: ...,
+ *  to: ...,
+ *  deadline: ...,
+ *  sig: ...,
+ * });
+ * ```
+ */
+export function encodeRecoverParams(options: RecoverParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.from,
+    options.to,
+    options.deadline,
+    options.sig,
+  ]);
+}
+
 /**
  * Calls the "recover" function on the contract.
  * @param options - The options for the "recover" function.
@@ -44,28 +91,7 @@ export type RecoverParams = Prettify<
 export function recover(options: BaseTransactionOptions<RecoverParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x2a42ede3",
-      [
-        {
-          type: "address",
-          name: "from",
-        },
-        {
-          type: "address",
-          name: "to",
-        },
-        {
-          type: "uint256",
-          name: "deadline",
-        },
-        {
-          type: "bytes",
-          name: "sig",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/recoverFor.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/recoverFor.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "recoverFor" function.
@@ -31,6 +32,64 @@ export type RecoverForParams = Prettify<
       asyncParams: () => Promise<RecoverForParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xba656434" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "from",
+  },
+  {
+    type: "address",
+    name: "to",
+  },
+  {
+    type: "uint256",
+    name: "recoveryDeadline",
+  },
+  {
+    type: "bytes",
+    name: "recoverySig",
+  },
+  {
+    type: "uint256",
+    name: "toDeadline",
+  },
+  {
+    type: "bytes",
+    name: "toSig",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "recoverFor" function.
+ * @param options - The options for the recoverFor function.
+ * @returns The encoded ABI parameters.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { encodeRecoverForParams } "thirdweb/extensions/farcaster";
+ * const result = encodeRecoverForParams({
+ *  from: ...,
+ *  to: ...,
+ *  recoveryDeadline: ...,
+ *  recoverySig: ...,
+ *  toDeadline: ...,
+ *  toSig: ...,
+ * });
+ * ```
+ */
+export function encodeRecoverForParams(options: RecoverForParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.from,
+    options.to,
+    options.recoveryDeadline,
+    options.recoverySig,
+    options.toDeadline,
+    options.toSig,
+  ]);
+}
+
 /**
  * Calls the "recoverFor" function on the contract.
  * @param options - The options for the "recoverFor" function.
@@ -57,36 +116,7 @@ export type RecoverForParams = Prettify<
 export function recoverFor(options: BaseTransactionOptions<RecoverForParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xba656434",
-      [
-        {
-          type: "address",
-          name: "from",
-        },
-        {
-          type: "address",
-          name: "to",
-        },
-        {
-          type: "uint256",
-          name: "recoveryDeadline",
-        },
-        {
-          type: "bytes",
-          name: "recoverySig",
-        },
-        {
-          type: "uint256",
-          name: "toDeadline",
-        },
-        {
-          type: "bytes",
-          name: "toSig",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/transfer.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/transfer.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "transfer" function.
@@ -19,6 +20,46 @@ export type TransferParams = Prettify<
       asyncParams: () => Promise<TransferParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xbe45fd62" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "to",
+  },
+  {
+    type: "uint256",
+    name: "deadline",
+  },
+  {
+    type: "bytes",
+    name: "sig",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "transfer" function.
+ * @param options - The options for the transfer function.
+ * @returns The encoded ABI parameters.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { encodeTransferParams } "thirdweb/extensions/farcaster";
+ * const result = encodeTransferParams({
+ *  to: ...,
+ *  deadline: ...,
+ *  sig: ...,
+ * });
+ * ```
+ */
+export function encodeTransferParams(options: TransferParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.to,
+    options.deadline,
+    options.sig,
+  ]);
+}
+
 /**
  * Calls the "transfer" function on the contract.
  * @param options - The options for the "transfer" function.
@@ -42,24 +83,7 @@ export type TransferParams = Prettify<
 export function transfer(options: BaseTransactionOptions<TransferParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xbe45fd62",
-      [
-        {
-          type: "address",
-          name: "to",
-        },
-        {
-          type: "uint256",
-          name: "deadline",
-        },
-        {
-          type: "bytes",
-          name: "sig",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/transferAndChangeRecovery.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/transferAndChangeRecovery.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "transferAndChangeRecovery" function.
@@ -20,6 +21,54 @@ export type TransferAndChangeRecoveryParams = Prettify<
       asyncParams: () => Promise<TransferAndChangeRecoveryParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x3ab8465d" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "to",
+  },
+  {
+    type: "address",
+    name: "recovery",
+  },
+  {
+    type: "uint256",
+    name: "deadline",
+  },
+  {
+    type: "bytes",
+    name: "sig",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "transferAndChangeRecovery" function.
+ * @param options - The options for the transferAndChangeRecovery function.
+ * @returns The encoded ABI parameters.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { encodeTransferAndChangeRecoveryParams } "thirdweb/extensions/farcaster";
+ * const result = encodeTransferAndChangeRecoveryParams({
+ *  to: ...,
+ *  recovery: ...,
+ *  deadline: ...,
+ *  sig: ...,
+ * });
+ * ```
+ */
+export function encodeTransferAndChangeRecoveryParams(
+  options: TransferAndChangeRecoveryParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.to,
+    options.recovery,
+    options.deadline,
+    options.sig,
+  ]);
+}
+
 /**
  * Calls the "transferAndChangeRecovery" function on the contract.
  * @param options - The options for the "transferAndChangeRecovery" function.
@@ -46,28 +95,7 @@ export function transferAndChangeRecovery(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x3ab8465d",
-      [
-        {
-          type: "address",
-          name: "to",
-        },
-        {
-          type: "address",
-          name: "recovery",
-        },
-        {
-          type: "uint256",
-          name: "deadline",
-        },
-        {
-          type: "bytes",
-          name: "sig",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/transferAndChangeRecoveryFor.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/transferAndChangeRecoveryFor.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "transferAndChangeRecoveryFor" function.
@@ -29,6 +30,72 @@ export type TransferAndChangeRecoveryForParams = Prettify<
       asyncParams: () => Promise<TransferAndChangeRecoveryForParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x4c5cbb34" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "from",
+  },
+  {
+    type: "address",
+    name: "to",
+  },
+  {
+    type: "address",
+    name: "recovery",
+  },
+  {
+    type: "uint256",
+    name: "fromDeadline",
+  },
+  {
+    type: "bytes",
+    name: "fromSig",
+  },
+  {
+    type: "uint256",
+    name: "toDeadline",
+  },
+  {
+    type: "bytes",
+    name: "toSig",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "transferAndChangeRecoveryFor" function.
+ * @param options - The options for the transferAndChangeRecoveryFor function.
+ * @returns The encoded ABI parameters.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { encodeTransferAndChangeRecoveryForParams } "thirdweb/extensions/farcaster";
+ * const result = encodeTransferAndChangeRecoveryForParams({
+ *  from: ...,
+ *  to: ...,
+ *  recovery: ...,
+ *  fromDeadline: ...,
+ *  fromSig: ...,
+ *  toDeadline: ...,
+ *  toSig: ...,
+ * });
+ * ```
+ */
+export function encodeTransferAndChangeRecoveryForParams(
+  options: TransferAndChangeRecoveryForParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.from,
+    options.to,
+    options.recovery,
+    options.fromDeadline,
+    options.fromSig,
+    options.toDeadline,
+    options.toSig,
+  ]);
+}
+
 /**
  * Calls the "transferAndChangeRecoveryFor" function on the contract.
  * @param options - The options for the "transferAndChangeRecoveryFor" function.
@@ -58,40 +125,7 @@ export function transferAndChangeRecoveryFor(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x4c5cbb34",
-      [
-        {
-          type: "address",
-          name: "from",
-        },
-        {
-          type: "address",
-          name: "to",
-        },
-        {
-          type: "address",
-          name: "recovery",
-        },
-        {
-          type: "uint256",
-          name: "fromDeadline",
-        },
-        {
-          type: "bytes",
-          name: "fromSig",
-        },
-        {
-          type: "uint256",
-          name: "toDeadline",
-        },
-        {
-          type: "bytes",
-          name: "toSig",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/transferFor.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/transferFor.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "transferFor" function.
@@ -28,6 +29,64 @@ export type TransferForParams = Prettify<
       asyncParams: () => Promise<TransferForParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x16f72842" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "from",
+  },
+  {
+    type: "address",
+    name: "to",
+  },
+  {
+    type: "uint256",
+    name: "fromDeadline",
+  },
+  {
+    type: "bytes",
+    name: "fromSig",
+  },
+  {
+    type: "uint256",
+    name: "toDeadline",
+  },
+  {
+    type: "bytes",
+    name: "toSig",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "transferFor" function.
+ * @param options - The options for the transferFor function.
+ * @returns The encoded ABI parameters.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { encodeTransferForParams } "thirdweb/extensions/farcaster";
+ * const result = encodeTransferForParams({
+ *  from: ...,
+ *  to: ...,
+ *  fromDeadline: ...,
+ *  fromSig: ...,
+ *  toDeadline: ...,
+ *  toSig: ...,
+ * });
+ * ```
+ */
+export function encodeTransferForParams(options: TransferForParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.from,
+    options.to,
+    options.fromDeadline,
+    options.fromSig,
+    options.toDeadline,
+    options.toSig,
+  ]);
+}
+
 /**
  * Calls the "transferFor" function on the contract.
  * @param options - The options for the "transferFor" function.
@@ -56,36 +115,7 @@ export function transferFor(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x16f72842",
-      [
-        {
-          type: "address",
-          name: "from",
-        },
-        {
-          type: "address",
-          name: "to",
-        },
-        {
-          type: "uint256",
-          name: "fromDeadline",
-        },
-        {
-          type: "bytes",
-          name: "fromSig",
-        },
-        {
-          type: "uint256",
-          name: "toDeadline",
-        },
-        {
-          type: "bytes",
-          name: "toSig",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyGateway/read/ADD_TYPEHASH.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyGateway/read/ADD_TYPEHASH.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0xab583c1b" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bytes32",
+  },
+] as const;
+
+/**
+ * Decodes the result of the ADD_TYPEHASH function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { decodeADD_TYPEHASHResult } from "thirdweb/extensions/farcaster";
+ * const result = decodeADD_TYPEHASHResult("...");
+ * ```
+ */
+export function decodeADD_TYPEHASHResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "ADD_TYPEHASH" function on the contract.
  * @param options - The options for the ADD_TYPEHASH function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function ADD_TYPEHASH(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xab583c1b",
-      [],
-      [
-        {
-          type: "bytes32",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyGateway/read/keyRegistry.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyGateway/read/keyRegistry.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x086b5198" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "address",
+  },
+] as const;
+
+/**
+ * Decodes the result of the keyRegistry function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { decodeKeyRegistryResult } from "thirdweb/extensions/farcaster";
+ * const result = decodeKeyRegistryResult("...");
+ * ```
+ */
+export function decodeKeyRegistryResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "keyRegistry" function on the contract.
  * @param options - The options for the keyRegistry function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function keyRegistry(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x086b5198",
-      [],
-      [
-        {
-          type: "address",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyGateway/read/nonces.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyGateway/read/nonces.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "nonces" function.
@@ -8,6 +11,51 @@ import type { AbiParameterToPrimitiveType } from "abitype";
 export type NoncesParams = {
   account: AbiParameterToPrimitiveType<{ type: "address"; name: "account" }>;
 };
+
+const FN_SELECTOR = "0x7ecebe00" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "account",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "nonces" function.
+ * @param options - The options for the nonces function.
+ * @returns The encoded ABI parameters.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { encodeNoncesParams } "thirdweb/extensions/farcaster";
+ * const result = encodeNoncesParams({
+ *  account: ...,
+ * });
+ * ```
+ */
+export function encodeNoncesParams(options: NoncesParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.account]);
+}
+
+/**
+ * Decodes the result of the nonces function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { decodeNoncesResult } from "thirdweb/extensions/farcaster";
+ * const result = decodeNoncesResult("...");
+ * ```
+ */
+export function decodeNoncesResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "nonces" function on the contract.
@@ -27,20 +75,7 @@ export type NoncesParams = {
 export async function nonces(options: BaseTransactionOptions<NoncesParams>) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x7ecebe00",
-      [
-        {
-          type: "address",
-          name: "account",
-        },
-      ],
-      [
-        {
-          type: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.account],
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyGateway/write/add.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyGateway/write/add.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "add" function.
@@ -23,6 +24,52 @@ export type AddParams = Prettify<
       asyncParams: () => Promise<AddParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x22b1a414" as const;
+const FN_INPUTS = [
+  {
+    type: "uint32",
+    name: "keyType",
+  },
+  {
+    type: "bytes",
+    name: "key",
+  },
+  {
+    type: "uint8",
+    name: "metadataType",
+  },
+  {
+    type: "bytes",
+    name: "metadata",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "add" function.
+ * @param options - The options for the add function.
+ * @returns The encoded ABI parameters.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { encodeAddParams } "thirdweb/extensions/farcaster";
+ * const result = encodeAddParams({
+ *  keyType: ...,
+ *  key: ...,
+ *  metadataType: ...,
+ *  metadata: ...,
+ * });
+ * ```
+ */
+export function encodeAddParams(options: AddParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.keyType,
+    options.key,
+    options.metadataType,
+    options.metadata,
+  ]);
+}
+
 /**
  * Calls the "add" function on the contract.
  * @param options - The options for the "add" function.
@@ -47,28 +94,7 @@ export type AddParams = Prettify<
 export function add(options: BaseTransactionOptions<AddParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x22b1a414",
-      [
-        {
-          type: "uint32",
-          name: "keyType",
-        },
-        {
-          type: "bytes",
-          name: "key",
-        },
-        {
-          type: "uint8",
-          name: "metadataType",
-        },
-        {
-          type: "bytes",
-          name: "metadata",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyGateway/write/addFor.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyGateway/write/addFor.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "addFor" function.
@@ -26,6 +27,70 @@ export type AddForParams = Prettify<
       asyncParams: () => Promise<AddForParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xa005d3d2" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "fidOwner",
+  },
+  {
+    type: "uint32",
+    name: "keyType",
+  },
+  {
+    type: "bytes",
+    name: "key",
+  },
+  {
+    type: "uint8",
+    name: "metadataType",
+  },
+  {
+    type: "bytes",
+    name: "metadata",
+  },
+  {
+    type: "uint256",
+    name: "deadline",
+  },
+  {
+    type: "bytes",
+    name: "sig",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "addFor" function.
+ * @param options - The options for the addFor function.
+ * @returns The encoded ABI parameters.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { encodeAddForParams } "thirdweb/extensions/farcaster";
+ * const result = encodeAddForParams({
+ *  fidOwner: ...,
+ *  keyType: ...,
+ *  key: ...,
+ *  metadataType: ...,
+ *  metadata: ...,
+ *  deadline: ...,
+ *  sig: ...,
+ * });
+ * ```
+ */
+export function encodeAddForParams(options: AddForParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.fidOwner,
+    options.keyType,
+    options.key,
+    options.metadataType,
+    options.metadata,
+    options.deadline,
+    options.sig,
+  ]);
+}
+
 /**
  * Calls the "addFor" function on the contract.
  * @param options - The options for the "addFor" function.
@@ -53,40 +118,7 @@ export type AddForParams = Prettify<
 export function addFor(options: BaseTransactionOptions<AddForParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xa005d3d2",
-      [
-        {
-          type: "address",
-          name: "fidOwner",
-        },
-        {
-          type: "uint32",
-          name: "keyType",
-        },
-        {
-          type: "bytes",
-          name: "key",
-        },
-        {
-          type: "uint8",
-          name: "metadataType",
-        },
-        {
-          type: "bytes",
-          name: "metadata",
-        },
-        {
-          type: "uint256",
-          name: "deadline",
-        },
-        {
-          type: "bytes",
-          name: "sig",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyRegistry/read/REMOVE_TYPEHASH.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyRegistry/read/REMOVE_TYPEHASH.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0xb5775561" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bytes32",
+  },
+] as const;
+
+/**
+ * Decodes the result of the REMOVE_TYPEHASH function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { decodeREMOVE_TYPEHASHResult } from "thirdweb/extensions/farcaster";
+ * const result = decodeREMOVE_TYPEHASHResult("...");
+ * ```
+ */
+export function decodeREMOVE_TYPEHASHResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "REMOVE_TYPEHASH" function on the contract.
  * @param options - The options for the REMOVE_TYPEHASH function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function REMOVE_TYPEHASH(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xb5775561",
-      [],
-      [
-        {
-          type: "bytes32",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyRegistry/read/gatewayFrozen.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyRegistry/read/gatewayFrozen.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x95e7549f" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bool",
+  },
+] as const;
+
+/**
+ * Decodes the result of the gatewayFrozen function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { decodeGatewayFrozenResult } from "thirdweb/extensions/farcaster";
+ * const result = decodeGatewayFrozenResult("...");
+ * ```
+ */
+export function decodeGatewayFrozenResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "gatewayFrozen" function on the contract.
  * @param options - The options for the gatewayFrozen function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function gatewayFrozen(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x95e7549f",
-      [],
-      [
-        {
-          type: "bool",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyRegistry/read/idRegistry.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyRegistry/read/idRegistry.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x0aa13b8c" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "address",
+  },
+] as const;
+
+/**
+ * Decodes the result of the idRegistry function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { decodeIdRegistryResult } from "thirdweb/extensions/farcaster";
+ * const result = decodeIdRegistryResult("...");
+ * ```
+ */
+export function decodeIdRegistryResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "idRegistry" function on the contract.
  * @param options - The options for the idRegistry function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function idRegistry(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x0aa13b8c",
-      [],
-      [
-        {
-          type: "address",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyRegistry/read/keyAt.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyRegistry/read/keyAt.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "keyAt" function.
@@ -10,6 +13,65 @@ export type KeyAtParams = {
   state: AbiParameterToPrimitiveType<{ type: "uint8"; name: "state" }>;
   index: AbiParameterToPrimitiveType<{ type: "uint256"; name: "index" }>;
 };
+
+const FN_SELECTOR = "0x0ea9442c" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "fid",
+  },
+  {
+    type: "uint8",
+    name: "state",
+  },
+  {
+    type: "uint256",
+    name: "index",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bytes",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "keyAt" function.
+ * @param options - The options for the keyAt function.
+ * @returns The encoded ABI parameters.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { encodeKeyAtParams } "thirdweb/extensions/farcaster";
+ * const result = encodeKeyAtParams({
+ *  fid: ...,
+ *  state: ...,
+ *  index: ...,
+ * });
+ * ```
+ */
+export function encodeKeyAtParams(options: KeyAtParams) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.fid,
+    options.state,
+    options.index,
+  ]);
+}
+
+/**
+ * Decodes the result of the keyAt function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { decodeKeyAtResult } from "thirdweb/extensions/farcaster";
+ * const result = decodeKeyAtResult("...");
+ * ```
+ */
+export function decodeKeyAtResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "keyAt" function on the contract.
@@ -31,28 +93,7 @@ export type KeyAtParams = {
 export async function keyAt(options: BaseTransactionOptions<KeyAtParams>) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x0ea9442c",
-      [
-        {
-          type: "uint256",
-          name: "fid",
-        },
-        {
-          type: "uint8",
-          name: "state",
-        },
-        {
-          type: "uint256",
-          name: "index",
-        },
-      ],
-      [
-        {
-          type: "bytes",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.fid, options.state, options.index],
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyRegistry/read/keyDataOf.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyRegistry/read/keyDataOf.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "keyDataOf" function.
@@ -9,6 +12,56 @@ export type KeyDataOfParams = {
   fid: AbiParameterToPrimitiveType<{ type: "uint256"; name: "fid" }>;
   key: AbiParameterToPrimitiveType<{ type: "bytes"; name: "key" }>;
 };
+
+const FN_SELECTOR = "0xac34cc5a" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "fid",
+  },
+  {
+    type: "bytes",
+    name: "key",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "address",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "keyDataOf" function.
+ * @param options - The options for the keyDataOf function.
+ * @returns The encoded ABI parameters.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { encodeKeyDataOfParams } "thirdweb/extensions/farcaster";
+ * const result = encodeKeyDataOfParams({
+ *  fid: ...,
+ *  key: ...,
+ * });
+ * ```
+ */
+export function encodeKeyDataOfParams(options: KeyDataOfParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.fid, options.key]);
+}
+
+/**
+ * Decodes the result of the keyDataOf function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { decodeKeyDataOfResult } from "thirdweb/extensions/farcaster";
+ * const result = decodeKeyDataOfResult("...");
+ * ```
+ */
+export function decodeKeyDataOfResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "keyDataOf" function on the contract.
@@ -31,24 +84,7 @@ export async function keyDataOf(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xac34cc5a",
-      [
-        {
-          type: "uint256",
-          name: "fid",
-        },
-        {
-          type: "bytes",
-          name: "key",
-        },
-      ],
-      [
-        {
-          type: "address",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.fid, options.key],
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyRegistry/read/keyGateway.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyRegistry/read/keyGateway.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x80334737" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "address",
+  },
+] as const;
+
+/**
+ * Decodes the result of the keyGateway function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { decodeKeyGatewayResult } from "thirdweb/extensions/farcaster";
+ * const result = decodeKeyGatewayResult("...");
+ * ```
+ */
+export function decodeKeyGatewayResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "keyGateway" function on the contract.
  * @param options - The options for the keyGateway function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function keyGateway(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x80334737",
-      [],
-      [
-        {
-          type: "address",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyRegistry/read/keysOf.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyRegistry/read/keysOf.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "keysOf" function.
@@ -9,6 +12,56 @@ export type KeysOfParams = {
   fid: AbiParameterToPrimitiveType<{ type: "uint256"; name: "fid" }>;
   state: AbiParameterToPrimitiveType<{ type: "uint8"; name: "state" }>;
 };
+
+const FN_SELECTOR = "0x1f64222f" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "fid",
+  },
+  {
+    type: "uint8",
+    name: "state",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bytes[]",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "keysOf" function.
+ * @param options - The options for the keysOf function.
+ * @returns The encoded ABI parameters.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { encodeKeysOfParams } "thirdweb/extensions/farcaster";
+ * const result = encodeKeysOfParams({
+ *  fid: ...,
+ *  state: ...,
+ * });
+ * ```
+ */
+export function encodeKeysOfParams(options: KeysOfParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.fid, options.state]);
+}
+
+/**
+ * Decodes the result of the keysOf function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { decodeKeysOfResult } from "thirdweb/extensions/farcaster";
+ * const result = decodeKeysOfResult("...");
+ * ```
+ */
+export function decodeKeysOfResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "keysOf" function on the contract.
@@ -29,24 +82,7 @@ export type KeysOfParams = {
 export async function keysOf(options: BaseTransactionOptions<KeysOfParams>) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x1f64222f",
-      [
-        {
-          type: "uint256",
-          name: "fid",
-        },
-        {
-          type: "uint8",
-          name: "state",
-        },
-      ],
-      [
-        {
-          type: "bytes[]",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.fid, options.state],
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyRegistry/read/maxKeysPerFid.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyRegistry/read/maxKeysPerFid.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0xe33acf38" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the maxKeysPerFid function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { decodeMaxKeysPerFidResult } from "thirdweb/extensions/farcaster";
+ * const result = decodeMaxKeysPerFidResult("...");
+ * ```
+ */
+export function decodeMaxKeysPerFidResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "maxKeysPerFid" function on the contract.
  * @param options - The options for the maxKeysPerFid function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function maxKeysPerFid(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xe33acf38",
-      [],
-      [
-        {
-          type: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyRegistry/read/totalKeys.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyRegistry/read/totalKeys.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "totalKeys" function.
@@ -9,6 +12,56 @@ export type TotalKeysParams = {
   fid: AbiParameterToPrimitiveType<{ type: "uint256"; name: "fid" }>;
   state: AbiParameterToPrimitiveType<{ type: "uint8"; name: "state" }>;
 };
+
+const FN_SELECTOR = "0x6840b75e" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "fid",
+  },
+  {
+    type: "uint8",
+    name: "state",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "totalKeys" function.
+ * @param options - The options for the totalKeys function.
+ * @returns The encoded ABI parameters.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { encodeTotalKeysParams } "thirdweb/extensions/farcaster";
+ * const result = encodeTotalKeysParams({
+ *  fid: ...,
+ *  state: ...,
+ * });
+ * ```
+ */
+export function encodeTotalKeysParams(options: TotalKeysParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.fid, options.state]);
+}
+
+/**
+ * Decodes the result of the totalKeys function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { decodeTotalKeysResult } from "thirdweb/extensions/farcaster";
+ * const result = decodeTotalKeysResult("...");
+ * ```
+ */
+export function decodeTotalKeysResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "totalKeys" function on the contract.
@@ -31,24 +84,7 @@ export async function totalKeys(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x6840b75e",
-      [
-        {
-          type: "uint256",
-          name: "fid",
-        },
-        {
-          type: "uint8",
-          name: "state",
-        },
-      ],
-      [
-        {
-          type: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.fid, options.state],
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyRegistry/write/remove.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyRegistry/write/remove.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "remove" function.
@@ -17,6 +18,32 @@ export type RemoveParams = Prettify<
       asyncParams: () => Promise<RemoveParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x58edef4c" as const;
+const FN_INPUTS = [
+  {
+    type: "bytes",
+    name: "key",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "remove" function.
+ * @param options - The options for the remove function.
+ * @returns The encoded ABI parameters.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { encodeRemoveParams } "thirdweb/extensions/farcaster";
+ * const result = encodeRemoveParams({
+ *  key: ...,
+ * });
+ * ```
+ */
+export function encodeRemoveParams(options: RemoveParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.key]);
+}
+
 /**
  * Calls the "remove" function on the contract.
  * @param options - The options for the "remove" function.
@@ -38,16 +65,7 @@ export type RemoveParams = Prettify<
 export function remove(options: BaseTransactionOptions<RemoveParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x58edef4c",
-      [
-        {
-          type: "bytes",
-          name: "key",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyRegistry/write/removeFor.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyRegistry/write/removeFor.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "removeFor" function.
@@ -20,6 +21,52 @@ export type RemoveForParams = Prettify<
       asyncParams: () => Promise<RemoveForParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x787bd966" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "fidOwner",
+  },
+  {
+    type: "bytes",
+    name: "key",
+  },
+  {
+    type: "uint256",
+    name: "deadline",
+  },
+  {
+    type: "bytes",
+    name: "sig",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "removeFor" function.
+ * @param options - The options for the removeFor function.
+ * @returns The encoded ABI parameters.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { encodeRemoveForParams } "thirdweb/extensions/farcaster";
+ * const result = encodeRemoveForParams({
+ *  fidOwner: ...,
+ *  key: ...,
+ *  deadline: ...,
+ *  sig: ...,
+ * });
+ * ```
+ */
+export function encodeRemoveForParams(options: RemoveForParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.fidOwner,
+    options.key,
+    options.deadline,
+    options.sig,
+  ]);
+}
+
 /**
  * Calls the "removeFor" function on the contract.
  * @param options - The options for the "removeFor" function.
@@ -44,28 +91,7 @@ export type RemoveForParams = Prettify<
 export function removeFor(options: BaseTransactionOptions<RemoveForParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x787bd966",
-      [
-        {
-          type: "address",
-          name: "fidOwner",
-        },
-        {
-          type: "bytes",
-          name: "key",
-        },
-        {
-          type: "uint256",
-          name: "deadline",
-        },
-        {
-          type: "bytes",
-          name: "sig",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IStorageRegistry/read/deprecationTimestamp.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IStorageRegistry/read/deprecationTimestamp.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x2c39d670" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the deprecationTimestamp function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { decodeDeprecationTimestampResult } from "thirdweb/extensions/farcaster";
+ * const result = decodeDeprecationTimestampResult("...");
+ * ```
+ */
+export function decodeDeprecationTimestampResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "deprecationTimestamp" function on the contract.
  * @param options - The options for the deprecationTimestamp function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function deprecationTimestamp(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x2c39d670",
-      [],
-      [
-        {
-          type: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IStorageRegistry/read/maxUnits.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IStorageRegistry/read/maxUnits.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x06517a29" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the maxUnits function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { decodeMaxUnitsResult } from "thirdweb/extensions/farcaster";
+ * const result = decodeMaxUnitsResult("...");
+ * ```
+ */
+export function decodeMaxUnitsResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "maxUnits" function on the contract.
  * @param options - The options for the maxUnits function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function maxUnits(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x06517a29",
-      [],
-      [
-        {
-          type: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IStorageRegistry/read/price.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IStorageRegistry/read/price.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "price" function.
@@ -8,6 +11,51 @@ import type { AbiParameterToPrimitiveType } from "abitype";
 export type PriceParams = {
   units: AbiParameterToPrimitiveType<{ type: "uint256"; name: "units" }>;
 };
+
+const FN_SELECTOR = "0x26a49e37" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "units",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "price" function.
+ * @param options - The options for the price function.
+ * @returns The encoded ABI parameters.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { encodePriceParams } "thirdweb/extensions/farcaster";
+ * const result = encodePriceParams({
+ *  units: ...,
+ * });
+ * ```
+ */
+export function encodePriceParams(options: PriceParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.units]);
+}
+
+/**
+ * Decodes the result of the price function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { decodePriceResult } from "thirdweb/extensions/farcaster";
+ * const result = decodePriceResult("...");
+ * ```
+ */
+export function decodePriceResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "price" function on the contract.
@@ -27,20 +75,7 @@ export type PriceParams = {
 export async function price(options: BaseTransactionOptions<PriceParams>) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x26a49e37",
-      [
-        {
-          type: "uint256",
-          name: "units",
-        },
-      ],
-      [
-        {
-          type: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.units],
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IStorageRegistry/read/rentedUnits.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IStorageRegistry/read/rentedUnits.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x2751c4fd" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the rentedUnits function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { decodeRentedUnitsResult } from "thirdweb/extensions/farcaster";
+ * const result = decodeRentedUnitsResult("...");
+ * ```
+ */
+export function decodeRentedUnitsResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "rentedUnits" function on the contract.
  * @param options - The options for the rentedUnits function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function rentedUnits(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x2751c4fd",
-      [],
-      [
-        {
-          type: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IStorageRegistry/read/unitPrice.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IStorageRegistry/read/unitPrice.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0xe73faa2d" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the unitPrice function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { decodeUnitPriceResult } from "thirdweb/extensions/farcaster";
+ * const result = decodeUnitPriceResult("...");
+ * ```
+ */
+export function decodeUnitPriceResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "unitPrice" function on the contract.
  * @param options - The options for the unitPrice function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function unitPrice(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xe73faa2d",
-      [],
-      [
-        {
-          type: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IStorageRegistry/read/usdUnitPrice.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IStorageRegistry/read/usdUnitPrice.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x40df0ba0" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the usdUnitPrice function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { decodeUsdUnitPriceResult } from "thirdweb/extensions/farcaster";
+ * const result = decodeUsdUnitPriceResult("...");
+ * ```
+ */
+export function decodeUsdUnitPriceResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "usdUnitPrice" function on the contract.
  * @param options - The options for the usdUnitPrice function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function usdUnitPrice(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x40df0ba0",
-      [],
-      [
-        {
-          type: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IStorageRegistry/write/batchRent.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IStorageRegistry/write/batchRent.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "batchRent" function.
@@ -18,6 +19,37 @@ export type BatchRentParams = Prettify<
       asyncParams: () => Promise<BatchRentParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xa82c356e" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256[]",
+    name: "fids",
+  },
+  {
+    type: "uint256[]",
+    name: "units",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "batchRent" function.
+ * @param options - The options for the batchRent function.
+ * @returns The encoded ABI parameters.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { encodeBatchRentParams } "thirdweb/extensions/farcaster";
+ * const result = encodeBatchRentParams({
+ *  fids: ...,
+ *  units: ...,
+ * });
+ * ```
+ */
+export function encodeBatchRentParams(options: BatchRentParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.fids, options.units]);
+}
+
 /**
  * Calls the "batchRent" function on the contract.
  * @param options - The options for the "batchRent" function.
@@ -40,20 +72,7 @@ export type BatchRentParams = Prettify<
 export function batchRent(options: BaseTransactionOptions<BatchRentParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xa82c356e",
-      [
-        {
-          type: "uint256[]",
-          name: "fids",
-        },
-        {
-          type: "uint256[]",
-          name: "units",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IStorageRegistry/write/rent.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IStorageRegistry/write/rent.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "rent" function.
@@ -18,6 +19,42 @@ export type RentParams = Prettify<
       asyncParams: () => Promise<RentParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x783a112b" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "fid",
+  },
+  {
+    type: "uint256",
+    name: "units",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+    name: "overpayment",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "rent" function.
+ * @param options - The options for the rent function.
+ * @returns The encoded ABI parameters.
+ * @extension FARCASTER
+ * @example
+ * ```
+ * import { encodeRentParams } "thirdweb/extensions/farcaster";
+ * const result = encodeRentParams({
+ *  fid: ...,
+ *  units: ...,
+ * });
+ * ```
+ */
+export function encodeRentParams(options: RentParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.fid, options.units]);
+}
+
 /**
  * Calls the "rent" function on the contract.
  * @param options - The options for the "rent" function.
@@ -40,25 +77,7 @@ export type RentParams = Prettify<
 export function rent(options: BaseTransactionOptions<RentParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x783a112b",
-      [
-        {
-          type: "uint256",
-          name: "fid",
-        },
-        {
-          type: "uint256",
-          name: "units",
-        },
-      ],
-      [
-        {
-          type: "uint256",
-          name: "overpayment",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/read/getAllListings.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/read/getAllListings.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "getAllListings" function.
@@ -9,6 +12,107 @@ export type GetAllListingsParams = {
   startId: AbiParameterToPrimitiveType<{ type: "uint256"; name: "_startId" }>;
   endId: AbiParameterToPrimitiveType<{ type: "uint256"; name: "_endId" }>;
 };
+
+const FN_SELECTOR = "0xc5275fb0" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_startId",
+  },
+  {
+    type: "uint256",
+    name: "_endId",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "tuple[]",
+    name: "listings",
+    components: [
+      {
+        type: "uint256",
+        name: "listingId",
+      },
+      {
+        type: "uint256",
+        name: "tokenId",
+      },
+      {
+        type: "uint256",
+        name: "quantity",
+      },
+      {
+        type: "uint256",
+        name: "pricePerToken",
+      },
+      {
+        type: "uint128",
+        name: "startTimestamp",
+      },
+      {
+        type: "uint128",
+        name: "endTimestamp",
+      },
+      {
+        type: "address",
+        name: "listingCreator",
+      },
+      {
+        type: "address",
+        name: "assetContract",
+      },
+      {
+        type: "address",
+        name: "currency",
+      },
+      {
+        type: "uint8",
+        name: "tokenType",
+      },
+      {
+        type: "uint8",
+        name: "status",
+      },
+      {
+        type: "bool",
+        name: "reserved",
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getAllListings" function.
+ * @param options - The options for the getAllListings function.
+ * @returns The encoded ABI parameters.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { encodeGetAllListingsParams } "thirdweb/extensions/marketplace";
+ * const result = encodeGetAllListingsParams({
+ *  startId: ...,
+ *  endId: ...,
+ * });
+ * ```
+ */
+export function encodeGetAllListingsParams(options: GetAllListingsParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.startId, options.endId]);
+}
+
+/**
+ * Decodes the result of the getAllListings function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { decodeGetAllListingsResult } from "thirdweb/extensions/marketplace";
+ * const result = decodeGetAllListingsResult("...");
+ * ```
+ */
+export function decodeGetAllListingsResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "getAllListings" function on the contract.
@@ -31,75 +135,7 @@ export async function getAllListings(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xc5275fb0",
-      [
-        {
-          type: "uint256",
-          name: "_startId",
-        },
-        {
-          type: "uint256",
-          name: "_endId",
-        },
-      ],
-      [
-        {
-          type: "tuple[]",
-          name: "listings",
-          components: [
-            {
-              type: "uint256",
-              name: "listingId",
-            },
-            {
-              type: "uint256",
-              name: "tokenId",
-            },
-            {
-              type: "uint256",
-              name: "quantity",
-            },
-            {
-              type: "uint256",
-              name: "pricePerToken",
-            },
-            {
-              type: "uint128",
-              name: "startTimestamp",
-            },
-            {
-              type: "uint128",
-              name: "endTimestamp",
-            },
-            {
-              type: "address",
-              name: "listingCreator",
-            },
-            {
-              type: "address",
-              name: "assetContract",
-            },
-            {
-              type: "address",
-              name: "currency",
-            },
-            {
-              type: "uint8",
-              name: "tokenType",
-            },
-            {
-              type: "uint8",
-              name: "status",
-            },
-            {
-              type: "bool",
-              name: "reserved",
-            },
-          ],
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.startId, options.endId],
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/read/getAllValidListings.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/read/getAllValidListings.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "getAllValidListings" function.
@@ -9,6 +12,109 @@ export type GetAllValidListingsParams = {
   startId: AbiParameterToPrimitiveType<{ type: "uint256"; name: "_startId" }>;
   endId: AbiParameterToPrimitiveType<{ type: "uint256"; name: "_endId" }>;
 };
+
+const FN_SELECTOR = "0x31654b4d" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_startId",
+  },
+  {
+    type: "uint256",
+    name: "_endId",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "tuple[]",
+    name: "listings",
+    components: [
+      {
+        type: "uint256",
+        name: "listingId",
+      },
+      {
+        type: "uint256",
+        name: "tokenId",
+      },
+      {
+        type: "uint256",
+        name: "quantity",
+      },
+      {
+        type: "uint256",
+        name: "pricePerToken",
+      },
+      {
+        type: "uint128",
+        name: "startTimestamp",
+      },
+      {
+        type: "uint128",
+        name: "endTimestamp",
+      },
+      {
+        type: "address",
+        name: "listingCreator",
+      },
+      {
+        type: "address",
+        name: "assetContract",
+      },
+      {
+        type: "address",
+        name: "currency",
+      },
+      {
+        type: "uint8",
+        name: "tokenType",
+      },
+      {
+        type: "uint8",
+        name: "status",
+      },
+      {
+        type: "bool",
+        name: "reserved",
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getAllValidListings" function.
+ * @param options - The options for the getAllValidListings function.
+ * @returns The encoded ABI parameters.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { encodeGetAllValidListingsParams } "thirdweb/extensions/marketplace";
+ * const result = encodeGetAllValidListingsParams({
+ *  startId: ...,
+ *  endId: ...,
+ * });
+ * ```
+ */
+export function encodeGetAllValidListingsParams(
+  options: GetAllValidListingsParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.startId, options.endId]);
+}
+
+/**
+ * Decodes the result of the getAllValidListings function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { decodeGetAllValidListingsResult } from "thirdweb/extensions/marketplace";
+ * const result = decodeGetAllValidListingsResult("...");
+ * ```
+ */
+export function decodeGetAllValidListingsResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "getAllValidListings" function on the contract.
@@ -31,75 +137,7 @@ export async function getAllValidListings(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x31654b4d",
-      [
-        {
-          type: "uint256",
-          name: "_startId",
-        },
-        {
-          type: "uint256",
-          name: "_endId",
-        },
-      ],
-      [
-        {
-          type: "tuple[]",
-          name: "listings",
-          components: [
-            {
-              type: "uint256",
-              name: "listingId",
-            },
-            {
-              type: "uint256",
-              name: "tokenId",
-            },
-            {
-              type: "uint256",
-              name: "quantity",
-            },
-            {
-              type: "uint256",
-              name: "pricePerToken",
-            },
-            {
-              type: "uint128",
-              name: "startTimestamp",
-            },
-            {
-              type: "uint128",
-              name: "endTimestamp",
-            },
-            {
-              type: "address",
-              name: "listingCreator",
-            },
-            {
-              type: "address",
-              name: "assetContract",
-            },
-            {
-              type: "address",
-              name: "currency",
-            },
-            {
-              type: "uint8",
-              name: "tokenType",
-            },
-            {
-              type: "uint8",
-              name: "status",
-            },
-            {
-              type: "bool",
-              name: "reserved",
-            },
-          ],
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.startId, options.endId],
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/read/getListing.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/read/getListing.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "getListing" function.
@@ -11,6 +14,102 @@ export type GetListingParams = {
     name: "_listingId";
   }>;
 };
+
+const FN_SELECTOR = "0x107a274a" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_listingId",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "tuple",
+    name: "listing",
+    components: [
+      {
+        type: "uint256",
+        name: "listingId",
+      },
+      {
+        type: "uint256",
+        name: "tokenId",
+      },
+      {
+        type: "uint256",
+        name: "quantity",
+      },
+      {
+        type: "uint256",
+        name: "pricePerToken",
+      },
+      {
+        type: "uint128",
+        name: "startTimestamp",
+      },
+      {
+        type: "uint128",
+        name: "endTimestamp",
+      },
+      {
+        type: "address",
+        name: "listingCreator",
+      },
+      {
+        type: "address",
+        name: "assetContract",
+      },
+      {
+        type: "address",
+        name: "currency",
+      },
+      {
+        type: "uint8",
+        name: "tokenType",
+      },
+      {
+        type: "uint8",
+        name: "status",
+      },
+      {
+        type: "bool",
+        name: "reserved",
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getListing" function.
+ * @param options - The options for the getListing function.
+ * @returns The encoded ABI parameters.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { encodeGetListingParams } "thirdweb/extensions/marketplace";
+ * const result = encodeGetListingParams({
+ *  listingId: ...,
+ * });
+ * ```
+ */
+export function encodeGetListingParams(options: GetListingParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.listingId]);
+}
+
+/**
+ * Decodes the result of the getListing function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { decodeGetListingResult } from "thirdweb/extensions/marketplace";
+ * const result = decodeGetListingResult("...");
+ * ```
+ */
+export function decodeGetListingResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "getListing" function on the contract.
@@ -32,71 +131,7 @@ export async function getListing(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x107a274a",
-      [
-        {
-          type: "uint256",
-          name: "_listingId",
-        },
-      ],
-      [
-        {
-          type: "tuple",
-          name: "listing",
-          components: [
-            {
-              type: "uint256",
-              name: "listingId",
-            },
-            {
-              type: "uint256",
-              name: "tokenId",
-            },
-            {
-              type: "uint256",
-              name: "quantity",
-            },
-            {
-              type: "uint256",
-              name: "pricePerToken",
-            },
-            {
-              type: "uint128",
-              name: "startTimestamp",
-            },
-            {
-              type: "uint128",
-              name: "endTimestamp",
-            },
-            {
-              type: "address",
-              name: "listingCreator",
-            },
-            {
-              type: "address",
-              name: "assetContract",
-            },
-            {
-              type: "address",
-              name: "currency",
-            },
-            {
-              type: "uint8",
-              name: "tokenType",
-            },
-            {
-              type: "uint8",
-              name: "status",
-            },
-            {
-              type: "bool",
-              name: "reserved",
-            },
-          ],
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.listingId],
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/read/totalListings.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/read/totalListings.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0xc78b616c" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the totalListings function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { decodeTotalListingsResult } from "thirdweb/extensions/marketplace";
+ * const result = decodeTotalListingsResult("...");
+ * ```
+ */
+export function decodeTotalListingsResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "totalListings" function on the contract.
  * @param options - The options for the totalListings function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function totalListings(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xc78b616c",
-      [],
-      [
-        {
-          type: "uint256",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/approveBuyerForListing.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/approveBuyerForListing.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "approveBuyerForListing" function.
@@ -22,6 +23,48 @@ export type ApproveBuyerForListingParams = Prettify<
       asyncParams: () => Promise<ApproveBuyerForListingParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x48dd77df" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_listingId",
+  },
+  {
+    type: "address",
+    name: "_buyer",
+  },
+  {
+    type: "bool",
+    name: "_toApprove",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "approveBuyerForListing" function.
+ * @param options - The options for the approveBuyerForListing function.
+ * @returns The encoded ABI parameters.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { encodeApproveBuyerForListingParams } "thirdweb/extensions/marketplace";
+ * const result = encodeApproveBuyerForListingParams({
+ *  listingId: ...,
+ *  buyer: ...,
+ *  toApprove: ...,
+ * });
+ * ```
+ */
+export function encodeApproveBuyerForListingParams(
+  options: ApproveBuyerForListingParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.listingId,
+    options.buyer,
+    options.toApprove,
+  ]);
+}
+
 /**
  * Calls the "approveBuyerForListing" function on the contract.
  * @param options - The options for the "approveBuyerForListing" function.
@@ -47,24 +90,7 @@ export function approveBuyerForListing(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x48dd77df",
-      [
-        {
-          type: "uint256",
-          name: "_listingId",
-        },
-        {
-          type: "address",
-          name: "_buyer",
-        },
-        {
-          type: "bool",
-          name: "_toApprove",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/approveCurrencyForListing.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/approveCurrencyForListing.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "approveCurrencyForListing" function.
@@ -25,6 +26,48 @@ export type ApproveCurrencyForListingParams = Prettify<
       asyncParams: () => Promise<ApproveCurrencyForListingParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xea8f9a3c" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_listingId",
+  },
+  {
+    type: "address",
+    name: "_currency",
+  },
+  {
+    type: "uint256",
+    name: "_pricePerTokenInCurrency",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "approveCurrencyForListing" function.
+ * @param options - The options for the approveCurrencyForListing function.
+ * @returns The encoded ABI parameters.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { encodeApproveCurrencyForListingParams } "thirdweb/extensions/marketplace";
+ * const result = encodeApproveCurrencyForListingParams({
+ *  listingId: ...,
+ *  currency: ...,
+ *  pricePerTokenInCurrency: ...,
+ * });
+ * ```
+ */
+export function encodeApproveCurrencyForListingParams(
+  options: ApproveCurrencyForListingParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.listingId,
+    options.currency,
+    options.pricePerTokenInCurrency,
+  ]);
+}
+
 /**
  * Calls the "approveCurrencyForListing" function on the contract.
  * @param options - The options for the "approveCurrencyForListing" function.
@@ -50,24 +93,7 @@ export function approveCurrencyForListing(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xea8f9a3c",
-      [
-        {
-          type: "uint256",
-          name: "_listingId",
-        },
-        {
-          type: "address",
-          name: "_currency",
-        },
-        {
-          type: "uint256",
-          name: "_pricePerTokenInCurrency",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/buyFromListing.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/buyFromListing.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "buyFromListing" function.
@@ -27,6 +28,60 @@ export type BuyFromListingParams = Prettify<
       asyncParams: () => Promise<BuyFromListingParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x704232dc" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_listingId",
+  },
+  {
+    type: "address",
+    name: "_buyFor",
+  },
+  {
+    type: "uint256",
+    name: "_quantity",
+  },
+  {
+    type: "address",
+    name: "_currency",
+  },
+  {
+    type: "uint256",
+    name: "_expectedTotalPrice",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "buyFromListing" function.
+ * @param options - The options for the buyFromListing function.
+ * @returns The encoded ABI parameters.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { encodeBuyFromListingParams } "thirdweb/extensions/marketplace";
+ * const result = encodeBuyFromListingParams({
+ *  listingId: ...,
+ *  buyFor: ...,
+ *  quantity: ...,
+ *  currency: ...,
+ *  expectedTotalPrice: ...,
+ * });
+ * ```
+ */
+export function encodeBuyFromListingParams(
+  options: BuyFromListingParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.listingId,
+    options.buyFor,
+    options.quantity,
+    options.currency,
+    options.expectedTotalPrice,
+  ]);
+}
+
 /**
  * Calls the "buyFromListing" function on the contract.
  * @param options - The options for the "buyFromListing" function.
@@ -54,32 +109,7 @@ export function buyFromListing(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x704232dc",
-      [
-        {
-          type: "uint256",
-          name: "_listingId",
-        },
-        {
-          type: "address",
-          name: "_buyFor",
-        },
-        {
-          type: "uint256",
-          name: "_quantity",
-        },
-        {
-          type: "address",
-          name: "_currency",
-        },
-        {
-          type: "uint256",
-          name: "_expectedTotalPrice",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/cancelListing.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/cancelListing.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "cancelListing" function.
@@ -20,6 +21,34 @@ export type CancelListingParams = Prettify<
       asyncParams: () => Promise<CancelListingParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x305a67a8" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_listingId",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "cancelListing" function.
+ * @param options - The options for the cancelListing function.
+ * @returns The encoded ABI parameters.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { encodeCancelListingParams } "thirdweb/extensions/marketplace";
+ * const result = encodeCancelListingParams({
+ *  listingId: ...,
+ * });
+ * ```
+ */
+export function encodeCancelListingParams(
+  options: CancelListingParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.listingId]);
+}
+
 /**
  * Calls the "cancelListing" function on the contract.
  * @param options - The options for the "cancelListing" function.
@@ -43,16 +72,7 @@ export function cancelListing(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x305a67a8",
-      [
-        {
-          type: "uint256",
-          name: "_listingId",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/createListing.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/createListing.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "createListing" function.
@@ -30,6 +31,73 @@ export type CreateListingParams = Prettify<
       asyncParams: () => Promise<CreateListingParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x746415b5" as const;
+const FN_INPUTS = [
+  {
+    type: "tuple",
+    name: "_params",
+    components: [
+      {
+        type: "address",
+        name: "assetContract",
+      },
+      {
+        type: "uint256",
+        name: "tokenId",
+      },
+      {
+        type: "uint256",
+        name: "quantity",
+      },
+      {
+        type: "address",
+        name: "currency",
+      },
+      {
+        type: "uint256",
+        name: "pricePerToken",
+      },
+      {
+        type: "uint128",
+        name: "startTimestamp",
+      },
+      {
+        type: "uint128",
+        name: "endTimestamp",
+      },
+      {
+        type: "bool",
+        name: "reserved",
+      },
+    ],
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+    name: "listingId",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "createListing" function.
+ * @param options - The options for the createListing function.
+ * @returns The encoded ABI parameters.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { encodeCreateListingParams } "thirdweb/extensions/marketplace";
+ * const result = encodeCreateListingParams({
+ *  params: ...,
+ * });
+ * ```
+ */
+export function encodeCreateListingParams(
+  options: CreateListingParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.params]);
+}
+
 /**
  * Calls the "createListing" function on the contract.
  * @param options - The options for the "createListing" function.
@@ -53,55 +121,7 @@ export function createListing(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x746415b5",
-      [
-        {
-          type: "tuple",
-          name: "_params",
-          components: [
-            {
-              type: "address",
-              name: "assetContract",
-            },
-            {
-              type: "uint256",
-              name: "tokenId",
-            },
-            {
-              type: "uint256",
-              name: "quantity",
-            },
-            {
-              type: "address",
-              name: "currency",
-            },
-            {
-              type: "uint256",
-              name: "pricePerToken",
-            },
-            {
-              type: "uint128",
-              name: "startTimestamp",
-            },
-            {
-              type: "uint128",
-              name: "endTimestamp",
-            },
-            {
-              type: "bool",
-              name: "reserved",
-            },
-          ],
-        },
-      ],
-      [
-        {
-          type: "uint256",
-          name: "listingId",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/updateListing.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/updateListing.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "updateListing" function.
@@ -34,6 +35,73 @@ export type UpdateListingParams = Prettify<
       asyncParams: () => Promise<UpdateListingParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x07b67758" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_listingId",
+  },
+  {
+    type: "tuple",
+    name: "_params",
+    components: [
+      {
+        type: "address",
+        name: "assetContract",
+      },
+      {
+        type: "uint256",
+        name: "tokenId",
+      },
+      {
+        type: "uint256",
+        name: "quantity",
+      },
+      {
+        type: "address",
+        name: "currency",
+      },
+      {
+        type: "uint256",
+        name: "pricePerToken",
+      },
+      {
+        type: "uint128",
+        name: "startTimestamp",
+      },
+      {
+        type: "uint128",
+        name: "endTimestamp",
+      },
+      {
+        type: "bool",
+        name: "reserved",
+      },
+    ],
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "updateListing" function.
+ * @param options - The options for the updateListing function.
+ * @returns The encoded ABI parameters.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { encodeUpdateListingParams } "thirdweb/extensions/marketplace";
+ * const result = encodeUpdateListingParams({
+ *  listingId: ...,
+ *  params: ...,
+ * });
+ * ```
+ */
+export function encodeUpdateListingParams(
+  options: UpdateListingParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.listingId, options.params]);
+}
+
 /**
  * Calls the "updateListing" function on the contract.
  * @param options - The options for the "updateListing" function.
@@ -58,54 +126,7 @@ export function updateListing(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x07b67758",
-      [
-        {
-          type: "uint256",
-          name: "_listingId",
-        },
-        {
-          type: "tuple",
-          name: "_params",
-          components: [
-            {
-              type: "address",
-              name: "assetContract",
-            },
-            {
-              type: "uint256",
-              name: "tokenId",
-            },
-            {
-              type: "uint256",
-              name: "quantity",
-            },
-            {
-              type: "address",
-              name: "currency",
-            },
-            {
-              type: "uint256",
-              name: "pricePerToken",
-            },
-            {
-              type: "uint128",
-              name: "startTimestamp",
-            },
-            {
-              type: "uint128",
-              name: "endTimestamp",
-            },
-            {
-              type: "bool",
-              name: "reserved",
-            },
-          ],
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/read/getAllAuctions.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/read/getAllAuctions.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "getAllAuctions" function.
@@ -9,6 +12,115 @@ export type GetAllAuctionsParams = {
   startId: AbiParameterToPrimitiveType<{ type: "uint256"; name: "_startId" }>;
   endId: AbiParameterToPrimitiveType<{ type: "uint256"; name: "_endId" }>;
 };
+
+const FN_SELECTOR = "0xc291537c" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_startId",
+  },
+  {
+    type: "uint256",
+    name: "_endId",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "tuple[]",
+    name: "auctions",
+    components: [
+      {
+        type: "uint256",
+        name: "auctionId",
+      },
+      {
+        type: "uint256",
+        name: "tokenId",
+      },
+      {
+        type: "uint256",
+        name: "quantity",
+      },
+      {
+        type: "uint256",
+        name: "minimumBidAmount",
+      },
+      {
+        type: "uint256",
+        name: "buyoutBidAmount",
+      },
+      {
+        type: "uint64",
+        name: "timeBufferInSeconds",
+      },
+      {
+        type: "uint64",
+        name: "bidBufferBps",
+      },
+      {
+        type: "uint64",
+        name: "startTimestamp",
+      },
+      {
+        type: "uint64",
+        name: "endTimestamp",
+      },
+      {
+        type: "address",
+        name: "auctionCreator",
+      },
+      {
+        type: "address",
+        name: "assetContract",
+      },
+      {
+        type: "address",
+        name: "currency",
+      },
+      {
+        type: "uint8",
+        name: "tokenType",
+      },
+      {
+        type: "uint8",
+        name: "status",
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getAllAuctions" function.
+ * @param options - The options for the getAllAuctions function.
+ * @returns The encoded ABI parameters.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { encodeGetAllAuctionsParams } "thirdweb/extensions/marketplace";
+ * const result = encodeGetAllAuctionsParams({
+ *  startId: ...,
+ *  endId: ...,
+ * });
+ * ```
+ */
+export function encodeGetAllAuctionsParams(options: GetAllAuctionsParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.startId, options.endId]);
+}
+
+/**
+ * Decodes the result of the getAllAuctions function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { decodeGetAllAuctionsResult } from "thirdweb/extensions/marketplace";
+ * const result = decodeGetAllAuctionsResult("...");
+ * ```
+ */
+export function decodeGetAllAuctionsResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "getAllAuctions" function on the contract.
@@ -31,83 +143,7 @@ export async function getAllAuctions(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xc291537c",
-      [
-        {
-          type: "uint256",
-          name: "_startId",
-        },
-        {
-          type: "uint256",
-          name: "_endId",
-        },
-      ],
-      [
-        {
-          type: "tuple[]",
-          name: "auctions",
-          components: [
-            {
-              type: "uint256",
-              name: "auctionId",
-            },
-            {
-              type: "uint256",
-              name: "tokenId",
-            },
-            {
-              type: "uint256",
-              name: "quantity",
-            },
-            {
-              type: "uint256",
-              name: "minimumBidAmount",
-            },
-            {
-              type: "uint256",
-              name: "buyoutBidAmount",
-            },
-            {
-              type: "uint64",
-              name: "timeBufferInSeconds",
-            },
-            {
-              type: "uint64",
-              name: "bidBufferBps",
-            },
-            {
-              type: "uint64",
-              name: "startTimestamp",
-            },
-            {
-              type: "uint64",
-              name: "endTimestamp",
-            },
-            {
-              type: "address",
-              name: "auctionCreator",
-            },
-            {
-              type: "address",
-              name: "assetContract",
-            },
-            {
-              type: "address",
-              name: "currency",
-            },
-            {
-              type: "uint8",
-              name: "tokenType",
-            },
-            {
-              type: "uint8",
-              name: "status",
-            },
-          ],
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.startId, options.endId],
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/read/getAllValidAuctions.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/read/getAllValidAuctions.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "getAllValidAuctions" function.
@@ -9,6 +12,117 @@ export type GetAllValidAuctionsParams = {
   startId: AbiParameterToPrimitiveType<{ type: "uint256"; name: "_startId" }>;
   endId: AbiParameterToPrimitiveType<{ type: "uint256"; name: "_endId" }>;
 };
+
+const FN_SELECTOR = "0x7b063801" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_startId",
+  },
+  {
+    type: "uint256",
+    name: "_endId",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "tuple[]",
+    name: "auctions",
+    components: [
+      {
+        type: "uint256",
+        name: "auctionId",
+      },
+      {
+        type: "uint256",
+        name: "tokenId",
+      },
+      {
+        type: "uint256",
+        name: "quantity",
+      },
+      {
+        type: "uint256",
+        name: "minimumBidAmount",
+      },
+      {
+        type: "uint256",
+        name: "buyoutBidAmount",
+      },
+      {
+        type: "uint64",
+        name: "timeBufferInSeconds",
+      },
+      {
+        type: "uint64",
+        name: "bidBufferBps",
+      },
+      {
+        type: "uint64",
+        name: "startTimestamp",
+      },
+      {
+        type: "uint64",
+        name: "endTimestamp",
+      },
+      {
+        type: "address",
+        name: "auctionCreator",
+      },
+      {
+        type: "address",
+        name: "assetContract",
+      },
+      {
+        type: "address",
+        name: "currency",
+      },
+      {
+        type: "uint8",
+        name: "tokenType",
+      },
+      {
+        type: "uint8",
+        name: "status",
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getAllValidAuctions" function.
+ * @param options - The options for the getAllValidAuctions function.
+ * @returns The encoded ABI parameters.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { encodeGetAllValidAuctionsParams } "thirdweb/extensions/marketplace";
+ * const result = encodeGetAllValidAuctionsParams({
+ *  startId: ...,
+ *  endId: ...,
+ * });
+ * ```
+ */
+export function encodeGetAllValidAuctionsParams(
+  options: GetAllValidAuctionsParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.startId, options.endId]);
+}
+
+/**
+ * Decodes the result of the getAllValidAuctions function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { decodeGetAllValidAuctionsResult } from "thirdweb/extensions/marketplace";
+ * const result = decodeGetAllValidAuctionsResult("...");
+ * ```
+ */
+export function decodeGetAllValidAuctionsResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "getAllValidAuctions" function on the contract.
@@ -31,83 +145,7 @@ export async function getAllValidAuctions(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x7b063801",
-      [
-        {
-          type: "uint256",
-          name: "_startId",
-        },
-        {
-          type: "uint256",
-          name: "_endId",
-        },
-      ],
-      [
-        {
-          type: "tuple[]",
-          name: "auctions",
-          components: [
-            {
-              type: "uint256",
-              name: "auctionId",
-            },
-            {
-              type: "uint256",
-              name: "tokenId",
-            },
-            {
-              type: "uint256",
-              name: "quantity",
-            },
-            {
-              type: "uint256",
-              name: "minimumBidAmount",
-            },
-            {
-              type: "uint256",
-              name: "buyoutBidAmount",
-            },
-            {
-              type: "uint64",
-              name: "timeBufferInSeconds",
-            },
-            {
-              type: "uint64",
-              name: "bidBufferBps",
-            },
-            {
-              type: "uint64",
-              name: "startTimestamp",
-            },
-            {
-              type: "uint64",
-              name: "endTimestamp",
-            },
-            {
-              type: "address",
-              name: "auctionCreator",
-            },
-            {
-              type: "address",
-              name: "assetContract",
-            },
-            {
-              type: "address",
-              name: "currency",
-            },
-            {
-              type: "uint8",
-              name: "tokenType",
-            },
-            {
-              type: "uint8",
-              name: "status",
-            },
-          ],
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.startId, options.endId],
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/read/getAuction.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/read/getAuction.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "getAuction" function.
@@ -11,6 +14,110 @@ export type GetAuctionParams = {
     name: "_auctionId";
   }>;
 };
+
+const FN_SELECTOR = "0x78bd7935" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_auctionId",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "tuple",
+    name: "auction",
+    components: [
+      {
+        type: "uint256",
+        name: "auctionId",
+      },
+      {
+        type: "uint256",
+        name: "tokenId",
+      },
+      {
+        type: "uint256",
+        name: "quantity",
+      },
+      {
+        type: "uint256",
+        name: "minimumBidAmount",
+      },
+      {
+        type: "uint256",
+        name: "buyoutBidAmount",
+      },
+      {
+        type: "uint64",
+        name: "timeBufferInSeconds",
+      },
+      {
+        type: "uint64",
+        name: "bidBufferBps",
+      },
+      {
+        type: "uint64",
+        name: "startTimestamp",
+      },
+      {
+        type: "uint64",
+        name: "endTimestamp",
+      },
+      {
+        type: "address",
+        name: "auctionCreator",
+      },
+      {
+        type: "address",
+        name: "assetContract",
+      },
+      {
+        type: "address",
+        name: "currency",
+      },
+      {
+        type: "uint8",
+        name: "tokenType",
+      },
+      {
+        type: "uint8",
+        name: "status",
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getAuction" function.
+ * @param options - The options for the getAuction function.
+ * @returns The encoded ABI parameters.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { encodeGetAuctionParams } "thirdweb/extensions/marketplace";
+ * const result = encodeGetAuctionParams({
+ *  auctionId: ...,
+ * });
+ * ```
+ */
+export function encodeGetAuctionParams(options: GetAuctionParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.auctionId]);
+}
+
+/**
+ * Decodes the result of the getAuction function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { decodeGetAuctionResult } from "thirdweb/extensions/marketplace";
+ * const result = decodeGetAuctionResult("...");
+ * ```
+ */
+export function decodeGetAuctionResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "getAuction" function on the contract.
@@ -32,79 +139,7 @@ export async function getAuction(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x78bd7935",
-      [
-        {
-          type: "uint256",
-          name: "_auctionId",
-        },
-      ],
-      [
-        {
-          type: "tuple",
-          name: "auction",
-          components: [
-            {
-              type: "uint256",
-              name: "auctionId",
-            },
-            {
-              type: "uint256",
-              name: "tokenId",
-            },
-            {
-              type: "uint256",
-              name: "quantity",
-            },
-            {
-              type: "uint256",
-              name: "minimumBidAmount",
-            },
-            {
-              type: "uint256",
-              name: "buyoutBidAmount",
-            },
-            {
-              type: "uint64",
-              name: "timeBufferInSeconds",
-            },
-            {
-              type: "uint64",
-              name: "bidBufferBps",
-            },
-            {
-              type: "uint64",
-              name: "startTimestamp",
-            },
-            {
-              type: "uint64",
-              name: "endTimestamp",
-            },
-            {
-              type: "address",
-              name: "auctionCreator",
-            },
-            {
-              type: "address",
-              name: "assetContract",
-            },
-            {
-              type: "address",
-              name: "currency",
-            },
-            {
-              type: "uint8",
-              name: "tokenType",
-            },
-            {
-              type: "uint8",
-              name: "status",
-            },
-          ],
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.auctionId],
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/read/getWinningBid.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/read/getWinningBid.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "getWinningBid" function.
@@ -11,6 +14,60 @@ export type GetWinningBidParams = {
     name: "_auctionId";
   }>;
 };
+
+const FN_SELECTOR = "0x6891939d" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_auctionId",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "address",
+    name: "bidder",
+  },
+  {
+    type: "address",
+    name: "currency",
+  },
+  {
+    type: "uint256",
+    name: "bidAmount",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getWinningBid" function.
+ * @param options - The options for the getWinningBid function.
+ * @returns The encoded ABI parameters.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { encodeGetWinningBidParams } "thirdweb/extensions/marketplace";
+ * const result = encodeGetWinningBidParams({
+ *  auctionId: ...,
+ * });
+ * ```
+ */
+export function encodeGetWinningBidParams(options: GetWinningBidParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.auctionId]);
+}
+
+/**
+ * Decodes the result of the getWinningBid function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { decodeGetWinningBidResult } from "thirdweb/extensions/marketplace";
+ * const result = decodeGetWinningBidResult("...");
+ * ```
+ */
+export function decodeGetWinningBidResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result);
+}
 
 /**
  * Calls the "getWinningBid" function on the contract.
@@ -32,29 +89,7 @@ export async function getWinningBid(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x6891939d",
-      [
-        {
-          type: "uint256",
-          name: "_auctionId",
-        },
-      ],
-      [
-        {
-          type: "address",
-          name: "bidder",
-        },
-        {
-          type: "address",
-          name: "currency",
-        },
-        {
-          type: "uint256",
-          name: "bidAmount",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.auctionId],
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/read/isAuctionExpired.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/read/isAuctionExpired.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "isAuctionExpired" function.
@@ -11,6 +14,51 @@ export type IsAuctionExpiredParams = {
     name: "_auctionId";
   }>;
 };
+
+const FN_SELECTOR = "0x1389b117" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_auctionId",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bool",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "isAuctionExpired" function.
+ * @param options - The options for the isAuctionExpired function.
+ * @returns The encoded ABI parameters.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { encodeIsAuctionExpiredParams } "thirdweb/extensions/marketplace";
+ * const result = encodeIsAuctionExpiredParams({
+ *  auctionId: ...,
+ * });
+ * ```
+ */
+export function encodeIsAuctionExpiredParams(options: IsAuctionExpiredParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.auctionId]);
+}
+
+/**
+ * Decodes the result of the isAuctionExpired function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { decodeIsAuctionExpiredResult } from "thirdweb/extensions/marketplace";
+ * const result = decodeIsAuctionExpiredResult("...");
+ * ```
+ */
+export function decodeIsAuctionExpiredResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "isAuctionExpired" function on the contract.
@@ -32,20 +80,7 @@ export async function isAuctionExpired(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x1389b117",
-      [
-        {
-          type: "uint256",
-          name: "_auctionId",
-        },
-      ],
-      [
-        {
-          type: "bool",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.auctionId],
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/read/isNewWinningBid.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/read/isNewWinningBid.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "isNewWinningBid" function.
@@ -15,6 +18,56 @@ export type IsNewWinningBidParams = {
     name: "_bidAmount";
   }>;
 };
+
+const FN_SELECTOR = "0x2eb566bd" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_auctionId",
+  },
+  {
+    type: "uint256",
+    name: "_bidAmount",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bool",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "isNewWinningBid" function.
+ * @param options - The options for the isNewWinningBid function.
+ * @returns The encoded ABI parameters.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { encodeIsNewWinningBidParams } "thirdweb/extensions/marketplace";
+ * const result = encodeIsNewWinningBidParams({
+ *  auctionId: ...,
+ *  bidAmount: ...,
+ * });
+ * ```
+ */
+export function encodeIsNewWinningBidParams(options: IsNewWinningBidParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.auctionId, options.bidAmount]);
+}
+
+/**
+ * Decodes the result of the isNewWinningBid function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { decodeIsNewWinningBidResult } from "thirdweb/extensions/marketplace";
+ * const result = decodeIsNewWinningBidResult("...");
+ * ```
+ */
+export function decodeIsNewWinningBidResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "isNewWinningBid" function on the contract.
@@ -37,24 +90,7 @@ export async function isNewWinningBid(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x2eb566bd",
-      [
-        {
-          type: "uint256",
-          name: "_auctionId",
-        },
-        {
-          type: "uint256",
-          name: "_bidAmount",
-        },
-      ],
-      [
-        {
-          type: "bool",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.auctionId, options.bidAmount],
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/bidInAuction.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/bidInAuction.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "bidInAuction" function.
@@ -24,6 +25,37 @@ export type BidInAuctionParams = Prettify<
       asyncParams: () => Promise<BidInAuctionParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x0858e5ad" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_auctionId",
+  },
+  {
+    type: "uint256",
+    name: "_bidAmount",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "bidInAuction" function.
+ * @param options - The options for the bidInAuction function.
+ * @returns The encoded ABI parameters.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { encodeBidInAuctionParams } "thirdweb/extensions/marketplace";
+ * const result = encodeBidInAuctionParams({
+ *  auctionId: ...,
+ *  bidAmount: ...,
+ * });
+ * ```
+ */
+export function encodeBidInAuctionParams(options: BidInAuctionParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.auctionId, options.bidAmount]);
+}
+
 /**
  * Calls the "bidInAuction" function on the contract.
  * @param options - The options for the "bidInAuction" function.
@@ -48,20 +80,7 @@ export function bidInAuction(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x0858e5ad",
-      [
-        {
-          type: "uint256",
-          name: "_auctionId",
-        },
-        {
-          type: "uint256",
-          name: "_bidAmount",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/cancelAuction.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/cancelAuction.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "cancelAuction" function.
@@ -20,6 +21,34 @@ export type CancelAuctionParams = Prettify<
       asyncParams: () => Promise<CancelAuctionParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x96b5a755" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_auctionId",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "cancelAuction" function.
+ * @param options - The options for the cancelAuction function.
+ * @returns The encoded ABI parameters.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { encodeCancelAuctionParams } "thirdweb/extensions/marketplace";
+ * const result = encodeCancelAuctionParams({
+ *  auctionId: ...,
+ * });
+ * ```
+ */
+export function encodeCancelAuctionParams(
+  options: CancelAuctionParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.auctionId]);
+}
+
 /**
  * Calls the "cancelAuction" function on the contract.
  * @param options - The options for the "cancelAuction" function.
@@ -43,16 +72,7 @@ export function cancelAuction(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x96b5a755",
-      [
-        {
-          type: "uint256",
-          name: "_auctionId",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/collectAuctionPayout.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/collectAuctionPayout.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "collectAuctionPayout" function.
@@ -20,6 +21,34 @@ export type CollectAuctionPayoutParams = Prettify<
       asyncParams: () => Promise<CollectAuctionPayoutParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xebf05a62" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_auctionId",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "collectAuctionPayout" function.
+ * @param options - The options for the collectAuctionPayout function.
+ * @returns The encoded ABI parameters.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { encodeCollectAuctionPayoutParams } "thirdweb/extensions/marketplace";
+ * const result = encodeCollectAuctionPayoutParams({
+ *  auctionId: ...,
+ * });
+ * ```
+ */
+export function encodeCollectAuctionPayoutParams(
+  options: CollectAuctionPayoutParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.auctionId]);
+}
+
 /**
  * Calls the "collectAuctionPayout" function on the contract.
  * @param options - The options for the "collectAuctionPayout" function.
@@ -43,16 +72,7 @@ export function collectAuctionPayout(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xebf05a62",
-      [
-        {
-          type: "uint256",
-          name: "_auctionId",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/collectAuctionTokens.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/collectAuctionTokens.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "collectAuctionTokens" function.
@@ -20,6 +21,34 @@ export type CollectAuctionTokensParams = Prettify<
       asyncParams: () => Promise<CollectAuctionTokensParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x03a54fe0" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_auctionId",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "collectAuctionTokens" function.
+ * @param options - The options for the collectAuctionTokens function.
+ * @returns The encoded ABI parameters.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { encodeCollectAuctionTokensParams } "thirdweb/extensions/marketplace";
+ * const result = encodeCollectAuctionTokensParams({
+ *  auctionId: ...,
+ * });
+ * ```
+ */
+export function encodeCollectAuctionTokensParams(
+  options: CollectAuctionTokensParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.auctionId]);
+}
+
 /**
  * Calls the "collectAuctionTokens" function on the contract.
  * @param options - The options for the "collectAuctionTokens" function.
@@ -43,16 +72,7 @@ export function collectAuctionTokens(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x03a54fe0",
-      [
-        {
-          type: "uint256",
-          name: "_auctionId",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/createAuction.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/createAuction.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "createAuction" function.
@@ -32,6 +33,81 @@ export type CreateAuctionParams = Prettify<
       asyncParams: () => Promise<CreateAuctionParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x16654d40" as const;
+const FN_INPUTS = [
+  {
+    type: "tuple",
+    name: "_params",
+    components: [
+      {
+        type: "address",
+        name: "assetContract",
+      },
+      {
+        type: "uint256",
+        name: "tokenId",
+      },
+      {
+        type: "uint256",
+        name: "quantity",
+      },
+      {
+        type: "address",
+        name: "currency",
+      },
+      {
+        type: "uint256",
+        name: "minimumBidAmount",
+      },
+      {
+        type: "uint256",
+        name: "buyoutBidAmount",
+      },
+      {
+        type: "uint64",
+        name: "timeBufferInSeconds",
+      },
+      {
+        type: "uint64",
+        name: "bidBufferBps",
+      },
+      {
+        type: "uint64",
+        name: "startTimestamp",
+      },
+      {
+        type: "uint64",
+        name: "endTimestamp",
+      },
+    ],
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+    name: "auctionId",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "createAuction" function.
+ * @param options - The options for the createAuction function.
+ * @returns The encoded ABI parameters.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { encodeCreateAuctionParams } "thirdweb/extensions/marketplace";
+ * const result = encodeCreateAuctionParams({
+ *  params: ...,
+ * });
+ * ```
+ */
+export function encodeCreateAuctionParams(
+  options: CreateAuctionParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.params]);
+}
+
 /**
  * Calls the "createAuction" function on the contract.
  * @param options - The options for the "createAuction" function.
@@ -55,63 +131,7 @@ export function createAuction(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x16654d40",
-      [
-        {
-          type: "tuple",
-          name: "_params",
-          components: [
-            {
-              type: "address",
-              name: "assetContract",
-            },
-            {
-              type: "uint256",
-              name: "tokenId",
-            },
-            {
-              type: "uint256",
-              name: "quantity",
-            },
-            {
-              type: "address",
-              name: "currency",
-            },
-            {
-              type: "uint256",
-              name: "minimumBidAmount",
-            },
-            {
-              type: "uint256",
-              name: "buyoutBidAmount",
-            },
-            {
-              type: "uint64",
-              name: "timeBufferInSeconds",
-            },
-            {
-              type: "uint64",
-              name: "bidBufferBps",
-            },
-            {
-              type: "uint64",
-              name: "startTimestamp",
-            },
-            {
-              type: "uint64",
-              name: "endTimestamp",
-            },
-          ],
-        },
-      ],
-      [
-        {
-          type: "uint256",
-          name: "auctionId",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/read/contractType.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/read/contractType.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0xcb2ef6f7" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bytes32",
+  },
+] as const;
+
+/**
+ * Decodes the result of the contractType function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { decodeContractTypeResult } from "thirdweb/extensions/marketplace";
+ * const result = decodeContractTypeResult("...");
+ * ```
+ */
+export function decodeContractTypeResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "contractType" function on the contract.
  * @param options - The options for the contractType function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function contractType(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xcb2ef6f7",
-      [],
-      [
-        {
-          type: "bytes32",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/read/contractURI.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/read/contractURI.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0xe8a3d485" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "string",
+  },
+] as const;
+
+/**
+ * Decodes the result of the contractURI function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { decodeContractURIResult } from "thirdweb/extensions/marketplace";
+ * const result = decodeContractURIResult("...");
+ * ```
+ */
+export function decodeContractURIResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "contractURI" function on the contract.
  * @param options - The options for the contractURI function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function contractURI(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xe8a3d485",
-      [],
-      [
-        {
-          type: "string",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/read/contractVersion.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/read/contractVersion.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0xa0a8e460" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint8",
+  },
+] as const;
+
+/**
+ * Decodes the result of the contractVersion function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { decodeContractVersionResult } from "thirdweb/extensions/marketplace";
+ * const result = decodeContractVersionResult("...");
+ * ```
+ */
+export function decodeContractVersionResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "contractVersion" function on the contract.
  * @param options - The options for the contractVersion function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function contractVersion(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xa0a8e460",
-      [],
-      [
-        {
-          type: "uint8",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/read/getPlatformFeeInfo.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/read/getPlatformFeeInfo.ts
@@ -1,6 +1,35 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0xd45573f6" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "address",
+  },
+  {
+    type: "uint16",
+  },
+] as const;
+
+/**
+ * Decodes the result of the getPlatformFeeInfo function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { decodeGetPlatformFeeInfoResult } from "thirdweb/extensions/marketplace";
+ * const result = decodeGetPlatformFeeInfoResult("...");
+ * ```
+ */
+export function decodeGetPlatformFeeInfoResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result);
+}
+
 /**
  * Calls the "getPlatformFeeInfo" function on the contract.
  * @param options - The options for the getPlatformFeeInfo function.
@@ -17,18 +46,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function getPlatformFeeInfo(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xd45573f6",
-      [],
-      [
-        {
-          type: "address",
-        },
-        {
-          type: "uint16",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/acceptOffer.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/acceptOffer.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "acceptOffer" function.
@@ -26,6 +27,52 @@ export type AcceptOfferParams = Prettify<
       asyncParams: () => Promise<AcceptOfferParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xb13c0e63" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_listingId",
+  },
+  {
+    type: "address",
+    name: "_offeror",
+  },
+  {
+    type: "address",
+    name: "_currency",
+  },
+  {
+    type: "uint256",
+    name: "_totalPrice",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "acceptOffer" function.
+ * @param options - The options for the acceptOffer function.
+ * @returns The encoded ABI parameters.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { encodeAcceptOfferParams } "thirdweb/extensions/marketplace";
+ * const result = encodeAcceptOfferParams({
+ *  listingId: ...,
+ *  offeror: ...,
+ *  currency: ...,
+ *  totalPrice: ...,
+ * });
+ * ```
+ */
+export function encodeAcceptOfferParams(options: AcceptOfferParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.listingId,
+    options.offeror,
+    options.currency,
+    options.totalPrice,
+  ]);
+}
+
 /**
  * Calls the "acceptOffer" function on the contract.
  * @param options - The options for the "acceptOffer" function.
@@ -52,28 +99,7 @@ export function acceptOffer(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xb13c0e63",
-      [
-        {
-          type: "uint256",
-          name: "_listingId",
-        },
-        {
-          type: "address",
-          name: "_offeror",
-        },
-        {
-          type: "address",
-          name: "_currency",
-        },
-        {
-          type: "uint256",
-          name: "_totalPrice",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/buy.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/buy.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "buy" function.
@@ -27,6 +28,58 @@ export type BuyParams = Prettify<
       asyncParams: () => Promise<BuyParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x7687ab02" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_listingId",
+  },
+  {
+    type: "address",
+    name: "_buyFor",
+  },
+  {
+    type: "uint256",
+    name: "_quantity",
+  },
+  {
+    type: "address",
+    name: "_currency",
+  },
+  {
+    type: "uint256",
+    name: "_totalPrice",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "buy" function.
+ * @param options - The options for the buy function.
+ * @returns The encoded ABI parameters.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { encodeBuyParams } "thirdweb/extensions/marketplace";
+ * const result = encodeBuyParams({
+ *  listingId: ...,
+ *  buyFor: ...,
+ *  quantity: ...,
+ *  currency: ...,
+ *  totalPrice: ...,
+ * });
+ * ```
+ */
+export function encodeBuyParams(options: BuyParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.listingId,
+    options.buyFor,
+    options.quantity,
+    options.currency,
+    options.totalPrice,
+  ]);
+}
+
 /**
  * Calls the "buy" function on the contract.
  * @param options - The options for the "buy" function.
@@ -52,32 +105,7 @@ export type BuyParams = Prettify<
 export function buy(options: BaseTransactionOptions<BuyParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x7687ab02",
-      [
-        {
-          type: "uint256",
-          name: "_listingId",
-        },
-        {
-          type: "address",
-          name: "_buyFor",
-        },
-        {
-          type: "uint256",
-          name: "_quantity",
-        },
-        {
-          type: "address",
-          name: "_currency",
-        },
-        {
-          type: "uint256",
-          name: "_totalPrice",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/cancelDirectListing.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/cancelDirectListing.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "cancelDirectListing" function.
@@ -20,6 +21,34 @@ export type CancelDirectListingParams = Prettify<
       asyncParams: () => Promise<CancelDirectListingParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x7506c84a" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_listingId",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "cancelDirectListing" function.
+ * @param options - The options for the cancelDirectListing function.
+ * @returns The encoded ABI parameters.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { encodeCancelDirectListingParams } "thirdweb/extensions/marketplace";
+ * const result = encodeCancelDirectListingParams({
+ *  listingId: ...,
+ * });
+ * ```
+ */
+export function encodeCancelDirectListingParams(
+  options: CancelDirectListingParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.listingId]);
+}
+
 /**
  * Calls the "cancelDirectListing" function on the contract.
  * @param options - The options for the "cancelDirectListing" function.
@@ -43,16 +72,7 @@ export function cancelDirectListing(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x7506c84a",
-      [
-        {
-          type: "uint256",
-          name: "_listingId",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/closeAuction.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/closeAuction.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "closeAuction" function.
@@ -21,6 +22,37 @@ export type CloseAuctionParams = Prettify<
       asyncParams: () => Promise<CloseAuctionParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x6bab66ae" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_listingId",
+  },
+  {
+    type: "address",
+    name: "_closeFor",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "closeAuction" function.
+ * @param options - The options for the closeAuction function.
+ * @returns The encoded ABI parameters.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { encodeCloseAuctionParams } "thirdweb/extensions/marketplace";
+ * const result = encodeCloseAuctionParams({
+ *  listingId: ...,
+ *  closeFor: ...,
+ * });
+ * ```
+ */
+export function encodeCloseAuctionParams(options: CloseAuctionParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.listingId, options.closeFor]);
+}
+
 /**
  * Calls the "closeAuction" function on the contract.
  * @param options - The options for the "closeAuction" function.
@@ -45,20 +77,7 @@ export function closeAuction(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x6bab66ae",
-      [
-        {
-          type: "uint256",
-          name: "_listingId",
-        },
-        {
-          type: "address",
-          name: "_closeFor",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/createListing.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/createListing.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "createListing" function.
@@ -31,6 +32,72 @@ export type CreateListingParams = Prettify<
       asyncParams: () => Promise<CreateListingParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x296f4e16" as const;
+const FN_INPUTS = [
+  {
+    type: "tuple",
+    name: "_params",
+    components: [
+      {
+        type: "address",
+        name: "assetContract",
+      },
+      {
+        type: "uint256",
+        name: "tokenId",
+      },
+      {
+        type: "uint256",
+        name: "startTime",
+      },
+      {
+        type: "uint256",
+        name: "secondsUntilEndTime",
+      },
+      {
+        type: "uint256",
+        name: "quantityToList",
+      },
+      {
+        type: "address",
+        name: "currencyToAccept",
+      },
+      {
+        type: "uint256",
+        name: "reservePricePerToken",
+      },
+      {
+        type: "uint256",
+        name: "buyoutPricePerToken",
+      },
+      {
+        type: "uint8",
+        name: "listingType",
+      },
+    ],
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "createListing" function.
+ * @param options - The options for the createListing function.
+ * @returns The encoded ABI parameters.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { encodeCreateListingParams } "thirdweb/extensions/marketplace";
+ * const result = encodeCreateListingParams({
+ *  params: ...,
+ * });
+ * ```
+ */
+export function encodeCreateListingParams(
+  options: CreateListingParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.params]);
+}
+
 /**
  * Calls the "createListing" function on the contract.
  * @param options - The options for the "createListing" function.
@@ -54,54 +121,7 @@ export function createListing(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x296f4e16",
-      [
-        {
-          type: "tuple",
-          name: "_params",
-          components: [
-            {
-              type: "address",
-              name: "assetContract",
-            },
-            {
-              type: "uint256",
-              name: "tokenId",
-            },
-            {
-              type: "uint256",
-              name: "startTime",
-            },
-            {
-              type: "uint256",
-              name: "secondsUntilEndTime",
-            },
-            {
-              type: "uint256",
-              name: "quantityToList",
-            },
-            {
-              type: "address",
-              name: "currencyToAccept",
-            },
-            {
-              type: "uint256",
-              name: "reservePricePerToken",
-            },
-            {
-              type: "uint256",
-              name: "buyoutPricePerToken",
-            },
-            {
-              type: "uint8",
-              name: "listingType",
-            },
-          ],
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/offer.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/offer.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "offer" function.
@@ -33,6 +34,58 @@ export type OfferParams = Prettify<
       asyncParams: () => Promise<OfferParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x5fef45e7" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_listingId",
+  },
+  {
+    type: "uint256",
+    name: "_quantityWanted",
+  },
+  {
+    type: "address",
+    name: "_currency",
+  },
+  {
+    type: "uint256",
+    name: "_pricePerToken",
+  },
+  {
+    type: "uint256",
+    name: "_expirationTimestamp",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "offer" function.
+ * @param options - The options for the offer function.
+ * @returns The encoded ABI parameters.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { encodeOfferParams } "thirdweb/extensions/marketplace";
+ * const result = encodeOfferParams({
+ *  listingId: ...,
+ *  quantityWanted: ...,
+ *  currency: ...,
+ *  pricePerToken: ...,
+ *  expirationTimestamp: ...,
+ * });
+ * ```
+ */
+export function encodeOfferParams(options: OfferParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.listingId,
+    options.quantityWanted,
+    options.currency,
+    options.pricePerToken,
+    options.expirationTimestamp,
+  ]);
+}
+
 /**
  * Calls the "offer" function on the contract.
  * @param options - The options for the "offer" function.
@@ -58,32 +111,7 @@ export type OfferParams = Prettify<
 export function offer(options: BaseTransactionOptions<OfferParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x5fef45e7",
-      [
-        {
-          type: "uint256",
-          name: "_listingId",
-        },
-        {
-          type: "uint256",
-          name: "_quantityWanted",
-        },
-        {
-          type: "address",
-          name: "_currency",
-        },
-        {
-          type: "uint256",
-          name: "_pricePerToken",
-        },
-        {
-          type: "uint256",
-          name: "_expirationTimestamp",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/setContractURI.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/setContractURI.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "setContractURI" function.
@@ -17,6 +18,34 @@ export type SetContractURIParams = Prettify<
       asyncParams: () => Promise<SetContractURIParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x938e3d7b" as const;
+const FN_INPUTS = [
+  {
+    type: "string",
+    name: "_uri",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "setContractURI" function.
+ * @param options - The options for the setContractURI function.
+ * @returns The encoded ABI parameters.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { encodeSetContractURIParams } "thirdweb/extensions/marketplace";
+ * const result = encodeSetContractURIParams({
+ *  uri: ...,
+ * });
+ * ```
+ */
+export function encodeSetContractURIParams(
+  options: SetContractURIParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.uri]);
+}
+
 /**
  * Calls the "setContractURI" function on the contract.
  * @param options - The options for the "setContractURI" function.
@@ -40,16 +69,7 @@ export function setContractURI(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x938e3d7b",
-      [
-        {
-          type: "string",
-          name: "_uri",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/setPlatformFeeInfo.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/setPlatformFeeInfo.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "setPlatformFeeInfo" function.
@@ -24,6 +25,42 @@ export type SetPlatformFeeInfoParams = Prettify<
       asyncParams: () => Promise<SetPlatformFeeInfoParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x1e7ac488" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "_platformFeeRecipient",
+  },
+  {
+    type: "uint256",
+    name: "_platformFeeBps",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "setPlatformFeeInfo" function.
+ * @param options - The options for the setPlatformFeeInfo function.
+ * @returns The encoded ABI parameters.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { encodeSetPlatformFeeInfoParams } "thirdweb/extensions/marketplace";
+ * const result = encodeSetPlatformFeeInfoParams({
+ *  platformFeeRecipient: ...,
+ *  platformFeeBps: ...,
+ * });
+ * ```
+ */
+export function encodeSetPlatformFeeInfoParams(
+  options: SetPlatformFeeInfoParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.platformFeeRecipient,
+    options.platformFeeBps,
+  ]);
+}
+
 /**
  * Calls the "setPlatformFeeInfo" function on the contract.
  * @param options - The options for the "setPlatformFeeInfo" function.
@@ -48,20 +85,7 @@ export function setPlatformFeeInfo(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x1e7ac488",
-      [
-        {
-          type: "address",
-          name: "_platformFeeRecipient",
-        },
-        {
-          type: "uint256",
-          name: "_platformFeeBps",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/updateListing.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/updateListing.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "updateListing" function.
@@ -44,6 +45,72 @@ export type UpdateListingParams = Prettify<
       asyncParams: () => Promise<UpdateListingParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xc4b5b15f" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_listingId",
+  },
+  {
+    type: "uint256",
+    name: "_quantityToList",
+  },
+  {
+    type: "uint256",
+    name: "_reservePricePerToken",
+  },
+  {
+    type: "uint256",
+    name: "_buyoutPricePerToken",
+  },
+  {
+    type: "address",
+    name: "_currencyToAccept",
+  },
+  {
+    type: "uint256",
+    name: "_startTime",
+  },
+  {
+    type: "uint256",
+    name: "_secondsUntilEndTime",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "updateListing" function.
+ * @param options - The options for the updateListing function.
+ * @returns The encoded ABI parameters.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { encodeUpdateListingParams } "thirdweb/extensions/marketplace";
+ * const result = encodeUpdateListingParams({
+ *  listingId: ...,
+ *  quantityToList: ...,
+ *  reservePricePerToken: ...,
+ *  buyoutPricePerToken: ...,
+ *  currencyToAccept: ...,
+ *  startTime: ...,
+ *  secondsUntilEndTime: ...,
+ * });
+ * ```
+ */
+export function encodeUpdateListingParams(
+  options: UpdateListingParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.listingId,
+    options.quantityToList,
+    options.reservePricePerToken,
+    options.buyoutPricePerToken,
+    options.currencyToAccept,
+    options.startTime,
+    options.secondsUntilEndTime,
+  ]);
+}
+
 /**
  * Calls the "updateListing" function on the contract.
  * @param options - The options for the "updateListing" function.
@@ -73,40 +140,7 @@ export function updateListing(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xc4b5b15f",
-      [
-        {
-          type: "uint256",
-          name: "_listingId",
-        },
-        {
-          type: "uint256",
-          name: "_quantityToList",
-        },
-        {
-          type: "uint256",
-          name: "_reservePricePerToken",
-        },
-        {
-          type: "uint256",
-          name: "_buyoutPricePerToken",
-        },
-        {
-          type: "address",
-          name: "_currencyToAccept",
-        },
-        {
-          type: "uint256",
-          name: "_startTime",
-        },
-        {
-          type: "uint256",
-          name: "_secondsUntilEndTime",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IOffers/read/getAllOffers.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IOffers/read/getAllOffers.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "getAllOffers" function.
@@ -9,6 +12,99 @@ export type GetAllOffersParams = {
   startId: AbiParameterToPrimitiveType<{ type: "uint256"; name: "_startId" }>;
   endId: AbiParameterToPrimitiveType<{ type: "uint256"; name: "_endId" }>;
 };
+
+const FN_SELECTOR = "0xc1edcfbe" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_startId",
+  },
+  {
+    type: "uint256",
+    name: "_endId",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "tuple[]",
+    name: "offers",
+    components: [
+      {
+        type: "uint256",
+        name: "offerId",
+      },
+      {
+        type: "uint256",
+        name: "tokenId",
+      },
+      {
+        type: "uint256",
+        name: "quantity",
+      },
+      {
+        type: "uint256",
+        name: "totalPrice",
+      },
+      {
+        type: "uint256",
+        name: "expirationTimestamp",
+      },
+      {
+        type: "address",
+        name: "offeror",
+      },
+      {
+        type: "address",
+        name: "assetContract",
+      },
+      {
+        type: "address",
+        name: "currency",
+      },
+      {
+        type: "uint8",
+        name: "tokenType",
+      },
+      {
+        type: "uint8",
+        name: "status",
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getAllOffers" function.
+ * @param options - The options for the getAllOffers function.
+ * @returns The encoded ABI parameters.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { encodeGetAllOffersParams } "thirdweb/extensions/marketplace";
+ * const result = encodeGetAllOffersParams({
+ *  startId: ...,
+ *  endId: ...,
+ * });
+ * ```
+ */
+export function encodeGetAllOffersParams(options: GetAllOffersParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.startId, options.endId]);
+}
+
+/**
+ * Decodes the result of the getAllOffers function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { decodeGetAllOffersResult } from "thirdweb/extensions/marketplace";
+ * const result = decodeGetAllOffersResult("...");
+ * ```
+ */
+export function decodeGetAllOffersResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "getAllOffers" function on the contract.
@@ -31,67 +127,7 @@ export async function getAllOffers(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xc1edcfbe",
-      [
-        {
-          type: "uint256",
-          name: "_startId",
-        },
-        {
-          type: "uint256",
-          name: "_endId",
-        },
-      ],
-      [
-        {
-          type: "tuple[]",
-          name: "offers",
-          components: [
-            {
-              type: "uint256",
-              name: "offerId",
-            },
-            {
-              type: "uint256",
-              name: "tokenId",
-            },
-            {
-              type: "uint256",
-              name: "quantity",
-            },
-            {
-              type: "uint256",
-              name: "totalPrice",
-            },
-            {
-              type: "uint256",
-              name: "expirationTimestamp",
-            },
-            {
-              type: "address",
-              name: "offeror",
-            },
-            {
-              type: "address",
-              name: "assetContract",
-            },
-            {
-              type: "address",
-              name: "currency",
-            },
-            {
-              type: "uint8",
-              name: "tokenType",
-            },
-            {
-              type: "uint8",
-              name: "status",
-            },
-          ],
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.startId, options.endId],
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IOffers/read/getAllValidOffers.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IOffers/read/getAllValidOffers.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "getAllValidOffers" function.
@@ -9,6 +12,101 @@ export type GetAllValidOffersParams = {
   startId: AbiParameterToPrimitiveType<{ type: "uint256"; name: "_startId" }>;
   endId: AbiParameterToPrimitiveType<{ type: "uint256"; name: "_endId" }>;
 };
+
+const FN_SELECTOR = "0x91940b3e" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_startId",
+  },
+  {
+    type: "uint256",
+    name: "_endId",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "tuple[]",
+    name: "offers",
+    components: [
+      {
+        type: "uint256",
+        name: "offerId",
+      },
+      {
+        type: "uint256",
+        name: "tokenId",
+      },
+      {
+        type: "uint256",
+        name: "quantity",
+      },
+      {
+        type: "uint256",
+        name: "totalPrice",
+      },
+      {
+        type: "uint256",
+        name: "expirationTimestamp",
+      },
+      {
+        type: "address",
+        name: "offeror",
+      },
+      {
+        type: "address",
+        name: "assetContract",
+      },
+      {
+        type: "address",
+        name: "currency",
+      },
+      {
+        type: "uint8",
+        name: "tokenType",
+      },
+      {
+        type: "uint8",
+        name: "status",
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getAllValidOffers" function.
+ * @param options - The options for the getAllValidOffers function.
+ * @returns The encoded ABI parameters.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { encodeGetAllValidOffersParams } "thirdweb/extensions/marketplace";
+ * const result = encodeGetAllValidOffersParams({
+ *  startId: ...,
+ *  endId: ...,
+ * });
+ * ```
+ */
+export function encodeGetAllValidOffersParams(
+  options: GetAllValidOffersParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.startId, options.endId]);
+}
+
+/**
+ * Decodes the result of the getAllValidOffers function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { decodeGetAllValidOffersResult } from "thirdweb/extensions/marketplace";
+ * const result = decodeGetAllValidOffersResult("...");
+ * ```
+ */
+export function decodeGetAllValidOffersResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "getAllValidOffers" function on the contract.
@@ -31,67 +129,7 @@ export async function getAllValidOffers(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x91940b3e",
-      [
-        {
-          type: "uint256",
-          name: "_startId",
-        },
-        {
-          type: "uint256",
-          name: "_endId",
-        },
-      ],
-      [
-        {
-          type: "tuple[]",
-          name: "offers",
-          components: [
-            {
-              type: "uint256",
-              name: "offerId",
-            },
-            {
-              type: "uint256",
-              name: "tokenId",
-            },
-            {
-              type: "uint256",
-              name: "quantity",
-            },
-            {
-              type: "uint256",
-              name: "totalPrice",
-            },
-            {
-              type: "uint256",
-              name: "expirationTimestamp",
-            },
-            {
-              type: "address",
-              name: "offeror",
-            },
-            {
-              type: "address",
-              name: "assetContract",
-            },
-            {
-              type: "address",
-              name: "currency",
-            },
-            {
-              type: "uint8",
-              name: "tokenType",
-            },
-            {
-              type: "uint8",
-              name: "status",
-            },
-          ],
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.startId, options.endId],
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IOffers/read/getOffer.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IOffers/read/getOffer.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "getOffer" function.
@@ -8,6 +11,94 @@ import type { AbiParameterToPrimitiveType } from "abitype";
 export type GetOfferParams = {
   offerId: AbiParameterToPrimitiveType<{ type: "uint256"; name: "_offerId" }>;
 };
+
+const FN_SELECTOR = "0x4579268a" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_offerId",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "tuple",
+    name: "offer",
+    components: [
+      {
+        type: "uint256",
+        name: "offerId",
+      },
+      {
+        type: "uint256",
+        name: "tokenId",
+      },
+      {
+        type: "uint256",
+        name: "quantity",
+      },
+      {
+        type: "uint256",
+        name: "totalPrice",
+      },
+      {
+        type: "uint256",
+        name: "expirationTimestamp",
+      },
+      {
+        type: "address",
+        name: "offeror",
+      },
+      {
+        type: "address",
+        name: "assetContract",
+      },
+      {
+        type: "address",
+        name: "currency",
+      },
+      {
+        type: "uint8",
+        name: "tokenType",
+      },
+      {
+        type: "uint8",
+        name: "status",
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getOffer" function.
+ * @param options - The options for the getOffer function.
+ * @returns The encoded ABI parameters.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { encodeGetOfferParams } "thirdweb/extensions/marketplace";
+ * const result = encodeGetOfferParams({
+ *  offerId: ...,
+ * });
+ * ```
+ */
+export function encodeGetOfferParams(options: GetOfferParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.offerId]);
+}
+
+/**
+ * Decodes the result of the getOffer function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { decodeGetOfferResult } from "thirdweb/extensions/marketplace";
+ * const result = decodeGetOfferResult("...");
+ * ```
+ */
+export function decodeGetOfferResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "getOffer" function on the contract.
@@ -29,63 +120,7 @@ export async function getOffer(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x4579268a",
-      [
-        {
-          type: "uint256",
-          name: "_offerId",
-        },
-      ],
-      [
-        {
-          type: "tuple",
-          name: "offer",
-          components: [
-            {
-              type: "uint256",
-              name: "offerId",
-            },
-            {
-              type: "uint256",
-              name: "tokenId",
-            },
-            {
-              type: "uint256",
-              name: "quantity",
-            },
-            {
-              type: "uint256",
-              name: "totalPrice",
-            },
-            {
-              type: "uint256",
-              name: "expirationTimestamp",
-            },
-            {
-              type: "address",
-              name: "offeror",
-            },
-            {
-              type: "address",
-              name: "assetContract",
-            },
-            {
-              type: "address",
-              name: "currency",
-            },
-            {
-              type: "uint8",
-              name: "tokenType",
-            },
-            {
-              type: "uint8",
-              name: "status",
-            },
-          ],
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.offerId],
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IOffers/write/acceptOffer.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IOffers/write/acceptOffer.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "acceptOffer" function.
@@ -17,6 +18,32 @@ export type AcceptOfferParams = Prettify<
       asyncParams: () => Promise<AcceptOfferParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xc815729d" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_offerId",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "acceptOffer" function.
+ * @param options - The options for the acceptOffer function.
+ * @returns The encoded ABI parameters.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { encodeAcceptOfferParams } "thirdweb/extensions/marketplace";
+ * const result = encodeAcceptOfferParams({
+ *  offerId: ...,
+ * });
+ * ```
+ */
+export function encodeAcceptOfferParams(options: AcceptOfferParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.offerId]);
+}
+
 /**
  * Calls the "acceptOffer" function on the contract.
  * @param options - The options for the "acceptOffer" function.
@@ -40,16 +67,7 @@ export function acceptOffer(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xc815729d",
-      [
-        {
-          type: "uint256",
-          name: "_offerId",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IOffers/write/cancelOffer.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IOffers/write/cancelOffer.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "cancelOffer" function.
@@ -17,6 +18,32 @@ export type CancelOfferParams = Prettify<
       asyncParams: () => Promise<CancelOfferParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xef706adf" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_offerId",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "cancelOffer" function.
+ * @param options - The options for the cancelOffer function.
+ * @returns The encoded ABI parameters.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { encodeCancelOfferParams } "thirdweb/extensions/marketplace";
+ * const result = encodeCancelOfferParams({
+ *  offerId: ...,
+ * });
+ * ```
+ */
+export function encodeCancelOfferParams(options: CancelOfferParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.offerId]);
+}
+
 /**
  * Calls the "cancelOffer" function on the contract.
  * @param options - The options for the "cancelOffer" function.
@@ -40,16 +67,7 @@ export function cancelOffer(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xef706adf",
-      [
-        {
-          type: "uint256",
-          name: "_offerId",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IOffers/write/makeOffer.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IOffers/write/makeOffer.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "makeOffer" function.
@@ -28,6 +29,63 @@ export type MakeOfferParams = Prettify<
       asyncParams: () => Promise<MakeOfferParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x016767fa" as const;
+const FN_INPUTS = [
+  {
+    type: "tuple",
+    name: "_params",
+    components: [
+      {
+        type: "address",
+        name: "assetContract",
+      },
+      {
+        type: "uint256",
+        name: "tokenId",
+      },
+      {
+        type: "uint256",
+        name: "quantity",
+      },
+      {
+        type: "address",
+        name: "currency",
+      },
+      {
+        type: "uint256",
+        name: "totalPrice",
+      },
+      {
+        type: "uint256",
+        name: "expirationTimestamp",
+      },
+    ],
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+    name: "offerId",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "makeOffer" function.
+ * @param options - The options for the makeOffer function.
+ * @returns The encoded ABI parameters.
+ * @extension MARKETPLACE
+ * @example
+ * ```
+ * import { encodeMakeOfferParams } "thirdweb/extensions/marketplace";
+ * const result = encodeMakeOfferParams({
+ *  params: ...,
+ * });
+ * ```
+ */
+export function encodeMakeOfferParams(options: MakeOfferParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.params]);
+}
+
 /**
  * Calls the "makeOffer" function on the contract.
  * @param options - The options for the "makeOffer" function.
@@ -49,47 +107,7 @@ export type MakeOfferParams = Prettify<
 export function makeOffer(options: BaseTransactionOptions<MakeOfferParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x016767fa",
-      [
-        {
-          type: "tuple",
-          name: "_params",
-          components: [
-            {
-              type: "address",
-              name: "assetContract",
-            },
-            {
-              type: "uint256",
-              name: "tokenId",
-            },
-            {
-              type: "uint256",
-              name: "quantity",
-            },
-            {
-              type: "address",
-              name: "currency",
-            },
-            {
-              type: "uint256",
-              name: "totalPrice",
-            },
-            {
-              type: "uint256",
-              name: "expirationTimestamp",
-            },
-          ],
-        },
-      ],
-      [
-        {
-          type: "uint256",
-          name: "offerId",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/prebuilts/__generated__/DropERC721/write/initialize.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/__generated__/DropERC721/write/initialize.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "initialize" function.
@@ -50,6 +51,88 @@ export type InitializeParams = Prettify<
       asyncParams: () => Promise<InitializeParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xe1591634" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "_defaultAdmin",
+  },
+  {
+    type: "string",
+    name: "_name",
+  },
+  {
+    type: "string",
+    name: "_symbol",
+  },
+  {
+    type: "string",
+    name: "_contractURI",
+  },
+  {
+    type: "address[]",
+    name: "_trustedForwarders",
+  },
+  {
+    type: "address",
+    name: "_saleRecipient",
+  },
+  {
+    type: "address",
+    name: "_royaltyRecipient",
+  },
+  {
+    type: "uint128",
+    name: "_royaltyBps",
+  },
+  {
+    type: "uint128",
+    name: "_platformFeeBps",
+  },
+  {
+    type: "address",
+    name: "_platformFeeRecipient",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "initialize" function.
+ * @param options - The options for the initialize function.
+ * @returns The encoded ABI parameters.
+ * @extension PREBUILTS
+ * @example
+ * ```
+ * import { encodeInitializeParams } "thirdweb/extensions/prebuilts";
+ * const result = encodeInitializeParams({
+ *  defaultAdmin: ...,
+ *  name: ...,
+ *  symbol: ...,
+ *  contractURI: ...,
+ *  trustedForwarders: ...,
+ *  saleRecipient: ...,
+ *  royaltyRecipient: ...,
+ *  royaltyBps: ...,
+ *  platformFeeBps: ...,
+ *  platformFeeRecipient: ...,
+ * });
+ * ```
+ */
+export function encodeInitializeParams(options: InitializeParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.defaultAdmin,
+    options.name,
+    options.symbol,
+    options.contractURI,
+    options.trustedForwarders,
+    options.saleRecipient,
+    options.royaltyRecipient,
+    options.royaltyBps,
+    options.platformFeeBps,
+    options.platformFeeRecipient,
+  ]);
+}
+
 /**
  * Calls the "initialize" function on the contract.
  * @param options - The options for the "initialize" function.
@@ -80,52 +163,7 @@ export type InitializeParams = Prettify<
 export function initialize(options: BaseTransactionOptions<InitializeParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xe1591634",
-      [
-        {
-          type: "address",
-          name: "_defaultAdmin",
-        },
-        {
-          type: "string",
-          name: "_name",
-        },
-        {
-          type: "string",
-          name: "_symbol",
-        },
-        {
-          type: "string",
-          name: "_contractURI",
-        },
-        {
-          type: "address[]",
-          name: "_trustedForwarders",
-        },
-        {
-          type: "address",
-          name: "_saleRecipient",
-        },
-        {
-          type: "address",
-          name: "_royaltyRecipient",
-        },
-        {
-          type: "uint128",
-          name: "_royaltyBps",
-        },
-        {
-          type: "uint128",
-          name: "_platformFeeBps",
-        },
-        {
-          type: "address",
-          name: "_platformFeeRecipient",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/IAppURI/read/appURI.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/IAppURI/read/appURI.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x094ec830" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "string",
+  },
+] as const;
+
+/**
+ * Decodes the result of the appURI function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension THIRDWEB
+ * @example
+ * ```
+ * import { decodeAppURIResult } from "thirdweb/extensions/thirdweb";
+ * const result = decodeAppURIResult("...");
+ * ```
+ */
+export function decodeAppURIResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "appURI" function on the contract.
  * @param options - The options for the appURI function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function appURI(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x094ec830",
-      [],
-      [
-        {
-          type: "string",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/IAppURI/write/setAppURI.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/IAppURI/write/setAppURI.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "setAppURI" function.
@@ -17,6 +18,32 @@ export type SetAppURIParams = Prettify<
       asyncParams: () => Promise<SetAppURIParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xfea18082" as const;
+const FN_INPUTS = [
+  {
+    type: "string",
+    name: "_uri",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "setAppURI" function.
+ * @param options - The options for the setAppURI function.
+ * @returns The encoded ABI parameters.
+ * @extension THIRDWEB
+ * @example
+ * ```
+ * import { encodeSetAppURIParams } "thirdweb/extensions/thirdweb";
+ * const result = encodeSetAppURIParams({
+ *  uri: ...,
+ * });
+ * ```
+ */
+export function encodeSetAppURIParams(options: SetAppURIParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.uri]);
+}
+
 /**
  * Calls the "setAppURI" function on the contract.
  * @param options - The options for the "setAppURI" function.
@@ -38,16 +65,7 @@ export type SetAppURIParams = Prettify<
 export function setAppURI(options: BaseTransactionOptions<SetAppURIParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xfea18082",
-      [
-        {
-          type: "string",
-          name: "_uri",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/IContractFactory/write/deployProxyByImplementation.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/IContractFactory/write/deployProxyByImplementation.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "deployProxyByImplementation" function.
@@ -22,6 +23,52 @@ export type DeployProxyByImplementationParams = Prettify<
       asyncParams: () => Promise<DeployProxyByImplementationParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x11b804ab" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "implementation",
+  },
+  {
+    type: "bytes",
+    name: "data",
+  },
+  {
+    type: "bytes32",
+    name: "salt",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "address",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "deployProxyByImplementation" function.
+ * @param options - The options for the deployProxyByImplementation function.
+ * @returns The encoded ABI parameters.
+ * @extension THIRDWEB
+ * @example
+ * ```
+ * import { encodeDeployProxyByImplementationParams } "thirdweb/extensions/thirdweb";
+ * const result = encodeDeployProxyByImplementationParams({
+ *  implementation: ...,
+ *  data: ...,
+ *  salt: ...,
+ * });
+ * ```
+ */
+export function encodeDeployProxyByImplementationParams(
+  options: DeployProxyByImplementationParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.implementation,
+    options.data,
+    options.salt,
+  ]);
+}
+
 /**
  * Calls the "deployProxyByImplementation" function on the contract.
  * @param options - The options for the "deployProxyByImplementation" function.
@@ -47,28 +94,7 @@ export function deployProxyByImplementation(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x11b804ab",
-      [
-        {
-          type: "address",
-          name: "implementation",
-        },
-        {
-          type: "bytes",
-          name: "data",
-        },
-        {
-          type: "bytes32",
-          name: "salt",
-        },
-      ],
-      [
-        {
-          type: "address",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/read/getAllPublishedContracts.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/read/getAllPublishedContracts.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "getAllPublishedContracts" function.
@@ -11,6 +14,76 @@ export type GetAllPublishedContractsParams = {
     name: "publisher";
   }>;
 };
+
+const FN_SELECTOR = "0xaf8db690" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "publisher",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "tuple[]",
+    name: "published",
+    components: [
+      {
+        type: "string",
+        name: "contractId",
+      },
+      {
+        type: "uint256",
+        name: "publishTimestamp",
+      },
+      {
+        type: "string",
+        name: "publishMetadataUri",
+      },
+      {
+        type: "bytes32",
+        name: "bytecodeHash",
+      },
+      {
+        type: "address",
+        name: "implementation",
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getAllPublishedContracts" function.
+ * @param options - The options for the getAllPublishedContracts function.
+ * @returns The encoded ABI parameters.
+ * @extension THIRDWEB
+ * @example
+ * ```
+ * import { encodeGetAllPublishedContractsParams } "thirdweb/extensions/thirdweb";
+ * const result = encodeGetAllPublishedContractsParams({
+ *  publisher: ...,
+ * });
+ * ```
+ */
+export function encodeGetAllPublishedContractsParams(
+  options: GetAllPublishedContractsParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.publisher]);
+}
+
+/**
+ * Decodes the result of the getAllPublishedContracts function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension THIRDWEB
+ * @example
+ * ```
+ * import { decodeGetAllPublishedContractsResult } from "thirdweb/extensions/thirdweb";
+ * const result = decodeGetAllPublishedContractsResult("...");
+ * ```
+ */
+export function decodeGetAllPublishedContractsResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "getAllPublishedContracts" function on the contract.
@@ -32,43 +105,7 @@ export async function getAllPublishedContracts(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xaf8db690",
-      [
-        {
-          type: "address",
-          name: "publisher",
-        },
-      ],
-      [
-        {
-          type: "tuple[]",
-          name: "published",
-          components: [
-            {
-              type: "string",
-              name: "contractId",
-            },
-            {
-              type: "uint256",
-              name: "publishTimestamp",
-            },
-            {
-              type: "string",
-              name: "publishMetadataUri",
-            },
-            {
-              type: "bytes32",
-              name: "bytecodeHash",
-            },
-            {
-              type: "address",
-              name: "implementation",
-            },
-          ],
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.publisher],
   });
 }

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/read/getPublishedContract.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/read/getPublishedContract.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "getPublishedContract" function.
@@ -15,6 +18,84 @@ export type GetPublishedContractParams = {
     name: "contractId";
   }>;
 };
+
+const FN_SELECTOR = "0x7ec047fa" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "publisher",
+  },
+  {
+    type: "string",
+    name: "contractId",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "tuple",
+    name: "published",
+    components: [
+      {
+        type: "string",
+        name: "contractId",
+      },
+      {
+        type: "uint256",
+        name: "publishTimestamp",
+      },
+      {
+        type: "string",
+        name: "publishMetadataUri",
+      },
+      {
+        type: "bytes32",
+        name: "bytecodeHash",
+      },
+      {
+        type: "address",
+        name: "implementation",
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getPublishedContract" function.
+ * @param options - The options for the getPublishedContract function.
+ * @returns The encoded ABI parameters.
+ * @extension THIRDWEB
+ * @example
+ * ```
+ * import { encodeGetPublishedContractParams } "thirdweb/extensions/thirdweb";
+ * const result = encodeGetPublishedContractParams({
+ *  publisher: ...,
+ *  contractId: ...,
+ * });
+ * ```
+ */
+export function encodeGetPublishedContractParams(
+  options: GetPublishedContractParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.publisher,
+    options.contractId,
+  ]);
+}
+
+/**
+ * Decodes the result of the getPublishedContract function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension THIRDWEB
+ * @example
+ * ```
+ * import { decodeGetPublishedContractResult } from "thirdweb/extensions/thirdweb";
+ * const result = decodeGetPublishedContractResult("...");
+ * ```
+ */
+export function decodeGetPublishedContractResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "getPublishedContract" function on the contract.
@@ -37,47 +118,7 @@ export async function getPublishedContract(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x7ec047fa",
-      [
-        {
-          type: "address",
-          name: "publisher",
-        },
-        {
-          type: "string",
-          name: "contractId",
-        },
-      ],
-      [
-        {
-          type: "tuple",
-          name: "published",
-          components: [
-            {
-              type: "string",
-              name: "contractId",
-            },
-            {
-              type: "uint256",
-              name: "publishTimestamp",
-            },
-            {
-              type: "string",
-              name: "publishMetadataUri",
-            },
-            {
-              type: "bytes32",
-              name: "bytecodeHash",
-            },
-            {
-              type: "address",
-              name: "implementation",
-            },
-          ],
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.publisher, options.contractId],
   });
 }

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/read/getPublishedContractVersions.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/read/getPublishedContractVersions.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "getPublishedContractVersions" function.
@@ -15,6 +18,84 @@ export type GetPublishedContractVersionsParams = {
     name: "contractId";
   }>;
 };
+
+const FN_SELECTOR = "0x80251dac" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "publisher",
+  },
+  {
+    type: "string",
+    name: "contractId",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "tuple[]",
+    name: "published",
+    components: [
+      {
+        type: "string",
+        name: "contractId",
+      },
+      {
+        type: "uint256",
+        name: "publishTimestamp",
+      },
+      {
+        type: "string",
+        name: "publishMetadataUri",
+      },
+      {
+        type: "bytes32",
+        name: "bytecodeHash",
+      },
+      {
+        type: "address",
+        name: "implementation",
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getPublishedContractVersions" function.
+ * @param options - The options for the getPublishedContractVersions function.
+ * @returns The encoded ABI parameters.
+ * @extension THIRDWEB
+ * @example
+ * ```
+ * import { encodeGetPublishedContractVersionsParams } "thirdweb/extensions/thirdweb";
+ * const result = encodeGetPublishedContractVersionsParams({
+ *  publisher: ...,
+ *  contractId: ...,
+ * });
+ * ```
+ */
+export function encodeGetPublishedContractVersionsParams(
+  options: GetPublishedContractVersionsParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.publisher,
+    options.contractId,
+  ]);
+}
+
+/**
+ * Decodes the result of the getPublishedContractVersions function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension THIRDWEB
+ * @example
+ * ```
+ * import { decodeGetPublishedContractVersionsResult } from "thirdweb/extensions/thirdweb";
+ * const result = decodeGetPublishedContractVersionsResult("...");
+ * ```
+ */
+export function decodeGetPublishedContractVersionsResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "getPublishedContractVersions" function on the contract.
@@ -37,47 +118,7 @@ export async function getPublishedContractVersions(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x80251dac",
-      [
-        {
-          type: "address",
-          name: "publisher",
-        },
-        {
-          type: "string",
-          name: "contractId",
-        },
-      ],
-      [
-        {
-          type: "tuple[]",
-          name: "published",
-          components: [
-            {
-              type: "string",
-              name: "contractId",
-            },
-            {
-              type: "uint256",
-              name: "publishTimestamp",
-            },
-            {
-              type: "string",
-              name: "publishMetadataUri",
-            },
-            {
-              type: "bytes32",
-              name: "bytecodeHash",
-            },
-            {
-              type: "address",
-              name: "implementation",
-            },
-          ],
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.publisher, options.contractId],
   });
 }

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/read/getPublishedUriFromCompilerUri.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/read/getPublishedUriFromCompilerUri.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "getPublishedUriFromCompilerUri" function.
@@ -11,6 +14,54 @@ export type GetPublishedUriFromCompilerUriParams = {
     name: "compilerMetadataUri";
   }>;
 };
+
+const FN_SELECTOR = "0x819e992f" as const;
+const FN_INPUTS = [
+  {
+    type: "string",
+    name: "compilerMetadataUri",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "string[]",
+    name: "publishedMetadataUris",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getPublishedUriFromCompilerUri" function.
+ * @param options - The options for the getPublishedUriFromCompilerUri function.
+ * @returns The encoded ABI parameters.
+ * @extension THIRDWEB
+ * @example
+ * ```
+ * import { encodeGetPublishedUriFromCompilerUriParams } "thirdweb/extensions/thirdweb";
+ * const result = encodeGetPublishedUriFromCompilerUriParams({
+ *  compilerMetadataUri: ...,
+ * });
+ * ```
+ */
+export function encodeGetPublishedUriFromCompilerUriParams(
+  options: GetPublishedUriFromCompilerUriParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.compilerMetadataUri]);
+}
+
+/**
+ * Decodes the result of the getPublishedUriFromCompilerUri function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension THIRDWEB
+ * @example
+ * ```
+ * import { decodeGetPublishedUriFromCompilerUriResult } from "thirdweb/extensions/thirdweb";
+ * const result = decodeGetPublishedUriFromCompilerUriResult("...");
+ * ```
+ */
+export function decodeGetPublishedUriFromCompilerUriResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "getPublishedUriFromCompilerUri" function on the contract.
@@ -32,21 +83,7 @@ export async function getPublishedUriFromCompilerUri(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x819e992f",
-      [
-        {
-          type: "string",
-          name: "compilerMetadataUri",
-        },
-      ],
-      [
-        {
-          type: "string[]",
-          name: "publishedMetadataUris",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.compilerMetadataUri],
   });
 }

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/read/getPublisherProfileUri.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/read/getPublisherProfileUri.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "getPublisherProfileUri" function.
@@ -11,6 +14,54 @@ export type GetPublisherProfileUriParams = {
     name: "publisher";
   }>;
 };
+
+const FN_SELECTOR = "0x4f781675" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "publisher",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "string",
+    name: "uri",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getPublisherProfileUri" function.
+ * @param options - The options for the getPublisherProfileUri function.
+ * @returns The encoded ABI parameters.
+ * @extension THIRDWEB
+ * @example
+ * ```
+ * import { encodeGetPublisherProfileUriParams } "thirdweb/extensions/thirdweb";
+ * const result = encodeGetPublisherProfileUriParams({
+ *  publisher: ...,
+ * });
+ * ```
+ */
+export function encodeGetPublisherProfileUriParams(
+  options: GetPublisherProfileUriParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.publisher]);
+}
+
+/**
+ * Decodes the result of the getPublisherProfileUri function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension THIRDWEB
+ * @example
+ * ```
+ * import { decodeGetPublisherProfileUriResult } from "thirdweb/extensions/thirdweb";
+ * const result = decodeGetPublisherProfileUriResult("...");
+ * ```
+ */
+export function decodeGetPublisherProfileUriResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "getPublisherProfileUri" function on the contract.
@@ -32,21 +83,7 @@ export async function getPublisherProfileUri(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x4f781675",
-      [
-        {
-          type: "address",
-          name: "publisher",
-        },
-      ],
-      [
-        {
-          type: "string",
-          name: "uri",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.publisher],
   });
 }

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/write/publishContract.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/write/publishContract.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "publishContract" function.
@@ -40,6 +41,66 @@ export type PublishContractParams = Prettify<
       asyncParams: () => Promise<PublishContractParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xd50299e6" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "publisher",
+  },
+  {
+    type: "string",
+    name: "contractId",
+  },
+  {
+    type: "string",
+    name: "publishMetadataUri",
+  },
+  {
+    type: "string",
+    name: "compilerMetadataUri",
+  },
+  {
+    type: "bytes32",
+    name: "bytecodeHash",
+  },
+  {
+    type: "address",
+    name: "implementation",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "publishContract" function.
+ * @param options - The options for the publishContract function.
+ * @returns The encoded ABI parameters.
+ * @extension THIRDWEB
+ * @example
+ * ```
+ * import { encodePublishContractParams } "thirdweb/extensions/thirdweb";
+ * const result = encodePublishContractParams({
+ *  publisher: ...,
+ *  contractId: ...,
+ *  publishMetadataUri: ...,
+ *  compilerMetadataUri: ...,
+ *  bytecodeHash: ...,
+ *  implementation: ...,
+ * });
+ * ```
+ */
+export function encodePublishContractParams(
+  options: PublishContractParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.publisher,
+    options.contractId,
+    options.publishMetadataUri,
+    options.compilerMetadataUri,
+    options.bytecodeHash,
+    options.implementation,
+  ]);
+}
+
 /**
  * Calls the "publishContract" function on the contract.
  * @param options - The options for the "publishContract" function.
@@ -68,36 +129,7 @@ export function publishContract(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xd50299e6",
-      [
-        {
-          type: "address",
-          name: "publisher",
-        },
-        {
-          type: "string",
-          name: "contractId",
-        },
-        {
-          type: "string",
-          name: "publishMetadataUri",
-        },
-        {
-          type: "string",
-          name: "compilerMetadataUri",
-        },
-        {
-          type: "bytes32",
-          name: "bytecodeHash",
-        },
-        {
-          type: "address",
-          name: "implementation",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/write/setPublisherProfileUri.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/write/setPublisherProfileUri.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "setPublisherProfileUri" function.
@@ -21,6 +22,39 @@ export type SetPublisherProfileUriParams = Prettify<
       asyncParams: () => Promise<SetPublisherProfileUriParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x6e578e54" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "publisher",
+  },
+  {
+    type: "string",
+    name: "uri",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "setPublisherProfileUri" function.
+ * @param options - The options for the setPublisherProfileUri function.
+ * @returns The encoded ABI parameters.
+ * @extension THIRDWEB
+ * @example
+ * ```
+ * import { encodeSetPublisherProfileUriParams } "thirdweb/extensions/thirdweb";
+ * const result = encodeSetPublisherProfileUriParams({
+ *  publisher: ...,
+ *  uri: ...,
+ * });
+ * ```
+ */
+export function encodeSetPublisherProfileUriParams(
+  options: SetPublisherProfileUriParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.publisher, options.uri]);
+}
+
 /**
  * Calls the "setPublisherProfileUri" function on the contract.
  * @param options - The options for the "setPublisherProfileUri" function.
@@ -45,20 +79,7 @@ export function setPublisherProfileUri(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x6e578e54",
-      [
-        {
-          type: "address",
-          name: "publisher",
-        },
-        {
-          type: "string",
-          name: "uri",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/write/unpublishContract.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/write/unpublishContract.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "unpublishContract" function.
@@ -24,6 +25,42 @@ export type UnpublishContractParams = Prettify<
       asyncParams: () => Promise<UnpublishContractParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x06eb56cc" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "publisher",
+  },
+  {
+    type: "string",
+    name: "contractId",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "unpublishContract" function.
+ * @param options - The options for the unpublishContract function.
+ * @returns The encoded ABI parameters.
+ * @extension THIRDWEB
+ * @example
+ * ```
+ * import { encodeUnpublishContractParams } "thirdweb/extensions/thirdweb";
+ * const result = encodeUnpublishContractParams({
+ *  publisher: ...,
+ *  contractId: ...,
+ * });
+ * ```
+ */
+export function encodeUnpublishContractParams(
+  options: UnpublishContractParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.publisher,
+    options.contractId,
+  ]);
+}
+
 /**
  * Calls the "unpublishContract" function on the contract.
  * @param options - The options for the "unpublishContract" function.
@@ -48,20 +85,7 @@ export function unpublishContract(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x06eb56cc",
-      [
-        {
-          type: "address",
-          name: "publisher",
-        },
-        {
-          type: "string",
-          name: "contractId",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/read/getAllRules.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/read/getAllRules.ts
@@ -1,6 +1,63 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x1184aef2" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "tuple[]",
+    name: "rules",
+    components: [
+      {
+        type: "bytes32",
+        name: "ruleId",
+      },
+      {
+        type: "address",
+        name: "token",
+      },
+      {
+        type: "uint8",
+        name: "tokenType",
+      },
+      {
+        type: "uint256",
+        name: "tokenId",
+      },
+      {
+        type: "uint256",
+        name: "balance",
+      },
+      {
+        type: "uint256",
+        name: "score",
+      },
+      {
+        type: "uint8",
+        name: "ruleType",
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Decodes the result of the getAllRules function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension THIRDWEB
+ * @example
+ * ```
+ * import { decodeGetAllRulesResult } from "thirdweb/extensions/thirdweb";
+ * const result = decodeGetAllRulesResult("...");
+ * ```
+ */
+export function decodeGetAllRulesResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "getAllRules" function on the contract.
  * @param options - The options for the getAllRules function.
@@ -17,46 +74,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function getAllRules(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x1184aef2",
-      [],
-      [
-        {
-          type: "tuple[]",
-          name: "rules",
-          components: [
-            {
-              type: "bytes32",
-              name: "ruleId",
-            },
-            {
-              type: "address",
-              name: "token",
-            },
-            {
-              type: "uint8",
-              name: "tokenType",
-            },
-            {
-              type: "uint256",
-              name: "tokenId",
-            },
-            {
-              type: "uint256",
-              name: "balance",
-            },
-            {
-              type: "uint256",
-              name: "score",
-            },
-            {
-              type: "uint8",
-              name: "ruleType",
-            },
-          ],
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/read/getRulesEngineOverride.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/read/getRulesEngineOverride.ts
@@ -1,6 +1,33 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0xa7145eb4" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "address",
+    name: "rulesEngineAddress",
+  },
+] as const;
+
+/**
+ * Decodes the result of the getRulesEngineOverride function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension THIRDWEB
+ * @example
+ * ```
+ * import { decodeGetRulesEngineOverrideResult } from "thirdweb/extensions/thirdweb";
+ * const result = decodeGetRulesEngineOverrideResult("...");
+ * ```
+ */
+export function decodeGetRulesEngineOverrideResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "getRulesEngineOverride" function on the contract.
  * @param options - The options for the getRulesEngineOverride function.
@@ -17,16 +44,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function getRulesEngineOverride(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xa7145eb4",
-      [],
-      [
-        {
-          type: "address",
-          name: "rulesEngineAddress",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/read/getScore.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/read/getScore.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "getScore" function.
@@ -11,6 +14,52 @@ export type GetScoreParams = {
     name: "_tokenOwner";
   }>;
 };
+
+const FN_SELECTOR = "0xd47875d0" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "_tokenOwner",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+    name: "score",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getScore" function.
+ * @param options - The options for the getScore function.
+ * @returns The encoded ABI parameters.
+ * @extension THIRDWEB
+ * @example
+ * ```
+ * import { encodeGetScoreParams } "thirdweb/extensions/thirdweb";
+ * const result = encodeGetScoreParams({
+ *  tokenOwner: ...,
+ * });
+ * ```
+ */
+export function encodeGetScoreParams(options: GetScoreParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.tokenOwner]);
+}
+
+/**
+ * Decodes the result of the getScore function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension THIRDWEB
+ * @example
+ * ```
+ * import { decodeGetScoreResult } from "thirdweb/extensions/thirdweb";
+ * const result = decodeGetScoreResult("...");
+ * ```
+ */
+export function decodeGetScoreResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "getScore" function on the contract.
@@ -32,21 +81,7 @@ export async function getScore(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xd47875d0",
-      [
-        {
-          type: "address",
-          name: "_tokenOwner",
-        },
-      ],
-      [
-        {
-          type: "uint256",
-          name: "score",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.tokenOwner],
   });
 }

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/write/createRuleMultiplicative.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/write/createRuleMultiplicative.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "createRuleMultiplicative" function.
@@ -26,6 +27,57 @@ export type CreateRuleMultiplicativeParams = Prettify<
       asyncParams: () => Promise<CreateRuleMultiplicativeParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x1e2e9cb5" as const;
+const FN_INPUTS = [
+  {
+    type: "tuple",
+    name: "rule",
+    components: [
+      {
+        type: "address",
+        name: "token",
+      },
+      {
+        type: "uint8",
+        name: "tokenType",
+      },
+      {
+        type: "uint256",
+        name: "tokenId",
+      },
+      {
+        type: "uint256",
+        name: "scorePerOwnedToken",
+      },
+    ],
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bytes32",
+    name: "ruleId",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "createRuleMultiplicative" function.
+ * @param options - The options for the createRuleMultiplicative function.
+ * @returns The encoded ABI parameters.
+ * @extension THIRDWEB
+ * @example
+ * ```
+ * import { encodeCreateRuleMultiplicativeParams } "thirdweb/extensions/thirdweb";
+ * const result = encodeCreateRuleMultiplicativeParams({
+ *  rule: ...,
+ * });
+ * ```
+ */
+export function encodeCreateRuleMultiplicativeParams(
+  options: CreateRuleMultiplicativeParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.rule]);
+}
+
 /**
  * Calls the "createRuleMultiplicative" function on the contract.
  * @param options - The options for the "createRuleMultiplicative" function.
@@ -49,39 +101,7 @@ export function createRuleMultiplicative(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x1e2e9cb5",
-      [
-        {
-          type: "tuple",
-          name: "rule",
-          components: [
-            {
-              type: "address",
-              name: "token",
-            },
-            {
-              type: "uint8",
-              name: "tokenType",
-            },
-            {
-              type: "uint256",
-              name: "tokenId",
-            },
-            {
-              type: "uint256",
-              name: "scorePerOwnedToken",
-            },
-          ],
-        },
-      ],
-      [
-        {
-          type: "bytes32",
-          name: "ruleId",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/write/createRuleThreshold.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/write/createRuleThreshold.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "createRuleThreshold" function.
@@ -27,6 +28,61 @@ export type CreateRuleThresholdParams = Prettify<
       asyncParams: () => Promise<CreateRuleThresholdParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x1022a25e" as const;
+const FN_INPUTS = [
+  {
+    type: "tuple",
+    name: "rule",
+    components: [
+      {
+        type: "address",
+        name: "token",
+      },
+      {
+        type: "uint8",
+        name: "tokenType",
+      },
+      {
+        type: "uint256",
+        name: "tokenId",
+      },
+      {
+        type: "uint256",
+        name: "balance",
+      },
+      {
+        type: "uint256",
+        name: "score",
+      },
+    ],
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bytes32",
+    name: "ruleId",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "createRuleThreshold" function.
+ * @param options - The options for the createRuleThreshold function.
+ * @returns The encoded ABI parameters.
+ * @extension THIRDWEB
+ * @example
+ * ```
+ * import { encodeCreateRuleThresholdParams } "thirdweb/extensions/thirdweb";
+ * const result = encodeCreateRuleThresholdParams({
+ *  rule: ...,
+ * });
+ * ```
+ */
+export function encodeCreateRuleThresholdParams(
+  options: CreateRuleThresholdParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.rule]);
+}
+
 /**
  * Calls the "createRuleThreshold" function on the contract.
  * @param options - The options for the "createRuleThreshold" function.
@@ -50,43 +106,7 @@ export function createRuleThreshold(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x1022a25e",
-      [
-        {
-          type: "tuple",
-          name: "rule",
-          components: [
-            {
-              type: "address",
-              name: "token",
-            },
-            {
-              type: "uint8",
-              name: "tokenType",
-            },
-            {
-              type: "uint256",
-              name: "tokenId",
-            },
-            {
-              type: "uint256",
-              name: "balance",
-            },
-            {
-              type: "uint256",
-              name: "score",
-            },
-          ],
-        },
-      ],
-      [
-        {
-          type: "bytes32",
-          name: "ruleId",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/write/deleteRule.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/write/deleteRule.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "deleteRule" function.
@@ -17,6 +18,32 @@ export type DeleteRuleParams = Prettify<
       asyncParams: () => Promise<DeleteRuleParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x9d907761" as const;
+const FN_INPUTS = [
+  {
+    type: "bytes32",
+    name: "ruleId",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "deleteRule" function.
+ * @param options - The options for the deleteRule function.
+ * @returns The encoded ABI parameters.
+ * @extension THIRDWEB
+ * @example
+ * ```
+ * import { encodeDeleteRuleParams } "thirdweb/extensions/thirdweb";
+ * const result = encodeDeleteRuleParams({
+ *  ruleId: ...,
+ * });
+ * ```
+ */
+export function encodeDeleteRuleParams(options: DeleteRuleParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.ruleId]);
+}
+
 /**
  * Calls the "deleteRule" function on the contract.
  * @param options - The options for the "deleteRule" function.
@@ -38,16 +65,7 @@ export type DeleteRuleParams = Prettify<
 export function deleteRule(options: BaseTransactionOptions<DeleteRuleParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x9d907761",
-      [
-        {
-          type: "bytes32",
-          name: "ruleId",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/write/setRulesEngineOverride.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/write/setRulesEngineOverride.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "setRulesEngineOverride" function.
@@ -20,6 +21,34 @@ export type SetRulesEngineOverrideParams = Prettify<
       asyncParams: () => Promise<SetRulesEngineOverrideParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x0eb0adb6" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "_rulesEngineAddress",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "setRulesEngineOverride" function.
+ * @param options - The options for the setRulesEngineOverride function.
+ * @returns The encoded ABI parameters.
+ * @extension THIRDWEB
+ * @example
+ * ```
+ * import { encodeSetRulesEngineOverrideParams } "thirdweb/extensions/thirdweb";
+ * const result = encodeSetRulesEngineOverrideParams({
+ *  rulesEngineAddress: ...,
+ * });
+ * ```
+ */
+export function encodeSetRulesEngineOverrideParams(
+  options: SetRulesEngineOverrideParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.rulesEngineAddress]);
+}
+
 /**
  * Calls the "setRulesEngineOverride" function on the contract.
  * @param options - The options for the "setRulesEngineOverride" function.
@@ -43,16 +72,7 @@ export function setRulesEngineOverride(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x0eb0adb6",
-      [
-        {
-          type: "address",
-          name: "_rulesEngineAddress",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/ITWFee/read/getFeeInfo.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/ITWFee/read/getFeeInfo.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "getFeeInfo" function.
@@ -9,6 +12,61 @@ export type GetFeeInfoParams = {
   proxy: AbiParameterToPrimitiveType<{ type: "address"; name: "_proxy" }>;
   type: AbiParameterToPrimitiveType<{ type: "uint256"; name: "_type" }>;
 };
+
+const FN_SELECTOR = "0x85b49ad0" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "_proxy",
+  },
+  {
+    type: "uint256",
+    name: "_type",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "address",
+    name: "recipient",
+  },
+  {
+    type: "uint256",
+    name: "bps",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getFeeInfo" function.
+ * @param options - The options for the getFeeInfo function.
+ * @returns The encoded ABI parameters.
+ * @extension THIRDWEB
+ * @example
+ * ```
+ * import { encodeGetFeeInfoParams } "thirdweb/extensions/thirdweb";
+ * const result = encodeGetFeeInfoParams({
+ *  proxy: ...,
+ *  type: ...,
+ * });
+ * ```
+ */
+export function encodeGetFeeInfoParams(options: GetFeeInfoParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.proxy, options.type]);
+}
+
+/**
+ * Decodes the result of the getFeeInfo function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension THIRDWEB
+ * @example
+ * ```
+ * import { decodeGetFeeInfoResult } from "thirdweb/extensions/thirdweb";
+ * const result = decodeGetFeeInfoResult("...");
+ * ```
+ */
+export function decodeGetFeeInfoResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result);
+}
 
 /**
  * Calls the "getFeeInfo" function on the contract.
@@ -31,29 +89,7 @@ export async function getFeeInfo(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x85b49ad0",
-      [
-        {
-          type: "address",
-          name: "_proxy",
-        },
-        {
-          type: "uint256",
-          name: "_type",
-        },
-      ],
-      [
-        {
-          type: "address",
-          name: "recipient",
-        },
-        {
-          type: "uint256",
-          name: "bps",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.proxy, options.type],
   });
 }

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/ITWMultichainRegistry/read/count.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/ITWMultichainRegistry/read/count.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "count" function.
@@ -8,6 +11,52 @@ import type { AbiParameterToPrimitiveType } from "abitype";
 export type CountParams = {
   deployer: AbiParameterToPrimitiveType<{ type: "address"; name: "_deployer" }>;
 };
+
+const FN_SELECTOR = "0x05d85eda" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "_deployer",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+    name: "deploymentCount",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "count" function.
+ * @param options - The options for the count function.
+ * @returns The encoded ABI parameters.
+ * @extension THIRDWEB
+ * @example
+ * ```
+ * import { encodeCountParams } "thirdweb/extensions/thirdweb";
+ * const result = encodeCountParams({
+ *  deployer: ...,
+ * });
+ * ```
+ */
+export function encodeCountParams(options: CountParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.deployer]);
+}
+
+/**
+ * Decodes the result of the count function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension THIRDWEB
+ * @example
+ * ```
+ * import { decodeCountResult } from "thirdweb/extensions/thirdweb";
+ * const result = decodeCountResult("...");
+ * ```
+ */
+export function decodeCountResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "count" function on the contract.
@@ -27,21 +76,7 @@ export type CountParams = {
 export async function count(options: BaseTransactionOptions<CountParams>) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x05d85eda",
-      [
-        {
-          type: "address",
-          name: "_deployer",
-        },
-      ],
-      [
-        {
-          type: "uint256",
-          name: "deploymentCount",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.deployer],
   });
 }

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/ITWMultichainRegistry/read/getAll.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/ITWMultichainRegistry/read/getAll.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "getAll" function.
@@ -8,6 +11,66 @@ import type { AbiParameterToPrimitiveType } from "abitype";
 export type GetAllParams = {
   deployer: AbiParameterToPrimitiveType<{ type: "address"; name: "_deployer" }>;
 };
+
+const FN_SELECTOR = "0xeb077342" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "_deployer",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "tuple[]",
+    name: "allDeployments",
+    components: [
+      {
+        type: "address",
+        name: "deploymentAddress",
+      },
+      {
+        type: "uint256",
+        name: "chainId",
+      },
+      {
+        type: "string",
+        name: "metadataURI",
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getAll" function.
+ * @param options - The options for the getAll function.
+ * @returns The encoded ABI parameters.
+ * @extension THIRDWEB
+ * @example
+ * ```
+ * import { encodeGetAllParams } "thirdweb/extensions/thirdweb";
+ * const result = encodeGetAllParams({
+ *  deployer: ...,
+ * });
+ * ```
+ */
+export function encodeGetAllParams(options: GetAllParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.deployer]);
+}
+
+/**
+ * Decodes the result of the getAll function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension THIRDWEB
+ * @example
+ * ```
+ * import { decodeGetAllResult } from "thirdweb/extensions/thirdweb";
+ * const result = decodeGetAllResult("...");
+ * ```
+ */
+export function decodeGetAllResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "getAll" function on the contract.
@@ -27,35 +90,7 @@ export type GetAllParams = {
 export async function getAll(options: BaseTransactionOptions<GetAllParams>) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xeb077342",
-      [
-        {
-          type: "address",
-          name: "_deployer",
-        },
-      ],
-      [
-        {
-          type: "tuple[]",
-          name: "allDeployments",
-          components: [
-            {
-              type: "address",
-              name: "deploymentAddress",
-            },
-            {
-              type: "uint256",
-              name: "chainId",
-            },
-            {
-              type: "string",
-              name: "metadataURI",
-            },
-          ],
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.deployer],
   });
 }

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/ITWMultichainRegistry/read/getMetadataUri.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/ITWMultichainRegistry/read/getMetadataUri.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "getMetadataUri" function.
@@ -12,6 +15,57 @@ export type GetMetadataUriParams = {
     name: "_deployment";
   }>;
 };
+
+const FN_SELECTOR = "0xf4c2012d" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_chainId",
+  },
+  {
+    type: "address",
+    name: "_deployment",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "string",
+    name: "metadataUri",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getMetadataUri" function.
+ * @param options - The options for the getMetadataUri function.
+ * @returns The encoded ABI parameters.
+ * @extension THIRDWEB
+ * @example
+ * ```
+ * import { encodeGetMetadataUriParams } "thirdweb/extensions/thirdweb";
+ * const result = encodeGetMetadataUriParams({
+ *  chainId: ...,
+ *  deployment: ...,
+ * });
+ * ```
+ */
+export function encodeGetMetadataUriParams(options: GetMetadataUriParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.chainId, options.deployment]);
+}
+
+/**
+ * Decodes the result of the getMetadataUri function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension THIRDWEB
+ * @example
+ * ```
+ * import { decodeGetMetadataUriResult } from "thirdweb/extensions/thirdweb";
+ * const result = decodeGetMetadataUriResult("...");
+ * ```
+ */
+export function decodeGetMetadataUriResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "getMetadataUri" function on the contract.
@@ -34,25 +88,7 @@ export async function getMetadataUri(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xf4c2012d",
-      [
-        {
-          type: "uint256",
-          name: "_chainId",
-        },
-        {
-          type: "address",
-          name: "_deployment",
-        },
-      ],
-      [
-        {
-          type: "string",
-          name: "metadataUri",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.chainId, options.deployment],
   });
 }

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/ITWMultichainRegistry/write/add.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/ITWMultichainRegistry/write/add.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "add" function.
@@ -26,6 +27,52 @@ export type AddParams = Prettify<
       asyncParams: () => Promise<AddParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x26c5b516" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "_deployer",
+  },
+  {
+    type: "address",
+    name: "_deployment",
+  },
+  {
+    type: "uint256",
+    name: "_chainId",
+  },
+  {
+    type: "string",
+    name: "metadataUri",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "add" function.
+ * @param options - The options for the add function.
+ * @returns The encoded ABI parameters.
+ * @extension THIRDWEB
+ * @example
+ * ```
+ * import { encodeAddParams } "thirdweb/extensions/thirdweb";
+ * const result = encodeAddParams({
+ *  deployer: ...,
+ *  deployment: ...,
+ *  chainId: ...,
+ *  metadataUri: ...,
+ * });
+ * ```
+ */
+export function encodeAddParams(options: AddParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.deployer,
+    options.deployment,
+    options.chainId,
+    options.metadataUri,
+  ]);
+}
+
 /**
  * Calls the "add" function on the contract.
  * @param options - The options for the "add" function.
@@ -50,28 +97,7 @@ export type AddParams = Prettify<
 export function add(options: BaseTransactionOptions<AddParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x26c5b516",
-      [
-        {
-          type: "address",
-          name: "_deployer",
-        },
-        {
-          type: "address",
-          name: "_deployment",
-        },
-        {
-          type: "uint256",
-          name: "_chainId",
-        },
-        {
-          type: "string",
-          name: "metadataUri",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/ITWMultichainRegistry/write/remove.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/ITWMultichainRegistry/write/remove.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "remove" function.
@@ -22,6 +23,46 @@ export type RemoveParams = Prettify<
       asyncParams: () => Promise<RemoveParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x59e5fd04" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "_deployer",
+  },
+  {
+    type: "address",
+    name: "_deployment",
+  },
+  {
+    type: "uint256",
+    name: "_chainId",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "remove" function.
+ * @param options - The options for the remove function.
+ * @returns The encoded ABI parameters.
+ * @extension THIRDWEB
+ * @example
+ * ```
+ * import { encodeRemoveParams } "thirdweb/extensions/thirdweb";
+ * const result = encodeRemoveParams({
+ *  deployer: ...,
+ *  deployment: ...,
+ *  chainId: ...,
+ * });
+ * ```
+ */
+export function encodeRemoveParams(options: RemoveParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.deployer,
+    options.deployment,
+    options.chainId,
+  ]);
+}
+
 /**
  * Calls the "remove" function on the contract.
  * @param options - The options for the "remove" function.
@@ -45,24 +86,7 @@ export type RemoveParams = Prettify<
 export function remove(options: BaseTransactionOptions<RemoveParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x59e5fd04",
-      [
-        {
-          type: "address",
-          name: "_deployer",
-        },
-        {
-          type: "address",
-          name: "_deployment",
-        },
-        {
-          type: "uint256",
-          name: "_chainId",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/IThirdwebContract/read/contractType.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/IThirdwebContract/read/contractType.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0xcb2ef6f7" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bytes32",
+  },
+] as const;
+
+/**
+ * Decodes the result of the contractType function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension THIRDWEB
+ * @example
+ * ```
+ * import { decodeContractTypeResult } from "thirdweb/extensions/thirdweb";
+ * const result = decodeContractTypeResult("...");
+ * ```
+ */
+export function decodeContractTypeResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "contractType" function on the contract.
  * @param options - The options for the contractType function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function contractType(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xcb2ef6f7",
-      [],
-      [
-        {
-          type: "bytes32",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/IThirdwebContract/read/contractURI.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/IThirdwebContract/read/contractURI.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0xe8a3d485" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "string",
+  },
+] as const;
+
+/**
+ * Decodes the result of the contractURI function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension THIRDWEB
+ * @example
+ * ```
+ * import { decodeContractURIResult } from "thirdweb/extensions/thirdweb";
+ * const result = decodeContractURIResult("...");
+ * ```
+ */
+export function decodeContractURIResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "contractURI" function on the contract.
  * @param options - The options for the contractURI function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function contractURI(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xe8a3d485",
-      [],
-      [
-        {
-          type: "string",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/IThirdwebContract/read/contractVersion.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/IThirdwebContract/read/contractVersion.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0xa0a8e460" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint8",
+  },
+] as const;
+
+/**
+ * Decodes the result of the contractVersion function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension THIRDWEB
+ * @example
+ * ```
+ * import { decodeContractVersionResult } from "thirdweb/extensions/thirdweb";
+ * const result = decodeContractVersionResult("...");
+ * ```
+ */
+export function decodeContractVersionResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "contractVersion" function on the contract.
  * @param options - The options for the contractVersion function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function contractVersion(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0xa0a8e460",
-      [],
-      [
-        {
-          type: "uint8",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/IThirdwebContract/write/setContractURI.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/IThirdwebContract/write/setContractURI.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "setContractURI" function.
@@ -17,6 +18,34 @@ export type SetContractURIParams = Prettify<
       asyncParams: () => Promise<SetContractURIParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x938e3d7b" as const;
+const FN_INPUTS = [
+  {
+    type: "string",
+    name: "_uri",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "setContractURI" function.
+ * @param options - The options for the setContractURI function.
+ * @returns The encoded ABI parameters.
+ * @extension THIRDWEB
+ * @example
+ * ```
+ * import { encodeSetContractURIParams } "thirdweb/extensions/thirdweb";
+ * const result = encodeSetContractURIParams({
+ *  uri: ...,
+ * });
+ * ```
+ */
+export function encodeSetContractURIParams(
+  options: SetContractURIParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.uri]);
+}
+
 /**
  * Calls the "setContractURI" function on the contract.
  * @param options - The options for the "setContractURI" function.
@@ -40,16 +69,7 @@ export function setContractURI(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x938e3d7b",
-      [
-        {
-          type: "string",
-          name: "_uri",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/uniswap/__generated__/IQuoter/write/quoteExactInput.ts
+++ b/packages/thirdweb/src/extensions/uniswap/__generated__/IQuoter/write/quoteExactInput.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "quoteExactInput" function.
@@ -18,6 +19,44 @@ export type QuoteExactInputParams = Prettify<
       asyncParams: () => Promise<QuoteExactInputParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xcdca1753" as const;
+const FN_INPUTS = [
+  {
+    type: "bytes",
+    name: "path",
+  },
+  {
+    type: "uint256",
+    name: "amountIn",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+    name: "amountOut",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "quoteExactInput" function.
+ * @param options - The options for the quoteExactInput function.
+ * @returns The encoded ABI parameters.
+ * @extension UNISWAP
+ * @example
+ * ```
+ * import { encodeQuoteExactInputParams } "thirdweb/extensions/uniswap";
+ * const result = encodeQuoteExactInputParams({
+ *  path: ...,
+ *  amountIn: ...,
+ * });
+ * ```
+ */
+export function encodeQuoteExactInputParams(
+  options: QuoteExactInputParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.path, options.amountIn]);
+}
+
 /**
  * Calls the "quoteExactInput" function on the contract.
  * @param options - The options for the "quoteExactInput" function.
@@ -42,25 +81,7 @@ export function quoteExactInput(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xcdca1753",
-      [
-        {
-          type: "bytes",
-          name: "path",
-        },
-        {
-          type: "uint256",
-          name: "amountIn",
-        },
-      ],
-      [
-        {
-          type: "uint256",
-          name: "amountOut",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/uniswap/__generated__/IQuoter/write/quoteExactInputSingle.ts
+++ b/packages/thirdweb/src/extensions/uniswap/__generated__/IQuoter/write/quoteExactInputSingle.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "quoteExactInputSingle" function.
@@ -24,6 +25,65 @@ export type QuoteExactInputSingleParams = Prettify<
       asyncParams: () => Promise<QuoteExactInputSingleParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xf7729d43" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "tokenIn",
+  },
+  {
+    type: "address",
+    name: "tokenOut",
+  },
+  {
+    type: "uint24",
+    name: "fee",
+  },
+  {
+    type: "uint256",
+    name: "amountIn",
+  },
+  {
+    type: "uint160",
+    name: "sqrtPriceLimitX96",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+    name: "amountOut",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "quoteExactInputSingle" function.
+ * @param options - The options for the quoteExactInputSingle function.
+ * @returns The encoded ABI parameters.
+ * @extension UNISWAP
+ * @example
+ * ```
+ * import { encodeQuoteExactInputSingleParams } "thirdweb/extensions/uniswap";
+ * const result = encodeQuoteExactInputSingleParams({
+ *  tokenIn: ...,
+ *  tokenOut: ...,
+ *  fee: ...,
+ *  amountIn: ...,
+ *  sqrtPriceLimitX96: ...,
+ * });
+ * ```
+ */
+export function encodeQuoteExactInputSingleParams(
+  options: QuoteExactInputSingleParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.tokenIn,
+    options.tokenOut,
+    options.fee,
+    options.amountIn,
+    options.sqrtPriceLimitX96,
+  ]);
+}
+
 /**
  * Calls the "quoteExactInputSingle" function on the contract.
  * @param options - The options for the "quoteExactInputSingle" function.
@@ -51,37 +111,7 @@ export function quoteExactInputSingle(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xf7729d43",
-      [
-        {
-          type: "address",
-          name: "tokenIn",
-        },
-        {
-          type: "address",
-          name: "tokenOut",
-        },
-        {
-          type: "uint24",
-          name: "fee",
-        },
-        {
-          type: "uint256",
-          name: "amountIn",
-        },
-        {
-          type: "uint160",
-          name: "sqrtPriceLimitX96",
-        },
-      ],
-      [
-        {
-          type: "uint256",
-          name: "amountOut",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/uniswap/__generated__/IQuoter/write/quoteExactOutput.ts
+++ b/packages/thirdweb/src/extensions/uniswap/__generated__/IQuoter/write/quoteExactOutput.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "quoteExactOutput" function.
@@ -21,6 +22,44 @@ export type QuoteExactOutputParams = Prettify<
       asyncParams: () => Promise<QuoteExactOutputParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x2f80bb1d" as const;
+const FN_INPUTS = [
+  {
+    type: "bytes",
+    name: "path",
+  },
+  {
+    type: "uint256",
+    name: "amountOut",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+    name: "amountIn",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "quoteExactOutput" function.
+ * @param options - The options for the quoteExactOutput function.
+ * @returns The encoded ABI parameters.
+ * @extension UNISWAP
+ * @example
+ * ```
+ * import { encodeQuoteExactOutputParams } "thirdweb/extensions/uniswap";
+ * const result = encodeQuoteExactOutputParams({
+ *  path: ...,
+ *  amountOut: ...,
+ * });
+ * ```
+ */
+export function encodeQuoteExactOutputParams(
+  options: QuoteExactOutputParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.path, options.amountOut]);
+}
+
 /**
  * Calls the "quoteExactOutput" function on the contract.
  * @param options - The options for the "quoteExactOutput" function.
@@ -45,25 +84,7 @@ export function quoteExactOutput(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x2f80bb1d",
-      [
-        {
-          type: "bytes",
-          name: "path",
-        },
-        {
-          type: "uint256",
-          name: "amountOut",
-        },
-      ],
-      [
-        {
-          type: "uint256",
-          name: "amountIn",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/uniswap/__generated__/IQuoter/write/quoteExactOutputSingle.ts
+++ b/packages/thirdweb/src/extensions/uniswap/__generated__/IQuoter/write/quoteExactOutputSingle.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "quoteExactOutputSingle" function.
@@ -27,6 +28,65 @@ export type QuoteExactOutputSingleParams = Prettify<
       asyncParams: () => Promise<QuoteExactOutputSingleParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x30d07f21" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "tokenIn",
+  },
+  {
+    type: "address",
+    name: "tokenOut",
+  },
+  {
+    type: "uint24",
+    name: "fee",
+  },
+  {
+    type: "uint256",
+    name: "amountOut",
+  },
+  {
+    type: "uint160",
+    name: "sqrtPriceLimitX96",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+    name: "amountIn",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "quoteExactOutputSingle" function.
+ * @param options - The options for the quoteExactOutputSingle function.
+ * @returns The encoded ABI parameters.
+ * @extension UNISWAP
+ * @example
+ * ```
+ * import { encodeQuoteExactOutputSingleParams } "thirdweb/extensions/uniswap";
+ * const result = encodeQuoteExactOutputSingleParams({
+ *  tokenIn: ...,
+ *  tokenOut: ...,
+ *  fee: ...,
+ *  amountOut: ...,
+ *  sqrtPriceLimitX96: ...,
+ * });
+ * ```
+ */
+export function encodeQuoteExactOutputSingleParams(
+  options: QuoteExactOutputSingleParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.tokenIn,
+    options.tokenOut,
+    options.fee,
+    options.amountOut,
+    options.sqrtPriceLimitX96,
+  ]);
+}
+
 /**
  * Calls the "quoteExactOutputSingle" function on the contract.
  * @param options - The options for the "quoteExactOutputSingle" function.
@@ -54,37 +114,7 @@ export function quoteExactOutputSingle(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x30d07f21",
-      [
-        {
-          type: "address",
-          name: "tokenIn",
-        },
-        {
-          type: "address",
-          name: "tokenOut",
-        },
-        {
-          type: "uint24",
-          name: "fee",
-        },
-        {
-          type: "uint256",
-          name: "amountOut",
-        },
-        {
-          type: "uint160",
-          name: "sqrtPriceLimitX96",
-        },
-      ],
-      [
-        {
-          type: "uint256",
-          name: "amountIn",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/uniswap/__generated__/ISwapRouter/write/exactInput.ts
+++ b/packages/thirdweb/src/extensions/uniswap/__generated__/ISwapRouter/write/exactInput.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "exactInput" function.
@@ -27,6 +28,59 @@ export type ExactInputParams = Prettify<
       asyncParams: () => Promise<ExactInputParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xc04b8d59" as const;
+const FN_INPUTS = [
+  {
+    type: "tuple",
+    name: "params",
+    components: [
+      {
+        type: "bytes",
+        name: "path",
+      },
+      {
+        type: "address",
+        name: "recipient",
+      },
+      {
+        type: "uint256",
+        name: "deadline",
+      },
+      {
+        type: "uint256",
+        name: "amountIn",
+      },
+      {
+        type: "uint256",
+        name: "amountOutMinimum",
+      },
+    ],
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+    name: "amountOut",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "exactInput" function.
+ * @param options - The options for the exactInput function.
+ * @returns The encoded ABI parameters.
+ * @extension UNISWAP
+ * @example
+ * ```
+ * import { encodeExactInputParams } "thirdweb/extensions/uniswap";
+ * const result = encodeExactInputParams({
+ *  params: ...,
+ * });
+ * ```
+ */
+export function encodeExactInputParams(options: ExactInputParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.params]);
+}
+
 /**
  * Calls the "exactInput" function on the contract.
  * @param options - The options for the "exactInput" function.
@@ -48,43 +102,7 @@ export type ExactInputParams = Prettify<
 export function exactInput(options: BaseTransactionOptions<ExactInputParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xc04b8d59",
-      [
-        {
-          type: "tuple",
-          name: "params",
-          components: [
-            {
-              type: "bytes",
-              name: "path",
-            },
-            {
-              type: "address",
-              name: "recipient",
-            },
-            {
-              type: "uint256",
-              name: "deadline",
-            },
-            {
-              type: "uint256",
-              name: "amountIn",
-            },
-            {
-              type: "uint256",
-              name: "amountOutMinimum",
-            },
-          ],
-        },
-      ],
-      [
-        {
-          type: "uint256",
-          name: "amountOut",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/uniswap/__generated__/ISwapRouter/write/exactInputSingle.ts
+++ b/packages/thirdweb/src/extensions/uniswap/__generated__/ISwapRouter/write/exactInputSingle.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "exactInputSingle" function.
@@ -30,6 +31,73 @@ export type ExactInputSingleParams = Prettify<
       asyncParams: () => Promise<ExactInputSingleParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x414bf389" as const;
+const FN_INPUTS = [
+  {
+    type: "tuple",
+    name: "params",
+    components: [
+      {
+        type: "address",
+        name: "tokenIn",
+      },
+      {
+        type: "address",
+        name: "tokenOut",
+      },
+      {
+        type: "uint24",
+        name: "fee",
+      },
+      {
+        type: "address",
+        name: "recipient",
+      },
+      {
+        type: "uint256",
+        name: "deadline",
+      },
+      {
+        type: "uint256",
+        name: "amountIn",
+      },
+      {
+        type: "uint256",
+        name: "amountOutMinimum",
+      },
+      {
+        type: "uint160",
+        name: "sqrtPriceLimitX96",
+      },
+    ],
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+    name: "amountOut",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "exactInputSingle" function.
+ * @param options - The options for the exactInputSingle function.
+ * @returns The encoded ABI parameters.
+ * @extension UNISWAP
+ * @example
+ * ```
+ * import { encodeExactInputSingleParams } "thirdweb/extensions/uniswap";
+ * const result = encodeExactInputSingleParams({
+ *  params: ...,
+ * });
+ * ```
+ */
+export function encodeExactInputSingleParams(
+  options: ExactInputSingleParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.params]);
+}
+
 /**
  * Calls the "exactInputSingle" function on the contract.
  * @param options - The options for the "exactInputSingle" function.
@@ -53,55 +121,7 @@ export function exactInputSingle(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x414bf389",
-      [
-        {
-          type: "tuple",
-          name: "params",
-          components: [
-            {
-              type: "address",
-              name: "tokenIn",
-            },
-            {
-              type: "address",
-              name: "tokenOut",
-            },
-            {
-              type: "uint24",
-              name: "fee",
-            },
-            {
-              type: "address",
-              name: "recipient",
-            },
-            {
-              type: "uint256",
-              name: "deadline",
-            },
-            {
-              type: "uint256",
-              name: "amountIn",
-            },
-            {
-              type: "uint256",
-              name: "amountOutMinimum",
-            },
-            {
-              type: "uint160",
-              name: "sqrtPriceLimitX96",
-            },
-          ],
-        },
-      ],
-      [
-        {
-          type: "uint256",
-          name: "amountOut",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/uniswap/__generated__/ISwapRouter/write/exactOutput.ts
+++ b/packages/thirdweb/src/extensions/uniswap/__generated__/ISwapRouter/write/exactOutput.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "exactOutput" function.
@@ -27,6 +28,59 @@ export type ExactOutputParams = Prettify<
       asyncParams: () => Promise<ExactOutputParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xf28c0498" as const;
+const FN_INPUTS = [
+  {
+    type: "tuple",
+    name: "params",
+    components: [
+      {
+        type: "bytes",
+        name: "path",
+      },
+      {
+        type: "address",
+        name: "recipient",
+      },
+      {
+        type: "uint256",
+        name: "deadline",
+      },
+      {
+        type: "uint256",
+        name: "amountOut",
+      },
+      {
+        type: "uint256",
+        name: "amountInMaximum",
+      },
+    ],
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+    name: "amountIn",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "exactOutput" function.
+ * @param options - The options for the exactOutput function.
+ * @returns The encoded ABI parameters.
+ * @extension UNISWAP
+ * @example
+ * ```
+ * import { encodeExactOutputParams } "thirdweb/extensions/uniswap";
+ * const result = encodeExactOutputParams({
+ *  params: ...,
+ * });
+ * ```
+ */
+export function encodeExactOutputParams(options: ExactOutputParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.params]);
+}
+
 /**
  * Calls the "exactOutput" function on the contract.
  * @param options - The options for the "exactOutput" function.
@@ -50,43 +104,7 @@ export function exactOutput(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xf28c0498",
-      [
-        {
-          type: "tuple",
-          name: "params",
-          components: [
-            {
-              type: "bytes",
-              name: "path",
-            },
-            {
-              type: "address",
-              name: "recipient",
-            },
-            {
-              type: "uint256",
-              name: "deadline",
-            },
-            {
-              type: "uint256",
-              name: "amountOut",
-            },
-            {
-              type: "uint256",
-              name: "amountInMaximum",
-            },
-          ],
-        },
-      ],
-      [
-        {
-          type: "uint256",
-          name: "amountIn",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/uniswap/__generated__/ISwapRouter/write/exactOutputSingle.ts
+++ b/packages/thirdweb/src/extensions/uniswap/__generated__/ISwapRouter/write/exactOutputSingle.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "exactOutputSingle" function.
@@ -30,6 +31,73 @@ export type ExactOutputSingleParams = Prettify<
       asyncParams: () => Promise<ExactOutputSingleParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xdb3e2198" as const;
+const FN_INPUTS = [
+  {
+    type: "tuple",
+    name: "params",
+    components: [
+      {
+        type: "address",
+        name: "tokenIn",
+      },
+      {
+        type: "address",
+        name: "tokenOut",
+      },
+      {
+        type: "uint24",
+        name: "fee",
+      },
+      {
+        type: "address",
+        name: "recipient",
+      },
+      {
+        type: "uint256",
+        name: "deadline",
+      },
+      {
+        type: "uint256",
+        name: "amountOut",
+      },
+      {
+        type: "uint256",
+        name: "amountInMaximum",
+      },
+      {
+        type: "uint160",
+        name: "sqrtPriceLimitX96",
+      },
+    ],
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+    name: "amountIn",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "exactOutputSingle" function.
+ * @param options - The options for the exactOutputSingle function.
+ * @returns The encoded ABI parameters.
+ * @extension UNISWAP
+ * @example
+ * ```
+ * import { encodeExactOutputSingleParams } "thirdweb/extensions/uniswap";
+ * const result = encodeExactOutputSingleParams({
+ *  params: ...,
+ * });
+ * ```
+ */
+export function encodeExactOutputSingleParams(
+  options: ExactOutputSingleParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.params]);
+}
+
 /**
  * Calls the "exactOutputSingle" function on the contract.
  * @param options - The options for the "exactOutputSingle" function.
@@ -53,55 +121,7 @@ export function exactOutputSingle(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xdb3e2198",
-      [
-        {
-          type: "tuple",
-          name: "params",
-          components: [
-            {
-              type: "address",
-              name: "tokenIn",
-            },
-            {
-              type: "address",
-              name: "tokenOut",
-            },
-            {
-              type: "uint24",
-              name: "fee",
-            },
-            {
-              type: "address",
-              name: "recipient",
-            },
-            {
-              type: "uint256",
-              name: "deadline",
-            },
-            {
-              type: "uint256",
-              name: "amountOut",
-            },
-            {
-              type: "uint256",
-              name: "amountInMaximum",
-            },
-            {
-              type: "uint160",
-              name: "sqrtPriceLimitX96",
-            },
-          ],
-        },
-      ],
-      [
-        {
-          type: "uint256",
-          name: "amountIn",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/uniswap/__generated__/IUniswapV3Factory/read/feeAmountTickSpacing.ts
+++ b/packages/thirdweb/src/extensions/uniswap/__generated__/IUniswapV3Factory/read/feeAmountTickSpacing.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "feeAmountTickSpacing" function.
@@ -8,6 +11,53 @@ import type { AbiParameterToPrimitiveType } from "abitype";
 export type FeeAmountTickSpacingParams = {
   fee: AbiParameterToPrimitiveType<{ type: "uint24"; name: "fee" }>;
 };
+
+const FN_SELECTOR = "0x22afcccb" as const;
+const FN_INPUTS = [
+  {
+    type: "uint24",
+    name: "fee",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "int24",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "feeAmountTickSpacing" function.
+ * @param options - The options for the feeAmountTickSpacing function.
+ * @returns The encoded ABI parameters.
+ * @extension UNISWAP
+ * @example
+ * ```
+ * import { encodeFeeAmountTickSpacingParams } "thirdweb/extensions/uniswap";
+ * const result = encodeFeeAmountTickSpacingParams({
+ *  fee: ...,
+ * });
+ * ```
+ */
+export function encodeFeeAmountTickSpacingParams(
+  options: FeeAmountTickSpacingParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.fee]);
+}
+
+/**
+ * Decodes the result of the feeAmountTickSpacing function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension UNISWAP
+ * @example
+ * ```
+ * import { decodeFeeAmountTickSpacingResult } from "thirdweb/extensions/uniswap";
+ * const result = decodeFeeAmountTickSpacingResult("...");
+ * ```
+ */
+export function decodeFeeAmountTickSpacingResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "feeAmountTickSpacing" function on the contract.
@@ -29,20 +79,7 @@ export async function feeAmountTickSpacing(
 ) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x22afcccb",
-      [
-        {
-          type: "uint24",
-          name: "fee",
-        },
-      ],
-      [
-        {
-          type: "int24",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.fee],
   });
 }

--- a/packages/thirdweb/src/extensions/uniswap/__generated__/IUniswapV3Factory/read/getPool.ts
+++ b/packages/thirdweb/src/extensions/uniswap/__generated__/IUniswapV3Factory/read/getPool.ts
@@ -1,6 +1,9 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
 
 /**
  * Represents the parameters for the "getPool" function.
@@ -10,6 +13,66 @@ export type GetPoolParams = {
   tokenB: AbiParameterToPrimitiveType<{ type: "address"; name: "tokenB" }>;
   fee: AbiParameterToPrimitiveType<{ type: "uint24"; name: "fee" }>;
 };
+
+const FN_SELECTOR = "0x1698ee82" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "tokenA",
+  },
+  {
+    type: "address",
+    name: "tokenB",
+  },
+  {
+    type: "uint24",
+    name: "fee",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "address",
+    name: "pool",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getPool" function.
+ * @param options - The options for the getPool function.
+ * @returns The encoded ABI parameters.
+ * @extension UNISWAP
+ * @example
+ * ```
+ * import { encodeGetPoolParams } "thirdweb/extensions/uniswap";
+ * const result = encodeGetPoolParams({
+ *  tokenA: ...,
+ *  tokenB: ...,
+ *  fee: ...,
+ * });
+ * ```
+ */
+export function encodeGetPoolParams(options: GetPoolParams) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.tokenA,
+    options.tokenB,
+    options.fee,
+  ]);
+}
+
+/**
+ * Decodes the result of the getPool function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension UNISWAP
+ * @example
+ * ```
+ * import { decodeGetPoolResult } from "thirdweb/extensions/uniswap";
+ * const result = decodeGetPoolResult("...");
+ * ```
+ */
+export function decodeGetPoolResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
 
 /**
  * Calls the "getPool" function on the contract.
@@ -31,29 +94,7 @@ export type GetPoolParams = {
 export async function getPool(options: BaseTransactionOptions<GetPoolParams>) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x1698ee82",
-      [
-        {
-          type: "address",
-          name: "tokenA",
-        },
-        {
-          type: "address",
-          name: "tokenB",
-        },
-        {
-          type: "uint24",
-          name: "fee",
-        },
-      ],
-      [
-        {
-          type: "address",
-          name: "pool",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [options.tokenA, options.tokenB, options.fee],
   });
 }

--- a/packages/thirdweb/src/extensions/uniswap/__generated__/IUniswapV3Factory/read/owner.ts
+++ b/packages/thirdweb/src/extensions/uniswap/__generated__/IUniswapV3Factory/read/owner.ts
@@ -1,6 +1,32 @@
 import { readContract } from "../../../../../transaction/read-contract.js";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x8da5cb5b" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "address",
+  },
+] as const;
+
+/**
+ * Decodes the result of the owner function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension UNISWAP
+ * @example
+ * ```
+ * import { decodeOwnerResult } from "thirdweb/extensions/uniswap";
+ * const result = decodeOwnerResult("...");
+ * ```
+ */
+export function decodeOwnerResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
 /**
  * Calls the "owner" function on the contract.
  * @param options - The options for the owner function.
@@ -17,15 +43,7 @@ import type { BaseTransactionOptions } from "../../../../../transaction/types.js
 export async function owner(options: BaseTransactionOptions) {
   return readContract({
     contract: options.contract,
-    method: [
-      "0x8da5cb5b",
-      [],
-      [
-        {
-          type: "address",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params: [],
   });
 }

--- a/packages/thirdweb/src/extensions/uniswap/__generated__/IUniswapV3Factory/write/createPool.ts
+++ b/packages/thirdweb/src/extensions/uniswap/__generated__/IUniswapV3Factory/write/createPool.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "createPool" function.
@@ -19,6 +20,51 @@ export type CreatePoolParams = Prettify<
       asyncParams: () => Promise<CreatePoolParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0xa1671295" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "tokenA",
+  },
+  {
+    type: "address",
+    name: "tokenB",
+  },
+  {
+    type: "uint24",
+    name: "fee",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "address",
+    name: "pool",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "createPool" function.
+ * @param options - The options for the createPool function.
+ * @returns The encoded ABI parameters.
+ * @extension UNISWAP
+ * @example
+ * ```
+ * import { encodeCreatePoolParams } "thirdweb/extensions/uniswap";
+ * const result = encodeCreatePoolParams({
+ *  tokenA: ...,
+ *  tokenB: ...,
+ *  fee: ...,
+ * });
+ * ```
+ */
+export function encodeCreatePoolParams(options: CreatePoolParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.tokenA,
+    options.tokenB,
+    options.fee,
+  ]);
+}
+
 /**
  * Calls the "createPool" function on the contract.
  * @param options - The options for the "createPool" function.
@@ -42,29 +88,7 @@ export type CreatePoolParams = Prettify<
 export function createPool(options: BaseTransactionOptions<CreatePoolParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0xa1671295",
-      [
-        {
-          type: "address",
-          name: "tokenA",
-        },
-        {
-          type: "address",
-          name: "tokenB",
-        },
-        {
-          type: "uint24",
-          name: "fee",
-        },
-      ],
-      [
-        {
-          type: "address",
-          name: "pool",
-        },
-      ],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/uniswap/__generated__/IUniswapV3Factory/write/enableFeeAmount.ts
+++ b/packages/thirdweb/src/extensions/uniswap/__generated__/IUniswapV3Factory/write/enableFeeAmount.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "enableFeeAmount" function.
@@ -21,6 +22,39 @@ export type EnableFeeAmountParams = Prettify<
       asyncParams: () => Promise<EnableFeeAmountParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x8a7c195f" as const;
+const FN_INPUTS = [
+  {
+    type: "uint24",
+    name: "fee",
+  },
+  {
+    type: "int24",
+    name: "tickSpacing",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "enableFeeAmount" function.
+ * @param options - The options for the enableFeeAmount function.
+ * @returns The encoded ABI parameters.
+ * @extension UNISWAP
+ * @example
+ * ```
+ * import { encodeEnableFeeAmountParams } "thirdweb/extensions/uniswap";
+ * const result = encodeEnableFeeAmountParams({
+ *  fee: ...,
+ *  tickSpacing: ...,
+ * });
+ * ```
+ */
+export function encodeEnableFeeAmountParams(
+  options: EnableFeeAmountParamsInternal,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.fee, options.tickSpacing]);
+}
+
 /**
  * Calls the "enableFeeAmount" function on the contract.
  * @param options - The options for the "enableFeeAmount" function.
@@ -45,20 +79,7 @@ export function enableFeeAmount(
 ) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x8a7c195f",
-      [
-        {
-          type: "uint24",
-          name: "fee",
-        },
-        {
-          type: "int24",
-          name: "tickSpacing",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {

--- a/packages/thirdweb/src/extensions/uniswap/__generated__/IUniswapV3Factory/write/setOwner.ts
+++ b/packages/thirdweb/src/extensions/uniswap/__generated__/IUniswapV3Factory/write/setOwner.ts
@@ -1,7 +1,8 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
 import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
-import type { AbiParameterToPrimitiveType } from "abitype";
 import type { Prettify } from "../../../../../utils/type-utils.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
 
 /**
  * Represents the parameters for the "setOwner" function.
@@ -17,6 +18,32 @@ export type SetOwnerParams = Prettify<
       asyncParams: () => Promise<SetOwnerParamsInternal>;
     }
 >;
+const FN_SELECTOR = "0x13af4035" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "newOwner",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "setOwner" function.
+ * @param options - The options for the setOwner function.
+ * @returns The encoded ABI parameters.
+ * @extension UNISWAP
+ * @example
+ * ```
+ * import { encodeSetOwnerParams } "thirdweb/extensions/uniswap";
+ * const result = encodeSetOwnerParams({
+ *  newOwner: ...,
+ * });
+ * ```
+ */
+export function encodeSetOwnerParams(options: SetOwnerParamsInternal) {
+  return encodeAbiParameters(FN_INPUTS, [options.newOwner]);
+}
+
 /**
  * Calls the "setOwner" function on the contract.
  * @param options - The options for the "setOwner" function.
@@ -38,16 +65,7 @@ export type SetOwnerParams = Prettify<
 export function setOwner(options: BaseTransactionOptions<SetOwnerParams>) {
   return prepareContractCall({
     contract: options.contract,
-    method: [
-      "0x13af4035",
-      [
-        {
-          type: "address",
-          name: "newOwner",
-        },
-      ],
-      [],
-    ],
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
     params:
       "asyncParams" in options
         ? async () => {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds constant function selectors, inputs, and outputs for various ERC standards. It also includes functions to decode contract call results.

### Detailed summary
- Added constant function selectors, inputs, and outputs for ERC20, ERC4337, ERC721, ERC1155, ERC6551 standards
- Implemented functions to decode contract call results for name, symbol, owner, and state functions

> The following files were skipped due to too many changes: `packages/thirdweb/src/extensions/erc6551/__generated__/IERC6551Account/read/state.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IAppURI/read/appURI.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/IUniswapV3Factory/read/owner.ts`, `packages/thirdweb/src/extensions/common/__generated__/IContractMetadata/read/symbol.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IERC20/read/decimals.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IBundler/read/idGateway.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IStorageRegistry/read/maxUnits.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IERC20/read/totalSupply.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/read/idCounter.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/read/idGateway.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IDrop/read/getActiveClaimConditionId.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/read/totalSupply.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IBundler/read/keyGateway.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IStorageRegistry/read/unitPrice.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IIdGateway/read/idRegistry.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IKeyRegistry/read/idRegistry.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IKeyRegistry/read/keyGateway.ts`, `packages/thirdweb/src/extensions/common/__generated__/IContractMetadata/read/contractURI.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/read/startTokenId.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ISignatureDropERC721/read/totalMinted.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IKeyGateway/read/keyRegistry.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IThirdwebContract/read/contractURI.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IStorageRegistry/read/rentedUnits.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/read/contractURI.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IKeyGateway/read/ADD_TYPEHASH.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/read/gatewayFrozen.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IKeyRegistry/read/gatewayFrozen.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IThirdwebContract/read/contractType.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IStorageRegistry/read/usdUnitPrice.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/read/contractType.ts`, `packages/thirdweb/src/extensions/erc1822/__generated__/IERC1822Proxiable/read/proxiableUUID.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IKeyRegistry/read/maxKeysPerFid.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/read/getAllAccounts.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/read/totalListings.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IERC20Permit/read/DOMAIN_SEPARATOR.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IIdGateway/read/storageRegistry.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IThirdwebContract/read/contractVersion.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IKeyRegistry/read/REMOVE_TYPEHASH.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/read/contractVersion.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IDrop/read/nextTokenIdToClaim.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721Enumerable/read/nextTokenIdToMint.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IIdGateway/read/REGISTER_TYPEHASH.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccountPermissions/read/getAllAdmins.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/read/TRANSFER_TYPEHASH.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155Enumerable/read/nextTokenIdToMint.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/read/CHANGE_RECOVERY_ADDRESS_TYPEHASH.ts`, `packages/thirdweb/src/extensions/common/__generated__/IPrimarySale/read/primarySaleRecipient.ts`, `packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/asset.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IStorageRegistry/read/deprecationTimestamp.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/read/accountImplementation.ts`, `packages/thirdweb/src/extensions/common/__generated__/IPlatformFee/read/getPlatformFeeInfo.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/read/TRANSFER_AND_CHANGE_RECOVERY_TYPEHASH.ts`, `packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/totalAssets.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/read/getPlatformFeeInfo.ts`, `packages/thirdweb/src/extensions/common/__generated__/IRoyalty/read/getDefaultRoyaltyInfo.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/read/getRulesEngineOverride.ts`, `packages/thirdweb/src/extensions/erc6551/__generated__/IERC6551Account/read/token.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IBurnableERC20/write/burn.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IBurnableERC721/write/burn.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IStaking20/write/stake.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IKeyRegistry/write/remove.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IStaking721/write/stake.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IOffers/write/acceptOffer.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IOffers/write/cancelOffer.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IStaking1155/write/claimRewards.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/incrementNonce.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IWETH/write/withdraw.ts`, `packages/thirdweb/src/extensions/common/__generated__/IContractMetadata/write/setContractURI.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IStaking20/write/withdraw.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IThirdwebContract/write/setContractURI.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/setContractURI.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IVotes/write/delegate.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IAppURI/write/setAppURI.ts`, `packages/thirdweb/src/extensions/common/__generated__/IOwnable/write/setOwner.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IStaking721/write/withdraw.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IClaimableERC721/read/verifyClaim.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/IUniswapV3Factory/write/setOwner.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/cancelListing.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/cancelAuction.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/depositTo.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/withdrawStake.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/getSenderAddress.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/write/deleteRule.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/addStake.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/ITokenStake/write/depositRewardTokens.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/INFTStake/write/depositRewardTokens.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/INFTMetadata/write/setTokenURI.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/INFTMetadata/write/setTokenURI.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ISharedMetadataBatch/write/deleteSharedMetadata.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IEditionStake/write/depositRewardTokens.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IMintableERC20/write/mintTo.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/ITokenStake/write/withdrawRewardTokens.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/INFTStake/write/withdrawRewardTokens.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IStaking1155/write/stake.ts`, `packages/thirdweb/src/extensions/common/__generated__/IPermissions/write/renounceRole.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IEditionStake/write/withdrawRewardTokens.ts`, `packages/thirdweb/src/extensions/common/__generated__/IRoyaltyPayments/write/setRoyaltyEngine.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/write/approve.ts`, `packages/thirdweb/src/extensions/common/__generated__/IPermissionsEnumerable/write/renounceRole.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/cancelDirectListing.ts`, `packages/thirdweb/src/extensions/common/__generated__/IMulticall/write/multicall.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IClaimableERC721/write/claim.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/changeRecoveryAddress.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/collectAuctionPayout.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/collectAuctionTokens.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IMintableERC721/write/mintTo.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IBurnableERC20/write/burnFrom.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IStaking1155/write/withdraw.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/closeAuction.ts`, `packages/thirdweb/src/extensions/common/__generated__/IPermissions/write/grantRole.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/bidInAuction.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IWETH/write/transfer.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IERC20/write/transfer.ts`, `packages/thirdweb/src/extensions/common/__generated__/IPermissionsEnumerable/write/grantRole.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/IUniswapV3Factory/write/enableFeeAmount.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IERC20/write/approve.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IStorageRegistry/write/batchRent.ts`, `packages/thirdweb/src/extensions/common/__generated__/IPermissions/write/revokeRole.ts`, `packages/thirdweb/src/extensions/common/__generated__/IPrimarySale/write/setPrimarySaleRecipient.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IStorageRegistry/write/rent.ts`, `packages/thirdweb/src/extensions/common/__generated__/IPermissionsEnumerable/write/revokeRole.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/write/setRulesEngineOverride.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/write/setApprovalForAll.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IClaimableERC1155/read/verifyClaim.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/write/setApprovalForAll.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IBurnableERC1155/write/burn.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/write/createAccount.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/write/transferFrom.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IDelayedReveal/write/reveal.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/write/unpublishContract.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccountPermissions/read/getAllSigners.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/IQuoter/write/quoteExactInput.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IERC20/write/transferFrom.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/withdrawTo.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/transfer.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IPaymaster/write/postOp.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/write/setPublisherProfileUri.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IClaimableERC1155/write/claim.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/IQuoter/write/quoteExactOutput.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/write/safeTransferFrom.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/write/onSignerAdded.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccountPermissions/read/getAllActiveSigners.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/read/getAllRules.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/ITWMultichainRegistry/write/remove.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IBurnableERC1155/write/burnBatch.ts`, `packages/thirdweb/src/extensions/common/__generated__/IPlatformFee/write/setPlatformFeeInfo.ts`, `packages/thirdweb/src/extensions/common/__generated__/IRoyalty/write/setDefaultRoyaltyInfo.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/write/onSignerRemoved.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/setPlatformFeeInfo.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ISharedMetadataBatch/read/getAllSharedMetadata.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IKeyGateway/write/add.ts`, `packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/write/mint.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IMintableERC1155/write/mintTo.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/recover.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IIdGateway/write/register.ts`, `packages/thirdweb/src/extensions/common/__generated__/IRoyalty/write/setRoyaltyInfoForToken.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/IUniswapV3Factory/write/createPool.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/ITWMultichainRegistry/write/add.ts`, `packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/write/deposit.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IKeyRegistry/write/removeFor.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ILazyMint/write/lazyMint.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/acceptOffer.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/approveBuyerForListing.ts`, `packages/thirdweb/src/extensions/ens/__generated__/AddressResolver/read/addr.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IAirdropERC20Claimable/write/claim.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IAirdropERC721Claimable/write/claim.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/read/uri.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IBundler/read/price.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/read/getScore.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IVotes/read/getVotes.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IIdGateway/read/price.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721Receiver/write/onERC721Received.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ISharedMetadata/write/setSharedMetadata.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/read/tokenURI.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/read/balanceOf.ts`, `packages/thirdweb/src/extensions/erc7504/__generated__/IRouterState/read/getAllExtensions.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IVotes/read/delegates.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IERC20/read/balanceOf.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/read/totalSupply.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/read/balanceOf.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IERC20Permit/read/nonces.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IAirdropERC20/write/airdropERC20.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IStorageRegistry/read/price.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/read/idOf.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/buy.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/write/safeTransferFrom.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/read/custodyOf.ts`, `packages/thirdweb/src/extensions/common/__generated__/IPermissions/read/getRoleAdmin.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IPackVRFDirect/write/openPackAndClaimRewards.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/read/getApproved.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IContractFactory/write/deployProxyByImplementation.ts`, `packages/thirdweb/src/extensions/common/__generated__/IRoyaltyPayments/write/getRoyalty.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IAirdropERC721/write/airdropERC721.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/changeRecoveryAddressFor.ts`, `packages/thirdweb/src/extensions/common/__generated__/IPermissionsEnumerable/read/getRoleAdmin.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/transferAndChangeRecovery.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/read/ownerOf.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IKeyGateway/read/nonces.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/approveCurrencyForListing.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/read/recoveryOf.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccountPermissions/read/isAdmin.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721Enumerable/read/tokenByIndex.ts`, `packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/write/redeem.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721AQueryable/read/tokensOfOwner.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IVotes/write/delegateBySig.ts`, `packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/maxRedeem.ts`, `packages/thirdweb/src/extensions/erc165/__generated__/IERC165/read/supportsInterface.ts`, `packages/thirdweb/src/extensions/common/__generated__/IRoyalty/read/supportsInterface.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/INFTMetadata/read/supportsInterface.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/ISwapRouter/write/exactOutput.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/read/isAuctionExpired.ts`, `packages/thirdweb/src/extensions/common/__generated__/IRoyaltyPayments/read/supportsInterface.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/INFTMetadata/read/supportsInterface.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccountPermissions/read/isActiveSigner.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155Receiver/read/supportsInterface.ts`, `packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/previewMint.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ISharedMetadataBatch/write/setSharedMetadata.ts`, `packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/write/withdraw.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155Receiver/write/onERC1155Received.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IVotes/read/getPastTotalSupply.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/ITWMultichainRegistry/read/count.ts`, `packages/thirdweb/src/extensions/erc2771/__generated__/IERC2771Context/read/isTrustedForwarder.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IAirdropERC1155Claimable/write/claim.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IPackVRFDirect/read/canClaimRewards.ts`, `packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/maxDeposit.ts`, `packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/maxWithdraw.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/write/safeBatchTransferFrom.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IKeyRegistry/read/keyDataOf.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/transferFor.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IKeyRegistry/read/totalKeys.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IERC20/read/allowance.ts`, `packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/maxMint.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IVotes/read/getPastVotes.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/buyFromListing.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/read/getNonce.ts`, `packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/previewRedeem.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/read/balanceOf.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/offer.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IAirdropERC1155/write/airdropERC1155.ts`, `packages/thirdweb/src/extensions/common/__generated__/IPermissionsEnumerable/read/getRoleMemberCount.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IPack/write/openPack.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IKeyRegistry/read/keysOf.ts`, `packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/previewDeposit.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/write/createRuleThreshold.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/ISwapRouter/write/exactInput.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/read/getAddress.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/write/createRuleMultiplicative.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/IUniswapV3Factory/read/feeAmountTickSpacing.ts`, `packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/convertToAssets.ts`, `packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/convertToShares.ts`, `packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/read/previewWithdraw.ts`, `packages/thirdweb/src/extensions/common/__generated__/IPermissions/read/hasRole.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/read/balanceOfBatch.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IERC20Permit/write/permit.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IStaking20/read/getStakeInfo.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155Receiver/write/onERC1155BatchReceived.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IIdGateway/write/registerFor.ts`, `packages/thirdweb/src/extensions/ens/__generated__/UniversalResolver/read/resolve.ts`, `packages/thirdweb/src/extensions/common/__generated__/IPermissionsEnumerable/read/hasRole.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IStaking721/read/getStakeInfo.ts`, `packages/thirdweb/src/extensions/common/__generated__/IPermissionsEnumerable/read/getRoleMember.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/read/getPublisherProfileUri.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IDelayedReveal/read/encryptDecrypt.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/read/getAccountsOfSigner.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/read/isNewWinningBid.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/recoverFor.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/ITWMultichainRegistry/read/getMetadataUri.ts`, `packages/thirdweb/src/extensions/common/__generated__/IRoyalty/read/royaltyInfo.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/read/isApprovedForAll.ts`, `packages/thirdweb/src/extensions/erc6551/__generated__/IERC6551Account/read/isValidSigner.ts`, `packages/thirdweb/src/extensions/erc2981/__generated__/IERC2981/read/royaltyInfo.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/read/getWinningBid.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IKeyGateway/write/addFor.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/read/isApprovedForAll.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/ITWFee/read/getFeeInfo.ts`, `packages/thirdweb/src/extensions/erc1271/__generated__/isValidSignature/read/isValidSignature.ts`, `packages/thirdweb/src/extensions/common/__generated__/IRoyalty/read/getRoyaltyInfoForToken.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IKeyRegistry/read/keyAt.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/IQuoter/write/quoteExactInputSingle.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IOffers/write/makeOffer.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IDrop1155/read/getActiveClaimConditionId.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/IQuoter/write/quoteExactOutputSingle.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721Enumerable/read/tokenOfOwnerByIndex.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IStaking1155/read/getStakeInfo.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/IUniswapV3Factory/read/getPool.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/write/publishContract.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721AQueryable/read/tokensOfOwnerIn.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IDropERC20/write/claim.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/read/getPublishedUriFromCompilerUri.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/createListing.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/ITWMultichainRegistry/read/getAll.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/ISwapRouter/write/exactInputSingle.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/ISwapRouter/write/exactOutputSingle.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IStaking1155/read/getStakeInfoForToken.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/updateListing.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/transferAndChangeRecoveryFor.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/createListing.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/updateListing.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/ISignatureMintERC20/write/mintWithSignature.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IDrop/write/claim.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/read/getDepositInfo.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IDrop/write/setClaimConditions.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/read/verifyFidSignature.ts`, `packages/thirdweb/src/extensions/common/__generated__/IClaimConditionsSinglePhase/write/setClaimConditions.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IDropERC20/write/setClaimConditions.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/createAuction.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/simulateValidation.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/ISignatureAction/read/verify.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IDrop1155/write/claim.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IDrop1155/write/setClaimConditions.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/handleOps.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/read/getAllPublishedContracts.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccountPermissions/write/setPermissionsForSigner.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccountPermissions/read/getPermissionsForSigner.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IBundler/write/register.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/read/getPublishedContract.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ISignatureMintERC721/write/mintWithSignature.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/simulateHandleOp.ts`, `packages/thirdweb/src/extensions/prebuilts/__generated__/DropERC721/write/initialize.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IPack/write/createPack.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/ISignatureMintERC1155/write/mintWithSignature.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IOffers/read/getOffer.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/read/getPublishedContractVersions.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IDrop/read/getClaimConditionById.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccount/write/validateUserOp.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/ISignatureMintERC20/read/verify.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/read/getUserOpHash.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/read/getListing.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IDrop1155/read/getClaimConditionById.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IOffers/read/getAllOffers.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/handleAggregatedOps.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IPaymaster/write/validatePaymasterUserOp.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IOffers/read/getAllValidOffers.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ISignatureMintERC721/read/verify.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/read/getAuction.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/read/getAllListings.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/ISignatureMintERC1155/read/verify.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/read/getAllValidListings.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccountPermissions/read/verifySignerPermissionRequest.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/read/getAllAuctions.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/read/getAllValidAuctions.ts`, `packages/thirdweb/scripts/generate/generate.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->