### PR TITLE
feat: add turbo build and update-version commands to release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "changeset": "changeset",
     "version-packages": "changeset version",
-    "release": "node ./scripts/pre-release.mjs && changeset publish",
+    "release": "node ./scripts/pre-release.mjs && turbo run update-version && turbo run build && changeset publish",
     "version-packages:nightly": "node scripts/pre-nightly.mjs && changeset version --snapshot nightly",
     "release:nightly": "node ./scripts/pre-release.mjs && turbo run update-version && turbo run build && changeset publish --tag nightly",
     "version-packages:next": "node scripts/pre-nightly.mjs && changeset version --snapshot next",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the release scripts in `package.json` to include additional build steps before publishing changesets.

### Detailed summary
- Added `turbo run update-version` and `turbo run build` steps before `changeset publish` in the `release` script
- Updated `release:nightly` script to include `--tag nightly` option for changeset publish

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->