### PR TITLE
chore: bump timeout for userop receipts to 2 mins

### DIFF
--- a/.changeset/modern-news-thank.md
+++ b/.changeset/modern-news-thank.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Bump timeout for userOps receipts to 2mins

--- a/legacy_packages/auth/test/smart-wallet.test.ts
+++ b/legacy_packages/auth/test/smart-wallet.test.ts
@@ -10,7 +10,7 @@ require("dotenv-mono").load();
 describe.runIf(process.env.TW_SECRET_KEY)(
   "Wallet Authentication - EVM - Smart Wallet",
   {
-    timeout: 60000,
+    timeout: 240000,
   },
   async () => {
     let adminWallet: any, signerWallet: any, attackerWallet: any;

--- a/legacy_packages/wallets/test/smart-wallet-integration.test.ts
+++ b/legacy_packages/wallets/test/smart-wallet-integration.test.ts
@@ -34,21 +34,20 @@ beforeAll(async () => {
     secretKey: SECRET_KEY,
   });
   contract = await sdk.getContract(
-    "0x638263e3eAa3917a53630e61B1fBa685308024fa", // arb sep edition drop
+    "0x638263e3eAa3917a53630e61B1fBa685308024fa", // edition drop
   );
 });
 
 describeIf(!!SECRET_KEY)(
   "SmartWallet core tests",
-  {
-    timeout: 240_000,
-  },
   () => {
     it("can connect", async () => {
       expect(smartWalletAddress).toHaveLength(42);
     });
 
-    it("can execute a tx via SDK", async () => {
+    it("can execute a tx via SDK", {
+      timeout: 120_000,
+    }, async () => {
       const tx = await contract.erc1155.claim(0, 1);
       expect(tx.receipt.transactionHash).toHaveLength(66);
       const isDeployed = await smartWallet.isDeployed();
@@ -57,13 +56,17 @@ describeIf(!!SECRET_KEY)(
       expect(balance.toNumber()).toEqual(1);
     });
 
-    it("can estimate a tx", async () => {
+    it("can estimate a tx", {
+      timeout: 120_000,
+    }, async () => {
       const preparedTx = await contract.erc1155.claim.prepare(0, 1);
       const estimates = await smartWallet.estimate(preparedTx);
       expect(estimates.wei.toString()).not.toBe("0");
     });
 
-    it("can execute a tx", async () => {
+    it("can execute a tx", {
+      timeout: 120_000,
+    }, async () => {
       const preparedTx = await contract.erc1155.claim.prepare(0, 1);
       const tx = await smartWallet.execute(preparedTx);
       expect(tx.receipt.transactionHash).toHaveLength(66);
@@ -71,7 +74,9 @@ describeIf(!!SECRET_KEY)(
       expect(balance.toNumber()).toEqual(2);
     });
 
-    it("can execute a batched tx", async () => {
+    it("can execute a batched tx", {
+      timeout: 120_000,
+    }, async () => {
       const preparedTx = await contract.erc1155.claim.prepare(0, 1);
       const tx = await smartWallet.executeBatch([preparedTx, preparedTx]);
       expect(tx.receipt.transactionHash).toHaveLength(66);
@@ -79,7 +84,9 @@ describeIf(!!SECRET_KEY)(
       expect(balance.toNumber()).toEqual(4);
     });
 
-    it("can execute a raw tx", async () => {
+    it("can execute a raw tx", {
+      timeout: 120_000,
+    }, async () => {
       const preparedTx = await contract.erc1155.claim.prepare(0, 1);
       const tx = await smartWallet.executeRaw({
         to: preparedTx.getTarget(),
@@ -90,7 +97,9 @@ describeIf(!!SECRET_KEY)(
       expect(balance.toNumber()).toEqual(5);
     });
 
-    it("can execute a batched raw tx", async () => {
+    it("can execute a batched raw tx", {
+      timeout: 120_000,
+    }, async () => {
       const preparedTx = await contract.erc1155.claim.prepare(0, 1);
       const tx = await smartWallet.executeBatchRaw([
         {
@@ -107,7 +116,9 @@ describeIf(!!SECRET_KEY)(
       expect(balance.toNumber()).toEqual(7);
     });
 
-    it("can sign and verify 1271 old factory", async () => {
+    it("can sign and verify 1271 old factory", {
+      timeout: 120_000,
+    }, async () => {
       const message = "0x1234";
       const sig = await smartWallet.signMessage(message);
       const isValidV1 = await smartWallet.verifySignature(
@@ -128,7 +139,9 @@ describeIf(!!SECRET_KEY)(
       expect(isValidV2).toEqual(true);
     });
 
-    it("can sign and verify 1271 new factory", async () => {
+    it("can sign and verify 1271 new factory", {
+      timeout: 120_000,
+    }, async () => {
       smartWallet = new SmartWallet({
         chain,
         factoryAddress: factoryAddressV2,

--- a/legacy_packages/wallets/test/smart-wallet-integration.test.ts
+++ b/legacy_packages/wallets/test/smart-wallet-integration.test.ts
@@ -140,7 +140,7 @@ describeIf(!!SECRET_KEY)(
     });
 
     it("can sign and verify 1271 new factory", {
-      timeout: 120_000,
+      timeout: 240_000,
     }, async () => {
       smartWallet = new SmartWallet({
         chain,

--- a/packages/thirdweb/src/wallets/smart/index.ts
+++ b/packages/thirdweb/src/wallets/smart/index.ts
@@ -295,7 +295,7 @@ async function waitForUserOpReceipt(args: {
   userOpHash: Hex;
 }): Promise<TransactionReceipt> {
   const { options, userOpHash } = args;
-  const timeout = 30000;
+  const timeout = 120000; // 2mins
   const interval = 1000;
   const endtime = Date.now() + timeout;
   while (Date.now() < endtime) {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR increases timeout values for userOps receipts to 2 minutes for improved performance.

### Detailed summary
- Increased timeout for userOps receipts to 2 minutes in Smart Wallet tests
- Adjusted timeout values for various functions in Smart Wallet tests to 2 minutes

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->