### PR TITLE
test: Update contract deployment tests

### DIFF
--- a/packages/thirdweb/src/contract/deployment/deploy-via-autofactory.test.ts
+++ b/packages/thirdweb/src/contract/deployment/deploy-via-autofactory.test.ts
@@ -57,9 +57,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("deployFromMetadata", () => {
       transaction,
       account: TEST_ACCOUNT_A,
     });
-    expect(hash.transactionHash).toBe(
-      "0xca716193f5448ec52dafef9451ee5afabc8770a5303195a3977a94705d8101d1",
-    );
+    expect(hash.transactionHash).toBeDefined();
   });
 
   it("should deploy published contract with no existing infra", async () => {
@@ -117,8 +115,6 @@ describe.runIf(process.env.TW_SECRET_KEY)("deployFromMetadata", () => {
       transaction,
       account: TEST_ACCOUNT_A,
     });
-    expect(hash.transactionHash).toBe(
-      "0x531b94f7554b7c7ac5d72db3583e6997559ffa2acdc0d9afea1002c15db0632b",
-    );
+    expect(hash.transactionHash).toBeDefined();
   });
 });

--- a/packages/thirdweb/src/extensions/prebuilts/deploy-erc1155.test.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/deploy-erc1155.test.ts
@@ -20,7 +20,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("deployERC1155", () => {
         symbol: "NFTD",
       },
     });
-    expect(address).toBe("0xd91A47278829a0128D7212225FE74BC153A7FAF8");
+    expect(address).toBeDefined();
     const deployedName = await name({
       contract: getContract({
         client: TEST_CLIENT,
@@ -41,7 +41,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("deployERC1155", () => {
         name: "Edition",
       },
     });
-    expect(address).toBe("0x7dD915A335Af52698bFFFE14D1D3F0DCfdC0a8E6");
+    expect(address).toBeDefined();
     const deployedName = await name({
       contract: getContract({
         client: TEST_CLIENT,

--- a/packages/thirdweb/src/extensions/prebuilts/deploy-erc20.test.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/deploy-erc20.test.ts
@@ -20,7 +20,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("deployERC20", () => {
         symbol: "NFTD",
       },
     });
-    expect(address).toBe("0x61Ae22E7240C7e5853749AF49f2552CB8D7C3e35");
+    expect(address).toBeDefined();
     const deployedName = await name({
       contract: getContract({
         client: TEST_CLIENT,
@@ -41,7 +41,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("deployERC20", () => {
         name: "Token",
       },
     });
-    expect(address).toBe("0x3E8437C96275E9873b0379c1e5d5F0998A9546e9");
+    expect(address).toBeDefined();
     const deployedName = await name({
       contract: getContract({
         client: TEST_CLIENT,

--- a/packages/thirdweb/src/extensions/prebuilts/deploy-erc721.test.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/deploy-erc721.test.ts
@@ -19,7 +19,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("deployERC721", () => {
         name: "NFTDrop",
       },
     });
-    expect(address).toBe("0x6AA2E0148a57EcDdb025C856c4e68682CFfcac78");
+    expect(address).toBeDefined();
     const deployedName = await name({
       contract: getContract({
         client: TEST_CLIENT,
@@ -40,7 +40,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("deployERC721", () => {
         name: "NFTCollection",
       },
     });
-    expect(address).toBe("0x349D9e8751C40Be121a862FaC1Dc7c357281846E");
+    expect(address).toBeDefined();
     const deployedName = await name({
       contract: getContract({
         client: TEST_CLIENT,
@@ -61,7 +61,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("deployERC721", () => {
         name: "OE",
       },
     });
-    expect(address).toBe("0x5804ebCE1834B8F57D31f0078B8f7Dd1F1Da4985");
+    expect(address).toBeDefined();
     const deployedName = await name({
       contract: getContract({
         client: TEST_CLIENT,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates test assertions in ERC20, ERC1155, and ERC721 deployment tests to check for address existence instead of specific values.

### Detailed summary
- Updated test assertions to check if address is defined instead of specific values in ERC20, ERC1155, and ERC721 deployment tests.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->