### PR TITLE
chore: update size limit for thirdweb

### DIFF
--- a/packages/thirdweb/.size-limit.json
+++ b/packages/thirdweb/.size-limit.json
@@ -2,7 +2,7 @@
   {
     "name": "thirdweb (esm)",
     "path": "./dist/esm/exports/thirdweb.js",
-    "limit": "40.1 kB",
+    "limit": "41 kB",
     "import": "*"
   },
   {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR increases the size limit for the `thirdweb (esm)` package to 41 kB.

### Detailed summary
- Increased the size limit in `.size-limit.json` for `thirdweb (esm)` package from 40.1 kB to 41 kB.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->