### PR TITLE
Prevent `MediaRenderer` flashing failed state while loading

### DIFF
--- a/.changeset/tidy-geese-sit.md
+++ b/.changeset/tidy-geese-sit.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fixes MediaRenderer flashing its failed state while loading

--- a/packages/thirdweb/src/react/web/ui/MediaRenderer/MediaRenderer.test.tsx
+++ b/packages/thirdweb/src/react/web/ui/MediaRenderer/MediaRenderer.test.tsx
@@ -1,0 +1,52 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { render, screen } from "../../../../../test/src/react-render.js";
+import { TEST_CLIENT } from "../../../../../test/src/test-clients.js";
+import { MediaRenderer } from "./MediaRenderer.js";
+
+describe("MediaRenderer", () => {
+  // beforeAll(() => {
+  //   vi.mock("./locale/getConnectLocale.js", () => ({
+  //     useConnectLocale: vi.fn().mockReturnValue({
+  //       data: {
+  //         defaultButtonTitle: "Connect Wallet",
+  //       },
+  //       isLoading: false,
+  //     }),
+  //   }));
+  // });
+
+  // afterAll(() => {
+  //   vi.clearAllMocks();
+  // });
+  it("should render nothing if no src provided", () => {
+    render(<MediaRenderer client={TEST_CLIENT} />);
+    expect(screen.queryByText("File")).not.toBeInTheDocument(); // would display file if it shows the "not found" div
+  });
+
+  it("should render unknown if nothing found", () => {
+    render(<MediaRenderer client={TEST_CLIENT} src="asaosdoiandoin" />);
+    setTimeout(() => {
+      expect(screen.queryByText("File")).toBeInTheDocument(); // would display file if it shows the "not found" div
+    }, 1000);
+  });
+
+  it("should render a plain image", () => {
+    render(
+      <MediaRenderer
+        client={TEST_CLIENT}
+        src="https://i.seadn.io/gae/r_b9GB0iYA39ichUlKdFLeG4UliK7YXi9SsM0Xdvm6pNDChYbN5E7Fxop1MdJCbmNvSlbER73YiA9WY1JbhEfkuIktoHfN9UlEZy4A?auto=format&dpr=1&w=1000"
+      />,
+    );
+    setTimeout(() => {
+      expect(screen.getByRole("img")).toBeInTheDocument();
+    }, 1000);
+  });
+});

--- a/packages/thirdweb/src/react/web/ui/MediaRenderer/MediaRenderer.test.tsx
+++ b/packages/thirdweb/src/react/web/ui/MediaRenderer/MediaRenderer.test.tsx
@@ -1,31 +1,9 @@
-import {
-  afterAll,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-} from "vitest";
+import { describe, expect, it } from "vitest";
 import { render, screen } from "../../../../../test/src/react-render.js";
 import { TEST_CLIENT } from "../../../../../test/src/test-clients.js";
 import { MediaRenderer } from "./MediaRenderer.js";
 
 describe("MediaRenderer", () => {
-  // beforeAll(() => {
-  //   vi.mock("./locale/getConnectLocale.js", () => ({
-  //     useConnectLocale: vi.fn().mockReturnValue({
-  //       data: {
-  //         defaultButtonTitle: "Connect Wallet",
-  //       },
-  //       isLoading: false,
-  //     }),
-  //   }));
-  // });
-
-  // afterAll(() => {
-  //   vi.clearAllMocks();
-  // });
   it("should render nothing if no src provided", () => {
     render(<MediaRenderer client={TEST_CLIENT} />);
     expect(screen.queryByText("File")).not.toBeInTheDocument(); // would display file if it shows the "not found" div

--- a/packages/thirdweb/src/react/web/ui/MediaRenderer/MediaRenderer.tsx
+++ b/packages/thirdweb/src/react/web/ui/MediaRenderer/MediaRenderer.tsx
@@ -73,19 +73,23 @@ export const MediaRenderer = /* @__PURE__ */ (() =>
         ...style,
       };
 
-      const mediaInfo = useResolvedMediaType(
+      const { mediaInfo, isFetched: mediaInfoIsFetched } = useResolvedMediaType(
         client,
         src ?? undefined,
         mimeType,
         gatewayUrl,
       );
 
-      const possiblePosterSrc = useResolvedMediaType(
+      const { mediaInfo: possiblePosterSrc } = useResolvedMediaType(
         client,
         poster ?? undefined,
         undefined,
         gatewayUrl,
       );
+
+      if (!mediaInfoIsFetched || !src) {
+        return <div style={style} />;
+      }
 
       if (mediaInfo.mimeType) {
         // html content

--- a/packages/thirdweb/src/react/web/ui/MediaRenderer/useResolvedMediaType.ts
+++ b/packages/thirdweb/src/react/web/ui/MediaRenderer/useResolvedMediaType.ts
@@ -34,7 +34,7 @@ export function useResolvedMediaType(
     }
   }, [uri, gatewayUrl, client]);
 
-  const resolvedMimType = useQuery({
+  const resolvedMimeType = useQuery({
     queryKey: ["mime-type", resolvedUrl],
     queryFn: () => resolveMimeType(resolvedUrl),
     enabled: !!resolvedUrl && !mimeType,
@@ -42,7 +42,7 @@ export function useResolvedMediaType(
   });
 
   return {
-    url: resolvedUrl,
-    mimeType: resolvedMimType.data,
+    mediaInfo: { url: resolvedUrl, mimeType: resolvedMimeType.data },
+    isFetched: resolvedMimeType.isFetched,
   };
 }


### PR DESCRIPTION
- Prevents MediaRenderer from flashing its failed state
- Adds tests for MediaRenderer
- Limits risk of `<a>` tag bug for MediaRenderers inside links (but still possible if rendering fails)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR fixes MediaRenderer flashing its failed state while loading by updating the useResolvedMediaType hook and adding tests.

### Detailed summary
- Updated `useResolvedMediaType` to return `mediaInfo` object with URL and MIME type
- Added `isFetched` property to `mediaInfo` object
- Updated `MediaRenderer` component to use new `useResolvedMediaType` return values
- Added tests for `MediaRenderer` component to cover different scenarios

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->