### PR TITLE
implement extensions for `royalty`, `platformfee` and `primarysale`

### DIFF
--- a/.changeset/selfish-peaches-carry.md
+++ b/.changeset/selfish-peaches-carry.md
@@ -1,0 +1,6 @@
+---
+"thirdweb": minor
+---
+
+- storage: `upload` now returns a single `uri` when a single file is passed to the `files` array.
+- extensions: added suport for `royalty`, `platformFee` and `primarySale` extensions

--- a/packages/thirdweb/src/exports/extensions/common.ts
+++ b/packages/thirdweb/src/exports/extensions/common.ts
@@ -31,8 +31,19 @@ export {
 // --------------------------------------------------------
 // Royalty
 // --------------------------------------------------------
+// read
 export { getDefaultRoyaltyInfo } from "../../extensions/common/__generated__/IRoyalty/read/getDefaultRoyaltyInfo.js";
 export {
   getRoyaltyInfoForToken,
   type GetRoyaltyInfoForTokenParams,
 } from "../../extensions/common/__generated__/IRoyalty/read/getRoyaltyInfoForToken.js";
+
+// write
+export {
+  setDefaultRoyaltyInfo,
+  type SetDefaultRoyaltyInfoParams,
+} from "../../extensions/common/__generated__/IRoyalty/write/setDefaultRoyaltyInfo.js";
+export {
+  setRoyaltyInfoForToken,
+  type SetRoyaltyInfoForTokenParams,
+} from "../../extensions/common/__generated__/IRoyalty/write/setRoyaltyInfoForToken.js";

--- a/packages/thirdweb/src/exports/extensions/common.ts
+++ b/packages/thirdweb/src/exports/extensions/common.ts
@@ -16,6 +16,11 @@ export {
   type SetOwnerParams,
 } from "../../extensions/common/__generated__/IOwnable/write/setOwner.js";
 
+export {
+  setContractMetadata,
+  type SetContractMetadataParams,
+} from "../../extensions/common/write/setContractMetadata.js";
+
 // events
 
 export {

--- a/packages/thirdweb/src/exports/extensions/common.ts
+++ b/packages/thirdweb/src/exports/extensions/common.ts
@@ -57,3 +57,12 @@ export {
   setPlatformFeeInfo,
   type SetPlatformFeeInfoParams,
 } from "../../extensions/common/__generated__/IPlatformFee/write/setPlatformFeeInfo.js";
+
+// --------------------------------------------------------
+// Primary Sale
+// --------------------------------------------------------
+export { primarySaleRecipient } from "../../extensions/common/__generated__/IPrimarySale/read/primarySaleRecipient.js";
+export {
+  setPrimarySaleRecipient,
+  type SetPrimarySaleRecipientParams,
+} from "../../extensions/common/__generated__/IPrimarySale/write/setPrimarySaleRecipient.js";

--- a/packages/thirdweb/src/exports/extensions/common.ts
+++ b/packages/thirdweb/src/exports/extensions/common.ts
@@ -47,3 +47,13 @@ export {
   setRoyaltyInfoForToken,
   type SetRoyaltyInfoForTokenParams,
 } from "../../extensions/common/__generated__/IRoyalty/write/setRoyaltyInfoForToken.js";
+
+// --------------------------------------------------------
+// Platform Fees
+// --------------------------------------------------------
+
+export { getPlatformFeeInfo } from "../../extensions/common/__generated__/IPlatformFee/read/getPlatformFeeInfo.js";
+export {
+  setPlatformFeeInfo,
+  type SetPlatformFeeInfoParams,
+} from "../../extensions/common/__generated__/IPlatformFee/write/setPlatformFeeInfo.js";

--- a/packages/thirdweb/src/exports/extensions/common.ts
+++ b/packages/thirdweb/src/exports/extensions/common.ts
@@ -22,3 +22,12 @@ export {
   ownerUpdatedEvent,
   type OwnerUpdatedEventFilters,
 } from "../../extensions/common/__generated__/IOwnable/events/OwnerUpdated.js";
+
+// --------------------------------------------------------
+// Royalty
+// --------------------------------------------------------
+export { getDefaultRoyaltyInfo } from "../../extensions/common/__generated__/IRoyalty/read/getDefaultRoyaltyInfo.js";
+export {
+  getRoyaltyInfoForToken,
+  type GetRoyaltyInfoForTokenParams,
+} from "../../extensions/common/__generated__/IRoyalty/read/getRoyaltyInfoForToken.js";

--- a/packages/thirdweb/src/extensions/common/write/setContractMetadata.ts
+++ b/packages/thirdweb/src/extensions/common/write/setContractMetadata.ts
@@ -1,0 +1,47 @@
+import { upload } from "../../../storage/upload.js";
+import type { BaseTransactionOptions } from "../../../transaction/types.js";
+import { setContractURI } from "../__generated__/IContractMetadata/write/setContractURI.js";
+
+export type SetContractMetadataParams = Record<string, unknown>;
+
+/**
+ * Sets the metadata for a contract.
+ *
+ * @param options - The options for setting the contract metadata.
+ * @returns - The prepared transaction to set the contract metadata.
+ * @extension COMMON
+ * @example
+ * ```ts
+ * import { setContractMetadata } from '@thirdweb/extensions/common';
+ *
+ * const transaction = setContractMetadata({
+ *  contract,
+ *  name: 'My NFT',
+ *  symbol: 'NFT',
+ * });
+ *
+ * // Send the transaction
+ * await sendTransaction({
+ *  transaction,
+ *  account,
+ * });
+ * ```
+ */
+export function setContractMetadata({
+  contract,
+  ...restParams
+}: BaseTransactionOptions<SetContractMetadataParams>) {
+  return setContractURI({
+    contract,
+    asyncParams: async () => {
+      const uri = await upload({
+        client: contract.client,
+        files: [restParams],
+      });
+
+      return {
+        uri,
+      };
+    },
+  });
+}

--- a/packages/thirdweb/src/extensions/erc1155/write/mintTo.ts
+++ b/packages/thirdweb/src/extensions/erc1155/write/mintTo.ts
@@ -48,12 +48,10 @@ export function mintTo(options: BaseTransactionOptions<MintToParams>) {
 
         // load the upload code if we need it
         const { upload } = await import("../../../storage/upload.js");
-        tokenUri = (
-          await upload({
-            client: options.contract.client,
-            files: [options.nft],
-          })
-        )[0] as string;
+        tokenUri = await upload({
+          client: options.contract.client,
+          files: [options.nft],
+        });
       }
       return {
         to: options.to,

--- a/packages/thirdweb/src/extensions/erc721/write/mintTo.ts
+++ b/packages/thirdweb/src/extensions/erc721/write/mintTo.ts
@@ -45,12 +45,10 @@ export function mintTo(options: BaseTransactionOptions<MintToParams>) {
 
         // load the upload code if we need it
         const { upload } = await import("../../../storage/upload.js");
-        tokenUri = (
-          await upload({
-            client: options.contract.client,
-            files: [options.nft],
-          })
-        )[0] as string;
+        tokenUri = await upload({
+          client: options.contract.client,
+          files: [options.nft],
+        });
       }
       return {
         to: options.to,

--- a/packages/thirdweb/src/extensions/erc721/write/setSharedMetadata.ts
+++ b/packages/thirdweb/src/extensions/erc721/write/setSharedMetadata.ts
@@ -26,12 +26,10 @@ export function setSharedMetadata(
             return options.nft.image;
           }
           const { upload } = await import("../../../storage/upload.js");
-          return (
-            await upload({
-              client: options.contract.client,
-              files: [options.nft.image],
-            })
-          )[0] as string;
+          return await upload({
+            client: options.contract.client,
+            files: [options.nft.image],
+          });
         })(),
         // animation URI resolution
         (async () => {
@@ -42,12 +40,10 @@ export function setSharedMetadata(
             return options.nft.animation_url;
           }
           const { upload } = await import("../../../storage/upload.js");
-          return (
-            await upload({
-              client: options.contract.client,
-              files: [options.nft.animation_url],
-            })
-          )[0] as string;
+          return await upload({
+            client: options.contract.client,
+            files: [options.nft.animation_url],
+          });
         })(),
       ];
 

--- a/packages/thirdweb/src/extensions/erc721/write/sigMint.ts
+++ b/packages/thirdweb/src/extensions/erc721/write/sigMint.ts
@@ -85,12 +85,10 @@ export async function generateMintSignature(
 
   let uri: string;
   if (typeof mintRequest.metadata === "object") {
-    uri = (
-      await upload({
-        client: options.contract.client,
-        files: [mintRequest.metadata],
-      })
-    )[0] as string;
+    uri = await upload({
+      client: options.contract.client,
+      files: [mintRequest.metadata],
+    });
   } else {
     uri = mintRequest.metadata;
   }

--- a/packages/thirdweb/src/extensions/prebuilts/deploy-erc1155.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/deploy-erc1155.ts
@@ -96,23 +96,21 @@ async function getInitializeTransaction(options: {
     options;
   const contractURI =
     options.params.contractURI ||
-    (
-      await upload({
-        client,
-        files: [
-          {
-            name: params.name,
-            description: params.description,
-            symbol: params.symbol,
-            image: params.image,
-            external_link: params.external_link,
-            social_urls: params.social_urls,
-            seller_fee_basis_points: params.royaltyBps,
-            fee_recipient: params.royaltyRecipient,
-          },
-        ],
-      })
-    )[0] ||
+    (await upload({
+      client,
+      files: [
+        {
+          name: params.name,
+          description: params.description,
+          symbol: params.symbol,
+          image: params.image,
+          external_link: params.external_link,
+          social_urls: params.social_urls,
+          seller_fee_basis_points: params.royaltyBps,
+          fee_recipient: params.royaltyRecipient,
+        },
+      ],
+    })) ||
     "";
   switch (type) {
     case "DropERC1155":

--- a/packages/thirdweb/src/extensions/prebuilts/deploy-erc20.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/deploy-erc20.ts
@@ -92,21 +92,19 @@ async function getInitializeTransaction(options: {
     options;
   const contractURI =
     options.params.contractURI ||
-    (
-      await upload({
-        client,
-        files: [
-          {
-            name: params.name,
-            description: params.description,
-            symbol: params.symbol,
-            image: params.image,
-            external_link: params.external_link,
-            social_urls: params.social_urls,
-          },
-        ],
-      })
-    )[0] ||
+    (await upload({
+      client,
+      files: [
+        {
+          name: params.name,
+          description: params.description,
+          symbol: params.symbol,
+          image: params.image,
+          external_link: params.external_link,
+          social_urls: params.social_urls,
+        },
+      ],
+    })) ||
     "";
   switch (type) {
     case "DropERC20":

--- a/packages/thirdweb/src/extensions/prebuilts/deploy-erc721.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/deploy-erc721.ts
@@ -102,23 +102,21 @@ async function getInitializeTransaction(options: {
     options;
   const contractURI =
     options.params.contractURI ||
-    (
-      await upload({
-        client,
-        files: [
-          {
-            name: params.name,
-            description: params.description,
-            symbol: params.symbol,
-            image: params.image,
-            external_link: params.external_link,
-            social_urls: params.social_urls,
-            seller_fee_basis_points: params.royaltyBps,
-            fee_recipient: params.royaltyRecipient,
-          },
-        ],
-      })
-    )[0] ||
+    (await upload({
+      client,
+      files: [
+        {
+          name: params.name,
+          description: params.description,
+          symbol: params.symbol,
+          image: params.image,
+          external_link: params.external_link,
+          social_urls: params.social_urls,
+          seller_fee_basis_points: params.royaltyBps,
+          fee_recipient: params.royaltyRecipient,
+        },
+      ],
+    })) ||
     "";
   switch (type) {
     case "DropERC721":

--- a/packages/thirdweb/src/extensions/prebuilts/deploy-marketplace.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/deploy-marketplace.ts
@@ -152,20 +152,18 @@ async function getInitializeTransaction(options: {
   const { client, implementationContract, params, accountAddress } = options;
   const contractURI =
     options.params.contractURI ||
-    (
-      await upload({
-        client,
-        files: [
-          {
-            name: params.name,
-            description: params.description,
-            image: params.image,
-            external_link: params.external_link,
-            social_urls: params.social_urls,
-          },
-        ],
-      })
-    )[0] ||
+    (await upload({
+      client,
+      files: [
+        {
+          name: params.name,
+          description: params.description,
+          image: params.image,
+          external_link: params.external_link,
+          social_urls: params.social_urls,
+        },
+      ],
+    })) ||
     "";
   return initMarketplace({
     contract: implementationContract,

--- a/packages/thirdweb/src/storage/upload/types.ts
+++ b/packages/thirdweb/src/storage/upload/types.ts
@@ -24,8 +24,10 @@ export type BuildFormDataOptions = {
   metadata?: Record<string, string>;
 };
 
-export type UploadOptions = {
-  files: (FileOrBufferOrString | Record<string, unknown>)[];
+export type UploadableFile = FileOrBufferOrString | Record<string, unknown>;
+
+export type UploadOptions<TFiles extends UploadableFile[]> = {
+  files: TFiles;
 } & BuildFormDataOptions;
 
 export type UploadFile = { name?: string; type?: string; uri: string };

--- a/packages/thirdweb/src/storage/upload/web-node.ts
+++ b/packages/thirdweb/src/storage/upload/web-node.ts
@@ -1,13 +1,13 @@
 import type { ThirdwebClient } from "../../client/client.js";
 import { getThirdwebDomains } from "../../utils/domains.js";
 import { getClientFetch } from "../../utils/fetch.js";
-import type { UploadOptions } from "./types.js";
+import type { UploadOptions, UploadableFile } from "./types.js";
 
-export async function uploadBatch(
+export async function uploadBatch<const TFiles extends UploadableFile[]>(
   client: ThirdwebClient,
   form: FormData,
   fileNames: string[],
-  options?: UploadOptions,
+  options?: UploadOptions<TFiles>,
 ) {
   const headers: HeadersInit = {};
 

--- a/packages/thirdweb/src/utils/ipfs.ts
+++ b/packages/thirdweb/src/utils/ipfs.ts
@@ -74,7 +74,7 @@ export async function uploadOrExtractURIs<
         fileStartNumber: startNumber || 0,
       },
     });
-    return uris;
+    return Array.isArray(uris) ? uris : [uris];
   }
   throw new Error(
     "Files must all be of the same type (all URI or all FileOrBufferOrString)",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing file upload functionality and standardizing return values. 

### Detailed summary
- `upload` function now returns a single URI when a single file is uploaded
- Added support for new extensions: `royalty`, `platformFee`, `primarySale`
- Updated types for `UploadOptions` and `UploadableFile`
- Improved handling of file uploads for multiple scenarios

> The following files were skipped due to too many changes: `packages/thirdweb/src/storage/upload.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->