### PR TITLE
Cleanup TransactionButton loading state

### DIFF
--- a/.changeset/dirty-flowers-share.md
+++ b/.changeset/dirty-flowers-share.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": minor
+---
+
+Adds the disabled prop to TransactionButton component

--- a/.changeset/unlucky-experts-fry.md
+++ b/.changeset/unlucky-experts-fry.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix TransactionButton layout shift while loading

--- a/packages/thirdweb/src/react/web/ui/TransactionButton/index.tsx
+++ b/packages/thirdweb/src/react/web/ui/TransactionButton/index.tsx
@@ -111,7 +111,6 @@ export function TransactionButton(props: TransactionButtonProps) {
     return (
       <Button
         gap="xs"
-        {...buttonProps}
         disabled={!account || disabled}
         variant={"primary"}
         data-is-loading={isPending}
@@ -146,9 +145,11 @@ export function TransactionButton(props: TransactionButtonProps) {
           }
         }}
         style={{
-          ...buttonProps.style,
           opacity: !account || disabled ? 0.5 : 1,
+          minWidth: "150px",
+          ...buttonProps.style,
         }}
+        {...buttonProps}
       >
         {children}
       </Button>
@@ -161,11 +162,14 @@ export function TransactionButton(props: TransactionButtonProps) {
       disabled={true}
       variant={"primary"}
       style={{
-        ...buttonProps.style,
         minWidth: "150px",
+        position: "relative",
+        ...buttonProps.style
       }}
     >
-      <Spinner size="md" color="primaryButtonText" />
+      <div style={{ position: "absolute", display: "flex", alignItems: "center", height: "100%", top: 0, bottom: 0, margin: "auto" }}>
+        <Spinner size="md" color="primaryButtonText" />
+      </div>
     </Button>
   );
 }

--- a/packages/thirdweb/src/react/web/ui/TransactionButton/index.tsx
+++ b/packages/thirdweb/src/react/web/ui/TransactionButton/index.tsx
@@ -164,11 +164,21 @@ export function TransactionButton(props: TransactionButtonProps) {
         opacity: !account || disabled ? 0.5 : 1,
         minWidth: "150px",
         position: "relative",
-        ...buttonProps.style
+        ...buttonProps.style,
       }}
       {...buttonProps}
     >
-      <div style={{ position: "absolute", display: "flex", alignItems: "center", height: "100%", top: 0, bottom: 0, margin: "auto" }}>
+      <div
+        style={{
+          position: "absolute",
+          display: "flex",
+          alignItems: "center",
+          height: "100%",
+          top: 0,
+          bottom: 0,
+          margin: "auto",
+        }}
+      >
         <Spinner size="md" color="primaryButtonText" />
       </div>
     </Button>

--- a/packages/thirdweb/src/react/web/ui/TransactionButton/index.tsx
+++ b/packages/thirdweb/src/react/web/ui/TransactionButton/index.tsx
@@ -158,7 +158,6 @@ export function TransactionButton(props: TransactionButtonProps) {
 
   return (
     <Button
-      {...buttonProps}
       disabled={true}
       variant={"primary"}
       style={{
@@ -167,6 +166,7 @@ export function TransactionButton(props: TransactionButtonProps) {
         position: "relative",
         ...buttonProps.style
       }}
+      {...buttonProps}
     >
       <div style={{ position: "absolute", display: "flex", alignItems: "center", height: "100%", top: 0, bottom: 0, margin: "auto" }}>
         <Spinner size="md" color="primaryButtonText" />

--- a/packages/thirdweb/src/react/web/ui/TransactionButton/index.tsx
+++ b/packages/thirdweb/src/react/web/ui/TransactionButton/index.tsx
@@ -65,6 +65,11 @@ export type TransactionButtonProps = {
    * Refer to [`GaslessOptions`](https://portal.thirdweb.com/references/typescript/v5/GaslessOptions) for more details.
    */
   gasless?: GaslessOptions;
+
+  /**
+   * The button's disabled state
+   */
+  disabled?: boolean;
 };
 
 /**
@@ -93,6 +98,7 @@ export function TransactionButton(props: TransactionButtonProps) {
     onError,
     onClick,
     gasless,
+    disabled,
     ...buttonProps
   } = props;
   const account = useActiveAccount();
@@ -106,7 +112,7 @@ export function TransactionButton(props: TransactionButtonProps) {
       <Button
         gap="xs"
         {...buttonProps}
-        disabled={!account}
+        disabled={!account || disabled}
         variant={"primary"}
         data-is-loading={isPending}
         onClick={async (e) => {
@@ -141,7 +147,7 @@ export function TransactionButton(props: TransactionButtonProps) {
         }}
         style={{
           ...buttonProps.style,
-          opacity: !account ? 0.5 : 1,
+          opacity: !account || disabled ? 0.5 : 1,
         }}
       >
         {children}


### PR DESCRIPTION
- Fixes layout shift from loading spinner
- Adds consistent minWidth for all states
- Allow for overriding styles using inline CSS without `!important`

<!-- start pr-codex -->

---

## PR-Codex overview
This PR fixes a layout shift issue in `TransactionButton` component during loading.

### Detailed summary
- Added `minWidth: "150px"` and `position: "relative"` styles to `TransactionButton`
- Wrapped `Spinner` component in a `div` with specific styles to prevent layout shift

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->