### PR TITLE
Fix automatic query invalidation

### DIFF
--- a/.changeset/long-spoons-wink.md
+++ b/.changeset/long-spoons-wink.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix automatic react query invalidation

--- a/packages/thirdweb/src/react/core/providers/thirdweb-provider.tsx
+++ b/packages/thirdweb/src/react/core/providers/thirdweb-provider.tsx
@@ -1,11 +1,9 @@
 "use client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useState } from "react";
-import {
-  type WaitForReceiptOptions,
-  waitForReceipt,
-} from "../../../transaction/actions/wait-for-tx-receipt.js";
+import { waitForReceipt } from "../../../transaction/actions/wait-for-tx-receipt.js";
 import { isBaseTransactionOptions } from "../../../transaction/types.js";
+import type { Hex } from "../../../utils/encoding/hex.js";
 import { isObjectWithKeys } from "../../../utils/type-guards.js";
 import { SetRootElementContext } from "./RootElementContext.js";
 import { invalidateWalletBalance } from "./invalidateWalletBalance.js";
@@ -34,16 +32,17 @@ export function ThirdwebProvider(props: React.PropsWithChildren) {
       new QueryClient({
         defaultOptions: {
           mutations: {
-            onSettled: (data, error, variables) => {
-              if (error) {
-                // TODO: remove - but useful for debug now
-                console.error("[Mutation Error]", error);
-              }
+            onSettled: (data, _error, variables) => {
               if (isBaseTransactionOptions(variables)) {
                 if (
-                  isObjectWithKeys(data, ["transactionHash", "client", "chain"])
+                  isObjectWithKeys(data, ["transactionHash"]) &&
+                  isObjectWithKeys(variables, ["client", "chain"])
                 ) {
-                  waitForReceipt(data as WaitForReceiptOptions)
+                  waitForReceipt({
+                    transactionHash: data.transactionHash as Hex, // We know it exists from the if
+                    client: variables.client,
+                    chain: variables.chain,
+                  })
                     .catch((e) => {
                       // swallow errors for receipts, but log
                       console.error("[Transaction Error]", e);


### PR DESCRIPTION
`onSettled` was looking for `client` and `chain` in the transaction receipt rather than the inputs.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing automatic react query invalidation in the `ThirdwebProvider`.

### Detailed summary
- Removed unnecessary `waitForReceiptOptions` type import
- Updated `onSettled` mutation handler to properly handle transaction data and variables
- Improved error handling in the `waitForReceipt` function

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->