### PR TITLE
Fix OTP input entered by clicking on “from messages” option in iOS safari

### DIFF
--- a/.changeset/calm-grapes-rule.md
+++ b/.changeset/calm-grapes-rule.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix OTP input entered by by clicking on “from messages” option in iOS safari

--- a/.changeset/old-fans-destroy.md
+++ b/.changeset/old-fans-destroy.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/react": patch
+---
+
+Fix OTP input entered by by clicking on “from messages” option in iOS safari

--- a/legacy_packages/react/src/components/OTPInput.tsx
+++ b/legacy_packages/react/src/components/OTPInput.tsx
@@ -94,13 +94,11 @@ export function OTPInput(props: {
               }
             }}
             onChange={(e) => {
-              let value = e.target.value;
+              const value = e.target.value;
 
               if (value.length > 1) {
-                const lastValue = value[value.length - 1];
-                if (lastValue) {
-                  value = lastValue;
-                }
+                setOTP(value.split("").filter((n) => /\d/.test(n)).map(Number));
+                return;
               }
 
               if (!/\d/.test(value) && value !== "") {

--- a/packages/thirdweb/src/react/web/ui/components/OTPInput.tsx
+++ b/packages/thirdweb/src/react/web/ui/components/OTPInput.tsx
@@ -96,13 +96,11 @@ export function OTPInput(props: {
               }
             }}
             onChange={(e) => {
-              let value = e.target.value;
+              const value = e.target.value;
 
               if (value.length > 1) {
-                const lastValue = value[value.length - 1];
-                if (lastValue) {
-                  value = lastValue;
-                }
+                setOTP(value.split(""));
+                return;
               }
 
               if (!/\d/.test(value) && value !== "") {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on fixing OTP input issues in iOS Safari by updating the OTP input handling logic in the `OTPInput.tsx` file.

### Detailed summary
- Updated OTP input handling logic for iOS Safari in `OTPInput.tsx`
- Changed the way OTP values are processed in the `onChange` event handler for better compatibility

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->