### PR TITLE
feat: Added new extensions for English Auctions

### DIFF
--- a/.changeset/moody-oranges-deny.md
+++ b/.changeset/moody-oranges-deny.md
@@ -1,0 +1,12 @@
+---
+"thirdweb": minor
+---
+
+Added new extensions for "English Auctions" in `thirdweb/extensions/marketplace` module:
+
+- `bidInAuction`
+- `cancelAuction`
+- `buyoutAuction`
+- `collectAuctionPayout`
+- `collectAuctionTokens`
+- `executeSale`


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds new extensions for "English Auctions" in the `thirdweb/extensions/marketplace` module.

### Detailed summary
- Added new extensions for "English Auctions":
  - `bidInAuction`
  - `cancelAuction`
  - `buyoutAuction`
  - `collectAuctionPayout`
  - `collectAuctionTokens`
  - `executeSale`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->