### PR TITLE
Fix: adds unset listing status to marketplace utils

### DIFF
--- a/.changeset/olive-papayas-develop.md
+++ b/.changeset/olive-papayas-develop.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Adds unset status for marketplace listings

--- a/packages/thirdweb/src/extensions/marketplace/utils.ts
+++ b/packages/thirdweb/src/extensions/marketplace/utils.ts
@@ -83,7 +83,6 @@ export async function getAllInBatches<const T>(
     maxSize: bigint;
   },
 ): Promise<T[]> {
-  console.log("2", options);
   let start = options.start;
   const batches: Promise<T>[] = [];
   while (options.end - start > options.maxSize) {
@@ -91,6 +90,5 @@ export async function getAllInBatches<const T>(
     start += options.maxSize;
   }
   batches.push(fn(start, options.end - 1n));
-  console.log("3", batches);
   return await Promise.all(batches);
 }

--- a/packages/thirdweb/src/extensions/marketplace/utils.ts
+++ b/packages/thirdweb/src/extensions/marketplace/utils.ts
@@ -48,6 +48,9 @@ export function computeStatus(options: {
   endTimestamp: bigint;
 }): ListingStatus {
   switch (options.listingStatus) {
+    case 0: {
+      return "UNSET";
+    }
     case 1: {
       if (options.startTimestamp > options.blockTimeStamp) {
         return "CREATED";
@@ -80,6 +83,7 @@ export async function getAllInBatches<const T>(
     maxSize: bigint;
   },
 ): Promise<T[]> {
+  console.log("2", options);
   let start = options.start;
   const batches: Promise<T>[] = [];
   while (options.end - start > options.maxSize) {
@@ -87,6 +91,6 @@ export async function getAllInBatches<const T>(
     start += options.maxSize;
   }
   batches.push(fn(start, options.end - 1n));
-
+  console.log("3", batches);
   return await Promise.all(batches);
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds support for an "UNSET" status in marketplace listings. 

### Detailed summary
- Added "UNSET" status for marketplace listings in `utils.ts`
- Updated `getAllInBatches` function to handle the new status

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->