### PR TITLE
fix: 721/1155 claimTo with custom currency

### DIFF
--- a/.changeset/shy-singers-tap.md
+++ b/.changeset/shy-singers-tap.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix 721/1155 claimTo

--- a/packages/thirdweb/src/extensions/erc1155/drops/write/claimTo.ts
+++ b/packages/thirdweb/src/extensions/erc1155/drops/write/claimTo.ts
@@ -3,6 +3,7 @@ import type { BaseTransactionOptions } from "../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../transaction/prepare-contract-call.js";
 import { getActiveClaimCondition } from "../read/getActiveClaimCondition.js";
 import { padHex } from "../../../../utils/encoding/hex.js";
+import { NATIVE_TOKEN_ADDRESS } from "../../../../constants/addresses.js";
 
 const CLAIM_ABI = {
   inputs: [
@@ -129,7 +130,11 @@ export function claimTo(options: BaseTransactionOptions<ClaimToParams>) {
         contract: options.contract,
         tokenId: options.tokenId,
       });
-      return cc.pricePerToken * BigInt(options.quantity);
+      if (cc.currency === NATIVE_TOKEN_ADDRESS) {
+        return cc.pricePerToken * BigInt(options.quantity);
+      } else {
+        return 0n;
+      }
     },
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/drops/write/claimTo.ts
+++ b/packages/thirdweb/src/extensions/erc721/drops/write/claimTo.ts
@@ -3,6 +3,7 @@ import type { BaseTransactionOptions } from "../../../../transaction/types.js";
 import { prepareContractCall } from "../../../../transaction/prepare-contract-call.js";
 import { getActiveClaimCondition } from "../read/getActiveClaimCondition.js";
 import { padHex } from "../../../../utils/encoding/hex.js";
+import { NATIVE_TOKEN_ADDRESS } from "../../../../constants/addresses.js";
 /**
  * Represents the parameters for claiming an ERC721 token.
  */
@@ -117,7 +118,11 @@ export function claimTo(options: BaseTransactionOptions<ClaimToParams>) {
       const cc = await getActiveClaimCondition({
         contract: options.contract,
       });
-      return cc.pricePerToken * BigInt(options.quantity);
+      if (cc.currency === NATIVE_TOKEN_ADDRESS) {
+        return cc.pricePerToken * BigInt(options.quantity);
+      } else {
+        return 0n;
+      }
     },
   });
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to fix the claimTo function in both ERC1155 and ERC721 extensions to handle the case where the currency is not the native token address.

### Detailed summary
- Updated `claimTo` function in ERC1155 and ERC721 extensions to return 0 if currency is not native token address
- Added check for currency type before calculating total price

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->