### PR TITLE
fix: CNCT-1176

### DIFF
--- a/.changeset/strong-onions-sing.md
+++ b/.changeset/strong-onions-sing.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+fix losing state when looking at transactions during pay

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx
@@ -498,20 +498,6 @@ function BuyScreenContent(props: BuyScreenContentProps) {
         )}
 
         <Container px="lg" flex="column" gap="sm">
-          {account && (
-            <Button
-              variant="outline"
-              fullWidth
-              style={{
-                padding: spacing.xs,
-                fontSize: fontSize.sm,
-              }}
-              onClick={props.onViewPendingTx}
-            >
-              View all transactions
-            </Button>
-          )}
-
           {!isExpanded && (
             <>
               {!account && props.connectButton ? (
@@ -527,6 +513,20 @@ function BuyScreenContent(props: BuyScreenContentProps) {
                 </Button>
               )}
             </>
+          )}
+
+          {account && (
+            <Button
+              variant="outline"
+              fullWidth
+              style={{
+                padding: spacing.xs,
+                fontSize: fontSize.sm,
+              }}
+              onClick={props.onViewPendingTx}
+            >
+              View all transactions
+            </Button>
           )}
         </Container>
 

--- a/packages/thirdweb/src/react/web/ui/PayEmbed.tsx
+++ b/packages/thirdweb/src/react/web/ui/PayEmbed.tsx
@@ -196,7 +196,8 @@ export function PayEmbed(props: PayEmbedProps) {
             }
           />
         </div>
-        <div style={{ display: screen === "buy" ? "none" : "inherit" }}>
+        {/* this does not need to persist so we can just show-hide it with JS */}
+        {screen === "tx-history" && (
           <BuyTxHistory
             client={props.client}
             onBack={() => {
@@ -208,7 +209,7 @@ export function PayEmbed(props: PayEmbedProps) {
             isBuyForTx={false}
             isEmbed={true}
           />
-        </div>
+        )}
       </>
     );
   }

--- a/packages/thirdweb/src/react/web/ui/PayEmbed.tsx
+++ b/packages/thirdweb/src/react/web/ui/PayEmbed.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useState } from "react";
 import type { Chain } from "../../../chains/types.js";
 import type { ThirdwebClient } from "../../../client/client.js";

--- a/packages/thirdweb/src/react/web/ui/PayEmbed.tsx
+++ b/packages/thirdweb/src/react/web/ui/PayEmbed.tsx
@@ -165,47 +165,51 @@ export function PayEmbed(props: PayEmbedProps) {
         <Spinner size="xl" color="secondaryText" />
       </div>
     );
-  } else if (screen === "tx-history") {
-    content = (
-      <BuyTxHistory
-        client={props.client}
-        onBack={() => {
-          setScreen("buy");
-        }}
-        onDone={() => {
-          // noop
-        }}
-        isBuyForTx={false}
-        isEmbed={true}
-      />
-    );
   } else {
+    // show and hide screens with CSS to not lose state when switching between them
     content = (
-      <BuyScreen
-        isEmbed={true}
-        supportedTokens={props.supportedTokens}
-        theme={props.theme || "dark"}
-        client={props.client}
-        connectLocale={localeQuery.data}
-        onViewPendingTx={() => {
-          setScreen("tx-history");
-        }}
-        payOptions={props.payOptions || {}}
-        onDone={() => {
-          // noop
-        }}
-        connectButton={
-          <ConnectButton
-            {...props.connectOptions}
+      <>
+        <div style={{ display: screen === "tx-history" ? "none" : "inherit" }}>
+          <BuyScreen
+            isEmbed={true}
+            supportedTokens={props.supportedTokens}
+            theme={props.theme || "dark"}
             client={props.client}
-            connectButton={{
-              style: {
-                width: "100%",
-              },
+            connectLocale={localeQuery.data}
+            onViewPendingTx={() => {
+              setScreen("tx-history");
             }}
+            payOptions={props.payOptions || {}}
+            onDone={() => {
+              // noop
+            }}
+            connectButton={
+              <ConnectButton
+                {...props.connectOptions}
+                client={props.client}
+                connectButton={{
+                  style: {
+                    width: "100%",
+                  },
+                }}
+              />
+            }
           />
-        }
-      />
+        </div>
+        <div style={{ display: screen === "buy" ? "none" : "inherit" }}>
+          <BuyTxHistory
+            client={props.client}
+            onBack={() => {
+              setScreen("buy");
+            }}
+            onDone={() => {
+              // noop
+            }}
+            isBuyForTx={false}
+            isEmbed={true}
+          />
+        </div>
+      </>
     );
   }
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR fixes losing state when switching between screens in the Buy section of the ConnectWallet feature.

### Detailed summary
- Fixed losing state issue when looking at transactions during pay
- Improved screen switching to maintain state
- Updated BuyScreen and PayEmbed components to handle state transitions efficiently

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->