### PR TITLE
Add missing lang for JSDoc code examples

### DIFF
--- a/packages/thirdweb/src/extensions/erc1271/checkContractWalletSignature.ts
+++ b/packages/thirdweb/src/extensions/erc1271/checkContractWalletSignature.ts
@@ -18,7 +18,7 @@ const MAGIC_VALUE = "0x1626ba7e";
  * @param options.signature - The signature to check.
  * @extension ERC1271
  * @example
- * ```
+ * ```ts
  * import { checkContractWalletSignature } from "thirdweb/extensions/erc1271";
  * const isValid = await checkContractWalletSignature({
  *  contract: myContract,

--- a/packages/thirdweb/src/extensions/erc4337/account/addAdmin.ts
+++ b/packages/thirdweb/src/extensions/erc4337/account/addAdmin.ts
@@ -19,7 +19,7 @@ export type AddAdminOptions = {
  * @param options - The options for the addAdmin function.
  * @returns The transaction object to be sent.
  * @example
- * ```
+ * ```ts
  * import { addAdmin } from 'thirdweb/extensions/erc4337';
  *
  * const transaction = addAdmin({

--- a/packages/thirdweb/src/extensions/erc4337/account/addSessionKey.ts
+++ b/packages/thirdweb/src/extensions/erc4337/account/addSessionKey.ts
@@ -24,7 +24,7 @@ export type AddSessionKeyOptions = {
  * @param options - The options for the removeSessionKey function.
  * @returns The transaction object to be sent.
  * @example
- * ```
+ * ```ts
  * import { addSessionKey } from 'thirdweb/extensions/erc4337';
  *
  * const transaction = addSessionKey({

--- a/packages/thirdweb/src/extensions/erc4337/account/removeAdmin.ts
+++ b/packages/thirdweb/src/extensions/erc4337/account/removeAdmin.ts
@@ -19,7 +19,7 @@ export type RemoveAdminOptions = {
  * @param options - The options for the removeAdmin function.
  * @returns The transaction object to be sent.
  * @example
- * ```
+ * ```ts
  * import { removeAdmin } from 'thirdweb/extensions/erc4337';
  *
  * const transaction = removeAdmin({

--- a/packages/thirdweb/src/extensions/erc4337/account/removeSessionKey.ts
+++ b/packages/thirdweb/src/extensions/erc4337/account/removeSessionKey.ts
@@ -19,7 +19,7 @@ export type RemoveSessionKeyOptions = {
  * @param options - The options for the removeSessionKey function.
  * @returns The transaction object to be sent.
  * @example
- * ```
+ * ```ts
  * import { removeSessionKey } from 'thirdweb/extensions/erc4337';
  *
  * const transaction = removeSessionKey({

--- a/packages/thirdweb/src/extensions/farcaster/ed25519.ts
+++ b/packages/thirdweb/src/extensions/farcaster/ed25519.ts
@@ -11,7 +11,7 @@ export type Ed25519Keypair = {
  * Generates an Ed25519 keypair to be used as an account signer.
  * @returns A promise resolving to the generated keypair.
  * @example
- * ```
+ * ```ts
  * createSigner()
  * ```
  * @extension FARCASTER

--- a/packages/thirdweb/src/extensions/farcaster/eip712Signatures/keyRequestSignature.ts
+++ b/packages/thirdweb/src/extensions/farcaster/eip712Signatures/keyRequestSignature.ts
@@ -69,7 +69,7 @@ export type SignKeyRequestOptions = {
  * @returns An object containing the domain, types, primary type, and the message for EIP-712 signing.
  * @extension FARCASTER
  * @example
- * ```
+ * ```ts
  * const message = {
  *   requestFid: 123456789n,
  *   key: "0x04bfc...",
@@ -93,7 +93,7 @@ export function getKeyRequestData(message: SignedKeyRequestMessage) {
  * @returns A promise that resolves to the signature of the key request.
  * @extension FARCASTER
  * @example
- * ```
+ * ```ts
  * const message = {
  *   requestFid: 123456789n,
  *   key: "0x04bfc...",
@@ -134,7 +134,7 @@ export type SignedKeyRequestMetadataOptions = Prettify<
  * @returns The encoded ABI parameters as a hexadecimal string.
  * @extension FARCASTER
  * @example
- * ```
+ * ```ts
  * const encodedMetadata = encodeSignedKeyRequestMetadata({
  *   requestSigner: "0x123...",
  *   keyRequestSignature: "0xabcd...",
@@ -167,7 +167,7 @@ export function encodeSignedKeyRequestMetadata(options: {
  * @returns A promise that resolves to the hexadecimal string of the encoded ABI parameters.
  * @extension FARCASTER
  * @example
- * ```
+ * ```ts
  * import { getSignedKeyRequestMetadata } from "thirdweb/extensions/farcaster";
  *
  * // Using an existing signature

--- a/packages/thirdweb/src/extensions/prebuilts/deploy-erc1155.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/deploy-erc1155.ts
@@ -42,7 +42,7 @@ export type DeployERC1155ContractOptions = Prettify<
  * @returns The deployed contract address.
  * @extension DEPLOY
  * @example
- * ```
+ * ```ts
  * import { deployERC1155Contract } from "thirdweb/deploys";
  * const contractAddress = await deployERC1155Contract({
  *  chain,

--- a/packages/thirdweb/src/extensions/prebuilts/deploy-erc20.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/deploy-erc20.ts
@@ -40,7 +40,7 @@ export type DeployERC20ContractOptions = Prettify<
  * @returns The deployed contract address.
  * @extension DEPLOY
  * @example
- * ```
+ * ```ts
  * import { deployERC20Contract } from "thirdweb/deploys";
  * const contractAddress = await deployERC20Contract({
  *  chain,

--- a/packages/thirdweb/src/extensions/prebuilts/deploy-erc721.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/deploy-erc721.ts
@@ -46,7 +46,7 @@ export type DeployERC721ContractOptions = Prettify<
  * @returns The deployed contract address.
  * @extension DEPLOY
  * @example
- * ```
+ * ```ts
  * import { deployERC721Contract } from "thirdweb/deploys";
  * const contractAddress = await deployERC721Contract({
  *  chain,

--- a/packages/thirdweb/src/extensions/prebuilts/deploy-published.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/deploy-published.ts
@@ -25,7 +25,7 @@ export type DeployPublishedContractOptions = {
  * @param options - the deploy options
  * @returns a promise that resolves to the deployed contract address
  * @example
- * ```
+ * ```ts
  * import { deployPublishedContract } from "thirdweb/deploys";
  *
  * const address = await deployedPublishedContract({

--- a/packages/thirdweb/src/react/core/storage.ts
+++ b/packages/thirdweb/src/react/core/storage.ts
@@ -6,7 +6,7 @@ let storage: AsyncStorage;
 /**
  * Gets the storage to be used in react.
  * @example
- * ```
+ * ```ts
  * const storage = getStorage();
  * ```
  * @returns The storage to use
@@ -22,7 +22,7 @@ export function getStorage(): AsyncStorage {
 /**
  * Sets the storage to be used in react.
  * @example
- * ```
+ * ```ts
  * setStorage(storage);
  * ```
  * @param _storage - The storage to use

--- a/packages/thirdweb/src/utils/uint8-array.ts
+++ b/packages/thirdweb/src/utils/uint8-array.ts
@@ -5,7 +5,7 @@ const uint8ArrayStringified = "[object Uint8Array]";
 /**
  * Throw a `TypeError` if the given value is not an instance of `Uint8Array`.
  * @example
- * ```
+ * ```ts
  * import {assertUint8Array} from 'uint8array-extras';
  *
  * try {
@@ -26,7 +26,7 @@ function assertUint8Array(value: unknown): asserts value is Uint8Array {
  *
  * Replacement for [`Buffer.isBuffer()`](https://nodejs.org/api/buffer.html#static-method-bufferisbufferobj).
  * @example
- * ```
+ * ```ts
  * import {isUint8Array} from 'uint8array-extras';
  *
  * console.log(isUint8Array(new Uint8Array()));
@@ -56,7 +56,7 @@ export function isUint8Array(value: unknown): value is Uint8Array {
  *
  * Replacement for [`Buffer#equals()`](https://nodejs.org/api/buffer.html#bufequalsotherbuffer).
  * @example
- * ```
+ * ```ts
  * import {areUint8ArraysEqual} from 'uint8array-extras';
  *
  * const a = new Uint8Array([1, 2, 3]);
@@ -96,7 +96,7 @@ export function areUint8ArraysEqual(a: Uint8Array, b: Uint8Array): boolean {
  *
  * Replacement for [`Buffer#toString()`](https://nodejs.org/api/buffer.html#buftostringencoding-start-end).
  * @example
- * ```
+ * ```ts
  * import {uint8ArrayToString} from 'uint8array-extras';
  *
  * const byteArray = new Uint8Array([72, 101, 108, 108, 111]);
@@ -125,7 +125,7 @@ function base64UrlToBase64(base64url: string) {
  *
  * Replacement for [`Buffer.from('SGVsbG8=', 'base64')`](https://nodejs.org/api/buffer.html#static-method-bufferfromstring-encoding).
  * @example
- * ```
+ * ```ts
  * import {base64ToUint8Array} from 'uint8array-extras';
  *
  * console.log(base64ToUint8Array('SGVsbG8='));
@@ -147,7 +147,7 @@ export function base64ToUint8Array(base64String: string): Uint8Array {
  *
  * Replacement for `Buffer.from('SGVsbG8=', 'base64').toString()` and [`atob()`](https://developer.mozilla.org/en-US/docs/Web/API/atob).
  * @example
- * ```
+ * ```ts
  * import {base64ToString} from 'uint8array-extras';
  *
  * console.log(base64ToString('SGVsbG8='));


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates code examples in various files by adding the `ts` language specifier for better syntax highlighting in documentation.

### Detailed summary
- Updated code examples in multiple files to include the `ts` language specifier for TypeScript syntax highlighting.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->