### PR TITLE
chore: Update lint script in package.json

### DIFF
--- a/legacy_packages/react-native/package.json
+++ b/legacy_packages/react-native/package.json
@@ -12,7 +12,7 @@
   ],
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "lint": "eslint src/ && tsc --noEmit",
+    "lint": "eslint src/",
     "fix": "eslint src/ --fix",
     "clean": "rm -rf dist/",
     "build": "tsc",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `lint` script in the `package.json` file of the `react-native` legacy package to only run ESLint on the `src/` directory without TypeScript checking.

### Detailed summary
- Updated the `lint` script to only run ESLint on the `src/` directory.
- Removed TypeScript checking from the `lint` script.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->