### PR TITLE
feat: Add `celo` chains to known `op stack` chains

### DIFF
--- a/.changeset/stupid-ads-knock.md
+++ b/.changeset/stupid-ads-knock.md
@@ -1,0 +1,6 @@
+---
+"@thirdweb-dev/sdk": patch
+"thirdweb": patch
+---
+
+add `celo` chains to known `op stack` chains

--- a/legacy_packages/sdk/src/evm/common/gas-price.ts
+++ b/legacy_packages/sdk/src/evm/common/gas-price.ts
@@ -11,6 +11,8 @@ import {
   BaseSepoliaTestnet,
   Zora,
   ZoraSepoliaTestnet,
+  Celo,
+  CeloAlfajoresTestnet,
 } from "@thirdweb-dev/chains";
 
 type FeeData = {
@@ -134,7 +136,9 @@ function isOpStackChain(chainId: number) {
     chainId === Base.chainId ||
     chainId === BaseSepoliaTestnet.chainId ||
     chainId === Zora.chainId ||
-    chainId === ZoraSepoliaTestnet.chainId
+    chainId === ZoraSepoliaTestnet.chainId ||
+    chainId === Celo.chainId ||
+    chainId === CeloAlfajoresTestnet.chainId
   );
 }
 

--- a/packages/thirdweb/src/chains/constants.ts
+++ b/packages/thirdweb/src/chains/constants.ts
@@ -15,6 +15,8 @@ const opChains = [
   zoraSepolia.id,
   34443, // mode
   919, // mode testnet
+  42220, // celo
+  44787, // celo testnet
 ];
 
 /**


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds support for `celo` chains in the Thirdweb SDK, including `Celo` and `CeloAlfajoresTestnet` chains.

### Detailed summary
- Added `celo` and `celo testnet` chains to `constants.ts`
- Updated `gas-price.ts` to include `Celo` and `CeloAlfajoresTestnet` chains in `isOpStackChain` function

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->