### PR TITLE
Unity 4.12.2

### DIFF
--- a/.changeset/six-spiders-sneeze.md
+++ b/.changeset/six-spiders-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/unity-js-bridge": patch
+---
+
+Unity 4.12.2

--- a/legacy_packages/unity-js-bridge/src/thirdweb-bridge.ts
+++ b/legacy_packages/unity-js-bridge/src/thirdweb-bridge.ts
@@ -171,7 +171,7 @@ class ThirdwebBridge implements TWBridge {
       // biome-ignore lint/suspicious/noExplicitAny: TODO: fix use of any
       (globalThis as any).X_SDK_PLATFORM = "unity";
       // biome-ignore lint/suspicious/noExplicitAny: TODO: fix use of any
-      (globalThis as any).X_SDK_VERSION = "4.12.1";
+      (globalThis as any).X_SDK_VERSION = "4.12.2";
       // biome-ignore lint/suspicious/noExplicitAny: TODO: fix use of any
       (globalThis as any).X_SDK_OS = browser?.os ?? "unknown";
     }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the Unity SDK version to 4.12.2 and fixes a version number inconsistency.

### Detailed summary
- Updated Unity SDK version to 4.12.2
- Fixed version number inconsistency in `thirdweb-bridge.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->