### PR TITLE
Filter out invalid listings with invalid currencies

### DIFF
--- a/.changeset/odd-pots-prove.md
+++ b/.changeset/odd-pots-prove.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Filters invalid listings and auctions from marketplace

--- a/packages/thirdweb/src/extensions/marketplace/direct-listings/read/getAllListings.ts
+++ b/packages/thirdweb/src/extensions/marketplace/direct-listings/read/getAllListings.ts
@@ -67,13 +67,17 @@ export async function getAllListings(
     }),
   ]);
 
-  return await Promise.all(
-    rawListings.map((rawListing) =>
-      mapDirectListing({
-        contract: options.contract,
-        latestBlock,
-        rawListing,
-      }),
-    ),
-  );
+  const listings = (
+    await Promise.all(
+      rawListings.map((rawListing) =>
+        mapDirectListing({
+          contract: options.contract,
+          latestBlock,
+          rawListing,
+        }).catch(() => null),
+      ),
+    )
+  ).filter((listing) => listing !== null);
+
+  return listings as DirectListing[]; // TODO: Fix when TS 5.5 is out
 }

--- a/packages/thirdweb/src/extensions/marketplace/direct-listings/read/getAllValidListings.ts
+++ b/packages/thirdweb/src/extensions/marketplace/direct-listings/read/getAllValidListings.ts
@@ -71,13 +71,17 @@ export async function getAllValidListings(
     }),
   ]);
 
-  return await Promise.all(
-    rawListings.map((rawListing) =>
-      mapDirectListing({
-        contract: options.contract,
-        latestBlock,
-        rawListing,
-      }),
-    ),
-  );
+  const listings = (
+    await Promise.all(
+      rawListings.map((rawListing) =>
+        mapDirectListing({
+          contract: options.contract,
+          latestBlock,
+          rawListing,
+        }).catch(() => null),
+      ),
+    )
+  ).filter((listing) => listing !== null);
+
+  return listings as DirectListing[]; // TODO: Fix when TS 5.5 is out
 }

--- a/packages/thirdweb/src/extensions/marketplace/english-auctions/read/getAllValidAuctions.ts
+++ b/packages/thirdweb/src/extensions/marketplace/english-auctions/read/getAllValidAuctions.ts
@@ -71,13 +71,17 @@ export async function getAllValidAuctions(
     }),
   ]);
 
-  return await Promise.all(
-    rawAuctions.map((rawAuction) =>
-      mapEnglishAuction({
-        contract: options.contract,
-        latestBlock,
-        rawAuction,
-      }),
-    ),
-  );
+  const auctions = (
+    await Promise.all(
+      rawAuctions.map((rawAuction) =>
+        mapEnglishAuction({
+          contract: options.contract,
+          latestBlock,
+          rawAuction,
+        }),
+      ),
+    )
+  ).filter((auction) => auction !== null);
+
+  return auctions as EnglishAuction[]; // TODO: Fix when TS 5.5 is out
 }


### PR DESCRIPTION
We did this on `getAllAuctions` just need to do it for the other marketplace getters

<!-- start pr-codex -->

---

## PR-Codex overview
This PR filters out invalid listings and auctions from the marketplace by adding error handling to return only valid items.

### Detailed summary
- Added error handling to filter out invalid auctions and listings
- Updated filtering logic to exclude null items
- Added type assertion for `EnglishAuction` and `DirectListing` arrays

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->