### PR TITLE
Fix radix warning for switch network button ref

### DIFF
--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/Details.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/Details.tsx
@@ -183,17 +183,20 @@ export const ConnectedWalletDetails: React.FC<{
   const isNetworkMismatch =
     props.chain && walletChain && walletChain.id !== props.chain.id;
 
+  // Note: Must wrap the `detailsButton.render` and `SwitchNetworkButton` in a fragment to avoid warning from radix-ui
   const trigger = props.detailsButton?.render ? (
-    <div>
+    <>
       <props.detailsButton.render />
-    </div>
+    </>
   ) : props.chain && isNetworkMismatch ? (
-    <SwitchNetworkButton
-      style={props.switchButton?.style}
-      className={props.switchButton?.className}
-      switchNetworkBtnTitle={props.switchButton?.label}
-      targetChain={props.chain}
-    />
+    <>
+      <SwitchNetworkButton
+        style={props.switchButton?.style}
+        className={props.switchButton?.className}
+        switchNetworkBtnTitle={props.switchButton?.label}
+        targetChain={props.chain}
+      />
+    </>
   ) : (
     <WalletInfoButton
       type="button"


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to address a warning from radix-ui by wrapping `detailsButton.render` and `SwitchNetworkButton` in a fragment in `Details.tsx`.

### Detailed summary
- Wrapped `detailsButton.render` and `SwitchNetworkButton` in a fragment to avoid radix-ui warning.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->