### PR TITLE
Adds `disabled` prop to TransactionButton

### DIFF
--- a/.changeset/dirty-flowers-share.md
+++ b/.changeset/dirty-flowers-share.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": minor
+---
+
+Adds the disabled prop to TransactionButton component

--- a/packages/thirdweb/src/react/web/ui/TransactionButton/index.tsx
+++ b/packages/thirdweb/src/react/web/ui/TransactionButton/index.tsx
@@ -65,6 +65,11 @@ export type TransactionButtonProps = {
    * Refer to [`GaslessOptions`](https://portal.thirdweb.com/references/typescript/v5/GaslessOptions) for more details.
    */
   gasless?: GaslessOptions;
+
+  /**
+   * The button's disabled state
+   */
+  disabled?: boolean;
 };
 
 /**
@@ -93,6 +98,7 @@ export function TransactionButton(props: TransactionButtonProps) {
     onError,
     onClick,
     gasless,
+    disabled,
     ...buttonProps
   } = props;
   const account = useActiveAccount();
@@ -106,7 +112,7 @@ export function TransactionButton(props: TransactionButtonProps) {
       <Button
         gap="xs"
         {...buttonProps}
-        disabled={!account}
+        disabled={!account || disabled}
         variant={"primary"}
         data-is-loading={isPending}
         onClick={async (e) => {
@@ -141,7 +147,7 @@ export function TransactionButton(props: TransactionButtonProps) {
         }}
         style={{
           ...buttonProps.style,
-          opacity: !account ? 0.5 : 1,
+          opacity: !account || disabled ? 0.5 : 1,
         }}
       >
         {children}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a `disabled` prop to the `TransactionButton` component in the `thirdweb` package.

### Detailed summary
- Added `disabled` prop to `TransactionButton` component
- Updated component logic to handle the disabled state based on the prop and active account status

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->