### PR TITLE
fix: Do not open wallet uri when connected using official WC modal

### DIFF
--- a/.changeset/dirty-bears-sort.md
+++ b/.changeset/dirty-bears-sort.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Do not subscribe to `session_request_sent` event when using `walletConnect` because that is already handled when connecting with official Modal

--- a/packages/thirdweb/src/wallets/create-wallet.ts
+++ b/packages/thirdweb/src/wallets/create-wallet.ts
@@ -168,7 +168,7 @@ export function createWallet<const ID extends WalletId>(
             ] = await connectWC(
               wcOptions,
               emitter,
-              wallet.id as WCSupportedWalletIds,
+              wallet.id as WCSupportedWalletIds | "walletConnect",
             );
             // set the states
             account = connectedAccount;


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

## Changes made

- [ ] Public API changes: list the public API changes made if any
- [ ] Internal API changes: explain the internal logic changes

## How to test

- [ ] Automated tests: link to unit test file
- [ ] Manual tests: step by step instructions on how to test

## Contributor NFT

Paste in your wallet address below and we will airdrop you a special NFT when your pull request is merged. 

```Address: ```


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on optimizing the `walletConnect` integration in the `thirdweb` package.

### Detailed summary
- Updated `wallet.id` to include `"walletConnect"`
- Modified functions to handle `walletConnect` separately
- Improved session request handling for `walletConnect` integration

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->