### PR TITLE
Fix(`getContractEvents`): properly offset when using blockRange

### DIFF
--- a/.changeset/witty-pumpkins-do.md
+++ b/.changeset/witty-pumpkins-do.md
@@ -1,0 +1,9 @@
+---
+"thirdweb": patch
+---
+
+Fixes inconsistent block numbers when fetching events.
+
+Prevents errors from inconsistent `eth_blockNumber` return values, `fromBlock` now waits for the latest block in `getContractEvents` to catch up if within a reasonable range.
+
+`getContractEvents` will now properly handle `blockRange` interaction with `fromBlock` and `toBlock` given they are both inclusive (i.e. it will only return logs for the number of blocks specified in `blockRange`).

--- a/.changeset/witty-pumpkins-do.md
+++ b/.changeset/witty-pumpkins-do.md
@@ -4,6 +4,4 @@
 
 Fixes inconsistent block numbers when fetching events.
 
-Prevents errors from inconsistent `eth_blockNumber` return values, `fromBlock` now waits for the latest block in `getContractEvents` to catch up if within a reasonable range.
-
 `getContractEvents` will now properly handle `blockRange` interaction with `fromBlock` and `toBlock` given they are both inclusive (i.e. it will only return logs for the number of blocks specified in `blockRange`).

--- a/packages/thirdweb/src/event/actions/get-events.test.ts
+++ b/packages/thirdweb/src/event/actions/get-events.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { FORK_BLOCK_NUMBER } from "../../../test/src/chains.js";
 import {
   DOODLES_CONTRACT,
   USDT_CONTRACT,
@@ -7,15 +8,13 @@ import { transferEvent } from "../../extensions/erc721/__generated__/IERC721A/ev
 import { prepareEvent } from "../prepare-event.js";
 import { getContractEvents } from "./get-events.js";
 
-const LATEST_SIMULATED_BLOCK = 19139495n;
-
 // skip this test suite if there is no secret key available to test with
 // TODO: remove reliance on secret key during unit tests entirely
 describe.runIf(process.env.TW_SECRET_KEY)("getEvents", () => {
   it("should get all events", async () => {
     const events = await getContractEvents({
       contract: USDT_CONTRACT,
-      fromBlock: LATEST_SIMULATED_BLOCK - 10n,
+      fromBlock: FORK_BLOCK_NUMBER - 10n,
     });
     expect(events.length).toBe(261);
   });
@@ -36,12 +35,12 @@ describe.runIf(process.env.TW_SECRET_KEY)("getEvents", () => {
       contract: USDT_CONTRACT,
       blockRange: 10n,
     });
-    expect(events.length).toBe(261);
+    expect(events.length).toBe(241);
 
     const explicitEvents = await getContractEvents({
       contract: USDT_CONTRACT,
-      fromBlock: LATEST_SIMULATED_BLOCK - 10n,
-      toBlock: LATEST_SIMULATED_BLOCK,
+      fromBlock: FORK_BLOCK_NUMBER - 9n, // 1 less than range as fromBlock and toBlock are inclusive
+      toBlock: FORK_BLOCK_NUMBER,
     });
     expect(explicitEvents.length).toEqual(events.length);
   });
@@ -49,22 +48,22 @@ describe.runIf(process.env.TW_SECRET_KEY)("getEvents", () => {
   it("should get events for blockRange using fromBlock and toBlock", async () => {
     const eventsFromBlock = await getContractEvents({
       contract: USDT_CONTRACT,
-      fromBlock: LATEST_SIMULATED_BLOCK - 50n,
+      fromBlock: FORK_BLOCK_NUMBER - 49n,
       blockRange: 20n,
     });
-    expect(eventsFromBlock.length).toBe(426);
+    expect(eventsFromBlock.length).toBe(412);
 
     const eventsToBlock = await getContractEvents({
       contract: USDT_CONTRACT,
-      toBlock: LATEST_SIMULATED_BLOCK - 30n,
+      toBlock: FORK_BLOCK_NUMBER - 30n,
       blockRange: 20n,
     });
-    expect(eventsToBlock.length).toBe(426);
+    expect(eventsToBlock.length).toBe(eventsFromBlock.length);
 
     const explicitEvents = await getContractEvents({
       contract: USDT_CONTRACT,
-      fromBlock: LATEST_SIMULATED_BLOCK - 50n,
-      toBlock: LATEST_SIMULATED_BLOCK - 30n,
+      fromBlock: FORK_BLOCK_NUMBER - 49n,
+      toBlock: FORK_BLOCK_NUMBER - 30n,
     });
     expect(explicitEvents.length).toEqual(eventsFromBlock.length);
   });
@@ -72,7 +71,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("getEvents", () => {
   it("should get individual events with signature", async () => {
     const events = await getContractEvents({
       contract: USDT_CONTRACT,
-      fromBlock: LATEST_SIMULATED_BLOCK - 100n,
+      fromBlock: FORK_BLOCK_NUMBER - 100n,
       events: [
         prepareEvent({
           signature: "event Burn(address indexed burner, uint256 amount)",
@@ -85,7 +84,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("getEvents", () => {
   it("should get specified events", async () => {
     const events = await getContractEvents({
       contract: USDT_CONTRACT,
-      fromBlock: LATEST_SIMULATED_BLOCK - 10n,
+      fromBlock: FORK_BLOCK_NUMBER - 10n,
       events: [
         prepareEvent({
           signature: "event Burn(address indexed burner, uint256 amount)",
@@ -125,7 +124,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("getEvents", () => {
   it("should get individual events with extension", async () => {
     const events = await getContractEvents({
       contract: DOODLES_CONTRACT,
-      fromBlock: LATEST_SIMULATED_BLOCK - 1000n,
+      fromBlock: FORK_BLOCK_NUMBER - 1000n,
       events: [transferEvent()],
     });
     expect(events.length).toBe(38);

--- a/packages/thirdweb/src/event/actions/get-events.ts
+++ b/packages/thirdweb/src/event/actions/get-events.ts
@@ -52,6 +52,7 @@ export type GetContractEventsResult<
  * Retrieves events from a contract based on the provided options.
  * @param options - The options for retrieving events.
  * @returns A promise that resolves to an array of parsed event logs.
+ * Note: toBlock and fromBlock are both inclusive.
  * @example
  * ```ts
  * import { getContractEvents } from "thirdweb";
@@ -115,6 +116,8 @@ export async function getContractEvents<
     throw new Error("Cannot specify blockHash and range simultaneously,");
   }
 
+  const latestBlockNumber = await eth_blockNumber(rpcRequest);
+
   // Compute toBlock and fromBlock if blockRange was passed
   if (blockRange) {
     const { fromBlock, toBlock } = restParams;
@@ -131,13 +134,13 @@ export async function getContractEvents<
     }
 
     if (fromBlock) {
-      restParams.toBlock = BigInt(fromBlock) + BigInt(blockRange);
+      restParams.toBlock = BigInt(fromBlock) + BigInt(blockRange) - 1n; // Subtract one because toBlock is inclusive
     } else if (toBlock) {
-      restParams.fromBlock = BigInt(toBlock) - BigInt(blockRange);
+      restParams.fromBlock = BigInt(toBlock) - BigInt(blockRange) + 1n; // Add one because fromBlock is inclusive
     } else {
       // If no from or to block specified, use the latest block as the to block
-      restParams.toBlock = await eth_blockNumber(rpcRequest);
-      restParams.fromBlock = BigInt(restParams.toBlock) - BigInt(blockRange);
+      restParams.toBlock = latestBlockNumber;
+      restParams.fromBlock = latestBlockNumber - BigInt(blockRange) + 1n; // Add one because fromBlock is inclusive
     }
   }
 

--- a/packages/thirdweb/src/event/actions/watch-events.ts
+++ b/packages/thirdweb/src/event/actions/watch-events.ts
@@ -72,7 +72,7 @@ export function watchContractEvents<
         ...options,
         // fromBlock is inclusive
         fromBlock: blockNumber,
-        // toBlock is exclusive
+        // toBlock is inclusive
         toBlock: blockNumber,
       });
       // if there were any logs associated with our event(s)

--- a/packages/thirdweb/src/transaction/actions/simulate.test.ts
+++ b/packages/thirdweb/src/transaction/actions/simulate.test.ts
@@ -28,7 +28,6 @@ describe.runIf(process.env.TW_SECRET_KEY)("simulate", async () => {
       transaction: tx,
       from: TEST_WALLET_A,
     });
-    console.log(typeof result);
     expect(result).toMatchInlineSnapshot("1609000000n");
   });
 });

--- a/packages/thirdweb/test/src/utils.ts
+++ b/packages/thirdweb/test/src/utils.ts
@@ -1,9 +1,5 @@
 import { getRpcClient } from "../../src/rpc/rpc.js";
-import {
-  FORKED_ETHEREUM_CHAIN,
-  FORKED_ETHEREUM_RPC,
-  FORK_BLOCK_NUMBER,
-} from "./chains.js";
+import { FORKED_ETHEREUM_CHAIN } from "./chains.js";
 import { TEST_CLIENT } from "./test-clients.js";
 
 export async function mineBlock() {
@@ -14,23 +10,5 @@ export async function mineBlock() {
   return rpcClient({
     method: "anvil_mine" as any,
     params: ["0x1"],
-  });
-}
-
-export async function reset() {
-  const rpcClient = getRpcClient({
-    chain: FORKED_ETHEREUM_CHAIN,
-    client: TEST_CLIENT,
-  });
-  return rpcClient({
-    method: "anvil_reset" as any,
-    params: [
-      {
-        forking: {
-          blockNumber: Number(FORK_BLOCK_NUMBER),
-          jsonRpcUrl: FORKED_ETHEREUM_RPC,
-        },
-      },
-    ] as any,
   });
 }


### PR DESCRIPTION
`getContractEvents` will now properly handle `blockRange` interaction with `fromBlock` and `toBlock` given they are both inclusive (i.e. it will only return logs for the number of blocks specified in `blockRange`).
