### PR TITLE
fix(evm): fix CWE-1333

### DIFF
--- a/.changeset/hungry-steaks-clean.md
+++ b/.changeset/hungry-steaks-clean.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/sdk": patch
+---
+
+fix CWE-1333

--- a/legacy_packages/sdk/src/evm/common/error.ts
+++ b/legacy_packages/sdk/src/evm/common/error.ts
@@ -404,6 +404,12 @@ export function parseRevertReason(error: any): string {
     errorString = error.toString();
   }
 
+  // if the error is just too long, just return the message to limit Regexp processing time
+  // see: https://cwe.mitre.org/data/definitions/1333.html
+  if (errorString.length > 5000) {
+    return error.message || "";
+  }
+
   return (
     parseMessageParts(/.*?"message":"([^"\\]*).*?/, errorString) ||
     parseMessageParts(/.*?"reason":"([^"\\]*).*?/, errorString) ||


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on fixing CWE-1333 by limiting Regexp processing time for error messages longer than 5000 characters.

### Detailed summary
- Added a condition to return error message if length exceeds 5000 characters.
- Improved error handling for long error messages to address CWE-1333.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->