### PR TITLE
[v4] Alias embeddedWallet to inAppWallet

### DIFF
--- a/.changeset/good-boxes-repair.md
+++ b/.changeset/good-boxes-repair.md
@@ -1,0 +1,7 @@
+---
+"@thirdweb-dev/react-native": patch
+"@thirdweb-dev/wallets": patch
+"@thirdweb-dev/react": patch
+---
+
+Alias embedded wallet to in-app wallet

--- a/legacy_packages/react-native/src/evm/index.ts
+++ b/legacy_packages/react-native/src/evm/index.ts
@@ -16,7 +16,9 @@ export { smartWallet } from "./wallets/wallets/smart-wallet";
 export { localWallet } from "./wallets/wallets/local-wallet";
 export { LocalWallet } from "./wallets/wallets/LocalWallet";
 export { EmbeddedWallet } from "./wallets/wallets/embedded/EmbeddedWallet";
+export { EmbeddedWallet as InAppWallet } from "./wallets/wallets/embedded/EmbeddedWallet";
 export { embeddedWallet } from "./wallets/wallets/embedded/embedded-wallet";
+export { embeddedWallet as inAppWallet } from "./wallets/wallets/embedded/embedded-wallet";
 export * from "./wallets/wallets/wallet-connect/WalletConnectBase";
 export { WalletConnect } from "./wallets/wallets/wallet-connect/WalletConnect";
 export { walletConnect } from "./wallets/wallets/wallet-connect/wallet-connect";
@@ -27,6 +29,7 @@ export { useMetaMaskWallet } from "./wallets/hooks/useMetaMaskWallet";
 export { useRainbowWallet } from "./wallets/hooks/useRainbowWallet";
 export { useTrustWallet } from "./wallets/hooks/useTrustWallet";
 export { useEmbeddedWallet } from "./wallets/hooks/useEmbeddedWallet";
+export { useEmbeddedWallet as useInAppWallet } from "./wallets/hooks/useEmbeddedWallet";
 export { useSmartWallet } from "./wallets/hooks/useSmartWallet";
 export { useEmbeddedWalletSendVerificationEmail } from "./wallets/hooks/useEmbeddedWalletSendVerificationEmail";
 

--- a/legacy_packages/react/src/evm/index.ts
+++ b/legacy_packages/react/src/evm/index.ts
@@ -61,6 +61,12 @@ export {
   useEmbeddedWalletUserEmail,
 } from "./hooks/wallets/useEmbeddedWallet";
 export { useEmbeddedWalletSendVerificationEmail } from "./hooks/useEmbeddedWalletSendVerificationEmail";
+export {
+  useEmbeddedWallet as useInAppWallet,
+  useEmbeddedWalletUserEmail as useInAppWalletUserEmail,
+} from "./hooks/wallets/useEmbeddedWallet";
+export { useEmbeddedWalletSendVerificationEmail as useInAppWalletSendVerificationEmail } from "./hooks/useEmbeddedWalletSendVerificationEmail";
+
 
 export {
   usePaperWalletUserEmail,

--- a/legacy_packages/react/src/index.ts
+++ b/legacy_packages/react/src/index.ts
@@ -16,7 +16,9 @@ export {
   type CoinbaseWalletConfigOptions,
 } from "./wallet/wallets/coinbase/coinbaseWallet";
 export { embeddedWallet } from "./wallet/wallets/embeddedWallet/embeddedWallet";
+export { embeddedWallet as inAppWallet } from "./wallet/wallets/embeddedWallet/embeddedWallet";
 export type { EmbeddedWalletConfigOptions } from "./wallet/wallets/embeddedWallet/types";
+export type { EmbeddedWalletConfigOptions as InAppWalletConfigOptions } from "./wallet/wallets/embeddedWallet/types";
 
 export {
   frameWallet,

--- a/legacy_packages/wallets/src/evm/index.ts
+++ b/legacy_packages/wallets/src/evm/index.ts
@@ -29,7 +29,21 @@ export { AbstractClientWallet } from "./wallets/base";
 export type { WalletOptions } from "./wallets/base";
 export { type BloctoOptions, BloctoWallet } from "./wallets/blocto";
 export * from "./wallets/coinbase-wallet";
-export * from "./wallets/embedded-wallet";
+export {
+  EmbeddedWallet, 
+  EmbeddedWallet as InAppWallet, 
+  type AuthParams, 
+  type AuthResult, 
+  type EmbeddedWalletAdditionalOptions, 
+  type EmbeddedWalletAdditionalOptions as InAppWalletWalletAdditionalOptions, 
+  type EmbeddedWalletConnectionArgs,
+  type EmbeddedWalletConnectionArgs as InAppWalletConnectionArgs, 
+  type EmbeddedWalletOauthStrategy,
+  type EmbeddedWalletOauthStrategy as InAppWalletOauthStrategy, 
+  type EmbeddedWalletOptions,
+  type EmbeddedWalletOptions as InAppWalletWalletOptions,
+  supportedSmsCountries
+} from "./wallets/embedded-wallet";
 export * from "./wallets/ethers";
 export * from "./wallets/frame";
 export * from "./wallets/imtoken";


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the codebase to alias the embedded wallet as the in-app wallet for better clarity and consistency.

### Detailed summary
- Aliased `embeddedWallet` as `inAppWallet`
- Updated types and functions to reflect the aliasing
- Renamed `EmbeddedWallet` to `InAppWallet` for consistency

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->