### PR TITLE
[React] Add Arweave URI support to <MediaRenderer />

### DIFF
--- a/.changeset/smooth-numbers-unite.md
+++ b/.changeset/smooth-numbers-unite.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Add Arweave URI support to <MediaRenderer />

--- a/packages/thirdweb/src/react/web/ui/MediaRenderer/useResolvedMediaType.ts
+++ b/packages/thirdweb/src/react/web/ui/MediaRenderer/useResolvedMediaType.ts
@@ -3,6 +3,7 @@ import { useMemo } from "react";
 import type { ThirdwebClient } from "../../../../client/client.js";
 import { resolveScheme } from "../../../../utils/ipfs.js";
 import { resolveMimeType } from "../../utils/resolveMimeType.js";
+import { resolveArweaveScheme } from "src/utils/arweave.js";
 
 /**
  * @internal
@@ -16,6 +17,9 @@ export function useResolvedMediaType(
   const resolvedUrl = useMemo(() => {
     if (!uri) {
       return "";
+    }
+    if (uri.startsWith("ar://")) {
+      return resolveArweaveScheme({ uri, gatewayUrl });
     }
     if (gatewayUrl) {
       return uri.replace("ipfs://", gatewayUrl);

--- a/packages/thirdweb/src/react/web/ui/MediaRenderer/useResolvedMediaType.ts
+++ b/packages/thirdweb/src/react/web/ui/MediaRenderer/useResolvedMediaType.ts
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
-import { resolveArweaveScheme } from "../../../../utils/arweave.js";
 import type { ThirdwebClient } from "../../../../client/client.js";
+import { resolveArweaveScheme } from "../../../../utils/arweave.js";
 import { resolveScheme } from "../../../../utils/ipfs.js";
 import { resolveMimeType } from "../../utils/resolveMimeType.js";
 

--- a/packages/thirdweb/src/react/web/ui/MediaRenderer/useResolvedMediaType.ts
+++ b/packages/thirdweb/src/react/web/ui/MediaRenderer/useResolvedMediaType.ts
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
-import { resolveArweaveScheme } from "src/utils/arweave.js";
+import { resolveArweaveScheme } from "../../../../utils/arweave.js";
 import type { ThirdwebClient } from "../../../../client/client.js";
 import { resolveScheme } from "../../../../utils/ipfs.js";
 import { resolveMimeType } from "../../utils/resolveMimeType.js";

--- a/packages/thirdweb/src/react/web/ui/MediaRenderer/useResolvedMediaType.ts
+++ b/packages/thirdweb/src/react/web/ui/MediaRenderer/useResolvedMediaType.ts
@@ -1,9 +1,9 @@
 import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
+import { resolveArweaveScheme } from "src/utils/arweave.js";
 import type { ThirdwebClient } from "../../../../client/client.js";
 import { resolveScheme } from "../../../../utils/ipfs.js";
 import { resolveMimeType } from "../../utils/resolveMimeType.js";
-import { resolveArweaveScheme } from "src/utils/arweave.js";
 
 /**
  * @internal


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR enhances `MediaRenderer` in `thirdweb` by adding Arweave URI support.

### Detailed summary
- Added support for Arweave URIs in `useResolvedMediaType`
- Imported `resolveArweaveScheme` for Arweave URI resolution

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->