### PR TITLE
Fix blockNumber inconsistencies

### DIFF
--- a/.changeset/witty-pumpkins-do.md
+++ b/.changeset/witty-pumpkins-do.md
@@ -4,6 +4,6 @@
 
 Fixes inconsistent block numbers when fetching events.
 
-Prevents errors from inconsistent `eth_blockNumber` return values, `fromBlock` now reverts back to "latest" when greater than the latest block.
+Prevents errors from inconsistent `eth_blockNumber` return values, `fromBlock` now waits for the latest block in `getContractEvents` to catch up if within a reasonable range.
 
 `getContractEvents` will now properly handle `blockRange` interaction with `fromBlock` and `toBlock` given they are both inclusive (i.e. it will only return logs for the number of blocks specified in `blockRange`).

--- a/.changeset/witty-pumpkins-do.md
+++ b/.changeset/witty-pumpkins-do.md
@@ -1,0 +1,9 @@
+---
+"thirdweb": patch
+---
+
+Fixes inconsistent block numbers when fetching events.
+
+Prevents errors from inconsistent `eth_blockNumber` return values, `fromBlock` now reverts back to "latest" when greater than the latest block.
+
+`getContractEvents` will now properly handle `blockRange` interaction with `fromBlock` and `toBlock` given they are both inclusive (i.e. it will only return logs for the number of blocks specified in `blockRange`).

--- a/packages/thirdweb/src/event/actions/get-events.test.ts
+++ b/packages/thirdweb/src/event/actions/get-events.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { FORK_BLOCK_NUMBER } from "../../../test/src/chains.js";
 import {
   DOODLES_CONTRACT,
   USDT_CONTRACT,
@@ -7,15 +8,13 @@ import { transferEvent } from "../../extensions/erc721/__generated__/IERC721A/ev
 import { prepareEvent } from "../prepare-event.js";
 import { getContractEvents } from "./get-events.js";
 
-const LATEST_SIMULATED_BLOCK = 19139495n;
-
 // skip this test suite if there is no secret key available to test with
 // TODO: remove reliance on secret key during unit tests entirely
 describe.runIf(process.env.TW_SECRET_KEY)("getEvents", () => {
   it("should get all events", async () => {
     const events = await getContractEvents({
       contract: USDT_CONTRACT,
-      fromBlock: LATEST_SIMULATED_BLOCK - 10n,
+      fromBlock: FORK_BLOCK_NUMBER - 10n,
     });
     expect(events.length).toBe(261);
   });
@@ -36,12 +35,12 @@ describe.runIf(process.env.TW_SECRET_KEY)("getEvents", () => {
       contract: USDT_CONTRACT,
       blockRange: 10n,
     });
-    expect(events.length).toBe(261);
+    expect(events.length).toBe(241);
 
     const explicitEvents = await getContractEvents({
       contract: USDT_CONTRACT,
-      fromBlock: LATEST_SIMULATED_BLOCK - 10n,
-      toBlock: LATEST_SIMULATED_BLOCK,
+      fromBlock: FORK_BLOCK_NUMBER - 9n, // 1 less than range as fromBlock and toBlock are inclusive
+      toBlock: FORK_BLOCK_NUMBER,
     });
     expect(explicitEvents.length).toEqual(events.length);
   });
@@ -49,22 +48,22 @@ describe.runIf(process.env.TW_SECRET_KEY)("getEvents", () => {
   it("should get events for blockRange using fromBlock and toBlock", async () => {
     const eventsFromBlock = await getContractEvents({
       contract: USDT_CONTRACT,
-      fromBlock: LATEST_SIMULATED_BLOCK - 50n,
+      fromBlock: FORK_BLOCK_NUMBER - 49n,
       blockRange: 20n,
     });
-    expect(eventsFromBlock.length).toBe(426);
+    expect(eventsFromBlock.length).toBe(412);
 
     const eventsToBlock = await getContractEvents({
       contract: USDT_CONTRACT,
-      toBlock: LATEST_SIMULATED_BLOCK - 30n,
+      toBlock: FORK_BLOCK_NUMBER - 30n,
       blockRange: 20n,
     });
-    expect(eventsToBlock.length).toBe(426);
+    expect(eventsToBlock.length).toBe(eventsFromBlock.length);
 
     const explicitEvents = await getContractEvents({
       contract: USDT_CONTRACT,
-      fromBlock: LATEST_SIMULATED_BLOCK - 50n,
-      toBlock: LATEST_SIMULATED_BLOCK - 30n,
+      fromBlock: FORK_BLOCK_NUMBER - 49n,
+      toBlock: FORK_BLOCK_NUMBER - 30n,
     });
     expect(explicitEvents.length).toEqual(eventsFromBlock.length);
   });
@@ -72,7 +71,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("getEvents", () => {
   it("should get individual events with signature", async () => {
     const events = await getContractEvents({
       contract: USDT_CONTRACT,
-      fromBlock: LATEST_SIMULATED_BLOCK - 100n,
+      fromBlock: FORK_BLOCK_NUMBER - 100n,
       events: [
         prepareEvent({
           signature: "event Burn(address indexed burner, uint256 amount)",
@@ -85,7 +84,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("getEvents", () => {
   it("should get specified events", async () => {
     const events = await getContractEvents({
       contract: USDT_CONTRACT,
-      fromBlock: LATEST_SIMULATED_BLOCK - 10n,
+      fromBlock: FORK_BLOCK_NUMBER - 10n,
       events: [
         prepareEvent({
           signature: "event Burn(address indexed burner, uint256 amount)",
@@ -125,7 +124,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("getEvents", () => {
   it("should get individual events with extension", async () => {
     const events = await getContractEvents({
       contract: DOODLES_CONTRACT,
-      fromBlock: LATEST_SIMULATED_BLOCK - 1000n,
+      fromBlock: FORK_BLOCK_NUMBER - 1000n,
       events: [transferEvent()],
     });
     expect(events.length).toBe(38);

--- a/packages/thirdweb/src/event/actions/watch-events.ts
+++ b/packages/thirdweb/src/event/actions/watch-events.ts
@@ -72,7 +72,7 @@ export function watchContractEvents<
         ...options,
         // fromBlock is inclusive
         fromBlock: blockNumber,
-        // toBlock is exclusive
+        // toBlock is inclusive
         toBlock: blockNumber,
       });
       // if there were any logs associated with our event(s)

--- a/packages/thirdweb/src/transaction/actions/simulate.test.ts
+++ b/packages/thirdweb/src/transaction/actions/simulate.test.ts
@@ -28,7 +28,6 @@ describe.runIf(process.env.TW_SECRET_KEY)("simulate", async () => {
       transaction: tx,
       from: TEST_WALLET_A,
     });
-    console.log(typeof result);
     expect(result).toMatchInlineSnapshot("1609000000n");
   });
 });


### PR DESCRIPTION
Fixes inconsistent block numbers when fetching events.

Prevents errors from inconsistent `eth_blockNumber` return values, `fromBlock` now waits for the latest block in `getContractEvents` to catch up if within a reasonable range.

`getContractEvents` will now properly handle `blockRange` interaction with `fromBlock` and `toBlock` given they are both inclusive (i.e. it will only return logs for the number of blocks specified in `blockRange`).



<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances event handling in the `thirdweb` package by fixing block number inconsistencies, ensuring inclusive block ranges, and optimizing block retrieval.

### Detailed summary
- Fixed inconsistent block numbers
- Ensured inclusive block ranges for `toBlock` and `fromBlock`
- Improved handling of block range interactions
- Optimized block retrieval logic for latest block number

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->