### PR TITLE
Remove old CLI templates

### DIFF
--- a/.changeset/dull-planets-sneeze.md
+++ b/.changeset/dull-planets-sneeze.md
@@ -3,4 +3,4 @@
 "thirdweb": patch
 ---
 
-Removes deprecated template options from the CLI
+Removes deprecated template options from the CLI, specifically PWA Vite, Express, and React

--- a/.changeset/dull-planets-sneeze.md
+++ b/.changeset/dull-planets-sneeze.md
@@ -1,0 +1,6 @@
+---
+"@thirdweb-dev/cli": patch
+"thirdweb": patch
+---
+
+Removes deprecated template options from the CLI

--- a/legacy_packages/cli/src/cli/index.ts
+++ b/legacy_packages/cli/src/cli/index.ts
@@ -253,12 +253,9 @@ const main = async () => {
     .option("--forge", "Initialize as a Forge project.")
     .option("--hardhat", "Initialize as a Hardhat project.")
     .option("--extension", "Create a smart contract extension.")
-    .option("--react", "Initialize as a Create React App project.")
     .option("--next", "Initialize as a Next.js project.")
     .option("--vite", "Initialize as a Vite project.")
-    .option("--express", "Initialize as a Express project.")
     .option("--node", "Initialize as a Node project.")
-    .option("--pwaVite", "Initialize as a PWA project.")
     .option(
       "--use-npm",
       "Explicitly tell the CLI to bootstrap the app using npm",

--- a/legacy_packages/cli/src/create/command.ts
+++ b/legacy_packages/cli/src/create/command.ts
@@ -212,6 +212,7 @@ export async function twCreate(
           choices: [
             { title: "Next.js", value: "next" },
             { title: "Vite", value: "vite" },
+            { title: "Node.js", value: "node" },
           ],
         });
 

--- a/legacy_packages/cli/src/create/command.ts
+++ b/legacy_packages/cli/src/create/command.ts
@@ -44,11 +44,6 @@ export async function twCreate(
 
   // case where users use `npx thirdweb create --option` directly
   if (!projectType && Object.keys(options).length > 0) {
-    if (options.react) {
-      projectType = "app";
-      framework = "cra";
-    }
-
     if (options.next) {
       projectType = "app";
       framework = "next";
@@ -62,21 +57,6 @@ export async function twCreate(
     if (options.node) {
       projectType = "app";
       framework = "node";
-    }
-
-    if (options.express) {
-      projectType = "app";
-      framework = "express";
-    }
-
-    if (options.pwaVite) {
-      projectType = "app";
-      framework = "pwa-vite";
-    }
-
-    if (options.reactNative) {
-      projectType = "app";
-      framework = "react-native";
     }
   }
 
@@ -84,20 +64,11 @@ export async function twCreate(
     if (options.next) {
       framework = "next";
     }
-    if (options.react) {
-      framework = "cra";
-    }
     if (options.vite) {
       framework = "vite";
     }
     if (options.node) {
       framework = "node";
-    }
-    if (options.express) {
-      framework = "express";
-    }
-    if (options.pwaVite) {
-      framework = "pwa-vite";
     }
 
     if (options.evm) {
@@ -240,11 +211,7 @@ export async function twCreate(
           message: CREATE_MESSAGES.framework,
           choices: [
             { title: "Next.js", value: "next" },
-            { title: "Create React App", value: "cra" },
             { title: "Vite", value: "vite" },
-            { title: "PWA Vite", value: "pwa-vite" },
-            { title: "Node.js", value: "node" },
-            { title: "Express", value: "express" },
           ],
         });
 

--- a/legacy_packages/cli/src/create/command.ts
+++ b/legacy_packages/cli/src/create/command.ts
@@ -212,7 +212,6 @@ export async function twCreate(
           choices: [
             { title: "Next.js", value: "next" },
             { title: "Vite", value: "vite" },
-            { title: "Node.js", value: "node" },
           ],
         });
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR removes deprecated template options (PWA Vite, Express, React) from the CLI and refactors the project initialization logic for clarity and consistency.

### Detailed summary
- Removed deprecated template options: PWA Vite, Express, React
- Refactored project initialization logic for Next.js, Vite, and Node projects
- Updated CLI prompts and choices for project frameworks

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->