### PR TITLE
Add extension: isERC20

### DIFF
--- a/.changeset/tidy-zoos-compare.md
+++ b/.changeset/tidy-zoos-compare.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Add isERC20 extension

--- a/.changeset/tidy-zoos-compare.md
+++ b/.changeset/tidy-zoos-compare.md
@@ -1,5 +1,5 @@
 ---
-"thirdweb": patch
+"thirdweb": minor
 ---
 
 Add isERC20 extension

--- a/packages/thirdweb/src/exports/extensions/erc20.ts
+++ b/packages/thirdweb/src/exports/extensions/erc20.ts
@@ -1,4 +1,5 @@
 // read
+export { isERC20 } from "../../extensions/erc20/read/isERC20.js";
 export {
   getBalance,
   type GetBalanceParams,

--- a/packages/thirdweb/src/extensions/erc20/read/isERC20.ts
+++ b/packages/thirdweb/src/extensions/erc20/read/isERC20.ts
@@ -1,0 +1,20 @@
+import type { BaseTransactionOptions } from "../../../transaction/types.js";
+import { supportsInterface } from "../../erc165/__generated__/IERC165/read/supportsInterface.js";
+
+/**
+ * Check if a contract supports the ERC20 interface.
+ * @param options - The transaction options.
+ * @returns A boolean indicating whether the contract supports the ERC20 interface.
+ * @extension ERC20
+ * @example
+ * ```ts
+ * import { isERC20 } from "thirdweb/extensions/erc20";
+ * const result = await isERC20({ contract });
+ * ```
+ */
+export function isERC20(options: BaseTransactionOptions) {
+  return supportsInterface({
+    contract: options.contract,
+    interfaceId: "0x36372b07",
+  });
+}


### PR DESCRIPTION
The interfaceId is retrieved from the following code:
```
pragma solidity ^0.8.0;

interface IERC20 {
  function totalSupply() external view returns (uint256);
  function balanceOf(address who) external view returns (uint256);
  function allowance(address owner, address spender) external view returns (uint256);
  function transfer(address to, uint256 value) external returns (bool);
  function approve(address spender, uint256 value) external returns (bool);
  function transferFrom(address from, address to, uint256 value) external returns (bool);
  event Transfer(address indexed from, address indexed to, uint256 value);
  event Approval(address indexed owner, address indexed spender, uint256 value);
}

contract InterfaceIdContract {
  function getInterfaceIdIERC20() public pure returns (bytes4) {
    return type(IERC20).interfaceId; // "0x36372b07"
  }
}
```

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds the `isERC20` extension to check if a contract supports the ERC20 interface in `thirdweb` package.

### Detailed summary
- Added `isERC20` extension to check ERC20 interface support
- Imported necessary types and functions
- Defined `isERC20` function to check ERC20 interface support

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->