### PR TITLE
Allow nonce to be zero on `toSerializableTransaction`

### DIFF
--- a/.changeset/grumpy-mirrors-invent.md
+++ b/.changeset/grumpy-mirrors-invent.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix issue with nonce set to 0 on toSerializableTransaction

--- a/packages/thirdweb/src/transaction/actions/to-serializable-transaction.test.ts
+++ b/packages/thirdweb/src/transaction/actions/to-serializable-transaction.test.ts
@@ -337,6 +337,16 @@ describe("toSerializableTransaction", () => {
   });
 
   describe("nonce override", () => {
+    test("should be able to be set to 0", async () => {
+      const serializableTransaction = await toSerializableTransaction({
+        transaction: {
+          ...transaction,
+          nonce: 0,
+        },
+      });
+      expect(serializableTransaction.nonce).toBe(0);
+    });
+
     test("should be able to be set", async () => {
       const randomNonce = Math.floor(Math.random() * 1000);
       const serializableTransaction = await toSerializableTransaction({

--- a/packages/thirdweb/src/transaction/actions/to-serializable-transaction.ts
+++ b/packages/thirdweb/src/transaction/actions/to-serializable-transaction.ts
@@ -28,7 +28,7 @@ export async function toSerializableTransaction(
       const resolvedNonce = await resolvePromisedValue(
         options.transaction.nonce,
       );
-      if (resolvedNonce) {
+      if (resolvedNonce !== undefined) {
         return resolvedNonce;
       }
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR fixes an issue where the nonce was incorrectly set to 0 in `toSerializableTransaction`.

### Detailed summary
- Fixed issue with nonce set to 0 on `toSerializableTransaction`
- Added a test to ensure nonce can be set to 0

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->