### PR TITLE
[v4 wallets] Start new session for walletConnect on connect method call

### DIFF
--- a/.changeset/weak-badgers-fold.md
+++ b/.changeset/weak-badgers-fold.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/wallets": patch
+---
+
+Always start new WalletConnect session when calling `connect` method for WalletConnect connector

--- a/legacy_packages/wallets/src/evm/connectors/wallet-connect/index.ts
+++ b/legacy_packages/wallets/src/evm/connectors/wallet-connect/index.ts
@@ -126,13 +126,9 @@ export class WalletConnectConnector extends WagmiConnector<
 
       const isChainsStale = await this._isChainsStale();
 
-      // If there is an active session with stale chains, disconnect the current session.
-      if (provider.session && isChainsStale) {
+      if (provider.session) {
         await provider.disconnect();
-      }
 
-      // If there no active session, or the chains are stale, connect.
-      if (!provider.session || isChainsStale) {
         const optionalChains = this.filteredChains
           .filter((chain) => chain.chainId !== targetChainId)
           .map((optionalChain) => optionalChain.chainId);

--- a/legacy_packages/wallets/src/evm/connectors/wallet-connect/index.ts
+++ b/legacy_packages/wallets/src/evm/connectors/wallet-connect/index.ts
@@ -124,8 +124,6 @@ export class WalletConnectConnector extends WagmiConnector<
       const provider = await this.getProvider();
       this.setupListeners();
 
-      const isChainsStale = await this._isChainsStale();
-
       if (provider.session) {
         await provider.disconnect();
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on ensuring a new WalletConnect session is always started when calling the `connect` method. 

### Detailed summary
- Always initiates a new WalletConnect session when calling `connect` method
- Removed condition to disconnect session with stale chains before connecting

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->