### PR TITLE
fix: jsDoc import for viem adapter

### DIFF
--- a/packages/thirdweb/src/adapters/viem.ts
+++ b/packages/thirdweb/src/adapters/viem.ts
@@ -29,7 +29,7 @@ export const viemAdapter = {
      * @returns The ThirdwebContract.
      * @example
      * ```ts
-     * import { viemAdapter } from "thirdweb/adapters";
+     * import { viemAdapter } from "thirdweb/adapters/viem";
      *
      * const contract = viemAdapter.contract.fromViem({
      *  viemContract: viemContract,
@@ -58,7 +58,7 @@ export const viemAdapter = {
    * @returns The Viem public client.
    * @example
    * ```ts
-   * import { viemAdapter } from "thirdweb/adapters";
+   * import { viemAdapter } from "thirdweb/adapters/viem";
    *
    *  const publicClient = viemAdapter.publicClient.toViem({
    *  chain: ethereum,
@@ -77,7 +77,7 @@ export const viemAdapter = {
      * @returns The Viem Wallet client.
      * @example
      * ```ts
-     * import { viemAdapter } from "thirdweb/adapters";
+     * import { viemAdapter } from "thirdweb/adapters/viem";
      *
      * const walletClient = viemAdapter.walletClient.toViem({
      *  wallet: wallet,
@@ -94,7 +94,7 @@ export const viemAdapter = {
      * @returns The Account.
      * @example
      * ```ts
-     * import { viemAdapter } from "thirdweb/adapters";
+     * import { viemAdapter } from "thirdweb/adapters/viem";
      *
      * const account = viemAdapter.walletClient.fromViem({
      *   walletClient,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the import path in the `viem.ts` file to point to the correct location within the `adapters` directory.

### Detailed summary
- Updated import path in `viem.ts` to point to `viem` directory within `adapters`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->