### PR TITLE
Adds `extraGas` override for transaction preparation

### DIFF
--- a/.changeset/fluffy-dodos-flash.md
+++ b/.changeset/fluffy-dodos-flash.md
@@ -1,0 +1,18 @@
+---
+"thirdweb": patch
+---
+
+Adds extraGas override to transactions. Useful when gas estimates are faulty or to ensure a transaction goes through.
+
+## Usage
+
+```ts
+const transaction = prepareTransaction({
+  to: "0x1234567890123456789012345678901234567890",
+  chain: ethereum,
+  client: thirdwebClient,
+  value: toWei("1.0"),
+  gasPrice: 30n,
+  extraGas: 50_000n,
+});
+```

--- a/packages/thirdweb/scripts/generate/generate.ts
+++ b/packages/thirdweb/scripts/generate/generate.ts
@@ -275,6 +275,7 @@ export function ${f.name}(
       maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
       maxPriorityFeePerGas: async () => (await asyncOptions()).overrides?.maxPriorityFeePerGas,
       nonce: async () => (await asyncOptions()).overrides?.nonce,
+      extraGas: async () => (await asyncOptions()).overrides?.extraGas,
       `
         : ""
     }

--- a/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/airdropERC1155.ts
+++ b/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/airdropERC1155.ts
@@ -177,5 +177,6 @@ export function airdropERC1155(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/airdropERC1155WithSignature.ts
+++ b/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/airdropERC1155WithSignature.ts
@@ -210,5 +210,6 @@ export function airdropERC1155WithSignature(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/airdropERC20.ts
+++ b/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/airdropERC20.ts
@@ -169,5 +169,6 @@ export function airdropERC20(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/airdropERC20WithSignature.ts
+++ b/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/airdropERC20WithSignature.ts
@@ -204,5 +204,6 @@ export function airdropERC20WithSignature(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/airdropERC721.ts
+++ b/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/airdropERC721.ts
@@ -171,5 +171,6 @@ export function airdropERC721(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/airdropERC721WithSignature.ts
+++ b/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/airdropERC721WithSignature.ts
@@ -204,5 +204,6 @@ export function airdropERC721WithSignature(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/airdropNativeToken.ts
+++ b/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/airdropNativeToken.ts
@@ -157,5 +157,6 @@ export function airdropNativeToken(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/claimERC1155.ts
+++ b/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/claimERC1155.ts
@@ -201,5 +201,6 @@ export function claimERC1155(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/claimERC20.ts
+++ b/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/claimERC20.ts
@@ -186,5 +186,6 @@ export function claimERC20(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/claimERC721.ts
+++ b/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/claimERC721.ts
@@ -186,5 +186,6 @@ export function claimERC721(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/initialize.ts
+++ b/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/initialize.ts
@@ -137,5 +137,6 @@ export function initialize(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/setMerkleRoot.ts
+++ b/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/setMerkleRoot.ts
@@ -173,5 +173,6 @@ export function setMerkleRoot(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/setOwner.ts
+++ b/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/setOwner.ts
@@ -135,5 +135,6 @@ export function setOwner(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/common/__generated__/IClaimConditionsSinglePhase/write/setClaimConditions.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IClaimConditionsSinglePhase/write/setClaimConditions.ts
@@ -200,5 +200,6 @@ export function setClaimConditions(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/common/__generated__/IContractMetadata/write/setContractURI.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IContractMetadata/write/setContractURI.ts
@@ -134,5 +134,6 @@ export function setContractURI(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/common/__generated__/IMulticall/write/multicall.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IMulticall/write/multicall.ts
@@ -137,5 +137,6 @@ export function multicall(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/common/__generated__/IOwnable/write/setOwner.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IOwnable/write/setOwner.ts
@@ -130,5 +130,6 @@ export function setOwner(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/common/__generated__/IPlatformFee/write/setPlatformFeeInfo.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IPlatformFee/write/setPlatformFeeInfo.ts
@@ -156,5 +156,6 @@ export function setPlatformFeeInfo(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/common/__generated__/IPrimarySale/write/setPrimarySaleRecipient.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IPrimarySale/write/setPrimarySaleRecipient.ts
@@ -141,5 +141,6 @@ export function setPrimarySaleRecipient(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/common/__generated__/IRoyalty/write/setDefaultRoyaltyInfo.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IRoyalty/write/setDefaultRoyaltyInfo.ts
@@ -158,5 +158,6 @@ export function setDefaultRoyaltyInfo(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/common/__generated__/IRoyalty/write/setRoyaltyInfoForToken.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IRoyalty/write/setRoyaltyInfoForToken.ts
@@ -165,5 +165,6 @@ export function setRoyaltyInfoForToken(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/common/__generated__/IRoyaltyPayments/write/getRoyalty.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IRoyaltyPayments/write/getRoyalty.ts
@@ -168,5 +168,6 @@ export function getRoyalty(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/common/__generated__/IRoyaltyPayments/write/setRoyaltyEngine.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IRoyaltyPayments/write/setRoyaltyEngine.ts
@@ -137,5 +137,6 @@ export function setRoyaltyEngine(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IAirdropERC1155/write/airdropERC1155.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IAirdropERC1155/write/airdropERC1155.ts
@@ -186,5 +186,6 @@ export function airdropERC1155(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IAirdropERC1155Claimable/write/claim.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IAirdropERC1155Claimable/write/claim.ts
@@ -177,5 +177,6 @@ export function claim(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IBurnableERC1155/write/burn.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IBurnableERC1155/write/burn.ts
@@ -154,5 +154,6 @@ export function burn(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IBurnableERC1155/write/burnBatch.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IBurnableERC1155/write/burnBatch.ts
@@ -156,5 +156,6 @@ export function burnBatch(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IClaimableERC1155/write/claim.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IClaimableERC1155/write/claim.ts
@@ -154,5 +154,6 @@ export function claim(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IDrop1155/write/claim.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IDrop1155/write/claim.ts
@@ -224,5 +224,6 @@ export function claim(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IDrop1155/write/setClaimConditions.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IDrop1155/write/setClaimConditions.ts
@@ -210,5 +210,6 @@ export function setClaimConditions(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/write/safeBatchTransferFrom.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/write/safeBatchTransferFrom.ts
@@ -185,5 +185,6 @@ export function safeBatchTransferFrom(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/write/safeTransferFrom.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/write/safeTransferFrom.ts
@@ -178,5 +178,6 @@ export function safeTransferFrom(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/write/setApprovalForAll.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/write/setApprovalForAll.ts
@@ -144,5 +144,6 @@ export function setApprovalForAll(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155Receiver/write/onERC1155BatchReceived.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155Receiver/write/onERC1155BatchReceived.ts
@@ -186,5 +186,6 @@ export function onERC1155BatchReceived(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155Receiver/write/onERC1155Received.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155Receiver/write/onERC1155Received.ts
@@ -184,5 +184,6 @@ export function onERC1155Received(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IEditionStake/write/depositRewardTokens.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IEditionStake/write/depositRewardTokens.ts
@@ -136,5 +136,6 @@ export function depositRewardTokens(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IEditionStake/write/withdrawRewardTokens.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IEditionStake/write/withdrawRewardTokens.ts
@@ -138,5 +138,6 @@ export function withdrawRewardTokens(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/ILazyMint/write/lazyMint.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/ILazyMint/write/lazyMint.ts
@@ -162,5 +162,6 @@ export function lazyMint(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IMintableERC1155/write/mintTo.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IMintableERC1155/write/mintTo.ts
@@ -164,5 +164,6 @@ export function mintTo(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/INFTMetadata/write/setTokenURI.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/INFTMetadata/write/setTokenURI.ts
@@ -140,5 +140,6 @@ export function setTokenURI(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IPack/write/createPack.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IPack/write/createPack.ts
@@ -234,5 +234,6 @@ export function createPack(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IPack/write/openPack.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IPack/write/openPack.ts
@@ -163,5 +163,6 @@ export function openPack(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IPackVRFDirect/write/openPackAndClaimRewards.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IPackVRFDirect/write/openPackAndClaimRewards.ts
@@ -172,5 +172,6 @@ export function openPackAndClaimRewards(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/ISignatureMintERC1155/write/mintWithSignature.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/ISignatureMintERC1155/write/mintWithSignature.ts
@@ -211,5 +211,6 @@ export function mintWithSignature(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IStaking1155/write/claimRewards.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IStaking1155/write/claimRewards.ts
@@ -132,5 +132,6 @@ export function claimRewards(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IStaking1155/write/stake.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IStaking1155/write/stake.ts
@@ -138,5 +138,6 @@ export function stake(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IStaking1155/write/withdraw.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IStaking1155/write/withdraw.ts
@@ -138,5 +138,6 @@ export function withdraw(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IAirdropERC20/write/airdropERC20.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IAirdropERC20/write/airdropERC20.ts
@@ -179,5 +179,6 @@ export function airdropERC20(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IAirdropERC20Claimable/write/claim.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IAirdropERC20Claimable/write/claim.ts
@@ -167,5 +167,6 @@ export function claim(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IBurnableERC20/write/burn.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IBurnableERC20/write/burn.ts
@@ -130,5 +130,6 @@ export function burn(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IBurnableERC20/write/burnFrom.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IBurnableERC20/write/burnFrom.ts
@@ -138,5 +138,6 @@ export function burnFrom(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IDropERC20/write/claim.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IDropERC20/write/claim.ts
@@ -214,5 +214,6 @@ export function claim(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IDropERC20/write/setClaimConditions.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IDropERC20/write/setClaimConditions.ts
@@ -200,5 +200,6 @@ export function setClaimConditions(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IERC20/write/approve.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IERC20/write/approve.ts
@@ -142,5 +142,6 @@ export function approve(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IERC20/write/transfer.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IERC20/write/transfer.ts
@@ -142,5 +142,6 @@ export function transfer(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IERC20/write/transferFrom.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IERC20/write/transferFrom.ts
@@ -160,5 +160,6 @@ export function transferFrom(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IERC20Permit/write/permit.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IERC20Permit/write/permit.ts
@@ -194,5 +194,6 @@ export function permit(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IMintableERC20/write/mintTo.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IMintableERC20/write/mintTo.ts
@@ -138,5 +138,6 @@ export function mintTo(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/ISignatureMintERC20/write/mintWithSignature.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/ISignatureMintERC20/write/mintWithSignature.ts
@@ -191,5 +191,6 @@ export function mintWithSignature(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IStaking20/write/stake.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IStaking20/write/stake.ts
@@ -130,5 +130,6 @@ export function stake(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IStaking20/write/withdraw.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IStaking20/write/withdraw.ts
@@ -130,5 +130,6 @@ export function withdraw(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/ITokenStake/write/depositRewardTokens.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/ITokenStake/write/depositRewardTokens.ts
@@ -136,5 +136,6 @@ export function depositRewardTokens(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/ITokenStake/write/withdrawRewardTokens.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/ITokenStake/write/withdrawRewardTokens.ts
@@ -138,5 +138,6 @@ export function withdrawRewardTokens(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IVotes/write/delegate.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IVotes/write/delegate.ts
@@ -133,5 +133,6 @@ export function delegate(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IVotes/write/delegateBySig.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IVotes/write/delegateBySig.ts
@@ -191,5 +191,6 @@ export function delegateBySig(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IWETH/write/transfer.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IWETH/write/transfer.ts
@@ -142,5 +142,6 @@ export function transfer(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IWETH/write/withdraw.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IWETH/write/withdraw.ts
@@ -130,5 +130,6 @@ export function withdraw(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IAccount/write/validateUserOp.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IAccount/write/validateUserOp.ts
@@ -231,5 +231,6 @@ export function validateUserOp(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/write/createAccount.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/write/createAccount.ts
@@ -147,5 +147,6 @@ export function createAccount(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/write/onSignerAdded.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/write/onSignerAdded.ts
@@ -161,5 +161,6 @@ export function onSignerAdded(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/write/onSignerRemoved.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/write/onSignerRemoved.ts
@@ -161,5 +161,6 @@ export function onSignerRemoved(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountPermissions/write/setPermissionsForSigner.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountPermissions/write/setPermissionsForSigner.ts
@@ -198,5 +198,6 @@ export function setPermissionsForSigner(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/addStake.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/addStake.ts
@@ -133,5 +133,6 @@ export function addStake(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/depositTo.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/depositTo.ts
@@ -132,5 +132,6 @@ export function depositTo(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/getSenderAddress.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/getSenderAddress.ts
@@ -134,5 +134,6 @@ export function getSenderAddress(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/handleAggregatedOps.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/handleAggregatedOps.ts
@@ -237,5 +237,6 @@ export function handleAggregatedOps(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/handleOps.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/handleOps.ts
@@ -205,5 +205,6 @@ export function handleOps(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/incrementNonce.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/incrementNonce.ts
@@ -134,5 +134,6 @@ export function incrementNonce(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/simulateHandleOp.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/simulateHandleOp.ts
@@ -223,5 +223,6 @@ export function simulateHandleOp(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/simulateValidation.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/simulateValidation.ts
@@ -198,5 +198,6 @@ export function simulateValidation(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/withdrawStake.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/withdrawStake.ts
@@ -137,5 +137,6 @@ export function withdrawStake(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/withdrawTo.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/withdrawTo.ts
@@ -152,5 +152,6 @@ export function withdrawTo(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IPaymaster/write/postOp.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IPaymaster/write/postOp.ts
@@ -157,5 +157,6 @@ export function postOp(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IPaymaster/write/validatePaymasterUserOp.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IPaymaster/write/validatePaymasterUserOp.ts
@@ -236,5 +236,6 @@ export function validatePaymasterUserOp(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/write/deposit.ts
+++ b/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/write/deposit.ts
@@ -154,5 +154,6 @@ export function deposit(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/write/mint.ts
+++ b/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/write/mint.ts
@@ -154,5 +154,6 @@ export function mint(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/write/redeem.ts
+++ b/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/write/redeem.ts
@@ -175,5 +175,6 @@ export function redeem(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/write/withdraw.ts
+++ b/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/write/withdraw.ts
@@ -175,5 +175,6 @@ export function withdraw(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IAirdropERC721/write/airdropERC721.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IAirdropERC721/write/airdropERC721.ts
@@ -181,5 +181,6 @@ export function airdropERC721(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IAirdropERC721Claimable/write/claim.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IAirdropERC721Claimable/write/claim.ts
@@ -167,5 +167,6 @@ export function claim(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IBurnableERC721/write/burn.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IBurnableERC721/write/burn.ts
@@ -130,5 +130,6 @@ export function burn(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IClaimableERC721/write/claim.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IClaimableERC721/write/claim.ts
@@ -138,5 +138,6 @@ export function claim(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IDelayedReveal/write/reveal.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IDelayedReveal/write/reveal.ts
@@ -146,5 +146,6 @@ export function reveal(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IDrop/write/claim.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IDrop/write/claim.ts
@@ -214,5 +214,6 @@ export function claim(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IDrop/write/setClaimConditions.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IDrop/write/setClaimConditions.ts
@@ -200,5 +200,6 @@ export function setClaimConditions(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/write/approve.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/write/approve.ts
@@ -138,5 +138,6 @@ export function approve(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/write/safeTransferFrom.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/write/safeTransferFrom.ts
@@ -158,5 +158,6 @@ export function safeTransferFrom(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/write/setApprovalForAll.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/write/setApprovalForAll.ts
@@ -144,5 +144,6 @@ export function setApprovalForAll(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/write/transferFrom.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/write/transferFrom.ts
@@ -156,5 +156,6 @@ export function transferFrom(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IERC721Receiver/write/onERC721Received.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IERC721Receiver/write/onERC721Received.ts
@@ -172,5 +172,6 @@ export function onERC721Received(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ILazyMint/write/lazyMint.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ILazyMint/write/lazyMint.ts
@@ -162,5 +162,6 @@ export function lazyMint(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IMintableERC721/write/mintTo.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IMintableERC721/write/mintTo.ts
@@ -142,5 +142,6 @@ export function mintTo(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/INFTMetadata/write/setTokenURI.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/INFTMetadata/write/setTokenURI.ts
@@ -140,5 +140,6 @@ export function setTokenURI(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/INFTStake/write/depositRewardTokens.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/INFTStake/write/depositRewardTokens.ts
@@ -136,5 +136,6 @@ export function depositRewardTokens(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/INFTStake/write/withdrawRewardTokens.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/INFTStake/write/withdrawRewardTokens.ts
@@ -138,5 +138,6 @@ export function withdrawRewardTokens(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ISharedMetadata/write/setSharedMetadata.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ISharedMetadata/write/setSharedMetadata.ts
@@ -163,5 +163,6 @@ export function setSharedMetadata(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ISharedMetadataBatch/write/deleteSharedMetadata.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ISharedMetadataBatch/write/deleteSharedMetadata.ts
@@ -138,5 +138,6 @@ export function deleteSharedMetadata(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ISharedMetadataBatch/write/setSharedMetadata.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ISharedMetadataBatch/write/setSharedMetadata.ts
@@ -171,5 +171,6 @@ export function setSharedMetadata(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ISignatureMintERC721/write/mintWithSignature.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ISignatureMintERC721/write/mintWithSignature.ts
@@ -206,5 +206,6 @@ export function mintWithSignature(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IStaking721/write/stake.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IStaking721/write/stake.ts
@@ -133,5 +133,6 @@ export function stake(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IStaking721/write/withdraw.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IStaking721/write/withdraw.ts
@@ -133,5 +133,6 @@ export function withdraw(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IBundler/write/register.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IBundler/write/register.ts
@@ -226,5 +226,6 @@ export function register(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IIdGateway/write/register.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IIdGateway/write/register.ts
@@ -153,5 +153,6 @@ export function register(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IIdGateway/write/registerFor.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IIdGateway/write/registerFor.ts
@@ -188,5 +188,6 @@ export function registerFor(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/changeRecoveryAddress.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/changeRecoveryAddress.ts
@@ -138,5 +138,6 @@ export function changeRecoveryAddress(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/changeRecoveryAddressFor.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/changeRecoveryAddressFor.ts
@@ -172,5 +172,6 @@ export function changeRecoveryAddressFor(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/recover.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/recover.ts
@@ -164,5 +164,6 @@ export function recover(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/recoverFor.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/recoverFor.ts
@@ -195,5 +195,6 @@ export function recoverFor(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/transfer.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/transfer.ts
@@ -154,5 +154,6 @@ export function transfer(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/transferAndChangeRecovery.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/transferAndChangeRecovery.ts
@@ -172,5 +172,6 @@ export function transferAndChangeRecovery(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/transferAndChangeRecoveryFor.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/transferAndChangeRecoveryFor.ts
@@ -208,5 +208,6 @@ export function transferAndChangeRecoveryFor(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/transferFor.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/transferFor.ts
@@ -192,5 +192,6 @@ export function transferFor(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyGateway/write/add.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyGateway/write/add.ts
@@ -167,5 +167,6 @@ export function add(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyGateway/write/addFor.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyGateway/write/addFor.ts
@@ -197,5 +197,6 @@ export function addFor(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyRegistry/write/remove.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyRegistry/write/remove.ts
@@ -130,5 +130,6 @@ export function remove(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyRegistry/write/removeFor.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyRegistry/write/removeFor.ts
@@ -166,5 +166,6 @@ export function removeFor(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IStorageRegistry/write/batchRent.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IStorageRegistry/write/batchRent.ts
@@ -140,5 +140,6 @@ export function batchRent(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IStorageRegistry/write/rent.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IStorageRegistry/write/rent.ts
@@ -143,5 +143,6 @@ export function rent(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/approveBuyerForListing.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/approveBuyerForListing.ts
@@ -165,5 +165,6 @@ export function approveBuyerForListing(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/approveCurrencyForListing.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/approveCurrencyForListing.ts
@@ -168,5 +168,6 @@ export function approveCurrencyForListing(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/buyFromListing.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/buyFromListing.ts
@@ -184,5 +184,6 @@ export function buyFromListing(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/cancelListing.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/cancelListing.ts
@@ -137,5 +137,6 @@ export function cancelListing(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/createListing.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/createListing.ts
@@ -186,5 +186,6 @@ export function createListing(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/updateListing.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/updateListing.ts
@@ -192,5 +192,6 @@ export function updateListing(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/bidInAuction.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/bidInAuction.ts
@@ -146,5 +146,6 @@ export function bidInAuction(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/cancelAuction.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/cancelAuction.ts
@@ -137,5 +137,6 @@ export function cancelAuction(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/collectAuctionPayout.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/collectAuctionPayout.ts
@@ -141,5 +141,6 @@ export function collectAuctionPayout(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/collectAuctionTokens.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/collectAuctionTokens.ts
@@ -141,5 +141,6 @@ export function collectAuctionTokens(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/createAuction.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/createAuction.ts
@@ -196,5 +196,6 @@ export function createAuction(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/acceptOffer.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/acceptOffer.ts
@@ -172,5 +172,6 @@ export function acceptOffer(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/buy.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/buy.ts
@@ -180,5 +180,6 @@ export function buy(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/cancelDirectListing.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/cancelDirectListing.ts
@@ -139,5 +139,6 @@ export function cancelDirectListing(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/closeAuction.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/closeAuction.ts
@@ -143,5 +143,6 @@ export function closeAuction(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/createListing.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/createListing.ts
@@ -186,5 +186,6 @@ export function createListing(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/offer.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/offer.ts
@@ -186,5 +186,6 @@ export function offer(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/setContractURI.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/setContractURI.ts
@@ -134,5 +134,6 @@ export function setContractURI(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/setPlatformFeeInfo.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/setPlatformFeeInfo.ts
@@ -156,5 +156,6 @@ export function setPlatformFeeInfo(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/updateListing.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/updateListing.ts
@@ -219,5 +219,6 @@ export function updateListing(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IOffers/write/acceptOffer.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IOffers/write/acceptOffer.ts
@@ -132,5 +132,6 @@ export function acceptOffer(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IOffers/write/cancelOffer.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IOffers/write/cancelOffer.ts
@@ -132,5 +132,6 @@ export function cancelOffer(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IOffers/write/makeOffer.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IOffers/write/makeOffer.ts
@@ -174,5 +174,6 @@ export function makeOffer(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/aggregate.ts
+++ b/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/aggregate.ts
@@ -164,5 +164,6 @@ export function aggregate(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/aggregate3.ts
+++ b/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/aggregate3.ts
@@ -177,5 +177,6 @@ export function aggregate3(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/aggregate3Value.ts
+++ b/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/aggregate3Value.ts
@@ -185,5 +185,6 @@ export function aggregate3Value(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/blockAndAggregate.ts
+++ b/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/blockAndAggregate.ts
@@ -185,5 +185,6 @@ export function blockAndAggregate(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/tryAggregate.ts
+++ b/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/tryAggregate.ts
@@ -187,5 +187,6 @@ export function tryAggregate(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/tryBlockAndAggregate.ts
+++ b/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/tryBlockAndAggregate.ts
@@ -203,5 +203,6 @@ export function tryBlockAndAggregate(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/permissions/__generated__/IPermissions/write/grantRole.ts
+++ b/packages/thirdweb/src/extensions/permissions/__generated__/IPermissions/write/grantRole.ts
@@ -140,5 +140,6 @@ export function grantRole(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/permissions/__generated__/IPermissions/write/renounceRole.ts
+++ b/packages/thirdweb/src/extensions/permissions/__generated__/IPermissions/write/renounceRole.ts
@@ -140,5 +140,6 @@ export function renounceRole(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/permissions/__generated__/IPermissions/write/revokeRole.ts
+++ b/packages/thirdweb/src/extensions/permissions/__generated__/IPermissions/write/revokeRole.ts
@@ -140,5 +140,6 @@ export function revokeRole(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/permissions/__generated__/IPermissionsEnumerable/write/grantRole.ts
+++ b/packages/thirdweb/src/extensions/permissions/__generated__/IPermissionsEnumerable/write/grantRole.ts
@@ -140,5 +140,6 @@ export function grantRole(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/permissions/__generated__/IPermissionsEnumerable/write/renounceRole.ts
+++ b/packages/thirdweb/src/extensions/permissions/__generated__/IPermissionsEnumerable/write/renounceRole.ts
@@ -140,5 +140,6 @@ export function renounceRole(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/permissions/__generated__/IPermissionsEnumerable/write/revokeRole.ts
+++ b/packages/thirdweb/src/extensions/permissions/__generated__/IPermissionsEnumerable/write/revokeRole.ts
@@ -140,5 +140,6 @@ export function revokeRole(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/prebuilts/__generated__/DropERC1155/write/initialize.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/__generated__/DropERC1155/write/initialize.ts
@@ -250,5 +250,6 @@ export function initialize(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/prebuilts/__generated__/DropERC20/write/initialize.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/__generated__/DropERC20/write/initialize.ts
@@ -224,5 +224,6 @@ export function initialize(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/prebuilts/__generated__/DropERC721/write/initialize.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/__generated__/DropERC721/write/initialize.ts
@@ -250,5 +250,6 @@ export function initialize(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/prebuilts/__generated__/Marketplace/write/initialize.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/__generated__/Marketplace/write/initialize.ts
@@ -191,5 +191,6 @@ export function initialize(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/prebuilts/__generated__/OpenEditionERC721/write/initialize.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/__generated__/OpenEditionERC721/write/initialize.ts
@@ -224,5 +224,6 @@ export function initialize(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/prebuilts/__generated__/TokenERC1155/write/initialize.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/__generated__/TokenERC1155/write/initialize.ts
@@ -250,5 +250,6 @@ export function initialize(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/prebuilts/__generated__/TokenERC20/write/initialize.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/__generated__/TokenERC20/write/initialize.ts
@@ -224,5 +224,6 @@ export function initialize(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/prebuilts/__generated__/TokenERC721/write/initialize.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/__generated__/TokenERC721/write/initialize.ts
@@ -250,5 +250,6 @@ export function initialize(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/IAppURI/write/setAppURI.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/IAppURI/write/setAppURI.ts
@@ -132,5 +132,6 @@ export function setAppURI(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/IContractFactory/write/deployProxyByImplementation.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/IContractFactory/write/deployProxyByImplementation.ts
@@ -169,5 +169,6 @@ export function deployProxyByImplementation(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/write/publishContract.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/write/publishContract.ts
@@ -206,5 +206,6 @@ export function publishContract(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/write/setPublisherProfileUri.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/write/setPublisherProfileUri.ts
@@ -149,5 +149,6 @@ export function setPublisherProfileUri(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/write/unpublishContract.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/write/unpublishContract.ts
@@ -153,5 +153,6 @@ export function unpublishContract(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/write/createRuleMultiplicative.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/write/createRuleMultiplicative.ts
@@ -170,5 +170,6 @@ export function createRuleMultiplicative(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/write/createRuleThreshold.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/write/createRuleThreshold.ts
@@ -173,5 +173,6 @@ export function createRuleThreshold(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/write/deleteRule.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/write/deleteRule.ts
@@ -132,5 +132,6 @@ export function deleteRule(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/write/setRulesEngineOverride.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/write/setRulesEngineOverride.ts
@@ -141,5 +141,6 @@ export function setRulesEngineOverride(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/ITWMultichainRegistry/write/add.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/ITWMultichainRegistry/write/add.ts
@@ -170,5 +170,6 @@ export function add(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/ITWMultichainRegistry/write/remove.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/ITWMultichainRegistry/write/remove.ts
@@ -157,5 +157,6 @@ export function remove(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/IThirdwebContract/write/setContractURI.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/IThirdwebContract/write/setContractURI.ts
@@ -134,5 +134,6 @@ export function setContractURI(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/uniswap/__generated__/IQuoter/write/quoteExactInput.ts
+++ b/packages/thirdweb/src/extensions/uniswap/__generated__/IQuoter/write/quoteExactInput.ts
@@ -147,5 +147,6 @@ export function quoteExactInput(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/uniswap/__generated__/IQuoter/write/quoteExactInputSingle.ts
+++ b/packages/thirdweb/src/extensions/uniswap/__generated__/IQuoter/write/quoteExactInputSingle.ts
@@ -190,5 +190,6 @@ export function quoteExactInputSingle(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/uniswap/__generated__/IQuoter/write/quoteExactOutput.ts
+++ b/packages/thirdweb/src/extensions/uniswap/__generated__/IQuoter/write/quoteExactOutput.ts
@@ -150,5 +150,6 @@ export function quoteExactOutput(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/uniswap/__generated__/IQuoter/write/quoteExactOutputSingle.ts
+++ b/packages/thirdweb/src/extensions/uniswap/__generated__/IQuoter/write/quoteExactOutputSingle.ts
@@ -193,5 +193,6 @@ export function quoteExactOutputSingle(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/uniswap/__generated__/ISwapRouter/write/exactInput.ts
+++ b/packages/thirdweb/src/extensions/uniswap/__generated__/ISwapRouter/write/exactInput.ts
@@ -169,5 +169,6 @@ export function exactInput(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/uniswap/__generated__/ISwapRouter/write/exactInputSingle.ts
+++ b/packages/thirdweb/src/extensions/uniswap/__generated__/ISwapRouter/write/exactInputSingle.ts
@@ -186,5 +186,6 @@ export function exactInputSingle(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/uniswap/__generated__/ISwapRouter/write/exactOutput.ts
+++ b/packages/thirdweb/src/extensions/uniswap/__generated__/ISwapRouter/write/exactOutput.ts
@@ -169,5 +169,6 @@ export function exactOutput(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/uniswap/__generated__/ISwapRouter/write/exactOutputSingle.ts
+++ b/packages/thirdweb/src/extensions/uniswap/__generated__/ISwapRouter/write/exactOutputSingle.ts
@@ -188,5 +188,6 @@ export function exactOutputSingle(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/uniswap/__generated__/IUniswapV3Factory/write/createPool.ts
+++ b/packages/thirdweb/src/extensions/uniswap/__generated__/IUniswapV3Factory/write/createPool.ts
@@ -161,5 +161,6 @@ export function createPool(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/uniswap/__generated__/IUniswapV3Factory/write/enableFeeAmount.ts
+++ b/packages/thirdweb/src/extensions/uniswap/__generated__/IUniswapV3Factory/write/enableFeeAmount.ts
@@ -145,5 +145,6 @@ export function enableFeeAmount(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/extensions/uniswap/__generated__/IUniswapV3Factory/write/setOwner.ts
+++ b/packages/thirdweb/src/extensions/uniswap/__generated__/IUniswapV3Factory/write/setOwner.ts
@@ -130,5 +130,6 @@ export function setOwner(
     maxPriorityFeePerGas: async () =>
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
   });
 }

--- a/packages/thirdweb/src/transaction/actions/to-serializable-transaction.test.ts
+++ b/packages/thirdweb/src/transaction/actions/to-serializable-transaction.test.ts
@@ -256,6 +256,47 @@ describe("toSerializableTransaction", () => {
     });
   });
 
+  describe("extraGas override", () => {
+    let gas: bigint;
+    beforeAll(() => {
+      gas = BigInt(Math.floor(Math.random() * 1000));
+    });
+
+    test("should be able to be set", async () => {
+      const serializableTransaction = await toSerializableTransaction({
+        transaction: {
+          ...transaction,
+          gas,
+          extraGas: BigInt(50_000),
+        },
+      });
+      expect(serializableTransaction.gas).toBe(gas + BigInt(50_000));
+    });
+
+    test("should be able to be a promised value", async () => {
+      const serializableTransaction = await toSerializableTransaction({
+        transaction: {
+          ...transaction,
+          gas,
+          extraGas: () => Promise.resolve(BigInt(50_000)),
+        },
+      });
+      expect(serializableTransaction.gas).toBe(gas + BigInt(50_000));
+    });
+
+    test("should not be overridden when set to an undefined promised value", async () => {
+      const serializableTransaction = await toSerializableTransaction({
+        transaction: {
+          ...transaction,
+          gas,
+          extraGas: () => Promise.resolve(undefined),
+        },
+      });
+
+      expect(serializableTransaction.gas).toBe(gas);
+    });
+  });
+
   describe("value override", () => {
     test("should be able to be set", async () => {
       const randomValue = BigInt(Math.floor(Math.random() * 1000));

--- a/packages/thirdweb/src/transaction/actions/to-serializable-transaction.ts
+++ b/packages/thirdweb/src/transaction/actions/to-serializable-transaction.ts
@@ -21,7 +21,7 @@ export async function toSerializableTransaction(
   const rpcRequest = getRpcClient(options.transaction);
   const chainId = options.transaction.chain.id;
   const from = options.from;
-  const [data, nonce, gas, feeData, to, accessList, value] = await Promise.all([
+  let [data, nonce, gas, feeData, to, accessList, value] = await Promise.all([
     encode(options.transaction),
     (async () => {
       // if the user has specified a nonce, use that
@@ -49,6 +49,11 @@ export async function toSerializableTransaction(
     resolvePromisedValue(options.transaction.accessList),
     resolvePromisedValue(options.transaction.value),
   ]);
+
+  const extraGas = await resolvePromisedValue(options.transaction.extraGas);
+  if (extraGas) {
+    gas += extraGas;
+  }
 
   return {
     to,

--- a/packages/thirdweb/src/transaction/prepare-transaction.ts
+++ b/packages/thirdweb/src/transaction/prepare-transaction.ts
@@ -17,6 +17,7 @@ export type StaticPrepareTransactionOptions = {
   maxPriorityFeePerGas?: bigint | undefined;
   maxFeePerBlobGas?: bigint | undefined;
   nonce?: number | undefined;
+  extraGas?: bigint | undefined;
   // tw specific
   chain: Chain;
   client: ThirdwebClient;


### PR DESCRIPTION
Most changed files are generated, the relevant files to review are:
`to-serializable-transaction.ts`
`to-serializable-transaction.test.ts`
`prepare-transaction.ts`
`generate.ts`

<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to add the `extraGas` property to various ERC-related transaction functions for flexibility and customization.

### Detailed summary
- Added `extraGas` property to multiple ERC-related transaction functions
- Enhances customization and flexibility for transaction gas configuration

> The following files were skipped due to too many changes: `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/addStake.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IDelayedReveal/write/reveal.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/write/transferFrom.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IKeyGateway/write/addFor.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/buy.ts`, `packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/airdropERC721.ts`, `packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/setMerkleRoot.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IBurnableERC1155/write/burn.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IStaking1155/write/withdraw.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IBurnableERC20/write/burnFrom.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/depositTo.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/handleOps.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IClaimableERC721/write/claim.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IMintableERC721/write/mintTo.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IIdGateway/write/register.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/recover.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IKeyRegistry/write/remove.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IOffers/write/makeOffer.ts`, `packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/airdropERC1155.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/withdrawTo.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/transfer.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/offer.ts`, `packages/thirdweb/src/extensions/prebuilts/__generated__/DropERC20/write/initialize.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/ISwapRouter/write/exactInput.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IClaimableERC1155/write/claim.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IMintableERC1155/write/mintTo.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccount/write/validateUserOp.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IDrop/write/setClaimConditions.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/INFTMetadata/write/setTokenURI.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IStorageRegistry/write/rent.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IOffers/write/acceptOffer.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IOffers/write/cancelOffer.ts`, `packages/thirdweb/src/extensions/prebuilts/__generated__/DropERC721/write/initialize.ts`, `packages/thirdweb/src/extensions/prebuilts/__generated__/TokenERC20/write/initialize.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/IQuoter/write/quoteExactInput.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/ISwapRouter/write/exactOutput.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/INFTMetadata/write/setTokenURI.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IAirdropERC20/write/airdropERC20.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/write/safeTransferFrom.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IIdGateway/write/registerFor.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/recoverFor.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IKeyRegistry/write/removeFor.ts`, `packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/aggregate.ts`, `packages/thirdweb/src/extensions/prebuilts/__generated__/DropERC1155/write/initialize.ts`, `packages/thirdweb/src/extensions/prebuilts/__generated__/Marketplace/write/initialize.ts`, `packages/thirdweb/src/extensions/prebuilts/__generated__/TokenERC721/write/initialize.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/write/deleteRule.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/IQuoter/write/quoteExactOutput.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/write/safeTransferFrom.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IStaking1155/write/claimRewards.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/withdrawStake.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/write/setApprovalForAll.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/transferFor.ts`, `packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/aggregate3.ts`, `packages/thirdweb/src/extensions/prebuilts/__generated__/TokenERC1155/write/initialize.ts`, `packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/airdropNativeToken.ts`, `packages/thirdweb/src/extensions/common/__generated__/IRoyaltyPayments/write/getRoyalty.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IBurnableERC1155/write/burnBatch.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/write/setApprovalForAll.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IAirdropERC20Claimable/write/claim.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/incrementNonce.ts`, `packages/thirdweb/src/extensions/permissions/__generated__/IPermissions/write/grantRole.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/ITWMultichainRegistry/write/add.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/IUniswapV3Factory/write/setOwner.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IDropERC20/write/setClaimConditions.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IAirdropERC721/write/airdropERC721.ts`, `packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/tryAggregate.ts`, `packages/thirdweb/src/extensions/permissions/__generated__/IPermissions/write/revokeRole.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IDrop1155/write/setClaimConditions.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/getSenderAddress.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/simulateHandleOp.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IAirdropERC721Claimable/write/claim.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/INFTStake/write/depositRewardTokens.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IStorageRegistry/write/batchRent.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/acceptOffer.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/ISwapRouter/write/exactInputSingle.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/IUniswapV3Factory/write/createPool.ts`, `packages/thirdweb/src/extensions/common/__generated__/IRoyalty/write/setDefaultRoyaltyInfo.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/ITokenStake/write/depositRewardTokens.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/write/createAccount.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/write/onSignerAdded.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/INFTStake/write/withdrawRewardTokens.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/closeAuction.ts`, `packages/thirdweb/src/extensions/permissions/__generated__/IPermissions/write/renounceRole.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/ITWMultichainRegistry/write/remove.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/IQuoter/write/quoteExactInputSingle.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/ISwapRouter/write/exactOutputSingle.ts`, `packages/thirdweb/src/extensions/common/__generated__/IPlatformFee/write/setPlatformFeeInfo.ts`, `packages/thirdweb/src/extensions/common/__generated__/IRoyalty/write/setRoyaltyInfoForToken.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IAirdropERC1155/write/airdropERC1155.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IAirdropERC1155Claimable/write/claim.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/write/safeBatchTransferFrom.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/ITokenStake/write/withdrawRewardTokens.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/simulateValidation.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/createListing.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/updateListing.ts`, `packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/aggregate3Value.ts`, `packages/thirdweb/src/extensions/prebuilts/__generated__/OpenEditionERC721/write/initialize.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/IQuoter/write/quoteExactOutputSingle.ts`, `packages/thirdweb/src/extensions/common/__generated__/IContractMetadata/write/setContractURI.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/write/onSignerRemoved.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/handleAggregatedOps.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721Receiver/write/onERC721Received.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/setContractURI.ts`, `packages/thirdweb/src/extensions/common/__generated__/IRoyaltyPayments/write/setRoyaltyEngine.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ISharedMetadata/write/setSharedMetadata.ts`, `packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/blockAndAggregate.ts`, `packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/airdropERC20WithSignature.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IEditionStake/write/depositRewardTokens.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/cancelListing.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/createListing.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/updateListing.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/bidInAuction.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/write/createRuleThreshold.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IThirdwebContract/write/setContractURI.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/IUniswapV3Factory/write/enableFeeAmount.ts`, `packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/airdropERC721WithSignature.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155Receiver/write/onERC1155Received.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IEditionStake/write/withdrawRewardTokens.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IPaymaster/write/validatePaymasterUserOp.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/buyFromListing.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/cancelAuction.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/createAuction.ts`, `packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/airdropERC1155WithSignature.ts`, `packages/thirdweb/src/extensions/common/__generated__/IPrimarySale/write/setPrimarySaleRecipient.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/ISignatureMintERC20/write/mintWithSignature.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/changeRecoveryAddress.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/setPlatformFeeInfo.ts`, `packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/tryBlockAndAggregate.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/write/publishContract.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/cancelDirectListing.ts`, `packages/thirdweb/src/extensions/permissions/__generated__/IPermissionsEnumerable/write/grantRole.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/write/setRulesEngineOverride.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ISharedMetadataBatch/write/setSharedMetadata.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ISignatureMintERC721/write/mintWithSignature.ts`, `packages/thirdweb/src/extensions/permissions/__generated__/IPermissionsEnumerable/write/revokeRole.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/write/unpublishContract.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IPackVRFDirect/write/openPackAndClaimRewards.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/changeRecoveryAddressFor.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/write/createRuleMultiplicative.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155Receiver/write/onERC1155BatchReceived.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/ISignatureMintERC1155/write/mintWithSignature.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/transferAndChangeRecovery.ts`, `packages/thirdweb/src/extensions/permissions/__generated__/IPermissionsEnumerable/write/renounceRole.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ISharedMetadataBatch/write/deleteSharedMetadata.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/collectAuctionPayout.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/collectAuctionTokens.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/transferAndChangeRecoveryFor.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/approveBuyerForListing.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/write/setPublisherProfileUri.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccountPermissions/write/setPermissionsForSigner.ts`, `packages/thirdweb/src/extensions/common/__generated__/IClaimConditionsSinglePhase/write/setClaimConditions.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/approveCurrencyForListing.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IContractFactory/write/deployProxyByImplementation.ts`, `.changeset/fluffy-dodos-flash.md`, `packages/thirdweb/src/transaction/actions/to-serializable-transaction.ts`, `packages/thirdweb/src/transaction/actions/to-serializable-transaction.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->