### PR TITLE
Unity 4.12 - Engine Relayer Support

### DIFF
--- a/.changeset/fuzzy-jokes-chew.md
+++ b/.changeset/fuzzy-jokes-chew.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/unity-js-bridge": patch
+---
+
+Unity 4.12 - Engine Relayer Support

--- a/legacy_packages/unity-js-bridge/src/thirdweb-bridge.ts
+++ b/legacy_packages/unity-js-bridge/src/thirdweb-bridge.ts
@@ -171,7 +171,7 @@ class ThirdwebBridge implements TWBridge {
       // biome-ignore lint/suspicious/noExplicitAny: TODO: fix use of any
       (globalThis as any).X_SDK_PLATFORM = "unity";
       // biome-ignore lint/suspicious/noExplicitAny: TODO: fix use of any
-      (globalThis as any).X_SDK_VERSION = "unity-4.11.0";
+      (globalThis as any).X_SDK_VERSION = "4.12.0";
       // biome-ignore lint/suspicious/noExplicitAny: TODO: fix use of any
       (globalThis as any).X_SDK_OS = browser?.os ?? "unknown";
     }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the Unity JavaScript bridge to support Engine Relayer in Unity 4.12.

### Detailed summary
- Updated `X_SDK_VERSION` to "4.12.0" in Unity JavaScript bridge for Unity 4.12 support.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->