### PR TITLE
Add extension: multicall3

### DIFF
--- a/.changeset/hot-crews-listen.md
+++ b/.changeset/hot-crews-listen.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Add multicall3 extension

--- a/.changeset/hot-crews-listen.md
+++ b/.changeset/hot-crews-listen.md
@@ -1,5 +1,5 @@
 ---
-"thirdweb": patch
+"thirdweb": minor
 ---
 
 Add multicall3 extension

--- a/packages/thirdweb/scripts/generate/abis/multicall3/IMulticall3.json
+++ b/packages/thirdweb/scripts/generate/abis/multicall3/IMulticall3.json
@@ -1,0 +1,440 @@
+[
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "target",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes",
+            "name": "callData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Multicall3.Call[]",
+        "name": "calls",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "aggregate",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "blockNumber",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes[]",
+        "name": "returnData",
+        "type": "bytes[]"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "target",
+            "type": "address"
+          },
+          {
+            "internalType": "bool",
+            "name": "allowFailure",
+            "type": "bool"
+          },
+          {
+            "internalType": "bytes",
+            "name": "callData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Multicall3.Call3[]",
+        "name": "calls",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "aggregate3",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "bool",
+            "name": "success",
+            "type": "bool"
+          },
+          {
+            "internalType": "bytes",
+            "name": "returnData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Multicall3.Result[]",
+        "name": "returnData",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "target",
+            "type": "address"
+          },
+          {
+            "internalType": "bool",
+            "name": "allowFailure",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint256",
+            "name": "value",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes",
+            "name": "callData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Multicall3.Call3Value[]",
+        "name": "calls",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "aggregate3Value",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "bool",
+            "name": "success",
+            "type": "bool"
+          },
+          {
+            "internalType": "bytes",
+            "name": "returnData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Multicall3.Result[]",
+        "name": "returnData",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "target",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes",
+            "name": "callData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Multicall3.Call[]",
+        "name": "calls",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "blockAndAggregate",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "blockNumber",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "blockHash",
+        "type": "bytes32"
+      },
+      {
+        "components": [
+          {
+            "internalType": "bool",
+            "name": "success",
+            "type": "bool"
+          },
+          {
+            "internalType": "bytes",
+            "name": "returnData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Multicall3.Result[]",
+        "name": "returnData",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getBasefee",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "basefee",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "blockNumber",
+        "type": "uint256"
+      }
+    ],
+    "name": "getBlockHash",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "blockHash",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getBlockNumber",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "blockNumber",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getChainId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "chainid",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getCurrentBlockCoinbase",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "coinbase",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getCurrentBlockDifficulty",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "difficulty",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getCurrentBlockGasLimit",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "gaslimit",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getCurrentBlockTimestamp",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "addr",
+        "type": "address"
+      }
+    ],
+    "name": "getEthBalance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "balance",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getLastBlockHash",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "blockHash",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "requireSuccess",
+        "type": "bool"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "target",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes",
+            "name": "callData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Multicall3.Call[]",
+        "name": "calls",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "tryAggregate",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "bool",
+            "name": "success",
+            "type": "bool"
+          },
+          {
+            "internalType": "bytes",
+            "name": "returnData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Multicall3.Result[]",
+        "name": "returnData",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "requireSuccess",
+        "type": "bool"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "target",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes",
+            "name": "callData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Multicall3.Call[]",
+        "name": "calls",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "tryBlockAndAggregate",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "blockNumber",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "blockHash",
+        "type": "bytes32"
+      },
+      {
+        "components": [
+          {
+            "internalType": "bool",
+            "name": "success",
+            "type": "bool"
+          },
+          {
+            "internalType": "bytes",
+            "name": "returnData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Multicall3.Result[]",
+        "name": "returnData",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  }
+]

--- a/packages/thirdweb/src/exports/extensions/multicall3.ts
+++ b/packages/thirdweb/src/exports/extensions/multicall3.ts
@@ -1,0 +1,43 @@
+// READ
+export { getBasefee } from "../../extensions/multicall3/__generated__/IMulticall3/read/getBasefee.js";
+export {
+  getBlockHash,
+  type GetBlockHashParams,
+} from "../../extensions/multicall3/__generated__/IMulticall3/read/getBlockHash.js";
+export { getBlockNumber } from "../../extensions/multicall3/__generated__/IMulticall3/read/getBlockNumber.js";
+export { getChainId } from "../../extensions/multicall3/__generated__/IMulticall3/read/getChainId.js";
+export { getCurrentBlockCoinbase } from "../../extensions/multicall3/__generated__/IMulticall3/read/getCurrentBlockCoinbase.js";
+export { getCurrentBlockDifficulty } from "../../extensions/multicall3/__generated__/IMulticall3/read/getCurrentBlockDifficulty.js";
+export { getCurrentBlockGasLimit } from "../../extensions/multicall3/__generated__/IMulticall3/read/getCurrentBlockGasLimit.js";
+export { getCurrentBlockTimestamp } from "../../extensions/multicall3/__generated__/IMulticall3/read/getCurrentBlockTimestamp.js";
+export {
+  getEthBalance,
+  type GetEthBalanceParams,
+} from "../../extensions/multicall3/__generated__/IMulticall3/read/getEthBalance.js";
+export { getLastBlockHash } from "../../extensions/multicall3/__generated__/IMulticall3/read/getLastBlockHash.js";
+
+// WRITE
+export {
+  aggregate,
+  type AggregateParams,
+} from "../../extensions/multicall3/__generated__/IMulticall3/write/aggregate.js";
+export {
+  aggregate3,
+  type Aggregate3Params,
+} from "../../extensions/multicall3/__generated__/IMulticall3/write/aggregate3.js";
+export {
+  aggregate3Value,
+  type Aggregate3ValueParams,
+} from "../../extensions/multicall3/__generated__/IMulticall3/write/aggregate3Value.js";
+export {
+  blockAndAggregate,
+  type BlockAndAggregateParams,
+} from "../../extensions/multicall3/__generated__/IMulticall3/write/blockAndAggregate.js";
+export {
+  tryAggregate,
+  type TryAggregateParams,
+} from "../../extensions/multicall3/__generated__/IMulticall3/write/tryAggregate.js";
+export {
+  tryBlockAndAggregate,
+  type TryBlockAndAggregateParams,
+} from "../../extensions/multicall3/__generated__/IMulticall3/write/tryBlockAndAggregate.js";

--- a/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/read/getBasefee.ts
+++ b/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/read/getBasefee.ts
@@ -1,0 +1,72 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0x3e64a696" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    internalType: "uint256",
+    name: "basefee",
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Checks if the `getBasefee` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `getBasefee` method is supported.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { isGetBasefeeSupported } from "thirdweb/extensions/multicall3";
+ *
+ * const supported = await isGetBasefeeSupported(contract);
+ * ```
+ */
+export async function isGetBasefeeSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Decodes the result of the getBasefee function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { decodeGetBasefeeResult } from "thirdweb/extensions/multicall3";
+ * const result = decodeGetBasefeeResult("...");
+ * ```
+ */
+export function decodeGetBasefeeResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "getBasefee" function on the contract.
+ * @param options - The options for the getBasefee function.
+ * @returns The parsed result of the function call.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { getBasefee } from "thirdweb/extensions/multicall3";
+ *
+ * const result = await getBasefee();
+ *
+ * ```
+ */
+export async function getBasefee(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/read/getBlockHash.ts
+++ b/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/read/getBlockHash.ts
@@ -1,0 +1,133 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "getBlockHash" function.
+ */
+export type GetBlockHashParams = {
+  blockNumber: AbiParameterToPrimitiveType<{
+    internalType: "uint256";
+    name: "blockNumber";
+    type: "uint256";
+  }>;
+};
+
+export const FN_SELECTOR = "0xee82ac5e" as const;
+const FN_INPUTS = [
+  {
+    internalType: "uint256",
+    name: "blockNumber",
+    type: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    internalType: "bytes32",
+    name: "blockHash",
+    type: "bytes32",
+  },
+] as const;
+
+/**
+ * Checks if the `getBlockHash` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `getBlockHash` method is supported.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { isGetBlockHashSupported } from "thirdweb/extensions/multicall3";
+ *
+ * const supported = await isGetBlockHashSupported(contract);
+ * ```
+ */
+export async function isGetBlockHashSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "getBlockHash" function.
+ * @param options - The options for the getBlockHash function.
+ * @returns The encoded ABI parameters.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { encodeGetBlockHashParams } "thirdweb/extensions/multicall3";
+ * const result = encodeGetBlockHashParams({
+ *  blockNumber: ...,
+ * });
+ * ```
+ */
+export function encodeGetBlockHashParams(options: GetBlockHashParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.blockNumber]);
+}
+
+/**
+ * Encodes the "getBlockHash" function into a Hex string with its parameters.
+ * @param options - The options for the getBlockHash function.
+ * @returns The encoded hexadecimal string.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { encodeGetBlockHash } "thirdweb/extensions/multicall3";
+ * const result = encodeGetBlockHash({
+ *  blockNumber: ...,
+ * });
+ * ```
+ */
+export function encodeGetBlockHash(options: GetBlockHashParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeGetBlockHashParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the getBlockHash function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { decodeGetBlockHashResult } from "thirdweb/extensions/multicall3";
+ * const result = decodeGetBlockHashResult("...");
+ * ```
+ */
+export function decodeGetBlockHashResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "getBlockHash" function on the contract.
+ * @param options - The options for the getBlockHash function.
+ * @returns The parsed result of the function call.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { getBlockHash } from "thirdweb/extensions/multicall3";
+ *
+ * const result = await getBlockHash({
+ *  blockNumber: ...,
+ * });
+ *
+ * ```
+ */
+export async function getBlockHash(
+  options: BaseTransactionOptions<GetBlockHashParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.blockNumber],
+  });
+}

--- a/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/read/getBlockNumber.ts
+++ b/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/read/getBlockNumber.ts
@@ -1,0 +1,74 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0x42cbb15c" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    internalType: "uint256",
+    name: "blockNumber",
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Checks if the `getBlockNumber` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `getBlockNumber` method is supported.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { isGetBlockNumberSupported } from "thirdweb/extensions/multicall3";
+ *
+ * const supported = await isGetBlockNumberSupported(contract);
+ * ```
+ */
+export async function isGetBlockNumberSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Decodes the result of the getBlockNumber function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { decodeGetBlockNumberResult } from "thirdweb/extensions/multicall3";
+ * const result = decodeGetBlockNumberResult("...");
+ * ```
+ */
+export function decodeGetBlockNumberResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "getBlockNumber" function on the contract.
+ * @param options - The options for the getBlockNumber function.
+ * @returns The parsed result of the function call.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { getBlockNumber } from "thirdweb/extensions/multicall3";
+ *
+ * const result = await getBlockNumber();
+ *
+ * ```
+ */
+export async function getBlockNumber(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/read/getChainId.ts
+++ b/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/read/getChainId.ts
@@ -1,0 +1,72 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0x3408e470" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    internalType: "uint256",
+    name: "chainid",
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Checks if the `getChainId` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `getChainId` method is supported.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { isGetChainIdSupported } from "thirdweb/extensions/multicall3";
+ *
+ * const supported = await isGetChainIdSupported(contract);
+ * ```
+ */
+export async function isGetChainIdSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Decodes the result of the getChainId function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { decodeGetChainIdResult } from "thirdweb/extensions/multicall3";
+ * const result = decodeGetChainIdResult("...");
+ * ```
+ */
+export function decodeGetChainIdResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "getChainId" function on the contract.
+ * @param options - The options for the getChainId function.
+ * @returns The parsed result of the function call.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { getChainId } from "thirdweb/extensions/multicall3";
+ *
+ * const result = await getChainId();
+ *
+ * ```
+ */
+export async function getChainId(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/read/getCurrentBlockCoinbase.ts
+++ b/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/read/getCurrentBlockCoinbase.ts
@@ -1,0 +1,74 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0xa8b0574e" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    internalType: "address",
+    name: "coinbase",
+    type: "address",
+  },
+] as const;
+
+/**
+ * Checks if the `getCurrentBlockCoinbase` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `getCurrentBlockCoinbase` method is supported.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { isGetCurrentBlockCoinbaseSupported } from "thirdweb/extensions/multicall3";
+ *
+ * const supported = await isGetCurrentBlockCoinbaseSupported(contract);
+ * ```
+ */
+export async function isGetCurrentBlockCoinbaseSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Decodes the result of the getCurrentBlockCoinbase function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { decodeGetCurrentBlockCoinbaseResult } from "thirdweb/extensions/multicall3";
+ * const result = decodeGetCurrentBlockCoinbaseResult("...");
+ * ```
+ */
+export function decodeGetCurrentBlockCoinbaseResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "getCurrentBlockCoinbase" function on the contract.
+ * @param options - The options for the getCurrentBlockCoinbase function.
+ * @returns The parsed result of the function call.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { getCurrentBlockCoinbase } from "thirdweb/extensions/multicall3";
+ *
+ * const result = await getCurrentBlockCoinbase();
+ *
+ * ```
+ */
+export async function getCurrentBlockCoinbase(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/read/getCurrentBlockDifficulty.ts
+++ b/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/read/getCurrentBlockDifficulty.ts
@@ -1,0 +1,76 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0x72425d9d" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    internalType: "uint256",
+    name: "difficulty",
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Checks if the `getCurrentBlockDifficulty` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `getCurrentBlockDifficulty` method is supported.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { isGetCurrentBlockDifficultySupported } from "thirdweb/extensions/multicall3";
+ *
+ * const supported = await isGetCurrentBlockDifficultySupported(contract);
+ * ```
+ */
+export async function isGetCurrentBlockDifficultySupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Decodes the result of the getCurrentBlockDifficulty function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { decodeGetCurrentBlockDifficultyResult } from "thirdweb/extensions/multicall3";
+ * const result = decodeGetCurrentBlockDifficultyResult("...");
+ * ```
+ */
+export function decodeGetCurrentBlockDifficultyResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "getCurrentBlockDifficulty" function on the contract.
+ * @param options - The options for the getCurrentBlockDifficulty function.
+ * @returns The parsed result of the function call.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { getCurrentBlockDifficulty } from "thirdweb/extensions/multicall3";
+ *
+ * const result = await getCurrentBlockDifficulty();
+ *
+ * ```
+ */
+export async function getCurrentBlockDifficulty(
+  options: BaseTransactionOptions,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/read/getCurrentBlockGasLimit.ts
+++ b/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/read/getCurrentBlockGasLimit.ts
@@ -1,0 +1,74 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0x86d516e8" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    internalType: "uint256",
+    name: "gaslimit",
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Checks if the `getCurrentBlockGasLimit` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `getCurrentBlockGasLimit` method is supported.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { isGetCurrentBlockGasLimitSupported } from "thirdweb/extensions/multicall3";
+ *
+ * const supported = await isGetCurrentBlockGasLimitSupported(contract);
+ * ```
+ */
+export async function isGetCurrentBlockGasLimitSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Decodes the result of the getCurrentBlockGasLimit function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { decodeGetCurrentBlockGasLimitResult } from "thirdweb/extensions/multicall3";
+ * const result = decodeGetCurrentBlockGasLimitResult("...");
+ * ```
+ */
+export function decodeGetCurrentBlockGasLimitResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "getCurrentBlockGasLimit" function on the contract.
+ * @param options - The options for the getCurrentBlockGasLimit function.
+ * @returns The parsed result of the function call.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { getCurrentBlockGasLimit } from "thirdweb/extensions/multicall3";
+ *
+ * const result = await getCurrentBlockGasLimit();
+ *
+ * ```
+ */
+export async function getCurrentBlockGasLimit(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/read/getCurrentBlockTimestamp.ts
+++ b/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/read/getCurrentBlockTimestamp.ts
@@ -1,0 +1,76 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0x0f28c97d" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    internalType: "uint256",
+    name: "timestamp",
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Checks if the `getCurrentBlockTimestamp` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `getCurrentBlockTimestamp` method is supported.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { isGetCurrentBlockTimestampSupported } from "thirdweb/extensions/multicall3";
+ *
+ * const supported = await isGetCurrentBlockTimestampSupported(contract);
+ * ```
+ */
+export async function isGetCurrentBlockTimestampSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Decodes the result of the getCurrentBlockTimestamp function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { decodeGetCurrentBlockTimestampResult } from "thirdweb/extensions/multicall3";
+ * const result = decodeGetCurrentBlockTimestampResult("...");
+ * ```
+ */
+export function decodeGetCurrentBlockTimestampResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "getCurrentBlockTimestamp" function on the contract.
+ * @param options - The options for the getCurrentBlockTimestamp function.
+ * @returns The parsed result of the function call.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { getCurrentBlockTimestamp } from "thirdweb/extensions/multicall3";
+ *
+ * const result = await getCurrentBlockTimestamp();
+ *
+ * ```
+ */
+export async function getCurrentBlockTimestamp(
+  options: BaseTransactionOptions,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/read/getEthBalance.ts
+++ b/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/read/getEthBalance.ts
@@ -1,0 +1,135 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "getEthBalance" function.
+ */
+export type GetEthBalanceParams = {
+  addr: AbiParameterToPrimitiveType<{
+    internalType: "address";
+    name: "addr";
+    type: "address";
+  }>;
+};
+
+export const FN_SELECTOR = "0x4d2301cc" as const;
+const FN_INPUTS = [
+  {
+    internalType: "address",
+    name: "addr",
+    type: "address",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    internalType: "uint256",
+    name: "balance",
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Checks if the `getEthBalance` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `getEthBalance` method is supported.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { isGetEthBalanceSupported } from "thirdweb/extensions/multicall3";
+ *
+ * const supported = await isGetEthBalanceSupported(contract);
+ * ```
+ */
+export async function isGetEthBalanceSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "getEthBalance" function.
+ * @param options - The options for the getEthBalance function.
+ * @returns The encoded ABI parameters.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { encodeGetEthBalanceParams } "thirdweb/extensions/multicall3";
+ * const result = encodeGetEthBalanceParams({
+ *  addr: ...,
+ * });
+ * ```
+ */
+export function encodeGetEthBalanceParams(options: GetEthBalanceParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.addr]);
+}
+
+/**
+ * Encodes the "getEthBalance" function into a Hex string with its parameters.
+ * @param options - The options for the getEthBalance function.
+ * @returns The encoded hexadecimal string.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { encodeGetEthBalance } "thirdweb/extensions/multicall3";
+ * const result = encodeGetEthBalance({
+ *  addr: ...,
+ * });
+ * ```
+ */
+export function encodeGetEthBalance(options: GetEthBalanceParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeGetEthBalanceParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the getEthBalance function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { decodeGetEthBalanceResult } from "thirdweb/extensions/multicall3";
+ * const result = decodeGetEthBalanceResult("...");
+ * ```
+ */
+export function decodeGetEthBalanceResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "getEthBalance" function on the contract.
+ * @param options - The options for the getEthBalance function.
+ * @returns The parsed result of the function call.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { getEthBalance } from "thirdweb/extensions/multicall3";
+ *
+ * const result = await getEthBalance({
+ *  addr: ...,
+ * });
+ *
+ * ```
+ */
+export async function getEthBalance(
+  options: BaseTransactionOptions<GetEthBalanceParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.addr],
+  });
+}

--- a/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/read/getLastBlockHash.ts
+++ b/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/read/getLastBlockHash.ts
@@ -1,0 +1,74 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0x27e86d6e" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    internalType: "bytes32",
+    name: "blockHash",
+    type: "bytes32",
+  },
+] as const;
+
+/**
+ * Checks if the `getLastBlockHash` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `getLastBlockHash` method is supported.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { isGetLastBlockHashSupported } from "thirdweb/extensions/multicall3";
+ *
+ * const supported = await isGetLastBlockHashSupported(contract);
+ * ```
+ */
+export async function isGetLastBlockHashSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Decodes the result of the getLastBlockHash function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { decodeGetLastBlockHashResult } from "thirdweb/extensions/multicall3";
+ * const result = decodeGetLastBlockHashResult("...");
+ * ```
+ */
+export function decodeGetLastBlockHashResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "getLastBlockHash" function on the contract.
+ * @param options - The options for the getLastBlockHash function.
+ * @returns The parsed result of the function call.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { getLastBlockHash } from "thirdweb/extensions/multicall3";
+ *
+ * const result = await getLastBlockHash();
+ *
+ * ```
+ */
+export async function getLastBlockHash(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/aggregate.ts
+++ b/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/aggregate.ts
@@ -1,0 +1,158 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "aggregate" function.
+ */
+export type AggregateParams = WithOverrides<{
+  calls: AbiParameterToPrimitiveType<{
+    components: [
+      { internalType: "address"; name: "target"; type: "address" },
+      { internalType: "bytes"; name: "callData"; type: "bytes" },
+    ];
+    internalType: "struct Multicall3.Call[]";
+    name: "calls";
+    type: "tuple[]";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0x252dba42" as const;
+const FN_INPUTS = [
+  {
+    components: [
+      {
+        internalType: "address",
+        name: "target",
+        type: "address",
+      },
+      {
+        internalType: "bytes",
+        name: "callData",
+        type: "bytes",
+      },
+    ],
+    internalType: "struct Multicall3.Call[]",
+    name: "calls",
+    type: "tuple[]",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    internalType: "uint256",
+    name: "blockNumber",
+    type: "uint256",
+  },
+  {
+    internalType: "bytes[]",
+    name: "returnData",
+    type: "bytes[]",
+  },
+] as const;
+
+/**
+ * Checks if the `aggregate` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `aggregate` method is supported.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { isAggregateSupported } from "thirdweb/extensions/multicall3";
+ *
+ * const supported = await isAggregateSupported(contract);
+ * ```
+ */
+export async function isAggregateSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "aggregate" function.
+ * @param options - The options for the aggregate function.
+ * @returns The encoded ABI parameters.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { encodeAggregateParams } "thirdweb/extensions/multicall3";
+ * const result = encodeAggregateParams({
+ *  calls: ...,
+ * });
+ * ```
+ */
+export function encodeAggregateParams(options: AggregateParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.calls]);
+}
+
+/**
+ * Encodes the "aggregate" function into a Hex string with its parameters.
+ * @param options - The options for the aggregate function.
+ * @returns The encoded hexadecimal string.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { encodeAggregate } "thirdweb/extensions/multicall3";
+ * const result = encodeAggregate({
+ *  calls: ...,
+ * });
+ * ```
+ */
+export function encodeAggregate(options: AggregateParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeAggregateParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Calls the "aggregate" function on the contract.
+ * @param options - The options for the "aggregate" function.
+ * @returns A prepared transaction object.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { aggregate } from "thirdweb/extensions/multicall3";
+ *
+ * const transaction = aggregate({
+ *  contract,
+ *  calls: ...,
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function aggregate(
+  options: BaseTransactionOptions<
+    | AggregateParams
+    | {
+        asyncParams: () => Promise<AggregateParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.calls] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+  });
+}

--- a/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/aggregate3.ts
+++ b/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/aggregate3.ts
@@ -1,0 +1,171 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "aggregate3" function.
+ */
+export type Aggregate3Params = WithOverrides<{
+  calls: AbiParameterToPrimitiveType<{
+    components: [
+      { internalType: "address"; name: "target"; type: "address" },
+      { internalType: "bool"; name: "allowFailure"; type: "bool" },
+      { internalType: "bytes"; name: "callData"; type: "bytes" },
+    ];
+    internalType: "struct Multicall3.Call3[]";
+    name: "calls";
+    type: "tuple[]";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0x82ad56cb" as const;
+const FN_INPUTS = [
+  {
+    components: [
+      {
+        internalType: "address",
+        name: "target",
+        type: "address",
+      },
+      {
+        internalType: "bool",
+        name: "allowFailure",
+        type: "bool",
+      },
+      {
+        internalType: "bytes",
+        name: "callData",
+        type: "bytes",
+      },
+    ],
+    internalType: "struct Multicall3.Call3[]",
+    name: "calls",
+    type: "tuple[]",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    components: [
+      {
+        internalType: "bool",
+        name: "success",
+        type: "bool",
+      },
+      {
+        internalType: "bytes",
+        name: "returnData",
+        type: "bytes",
+      },
+    ],
+    internalType: "struct Multicall3.Result[]",
+    name: "returnData",
+    type: "tuple[]",
+  },
+] as const;
+
+/**
+ * Checks if the `aggregate3` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `aggregate3` method is supported.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { isAggregate3Supported } from "thirdweb/extensions/multicall3";
+ *
+ * const supported = await isAggregate3Supported(contract);
+ * ```
+ */
+export async function isAggregate3Supported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "aggregate3" function.
+ * @param options - The options for the aggregate3 function.
+ * @returns The encoded ABI parameters.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { encodeAggregate3Params } "thirdweb/extensions/multicall3";
+ * const result = encodeAggregate3Params({
+ *  calls: ...,
+ * });
+ * ```
+ */
+export function encodeAggregate3Params(options: Aggregate3Params) {
+  return encodeAbiParameters(FN_INPUTS, [options.calls]);
+}
+
+/**
+ * Encodes the "aggregate3" function into a Hex string with its parameters.
+ * @param options - The options for the aggregate3 function.
+ * @returns The encoded hexadecimal string.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { encodeAggregate3 } "thirdweb/extensions/multicall3";
+ * const result = encodeAggregate3({
+ *  calls: ...,
+ * });
+ * ```
+ */
+export function encodeAggregate3(options: Aggregate3Params) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeAggregate3Params(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Calls the "aggregate3" function on the contract.
+ * @param options - The options for the "aggregate3" function.
+ * @returns A prepared transaction object.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { aggregate3 } from "thirdweb/extensions/multicall3";
+ *
+ * const transaction = aggregate3({
+ *  contract,
+ *  calls: ...,
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function aggregate3(
+  options: BaseTransactionOptions<
+    | Aggregate3Params
+    | {
+        asyncParams: () => Promise<Aggregate3Params>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.calls] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+  });
+}

--- a/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/aggregate3Value.ts
+++ b/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/aggregate3Value.ts
@@ -1,0 +1,179 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "aggregate3Value" function.
+ */
+export type Aggregate3ValueParams = WithOverrides<{
+  calls: AbiParameterToPrimitiveType<{
+    components: [
+      { internalType: "address"; name: "target"; type: "address" },
+      { internalType: "bool"; name: "allowFailure"; type: "bool" },
+      { internalType: "uint256"; name: "value"; type: "uint256" },
+      { internalType: "bytes"; name: "callData"; type: "bytes" },
+    ];
+    internalType: "struct Multicall3.Call3Value[]";
+    name: "calls";
+    type: "tuple[]";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0x174dea71" as const;
+const FN_INPUTS = [
+  {
+    components: [
+      {
+        internalType: "address",
+        name: "target",
+        type: "address",
+      },
+      {
+        internalType: "bool",
+        name: "allowFailure",
+        type: "bool",
+      },
+      {
+        internalType: "uint256",
+        name: "value",
+        type: "uint256",
+      },
+      {
+        internalType: "bytes",
+        name: "callData",
+        type: "bytes",
+      },
+    ],
+    internalType: "struct Multicall3.Call3Value[]",
+    name: "calls",
+    type: "tuple[]",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    components: [
+      {
+        internalType: "bool",
+        name: "success",
+        type: "bool",
+      },
+      {
+        internalType: "bytes",
+        name: "returnData",
+        type: "bytes",
+      },
+    ],
+    internalType: "struct Multicall3.Result[]",
+    name: "returnData",
+    type: "tuple[]",
+  },
+] as const;
+
+/**
+ * Checks if the `aggregate3Value` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `aggregate3Value` method is supported.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { isAggregate3ValueSupported } from "thirdweb/extensions/multicall3";
+ *
+ * const supported = await isAggregate3ValueSupported(contract);
+ * ```
+ */
+export async function isAggregate3ValueSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "aggregate3Value" function.
+ * @param options - The options for the aggregate3Value function.
+ * @returns The encoded ABI parameters.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { encodeAggregate3ValueParams } "thirdweb/extensions/multicall3";
+ * const result = encodeAggregate3ValueParams({
+ *  calls: ...,
+ * });
+ * ```
+ */
+export function encodeAggregate3ValueParams(options: Aggregate3ValueParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.calls]);
+}
+
+/**
+ * Encodes the "aggregate3Value" function into a Hex string with its parameters.
+ * @param options - The options for the aggregate3Value function.
+ * @returns The encoded hexadecimal string.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { encodeAggregate3Value } "thirdweb/extensions/multicall3";
+ * const result = encodeAggregate3Value({
+ *  calls: ...,
+ * });
+ * ```
+ */
+export function encodeAggregate3Value(options: Aggregate3ValueParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeAggregate3ValueParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Calls the "aggregate3Value" function on the contract.
+ * @param options - The options for the "aggregate3Value" function.
+ * @returns A prepared transaction object.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { aggregate3Value } from "thirdweb/extensions/multicall3";
+ *
+ * const transaction = aggregate3Value({
+ *  contract,
+ *  calls: ...,
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function aggregate3Value(
+  options: BaseTransactionOptions<
+    | Aggregate3ValueParams
+    | {
+        asyncParams: () => Promise<Aggregate3ValueParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.calls] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+  });
+}

--- a/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/blockAndAggregate.ts
+++ b/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/blockAndAggregate.ts
@@ -1,0 +1,179 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "blockAndAggregate" function.
+ */
+export type BlockAndAggregateParams = WithOverrides<{
+  calls: AbiParameterToPrimitiveType<{
+    components: [
+      { internalType: "address"; name: "target"; type: "address" },
+      { internalType: "bytes"; name: "callData"; type: "bytes" },
+    ];
+    internalType: "struct Multicall3.Call[]";
+    name: "calls";
+    type: "tuple[]";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0xc3077fa9" as const;
+const FN_INPUTS = [
+  {
+    components: [
+      {
+        internalType: "address",
+        name: "target",
+        type: "address",
+      },
+      {
+        internalType: "bytes",
+        name: "callData",
+        type: "bytes",
+      },
+    ],
+    internalType: "struct Multicall3.Call[]",
+    name: "calls",
+    type: "tuple[]",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    internalType: "uint256",
+    name: "blockNumber",
+    type: "uint256",
+  },
+  {
+    internalType: "bytes32",
+    name: "blockHash",
+    type: "bytes32",
+  },
+  {
+    components: [
+      {
+        internalType: "bool",
+        name: "success",
+        type: "bool",
+      },
+      {
+        internalType: "bytes",
+        name: "returnData",
+        type: "bytes",
+      },
+    ],
+    internalType: "struct Multicall3.Result[]",
+    name: "returnData",
+    type: "tuple[]",
+  },
+] as const;
+
+/**
+ * Checks if the `blockAndAggregate` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `blockAndAggregate` method is supported.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { isBlockAndAggregateSupported } from "thirdweb/extensions/multicall3";
+ *
+ * const supported = await isBlockAndAggregateSupported(contract);
+ * ```
+ */
+export async function isBlockAndAggregateSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "blockAndAggregate" function.
+ * @param options - The options for the blockAndAggregate function.
+ * @returns The encoded ABI parameters.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { encodeBlockAndAggregateParams } "thirdweb/extensions/multicall3";
+ * const result = encodeBlockAndAggregateParams({
+ *  calls: ...,
+ * });
+ * ```
+ */
+export function encodeBlockAndAggregateParams(
+  options: BlockAndAggregateParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.calls]);
+}
+
+/**
+ * Encodes the "blockAndAggregate" function into a Hex string with its parameters.
+ * @param options - The options for the blockAndAggregate function.
+ * @returns The encoded hexadecimal string.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { encodeBlockAndAggregate } "thirdweb/extensions/multicall3";
+ * const result = encodeBlockAndAggregate({
+ *  calls: ...,
+ * });
+ * ```
+ */
+export function encodeBlockAndAggregate(options: BlockAndAggregateParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeBlockAndAggregateParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Calls the "blockAndAggregate" function on the contract.
+ * @param options - The options for the "blockAndAggregate" function.
+ * @returns A prepared transaction object.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { blockAndAggregate } from "thirdweb/extensions/multicall3";
+ *
+ * const transaction = blockAndAggregate({
+ *  contract,
+ *  calls: ...,
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function blockAndAggregate(
+  options: BaseTransactionOptions<
+    | BlockAndAggregateParams
+    | {
+        asyncParams: () => Promise<BlockAndAggregateParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.calls] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+  });
+}

--- a/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/tryAggregate.ts
+++ b/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/tryAggregate.ts
@@ -1,0 +1,181 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "tryAggregate" function.
+ */
+export type TryAggregateParams = WithOverrides<{
+  requireSuccess: AbiParameterToPrimitiveType<{
+    internalType: "bool";
+    name: "requireSuccess";
+    type: "bool";
+  }>;
+  calls: AbiParameterToPrimitiveType<{
+    components: [
+      { internalType: "address"; name: "target"; type: "address" },
+      { internalType: "bytes"; name: "callData"; type: "bytes" },
+    ];
+    internalType: "struct Multicall3.Call[]";
+    name: "calls";
+    type: "tuple[]";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0xbce38bd7" as const;
+const FN_INPUTS = [
+  {
+    internalType: "bool",
+    name: "requireSuccess",
+    type: "bool",
+  },
+  {
+    components: [
+      {
+        internalType: "address",
+        name: "target",
+        type: "address",
+      },
+      {
+        internalType: "bytes",
+        name: "callData",
+        type: "bytes",
+      },
+    ],
+    internalType: "struct Multicall3.Call[]",
+    name: "calls",
+    type: "tuple[]",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    components: [
+      {
+        internalType: "bool",
+        name: "success",
+        type: "bool",
+      },
+      {
+        internalType: "bytes",
+        name: "returnData",
+        type: "bytes",
+      },
+    ],
+    internalType: "struct Multicall3.Result[]",
+    name: "returnData",
+    type: "tuple[]",
+  },
+] as const;
+
+/**
+ * Checks if the `tryAggregate` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `tryAggregate` method is supported.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { isTryAggregateSupported } from "thirdweb/extensions/multicall3";
+ *
+ * const supported = await isTryAggregateSupported(contract);
+ * ```
+ */
+export async function isTryAggregateSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "tryAggregate" function.
+ * @param options - The options for the tryAggregate function.
+ * @returns The encoded ABI parameters.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { encodeTryAggregateParams } "thirdweb/extensions/multicall3";
+ * const result = encodeTryAggregateParams({
+ *  requireSuccess: ...,
+ *  calls: ...,
+ * });
+ * ```
+ */
+export function encodeTryAggregateParams(options: TryAggregateParams) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.requireSuccess,
+    options.calls,
+  ]);
+}
+
+/**
+ * Encodes the "tryAggregate" function into a Hex string with its parameters.
+ * @param options - The options for the tryAggregate function.
+ * @returns The encoded hexadecimal string.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { encodeTryAggregate } "thirdweb/extensions/multicall3";
+ * const result = encodeTryAggregate({
+ *  requireSuccess: ...,
+ *  calls: ...,
+ * });
+ * ```
+ */
+export function encodeTryAggregate(options: TryAggregateParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeTryAggregateParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Calls the "tryAggregate" function on the contract.
+ * @param options - The options for the "tryAggregate" function.
+ * @returns A prepared transaction object.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { tryAggregate } from "thirdweb/extensions/multicall3";
+ *
+ * const transaction = tryAggregate({
+ *  contract,
+ *  requireSuccess: ...,
+ *  calls: ...,
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function tryAggregate(
+  options: BaseTransactionOptions<
+    | TryAggregateParams
+    | {
+        asyncParams: () => Promise<TryAggregateParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.requireSuccess, resolvedOptions.calls] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+  });
+}

--- a/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/tryBlockAndAggregate.ts
+++ b/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/tryBlockAndAggregate.ts
@@ -1,0 +1,197 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "tryBlockAndAggregate" function.
+ */
+export type TryBlockAndAggregateParams = WithOverrides<{
+  requireSuccess: AbiParameterToPrimitiveType<{
+    internalType: "bool";
+    name: "requireSuccess";
+    type: "bool";
+  }>;
+  calls: AbiParameterToPrimitiveType<{
+    components: [
+      { internalType: "address"; name: "target"; type: "address" },
+      { internalType: "bytes"; name: "callData"; type: "bytes" },
+    ];
+    internalType: "struct Multicall3.Call[]";
+    name: "calls";
+    type: "tuple[]";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0x399542e9" as const;
+const FN_INPUTS = [
+  {
+    internalType: "bool",
+    name: "requireSuccess",
+    type: "bool",
+  },
+  {
+    components: [
+      {
+        internalType: "address",
+        name: "target",
+        type: "address",
+      },
+      {
+        internalType: "bytes",
+        name: "callData",
+        type: "bytes",
+      },
+    ],
+    internalType: "struct Multicall3.Call[]",
+    name: "calls",
+    type: "tuple[]",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    internalType: "uint256",
+    name: "blockNumber",
+    type: "uint256",
+  },
+  {
+    internalType: "bytes32",
+    name: "blockHash",
+    type: "bytes32",
+  },
+  {
+    components: [
+      {
+        internalType: "bool",
+        name: "success",
+        type: "bool",
+      },
+      {
+        internalType: "bytes",
+        name: "returnData",
+        type: "bytes",
+      },
+    ],
+    internalType: "struct Multicall3.Result[]",
+    name: "returnData",
+    type: "tuple[]",
+  },
+] as const;
+
+/**
+ * Checks if the `tryBlockAndAggregate` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `tryBlockAndAggregate` method is supported.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { isTryBlockAndAggregateSupported } from "thirdweb/extensions/multicall3";
+ *
+ * const supported = await isTryBlockAndAggregateSupported(contract);
+ * ```
+ */
+export async function isTryBlockAndAggregateSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "tryBlockAndAggregate" function.
+ * @param options - The options for the tryBlockAndAggregate function.
+ * @returns The encoded ABI parameters.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { encodeTryBlockAndAggregateParams } "thirdweb/extensions/multicall3";
+ * const result = encodeTryBlockAndAggregateParams({
+ *  requireSuccess: ...,
+ *  calls: ...,
+ * });
+ * ```
+ */
+export function encodeTryBlockAndAggregateParams(
+  options: TryBlockAndAggregateParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.requireSuccess,
+    options.calls,
+  ]);
+}
+
+/**
+ * Encodes the "tryBlockAndAggregate" function into a Hex string with its parameters.
+ * @param options - The options for the tryBlockAndAggregate function.
+ * @returns The encoded hexadecimal string.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { encodeTryBlockAndAggregate } "thirdweb/extensions/multicall3";
+ * const result = encodeTryBlockAndAggregate({
+ *  requireSuccess: ...,
+ *  calls: ...,
+ * });
+ * ```
+ */
+export function encodeTryBlockAndAggregate(
+  options: TryBlockAndAggregateParams,
+) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeTryBlockAndAggregateParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Calls the "tryBlockAndAggregate" function on the contract.
+ * @param options - The options for the "tryBlockAndAggregate" function.
+ * @returns A prepared transaction object.
+ * @extension MULTICALL3
+ * @example
+ * ```ts
+ * import { tryBlockAndAggregate } from "thirdweb/extensions/multicall3";
+ *
+ * const transaction = tryBlockAndAggregate({
+ *  contract,
+ *  requireSuccess: ...,
+ *  calls: ...,
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function tryBlockAndAggregate(
+  options: BaseTransactionOptions<
+    | TryBlockAndAggregateParams
+    | {
+        asyncParams: () => Promise<TryBlockAndAggregateParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.requireSuccess, resolvedOptions.calls] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+  });
+}


### PR DESCRIPTION
ABI source: https://www.multicall3.com/abi

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds the `multicall3` extension to the `thirdweb` package.

### Detailed summary
- Added `getBasefee`, `getBlockHash`, `getBlockNumber`, `getChainId`, `getCurrentBlockCoinbase`, and more functions to the `multicall3` extension
- Implemented methods to check support, decode results, and call functions for each added feature

> The following files were skipped due to too many changes: `packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/read/getLastBlockHash.ts`, `packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/read/getCurrentBlockCoinbase.ts`, `packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/read/getCurrentBlockGasLimit.ts`, `packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/read/getCurrentBlockTimestamp.ts`, `packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/read/getCurrentBlockDifficulty.ts`, `packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/read/getEthBalance.ts`, `packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/read/getBlockHash.ts`, `packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/aggregate.ts`, `packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/aggregate3.ts`, `packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/blockAndAggregate.ts`, `packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/tryAggregate.ts`, `packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/aggregate3Value.ts`, `packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/tryBlockAndAggregate.ts`, `packages/thirdweb/scripts/generate/abis/multicall3/IMulticall3.json`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->