### PR TITLE
Fix: Adds missing use client

### DIFF
--- a/.changeset/nasty-gorillas-cry.md
+++ b/.changeset/nasty-gorillas-cry.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Adds missing use client directive for AutoConnect component

--- a/packages/thirdweb/src/react/core/hooks/connection/useAutoConnect.tsx
+++ b/packages/thirdweb/src/react/core/hooks/connection/useAutoConnect.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { useEffect } from "react";
 import type { ThirdwebClient } from "../../../../client/client.js";
 import type { Wallet } from "../../../../wallets/interfaces/wallet.js";


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds the missing `use client` directive for the `AutoConnect` component in `useAutoConnect.tsx`.

### Detailed summary
- Added missing `use client` directive for `AutoConnect` component in `useAutoConnect.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->