### PR TITLE
Fix custom details button not opening the details modal

### DIFF
--- a/.changeset/curly-laws-wait.md
+++ b/.changeset/curly-laws-wait.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix custom details button not opening the details modal in `ConnectButton`

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/Details.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/Details.tsx
@@ -178,11 +178,12 @@ export const ConnectedWalletDetails: React.FC<{
   const isNetworkMismatch =
     props.chain && walletChain && walletChain.id !== props.chain.id;
 
-  // Note: Must wrap the `detailsButton.render` and `SwitchNetworkButton` in a fragment to avoid warning from radix-ui
+  // Note: Must wrap the `SwitchNetworkButton` in a fragment to avoid warning from radix-ui
+  // Note: Must wrap the `detailsButton.render` in an container element
   const trigger = props.detailsButton?.render ? (
-    <>
+    <div>
       <props.detailsButton.render />
-    </>
+    </div>
   ) : props.chain && isNetworkMismatch ? (
     <>
       <SwitchNetworkButton


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR fixes issues with the custom details button in `ConnectButton` not opening the details modal.

### Detailed summary
- Fixed custom details button functionality in `ConnectButton`
- Wrapped `SwitchNetworkButton` in a fragment to avoid warning
- Wrapped `detailsButton.render` in a container element to resolve issue

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->