### PR TITLE
Add `onConnect` prop on `AutoConnect`

### DIFF
--- a/.changeset/gorgeous-maps-mate.md
+++ b/.changeset/gorgeous-maps-mate.md
@@ -1,0 +1,6 @@
+---
+"thirdweb": patch
+---
+
+- Add onConnect prop on `AutoConnect` component
+- Call the `onConnect` callback passed to `ConnectButton` and `ConnectEmbed` when wallet is auto-connected

--- a/packages/thirdweb/src/react/core/hooks/connection/useAutoConnect.tsx
+++ b/packages/thirdweb/src/react/core/hooks/connection/useAutoConnect.tsx
@@ -205,9 +205,15 @@ export function AutoConnect(props: AutoConnectProps) {
             message: `AutoConnect timeout : ${timeout}ms limit exceeded.`,
           });
 
-          connect(activeWallet);
-          if (onConnect) {
-            onConnect(activeWallet);
+          // connected wallet could be activeWallet or smart wallet
+          const connectedWallet = await connect(activeWallet);
+
+          if (!connectedWallet) {
+            setConnectionStatus("disconnected");
+          }
+
+          if (onConnect && connectedWallet) {
+            onConnect(connectedWallet);
           }
         } catch (e) {
           console.error("Failed to auto connect last active wallet");

--- a/packages/thirdweb/src/react/core/hooks/connection/useAutoConnect.tsx
+++ b/packages/thirdweb/src/react/core/hooks/connection/useAutoConnect.tsx
@@ -109,6 +109,19 @@ export type AutoConnectProps = {
    * />
    */
   accountAbstraction?: SmartWalletOptions;
+
+  /**
+   * Callback to be called on successful auto-connection of last active wallet. The callback is called with the connected wallet
+   *
+   * ```tsx
+   * <AutoConnect
+   *  onConnect={(wallet) => {
+   *    console.log("auto connected to", wallet)
+   *  }}
+   * />
+   * ```
+   */
+  onConnect?: (wallet: Wallet) => void;
 };
 
 /**
@@ -149,7 +162,7 @@ export function AutoConnect(props: AutoConnectProps) {
     accountAbstraction: props.accountAbstraction,
   });
   const { isAutoConnecting } = connectionManager;
-  const { wallets } = props;
+  const { wallets, onConnect } = props;
   const timeout = props.timeout ?? 15000;
   // get the supported wallets from thirdweb provider
   // check the storage for last connected wallets and connect them all
@@ -193,6 +206,9 @@ export function AutoConnect(props: AutoConnectProps) {
           });
 
           connect(activeWallet);
+          if (onConnect) {
+            onConnect(activeWallet);
+          }
         } catch (e) {
           console.error("Failed to auto connect last active wallet");
           console.error(e);

--- a/packages/thirdweb/src/react/core/hooks/connection/useAutoConnect.tsx
+++ b/packages/thirdweb/src/react/core/hooks/connection/useAutoConnect.tsx
@@ -208,12 +208,16 @@ export function AutoConnect(props: AutoConnectProps) {
           // connected wallet could be activeWallet or smart wallet
           const connectedWallet = await connect(activeWallet);
 
-          if (!connectedWallet) {
+          if (connectedWallet) {
+            if (onConnect) {
+              try {
+                onConnect(connectedWallet);
+              } catch {
+                // ignore
+              }
+            }
+          } else {
             setConnectionStatus("disconnected");
-          }
-
-          if (onConnect && connectedWallet) {
-            onConnect(connectedWallet);
           }
         } catch (e) {
           console.error("Failed to auto connect last active wallet");

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/ConnectWallet.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/ConnectWallet.tsx
@@ -63,6 +63,7 @@ export function ConnectButton(props: ConnectButtonProps) {
           : props.autoConnect?.timeout
       }
       accountAbstraction={props.accountAbstraction}
+      onConnect={props.onConnect}
     />
   );
 

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/ConnectWalletProps.ts
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/ConnectWalletProps.ts
@@ -576,28 +576,16 @@ export type ConnectButtonProps = {
   supportedTokens?: SupportedTokens;
 
   /**
-   * Callback to be called on successful connection of wallet. The callback is called with the connected account
+   * Callback to be called on successful connection of wallet - including auto connect.
+   * The callback is called with the connected wallet
    *
    * ```tsx
    * <ConnectButton
-   *  onConnect={(account) => {
-   *    console.log("connected to", account)
+   *  onConnect={(wallet) => {
+   *    console.log("connected to", wallet)
    *  }}
    * />
    * ```
-   *
-   * Note that this does not include the sign in, If you want to call a callback after user connects AND signs in with their wallet, use `auth.onLogin` prop instead
-   *
-   * ```tsx
-   * <ConnectButton
-   *  auth={{
-   *   onLogin: () => {
-   *     console.log("wallet connected and signed in")
-   *   }
-   *  }}
-   * />
-   * ```
-   *
    */
   onConnect?: (wallet: Wallet) => void;
 

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/ConnectEmbed.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/ConnectEmbed.tsx
@@ -225,26 +225,16 @@ export type ConnectEmbedProps = {
   privacyPolicyUrl?: string;
 
   /**
-   * Callback to be called on successful connection of wallet. The callback is called with the connected account
+   * Callback to be called on successful connection of wallet - including auto-connect.
+   * The callback is called with the connected wallet
    *
    * ```tsx
    * <ConnectEmbed
-   *  onConnect={(account) => {
-   *    console.log("connected to", account)
+   *  onConnect={(wallet) => {
+   *    console.log("connected to", wallet)
    *  }}
    * />
    * ```
-   *
-   * Note that this does not include the sign in, If you want to call a callback after user connects AND signs in with their wallet, use `auth.onLogin` prop instead
-   *
-   * ```tsx
-   * <ConnectEmbed
-   *  auth={{
-   *   onLogin: () => {
-   *     console.log("wallet connected and signed in")
-   *   }
-   *  }}
-   * />
    * ```
    */
   onConnect?: (wallet: Wallet) => void;
@@ -366,6 +356,7 @@ export function ConnectEmbed(props: ConnectEmbedProps) {
           ? undefined
           : props.autoConnect?.timeout
       }
+      onConnect={props.onConnect}
     />
   );
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds an `onConnect` callback prop to `AutoConnect` component for successful wallet connection handling.

### Detailed summary
- Added `onConnect` prop to `AutoConnect` component
- Updated `ConnectButton` and `ConnectEmbed` to call `onConnect` callback
- Modified callback parameter name to `wallet` for consistency

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->