### PR TITLE
Bump React minimal size

### DIFF
--- a/packages/thirdweb/.size-limit.json
+++ b/packages/thirdweb/.size-limit.json
@@ -25,7 +25,7 @@
   {
     "name": "thirdweb/react (minimal + tree-shaking)",
     "path": "./dist/esm/exports/react.js",
-    "limit": "16 kB",
+    "limit": "18 kB",
     "import": "{ ThirdwebProvider, useConnect }"
   }
 ]


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR increases the size limit for `thirdweb/react (minimal + tree-shaking)` from 16 kB to 18 kB.

### Detailed summary
- Increased size limit from 16 kB to 18 kB for `thirdweb/react (minimal + tree-shaking)` in `.size-limit.json`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->