### PR TITLE
`shortenAddress` util

### DIFF
--- a/.changeset/sixty-forks-repeat.md
+++ b/.changeset/sixty-forks-repeat.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": minor
+---
+
+Adds shortenAddress util

--- a/packages/thirdweb/src/exports/utils.ts
+++ b/packages/thirdweb/src/exports/utils.ts
@@ -124,6 +124,7 @@ export {
   checksumAddress,
   getAddress,
   isAddress,
+  shortenAddress,
   type Address,
   type AddressInput,
 } from "../utils/address.js";

--- a/packages/thirdweb/src/utils/address.test.ts
+++ b/packages/thirdweb/src/utils/address.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "vitest";
 
-import { checksumAddress, getAddress, isAddress } from "./address.js";
+import {
+  checksumAddress,
+  getAddress,
+  isAddress,
+  shortenAddress,
+} from "./address.js";
 
 describe("getAddress", () => {
   test("checksums address", () => {
@@ -79,5 +84,13 @@ describe("checksumAddress", () => {
     expect(
       checksumAddress("0x15d34aaf54267db7d7c367839aaf71a00a2c6a65"),
     ).toMatchInlineSnapshot('"0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65"');
+  });
+});
+
+describe("shortenAddress", () => {
+  test("shortens address", () => {
+    expect(
+      shortenAddress("0xa0cf798816d4b9b9866b5330eea46a18382f251e"),
+    ).toMatchInlineSnapshot('"0xa0...251e"');
   });
 });

--- a/packages/thirdweb/src/utils/address.test.ts
+++ b/packages/thirdweb/src/utils/address.test.ts
@@ -91,6 +91,6 @@ describe("shortenAddress", () => {
   test("shortens address", () => {
     expect(
       shortenAddress("0xa0cf798816d4b9b9866b5330eea46a18382f251e"),
-    ).toMatchInlineSnapshot('"0xa0...251e"');
+    ).toMatchInlineSnapshot('"0xA0...251e"');
   });
 });

--- a/packages/thirdweb/src/utils/address.ts
+++ b/packages/thirdweb/src/utils/address.ts
@@ -97,7 +97,7 @@ export function getAddress(address: string): Address {
 }
 
 /**
- * Shortens an address if valid. Note this function does not check if the provided address is an ENS.
+ * Checksums and formats an address if valid. Note this function does not check if the provided address is an ENS.
  * @param address - The address to shorten.
  * @param length - The number of characters to keep from the start and end of the address.
  * @returns The shortened address.

--- a/packages/thirdweb/src/utils/address.ts
+++ b/packages/thirdweb/src/utils/address.ts
@@ -111,8 +111,6 @@ export function getAddress(address: string): Address {
  * @utils
  */
 export function shortenAddress(address: Address, length = 4) {
-  if (!isAddress(address)) {
-    throw new Error(`Invalid address: ${address}`);
-  }
-  return `${address.slice(0, length)}...${address.slice(-length)}`;
+  const _address = getAddress(address);
+  return `${_address.slice(0, length)}...${_address.slice(-length)}`;
 }

--- a/packages/thirdweb/src/utils/address.ts
+++ b/packages/thirdweb/src/utils/address.ts
@@ -95,3 +95,24 @@ export function getAddress(address: string): Address {
   }
   return checksumAddress(address);
 }
+
+/**
+ * Shortens an address if valid. Note this function does not check if the provided address is an ENS.
+ * @param address - The address to shorten.
+ * @param length - The number of characters to keep from the start and end of the address.
+ * @returns The shortened address.
+ * @example
+ * ```ts
+ * import { shortenAddress } from 'thirdweb/utils';
+ *
+ * shortenAddress('0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed');
+ * //=> '0x5aAe...Ef1BeAed'
+ * ```
+ * @utils
+ */
+export function shortenAddress(address: Address, length = 4) {
+  if (!isAddress(address)) {
+    throw new Error(`Invalid address: ${address}`);
+  }
+  return `${address.slice(0, length)}...${address.slice(-length)}`;
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a new `shortenAddress` utility function to the `thirdweb` package for formatting and shortening Ethereum addresses.

### Detailed summary
- Added `shortenAddress` utility function to format and shorten Ethereum addresses
- Updated tests to include `shortenAddress`
- Added JSDoc comments for `shortenAddress` explaining its functionality

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->