### PR TITLE
Clear in-app wallet state on disconnect

### DIFF
--- a/.changeset/famous-pens-perform.md
+++ b/.changeset/famous-pens-perform.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fully clear in-app wallet user data when disconnecting

--- a/packages/thirdweb/src/wallets/create-wallet.ts
+++ b/packages/thirdweb/src/wallets/create-wallet.ts
@@ -17,6 +17,7 @@ import type { ThirdwebClient } from "../client/client.js";
 import { getContract } from "../contract/contract.js";
 import { isContractDeployed } from "../utils/bytecode/is-contract-deployed.js";
 import { COINBASE } from "./constants.js";
+import { logoutAuthenticatedUser } from "./in-app/core/authentication/index.js";
 import { DEFAULT_ACCOUNT_FACTORY } from "./smart/lib/constants.js";
 import type { WCConnectOptions } from "./wallet-connect/types.js";
 import { createWalletEmitter } from "./wallet-emitter.js";
@@ -495,7 +496,13 @@ export function inAppWallet(
       return account;
     },
     disconnect: async () => {
-      // simply un-set the states
+      // If no client is assigned, we should be fine just unsetting the states
+      if (client) {
+        const result = await logoutAuthenticatedUser({ client });
+        if (!result.success) {
+          throw new Error("Failed to logout");
+        }
+      }
       account = undefined;
       chain = undefined;
       emitter.emit("disconnect", undefined);

--- a/packages/thirdweb/src/wallets/in-app/core/authentication/index.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/authentication/index.ts
@@ -11,6 +11,10 @@ import {
 import type { InAppWalletSdk } from "../../implementations/lib/in-app-wallet.js";
 import type { AuthArgsType, PreAuthArgsType } from "./type.js";
 
+export type GetAuthenticatedUserParams = {
+  client: ThirdwebClient;
+};
+
 const ewsSDKCache = new WeakMap<ThirdwebClient, InAppWalletSdk>();
 
 /**
@@ -31,9 +35,15 @@ async function getInAppWalletSDK(client: ThirdwebClient) {
   return ewSDK;
 }
 
-export type GetAuthenticatedUserParams = {
-  client: ThirdwebClient;
-};
+/**
+ * @internal
+ */
+export async function logoutAuthenticatedUser(
+  options: GetAuthenticatedUserParams,
+) {
+  const ewSDK = await getInAppWalletSDK(options.client);
+  return ewSDK.auth.logout();
+}
 
 /**
  * Retrieves the authenticated user for the active in-app wallet.


### PR DESCRIPTION
## Problem solved

We currently do not clear an in-app's wallet state on disconnect, only on login of a new wallet. This PR executes are full logout on disconnect if possible -- if there is no client we can't (but there alwasy should be)

## Changes made

- [ ] Internal logout on in-app wallet disconnect


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the in-app wallet functionality by fully clearing user data on disconnection.

### Detailed summary
- Added a function to fully clear in-app wallet user data on disconnection.
- Updated the logout functionality in the in-app wallet authentication module.
- Implemented the logout process in the `disconnect` method of the wallet.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->