### PR TITLE
feat: expose `useSendBatchTransaction` for smart accounts

### DIFF
--- a/.changeset/tidy-colts-hug.md
+++ b/.changeset/tidy-colts-hug.md
@@ -2,4 +2,4 @@
 "thirdweb": patch
 ---
 
-Export useSendBatchTransaction() for smart accounts
+Export `useSendBatchTransaction()` for smart accounts

--- a/.changeset/tidy-colts-hug.md
+++ b/.changeset/tidy-colts-hug.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Export useSendBatchTransaction() for smart accounts

--- a/.changeset/tidy-colts-hug.md
+++ b/.changeset/tidy-colts-hug.md
@@ -1,5 +1,5 @@
 ---
-"thirdweb": patch
+"thirdweb": minor
 ---
 
 Export `useSendBatchTransaction()` for smart accounts

--- a/packages/thirdweb/src/exports/react.ts
+++ b/packages/thirdweb/src/exports/react.ts
@@ -53,6 +53,7 @@ export {
 // contract related
 export { useReadContract } from "../react/core/hooks/contract/useReadContract.js";
 export { useSendTransaction } from "../react/core/hooks/contract/useSendTransaction.js";
+export { useSendBatchTransaction } from "../react/core/hooks/contract/useSendBatchTransaction.js";
 export { useSendAndConfirmTransaction } from "../react/core/hooks/contract/useSendAndConfirmTransaction.js";
 export { useEstimateGas } from "../react/core/hooks/contract/useEstimateGas.js";
 export { useEstimateGasCost } from "../react/core/hooks/contract/useEstimateGasCost.js";

--- a/packages/thirdweb/src/exports/thirdweb.ts
+++ b/packages/thirdweb/src/exports/thirdweb.ts
@@ -104,6 +104,10 @@ export {
 } from "../transaction/actions/send-transaction.js";
 export { sendAndConfirmTransaction } from "../transaction/actions/send-and-confirm-transaction.js";
 export {
+  sendBatchTransaction,
+  type SendBatchTransactionOptions,
+} from "../transaction/actions/send-batch-transaction.js";
+export {
   simulateTransaction,
   type SimulateOptions,
 } from "../transaction/actions/simulate.js";

--- a/packages/thirdweb/src/react/core/hooks/contract/useSendBatchTransaction.ts
+++ b/packages/thirdweb/src/react/core/hooks/contract/useSendBatchTransaction.ts
@@ -1,8 +1,8 @@
 import { type UseMutationResult, useMutation } from "@tanstack/react-query";
+import { sendBatchTransaction } from "../../../../exports/transaction.js";
 import type { WaitForReceiptOptions } from "../../../../transaction/actions/wait-for-tx-receipt.js";
 import type { PreparedTransaction } from "../../../../transaction/prepare-transaction.js";
 import { useActiveAccount } from "../wallets/wallet-hooks.js";
-import { sendBatchTransaction } from "../../../../exports/transaction.js";
 
 /**
  * A hook to send a transaction.

--- a/packages/thirdweb/src/react/core/hooks/contract/useSendBatchTransaction.ts
+++ b/packages/thirdweb/src/react/core/hooks/contract/useSendBatchTransaction.ts
@@ -1,0 +1,38 @@
+import { type UseMutationResult, useMutation } from "@tanstack/react-query";
+import type { WaitForReceiptOptions } from "../../../../transaction/actions/wait-for-tx-receipt.js";
+import type { PreparedTransaction } from "../../../../transaction/prepare-transaction.js";
+import { useActiveAccount } from "../wallets/wallet-hooks.js";
+import { sendBatchTransaction } from "../../../../exports/transaction.js";
+
+/**
+ * A hook to send a transaction.
+ * @returns A mutation object to send a transaction.
+ * @example
+ * ```jsx
+ * import { useSendBatchTransaction } from "thirdweb/react";
+ * const { mutate: sendBatch, data: transactionResult } = useSendBatchTransaction();
+ *
+ * // later
+ * sendBatch([tx1, tx2]);
+ * ```
+ * @transaction
+ */
+export function useSendBatchTransaction(): UseMutationResult<
+  WaitForReceiptOptions,
+  Error,
+  PreparedTransaction[]
+> {
+  const account = useActiveAccount();
+
+  return useMutation({
+    mutationFn: async (transactions) => {
+      if (!account) {
+        throw new Error("No active account");
+      }
+      return await sendBatchTransaction({
+        transactions,
+        account,
+      });
+    },
+  });
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds the `useSendBatchTransaction()` hook for sending batch transactions in smart accounts.

### Detailed summary
- Added `useSendBatchTransaction()` hook for batch transactions
- Exported `sendBatchTransaction` and related types
- Updated relevant imports in `thirdweb.ts` and `useSendBatchTransaction.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->