### PR TITLE
Jd/cleanups

### DIFF
--- a/packages/thirdweb/src/exports/extensions/erc721.ts
+++ b/packages/thirdweb/src/exports/extensions/erc721.ts
@@ -78,10 +78,7 @@ export {
   setTokenURI,
   type SetTokenURIParams,
 } from "../../extensions/erc721/__generated__/INFTMetadata/write/setTokenURI.js";
-export {
-  lazyMint,
-  type LazyMintParams,
-} from "../../extensions/erc721/write/lazyMint.js";
+
 /**
  * EVENTS extension for ERC721
  */
@@ -103,6 +100,14 @@ export {
   claimTo,
   type ClaimToParams,
 } from "../../extensions/erc721/drops/write/claimTo.js";
+export {
+  lazyMint,
+  type LazyMintParams,
+} from "../../extensions/erc721/write/lazyMint.js";
+export {
+  setClaimConditions,
+  type SetClaimConditionsParams,
+} from "../../extensions/erc721/drops/write/setClaimConditions.js";
 
 /**
  * SIGNATURE extension for ERC721

--- a/packages/thirdweb/src/extensions/permissions/permissions.test.ts
+++ b/packages/thirdweb/src/extensions/permissions/permissions.test.ts
@@ -31,7 +31,8 @@ describe.runIf(process.env.TW_SECRET_KEY)("Permissions", () => {
       chain: ANVIL_CHAIN,
       client: TEST_CLIENT,
     });
-  });
+    // this deploys a contract, it may take some time
+  }, 60_000);
 
   it("should check if the target account has the role", async () => {
     // after deployment the deployer should have the admin role


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a timeout to contract deployment tests and reorganizes ERC721 extension exports.

### Detailed summary
- Added a timeout of 60 seconds to contract deployment test
- Reorganized ERC721 extension exports
- Moved `lazyMint` and `setClaimConditions` exports to appropriate locations

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->