### PR TITLE
Update: Added httpMethod to usage-tracker

### DIFF
--- a/.changeset/gorgeous-wombats-press.md
+++ b/.changeset/gorgeous-wombats-press.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+added httpMethod to usage-tracker

--- a/packages/service-utils/src/cf-worker/usage.ts
+++ b/packages/service-utils/src/cf-worker/usage.ts
@@ -70,6 +70,7 @@ const usageEventSchema = z.object({
   tokenAddress: z.string().optional(),
   amountWei: z.string().optional(),
   amountUSDCents: z.number().nonnegative().optional(),
+  httpMethod: z.enum(["GET", "POST", "PUT", "DELETE", "PATCH"]).optional(),
 });
 export type UsageEvent = z.infer<typeof usageEventSchema>;
 

--- a/packages/service-utils/src/cf-worker/usage.ts
+++ b/packages/service-utils/src/cf-worker/usage.ts
@@ -70,7 +70,7 @@ const usageEventSchema = z.object({
   tokenAddress: z.string().optional(),
   amountWei: z.string().optional(),
   amountUSDCents: z.number().nonnegative().optional(),
-  httpMethod: z.enum(["GET", "POST", "PUT", "DELETE", "PATCH"]).optional(),
+  httpMethod: z.enum(["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "CONNECT", "OPTIONS", "TRACE" ]).optional(),
 });
 export type UsageEvent = z.infer<typeof usageEventSchema>;
 

--- a/packages/service-utils/src/cf-worker/usage.ts
+++ b/packages/service-utils/src/cf-worker/usage.ts
@@ -70,7 +70,19 @@ const usageEventSchema = z.object({
   tokenAddress: z.string().optional(),
   amountWei: z.string().optional(),
   amountUSDCents: z.number().nonnegative().optional(),
-  httpMethod: z.enum(["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "CONNECT", "OPTIONS", "TRACE" ]).optional(),
+  httpMethod: z
+    .enum([
+      "GET",
+      "POST",
+      "PUT",
+      "DELETE",
+      "PATCH",
+      "HEAD",
+      "CONNECT",
+      "OPTIONS",
+      "TRACE",
+    ])
+    .optional(),
 });
 export type UsageEvent = z.infer<typeof usageEventSchema>;
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds the `httpMethod` property to the `usage.ts` file in `@thirdweb-dev/service-utils`, enhancing the usage tracker with support for different HTTP methods.

### Detailed summary
- Added `httpMethod` property to `usage.ts`
- Enumerated HTTP methods (`GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `HEAD`, `CONNECT`, `OPTIONS`, `TRACE`)
- Updated `UsageEvent` type definition

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->