### PR TITLE
feat: `prepareDeployDeterministicTransaction`

### DIFF
--- a/.changeset/selfish-tools-double.md
+++ b/.changeset/selfish-tools-double.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": minor
+---
+
+New `prepareDeterministicDeployTransaction` extension for deploying published contracts with the same address on multiple chains

--- a/packages/thirdweb/src/contract/deployment/deploy-deterministic.test.ts
+++ b/packages/thirdweb/src/contract/deployment/deploy-deterministic.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+  FORKED_ETHEREUM_CHAIN,
+  FORKED_OPTIMISM_CHAIN,
+} from "../../../test/src/chains.js";
+import { TEST_CLIENT } from "../../../test/src/test-clients.js";
+import { TEST_ACCOUNT_A } from "../../../test/src/test-wallets.js";
+import { simulateTransaction } from "../../transaction/actions/simulate.js";
+import { ENTRYPOINT_ADDRESS } from "../../wallets/smart/lib/constants.js";
+import { prepareDeterministicDeployTransaction } from "./deploy-deterministic.js";
+
+// skip this test suite if there is no secret key available to test with
+// TODO: remove reliance on secret key during unit tests entirely
+describe.runIf(process.env.TW_SECRET_KEY)("deployFromMetadata", () => {
+  it("should deploy contracts at the same address", async () => {
+    const tx1 = prepareDeterministicDeployTransaction({
+      chain: FORKED_ETHEREUM_CHAIN,
+      client: TEST_CLIENT,
+      contractId: "AccountFactory",
+      constructorParams: [TEST_ACCOUNT_A.address, ENTRYPOINT_ADDRESS],
+    });
+    const tx2 = prepareDeterministicDeployTransaction({
+      chain: FORKED_OPTIMISM_CHAIN,
+      client: TEST_CLIENT,
+      contractId: "AccountFactory",
+      constructorParams: [TEST_ACCOUNT_A.address, ENTRYPOINT_ADDRESS],
+    });
+    const [tx1Result, tx2Result] = await Promise.all([
+      simulateTransaction({ transaction: tx1 }),
+      simulateTransaction({ transaction: tx2 }),
+    ]);
+    expect(tx1Result).toEqual(tx2Result);
+  });
+
+  it("should respect salt param", async () => {
+    const tx1 = prepareDeterministicDeployTransaction({
+      chain: FORKED_ETHEREUM_CHAIN,
+      client: TEST_CLIENT,
+      contractId: "AccountFactory",
+      constructorParams: [TEST_ACCOUNT_A.address, ENTRYPOINT_ADDRESS],
+      salt: "some-salt",
+    });
+    const tx2 = prepareDeterministicDeployTransaction({
+      chain: FORKED_OPTIMISM_CHAIN,
+      client: TEST_CLIENT,
+      contractId: "AccountFactory",
+      constructorParams: [TEST_ACCOUNT_A.address, ENTRYPOINT_ADDRESS],
+    });
+    const [tx1Result, tx2Result] = await Promise.all([
+      simulateTransaction({ transaction: tx1 }),
+      simulateTransaction({ transaction: tx2 }),
+    ]);
+    expect(tx1Result !== tx2Result).toBe(true);
+  });
+});

--- a/packages/thirdweb/src/contract/deployment/deploy-deterministic.test.ts
+++ b/packages/thirdweb/src/contract/deployment/deploy-deterministic.test.ts
@@ -6,7 +6,7 @@ import {
 import { TEST_CLIENT } from "../../../test/src/test-clients.js";
 import { TEST_ACCOUNT_A } from "../../../test/src/test-wallets.js";
 import { simulateTransaction } from "../../transaction/actions/simulate.js";
-import { ENTRYPOINT_ADDRESS } from "../../wallets/smart/lib/constants.js";
+import { ENTRYPOINT_ADDRESS_v0_6 } from "../../wallets/smart/lib/constants.js";
 import { prepareDeterministicDeployTransaction } from "./deploy-deterministic.js";
 
 // skip this test suite if there is no secret key available to test with
@@ -17,13 +17,13 @@ describe.runIf(process.env.TW_SECRET_KEY)("deployFromMetadata", () => {
       chain: FORKED_ETHEREUM_CHAIN,
       client: TEST_CLIENT,
       contractId: "AccountFactory",
-      constructorParams: [TEST_ACCOUNT_A.address, ENTRYPOINT_ADDRESS],
+      constructorParams: [TEST_ACCOUNT_A.address, ENTRYPOINT_ADDRESS_v0_6],
     });
     const tx2 = prepareDeterministicDeployTransaction({
       chain: FORKED_OPTIMISM_CHAIN,
       client: TEST_CLIENT,
       contractId: "AccountFactory",
-      constructorParams: [TEST_ACCOUNT_A.address, ENTRYPOINT_ADDRESS],
+      constructorParams: [TEST_ACCOUNT_A.address, ENTRYPOINT_ADDRESS_v0_6],
     });
     const [tx1Result, tx2Result] = await Promise.all([
       simulateTransaction({ transaction: tx1 }),
@@ -37,14 +37,14 @@ describe.runIf(process.env.TW_SECRET_KEY)("deployFromMetadata", () => {
       chain: FORKED_ETHEREUM_CHAIN,
       client: TEST_CLIENT,
       contractId: "AccountFactory",
-      constructorParams: [TEST_ACCOUNT_A.address, ENTRYPOINT_ADDRESS],
+      constructorParams: [TEST_ACCOUNT_A.address, ENTRYPOINT_ADDRESS_v0_6],
       salt: "some-salt",
     });
     const tx2 = prepareDeterministicDeployTransaction({
       chain: FORKED_OPTIMISM_CHAIN,
       client: TEST_CLIENT,
       contractId: "AccountFactory",
-      constructorParams: [TEST_ACCOUNT_A.address, ENTRYPOINT_ADDRESS],
+      constructorParams: [TEST_ACCOUNT_A.address, ENTRYPOINT_ADDRESS_v0_6],
     });
     const [tx1Result, tx2Result] = await Promise.all([
       simulateTransaction({ transaction: tx1 }),

--- a/packages/thirdweb/src/contract/deployment/deploy-deterministic.ts
+++ b/packages/thirdweb/src/contract/deployment/deploy-deterministic.ts
@@ -1,0 +1,55 @@
+import { prepareTransaction } from "../../transaction/prepare-transaction.js";
+import { computeDeploymentInfoFromContractId } from "../../utils/any-evm/compute-published-contract-deploy-info.js";
+import type { Prettify } from "../../utils/type-utils.js";
+import type { ClientAndChain } from "../../utils/types.js";
+import { computeCreate2FactoryAddress } from "./utils/create-2-factory.js";
+
+export type DeployDetemisiticParams = Prettify<
+  ClientAndChain & {
+    contractId: string;
+    constructorParams: unknown[];
+    publisher?: string;
+    version?: string;
+    salt?: string;
+  }
+>;
+
+/**
+ * Deploy a contract deterministically - will maintain the same address across chains.
+ * This is meant to be used with published contracts configured with the 'direct deploy' method.
+ * Under the hood, this uses a keyless transaction with a common create2 factory.
+ * @param options - the options to deploy the contract
+ * @returns - the transaction to deploy the contract
+ * @extension DEPLOY
+ * @example
+ * ```ts
+ * import { prepareDeterministicDeployTransaction } from "thirdweb/deploys";
+ * import { sepolia } from "thirdweb/chains";
+ *
+ * const tx = prepareDeterministicDeployTransaction({
+ *  client,
+ *  chain: sepolia,
+ *  contractId: "AccountFactory",
+ *  constructorParams: [123],
+ * });
+ * ```
+ */
+export function prepareDeterministicDeployTransaction(
+  options: DeployDetemisiticParams,
+) {
+  const { client, chain } = options;
+  return prepareTransaction({
+    client,
+    chain,
+    to: () =>
+      computeCreate2FactoryAddress({
+        client,
+        chain,
+      }),
+    data: async () => {
+      const infraContractInfo =
+        await computeDeploymentInfoFromContractId(options);
+      return infraContractInfo.initBytecodeWithsalt;
+    },
+  });
+}

--- a/packages/thirdweb/src/contract/deployment/deploy-with-abi.ts
+++ b/packages/thirdweb/src/contract/deployment/deploy-with-abi.ts
@@ -33,7 +33,7 @@ export type PrepareDirectDeployTransactionOptions<
  * @returns - The prepared transaction.
  * @example
  * ```ts
- * import { prepareDirectDeployTransaction } from "thirdweb/contract";
+ * import { prepareDirectDeployTransaction } from "thirdweb/deploys";
  * import { ethereum } from "thirdweb/chains";
  * const tx = prepareDirectDeployTransaction({
  *  client,

--- a/packages/thirdweb/src/exports/deploys.ts
+++ b/packages/thirdweb/src/exports/deploys.ts
@@ -32,3 +32,4 @@ export {
   deployContract,
   type PrepareDirectDeployTransactionOptions,
 } from "../contract/deployment/deploy-with-abi.js";
+export { computePublishedContractAddress } from "../utils/any-evm/compute-published-contract-address.js";

--- a/packages/thirdweb/src/exports/deploys.ts
+++ b/packages/thirdweb/src/exports/deploys.ts
@@ -26,6 +26,7 @@ export {
 
 export { prepareDirectDeployTransaction } from "../contract/deployment/deploy-with-abi.js";
 export { prepareAutoFactoryDeployTransaction } from "../contract/deployment/deploy-via-autofactory.js";
+export { prepareDeterministicDeployTransaction } from "../contract/deployment/deploy-deterministic.js";
 export { deployViaAutoFactory } from "../contract/deployment/deploy-via-autofactory.js";
 export {
   deployContract,

--- a/packages/thirdweb/src/exports/utils.ts
+++ b/packages/thirdweb/src/exports/utils.ts
@@ -141,3 +141,8 @@ export { resolvePromisedValue } from "../utils/promise/resolve-promised-value.js
 // json
 // ------------------------------------------------
 export { stringify } from "../utils/json.js";
+
+// ------------------------------------------------
+// values
+// ------------------------------------------------
+export { maxUint256 } from "viem";

--- a/packages/thirdweb/src/exports/wallets/smart.ts
+++ b/packages/thirdweb/src/exports/wallets/smart.ts
@@ -7,4 +7,4 @@ export type {
   PaymasterResult,
 } from "../../wallets/smart/types.js";
 
-export { ENTRYPOINT_ADDRESS } from "../../wallets/smart/lib/constants.js";
+export { ENTRYPOINT_ADDRESS_v0_6 } from "../../wallets/smart/lib/constants.js";

--- a/packages/thirdweb/src/exports/wallets/smart.ts
+++ b/packages/thirdweb/src/exports/wallets/smart.ts
@@ -7,4 +7,4 @@ export type {
   PaymasterResult,
 } from "../../wallets/smart/types.js";
 
-// TODO: add exports for smart wallet utils here
+export { ENTRYPOINT_ADDRESS } from "../../wallets/smart/lib/constants.js";

--- a/packages/thirdweb/src/extensions/erc4337/account/permissions.test.ts
+++ b/packages/thirdweb/src/extensions/erc4337/account/permissions.test.ts
@@ -14,7 +14,7 @@ import { getOrDeployInfraContract } from "../../../contract/deployment/utils/boo
 import { parseEventLogs } from "../../../event/actions/parse-logs.js";
 import { sendAndConfirmTransaction } from "../../../transaction/actions/send-and-confirm-transaction.js";
 import { simulateTransaction } from "../../../transaction/actions/simulate.js";
-import { ENTRYPOINT_ADDRESS } from "../../../wallets/smart/lib/constants.js";
+import { ENTRYPOINT_ADDRESS_v0_6 } from "../../../wallets/smart/lib/constants.js";
 import { createAccount } from "../__generated__/IAccountFactory/write/createAccount.js";
 import { adminUpdatedEvent } from "../__generated__/IAccountPermissions/events/AdminUpdated.js";
 import { signerPermissionsUpdatedEvent } from "../__generated__/IAccountPermissions/events/SignerPermissionsUpdated.js";
@@ -34,7 +34,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("Account Permissions", () => {
       chain: ANVIL_CHAIN,
       client: TEST_CLIENT,
       contractId: "AccountFactory",
-      constructorParams: [TEST_ACCOUNT_A.address, ENTRYPOINT_ADDRESS],
+      constructorParams: [TEST_ACCOUNT_A.address, ENTRYPOINT_ADDRESS_v0_6],
     });
     const transaction = createAccount({
       contract: accountFactoryContract,

--- a/packages/thirdweb/src/extensions/prebuilts/deploy-published.test.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/deploy-published.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { ANVIL_CHAIN } from "../../../test/src/chains.js";
 import { TEST_CLIENT } from "../../../test/src/test-clients.js";
 import { TEST_ACCOUNT_A } from "../../../test/src/test-wallets.js";
-import { ENTRYPOINT_ADDRESS } from "../../wallets/smart/lib/constants.js";
+import { ENTRYPOINT_ADDRESS_v0_6 } from "../../wallets/smart/lib/constants.js";
 import { deployPublishedContract } from "./deploy-published.js";
 
 describe.runIf(process.env.TW_SECRET_KEY)(
@@ -17,7 +17,7 @@ describe.runIf(process.env.TW_SECRET_KEY)(
         chain: ANVIL_CHAIN,
         account: TEST_ACCOUNT_A,
         contractId: "AccountFactory",
-        contractParams: [TEST_ACCOUNT_A.address, ENTRYPOINT_ADDRESS],
+        contractParams: [TEST_ACCOUNT_A.address, ENTRYPOINT_ADDRESS_v0_6],
       });
       expect(address).toBeDefined();
       expect(address.length).toBe(42);

--- a/packages/thirdweb/src/storage/upload/web-node.ts
+++ b/packages/thirdweb/src/storage/upload/web-node.ts
@@ -31,9 +31,7 @@ export async function uploadBatch<const TFiles extends UploadableFile[]>(
       );
     }
     throw new Error(
-      `Failed to upload files to IPFS - ${res.status} - ${
-        res.statusText
-      } - ${await res.text()}`,
+      `Failed to upload files to IPFS - ${res.status} - ${res.statusText}`,
     );
   }
 

--- a/packages/thirdweb/src/utils/any-evm/compute-published-contract-address.ts
+++ b/packages/thirdweb/src/utils/any-evm/compute-published-contract-address.ts
@@ -18,7 +18,7 @@ import type { FetchDeployMetadataResult } from "./deploy-metadata.js";
  * @param args.version - The version of the contract.
  * @example
  * ```ts
- * import { computePublishedContractAddress } from "thirdweb/contract";
+ * import { computePublishedContractAddress } from "thirdweb/deploys";
  *
  * const contractMetadata = await fetchPublishedContractMetadata({
  *  client,
@@ -27,7 +27,7 @@ import type { FetchDeployMetadataResult } from "./deploy-metadata.js";
  * const address = await computePublishedContractAddress({
  *   client,
  *   chain,
- *   contractId: "DropERC721",
+ *   contractId: "AccountFactory",
  *   constructorParams,
  * });
  * ```
@@ -40,6 +40,7 @@ export async function computePublishedContractAddress(args: {
   constructorParams: unknown[];
   publisher?: string;
   version?: string;
+  salt?: string;
 }): Promise<string> {
   const info = await computeDeploymentInfoFromContractId(args);
   return computeDeploymentAddress(info);
@@ -53,6 +54,7 @@ export async function computeContractAddress(args: {
   chain: Chain;
   contractMetadata: FetchDeployMetadataResult;
   constructorParams: unknown[];
+  salt?: string;
 }): Promise<string> {
   const info = await computeDeploymentInfoFromMetadata(args);
   return computeDeploymentAddress(info);

--- a/packages/thirdweb/src/utils/any-evm/compute-published-contract-deploy-info.ts
+++ b/packages/thirdweb/src/utils/any-evm/compute-published-contract-deploy-info.ts
@@ -17,8 +17,9 @@ export async function computeDeploymentInfoFromContractId(args: {
   constructorParams: unknown[];
   publisher?: string;
   version?: string;
+  salt?: string;
 }) {
-  const { client, chain, contractId, constructorParams } = args;
+  const { client, chain, contractId, constructorParams, salt } = args;
   const contractMetadata = await fetchPublishedContractMetadata({
     client,
     contractId,
@@ -29,6 +30,7 @@ export async function computeDeploymentInfoFromContractId(args: {
     chain,
     contractMetadata,
     constructorParams,
+    salt,
   });
 }
 
@@ -40,8 +42,9 @@ export async function computeDeploymentInfoFromMetadata(args: {
   chain: Chain;
   contractMetadata: FetchDeployMetadataResult;
   constructorParams: unknown[];
+  salt?: string;
 }) {
-  const { client, chain, contractMetadata, constructorParams } = args;
+  const { client, chain, contractMetadata, constructorParams, salt } = args;
   const { compilerMetadata } = contractMetadata;
   const create2FactoryAddress = await computeCreate2FactoryAddress({
     client,
@@ -59,6 +62,7 @@ export async function computeDeploymentInfoFromMetadata(args: {
   const initBytecodeWithsalt = getInitBytecodeWithSalt({
     bytecode,
     encodedArgs,
+    salt,
   });
   return {
     bytecode,

--- a/packages/thirdweb/src/wallets/smart/lib/bundler.ts
+++ b/packages/thirdweb/src/wallets/smart/lib/bundler.ts
@@ -13,7 +13,7 @@ import type {
 } from "../types.js";
 import {
   DEBUG,
-  ENTRYPOINT_ADDRESS,
+  ENTRYPOINT_ADDRESS_v0_6,
   MANAGED_ACCOUNT_GAS_BUFFER,
   getDefaultBundlerUrl,
 } from "./constants.js";
@@ -31,7 +31,7 @@ export async function bundleUserOp(args: {
     operation: "eth_sendUserOperation",
     params: [
       hexlifyUserOp(args.userOp),
-      args.options.overrides?.entrypointAddress ?? ENTRYPOINT_ADDRESS,
+      args.options.overrides?.entrypointAddress ?? ENTRYPOINT_ADDRESS_v0_6,
     ],
   });
 }
@@ -48,7 +48,7 @@ export async function estimateUserOpGas(args: {
     operation: "eth_estimateUserOperationGas",
     params: [
       hexlifyUserOp(args.userOp),
-      args.options.overrides?.entrypointAddress ?? ENTRYPOINT_ADDRESS,
+      args.options.overrides?.entrypointAddress ?? ENTRYPOINT_ADDRESS_v0_6,
     ],
   });
 

--- a/packages/thirdweb/src/wallets/smart/lib/constants.ts
+++ b/packages/thirdweb/src/wallets/smart/lib/constants.ts
@@ -6,7 +6,8 @@ export const DEBUG = false;
 export const DUMMY_SIGNATURE =
   "0xfffffffffffffffffffffffffffffff0000000000000000000000000000000007aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1c";
 
-export const ENTRYPOINT_ADDRESS = "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789"; // v0.6
+export const ENTRYPOINT_ADDRESS_v0_6 =
+  "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789"; // v0.6
 export const MANAGED_ACCOUNT_GAS_BUFFER = 50000n;
 
 /**

--- a/packages/thirdweb/src/wallets/smart/lib/paymaster.ts
+++ b/packages/thirdweb/src/wallets/smart/lib/paymaster.ts
@@ -8,7 +8,7 @@ import type {
 } from "../types.js";
 import {
   DEBUG,
-  ENTRYPOINT_ADDRESS,
+  ENTRYPOINT_ADDRESS_v0_6,
   getDefaultPaymasterUrl,
 } from "./constants.js";
 import { hexlifyUserOp } from "./utils.js";
@@ -33,7 +33,8 @@ export async function getPaymasterAndData(args: {
 
   const client = options.client;
   const paymasterUrl = getDefaultPaymasterUrl(options.chain);
-  const entrypoint = options.overrides?.entrypointAddress ?? ENTRYPOINT_ADDRESS;
+  const entrypoint =
+    options.overrides?.entrypointAddress ?? ENTRYPOINT_ADDRESS_v0_6;
 
   // Ask the paymaster to sign the transaction and return a valid paymasterAndData value.
   const fetchWithHeaders = getClientFetch(client);

--- a/packages/thirdweb/src/wallets/smart/lib/userop.ts
+++ b/packages/thirdweb/src/wallets/smart/lib/userop.ts
@@ -17,7 +17,7 @@ import { estimateUserOpGas, getUserOpGasPrice } from "./bundler.js";
 import { prepareCreateAccount } from "./calls.js";
 import {
   DUMMY_SIGNATURE,
-  ENTRYPOINT_ADDRESS,
+  ENTRYPOINT_ADDRESS_v0_6,
   getDefaultBundlerUrl,
 } from "./constants.js";
 import { getPaymasterAndData } from "./paymaster.js";
@@ -173,7 +173,7 @@ export async function signUserOp(args: {
   const { userOp, options } = args;
   const userOpHash = getUserOpHash({
     userOp,
-    entryPoint: options.overrides?.entrypointAddress || ENTRYPOINT_ADDRESS,
+    entryPoint: options.overrides?.entrypointAddress || ENTRYPOINT_ADDRESS_v0_6,
     chainId: options.chain.id,
   });
   if (options.personalAccount.signMessage) {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new extension `prepareDeterministicDeployTransaction` for deploying contracts with the same address on multiple chains.

### Detailed summary
- Added `prepareDeterministicDeployTransaction` extension for deterministic contract deployment
- Updated exports in `utils.ts`, `deploys.ts`, `deploy-deterministic.ts`
- Renamed `ENTRYPOINT_ADDRESS` to `ENTRYPOINT_ADDRESS_v0_6` in multiple files

> The following files were skipped due to too many changes: `packages/thirdweb/src/contract/deployment/deploy-deterministic.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->