### PR TITLE
fix: ENS jsDocs exports

### DIFF
--- a/packages/thirdweb/package.json
+++ b/packages/thirdweb/package.json
@@ -109,54 +109,22 @@
   },
   "typesVersions": {
     "*": {
-      "adapters/*": [
-        "./dist/types/exports/adapters/*.d.ts"
-      ],
-      "auth": [
-        "./dist/types/exports/auth.d.ts"
-      ],
-      "chains": [
-        "./dist/types/exports/chains.d.ts"
-      ],
-      "contract": [
-        "./dist/types/exports/contract.d.ts"
-      ],
-      "deploys": [
-        "./dist/types/exports/deploys.d.ts"
-      ],
-      "event": [
-        "./dist/types/exports/event.d.ts"
-      ],
-      "extensions/*": [
-        "./dist/types/exports/extensions/*.d.ts"
-      ],
-      "pay": [
-        "./dist/types/exports/pay.d.ts"
-      ],
-      "react": [
-        "./dist/types/exports/react.d.ts"
-      ],
-      "react-native": [
-        "./dist/types/exports/react-native.d.ts"
-      ],
-      "rpc": [
-        "./dist/types/exports/rpc.d.ts"
-      ],
-      "storage": [
-        "./dist/types/exports/storage.d.ts"
-      ],
-      "transaction": [
-        "./dist/types/exports/transaction.d.ts"
-      ],
-      "utils": [
-        "./dist/types/exports/utils.d.ts"
-      ],
-      "wallets": [
-        "./dist/types/exports/wallets.d.ts"
-      ],
-      "wallets/*": [
-        "./dist/types/exports/wallets/*.d.ts"
-      ]
+      "adapters/*": ["./dist/types/exports/adapters/*.d.ts"],
+      "auth": ["./dist/types/exports/auth.d.ts"],
+      "chains": ["./dist/types/exports/chains.d.ts"],
+      "contract": ["./dist/types/exports/contract.d.ts"],
+      "deploys": ["./dist/types/exports/deploys.d.ts"],
+      "event": ["./dist/types/exports/event.d.ts"],
+      "extensions/*": ["./dist/types/exports/extensions/*.d.ts"],
+      "pay": ["./dist/types/exports/pay.d.ts"],
+      "react": ["./dist/types/exports/react.d.ts"],
+      "react-native": ["./dist/types/exports/react-native.d.ts"],
+      "rpc": ["./dist/types/exports/rpc.d.ts"],
+      "storage": ["./dist/types/exports/storage.d.ts"],
+      "transaction": ["./dist/types/exports/transaction.d.ts"],
+      "utils": ["./dist/types/exports/utils.d.ts"],
+      "wallets": ["./dist/types/exports/wallets.d.ts"],
+      "wallets/*": ["./dist/types/exports/wallets/*.d.ts"]
     }
   },
   "browser": {

--- a/packages/thirdweb/src/extensions/ens/resolve-address.ts
+++ b/packages/thirdweb/src/extensions/ens/resolve-address.ts
@@ -23,7 +23,7 @@ export type ResolveAddressOptions = {
  * @param options - The options for resolving an ENS address.
  * @example
  * ```ts
- * import { resolveAddress } from "thirdweb/ens";
+ * import { resolveAddress } from "thirdweb/extensions/ens";
  * const address = await resolveAddress({
  *    client,
  *    name: "vitalik.eth",

--- a/packages/thirdweb/src/extensions/ens/resolve-avatar.ts
+++ b/packages/thirdweb/src/extensions/ens/resolve-avatar.ts
@@ -16,7 +16,7 @@ export type ResolveAvatarOptions = {
  * @param options - The options for resolving an ENS address.
  * @example
  * ```ts
- * import { resolveAvatar } from "thirdweb/ens";
+ * import { resolveAvatar } from "thirdweb/extensions/ens";
  * const address = await resolveAvatar({
  *    client,
  *    name: "vitalik.eth",

--- a/packages/thirdweb/src/extensions/ens/resolve-name.ts
+++ b/packages/thirdweb/src/extensions/ens/resolve-name.ts
@@ -21,7 +21,7 @@ export type ResolveNameOptions = {
  * @param options - The options for resolving an ENS address.
  * @example
  * ```ts
- * import { resolveName } from "thirdweb/ens";
+ * import { resolveName } from "thirdweb/extensions/ens";
  * const name = await resolveName({
  *    client,
  *    address: "0x1234...",

--- a/packages/thirdweb/src/extensions/ens/resolve-text.ts
+++ b/packages/thirdweb/src/extensions/ens/resolve-text.ts
@@ -26,7 +26,7 @@ export type ResolveTextOptions = {
  * @param options - The options for resolving an ENS address.
  * @example
  * ```ts
- * import { resolveText } from "thirdweb/ens";
+ * import { resolveText } from "thirdweb/extensions/ens";
  * const twitterUsername = await resolveText({
  *    client,
  *    name: "vitalik.eth",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update import paths for ENS-related functions in the `thirdweb` package.

### Detailed summary
- Updated import paths for ENS functions in `resolve-name.ts`, `resolve-avatar.ts`, `resolve-text.ts`, and `resolve-address.ts`
- Updated import paths in `package.json` for ENS-related types.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->