### PR TITLE
Cleanup getUniswapV3Pool docs and internal naming

### DIFF
--- a/packages/thirdweb/src/exports/extensions/uniswap.ts
+++ b/packages/thirdweb/src/exports/extensions/uniswap.ts
@@ -61,7 +61,7 @@ export {
 } from "../../extensions/uniswap/__generated__/IUniswapV3Factory/write/setOwner.js";
 
 export {
-  getUniswapV3Pools as getUniswapV3Pool,
-  type GetUniswapV3PoolsParams as GetUniswapV3PoolParams,
-  type GetUniswapV3PoolsResult as GetUniswapV3PoolResult,
+  getUniswapV3Pool,
+  type GetUniswapV3PoolParams,
+  type GetUniswapV3PoolResult,
 } from "../../extensions/uniswap/read/getUniswapV3Pools.js";

--- a/packages/thirdweb/src/extensions/uniswap/read/getUniswapV3Pools.test.ts
+++ b/packages/thirdweb/src/extensions/uniswap/read/getUniswapV3Pools.test.ts
@@ -6,11 +6,11 @@ import {
   UNISWAPV3_FACTORY_CONTRACT,
   WETH_CONTRACT_ADDRESS,
 } from "~test/test-contracts.js";
-import { getUniswapV3Pools } from "./getUniswapV3Pools.js";
+import { getUniswapV3Pool } from "./getUniswapV3Pools.js";
 
 describe.runIf(process.env.TW_SECRET_KEY)("uniswap.getUniswapV3Pool", () => {
   it("should return the WETH/OHM pool address and fee", async () => {
-    const pools = await getUniswapV3Pools({
+    const pools = await getUniswapV3Pool({
       contract: UNISWAPV3_FACTORY_CONTRACT,
       tokenA: WETH_CONTRACT_ADDRESS,
       tokenB: OHM_CONTRACT_ADDRESS,
@@ -30,7 +30,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("uniswap.getUniswapV3Pool", () => {
   });
 
   it("should return an empty array when no pool exists for the pair", async () => {
-    const pools = await getUniswapV3Pools({
+    const pools = await getUniswapV3Pool({
       contract: UNISWAPV3_FACTORY_CONTRACT,
       tokenA: MOG_CONTRACT_ADDRESS,
       tokenB: OHM_CONTRACT_ADDRESS,

--- a/packages/thirdweb/src/extensions/uniswap/read/getUniswapV3Pools.ts
+++ b/packages/thirdweb/src/extensions/uniswap/read/getUniswapV3Pools.ts
@@ -6,12 +6,12 @@ import { UniswapFee } from "../types.js";
 /**
  * Represents the parameters for the `findUniswapV3Pool` function.
  */
-export type GetUniswapV3PoolsParams = {
+export type GetUniswapV3PoolParams = {
   tokenA: Address;
   tokenB: Address;
 };
 
-export type GetUniswapV3PoolsResult = {
+export type GetUniswapV3PoolResult = {
   poolFee: UniswapFee;
   poolAddress: Address;
 };
@@ -24,16 +24,16 @@ export type GetUniswapV3PoolsResult = {
  * @example
  * ```ts
  * import { getUniswapV3Pool } from "thirdweb/extensions/uniswap";
- * const { poolFee, poolAddress } = await getUniswapV3Pool({
+ * const pools = await getUniswapV3Pool({
  *  tokenA: "0x...",
  *  tokenB: "0x...",
- *  factoryContract: contract
+ *  contract: factoryContract
  * });
  * ```
  */
-export async function getUniswapV3Pools(
-  options: BaseTransactionOptions<GetUniswapV3PoolsParams>,
-): Promise<GetUniswapV3PoolsResult[]> {
+export async function getUniswapV3Pool(
+  options: BaseTransactionOptions<GetUniswapV3PoolParams>,
+): Promise<GetUniswapV3PoolResult[]> {
   const { getPool } = await import(
     "../__generated__/IUniswapV3Factory/read/getPool.js"
   );


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the naming and structure of Uniswap V3 pool functions and types.

### Detailed summary
- Renamed `getUniswapV3Pools` to `getUniswapV3Pool`
- Updated type names from `GetUniswapV3PoolsParams` to `GetUniswapV3PoolParams` and `GetUniswapV3PoolsResult` to `GetUniswapV3PoolResult`
- Updated function parameters and return types accordingly

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->