### PR TITLE
Enable Buy Modal by default with useSendTransaction hook

### DIFF
--- a/.changeset/ten-seahorses-fly.md
+++ b/.changeset/ten-seahorses-fly.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Enable Buy Modal by default with useSendTransaction hook

--- a/packages/thirdweb/src/react/web/hooks/useSendTransaction.tsx
+++ b/packages/thirdweb/src/react/web/hooks/useSendTransaction.tsx
@@ -70,8 +70,9 @@ export function useSendTransaction(config: SendTransactionConfig = {}) {
 
   const setRootEl = useContext(SetRootElementContext);
   return useSendTransactionCore(
-    typeof payModal === "object"
-      ? (data) => {
+    payModal === false
+      ? undefined
+      : (data) => {
           setRootEl(
             <TxModal
               tx={data.tx}
@@ -89,8 +90,7 @@ export function useSendTransaction(config: SendTransactionConfig = {}) {
               nativeTokenSymbol={data.walletBalance.symbol}
             />,
           );
-        }
-      : undefined,
+        },
   );
 }
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to enable the Buy Modal by default using the `useSendTransaction` hook in `useSendTransaction.tsx`.

### Detailed summary
- Enabled Buy Modal by default with the `useSendTransaction` hook
- Updated conditional rendering logic in the `useSendTransaction` function

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->