### PR TITLE
fix: deploy WETH9 infra contract for marketplace deploys

### DIFF
--- a/packages/thirdweb/src/extensions/prebuilts/deploy-marketplace.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/deploy-marketplace.ts
@@ -4,14 +4,18 @@ import type {
   AbiParametersToPrimitiveTypes,
   Address,
 } from "abitype";
-import { toFunctionSelector, toFunctionSignature, zeroAddress } from "viem";
+import { toFunctionSelector, toFunctionSignature } from "viem";
 import type { ThirdwebClient } from "../../client/client.js";
 import { resolveContractAbi } from "../../contract/actions/resolve-abi.js";
 import type { ThirdwebContract } from "../../contract/contract.js";
 import { deployViaAutoFactory } from "../../contract/deployment/deploy-via-autofactory.js";
-import { getOrDeployInfraForPublishedContract } from "../../contract/deployment/utils/bootstrap.js";
+import {
+  getOrDeployInfraContract,
+  getOrDeployInfraForPublishedContract,
+} from "../../contract/deployment/utils/bootstrap.js";
 import { upload } from "../../storage/upload.js";
 import type { FileOrBufferOrString } from "../../storage/upload/types.js";
+import { getRoyaltyEngineV1ByChainId } from "../../utils/royalty-engine.js";
 import type { Prettify } from "../../utils/type-utils.js";
 import type { ClientAndChainAndAccount } from "../../utils/types.js";
 import { initialize as initMarketplace } from "./__generated__/Marketplace/write/initialize.js";
@@ -42,15 +46,19 @@ export async function deployMarketplaceContract(
   options: DeployMarketplaceContractOptions,
 ) {
   const { chain, client, account, params } = options;
+  const WETH = await getOrDeployInfraContract({
+    chain,
+    client,
+    account,
+    contractId: "WETH9",
+    constructorParams: [],
+  });
   const direct = await getOrDeployInfraForPublishedContract({
     chain,
     client,
     account,
     contractId: "DirectListingsLogic",
-    constructorParams: [
-      // TODO - actually determine ... "weth"?
-      zeroAddress, // _weth
-    ],
+    constructorParams: [WETH.address],
   });
 
   const english = await getOrDeployInfraForPublishedContract({
@@ -58,10 +66,7 @@ export async function deployMarketplaceContract(
     client,
     account,
     contractId: "EnglishAuctionsLogic",
-    constructorParams: [
-      // TODO - actually determine ... "weth"?
-      zeroAddress, // _weth
-    ],
+    constructorParams: [WETH.address],
   });
 
   const offers = await getOrDeployInfraForPublishedContract({
@@ -119,10 +124,8 @@ export async function deployMarketplaceContract(
               functions: offersFunctions,
             },
           ],
-          // TODO - actually determine ... "royaltyEngineAddress"?
-          royaltyEngineAddress: zeroAddress,
-          // TODO - actually determine ... "weth"?
-          nativeTokenWrapper: zeroAddress,
+          royaltyEngineAddress: getRoyaltyEngineV1ByChainId(chain.id),
+          nativeTokenWrapper: WETH.address,
         },
       ] as MarketplaceConstructorParams,
     });

--- a/packages/thirdweb/src/utils/royalty-engine.ts
+++ b/packages/thirdweb/src/utils/royalty-engine.ts
@@ -1,0 +1,21 @@
+import { ADDRESS_ZERO } from "../constants/addresses.js";
+
+/**
+ * Returns the RoyaltyEngineV1 address for a given chain
+ * @param chainId - the chain id
+ * @public
+ */
+export function getRoyaltyEngineV1ByChainId(chainId: number): string {
+  return ROYALTY_ENGINE_V1_ADDRESS[chainId] || ADDRESS_ZERO;
+}
+
+export const ROYALTY_ENGINE_V1_ADDRESS: Record<number, string> =
+  /* @__PURE__ */ {
+    1: "0x0385603ab55642cb4dd5de3ae9e306809991804f",
+    56: "0xEF770dFb6D5620977213f55f99bfd781D04BBE15",
+    137: "0x28EdFcF0Be7E86b07493466e7631a213bDe8eEF2",
+    8453: "0xEF770dFb6D5620977213f55f99bfd781D04BBE15",
+    43114: "0xEF770dFb6D5620977213f55f99bfd781D04BBE15",
+    10: "0xEF770dFb6D5620977213f55f99bfd781D04BBE15",
+    42161: "0xEF770dFb6D5620977213f55f99bfd781D04BBE15",
+  };


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update the `deployMarketplaceContract` function to use the `getRoyaltyEngineV1ByChainId` function and adjust contract deployment logic accordingly.

### Detailed summary
- Added `getRoyaltyEngineV1ByChainId` function to fetch RoyaltyEngineV1 address
- Updated contract deployment to use the RoyaltyEngineV1 address based on chain ID
- Adjusted constructor parameters for contract deployments to include WETH address

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->