### PR TITLE
Read RPC on Viem chain adapter

### DIFF
--- a/.changeset/metal-toes-tickle.md
+++ b/.changeset/metal-toes-tickle.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Read RPC url from viem chain in viem chain adapter

--- a/packages/thirdweb/src/chains/utils.test.ts
+++ b/packages/thirdweb/src/chains/utils.test.ts
@@ -1,0 +1,32 @@
+import { defineChain as viemChain } from "viem";
+import { describe, expect, it } from "vitest";
+import { defineChain } from "./utils.js";
+
+describe("defineChain", () => {
+  it("should convert viem chain to thirdweb chain", () => {
+    const zoraViem = viemChain({
+      id: 7777777,
+      name: "Zora",
+      nativeCurrency: {
+        decimals: 18,
+        name: "Ether",
+        symbol: "ETH",
+      },
+      rpcUrls: {
+        default: {
+          http: ["https://rpc.zora.energy"],
+          webSocket: ["wss://rpc.zora.energy"],
+        },
+      },
+      blockExplorers: {
+        default: { name: "Explorer", url: "https://explorer.zora.energy" },
+      },
+    });
+    const thirdwebViem = defineChain(zoraViem);
+
+    expect(thirdwebViem.id).toEqual(zoraViem.id);
+    expect(thirdwebViem.name).toEqual(zoraViem.name);
+    expect(thirdwebViem.nativeCurrency).toEqual(zoraViem.nativeCurrency);
+    expect(thirdwebViem.rpc).toEqual(zoraViem.rpcUrls.default.http[0]);
+  });
+});

--- a/packages/thirdweb/src/chains/utils.ts
+++ b/packages/thirdweb/src/chains/utils.ts
@@ -91,6 +91,9 @@ function convertViemChain(viemChain: ViemChain): Chain {
       symbol: viemChain.nativeCurrency.symbol,
       decimals: viemChain.nativeCurrency.decimals,
     },
+    rpc:
+      viemChain.rpcUrls.default.http[0] ??
+      `https://${viemChain.id}.rpc.thirdweb.com`,
     blockExplorers: viemChain?.blockExplorers
       ? Object.values(viemChain?.blockExplorers).map((explorer) => {
           return {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `viemChain` adapter to read RPC URL from `viemChain` in the `thirdweb` package.

### Detailed summary
- Added logic to read RPC URL from `viemChain` in `viemChain` adapter
- Added test for converting `viem` chain to `thirdweb` chain in `utils.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->