### PR TITLE
fix(legacy_packages): fix `onAuthSuccess` not being passed through to…

### DIFF
--- a/.changeset/three-teachers-play.md
+++ b/.changeset/three-teachers-play.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/react": patch
+---
+
+fix `onAuthSuccess` not being passed through to the underlying wallet

--- a/legacy_packages/react/src/wallet/wallets/embeddedWallet/embeddedWallet.tsx
+++ b/legacy_packages/react/src/wallet/wallets/embeddedWallet/embeddedWallet.tsx
@@ -124,6 +124,7 @@ export const embeddedWallet = (
       return new EmbeddedWallet({
         ...walletOptions,
         clientId: walletOptions?.clientId ?? "",
+        onAuthSuccess: options?.onAuthSuccess,
       });
     },
     selectUI(props) {

--- a/legacy_packages/react/src/wallet/wallets/embeddedWallet/embeddedWallet.tsx
+++ b/legacy_packages/react/src/wallet/wallets/embeddedWallet/embeddedWallet.tsx
@@ -123,8 +123,8 @@ export const embeddedWallet = (
     create(walletOptions: WalletOptions) {
       return new EmbeddedWallet({
         ...walletOptions,
+        ...options,
         clientId: walletOptions?.clientId ?? "",
-        onAuthSuccess: options?.onAuthSuccess,
       });
     },
     selectUI(props) {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR fixes the issue where `onAuthSuccess` was not being passed to the embedded wallet component.

### Detailed summary
- Fixed issue with `onAuthSuccess` not being passed to the embedded wallet component in `embeddedWallet.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->