### PR TITLE
Tiny bump to esm size limit

### DIFF
--- a/packages/thirdweb/.size-limit.json
+++ b/packages/thirdweb/.size-limit.json
@@ -2,7 +2,7 @@
   {
     "name": "thirdweb (esm)",
     "path": "./dist/esm/exports/thirdweb.js",
-    "limit": "40 kB",
+    "limit": "40.1 kB",
     "import": "*"
   },
   {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR increases the size limit for the `thirdweb (esm)` bundle in the `.size-limit.json` configuration file slightly from 40 kB to 40.1 kB.

### Detailed summary
- Increased the size limit for the `thirdweb (esm)` bundle in `.size-limit.json` from 40 kB to 40.1 kB.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->