### PR TITLE
Fix legacy tests (again)

### DIFF
--- a/legacy_packages/sdk/package.json
+++ b/legacy_packages/sdk/package.json
@@ -68,7 +68,7 @@
     "generate-docs:evm": "api-extractor run --local --config ./config/api-extractor-evm.json && api-documenter markdown -i ./temp -o ./docs/evm && rm -rf ./temp-evm && mv ./temp ./temp-evm",
     "generate-snippets": "node ./scripts/generate-snippets.mjs && node ./scripts/generate-feature-snippets-evm.mjs",
     "build": "tsc && preconstruct build",
-    "test:all": "SWC_NODE_PROJECT=./tsconfig.test.json nyc --reporter lcovonly --report-dir ./coverage/evm mocha --config './test/evm/.mocharc.json' --timeout 90000 --parallel './test/evm/**/*.test.ts'",
+    "test:all": "SWC_NODE_PROJECT=./tsconfig.test.json nyc --reporter lcovonly --report-dir ./coverage/evm mocha --config './test/evm/.mocharc.json' --timeout 180000 --parallel './test/evm/**/*.test.ts'",
     "test": "make test-evm",
     "test:single": "SWC_NODE_PROJECT=./tsconfig.test.json mocha --config './test/evm/.mocharc.json' --timeout 90000",
     "push": "yalc push",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "preinstall": "npx only-allow pnpm",
     "test": "turbo run test --filter=./packages/*",
-    "test:legacy": "turbo run test --filter=./legacy_packages/* --filter=!sdk",
+    "test:legacy": "turbo run test --filter=./legacy_packages/*",
     "e2e": "turbo run e2e --filter=./packages/*",
     "e2e:legacy": "turbo run e2e --filter=./legacy_packages/*",
     "build:packages": "turbo run build --filter=./packages/*",


### PR DESCRIPTION
Increase legacy test timeout


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates test timeouts and removes a filter in the legacy test script. 

### Detailed summary
- Increased test timeout to 180000ms in `test:all` script
- Removed unnecessary filter `--filter=!sdk` in `test:legacy` script

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->