### PR TITLE
chore(v4): get gas price from bundler for userOps

### DIFF
--- a/.changeset/grumpy-doors-grow.md
+++ b/.changeset/grumpy-doors-grow.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/wallets": patch
+---
+
+Get gas price from bundler for userOperations

--- a/legacy_packages/wallets/src/evm/connectors/smart-wallet/lib/http-rpc-client.ts
+++ b/legacy_packages/wallets/src/evm/connectors/smart-wallet/lib/http-rpc-client.ts
@@ -134,6 +134,17 @@ export class HttpRpcClient {
     );
   }
 
+  async getUserOperationGasPrice(): Promise<{
+    maxFeePerGas: string;
+    maxPriorityFeePerGas: string;
+  }> {
+    await this.initializing;
+    return await this.userOpJsonRpcProvider.send(
+      "thirdweb_getUserOperationGasPrice",
+      [],
+    );
+  }
+
   async getUserOperationReceipt(userOpHash: string): Promise<any> {
     await this.initializing;
     return await this.userOpJsonRpcProvider.send(


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to enhance the `getUserOperationGasPrice` method by retrieving gas prices from the bundler for `userOperations`.

### Detailed summary
- Added `getUserOperationGasPrice` method to fetch gas prices from bundler
- Updated fee retrieval logic in `BaseAccountAPI` to use bundler if available

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->