### PR TITLE
Feature: Adds `blockRange` option to `getContractEvents`

### DIFF
--- a/.changeset/dirty-lemons-clap.md
+++ b/.changeset/dirty-lemons-clap.md
@@ -1,0 +1,39 @@
+---
+"thirdweb": patch
+---
+
+Can now optionally specify `blockRange` on `getContractEvents` in combination with `toBlock` and `fromBlock`.
+
+## Usage
+
+Specify a `blockRange`, defaulting `toBlock` to the current block number.
+
+```ts
+await getContractEvents({
+  contract: myContract,
+  blockRange: 123456n,
+  events: [preparedEvent, preparedEvent2],
+});
+```
+
+Specify a block range with `toBlock`.
+
+```ts
+await getContractEvents({
+  contract: myContract,
+  toBlock: endBlock,
+  blockRange: 123456n,
+  events: [preparedEvent, preparedEvent2],
+});
+```
+
+Specify a block range starting from `fromBlock` (great for pagination).
+
+```ts
+await getContractEvents({
+  contract: myContract,
+  fromBlock: lastBlockFetched,
+  blockRange: 123456n,
+  events: [preparedEvent, preparedEvent2],
+});
+```

--- a/packages/thirdweb/src/event/actions/get-events.test.ts
+++ b/packages/thirdweb/src/event/actions/get-events.test.ts
@@ -7,21 +7,74 @@ import { transferEvent } from "../../extensions/erc721/__generated__/IERC721A/ev
 import { prepareEvent } from "../prepare-event.js";
 import { getContractEvents } from "./get-events.js";
 
+const LATEST_SIMULATED_BLOCK = 19139495n;
+
 // skip this test suite if there is no secret key available to test with
 // TODO: remove reliance on secret key during unit tests entirely
 describe.runIf(process.env.TW_SECRET_KEY)("getEvents", () => {
   it("should get all events", async () => {
     const events = await getContractEvents({
       contract: USDT_CONTRACT,
-      fromBlock: 19139495n - 10n,
+      fromBlock: LATEST_SIMULATED_BLOCK - 10n,
     });
     expect(events.length).toBe(261);
+  });
+
+  it("should get events for blockHash", async () => {
+    const BLOCK_HASH =
+      "0xb0ad5ee7b4912b50e5a2d7993796944653a4c0632c57740fe4a7a1c61e426324";
+    const events = await getContractEvents({
+      contract: USDT_CONTRACT,
+      blockHash: BLOCK_HASH,
+    });
+    for (const e of events) {
+      expect(e.blockHash).toBe(BLOCK_HASH);
+    }
+    expect(events.length).toBe(14);
+  });
+
+  it("should get events for blockRange", async () => {
+    const events = await getContractEvents({
+      contract: USDT_CONTRACT,
+      blockRange: 10n,
+    });
+    expect(events.length).toBe(261);
+
+    const explicitEvents = await getContractEvents({
+      contract: USDT_CONTRACT,
+      fromBlock: LATEST_SIMULATED_BLOCK - 10n,
+      toBlock: LATEST_SIMULATED_BLOCK,
+    });
+    expect(explicitEvents.length).toEqual(events.length);
+  });
+
+  it("should get events for blockRange using fromBlock and toBlock", async () => {
+    const eventsFromBlock = await getContractEvents({
+      contract: USDT_CONTRACT,
+      fromBlock: LATEST_SIMULATED_BLOCK - 50n,
+      blockRange: 20n,
+    });
+    expect(eventsFromBlock.length).toBe(426);
+
+    const eventsToBlock = await getContractEvents({
+      contract: USDT_CONTRACT,
+      toBlock: LATEST_SIMULATED_BLOCK - 30n,
+      blockRange: 20n,
+    });
+    expect(eventsToBlock.length).toBe(426);
+
+    const explicitEvents = await getContractEvents({
+      contract: USDT_CONTRACT,
+      fromBlock: LATEST_SIMULATED_BLOCK - 50n,
+      toBlock: LATEST_SIMULATED_BLOCK - 30n,
+    });
+    expect(explicitEvents.length).toEqual(eventsFromBlock.length);
   });
 
   it("should get individual events with signature", async () => {
     const events = await getContractEvents({
       contract: USDT_CONTRACT,
-      fromBlock: 19139495n - 100n,
+      fromBlock: LATEST_SIMULATED_BLOCK - 100n,
       events: [
         prepareEvent({
           signature: "event Burn(address indexed burner, uint256 amount)",
@@ -34,7 +87,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("getEvents", () => {
   it("should get specified events", async () => {
     const events = await getContractEvents({
       contract: USDT_CONTRACT,
-      fromBlock: 19139495n - 10n,
+      fromBlock: LATEST_SIMULATED_BLOCK - 10n,
       events: [
         prepareEvent({
           signature: "event Burn(address indexed burner, uint256 amount)",
@@ -74,7 +127,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("getEvents", () => {
   it("should get individual events with extension", async () => {
     const events = await getContractEvents({
       contract: DOODLES_CONTRACT,
-      fromBlock: 19139495n - 1000n,
+      fromBlock: LATEST_SIMULATED_BLOCK - 1000n,
       events: [transferEvent()],
     });
     expect(events.length).toBe(38);

--- a/packages/thirdweb/src/rpc/actions/eth_getLogs.ts
+++ b/packages/thirdweb/src/rpc/actions/eth_getLogs.ts
@@ -16,11 +16,31 @@ export type GetLogsBlockParams =
       fromBlock?: BlockNumber | BlockTag;
       toBlock?: BlockNumber | BlockTag;
       blockHash?: never;
+      blockRange?: never;
     }
   | {
       fromBlock?: never;
       toBlock?: never;
       blockHash?: Hash;
+      blockRange?: never;
+    }
+  | {
+      fromBlock?: BlockNumber | "latest";
+      toBlock?: never;
+      blockRange: BlockNumber;
+      blockHash?: never;
+    }
+  | {
+      fromBlock?: never;
+      toBlock?: BlockNumber | "latest";
+      blockRange: BlockNumber;
+      blockHash?: never;
+    }
+  | {
+      fromBlock?: never;
+      toBlock?: never;
+      blockRange: BlockNumber;
+      blockHash?: never;
     };
 
 export type GetLogsParams = {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to enhance event retrieval in Thirdweb by introducing the `blockRange` parameter for more flexible event querying.

### Detailed summary
- Added `blockRange` parameter to `GetLogsParams` for event retrieval
- Updated `GetLogsParams` to handle `blockRange` with `fromBlock` and `toBlock`
- Enhanced `getContractEvents` to support `blockRange` for pagination and specific block hash retrieval

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->