### PR TITLE
Better error message on failed `predictAddress`

### DIFF
--- a/.changeset/flat-turkeys-promise.md
+++ b/.changeset/flat-turkeys-promise.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Better error message for failed smart wallet connections

--- a/packages/thirdweb/src/wallets/smart/index.ts
+++ b/packages/thirdweb/src/wallets/smart/index.ts
@@ -63,6 +63,8 @@ export async function connectSmartWallet(
   const accountAddress = await predictAddress(factoryContract, {
     personalAccountAddress: personalAccount.address,
     ...options,
+  }).then((address) => address).catch(() => {
+    throw new Error(`Failed to get account address with factory contract ${factoryContract.address} on chain ID ${chain.id}. Are you on the right chain?`);
   });
 
   const accountContract = getContract({

--- a/packages/thirdweb/src/wallets/smart/index.ts
+++ b/packages/thirdweb/src/wallets/smart/index.ts
@@ -63,9 +63,13 @@ export async function connectSmartWallet(
   const accountAddress = await predictAddress(factoryContract, {
     personalAccountAddress: personalAccount.address,
     ...options,
-  }).then((address) => address).catch(() => {
-    throw new Error(`Failed to get account address with factory contract ${factoryContract.address} on chain ID ${chain.id}. Are you on the right chain?`);
-  });
+  })
+    .then((address) => address)
+    .catch(() => {
+      throw new Error(
+        `Failed to get account address with factory contract ${factoryContract.address} on chain ID ${chain.id}. Are you on the right chain?`,
+      );
+    });
 
   const accountContract = getContract({
     client,


### PR DESCRIPTION
Was getting a random viem error when trying to connect a smart wallet, turns out I was just on the wrong chain 🤦 

This should make the error a bit more clear for that case

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to improve error handling for failed smart wallet connections.

### Detailed summary
- Improved error message when smart wallet connection fails
- Added a catch block to handle errors and throw a specific error message with relevant details

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->