### PR TITLE
feat: Add support for updating metadata for ERC1155 contracts

### DIFF
--- a/.changeset/rare-forks-hear.md
+++ b/.changeset/rare-forks-hear.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": minor
+---
+
+Add support for updating metadata for ERC1155 contracts

--- a/packages/thirdweb/src/exports/extensions/erc1155.ts
+++ b/packages/thirdweb/src/exports/extensions/erc1155.ts
@@ -68,6 +68,11 @@ export {
   mintAdditionalSupplyTo,
   type MintAdditionalSupplyToParams,
 } from "../../extensions/erc1155/write/mintAdditionalSupplyTo.js";
+export {
+  setTokenURI,
+  type SetTokenURIParams,
+} from "../../extensions/erc1155/__generated__/INFTMetadata/write/setTokenURI.js";
+export { freezeMetadata } from "../../extensions/erc1155/__generated__/INFTMetadata/write/freezeMetadata.js";
 
 // EVENTS
 
@@ -83,6 +88,9 @@ export {
   approvalForAllEvent,
   type ApprovalForAllEventFilters,
 } from "../../extensions/erc1155/__generated__/IERC1155/events/ApprovalForAll.js";
+export { metadataUpdateEvent } from "../../extensions/erc1155/__generated__/INFTMetadata/events/MetadataUpdate.js";
+export { metadataFrozenEvent } from "../../extensions/erc1155/__generated__/INFTMetadata/events/MetadataFrozen.js";
+export { batchMetadataUpdateEvent } from "../../extensions/erc1155/__generated__/INFTMetadata/events/BatchMetadataUpdate.js";
 
 /**
  * DROPS extension for ERC1155


### PR DESCRIPTION
closes: CNCT-555, CNCT-591

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for updating metadata for ERC1155 contracts.

### Detailed summary
- Added support for updating metadata for ERC1155 contracts
- Exported functions for setting token URI and freezing metadata
- Included events for metadata updates and batch metadata updates

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->