### PR TITLE
feat: Wallet connection improvements

### DIFF
--- a/.changeset/little-falcons-remain.md
+++ b/.changeset/little-falcons-remain.md
@@ -1,0 +1,8 @@
+---
+"thirdweb": patch
+---
+
+Various Improvements for wallet connection
+
+- change `accountsChanged` event to `accountChanged` event and emit new `Account` object instead of creating it in the connection manager
+- WalletConnect connection improvements

--- a/packages/thirdweb/src/wallets/coinbase/coinbaseSDKWallet.ts
+++ b/packages/thirdweb/src/wallets/coinbase/coinbaseSDKWallet.ts
@@ -229,10 +229,14 @@ function onConnect(
   }
 
   function onAccountsChanged(accounts: string[]) {
-    if (accounts.length === 0) {
-      onDisconnect();
+    if (accounts[0]) {
+      const newAccount = {
+        ...account,
+        address: getAddress(accounts[0]),
+      };
+      emitter.emit("accountChanged", newAccount);
     } else {
-      emitter.emit("accountsChanged", accounts);
+      onDisconnect();
     }
   }
 

--- a/packages/thirdweb/src/wallets/create-wallet.ts
+++ b/packages/thirdweb/src/wallets/create-wallet.ts
@@ -84,6 +84,10 @@ export function createWallet<const ID extends WalletId>(
         unsubscribeDisconnect();
       });
 
+      emitter.subscribe("accountChanged", (_account) => {
+        account = _account;
+      });
+
       let handleSwitchChain: (chain: Chain) => Promise<void> = async () => {
         throw new Error("Not implemented yet");
       };
@@ -461,6 +465,10 @@ function coinbaseWalletSDK(): Wallet<"com.coinbase.wallet"> {
     // unsubscribe
     unsubscribeChainChanged();
     unsubscribeDisconnect();
+  });
+
+  emitter.subscribe("accountChanged", (_account) => {
+    account = _account;
   });
 
   return {

--- a/packages/thirdweb/src/wallets/injected/index.ts
+++ b/packages/thirdweb/src/wallets/injected/index.ts
@@ -200,10 +200,15 @@ async function onConnect(
   }
 
   function onAccountsChanged(accounts: string[]) {
-    if (accounts.length === 0) {
-      onDisconnect();
+    if (accounts[0]) {
+      const newAccount = {
+        ...account,
+        address: getAddress(accounts[0]),
+      };
+
+      emitter.emit("accountChanged", newAccount);
     } else {
-      emitter.emit("accountsChanged", accounts);
+      onDisconnect();
     }
   }
 

--- a/packages/thirdweb/src/wallets/manager/index.ts
+++ b/packages/thirdweb/src/wallets/manager/index.ts
@@ -102,27 +102,12 @@ export function createConnectionManager(storage: AsyncStorage) {
 
     // setup listeners
 
-    const onAccountsChanged = (addresses: string[]) => {
-      const newAddress = addresses[0];
-      if (!newAddress) {
-        onWalletDisconnect(wallet);
-        return;
-      } else {
-        // TODO: get this new object as argument from onAccountsChanged
-        // this requires emitting events from the wallet
-        const newAccount: Account = {
-          ...account,
-          address: newAddress,
-        };
-
-        activeAccountStore.setValue(newAccount);
-      }
+    const onAccountsChanged = (newAccount: Account) => {
+      activeAccountStore.setValue(newAccount);
     };
 
-    const unsubAccounts = wallet.subscribe(
-      "accountsChanged",
-      onAccountsChanged,
-    );
+    const unsubAccounts = wallet.subscribe("accountChanged", onAccountsChanged);
+
     const unsubChainChanged = wallet.subscribe("chainChanged", (chain) =>
       activeWalletChainStore.setValue(chain),
     );

--- a/packages/thirdweb/src/wallets/wallet-emitter.ts
+++ b/packages/thirdweb/src/wallets/wallet-emitter.ts
@@ -1,9 +1,10 @@
 import type { Chain } from "../chains/types.js";
 import { createEmitter, type Emitter } from "../utils/tiny-emitter.js";
+import type { Account } from "./interfaces/wallet.js";
 import type { WalletAutoConnectionOption, WalletId } from "./wallet-types.js";
 
 export type WalletEmitterEvents<TWalletId extends WalletId> = {
-  accountsChanged: string[];
+  accountChanged: Account;
   disconnect?: never;
   chainChanged: Chain;
   onConnect: WalletAutoConnectionOption<TWalletId>;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR improves wallet connection handling by changing the `accountsChanged` event to `accountChanged` and emitting a new `Account` object. 

### Detailed summary
- Renamed `accountsChanged` event to `accountChanged` event
- Emit new `Account` object instead of creating it in the connection manager
- Enhanced WalletConnect connection handling
- Updated types and interfaces for better clarity

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->