### PR TITLE
test: run "Account Permissions" only if TW_SECRET_KEY is defined

### DIFF
--- a/packages/thirdweb/src/extensions/erc4337/account/permissions.test.ts
+++ b/packages/thirdweb/src/extensions/erc4337/account/permissions.test.ts
@@ -23,7 +23,7 @@ import { adminUpdatedEvent } from "../__generated__/IAccountPermissions/events/A
 import { signerPermissionsUpdatedEvent } from "../__generated__/IAccountPermissions/events/SignerPermissionsUpdated.js";
 import { ADDRESS_ZERO } from "../../../constants/addresses.js";
 
-describe("Account Permissions", () => {
+describe.runIf(process.env.TW_SECRET_KEY)("Account Permissions", () => {
   let accountFactoryContract: ThirdwebContract;
   let accountContract: ThirdwebContract;
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding a conditional test execution based on the presence of a secret key in the environment variable for the "Account Permissions" feature.

### Detailed summary
- Updated the test suite to conditionally run based on the presence of a secret key in the environment variable.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->