### PR TITLE
show email selection by default for in-app wallet in Connect UI

### DIFF
--- a/.changeset/mighty-dogs-agree.md
+++ b/.changeset/mighty-dogs-agree.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/react": patch
+---
+
+Show email by default and not phone number selection UI for in-app wallet in Connect UI

--- a/legacy_packages/react/src/wallet/wallets/embeddedWallet/embeddedWallet.tsx
+++ b/legacy_packages/react/src/wallet/wallets/embeddedWallet/embeddedWallet.tsx
@@ -23,8 +23,8 @@ import {
 } from "./types";
 
 const DEFAULT_AUTH_OPTIONS: AuthOption[] = [
-  "phone",
   "email",
+  "phone",
   "google",
   "apple",
   "facebook",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the in-app wallet in Connect UI to show email by default instead of phone number selection. 

### Detailed summary
- Updated default authentication options to show email first
- Added Google, Apple, and Facebook authentication options

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->