### PR TITLE
Improve error message for resolveAbiFromBytecode

### DIFF
--- a/.changeset/brown-jeans-explain.md
+++ b/.changeset/brown-jeans-explain.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Improve error message for `resolveAbiFromBytecode`

--- a/packages/thirdweb/src/contract/actions/resolve-abi.ts
+++ b/packages/thirdweb/src/contract/actions/resolve-abi.ts
@@ -118,8 +118,11 @@ export async function resolveAbiFromBytecode(
 ): Promise<Abi> {
   const bytecode = await getBytecode(contract);
   if (bytecode === "0x") {
+    const { id, name } = contract.chain;
     throw new Error(
-      `Failed to load contract bytecode. Make sure the contract [${contract.address}] exists on the chain [${contract.chain.name || "Unknown Chain"} (chain id: ${chain.id})]`,
+      `Failed to load contract bytecode. Make sure the contract [${
+        contract.address
+      }] exists on the chain [${name || "Unknown Chain"} (chain id: ${id})]`,
     );
   }
   const ipfsUri = extractIPFSUri(bytecode);

--- a/packages/thirdweb/src/contract/actions/resolve-abi.ts
+++ b/packages/thirdweb/src/contract/actions/resolve-abi.ts
@@ -119,7 +119,7 @@ export async function resolveAbiFromBytecode(
   const bytecode = await getBytecode(contract);
   if (bytecode === "0x") {
     throw new Error(
-      `Failed to load contract bytecode. Make sure the contract [${contract.address}] exists on the chain [${contract.chain.name}]`,
+      `Failed to load contract bytecode. Make sure the contract [${contract.address}] exists on the chain [${contract.chain.name || "Unknown Chain"} (chain id: ${chain.id})]`,
     );
   }
   const ipfsUri = extractIPFSUri(bytecode);

--- a/packages/thirdweb/src/contract/actions/resolve-abi.ts
+++ b/packages/thirdweb/src/contract/actions/resolve-abi.ts
@@ -117,6 +117,11 @@ export async function resolveAbiFromBytecode(
   contract: ThirdwebContract<any>,
 ): Promise<Abi> {
   const bytecode = await getBytecode(contract);
+  if (bytecode === "0x") {
+    throw new Error(
+      `Failed to load contract bytecode. Make sure the contract [${contract.address}] exists on the chain [${contract.chain.name}]`,
+    );
+  }
   const ipfsUri = extractIPFSUri(bytecode);
   if (!ipfsUri) {
     // just early exit if we can't find an IPFS URI


### PR DESCRIPTION
Just spent half an hour to debug the code for someone. Thought the DX can be improved with this PR.

Let's say you have a valid contract address on polygon, but you put in the wrong chain (ethereum):

```
const wrongContract = getContract({
  address: "address-on-polygon",
  chain: ethereum, // but the chain should be polygon
  client,
});
```

When this contract goes through `resolveAbiFromBytecode`, it will cause an error like this, which isn't quite informative:

```
 ⨯ Error: Unexpected end of CBOR data
    at checkedRead (file:///Users/kienngo/Desktop/personal-projects/local/node_modules/thirdweb/dist/esm/utils/bytecode/cbor-decode.js:103:27)
    at decode (file:///Users/kienngo/Desktop/personal-projects/local/node_modules/thirdweb/dist/esm/utils/bytecode/cbor-decode.js:77:16)
    at extractIPFSUri (file:///Users/kienngo/Desktop/personal-projects/local/node_modules/thirdweb/dist/esm/utils/bytecode/extractIPFS.js:31:22)
    at handler (webpack-internal:///(api)/./src/pages/api/resolve-abi.ts:29:83)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async K (/Users/kienngo/Desktop/personal-projects/local/node_modules/next/dist/compiled/next-server/pages-api.runtime.dev.js:21:2946)
    at async U.render (/Users/kienngo/Desktop/personal-projects/local/node_modules/next/dist/compiled/next-server/pages-api.runtime.dev.js:21:3827)
    at async DevServer.runApi (/Users/kienngo/Desktop/personal-projects/local/node_modules/next/dist/server/next-server.js:554:9)
    at async NextNodeServer.handleCatchallRenderRequest (/Users/kienngo/Desktop/personal-projects/local/node_modules/next/dist/server/next-server.js:266:37)
    at async DevServer.handleRequestImpl (/Users/kienngo/Desktop/personal-projects/local/node_modules/next/dist/server/base-server.js:791:17)
    at async /Users/kienngo/Desktop/personal-projects/local/node_modules/next/dist/server/dev/next-dev-server.js:331:20
    at async Span.traceAsyncFn (/Users/kienngo/Desktop/personal-projects/local/node_modules/next/dist/trace/trace.js:151:20)
    at async DevServer.handleRequest (/Users/kienngo/Desktop/personal-projects/local/node_modules/next/dist/server/dev/next-dev-server.js:328:24)
    at async invokeRender (/Users/kienngo/Desktop/personal-projects/local/node_modules/next/dist/server/lib/router-server.js:174:21)
    at async handleRequest (/Users/kienngo/Desktop/personal-projects/local/node_modules/next/dist/server/lib/router-server.js:353:24) {
  incomplete: true,
  page: '/api/resolve-abi'
}
```

So having an error message that "just might" help users figure out what they did wrong can be helpful ^^

<!-- start pr-codex -->

---

## PR-Codex overview
This PR improves the error message for `resolveAbiFromBytecode` function in the `resolve-abi.ts` file.

### Detailed summary
- Added a check for empty bytecode before processing
- Improved error message with contract address and chain information

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->