### PR TITLE
[CLI] Publish and deploy updates for ZKSync

### DIFF
--- a/.changeset/brave-pandas-whisper.md
+++ b/.changeset/brave-pandas-whisper.md
@@ -1,0 +1,6 @@
+---
+"@thirdweb-dev/cli": patch
+"@thirdweb-dev/sdk": patch
+---
+
+cli changes for zksync publish

--- a/legacy_packages/cli/src/cli/index.ts
+++ b/legacy_packages/cli/src/cli/index.ts
@@ -377,6 +377,7 @@ const main = async () => {
     .option("--dry-run", "dry run (skip actually publishing)")
     .option("-d, --debug", "show debug logs")
     .option("--ci", "Continuous Integration mode")
+    .option("--zksync", "Publish with ZKSync settings")
     .option(
       "--link-lib <library:address...>",
       "Specify library names and addresses",

--- a/legacy_packages/cli/src/common/processor.ts
+++ b/legacy_packages/cli/src/common/processor.ts
@@ -61,9 +61,7 @@ export async function processProject(
 
   logger.debug("Processing project at path " + projectPath);
 
-  const projectType = options.zksync
-    ? "hardhat"
-    : await detect(projectPath, options);
+  const projectType = await detect(projectPath, options);
 
   if (projectType === "none") {
     if (command === "deploy") {
@@ -106,9 +104,25 @@ export async function processProject(
   }
 
   let compiledResult: { contracts: ContractPayload[] };
+  let zkCompiledResult: { contracts: ContractPayload[] };
   const compileLoader = spinner("Compiling project...");
   try {
     compiledResult = await build(projectPath, projectType, options);
+
+    if (options.zksync) {
+      zkCompiledResult = await build(projectPath, "zk-hardhat", options);
+
+      if (
+        compiledResult.contracts.length !== zkCompiledResult.contracts.length
+      ) {
+        logger.error(
+          "Length mismatch: zksolc and solc compiled contracts differ.",
+        );
+        process.exit(1);
+      }
+    } else {
+      zkCompiledResult = { contracts: [] };
+    }
   } catch (e) {
     compileLoader.fail("Compilation failed");
     logger.error(e);
@@ -223,6 +237,23 @@ export async function processProject(
     process.exit(1);
   }
 
+  let zkSelectedContracts: ContractPayload[] = [];
+  if (options.zksync) {
+    const fileNames = selectedContracts.map((selected) => selected.fileName);
+    zkSelectedContracts = zkCompiledResult.contracts.filter((contract) => {
+      const index = fileNames.indexOf(contract.fileName);
+
+      return index !== -1;
+    });
+
+    if (zkSelectedContracts.length !== selectedContracts.length) {
+      info(
+        "Selected contract not present in zksolc compiled contracts. Aborting.",
+      );
+      process.exit(1);
+    }
+  }
+
   if (options.dryRun) {
     info("Dry run, skipping deployment");
     process.exit(0);
@@ -332,6 +363,81 @@ export async function processProject(
           metadataUri: metadataURIs[i],
           bytecodeUri: bytecodeURIs[i],
           analytics,
+          compilers: {
+            solc: [
+              {
+                compilerVersion: compiledResult.contracts[0].compilerVersion,
+                evmVersion: compiledResult.contracts[0].evmVersion,
+                metadataUri: metadataURIs[i],
+                bytecodeUri: bytecodeURIs[i],
+              },
+            ],
+          },
+        };
+      });
+    }
+
+    // upload zk-contracts if present
+    if (zkSelectedContracts.length > 0) {
+      for (let i = 0; i < zkSelectedContracts.length; i++) {
+        const contract = zkSelectedContracts[i];
+        if (contract.sources) {
+          // upload sources in batches to avoid getting rate limited (needs to be single uploads)
+          const batchSize = 3;
+          for (let j = 0; j < contract.sources.length; j = j + batchSize) {
+            const batch = contract.sources.slice(j, j + batchSize);
+            logger.debug(`Uploading Sources:\n${batch.join("\n")}\n`);
+            await Promise.all(
+              batch.map(async (c) => {
+                const file = readFileSync(c, "utf-8");
+                if (file.includes(soliditySDKPackage)) {
+                  usesSoliditySDK = true;
+                }
+                return await storage.upload(file, {
+                  uploadWithoutDirectory: true,
+                });
+              }),
+            );
+          }
+        }
+      }
+
+      // Upload build output metadatas (need to be single uploads)
+      const zkMetadataURIs = await Promise.all(
+        zkSelectedContracts.map(async (c) => {
+          logger.debug(`Uploading ${c.name}...`);
+
+          return await storage.upload(JSON.parse(JSON.stringify(c.metadata)), {
+            uploadWithoutDirectory: true,
+          });
+        }),
+      );
+
+      // Upload batch all bytecodes
+      const zkBytecodes = zkSelectedContracts.map((c) => c.bytecode);
+      const zkBytecodeURIs = await storage.uploadBatch(zkBytecodes);
+
+      combinedContents = combinedContents.map((c, i) => {
+        return {
+          ...c,
+          compilers: {
+            zksolc: [
+              {
+                compilerVersion: zkCompiledResult.contracts[0].compilerVersion,
+                evmVersion: zkCompiledResult.contracts[0].evmVersion,
+                metadataUri: zkMetadataURIs[i],
+                bytecodeUri: zkBytecodeURIs[i],
+              },
+            ],
+            solc: [
+              {
+                compilerVersion: compiledResult.contracts[0].compilerVersion,
+                evmVersion: compiledResult.contracts[0].evmVersion,
+                metadataUri: metadataURIs[i],
+                bytecodeUri: bytecodeURIs[i],
+              },
+            ],
+          },
         };
       });
     }
@@ -362,8 +468,8 @@ export function getUrl(hashes: string[], command: string) {
   if (hashes.length === 1) {
     url = new URL(
       THIRDWEB_URL +
-      `/contracts/${command}/` +
-      encodeURIComponent(hashes[0].replace("ipfs://", "")),
+        `/contracts/${command}/` +
+        encodeURIComponent(hashes[0].replace("ipfs://", "")),
     );
   } else {
     url = new URL(THIRDWEB_URL + "/contracts/" + command);

--- a/legacy_packages/cli/src/core/builder/brownie.ts
+++ b/legacy_packages/cli/src/core/builder/brownie.ts
@@ -56,6 +56,8 @@ export class BrownieBuilder extends BaseBuilder {
             sources: [], // TODO
             fileName: "", // TODO
             name: contractName,
+            compilerVersion: "",
+            evmVersion: "",
           });
           break;
         }

--- a/legacy_packages/cli/src/core/builder/build.ts
+++ b/legacy_packages/cli/src/core/builder/build.ts
@@ -5,6 +5,7 @@ import { FoundryBuilder } from "./foundry";
 import { HardhatBuilder } from "./hardhat";
 import { SolcBuilder } from "./solc";
 import { TruffleBuilder } from "./truffle";
+import { ZKHardhatBuilder } from "./zkHardhat";
 
 export default async function build(
   path: string,
@@ -17,6 +18,10 @@ export default async function build(
   switch (projectType) {
     case "hardhat": {
       builder = new HardhatBuilder();
+      break;
+    }
+    case "zk-hardhat": {
+      builder = new ZKHardhatBuilder();
       break;
     }
     case "foundry": {

--- a/legacy_packages/cli/src/core/builder/foundry.ts
+++ b/legacy_packages/cli/src/core/builder/foundry.ts
@@ -107,6 +107,9 @@ export class FoundryBuilder extends BaseBuilder {
         contractInfo.rawMetadata ||
         this.sanitizeParsedMetadata(parsedMetadata, contractInfo.abi);
 
+      const evmVersion = metadata.settings?.evmVersion || "";
+      const compilerVersion = metadata.compiler?.version || "";
+
       const sources = Object.keys(parsedMetadata.sources)
         .map((path) => {
           if (path.startsWith("/") && existsSync(path)) {
@@ -146,6 +149,8 @@ export class FoundryBuilder extends BaseBuilder {
           bytecode,
           fileName,
           sources,
+          compilerVersion,
+          evmVersion,
         });
       }
     }

--- a/legacy_packages/cli/src/core/builder/hardhat.ts
+++ b/legacy_packages/cli/src/core/builder/hardhat.ts
@@ -35,7 +35,7 @@ export class HardhatBuilder extends BaseBuilder {
 
     logger.debug("successfully extracted hardhat config", actualHardhatConfig);
 
-    // await execute("npx hardhat clean", options.projectPath);
+    await execute("npx hardhat clean", options.projectPath);
     await execute(`npx hardhat compile`, options.projectPath);
 
     const solcConfigs = actualHardhatConfig.solidity.compilers;

--- a/legacy_packages/cli/src/core/builder/solc.ts
+++ b/legacy_packages/cli/src/core/builder/solc.ts
@@ -116,6 +116,9 @@ export class SolcBuilder extends BaseBuilder {
       const parsedMetadata = JSON.parse(metadata);
       const abi = parsedMetadata.output.abi;
 
+      const evmVersion = parsedMetadata.settings?.evmVersion || "";
+      const compilerVersion = parsedMetadata.compiler?.version || "";
+
       const target = parsedMetadata.settings.compilationTarget;
       if (
         Object.keys(target).length === 0 ||
@@ -156,6 +159,8 @@ export class SolcBuilder extends BaseBuilder {
           name: contractName,
           fileName,
           sources: _sources,
+          compilerVersion,
+          evmVersion,
         });
       }
     }

--- a/legacy_packages/cli/src/core/builder/truffle.ts
+++ b/legacy_packages/cli/src/core/builder/truffle.ts
@@ -13,10 +13,9 @@ export class TruffleBuilder extends BaseBuilder {
   }> {
     // get the current config first
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const truffleConfig = require(join(
-      options.projectPath,
-      "truffle-config.js",
-    ));
+    const truffleConfig = require(
+      join(options.projectPath, "truffle-config.js"),
+    );
 
     const buildPath = join(
       options.projectPath,
@@ -41,6 +40,9 @@ export class TruffleBuilder extends BaseBuilder {
         contractInfo;
       const meta = JSON.parse(metadata);
       const abi = meta.output.abi;
+
+      const evmVersion = meta.settings?.evmVersion || "";
+      const compilerVersion = meta.compiler?.version || "";
 
       const target = meta.settings.compilationTarget;
       if (
@@ -81,6 +83,8 @@ export class TruffleBuilder extends BaseBuilder {
           name: contractName,
           fileName,
           sources,
+          compilerVersion,
+          evmVersion,
         });
       }
     }

--- a/legacy_packages/cli/src/core/builder/zkHardhat.ts
+++ b/legacy_packages/cli/src/core/builder/zkHardhat.ts
@@ -34,10 +34,10 @@ export class ZKHardhatBuilder extends BaseBuilder {
 
     logger.debug("successfully extracted hardhat config", actualHardhatConfig);
 
-    // await execute("npx hardhat clean", options.projectPath);
+    await execute("npx hardhat clean", options.projectPath);
 
     let ignoreIpfsHash = false;
-    // if (options.zksync) {
+
     const zkNetwork = Object.entries(actualHardhatConfig.networks).find(
       (network) => {
         return (network[1] as any).zksync;
@@ -54,21 +54,6 @@ export class ZKHardhatBuilder extends BaseBuilder {
       `npx hardhat compile --network ${zkNetwork?.[0]}`,
       options.projectPath,
     );
-    // } else {
-    //   await execute(`npx hardhat compile`, options.projectPath);
-    // }
-
-    // const solcConfigs = actualHardhatConfig.solidity.compilers;
-    // if (solcConfigs) {
-    //   for (const solcConfig of solcConfigs) {
-    //     const byteCodeHash = solcConfig.settings?.metadata?.bytecodeHash;
-    //     if (byteCodeHash && byteCodeHash !== "ipfs") {
-    //       throw new Error(
-    //         `Deploying requires "bytecodeHash: 'ipfs'" in your hardhat.config.js file, but it's currently set as "bytecodeHash: '${byteCodeHash}'". Please change it to 'ipfs' and try again.`,
-    //       );
-    //     }
-    //   }
-    // }
 
     const artifactsPath = actualHardhatConfig.paths.artifacts;
     const sourcesDir = actualHardhatConfig.paths.sources.replace(

--- a/legacy_packages/cli/src/core/detection/detect.ts
+++ b/legacy_packages/cli/src/core/detection/detect.ts
@@ -27,6 +27,17 @@ export default async function detect(
     .filter((detector) => detector.matches(path))
     .map((detector) => detector.projectType);
 
+  if (options.zksync) {
+    const hardhatProject = possibleProjectTypes.filter(
+      (projectType) => projectType === "hardhat",
+    );
+
+    if (hardhatProject.length === 0) {
+      logger.warn("ZKSync compilation requires hardhat plugins. Aborting.");
+      process.exit(1);
+    }
+  }
+
   //if there is no project returned at all then just return unknown}
   if (!possibleProjectTypes.length) {
     const canCompile = hasContracts(path);
@@ -51,15 +62,28 @@ export default async function detect(
   }
   //if there is only one possible option just return it
   if (possibleProjectTypes.length === 1) {
-    info(`Detected project type: ${possibleProjectTypes[0]}`);
+    if (options.zksync) {
+      info("ZKSync compilation will use hardhat");
+    } else {
+      info(`Detected project type: ${possibleProjectTypes[0]}`);
+    }
     return possibleProjectTypes[0];
   }
 
-  info(
-    `Detected multiple possible build tools: ${possibleProjectTypes
-      .map((s) => `"${s}"`)
-      .join(", ")}`,
-  );
+  if (options.zksync) {
+    info("ZKSync compilation will use hardhat");
+    info(
+      `For regular solc compilation, these are the available options: ${possibleProjectTypes
+        .map((s) => `"${s}"`)
+        .join(", ")}`,
+    );
+  } else {
+    info(
+      `Detected multiple possible build tools: ${possibleProjectTypes
+        .map((s) => `"${s}"`)
+        .join(", ")}`,
+    );
+  }
 
   const question = "How would you like to compile your contracts";
 

--- a/legacy_packages/cli/src/core/interfaces/ContractPayload.ts
+++ b/legacy_packages/cli/src/core/interfaces/ContractPayload.ts
@@ -26,4 +26,8 @@ export interface ContractPayload {
    * The source file paths
    */
   sources: string[];
+
+  compilerVersion: string;
+
+  evmVersion: string;
 }

--- a/legacy_packages/cli/src/core/types/ProjectType.ts
+++ b/legacy_packages/cli/src/core/types/ProjectType.ts
@@ -2,6 +2,7 @@ export type ProjectType =
   | "brownie"
   | "foundry"
   | "hardhat"
+  | "zk-hardhat"
   | "truffle"
   | "solc"
   | "vite"

--- a/legacy_packages/sdk/src/evm/core/classes/contract-publisher.ts
+++ b/legacy_packages/sdk/src/evm/core/classes/contract-publisher.ts
@@ -487,6 +487,7 @@ export class ContractPublisher extends RPCConnectionHandler {
         bytecodeUri: predeployMetadata.bytecodeUri,
         name: predeployMetadata.name,
         analytics: predeployMetadata.analytics,
+        compilers: predeployMetadata.compilers,
         publisher,
       });
       const fullMetadataUri = await this.storage.upload(fullMetadata);

--- a/legacy_packages/sdk/src/evm/schema/contracts/custom.ts
+++ b/legacy_packages/sdk/src/evm/schema/contracts/custom.ts
@@ -115,6 +115,14 @@ export type AbiInput = z.input<typeof AbiSchema>;
 /**
  * @internal
  */
+export const CompilerTypeInput = /* @__PURE__ */ (() =>
+  z.union([z.literal("solc"), z.literal("zksolc")]))();
+
+export type CompilerType = z.input<typeof CompilerTypeInput>;
+
+/**
+ * @internal
+ */
 export const PreDeployMetadata = /* @__PURE__ */ (() =>
   z
     .object({
@@ -122,6 +130,21 @@ export const PreDeployMetadata = /* @__PURE__ */ (() =>
       metadataUri: z.string(),
       bytecodeUri: z.string(),
       analytics: z.any().optional(),
+      compilers: z
+        .record(
+          CompilerTypeInput,
+          // z.record(
+          z.array(
+            z.object({
+              compilerVersion: z.string().optional(),
+              evmVersion: z.string().optional(),
+              metadataUri: z.string(),
+              bytecodeUri: z.string(),
+            }),
+          ),
+          // ),
+        )
+        .optional(),
     })
     .catchall(z.any()))();
 

--- a/legacy_packages/sdk/src/evm/zksync/zksync-verification.ts
+++ b/legacy_packages/sdk/src/evm/zksync/zksync-verification.ts
@@ -6,7 +6,6 @@ import { getChainProvider } from "../constants/urls";
 import { Abi } from "../schema/contracts/custom";
 import { twProxyArtifactZK } from "./temp-artifact/TWProxy";
 import { fetchSourceFilesFromMetadata } from "../common/fetchSourceFilesFromMetadata";
-import { fetchRawPredeployMetadata } from "../common/feature-detection/fetchRawPredeployMetadata";
 import { fetchContractMetadata } from "../common/fetchContractMetadata";
 import { checkVerificationStatus } from "../common/verification";
 import { ThirdwebSDK } from "../core/sdk";

--- a/legacy_packages/sdk/src/evm/zksync/zksync-verification.ts
+++ b/legacy_packages/sdk/src/evm/zksync/zksync-verification.ts
@@ -180,14 +180,14 @@ async function zkFetchConstructorParams(
         utils.hexDataSlice(transaction.data, 4),
       );
 
-      return decoded[2];
+      return decoded[2].startsWith("0x") ? decoded[2] : `0x${decoded[2]}`;
     } else {
       // TODO: decode for create2 deployments via factory
-      return "";
+      return "0x";
     }
   } else {
     // Could not retrieve constructor parameters, using empty parameters as fallback
-    return "";
+    return "0x";
   }
 }
 

--- a/legacy_packages/sdk/src/evm/zksync/zksync-verification.ts
+++ b/legacy_packages/sdk/src/evm/zksync/zksync-verification.ts
@@ -45,9 +45,12 @@ export async function zkVerify(
     } else {
       invariant(contractUri, "No contract URI provided");
       const rawMeta = await fetchRawPredeployMetadata(contractUri, storage);
-      const metadataUri = rawMeta.compilers?.zksolc?.metadataUri;
+      const zksolcs = rawMeta.compilers?.zksolc;
+      invariant(zksolcs && zksolcs.length > 0, "No zk compilers found");
 
+      const metadataUri = zksolcs[0].metadataUri;
       invariant(metadataUri, "ZkSolc metadata not found");
+
       const parsedMetadata = await fetchContractMetadata(metadataUri, storage);
 
       compilerMetadata = {


### PR DESCRIPTION
## Problem solved

Publish and deploy updates for ZKSync

## Changes made

- `--zksync` option for publish command - uploads zksolc compiled metadata in addition to regular solc metadata
- predeploy metadata now contains an optional field for other compilers
- zksync contract verification changes

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces support for ZKSync settings in the CLI, including changes to compiler versions, EVM versions, and contract publishing.

### Detailed summary
- Added support for `zk-hardhat` project type
- Updated compiler and EVM versions in various builders
- Added ZKSync option in CLI commands
- Enhanced contract metadata handling for ZKSync verification

> The following files were skipped due to too many changes: `legacy_packages/cli/src/common/processor.ts`, `legacy_packages/cli/src/core/builder/zkHardhat.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->