### PR TITLE
fix: react query invalidation

### DIFF
--- a/.changeset/brown-ears-jam.md
+++ b/.changeset/brown-ears-jam.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix query invalidation when using react hooks

--- a/packages/thirdweb/src/react/core/providers/thirdweb-provider.tsx
+++ b/packages/thirdweb/src/react/core/providers/thirdweb-provider.tsx
@@ -47,22 +47,25 @@ export function ThirdwebProvider(props: React.PropsWithChildren) {
                       console.error("[Transaction Error]", e);
                     })
                     .then(() => {
-                      return queryClient.invalidateQueries({
-                        queryKey: [
-                          // invalidate any readContract queries for this chainId:contractAddress
-                          [
-                            "readContract",
-                            variables.__contract?.chain.id,
-                            variables.__contract?.address,
-                          ] as const,
+                      return Promise.all([
+                        queryClient.invalidateQueries({
+                          queryKey:
+                            // invalidate any readContract queries for this chainId:contractAddress
+                            [
+                              "readContract",
+                              variables.__contract?.chain.id,
+                              variables.__contract?.address,
+                            ] as const,
+                        }),
+                        queryClient.invalidateQueries({
                           // invalidate any walletBalance queries for this chainId
                           // TODO: add wallet address in here if we can get it somehow
-                          [
+                          queryKey: [
                             "walletBalance",
                             variables.__contract?.chain.id,
                           ] as const,
-                        ],
-                      });
+                        }),
+                      ]);
                     });
                 }
               }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on fixing query invalidation in `thirdweb-provider.tsx` for react hooks usage.

### Detailed summary
- Updated query invalidation to use `Promise.all` for multiple queries
- Fixed queryKey structure for `readContract` and `walletBalance` queries

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->