### PR TITLE
feat: Add modalSize prop on ConnectEmbed

### DIFF
--- a/.changeset/sharp-gorillas-melt.md
+++ b/.changeset/sharp-gorillas-melt.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Add `modalSize` prop on `ConnectEmbed` to allow `"wide"` modal size.

--- a/packages/thirdweb/src/react/web/ui/components/Modal.tsx
+++ b/packages/thirdweb/src/react/web/ui/components/Modal.tsx
@@ -187,6 +187,9 @@ const DialogContent = /* @__PURE__ */ StyledDiv(() => {
     outline: "none",
     overflow: "hidden",
     fontFamily: theme.fontFamily,
+    "& *": {
+      boxSizing: "border-box",
+    },
     [media.mobile]: {
       top: "auto",
       bottom: 0,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a `modalSize` prop to `ConnectEmbed` component for wide modal support.

### Detailed summary
- Added `modalSize` prop to support `"wide"` modal size in `ConnectEmbed`
- Updated `constants.js` with wide modal constants
- Implemented logic to handle `compact` and `wide` modal sizes
- Updated styles in `EmbedContainer` based on modal size
- Adjusted `EmbedContainer` height and width based on modal size

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->