### PR TITLE
Fix: Use 127.0.0.1 on anvil rpc

### DIFF
--- a/packages/thirdweb/src/chains/chain-definitions/anvil.ts
+++ b/packages/thirdweb/src/chains/chain-definitions/anvil.ts
@@ -3,7 +3,7 @@ import { defineChain } from "../utils.js";
 export const anvil = /* @__PURE__ */ defineChain({
   id: 31337,
   name: "Anvil",
-  rpc: "http://localhost:8545",
+  rpc: "http://127.0.0.1:8545",
   testnet: true,
   nativeCurrency: {
     name: "Anvil Ether",


### PR DESCRIPTION
Bun (and maybe others) doesn't resolve localhost so switch to 127.0.0.1

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the RPC endpoint for the Anvil chain definition in the `anvil.ts` file.

### Detailed summary
- Updated the RPC endpoint from "http://localhost:8545" to "http://127.0.0.1:8545" for the Anvil chain definition.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->