### PR TITLE
fix: claim with price and no allowlists

### DIFF
--- a/.changeset/lovely-houses-flash.md
+++ b/.changeset/lovely-houses-flash.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix claiming drops with prices and no allowlists

--- a/packages/thirdweb/src/extensions/erc1155/drop1155.test.ts
+++ b/packages/thirdweb/src/extensions/erc1155/drop1155.test.ts
@@ -113,6 +113,37 @@ describe.runIf(process.env.TW_SECRET_KEY)(
       ).resolves.toBe(1n);
     });
 
+    it("should allow to claim tokens with price", async () => {
+      await expect(
+        balanceOf({ contract, owner: TEST_ACCOUNT_A.address, tokenId: 0n }),
+      ).resolves.toBe(1n);
+      await sendAndConfirmTransaction({
+        transaction: setClaimConditions({
+          contract,
+          phases: [
+            {
+              price: "0.001",
+            },
+          ],
+          tokenId: 0n,
+        }),
+        account: TEST_ACCOUNT_A,
+      });
+      const claimTx = claimTo({
+        contract,
+        to: TEST_ACCOUNT_A.address,
+        tokenId: 0n,
+        quantity: 1n,
+      });
+      await sendAndConfirmTransaction({
+        transaction: claimTx,
+        account: TEST_ACCOUNT_A,
+      });
+      await expect(
+        balanceOf({ contract, owner: TEST_ACCOUNT_A.address, tokenId: 0n }),
+      ).resolves.toBe(2n);
+    });
+
     describe("Allowlists", () => {
       it("should allow to claim tokens with an allowlist", async () => {
         const tokenId = 1n;

--- a/packages/thirdweb/src/utils/extensions/drops/get-claim-params.ts
+++ b/packages/thirdweb/src/utils/extensions/drops/get-claim-params.ts
@@ -67,7 +67,7 @@ export async function getClaimParams(options: GetClaimParamsOptions) {
         currency: ADDRESS_ZERO,
         proof: [],
         quantityLimitPerWallet: 0n,
-        pricePerToken: 0n,
+        pricePerToken: maxUint256,
       } satisfies OverrideProof;
     }
     // lazy-load the fetchProofsForClaimer function if we need it
@@ -87,7 +87,7 @@ export async function getClaimParams(options: GetClaimParamsOptions) {
         currency: ADDRESS_ZERO,
         proof: [],
         quantityLimitPerWallet: 0n,
-        pricePerToken: 0n,
+        pricePerToken: maxUint256,
       } satisfies OverrideProof;
     }
     // otherwise return the proof


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on fixing claiming drops with prices and no allowlists. 

### Detailed summary
- Updated `pricePerToken` to `maxUint256` in `getClaimParams` function.
- Added a test to allow claiming tokens with a price in `drop1155.test.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->