### PR TITLE
chore: update stale issue settings

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,5 +1,5 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 60
+daysUntilStale: 14
 # Number of days of inactivity before a stale issue is closed
 daysUntilClose: 7
 # Issues with these labels will never be considered stale


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR reduces the number of days until an issue is considered stale from 60 to 14 and days until close from 7.

### Detailed summary
- Updated `daysUntilStale` value in `.github/stale.yml` from 60 to 14
- Updated `daysUntilClose` value in `.github/stale.yml` from 7 to 7

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->