### PR TITLE
Allow overriding the queryKey in useReadContract

### DIFF
--- a/.changeset/fresh-vans-perform.md
+++ b/.changeset/fresh-vans-perform.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Override the queryKey using queryOptions in useReadContract

--- a/packages/thirdweb/src/react/core/hooks/contract/useReadContract.ts
+++ b/packages/thirdweb/src/react/core/hooks/contract/useReadContract.ts
@@ -19,7 +19,7 @@ import type { PreparedMethod } from "../../../../utils/abi/prepare-method.js";
 import { getFunctionId } from "../../../../utils/function-id.js";
 import { stringify } from "../../../../utils/json.js";
 
-type PickedQueryOptions = Pick<UseQueryOptions, "enabled">;
+type PickedQueryOptions = Pick<UseQueryOptions, "enabled" | "queryKey">;
 
 /**
  * A hook to read from a contract.


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on overriding the queryKey using queryOptions in the `useReadContract` hook.

### Detailed summary
- Added "queryKey" to the PickedQueryOptions type in `useReadContract.ts`
- Allows for overriding the queryKey using queryOptions in the `useReadContract` hook

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->