### PR TITLE
Fix wallet image fallback

### DIFF
--- a/.changeset/bright-eyes-fix.md
+++ b/.changeset/bright-eyes-fix.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix WalletImage fallback icon

--- a/packages/thirdweb/src/react/web/ui/components/Img.tsx
+++ b/packages/thirdweb/src/react/web/ui/components/Img.tsx
@@ -27,7 +27,7 @@ export const Img: React.FC<{
   const widthPx = `${props.width}px`;
   const heightPx = `${props.height || props.width}px`;
 
-  if (!propSrc) {
+  if (propSrc === undefined) {
     return <Skeleton width={widthPx} height={heightPx} />;
   }
 

--- a/packages/thirdweb/src/react/web/ui/components/WalletImage.tsx
+++ b/packages/thirdweb/src/react/web/ui/components/WalletImage.tsx
@@ -112,7 +112,7 @@ function WalletImageQuery(props: {
   return (
     <Img
       client={props.client}
-      src={walletImage.data}
+      src={walletImage.isLoading ? undefined : walletImage.data || ""}
       fallbackImage={genericWalletIcon}
       width={props.size}
       height={props.size}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on fixing the WalletImage fallback icon issue by adjusting the condition for rendering the fallback icon.

### Detailed summary
- Updated condition to render fallback icon in WalletImage component
- Adjusted logic to display Skeleton component when `propSrc` is `undefined`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->