### PR TITLE
Unity 4.12.1

### DIFF
--- a/.changeset/giant-kiwis-impress.md
+++ b/.changeset/giant-kiwis-impress.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/unity-js-bridge": patch
+---
+
+Unity 4.12.1

--- a/legacy_packages/unity-js-bridge/src/thirdweb-bridge.ts
+++ b/legacy_packages/unity-js-bridge/src/thirdweb-bridge.ts
@@ -171,7 +171,7 @@ class ThirdwebBridge implements TWBridge {
       // biome-ignore lint/suspicious/noExplicitAny: TODO: fix use of any
       (globalThis as any).X_SDK_PLATFORM = "unity";
       // biome-ignore lint/suspicious/noExplicitAny: TODO: fix use of any
-      (globalThis as any).X_SDK_VERSION = "4.12.0";
+      (globalThis as any).X_SDK_VERSION = "4.12.1";
       // biome-ignore lint/suspicious/noExplicitAny: TODO: fix use of any
       (globalThis as any).X_SDK_OS = browser?.os ?? "unknown";
     }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the Unity SDK version to 4.12.1 and sets the platform and version accordingly.

### Detailed summary
- Updated Unity SDK version to 4.12.1
- Set `X_SDK_PLATFORM` to "unity"
- Updated `X_SDK_VERSION` to "4.12.1"
- Set `X_SDK_OS` to browser's OS or "unknown"

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->