### PR TITLE
chore: update release-artifacts timeout

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   release-artifacts:
-    timeout-minutes: 15
+    timeout-minutes: 60
     runs-on: ubuntu-latest-16
     steps:
       - name: Checkout branch


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR increases the timeout for the `release-artifacts` job to 60 minutes.

### Detailed summary
- Increased timeout for the `release-artifacts` job from 15 to 60 minutes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->