### PR TITLE
chore: point CLI backwards compatibility @latest instead of @beta

### DIFF
--- a/.changeset/chilled-falcons-judge.md
+++ b/.changeset/chilled-falcons-judge.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+point CLI backwards compatibility @latest instead of @beta

--- a/packages/thirdweb/README.md
+++ b/packages/thirdweb/README.md
@@ -14,7 +14,7 @@
 ## Installation
 
 ```bash
-npm install thirdweb@beta
+npm install thirdweb
 ```
 
 ## Features

--- a/packages/thirdweb/src/cli/bin.ts
+++ b/packages/thirdweb/src/cli/bin.ts
@@ -37,7 +37,7 @@ async function main() {
       }
       const runner = bunAvailable ? "bunx" : "npx";
       // eslint-disable-next-line better-tree-shaking/no-top-level-side-effects
-      spawn(runner, ["--yes", "@thirdweb-dev/cli@beta", command, ...rest], {
+      spawn(runner, ["--yes", "@thirdweb-dev/cli@latest", command, ...rest], {
         stdio: "inherit",
       });
     }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the installation command for `thirdweb` package and changes the CLI command to point to the latest version instead of beta.

### Detailed summary
- Updated `npm install thirdweb@beta` to `npm install thirdweb`
- Changed CLI command to point to `@latest` version instead of `@beta`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->