### PR TITLE
[SDK] fromGwei helper function

### DIFF
--- a/.changeset/fast-hairs-accept.md
+++ b/.changeset/fast-hairs-accept.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": minor
+---
+
+Adds fromGwei unit converter

--- a/packages/thirdweb/src/exports/thirdweb.ts
+++ b/packages/thirdweb/src/exports/thirdweb.ts
@@ -147,7 +147,7 @@ export type { NFT } from "../utils/nft/parseNft.js";
 /**
  * UNITS
  */
-export { toEther, toTokens, toUnits, toWei } from "../utils/units.js";
+export { toEther, toTokens, toUnits, toWei, fromGwei } from "../utils/units.js";
 
 export {
   getBuyWithCryptoQuote,

--- a/packages/thirdweb/src/exports/utils.ts
+++ b/packages/thirdweb/src/exports/utils.ts
@@ -7,7 +7,7 @@ export { ensureBytecodePrefix } from "../utils/bytecode/prefix.js";
 export { resolveImplementation } from "../utils/bytecode/resolveImplementation.js";
 
 // units
-export { toEther, toTokens, toUnits, toWei } from "../utils/units.js";
+export { toEther, toTokens, toUnits, toWei, fromGwei } from "../utils/units.js";
 
 // any-evm utils
 export {

--- a/packages/thirdweb/src/utils/units.test.ts
+++ b/packages/thirdweb/src/utils/units.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { toEther, toTokens, toUnits, toWei } from "./units.js";
+import { fromGwei, toEther, toTokens, toUnits, toWei } from "./units.js";
 
 describe("toTokens", () => {
   it("converts value to number", () => {
@@ -266,5 +266,48 @@ describe("toWei", () => {
     expect(toWei("-1.2345678000000000912345222")).toMatchInlineSnapshot(
       "-1234567800000000091n",
     );
+  });
+});
+
+describe("fromGwei", () => {
+  it("converts gwei to wei correctly", () => {
+    expect(fromGwei("1")).toMatchInlineSnapshot("1000000000n");
+    expect(fromGwei("10")).toMatchInlineSnapshot("10000000000n");
+    expect(fromGwei("100")).toMatchInlineSnapshot("100000000000n");
+    expect(fromGwei("1000")).toMatchInlineSnapshot("1000000000000n");
+    expect(fromGwei("12345")).toMatchInlineSnapshot("12345000000000n");
+    expect(fromGwei("0")).toMatchInlineSnapshot("0n");
+    expect(fromGwei("-1")).toMatchInlineSnapshot("-1000000000n");
+    expect(fromGwei("-10")).toMatchInlineSnapshot("-10000000000n");
+    expect(fromGwei("-100")).toMatchInlineSnapshot("-100000000000n");
+    expect(fromGwei("-1000")).toMatchInlineSnapshot("-1000000000000n");
+    expect(fromGwei("-12345")).toMatchInlineSnapshot("-12345000000000n");
+  });
+
+  it("handles fractional gwei inputs", () => {
+    expect(fromGwei("1.2345")).toMatchInlineSnapshot("1234500000n");
+    expect(fromGwei("10.6789")).toMatchInlineSnapshot("10678900000n");
+    expect(fromGwei("0.0001")).toMatchInlineSnapshot("100000n");
+    expect(fromGwei("0.9999")).toMatchInlineSnapshot("999900000n");
+    expect(fromGwei("-1.2345")).toMatchInlineSnapshot("-1234500000n");
+    expect(fromGwei("-10.6789")).toMatchInlineSnapshot("-10678900000n");
+    expect(fromGwei("-0.0001")).toMatchInlineSnapshot("-100000n");
+    expect(fromGwei("-0.9999")).toMatchInlineSnapshot("-999900000n");
+  });
+
+  // I'm not sure there is any case that gwei would be fractional, but just in case someone tries it
+  it("rounds fractional gwei inputs correctly and trims excessive decimals", () => {
+    expect(fromGwei("1.000000000000008")).toMatchInlineSnapshot("1000000000n");
+    expect(fromGwei("1.000000000000004")).toMatchInlineSnapshot("1000000000n");
+    expect(fromGwei("0.0000000000000001")).toMatchInlineSnapshot("0n");
+    expect(fromGwei("0.0000000000000009")).toMatchInlineSnapshot("0n");
+    expect(fromGwei("-1.000000000000008")).toMatchInlineSnapshot(
+      "-1000000000n",
+    );
+    expect(fromGwei("-1.000000000000004")).toMatchInlineSnapshot(
+      "-1000000000n",
+    );
+    expect(fromGwei("-0.0000000000000001")).toMatchInlineSnapshot("0n");
+    expect(fromGwei("-0.0000000000000009")).toMatchInlineSnapshot("0n");
   });
 });

--- a/packages/thirdweb/src/utils/units.ts
+++ b/packages/thirdweb/src/utils/units.ts
@@ -130,3 +130,19 @@ export function toUnits(tokens: string, decimals: number): bigint {
 export function toWei(tokens: string) {
   return toUnits(tokens, 18);
 }
+
+/**
+ * Converts the specified number from gwei to wei.
+ * @param gwei The number of gwei to convert.
+ * @returns The converted value in wei.
+ * @example
+ * ```ts
+ * import { fromGwei } from "thirdweb/utils";
+ * fromGwei('1')
+ * // 1000000000n
+ * ```
+ * @utils
+ */
+export function fromGwei(gwei: string) {
+  return toUnits(gwei, 9);
+}


### PR DESCRIPTION
Tiny PR to add a fromGwei helper function to convert gwei to wei. Useful when setting the gas price on transactions.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new `fromGwei` unit converter function to the `thirdweb` package for converting values from gwei to wei.

### Detailed summary
- Added `fromGwei` unit converter function to convert values from gwei to wei
- Updated exports in `utils.ts` and `thirdweb.ts`
- Added tests for `fromGwei` function in `units.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->