### PR TITLE
Docs: update incorrect code snippet for viem adapter

### DIFF
--- a/.changeset/curly-camels-matter.md
+++ b/.changeset/curly-camels-matter.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Docs: update incorrect code snippet for viem adapter

--- a/packages/thirdweb/src/adapters/viem.ts
+++ b/packages/thirdweb/src/adapters/viem.ts
@@ -80,7 +80,7 @@ export const viemAdapter = {
      * import { viemAdapter } from "thirdweb/adapters/viem";
      *
      * const walletClient = viemAdapter.walletClient.toViem({
-     *  wallet: wallet,
+     *  account: wallet,
      *  client,
      *  chain: ethereum,
      * });

--- a/packages/thirdweb/src/adapters/viem.ts
+++ b/packages/thirdweb/src/adapters/viem.ts
@@ -80,7 +80,7 @@ export const viemAdapter = {
      * import { viemAdapter } from "thirdweb/adapters/viem";
      *
      * const walletClient = viemAdapter.walletClient.toViem({
-     *  account: wallet,
+     *  account,
      *  client,
      *  chain: ethereum,
      * });


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the incorrect code snippet in the `viemAdapter` for the `thirdweb` package.

### Detailed summary
- Updated code snippet in `viem.ts` to replace `wallet` with `account` for `walletClient` initialization.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->