### PR TITLE
fix(rpc): Fix issue with block number polling

### DIFF
--- a/.changeset/olive-adults-leave.md
+++ b/.changeset/olive-adults-leave.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+fix `watchBlockNumber` polling when fully unsubscribing and later re-subscribing

--- a/packages/thirdweb/src/rpc/watchBlockNumber.test.ts
+++ b/packages/thirdweb/src/rpc/watchBlockNumber.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { watchBlockNumber } from "./watchBlockNumber.js";
-import { baseSepolia } from "../chains/chain-definitions/base-sepolia.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { TEST_CLIENT } from "../../test/src/test-clients.js";
+import { baseSepolia } from "../chains/chain-definitions/base-sepolia.js";
 import { wait } from "../utils/promise/wait.js";
+import { watchBlockNumber } from "./watchBlockNumber.js";
 
 describe.runIf(process.env.TW_SECRET_KEY)("watch block number", () => {
   const onNewBlockNumber = vi.fn();

--- a/packages/thirdweb/src/rpc/watchBlockNumber.test.ts
+++ b/packages/thirdweb/src/rpc/watchBlockNumber.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { watchBlockNumber } from "./watchBlockNumber.js";
+import { baseSepolia } from "../chains/chain-definitions/base-sepolia.js";
+import { TEST_CLIENT } from "../../test/src/test-clients.js";
+import { wait } from "../utils/promise/wait.js";
+
+describe.runIf(process.env.TW_SECRET_KEY)("watch block number", () => {
+  const onNewBlockNumber = vi.fn();
+  const onNewBlockNumber2 = vi.fn();
+
+  beforeEach(() => {
+    onNewBlockNumber.mockClear();
+    onNewBlockNumber2.mockClear();
+  });
+
+  it("should set up the watcher", () => {
+    const onNewBlockNumber = vi.fn();
+    const unwatch = watchBlockNumber({
+      client: TEST_CLIENT,
+      chain: baseSepolia,
+      onNewBlockNumber,
+    });
+
+    expect(onNewBlockNumber).toHaveBeenCalledTimes(0);
+    expect(unwatch).toBeTypeOf("function");
+
+    unwatch();
+  });
+
+  it("should call the onNewBlockNumber callback", async () => {
+    const unwatch = watchBlockNumber({
+      client: TEST_CLIENT,
+      chain: baseSepolia,
+      onNewBlockNumber,
+    });
+
+    expect(onNewBlockNumber).toHaveBeenCalledTimes(0);
+
+    // wait for 5 seconds which should always be sufficient for a new block to be mined
+    await wait(5000);
+
+    expect(onNewBlockNumber).toHaveBeenCalled();
+
+    unwatch();
+  });
+
+  it("should re-use the same watcher for multiple calls", async () => {
+    const unwatch = watchBlockNumber({
+      client: TEST_CLIENT,
+      chain: baseSepolia,
+      onNewBlockNumber,
+    });
+    const unwatch2 = watchBlockNumber({
+      client: TEST_CLIENT,
+      chain: baseSepolia,
+      onNewBlockNumber: onNewBlockNumber2,
+    });
+
+    expect(onNewBlockNumber).toHaveBeenCalledTimes(0);
+    expect(onNewBlockNumber2).toHaveBeenCalledTimes(0);
+
+    // wait for 5 seconds which should always be sufficient for a new block to be mined
+    await wait(5000);
+
+    expect(onNewBlockNumber).toHaveBeenCalled();
+    expect(onNewBlockNumber2).toHaveBeenCalled();
+
+    // TODO: ensure that unwatch and unwatch2 are acting ont he same poller
+
+    unwatch();
+    unwatch2();
+  });
+
+  it("should stop polling when unsubscribed", async () => {
+    const unwatch = watchBlockNumber({
+      client: TEST_CLIENT,
+      chain: baseSepolia,
+      onNewBlockNumber,
+    });
+
+    expect(onNewBlockNumber).toHaveBeenCalledTimes(0);
+
+    // wait for 5 seconds which should always be sufficient for a new block to be mined
+    await wait(5000);
+
+    expect(onNewBlockNumber).toHaveBeenCalled();
+
+    onNewBlockNumber.mockClear();
+
+    unwatch();
+
+    // wait for 5 seconds which should always be sufficient for a new block to be mined
+    await wait(5000);
+
+    expect(onNewBlockNumber).toHaveBeenCalledTimes(0);
+  });
+
+  it("should re-start from a fresh block when fully unsubscribed and re-subscribed", async () => {
+    const unwatch = watchBlockNumber({
+      client: TEST_CLIENT,
+      chain: baseSepolia,
+      onNewBlockNumber,
+    });
+
+    expect(onNewBlockNumber).toHaveBeenCalledTimes(0);
+
+    // wait for 5 seconds which should always be sufficient for a new block to be mined
+    await wait(5000);
+
+    expect(onNewBlockNumber).toHaveBeenCalled();
+
+    const lastBlockNumber = onNewBlockNumber.mock.lastCall?.[0];
+
+    onNewBlockNumber.mockClear();
+
+    unwatch();
+
+    // wait for 5 seconds which should always be sufficient for a new block to be mined
+    await wait(5000);
+
+    expect(onNewBlockNumber).toHaveBeenCalledTimes(0);
+
+    const unwatch2 = watchBlockNumber({
+      client: TEST_CLIENT,
+      chain: baseSepolia,
+      onNewBlockNumber,
+    });
+
+    // wait for 5 seconds which should always be sufficient for a new block to be mined
+    await wait(5000);
+
+    expect(onNewBlockNumber).toHaveBeenCalled();
+
+    const firstBlockNumber = onNewBlockNumber.mock.calls[0]?.[0];
+
+    // we need to have skipped blocks here
+    expect(firstBlockNumber).toBeGreaterThan(lastBlockNumber + 1n);
+
+    unwatch2();
+  });
+});

--- a/packages/thirdweb/src/rpc/watchBlockNumber.ts
+++ b/packages/thirdweb/src/rpc/watchBlockNumber.ts
@@ -49,6 +49,8 @@ function createBlockNumberPoller(
   async function poll() {
     // stop polling if there are no more subscriptions
     if (!isActive) {
+      lastBlockNumber = undefined;
+      lastBlockAt = undefined;
       return;
     }
     const blockNumber = await eth_blockNumber(rpcRequest);
@@ -112,6 +114,8 @@ function createBlockNumberPoller(
       subscribers = subscribers.filter((fn) => fn !== callBack);
       // if the new subscribers Array is empty (aka we were the last subscriber) -> stop polling
       if (subscribers.length === 0) {
+        lastBlockNumber = undefined;
+        lastBlockAt = undefined;
         isActive = false;
       }
     };


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on fixing the `watchBlockNumber` polling behavior when fully unsubscribing and re-subscribing.

### Detailed summary
- Fixed polling behavior when fully unsubscribing and re-subscribing
- Added tests for setting up the watcher, callback invocation, re-using the watcher, stopping polling when unsubscribed, and restarting from a fresh block

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->