### PR TITLE
Add optional icon in ChainOptions

### DIFF
--- a/.changeset/serious-taxis-float.md
+++ b/.changeset/serious-taxis-float.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Add optional `icon` in `ChainOptions` when defining a chain

--- a/packages/thirdweb/src/chains/types.ts
+++ b/packages/thirdweb/src/chains/types.ts
@@ -6,6 +6,7 @@ export type ChainOptions = {
   id: number;
   name?: string;
   rpc?: string;
+  icon?: Icon;
   nativeCurrency?: {
     name?: string;
     symbol?: string;

--- a/packages/thirdweb/src/exports/chains.ts
+++ b/packages/thirdweb/src/exports/chains.ts
@@ -1,7 +1,5 @@
-// chain type
-export type { Chain } from "../chains/types.js";
-// chain Metadata type
-export type { ChainMetadata } from "../chains/types.js";
+// chain types
+export type { Chain, ChainOptions, ChainMetadata } from "../chains/types.js";
 // define chain, chainMetadata
 export {
   defineChain,


### PR DESCRIPTION
closes CNCT-1085

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds an optional `icon` property to the `ChainOptions` interface in the `Chain` definition, enhancing chain configuration capabilities.

### Detailed summary
- Added optional `icon` property in `ChainOptions`
- Updated `ChainOptions` interface in `types.ts`
- Updated `chains.ts` exports to include `ChainOptions`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->