### PR TITLE
Fix event duplication in useContractEvents

### DIFF
--- a/.changeset/tame-rivers-rhyme.md
+++ b/.changeset/tame-rivers-rhyme.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fixes useContractEvents duplicating events

--- a/packages/thirdweb/src/event/actions/watch-events.ts
+++ b/packages/thirdweb/src/event/actions/watch-events.ts
@@ -16,6 +16,7 @@ export type WatchContractEventsOptions<
 > = Prettify<
   GetContractEventsOptionsDirect<abi, abiEvents, TStrict> & {
     onEvents: (events: ParseEventLogsResult<abiEvents, TStrict>) => void;
+    latestBlockNumber?: bigint;
   }
 >;
 
@@ -79,5 +80,6 @@ export function watchContractEvents<
         options.onEvents(logs);
       }
     },
+    latestBlockNumber: options.latestBlockNumber,
   });
 }


### PR DESCRIPTION
## Problem solved

There was a bug where if the events filters passed to `useContractEvents` updated every render (which in most naive use cases they do), duplicate events are repeatedly added to the events list until a new block is mined. This was because every time a new poller spawned, it didn't know what block the previous poller had left off on, and so it just added the events from the current block.

## Changes made

- [ ] Internal API changes: The latestBlockNumber is now tracked with a ref and optionally passed to the poller
- [ ] Updated docs to be more descriptive
