### PR TITLE
fix: handle signature mint with price and currency

### DIFF
--- a/.changeset/fluffy-frogs-smoke.md
+++ b/.changeset/fluffy-frogs-smoke.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+fix: handle signature minting with price and currency

--- a/packages/thirdweb/src/extensions/erc1155/write/sigMint.ts
+++ b/packages/thirdweb/src/extensions/erc1155/write/sigMint.ts
@@ -1,14 +1,21 @@
 import type { AbiParameterToPrimitiveType, Address } from "abitype";
 import { maxUint256 } from "viem";
-import { NATIVE_TOKEN_ADDRESS } from "../../../constants/addresses.js";
+import {
+  NATIVE_TOKEN_ADDRESS,
+  isNativeTokenAddress,
+} from "../../../constants/addresses.js";
 import type { ThirdwebContract } from "../../../contract/contract.js";
+import type { BaseTransactionOptions } from "../../../transaction/types.js";
 import { toBigInt } from "../../../utils/bigint.js";
 import { dateToSeconds, tenYearsFromNow } from "../../../utils/date.js";
 import type { Hex } from "../../../utils/encoding/hex.js";
 import type { NFTInput } from "../../../utils/nft/parseNft.js";
 import { randomBytes32 } from "../../../utils/uuid.js";
 import type { Account } from "../../../wallets/interfaces/wallet.js";
-import { mintWithSignature as generatedMintWithSignature } from "../__generated__/ISignatureMintERC1155/write/mintWithSignature.js";
+import {
+  type MintWithSignatureParams,
+  mintWithSignature as generatedMintWithSignature,
+} from "../__generated__/ISignatureMintERC1155/write/mintWithSignature.js";
 
 /**
  * Mints a new ERC1155 token with the given minter signature
@@ -29,7 +36,19 @@ import { mintWithSignature as generatedMintWithSignature } from "../__generated_
  * @extension ERC1155
  * @returns A promise that resolves to the transaction result.
  */
-export const mintWithSignature = generatedMintWithSignature;
+export function mintWithSignature(
+  options: BaseTransactionOptions<MintWithSignatureParams>,
+) {
+  const value = isNativeTokenAddress(options.payload.currency)
+    ? options.payload.pricePerToken * options.payload.quantity
+    : 0n;
+  return generatedMintWithSignature({
+    ...options,
+    overrides: {
+      value,
+    },
+  });
+}
 
 export type GenerateMintSignatureOptions = {
   account: Account;

--- a/packages/thirdweb/src/extensions/erc1155/write/sigMint1155.test.ts
+++ b/packages/thirdweb/src/extensions/erc1155/write/sigMint1155.test.ts
@@ -61,6 +61,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("generateMintSignature1155", () => {
       mintRequest: {
         to: TEST_ACCOUNT_B.address,
         quantity: 10n,
+        pricePerToken: "0.1",
         metadata: {
           name: "My NFT",
           description: "This is my NFT",

--- a/packages/thirdweb/src/extensions/erc20/write/sigMint.ts
+++ b/packages/thirdweb/src/extensions/erc20/write/sigMint.ts
@@ -1,12 +1,19 @@
 import type { AbiParameterToPrimitiveType, Address } from "abitype";
-import { NATIVE_TOKEN_ADDRESS } from "../../../constants/addresses.js";
+import {
+  NATIVE_TOKEN_ADDRESS,
+  isNativeTokenAddress,
+} from "../../../constants/addresses.js";
 import type { ThirdwebContract } from "../../../contract/contract.js";
+import type { BaseTransactionOptions } from "../../../transaction/types.js";
 import { dateToSeconds, tenYearsFromNow } from "../../../utils/date.js";
 import type { Hex } from "../../../utils/encoding/hex.js";
 import { randomBytes32 } from "../../../utils/uuid.js";
 import type { Account } from "../../../wallets/interfaces/wallet.js";
 import { name } from "../../common/read/name.js";
-import { mintWithSignature as generatedMintWithSignature } from "../__generated__/ISignatureMintERC20/write/mintWithSignature.js";
+import {
+  type MintWithSignatureParams,
+  mintWithSignature as generatedMintWithSignature,
+} from "../__generated__/ISignatureMintERC20/write/mintWithSignature.js";
 
 /**
  * Mints a new ERC20 token with the given minter signature
@@ -27,7 +34,19 @@ import { mintWithSignature as generatedMintWithSignature } from "../__generated_
  * @extension ERC20
  * @returns A promise that resolves to the transaction result.
  */
-export const mintWithSignature = generatedMintWithSignature;
+export function mintWithSignature(
+  options: BaseTransactionOptions<MintWithSignatureParams>,
+) {
+  const value = isNativeTokenAddress(options.payload.currency)
+    ? options.payload.price
+    : 0n;
+  return generatedMintWithSignature({
+    ...options,
+    overrides: {
+      value,
+    },
+  });
+}
 
 export type GenerateMintSignatureOptions = {
   account: Account;

--- a/packages/thirdweb/src/extensions/erc721/write/sigMint.ts
+++ b/packages/thirdweb/src/extensions/erc721/write/sigMint.ts
@@ -1,13 +1,20 @@
 import type { AbiParameterToPrimitiveType, Address } from "abitype";
 import type { Hex } from "viem";
-import { NATIVE_TOKEN_ADDRESS } from "../../../constants/addresses.js";
+import {
+  NATIVE_TOKEN_ADDRESS,
+  isNativeTokenAddress,
+} from "../../../constants/addresses.js";
 import type { ThirdwebContract } from "../../../contract/contract.js";
+import type { BaseTransactionOptions } from "../../../transaction/types.js";
 import { toBigInt } from "../../../utils/bigint.js";
 import { dateToSeconds, tenYearsFromNow } from "../../../utils/date.js";
 import type { NFTInput } from "../../../utils/nft/parseNft.js";
 import { randomBytes32 } from "../../../utils/uuid.js";
 import type { Account } from "../../../wallets/interfaces/wallet.js";
-import { mintWithSignature as generatedMintWithSignature } from "../__generated__/ISignatureMintERC721/write/mintWithSignature.js";
+import {
+  type MintWithSignatureParams,
+  mintWithSignature as generatedMintWithSignature,
+} from "../__generated__/ISignatureMintERC721/write/mintWithSignature.js";
 
 /**
  * Mints a new ERC721 token with the given minter signature
@@ -28,7 +35,19 @@ import { mintWithSignature as generatedMintWithSignature } from "../__generated_
  * @extension ERC721
  * @returns A promise that resolves to the transaction result.
  */
-export const mintWithSignature = generatedMintWithSignature;
+export function mintWithSignature(
+  options: BaseTransactionOptions<MintWithSignatureParams>,
+) {
+  const value = isNativeTokenAddress(options.payload.currency)
+    ? options.payload.price
+    : 0n;
+  return generatedMintWithSignature({
+    ...options,
+    overrides: {
+      value,
+    },
+  });
+}
 
 export type GenerateMintSignatureOptions = {
   account: Account;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on fixing the signature minting process for ERC1155 tokens by handling price and currency correctly.

### Detailed summary
- Added handling of price and currency in signature minting for ERC1155 tokens
- Updated functions to include `isNativeTokenAddress` and `BaseTransactionOptions`
- Adjusted value calculation based on currency type for ERC20, ERC721, and ERC1155 tokens

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->