### PR TITLE
[test] Fix sourcemap warnings in CRA

### DIFF
--- a/.changeset/tall-comics-rescue.md
+++ b/.changeset/tall-comics-rescue.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix sourcemap warnings in CRA

--- a/packages/thirdweb/package.json
+++ b/packages/thirdweb/package.json
@@ -165,6 +165,7 @@
   "sideEffects": false,
   "files": [
     "dist/*",
+    "src/*",
     "!**/*.tsbuildinfo",
     "!**/*.test.ts",
     "!**/*.test.ts.snap",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on fixing sourcemap warnings in Create React App (CRA) within the `thirdweb` package.

### Detailed summary
- Updated `"files"` in `thirdweb/package.json` to include `"src/*"` for sourcemap fixes in CRA.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->