### PR TITLE
Fix `sendCallsStatus` test types

### DIFF
--- a/packages/thirdweb/src/wallets/eip5792/get-calls-status.test.ts
+++ b/packages/thirdweb/src/wallets/eip5792/get-calls-status.test.ts
@@ -14,15 +14,18 @@ const RAW_UNSUPPORTED_ERROR = {
 };
 
 const SEND_CALLS_OPTIONS: Omit<SendCallsOptions, "wallet"> = {
-  client: TEST_CLIENT,
   calls: [
     {
       to: "0x2a4f24F935Eb178e3e7BA9B53A5Ee6d8407C0709",
       data: "0xabcdef",
+      chain: ANVIL_CHAIN,
+      client: TEST_CLIENT,
     },
     {
       to: "0xa922b54716264130634d6ff183747a8ead91a40b",
       value: 123n,
+      chain: ANVIL_CHAIN,
+      client: TEST_CLIENT,
     },
   ],
 };


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to add `chain` and `client` properties to the `calls` array in the `SEND_CALLS_OPTIONS` constant in the `get-calls-status.test.ts` file.

### Detailed summary
- Added `chain` property with value `ANVIL_CHAIN` to the first call object
- Added `client` property with value `TEST_CLIENT` to the first call object
- Added `chain` property with value `ANVIL_CHAIN` to the second call object
- Added `client` property with value `TEST_CLIENT` to the second call object

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->