### PR TITLE
Improve useReadContract example

### DIFF
--- a/packages/thirdweb/src/react/core/hooks/contract/useReadContract.ts
+++ b/packages/thirdweb/src/react/core/hooks/contract/useReadContract.ts
@@ -52,8 +52,8 @@ export function useReadContract<
  * @example
  * ```jsx
  * import { useReadContract } from "thirdweb/react";
- * import { totalSupply } form "thirdweb/extensions/erc20"
- * const { data, isLoading } = useReadContract(totalSupply);
+ * import { getOwnedNFTs } form "thirdweb/extensions/erc721"
+ * const { data, isLoading } = useReadContract(getOwnedNFTs, { contract, owner: address });
  * ```
  */
 export function useReadContract<


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `useReadContract` hook to fetch owned NFTs instead of total supply in the `useReadContract.ts` file.

### Detailed summary
- Updated import from `erc20` to `erc721`
- Changed function call to `getOwnedNFTs` with additional parameters `{ contract, owner: address }`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->