### PR TITLE
Fix custom RPCs on wallet connection components

### DIFF
--- a/.changeset/calm-glasses-cross.md
+++ b/.changeset/calm-glasses-cross.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fixes rpc overrides on react components

--- a/packages/thirdweb/src/react/core/hooks/connection/useAutoConnect.tsx
+++ b/packages/thirdweb/src/react/core/hooks/connection/useAutoConnect.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import type { Chain } from "../../../../chains/types.js";
 import type { ThirdwebClient } from "../../../../client/client.js";
 import { createWallet } from "../../../../wallets/create-wallet.js";
 // import {
@@ -118,6 +119,18 @@ export type AutoConnectProps = {
    * />
    */
   accountAbstraction?: SmartWalletOptions;
+
+  /**
+   * Specify the chain to connect to.
+   *
+   * ```tsx
+   * <AutoConnect
+   *  client={client}
+   *  chain={sepolia}
+   * />
+   * ```
+   */
+  chain?: Chain;
 };
 
 /**
@@ -182,6 +195,7 @@ export function AutoConnect(props: AutoConnectProps) {
         setConnectionStatus("connecting");
         return wallet.autoConnect({
           client: props.client,
+          chain: props.chain,
         });
       }
 

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/ConnectWallet.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/ConnectWallet.tsx
@@ -62,6 +62,7 @@ export function ConnectButton(props: ConnectButtonProps) {
           ? undefined
           : props.autoConnect?.timeout
       }
+      chain={props.chain}
       accountAbstraction={props.accountAbstraction}
     />
   );

--- a/packages/thirdweb/src/wallets/coinbase/coinbaseSDKWallet.ts
+++ b/packages/thirdweb/src/wallets/coinbase/coinbaseSDKWallet.ts
@@ -280,18 +280,19 @@ export async function connectCoinbaseWalletSDK(
   })) as string | number;
 
   const chainId = normalizeChainId(connectedChainId);
-  let chain = defineChain(chainId);
+  let connectedChain = defineChain(chainId);
+  
   // Switch to chain if provided
   if (
-    connectedChainId &&
-    options?.chain &&
-    connectedChainId !== options?.chain.id
+    options?.chain
   ) {
-    await switchChainCoinbaseWalletSDK(provider, options.chain);
-    chain = options.chain;
+    if (options.chain.id !== chainId) {
+      await switchChainCoinbaseWalletSDK(provider, options.chain);
+    }
+    connectedChain = options.chain;
   }
 
-  return onConnect(address, chain, provider, emitter);
+  return onConnect(address, connectedChain, provider, emitter);
 }
 
 /**
@@ -318,9 +319,13 @@ export async function autoConnectCoinbaseWalletSDK(
     method: "eth_chainId",
   })) as string | number;
   const chainId = normalizeChainId(connectedChainId);
-  const chain = defineChain(chainId);
+  let connectedChain = defineChain(chainId);
 
-  return onConnect(address, chain, provider, emitter);
+  if (options.chain && chainId === options.chain.id) {
+    connectedChain = options.chain;
+  }
+
+  return onConnect(address, connectedChain, provider, emitter);
 }
 
 async function switchChainCoinbaseWalletSDK(

--- a/packages/thirdweb/src/wallets/create-wallet.ts
+++ b/packages/thirdweb/src/wallets/create-wallet.ts
@@ -119,6 +119,7 @@ export function createWallet<const ID extends WalletId>(
             ] = await autoConnectInjectedWallet(
               id as InjectedSupportedWalletIds,
               emitter,
+              options.chain,
             );
             // set the states
             account = connectedAccount;

--- a/packages/thirdweb/src/wallets/injected/index.ts
+++ b/packages/thirdweb/src/wallets/injected/index.ts
@@ -107,7 +107,6 @@ export async function autoConnectInjectedWallet(
   let connectedChain = defineChain(chainId);
 
   if (chain && chainId === chain.id) {
-    console.log("Connecting to custom chain", chain);
     connectedChain = chain;
   }
 

--- a/packages/thirdweb/src/wallets/injected/index.ts
+++ b/packages/thirdweb/src/wallets/injected/index.ts
@@ -66,8 +66,10 @@ export async function connectInjectedWallet(
   let connectedChain = defineChain(chainId);
 
   // if we want a specific chainId and it is not the same as the provider chainId, trigger switchChain
-  if (options.chain && options.chain.id !== chainId) {
-    await switchChain(provider, options.chain);
+  if (options.chain) {
+    if (options.chain.id !== chainId) {
+      await switchChain(provider, options.chain);
+    }
     connectedChain = options.chain;
   }
 
@@ -80,6 +82,7 @@ export async function connectInjectedWallet(
 export async function autoConnectInjectedWallet(
   id: InjectedSupportedWalletIds,
   emitter: WalletEmitter<InjectedSupportedWalletIds>,
+  chain?: Chain,
 ): Promise<ReturnType<typeof onConnect>> {
   const provider = getInjectedProvider(id);
 
@@ -101,7 +104,12 @@ export async function autoConnectInjectedWallet(
     .request({ method: "eth_chainId" })
     .then(normalizeChainId);
 
-  const connectedChain = defineChain(chainId);
+  let connectedChain = defineChain(chainId);
+
+  if (chain && chainId === chain.id) {
+    console.log("Connecting to custom chain", chain);
+    connectedChain = chain;
+  }
 
   return onConnect(provider, address, connectedChain, emitter);
 }

--- a/packages/thirdweb/src/wallets/wallet-connect/types.ts
+++ b/packages/thirdweb/src/wallets/wallet-connect/types.ts
@@ -179,6 +179,11 @@ export type WCAutoConnectOptions = {
   client: ThirdwebClient;
 
   savedConnectParams?: SavedConnectParams;
+
+  /**
+   * Optional chain to connect to.
+   */
+  chain?: Chain;
 };
 
 type SavedConnectParams = {


### PR DESCRIPTION
## Problem solved

Custom chains weren't propagating to the generated wallets.

## Changes made

- [ ] Optional custom chain added to AutoConnect component
- [ ] Option custom chain passed to autoConnectInjectedWallet

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing RPC overrides on React components in the `thirdweb` package.

### Detailed summary
- Added `chain` parameter to various functions for specifying the chain to connect to
- Updated handling of chain switching logic in wallet-related files
- Improved chain connection logic in wallet SDK implementations

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->