### PR TITLE
WIP -- generate flow for extensions [DO NOT MERGE]

### DIFF
--- a/packages/thirdweb/scripts/generate/abis/erc721/ERC721Core.json
+++ b/packages/thirdweb/scripts/generate/abis/erc721/ERC721Core.json
@@ -1,0 +1,879 @@
+[
+  {
+    "type": "constructor",
+    "inputs": [
+      { "name": "_name", "type": "string", "internalType": "string" },
+      { "name": "_symbol", "type": "string", "internalType": "string" },
+      { "name": "_contractURI", "type": "string", "internalType": "string" },
+      { "name": "_owner", "type": "address", "internalType": "address" },
+      {
+        "name": "_onInitializeCall",
+        "type": "tuple",
+        "internalType": "struct IHookInstaller.OnInitializeParams",
+        "components": [
+          { "name": "target", "type": "address", "internalType": "address" },
+          { "name": "value", "type": "uint256", "internalType": "uint256" },
+          { "name": "data", "type": "bytes", "internalType": "bytes" }
+        ]
+      },
+      {
+        "name": "_hooksToInstall",
+        "type": "tuple[]",
+        "internalType": "struct IHookInstaller.InstallHookParams[]",
+        "components": [
+          {
+            "name": "hook",
+            "type": "address",
+            "internalType": "contract IHook"
+          },
+          {
+            "name": "initCallValue",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          { "name": "initCalldata", "type": "bytes", "internalType": "bytes" }
+        ]
+      }
+    ],
+    "stateMutability": "payable"
+  },
+  { "type": "fallback", "stateMutability": "payable" },
+  { "type": "receive", "stateMutability": "payable" },
+  {
+    "type": "function",
+    "name": "BEFORE_APPROVE_ERC20_FLAG",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "BEFORE_APPROVE_ERC721_FLAG",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "BEFORE_APPROVE_FOR_ALL_FLAG",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "BEFORE_BATCH_TRANSFER_ERC1155_FLAG",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "BEFORE_BURN_ERC1155_FLAG",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "BEFORE_BURN_ERC20_FLAG",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "BEFORE_BURN_ERC721_FLAG",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "BEFORE_MINT_ERC1155_FLAG",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "BEFORE_MINT_ERC20_FLAG",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "BEFORE_MINT_ERC721_FLAG",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "BEFORE_TRANSFER_ERC1155_FLAG",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "BEFORE_TRANSFER_ERC20_FLAG",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "BEFORE_TRANSFER_ERC721_FLAG",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "ON_ROYALTY_INFO_FLAG",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "ON_TOKEN_URI_FLAG",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "_highestBitToZero",
+    "inputs": [
+      { "name": "_value", "type": "uint256", "internalType": "uint256" }
+    ],
+    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "approve",
+    "inputs": [
+      { "name": "_spender", "type": "address", "internalType": "address" },
+      { "name": "_id", "type": "uint256", "internalType": "uint256" }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "balanceOf",
+    "inputs": [
+      { "name": "owner", "type": "address", "internalType": "address" }
+    ],
+    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "burn",
+    "inputs": [
+      { "name": "_tokenId", "type": "uint256", "internalType": "uint256" },
+      { "name": "_data", "type": "bytes", "internalType": "bytes" }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "cancelOwnershipHandover",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "completeOwnershipHandover",
+    "inputs": [
+      { "name": "pendingOwner", "type": "address", "internalType": "address" }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "contractURI",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "string", "internalType": "string" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "explicitOwnershipOf",
+    "inputs": [
+      { "name": "tokenId", "type": "uint256", "internalType": "uint256" }
+    ],
+    "outputs": [
+      {
+        "name": "ownership",
+        "type": "tuple",
+        "internalType": "struct IERC721A.TokenOwnership",
+        "components": [
+          { "name": "addr", "type": "address", "internalType": "address" },
+          {
+            "name": "startTimestamp",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          { "name": "burned", "type": "bool", "internalType": "bool" },
+          { "name": "extraData", "type": "uint24", "internalType": "uint24" }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "explicitOwnershipsOf",
+    "inputs": [
+      { "name": "tokenIds", "type": "uint256[]", "internalType": "uint256[]" }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple[]",
+        "internalType": "struct IERC721A.TokenOwnership[]",
+        "components": [
+          { "name": "addr", "type": "address", "internalType": "address" },
+          {
+            "name": "startTimestamp",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          { "name": "burned", "type": "bool", "internalType": "bool" },
+          { "name": "extraData", "type": "uint24", "internalType": "uint24" }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getAllHooks",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "hooks",
+        "type": "tuple",
+        "internalType": "struct IERC721HookInstaller.ERC721Hooks",
+        "components": [
+          {
+            "name": "beforeMint",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "beforeTransfer",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "beforeBurn",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "beforeApprove",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "beforeApproveForAll",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "tokenURI",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "royaltyInfo",
+            "type": "address",
+            "internalType": "address"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getApproved",
+    "inputs": [
+      { "name": "tokenId", "type": "uint256", "internalType": "uint256" }
+    ],
+    "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getHookFallbackFunctionCall",
+    "inputs": [
+      { "name": "_selector", "type": "bytes4", "internalType": "bytes4" }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct IHookInstaller.HookFallbackFunctionCall",
+        "components": [
+          { "name": "target", "type": "address", "internalType": "address" },
+          {
+            "name": "callType",
+            "type": "uint8",
+            "internalType": "enum IHookInfo.CallType"
+          },
+          { "name": "permissioned", "type": "bool", "internalType": "bool" }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getHookImplementation",
+    "inputs": [
+      { "name": "_flag", "type": "uint256", "internalType": "uint256" }
+    ],
+    "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "installHook",
+    "inputs": [
+      {
+        "name": "_params",
+        "type": "tuple",
+        "internalType": "struct IHookInstaller.InstallHookParams",
+        "components": [
+          {
+            "name": "hook",
+            "type": "address",
+            "internalType": "contract IHook"
+          },
+          {
+            "name": "initCallValue",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          { "name": "initCalldata", "type": "bytes", "internalType": "bytes" }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "isApprovedForAll",
+    "inputs": [
+      { "name": "owner", "type": "address", "internalType": "address" },
+      { "name": "operator", "type": "address", "internalType": "address" }
+    ],
+    "outputs": [{ "name": "", "type": "bool", "internalType": "bool" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "mint",
+    "inputs": [
+      { "name": "_to", "type": "address", "internalType": "address" },
+      { "name": "_quantity", "type": "uint256", "internalType": "uint256" },
+      { "name": "_data", "type": "bytes", "internalType": "bytes" }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "multicall",
+    "inputs": [
+      { "name": "data", "type": "bytes[]", "internalType": "bytes[]" }
+    ],
+    "outputs": [{ "name": "", "type": "bytes[]", "internalType": "bytes[]" }],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "name",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "string", "internalType": "string" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "owner",
+    "inputs": [],
+    "outputs": [
+      { "name": "result", "type": "address", "internalType": "address" }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "ownerOf",
+    "inputs": [
+      { "name": "tokenId", "type": "uint256", "internalType": "uint256" }
+    ],
+    "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "ownershipHandoverExpiresAt",
+    "inputs": [
+      { "name": "pendingOwner", "type": "address", "internalType": "address" }
+    ],
+    "outputs": [
+      { "name": "result", "type": "uint256", "internalType": "uint256" }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "renounceOwnership",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "requestOwnershipHandover",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "royaltyInfo",
+    "inputs": [
+      { "name": "_tokenId", "type": "uint256", "internalType": "uint256" },
+      { "name": "_salePrice", "type": "uint256", "internalType": "uint256" }
+    ],
+    "outputs": [
+      { "name": "", "type": "address", "internalType": "address" },
+      { "name": "", "type": "uint256", "internalType": "uint256" }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "safeTransferFrom",
+    "inputs": [
+      { "name": "from", "type": "address", "internalType": "address" },
+      { "name": "to", "type": "address", "internalType": "address" },
+      { "name": "tokenId", "type": "uint256", "internalType": "uint256" }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "safeTransferFrom",
+    "inputs": [
+      { "name": "from", "type": "address", "internalType": "address" },
+      { "name": "to", "type": "address", "internalType": "address" },
+      { "name": "tokenId", "type": "uint256", "internalType": "uint256" },
+      { "name": "_data", "type": "bytes", "internalType": "bytes" }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "setApprovalForAll",
+    "inputs": [
+      { "name": "_operator", "type": "address", "internalType": "address" },
+      { "name": "_approved", "type": "bool", "internalType": "bool" }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setContractURI",
+    "inputs": [{ "name": "_uri", "type": "string", "internalType": "string" }],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "supportsInterface",
+    "inputs": [
+      { "name": "_interfaceId", "type": "bytes4", "internalType": "bytes4" }
+    ],
+    "outputs": [{ "name": "", "type": "bool", "internalType": "bool" }],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "symbol",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "string", "internalType": "string" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "tokenURI",
+    "inputs": [{ "name": "_id", "type": "uint256", "internalType": "uint256" }],
+    "outputs": [{ "name": "", "type": "string", "internalType": "string" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "tokensOfOwner",
+    "inputs": [
+      { "name": "owner", "type": "address", "internalType": "address" }
+    ],
+    "outputs": [
+      { "name": "", "type": "uint256[]", "internalType": "uint256[]" }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "tokensOfOwnerIn",
+    "inputs": [
+      { "name": "owner", "type": "address", "internalType": "address" },
+      { "name": "start", "type": "uint256", "internalType": "uint256" },
+      { "name": "stop", "type": "uint256", "internalType": "uint256" }
+    ],
+    "outputs": [
+      { "name": "", "type": "uint256[]", "internalType": "uint256[]" }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "totalSupply",
+    "inputs": [],
+    "outputs": [
+      { "name": "result", "type": "uint256", "internalType": "uint256" }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "transferFrom",
+    "inputs": [
+      { "name": "_from", "type": "address", "internalType": "address" },
+      { "name": "_to", "type": "address", "internalType": "address" },
+      { "name": "_id", "type": "uint256", "internalType": "uint256" }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "transferOwnership",
+    "inputs": [
+      { "name": "newOwner", "type": "address", "internalType": "address" }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "uninstallHook",
+    "inputs": [
+      {
+        "name": "_hooksToUninstall",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "Approval",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "approved",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ApprovalForAll",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "approved",
+        "type": "bool",
+        "indexed": false,
+        "internalType": "bool"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ConsecutiveTransfer",
+    "inputs": [
+      {
+        "name": "fromTokenId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "toTokenId",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "from",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ContractURIUpdated",
+    "inputs": [],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "HooksInstalled",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "hooks",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "HooksUninstalled",
+    "inputs": [
+      {
+        "name": "hooks",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipHandoverCanceled",
+    "inputs": [
+      {
+        "name": "pendingOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipHandoverRequested",
+    "inputs": [
+      {
+        "name": "pendingOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipTransferred",
+    "inputs": [
+      {
+        "name": "oldOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Transfer",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  { "type": "error", "name": "AlreadyInitialized", "inputs": [] },
+  {
+    "type": "error",
+    "name": "ApprovalCallerNotOwnerNorApproved",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ApprovalQueryForNonexistentToken",
+    "inputs": []
+  },
+  { "type": "error", "name": "BalanceQueryForZeroAddress", "inputs": [] },
+  { "type": "error", "name": "ERC721CoreHookCallFailed", "inputs": [] },
+  {
+    "type": "error",
+    "name": "ERC721CoreHookInitializeCallFailed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ERC721CoreInsufficientValueInConstructor",
+    "inputs": []
+  },
+  { "type": "error", "name": "ERC721CoreMintDisabled", "inputs": [] },
+  {
+    "type": "error",
+    "name": "ERC721CoreOnInitializeCallFailed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "HookInstallerFallbackFunctionDoesNotExist",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "HookInstallerHookAlreadyInstalled",
+    "inputs": []
+  },
+  { "type": "error", "name": "HookInstallerHookCallFailed", "inputs": [] },
+  {
+    "type": "error",
+    "name": "HookInstallerHookFallbackFunctionUsed",
+    "inputs": [
+      {
+        "name": "functionSelector",
+        "type": "bytes4",
+        "internalType": "bytes4"
+      }
+    ]
+  },
+  { "type": "error", "name": "HookInstallerHookNotInstalled", "inputs": [] },
+  { "type": "error", "name": "HookInstallerInvalidMsgValue", "inputs": [] },
+  { "type": "error", "name": "HookInstallerNoSupportedHooks", "inputs": [] },
+  { "type": "error", "name": "HookInstallerNotAuthorized", "inputs": [] },
+  { "type": "error", "name": "HookInstallerUnauthorizedCall", "inputs": [] },
+  { "type": "error", "name": "HookInstallerZeroAddress", "inputs": [] },
+  { "type": "error", "name": "InvalidQueryRange", "inputs": [] },
+  {
+    "type": "error",
+    "name": "MintERC2309QuantityExceedsLimit",
+    "inputs": []
+  },
+  { "type": "error", "name": "MintToZeroAddress", "inputs": [] },
+  { "type": "error", "name": "MintZeroQuantity", "inputs": [] },
+  { "type": "error", "name": "NewOwnerIsZeroAddress", "inputs": [] },
+  { "type": "error", "name": "NoHandoverRequest", "inputs": [] },
+  { "type": "error", "name": "NotCompatibleWithSpotMints", "inputs": [] },
+  { "type": "error", "name": "OwnerQueryForNonexistentToken", "inputs": [] },
+  {
+    "type": "error",
+    "name": "OwnershipNotInitializedForExtraData",
+    "inputs": []
+  },
+  { "type": "error", "name": "SequentialMintExceedsLimit", "inputs": [] },
+  { "type": "error", "name": "SequentialUpToTooSmall", "inputs": [] },
+  { "type": "error", "name": "SpotMintTokenIdTooSmall", "inputs": [] },
+  { "type": "error", "name": "TokenAlreadyExists", "inputs": [] },
+  {
+    "type": "error",
+    "name": "TransferCallerNotOwnerNorApproved",
+    "inputs": []
+  },
+  { "type": "error", "name": "TransferFromIncorrectOwner", "inputs": [] },
+  {
+    "type": "error",
+    "name": "TransferToNonERC721ReceiverImplementer",
+    "inputs": []
+  },
+  { "type": "error", "name": "TransferToZeroAddress", "inputs": [] },
+  { "type": "error", "name": "URIQueryForNonexistentToken", "inputs": [] },
+  { "type": "error", "name": "Unauthorized", "inputs": [] }
+]

--- a/packages/thirdweb/scripts/generate/abis/hooks/MintHook.json
+++ b/packages/thirdweb/scripts/generate/abis/hooks/MintHook.json
@@ -1,0 +1,1007 @@
+[
+  {
+    "type": "function",
+    "name": "BEFORE_APPROVE_ERC20_FLAG",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "BEFORE_APPROVE_ERC721_FLAG",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "BEFORE_APPROVE_FOR_ALL_FLAG",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "BEFORE_BATCH_TRANSFER_ERC1155_FLAG",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "BEFORE_BURN_ERC1155_FLAG",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "BEFORE_BURN_ERC20_FLAG",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "BEFORE_BURN_ERC721_FLAG",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "BEFORE_MINT_ERC1155_FLAG",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "BEFORE_MINT_ERC20_FLAG",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "BEFORE_MINT_ERC721_FLAG",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "BEFORE_TRANSFER_ERC1155_FLAG",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "BEFORE_TRANSFER_ERC20_FLAG",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "BEFORE_TRANSFER_ERC721_FLAG",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "ON_ROYALTY_INFO_FLAG",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "ON_TOKEN_URI_FLAG",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "allowlistMint",
+    "inputs": [
+      {
+        "name": "_params",
+        "type": "tuple",
+        "internalType": "struct MintHook.ClaimParams",
+        "components": [
+          {
+            "name": "allowlistProof",
+            "type": "bytes32[]",
+            "internalType": "bytes32[]"
+          },
+          {
+            "name": "expectedPricePerUnit",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "expectedCurrency",
+            "type": "address",
+            "internalType": "address"
+          }
+        ]
+      }
+    ],
+    "outputs": [{ "name": "", "type": "bytes", "internalType": "bytes" }],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "beforeMintERC1155",
+    "inputs": [
+      { "name": "_to", "type": "address", "internalType": "address" },
+      { "name": "_id", "type": "uint256", "internalType": "uint256" },
+      { "name": "_quantity", "type": "uint256", "internalType": "uint256" },
+      { "name": "_data", "type": "bytes", "internalType": "bytes" }
+    ],
+    "outputs": [{ "name": "", "type": "bytes", "internalType": "bytes" }],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "beforeMintERC20",
+    "inputs": [
+      { "name": "_to", "type": "address", "internalType": "address" },
+      { "name": "_quantity", "type": "uint256", "internalType": "uint256" },
+      { "name": "_data", "type": "bytes", "internalType": "bytes" }
+    ],
+    "outputs": [{ "name": "", "type": "bytes", "internalType": "bytes" }],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "beforeMintERC721",
+    "inputs": [
+      { "name": "_to", "type": "address", "internalType": "address" },
+      { "name": "_quantity", "type": "uint256", "internalType": "uint256" },
+      { "name": "_data", "type": "bytes", "internalType": "bytes" }
+    ],
+    "outputs": [{ "name": "", "type": "bytes", "internalType": "bytes" }],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "decodeClaimParams",
+    "inputs": [{ "name": "_data", "type": "bytes", "internalType": "bytes" }],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct MintHook.ClaimParams",
+        "components": [
+          {
+            "name": "allowlistProof",
+            "type": "bytes32[]",
+            "internalType": "bytes32[]"
+          },
+          {
+            "name": "expectedPricePerUnit",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "expectedCurrency",
+            "type": "address",
+            "internalType": "address"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "decodeSignatureMintERC1155Params",
+    "inputs": [{ "name": "_data", "type": "bytes", "internalType": "bytes" }],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct MintHook.SignatureMintParamsERC1155",
+        "components": [
+          {
+            "name": "request",
+            "type": "tuple",
+            "internalType": "struct MintHook.SignatureMintRequestERC1155",
+            "components": [
+              {
+                "name": "tokenId",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "token",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "startTimestamp",
+                "type": "uint48",
+                "internalType": "uint48"
+              },
+              {
+                "name": "endTimestamp",
+                "type": "uint48",
+                "internalType": "uint48"
+              },
+              {
+                "name": "recipient",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "quantity",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "currency",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "pricePerUnit",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              { "name": "uid", "type": "bytes32", "internalType": "bytes32" }
+            ]
+          },
+          { "name": "signature", "type": "bytes", "internalType": "bytes" }
+        ]
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "decodeSignatureMintERC20Params",
+    "inputs": [{ "name": "_data", "type": "bytes", "internalType": "bytes" }],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct MintHook.SignatureMintParamsERC20",
+        "components": [
+          {
+            "name": "request",
+            "type": "tuple",
+            "internalType": "struct MintHook.SignatureMintRequestERC20",
+            "components": [
+              {
+                "name": "token",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "startTimestamp",
+                "type": "uint48",
+                "internalType": "uint48"
+              },
+              {
+                "name": "endTimestamp",
+                "type": "uint48",
+                "internalType": "uint48"
+              },
+              {
+                "name": "recipient",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "quantity",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "currency",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "pricePerUnit",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              { "name": "uid", "type": "bytes32", "internalType": "bytes32" }
+            ]
+          },
+          { "name": "signature", "type": "bytes", "internalType": "bytes" }
+        ]
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "decodeSignatureMintERC721Params",
+    "inputs": [{ "name": "_data", "type": "bytes", "internalType": "bytes" }],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct MintHook.SignatureMintParamsERC721",
+        "components": [
+          {
+            "name": "request",
+            "type": "tuple",
+            "internalType": "struct MintHook.SignatureMintRequestERC721",
+            "components": [
+              {
+                "name": "token",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "startTimestamp",
+                "type": "uint48",
+                "internalType": "uint48"
+              },
+              {
+                "name": "endTimestamp",
+                "type": "uint48",
+                "internalType": "uint48"
+              },
+              {
+                "name": "recipient",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "quantity",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "currency",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "pricePerUnit",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              { "name": "uid", "type": "bytes32", "internalType": "bytes32" }
+            ]
+          },
+          { "name": "signature", "type": "bytes", "internalType": "bytes" }
+        ]
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "eip712Domain",
+    "inputs": [],
+    "outputs": [
+      { "name": "fields", "type": "bytes1", "internalType": "bytes1" },
+      { "name": "name", "type": "string", "internalType": "string" },
+      { "name": "version", "type": "string", "internalType": "string" },
+      { "name": "chainId", "type": "uint256", "internalType": "uint256" },
+      {
+        "name": "verifyingContract",
+        "type": "address",
+        "internalType": "address"
+      },
+      { "name": "salt", "type": "bytes32", "internalType": "bytes32" },
+      {
+        "name": "extensions",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getClaimPhaseERC1155",
+    "inputs": [
+      { "name": "_token", "type": "address", "internalType": "address" },
+      { "name": "_id", "type": "uint256", "internalType": "uint256" }
+    ],
+    "outputs": [
+      {
+        "name": "claimPhase",
+        "type": "tuple",
+        "internalType": "struct MintHook.ClaimPhase",
+        "components": [
+          {
+            "name": "availableSupply",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "allowlistMerkleRoot",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "pricePerUnit",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "currency",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "startTimestamp",
+            "type": "uint48",
+            "internalType": "uint48"
+          },
+          {
+            "name": "endTimestamp",
+            "type": "uint48",
+            "internalType": "uint48"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getClaimPhaseERC20",
+    "inputs": [
+      { "name": "_token", "type": "address", "internalType": "address" }
+    ],
+    "outputs": [
+      {
+        "name": "claimPhase",
+        "type": "tuple",
+        "internalType": "struct MintHook.ClaimPhase",
+        "components": [
+          {
+            "name": "availableSupply",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "allowlistMerkleRoot",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "pricePerUnit",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "currency",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "startTimestamp",
+            "type": "uint48",
+            "internalType": "uint48"
+          },
+          {
+            "name": "endTimestamp",
+            "type": "uint48",
+            "internalType": "uint48"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getClaimPhaseERC721",
+    "inputs": [
+      { "name": "_token", "type": "address", "internalType": "address" }
+    ],
+    "outputs": [
+      {
+        "name": "claimPhase",
+        "type": "tuple",
+        "internalType": "struct MintHook.ClaimPhase",
+        "components": [
+          {
+            "name": "availableSupply",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "allowlistMerkleRoot",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "pricePerUnit",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "currency",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "startTimestamp",
+            "type": "uint48",
+            "internalType": "uint48"
+          },
+          {
+            "name": "endTimestamp",
+            "type": "uint48",
+            "internalType": "uint48"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getHookInfo",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "info",
+        "type": "tuple",
+        "internalType": "struct IHookInfo.HookInfo",
+        "components": [
+          {
+            "name": "hookFlags",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "hookFallbackFunctions",
+            "type": "tuple[]",
+            "internalType": "struct IHookInfo.HookFallbackFunction[]",
+            "components": [
+              {
+                "name": "functionSelector",
+                "type": "bytes4",
+                "internalType": "bytes4"
+              },
+              {
+                "name": "callType",
+                "type": "uint8",
+                "internalType": "enum IHookInfo.CallType"
+              },
+              {
+                "name": "permissioned",
+                "type": "bool",
+                "internalType": "bool"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "getSaleConfig",
+    "inputs": [
+      { "name": "_token", "type": "address", "internalType": "address" }
+    ],
+    "outputs": [
+      {
+        "name": "primarySaleRecipient",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "platformFeeRecipient",
+        "type": "address",
+        "internalType": "address"
+      },
+      { "name": "platformFeeBps", "type": "uint16", "internalType": "uint16" }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "multicall",
+    "inputs": [
+      { "name": "data", "type": "bytes[]", "internalType": "bytes[]" }
+    ],
+    "outputs": [{ "name": "", "type": "bytes[]", "internalType": "bytes[]" }],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setClaimPhaseERC1155",
+    "inputs": [
+      { "name": "_id", "type": "uint256", "internalType": "uint256" },
+      {
+        "name": "_claimPhase",
+        "type": "tuple",
+        "internalType": "struct MintHook.ClaimPhase",
+        "components": [
+          {
+            "name": "availableSupply",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "allowlistMerkleRoot",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "pricePerUnit",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "currency",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "startTimestamp",
+            "type": "uint48",
+            "internalType": "uint48"
+          },
+          {
+            "name": "endTimestamp",
+            "type": "uint48",
+            "internalType": "uint48"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setClaimPhaseERC20",
+    "inputs": [
+      {
+        "name": "_claimPhase",
+        "type": "tuple",
+        "internalType": "struct MintHook.ClaimPhase",
+        "components": [
+          {
+            "name": "availableSupply",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "allowlistMerkleRoot",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "pricePerUnit",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "currency",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "startTimestamp",
+            "type": "uint48",
+            "internalType": "uint48"
+          },
+          {
+            "name": "endTimestamp",
+            "type": "uint48",
+            "internalType": "uint48"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setClaimPhaseERC721",
+    "inputs": [
+      {
+        "name": "_claimPhase",
+        "type": "tuple",
+        "internalType": "struct MintHook.ClaimPhase",
+        "components": [
+          {
+            "name": "availableSupply",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "allowlistMerkleRoot",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "pricePerUnit",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "currency",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "startTimestamp",
+            "type": "uint48",
+            "internalType": "uint48"
+          },
+          {
+            "name": "endTimestamp",
+            "type": "uint48",
+            "internalType": "uint48"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setSaleConfig",
+    "inputs": [
+      {
+        "name": "_primarySaleRecipient",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_platformFeeRecipient",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_platformFeeBps",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "signatureMintERC1155",
+    "inputs": [
+      {
+        "name": "_params",
+        "type": "tuple",
+        "internalType": "struct MintHook.SignatureMintParamsERC1155",
+        "components": [
+          {
+            "name": "request",
+            "type": "tuple",
+            "internalType": "struct MintHook.SignatureMintRequestERC1155",
+            "components": [
+              {
+                "name": "tokenId",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "token",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "startTimestamp",
+                "type": "uint48",
+                "internalType": "uint48"
+              },
+              {
+                "name": "endTimestamp",
+                "type": "uint48",
+                "internalType": "uint48"
+              },
+              {
+                "name": "recipient",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "quantity",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "currency",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "pricePerUnit",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              { "name": "uid", "type": "bytes32", "internalType": "bytes32" }
+            ]
+          },
+          { "name": "signature", "type": "bytes", "internalType": "bytes" }
+        ]
+      }
+    ],
+    "outputs": [{ "name": "", "type": "bytes", "internalType": "bytes" }],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "signatureMintERC20",
+    "inputs": [
+      {
+        "name": "_params",
+        "type": "tuple",
+        "internalType": "struct MintHook.SignatureMintParamsERC20",
+        "components": [
+          {
+            "name": "request",
+            "type": "tuple",
+            "internalType": "struct MintHook.SignatureMintRequestERC20",
+            "components": [
+              {
+                "name": "token",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "startTimestamp",
+                "type": "uint48",
+                "internalType": "uint48"
+              },
+              {
+                "name": "endTimestamp",
+                "type": "uint48",
+                "internalType": "uint48"
+              },
+              {
+                "name": "recipient",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "quantity",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "currency",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "pricePerUnit",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              { "name": "uid", "type": "bytes32", "internalType": "bytes32" }
+            ]
+          },
+          { "name": "signature", "type": "bytes", "internalType": "bytes" }
+        ]
+      }
+    ],
+    "outputs": [{ "name": "", "type": "bytes", "internalType": "bytes" }],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "signatureMintERC721",
+    "inputs": [
+      {
+        "name": "_params",
+        "type": "tuple",
+        "internalType": "struct MintHook.SignatureMintParamsERC721",
+        "components": [
+          {
+            "name": "request",
+            "type": "tuple",
+            "internalType": "struct MintHook.SignatureMintRequestERC721",
+            "components": [
+              {
+                "name": "token",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "startTimestamp",
+                "type": "uint48",
+                "internalType": "uint48"
+              },
+              {
+                "name": "endTimestamp",
+                "type": "uint48",
+                "internalType": "uint48"
+              },
+              {
+                "name": "recipient",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "quantity",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "currency",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "pricePerUnit",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              { "name": "uid", "type": "bytes32", "internalType": "bytes32" }
+            ]
+          },
+          { "name": "signature", "type": "bytes", "internalType": "bytes" }
+        ]
+      }
+    ],
+    "outputs": [{ "name": "", "type": "bytes", "internalType": "bytes" }],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "error",
+    "name": "BeforeMintHookERC1155NotImplemented",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "BeforeMintHookERC20NotImplemented",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "BeforeMintHookERC721NotImplemented",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MintHookClaimPhaseNotInAllowlist",
+    "inputs": []
+  },
+  { "type": "error", "name": "MintHookClaimPhaseOutOfSupply", "inputs": [] },
+  {
+    "type": "error",
+    "name": "MintHookClaimPhaseOutOfTimeWindow",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MintHookClaimPhasePriceMismatch",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MintHookIncorrectNativeTokenSent",
+    "inputs": []
+  },
+  { "type": "error", "name": "MintHookRequestExpired", "inputs": [] },
+  { "type": "error", "name": "MintHookRequestInvalidToken", "inputs": [] },
+  { "type": "error", "name": "MintHookRequestMismatch", "inputs": [] },
+  { "type": "error", "name": "MintHookRequestUidReused", "inputs": [] },
+  {
+    "type": "error",
+    "name": "MintHookRequestUnauthorizedSignature",
+    "inputs": []
+  },
+  { "type": "error", "name": "MintHookUnrecognizedParams", "inputs": [] }
+]

--- a/packages/thirdweb/src/exports/extensions/erc721Core.ts
+++ b/packages/thirdweb/src/exports/extensions/erc721Core.ts
@@ -1,0 +1,7 @@
+/**
+ * WRITE extension for ERC721
+ */
+export {
+  mint,
+  type MintParams,
+} from "../../extensions/erc721/__generated__/ERC721Core/write/mint.js";

--- a/packages/thirdweb/src/exports/extensions/hooks.ts
+++ b/packages/thirdweb/src/exports/extensions/hooks.ts
@@ -1,0 +1,13 @@
+/**
+ * READ extension for MintHook
+ */
+
+export {
+  encodeAllowlistMintParams,
+  type AllowlistMintParams,
+} from "../../extensions/hooks/__generated__/MintHook/read/allowlistMint.js";
+
+export {
+  encodeSignatureMintERC721Params,
+  type SignatureMintERC721Params,
+} from "../../extensions/hooks/__generated__/MintHook/read/signatureMintERC721.js";

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/events/Approval.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/events/Approval.ts
@@ -1,0 +1,56 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+import type { AbiParameterToPrimitiveType } from "abitype";
+
+/**
+ * Represents the filters for the "Approval" event.
+ */
+export type ApprovalEventFilters = Partial<{
+  owner: AbiParameterToPrimitiveType<{
+    name: "owner";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+  approved: AbiParameterToPrimitiveType<{
+    name: "approved";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+  tokenId: AbiParameterToPrimitiveType<{
+    name: "tokenId";
+    type: "uint256";
+    indexed: true;
+    internalType: "uint256";
+  }>;
+}>;
+
+/**
+ * Creates an event object for the Approval event.
+ * @param filters - Optional filters to apply to the event.
+ * @returns The prepared event object.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { approvalEvent } from "thirdweb/extensions/erc721";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  approvalEvent({
+ *  owner: ...,
+ *  approved: ...,
+ *  tokenId: ...,
+ * })
+ * ],
+ * });
+ * ```
+ */
+export function approvalEvent(filters: ApprovalEventFilters = {}) {
+  return prepareEvent({
+    signature:
+      "event Approval(address indexed owner, address indexed approved, uint256 indexed tokenId)",
+    filters,
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/events/ApprovalForAll.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/events/ApprovalForAll.ts
@@ -1,0 +1,49 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+import type { AbiParameterToPrimitiveType } from "abitype";
+
+/**
+ * Represents the filters for the "ApprovalForAll" event.
+ */
+export type ApprovalForAllEventFilters = Partial<{
+  owner: AbiParameterToPrimitiveType<{
+    name: "owner";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+  operator: AbiParameterToPrimitiveType<{
+    name: "operator";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+}>;
+
+/**
+ * Creates an event object for the ApprovalForAll event.
+ * @param filters - Optional filters to apply to the event.
+ * @returns The prepared event object.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { approvalForAllEvent } from "thirdweb/extensions/erc721";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  approvalForAllEvent({
+ *  owner: ...,
+ *  operator: ...,
+ * })
+ * ],
+ * });
+ * ```
+ */
+export function approvalForAllEvent(filters: ApprovalForAllEventFilters = {}) {
+  return prepareEvent({
+    signature:
+      "event ApprovalForAll(address indexed owner, address indexed operator, bool approved)",
+    filters,
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/events/ConsecutiveTransfer.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/events/ConsecutiveTransfer.ts
@@ -1,0 +1,58 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+import type { AbiParameterToPrimitiveType } from "abitype";
+
+/**
+ * Represents the filters for the "ConsecutiveTransfer" event.
+ */
+export type ConsecutiveTransferEventFilters = Partial<{
+  fromTokenId: AbiParameterToPrimitiveType<{
+    name: "fromTokenId";
+    type: "uint256";
+    indexed: true;
+    internalType: "uint256";
+  }>;
+  from: AbiParameterToPrimitiveType<{
+    name: "from";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+  to: AbiParameterToPrimitiveType<{
+    name: "to";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+}>;
+
+/**
+ * Creates an event object for the ConsecutiveTransfer event.
+ * @param filters - Optional filters to apply to the event.
+ * @returns The prepared event object.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { consecutiveTransferEvent } from "thirdweb/extensions/erc721";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  consecutiveTransferEvent({
+ *  fromTokenId: ...,
+ *  from: ...,
+ *  to: ...,
+ * })
+ * ],
+ * });
+ * ```
+ */
+export function consecutiveTransferEvent(
+  filters: ConsecutiveTransferEventFilters = {},
+) {
+  return prepareEvent({
+    signature:
+      "event ConsecutiveTransfer(uint256 indexed fromTokenId, uint256 toTokenId, address indexed from, address indexed to)",
+    filters,
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/events/ContractURIUpdated.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/events/ContractURIUpdated.ts
@@ -1,0 +1,24 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+
+/**
+ * Creates an event object for the ContractURIUpdated event.
+ * @returns The prepared event object.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { contractURIUpdatedEvent } from "thirdweb/extensions/erc721";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  contractURIUpdatedEvent()
+ * ],
+ * });
+ * ```
+ */
+export function contractURIUpdatedEvent() {
+  return prepareEvent({
+    signature: "event ContractURIUpdated()",
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/events/HooksInstalled.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/events/HooksInstalled.ts
@@ -1,0 +1,42 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+import type { AbiParameterToPrimitiveType } from "abitype";
+
+/**
+ * Represents the filters for the "HooksInstalled" event.
+ */
+export type HooksInstalledEventFilters = Partial<{
+  implementation: AbiParameterToPrimitiveType<{
+    name: "implementation";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+}>;
+
+/**
+ * Creates an event object for the HooksInstalled event.
+ * @param filters - Optional filters to apply to the event.
+ * @returns The prepared event object.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { hooksInstalledEvent } from "thirdweb/extensions/erc721";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  hooksInstalledEvent({
+ *  implementation: ...,
+ * })
+ * ],
+ * });
+ * ```
+ */
+export function hooksInstalledEvent(filters: HooksInstalledEventFilters = {}) {
+  return prepareEvent({
+    signature:
+      "event HooksInstalled(address indexed implementation, uint256 hooks)",
+    filters,
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/events/HooksUninstalled.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/events/HooksUninstalled.ts
@@ -1,0 +1,24 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+
+/**
+ * Creates an event object for the HooksUninstalled event.
+ * @returns The prepared event object.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { hooksUninstalledEvent } from "thirdweb/extensions/erc721";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  hooksUninstalledEvent()
+ * ],
+ * });
+ * ```
+ */
+export function hooksUninstalledEvent() {
+  return prepareEvent({
+    signature: "event HooksUninstalled(uint256 hooks)",
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/events/OwnershipHandoverCanceled.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/events/OwnershipHandoverCanceled.ts
@@ -1,0 +1,43 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+import type { AbiParameterToPrimitiveType } from "abitype";
+
+/**
+ * Represents the filters for the "OwnershipHandoverCanceled" event.
+ */
+export type OwnershipHandoverCanceledEventFilters = Partial<{
+  pendingOwner: AbiParameterToPrimitiveType<{
+    name: "pendingOwner";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+}>;
+
+/**
+ * Creates an event object for the OwnershipHandoverCanceled event.
+ * @param filters - Optional filters to apply to the event.
+ * @returns The prepared event object.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { ownershipHandoverCanceledEvent } from "thirdweb/extensions/erc721";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  ownershipHandoverCanceledEvent({
+ *  pendingOwner: ...,
+ * })
+ * ],
+ * });
+ * ```
+ */
+export function ownershipHandoverCanceledEvent(
+  filters: OwnershipHandoverCanceledEventFilters = {},
+) {
+  return prepareEvent({
+    signature: "event OwnershipHandoverCanceled(address indexed pendingOwner)",
+    filters,
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/events/OwnershipHandoverRequested.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/events/OwnershipHandoverRequested.ts
@@ -1,0 +1,43 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+import type { AbiParameterToPrimitiveType } from "abitype";
+
+/**
+ * Represents the filters for the "OwnershipHandoverRequested" event.
+ */
+export type OwnershipHandoverRequestedEventFilters = Partial<{
+  pendingOwner: AbiParameterToPrimitiveType<{
+    name: "pendingOwner";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+}>;
+
+/**
+ * Creates an event object for the OwnershipHandoverRequested event.
+ * @param filters - Optional filters to apply to the event.
+ * @returns The prepared event object.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { ownershipHandoverRequestedEvent } from "thirdweb/extensions/erc721";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  ownershipHandoverRequestedEvent({
+ *  pendingOwner: ...,
+ * })
+ * ],
+ * });
+ * ```
+ */
+export function ownershipHandoverRequestedEvent(
+  filters: OwnershipHandoverRequestedEventFilters = {},
+) {
+  return prepareEvent({
+    signature: "event OwnershipHandoverRequested(address indexed pendingOwner)",
+    filters,
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/events/OwnershipTransferred.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/events/OwnershipTransferred.ts
@@ -1,0 +1,51 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+import type { AbiParameterToPrimitiveType } from "abitype";
+
+/**
+ * Represents the filters for the "OwnershipTransferred" event.
+ */
+export type OwnershipTransferredEventFilters = Partial<{
+  oldOwner: AbiParameterToPrimitiveType<{
+    name: "oldOwner";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+  newOwner: AbiParameterToPrimitiveType<{
+    name: "newOwner";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+}>;
+
+/**
+ * Creates an event object for the OwnershipTransferred event.
+ * @param filters - Optional filters to apply to the event.
+ * @returns The prepared event object.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { ownershipTransferredEvent } from "thirdweb/extensions/erc721";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  ownershipTransferredEvent({
+ *  oldOwner: ...,
+ *  newOwner: ...,
+ * })
+ * ],
+ * });
+ * ```
+ */
+export function ownershipTransferredEvent(
+  filters: OwnershipTransferredEventFilters = {},
+) {
+  return prepareEvent({
+    signature:
+      "event OwnershipTransferred(address indexed oldOwner, address indexed newOwner)",
+    filters,
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/events/Transfer.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/events/Transfer.ts
@@ -1,0 +1,56 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+import type { AbiParameterToPrimitiveType } from "abitype";
+
+/**
+ * Represents the filters for the "Transfer" event.
+ */
+export type TransferEventFilters = Partial<{
+  from: AbiParameterToPrimitiveType<{
+    name: "from";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+  to: AbiParameterToPrimitiveType<{
+    name: "to";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+  tokenId: AbiParameterToPrimitiveType<{
+    name: "tokenId";
+    type: "uint256";
+    indexed: true;
+    internalType: "uint256";
+  }>;
+}>;
+
+/**
+ * Creates an event object for the Transfer event.
+ * @param filters - Optional filters to apply to the event.
+ * @returns The prepared event object.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { transferEvent } from "thirdweb/extensions/erc721";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  transferEvent({
+ *  from: ...,
+ *  to: ...,
+ *  tokenId: ...,
+ * })
+ * ],
+ * });
+ * ```
+ */
+export function transferEvent(filters: TransferEventFilters = {}) {
+  return prepareEvent({
+    signature:
+      "event Transfer(address indexed from, address indexed to, uint256 indexed tokenId)",
+    filters,
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/BEFORE_APPROVE_ERC20_FLAG.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/BEFORE_APPROVE_ERC20_FLAG.ts
@@ -1,0 +1,53 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x8971e55c" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the BEFORE_APPROVE_ERC20_FLAG function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { decodeBEFORE_APPROVE_ERC20_FLAGResult } from "thirdweb/extensions/erc721";
+ * const result = decodeBEFORE_APPROVE_ERC20_FLAGResult("...");
+ * ```
+ */
+export function decodeBEFORE_APPROVE_ERC20_FLAGResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "BEFORE_APPROVE_ERC20_FLAG" function on the contract.
+ * @param options - The options for the BEFORE_APPROVE_ERC20_FLAG function.
+ * @returns The parsed result of the function call.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { BEFORE_APPROVE_ERC20_FLAG } from "thirdweb/extensions/erc721";
+ *
+ * const result = await BEFORE_APPROVE_ERC20_FLAG();
+ *
+ * ```
+ */
+export async function BEFORE_APPROVE_ERC20_FLAG(
+  options: BaseTransactionOptions,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/BEFORE_APPROVE_ERC721_FLAG.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/BEFORE_APPROVE_ERC721_FLAG.ts
@@ -1,0 +1,53 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x64dfcb7f" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the BEFORE_APPROVE_ERC721_FLAG function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { decodeBEFORE_APPROVE_ERC721_FLAGResult } from "thirdweb/extensions/erc721";
+ * const result = decodeBEFORE_APPROVE_ERC721_FLAGResult("...");
+ * ```
+ */
+export function decodeBEFORE_APPROVE_ERC721_FLAGResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "BEFORE_APPROVE_ERC721_FLAG" function on the contract.
+ * @param options - The options for the BEFORE_APPROVE_ERC721_FLAG function.
+ * @returns The parsed result of the function call.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { BEFORE_APPROVE_ERC721_FLAG } from "thirdweb/extensions/erc721";
+ *
+ * const result = await BEFORE_APPROVE_ERC721_FLAG();
+ *
+ * ```
+ */
+export async function BEFORE_APPROVE_ERC721_FLAG(
+  options: BaseTransactionOptions,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/BEFORE_APPROVE_FOR_ALL_FLAG.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/BEFORE_APPROVE_FOR_ALL_FLAG.ts
@@ -1,0 +1,53 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0xfcfea892" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the BEFORE_APPROVE_FOR_ALL_FLAG function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { decodeBEFORE_APPROVE_FOR_ALL_FLAGResult } from "thirdweb/extensions/erc721";
+ * const result = decodeBEFORE_APPROVE_FOR_ALL_FLAGResult("...");
+ * ```
+ */
+export function decodeBEFORE_APPROVE_FOR_ALL_FLAGResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "BEFORE_APPROVE_FOR_ALL_FLAG" function on the contract.
+ * @param options - The options for the BEFORE_APPROVE_FOR_ALL_FLAG function.
+ * @returns The parsed result of the function call.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { BEFORE_APPROVE_FOR_ALL_FLAG } from "thirdweb/extensions/erc721";
+ *
+ * const result = await BEFORE_APPROVE_FOR_ALL_FLAG();
+ *
+ * ```
+ */
+export async function BEFORE_APPROVE_FOR_ALL_FLAG(
+  options: BaseTransactionOptions,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/BEFORE_BATCH_TRANSFER_ERC1155_FLAG.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/BEFORE_BATCH_TRANSFER_ERC1155_FLAG.ts
@@ -1,0 +1,53 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x044ac9e1" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the BEFORE_BATCH_TRANSFER_ERC1155_FLAG function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { decodeBEFORE_BATCH_TRANSFER_ERC1155_FLAGResult } from "thirdweb/extensions/erc721";
+ * const result = decodeBEFORE_BATCH_TRANSFER_ERC1155_FLAGResult("...");
+ * ```
+ */
+export function decodeBEFORE_BATCH_TRANSFER_ERC1155_FLAGResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "BEFORE_BATCH_TRANSFER_ERC1155_FLAG" function on the contract.
+ * @param options - The options for the BEFORE_BATCH_TRANSFER_ERC1155_FLAG function.
+ * @returns The parsed result of the function call.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { BEFORE_BATCH_TRANSFER_ERC1155_FLAG } from "thirdweb/extensions/erc721";
+ *
+ * const result = await BEFORE_BATCH_TRANSFER_ERC1155_FLAG();
+ *
+ * ```
+ */
+export async function BEFORE_BATCH_TRANSFER_ERC1155_FLAG(
+  options: BaseTransactionOptions,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/BEFORE_BURN_ERC1155_FLAG.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/BEFORE_BURN_ERC1155_FLAG.ts
@@ -1,0 +1,53 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0xc42ed21c" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the BEFORE_BURN_ERC1155_FLAG function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { decodeBEFORE_BURN_ERC1155_FLAGResult } from "thirdweb/extensions/erc721";
+ * const result = decodeBEFORE_BURN_ERC1155_FLAGResult("...");
+ * ```
+ */
+export function decodeBEFORE_BURN_ERC1155_FLAGResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "BEFORE_BURN_ERC1155_FLAG" function on the contract.
+ * @param options - The options for the BEFORE_BURN_ERC1155_FLAG function.
+ * @returns The parsed result of the function call.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { BEFORE_BURN_ERC1155_FLAG } from "thirdweb/extensions/erc721";
+ *
+ * const result = await BEFORE_BURN_ERC1155_FLAG();
+ *
+ * ```
+ */
+export async function BEFORE_BURN_ERC1155_FLAG(
+  options: BaseTransactionOptions,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/BEFORE_BURN_ERC20_FLAG.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/BEFORE_BURN_ERC20_FLAG.ts
@@ -1,0 +1,51 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x9652b35b" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the BEFORE_BURN_ERC20_FLAG function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { decodeBEFORE_BURN_ERC20_FLAGResult } from "thirdweb/extensions/erc721";
+ * const result = decodeBEFORE_BURN_ERC20_FLAGResult("...");
+ * ```
+ */
+export function decodeBEFORE_BURN_ERC20_FLAGResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "BEFORE_BURN_ERC20_FLAG" function on the contract.
+ * @param options - The options for the BEFORE_BURN_ERC20_FLAG function.
+ * @returns The parsed result of the function call.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { BEFORE_BURN_ERC20_FLAG } from "thirdweb/extensions/erc721";
+ *
+ * const result = await BEFORE_BURN_ERC20_FLAG();
+ *
+ * ```
+ */
+export async function BEFORE_BURN_ERC20_FLAG(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/BEFORE_BURN_ERC721_FLAG.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/BEFORE_BURN_ERC721_FLAG.ts
@@ -1,0 +1,51 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x5a928783" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the BEFORE_BURN_ERC721_FLAG function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { decodeBEFORE_BURN_ERC721_FLAGResult } from "thirdweb/extensions/erc721";
+ * const result = decodeBEFORE_BURN_ERC721_FLAGResult("...");
+ * ```
+ */
+export function decodeBEFORE_BURN_ERC721_FLAGResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "BEFORE_BURN_ERC721_FLAG" function on the contract.
+ * @param options - The options for the BEFORE_BURN_ERC721_FLAG function.
+ * @returns The parsed result of the function call.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { BEFORE_BURN_ERC721_FLAG } from "thirdweb/extensions/erc721";
+ *
+ * const result = await BEFORE_BURN_ERC721_FLAG();
+ *
+ * ```
+ */
+export async function BEFORE_BURN_ERC721_FLAG(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/BEFORE_MINT_ERC1155_FLAG.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/BEFORE_MINT_ERC1155_FLAG.ts
@@ -1,0 +1,53 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x5a1d92c0" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the BEFORE_MINT_ERC1155_FLAG function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { decodeBEFORE_MINT_ERC1155_FLAGResult } from "thirdweb/extensions/erc721";
+ * const result = decodeBEFORE_MINT_ERC1155_FLAGResult("...");
+ * ```
+ */
+export function decodeBEFORE_MINT_ERC1155_FLAGResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "BEFORE_MINT_ERC1155_FLAG" function on the contract.
+ * @param options - The options for the BEFORE_MINT_ERC1155_FLAG function.
+ * @returns The parsed result of the function call.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { BEFORE_MINT_ERC1155_FLAG } from "thirdweb/extensions/erc721";
+ *
+ * const result = await BEFORE_MINT_ERC1155_FLAG();
+ *
+ * ```
+ */
+export async function BEFORE_MINT_ERC1155_FLAG(
+  options: BaseTransactionOptions,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/BEFORE_MINT_ERC20_FLAG.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/BEFORE_MINT_ERC20_FLAG.ts
@@ -1,0 +1,51 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0xe0345fe6" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the BEFORE_MINT_ERC20_FLAG function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { decodeBEFORE_MINT_ERC20_FLAGResult } from "thirdweb/extensions/erc721";
+ * const result = decodeBEFORE_MINT_ERC20_FLAGResult("...");
+ * ```
+ */
+export function decodeBEFORE_MINT_ERC20_FLAGResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "BEFORE_MINT_ERC20_FLAG" function on the contract.
+ * @param options - The options for the BEFORE_MINT_ERC20_FLAG function.
+ * @returns The parsed result of the function call.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { BEFORE_MINT_ERC20_FLAG } from "thirdweb/extensions/erc721";
+ *
+ * const result = await BEFORE_MINT_ERC20_FLAG();
+ *
+ * ```
+ */
+export async function BEFORE_MINT_ERC20_FLAG(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/BEFORE_MINT_ERC721_FLAG.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/BEFORE_MINT_ERC721_FLAG.ts
@@ -1,0 +1,51 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0xc44f5ef5" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the BEFORE_MINT_ERC721_FLAG function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { decodeBEFORE_MINT_ERC721_FLAGResult } from "thirdweb/extensions/erc721";
+ * const result = decodeBEFORE_MINT_ERC721_FLAGResult("...");
+ * ```
+ */
+export function decodeBEFORE_MINT_ERC721_FLAGResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "BEFORE_MINT_ERC721_FLAG" function on the contract.
+ * @param options - The options for the BEFORE_MINT_ERC721_FLAG function.
+ * @returns The parsed result of the function call.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { BEFORE_MINT_ERC721_FLAG } from "thirdweb/extensions/erc721";
+ *
+ * const result = await BEFORE_MINT_ERC721_FLAG();
+ *
+ * ```
+ */
+export async function BEFORE_MINT_ERC721_FLAG(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/BEFORE_TRANSFER_ERC1155_FLAG.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/BEFORE_TRANSFER_ERC1155_FLAG.ts
@@ -1,0 +1,53 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0xfd87b270" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the BEFORE_TRANSFER_ERC1155_FLAG function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { decodeBEFORE_TRANSFER_ERC1155_FLAGResult } from "thirdweb/extensions/erc721";
+ * const result = decodeBEFORE_TRANSFER_ERC1155_FLAGResult("...");
+ * ```
+ */
+export function decodeBEFORE_TRANSFER_ERC1155_FLAGResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "BEFORE_TRANSFER_ERC1155_FLAG" function on the contract.
+ * @param options - The options for the BEFORE_TRANSFER_ERC1155_FLAG function.
+ * @returns The parsed result of the function call.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { BEFORE_TRANSFER_ERC1155_FLAG } from "thirdweb/extensions/erc721";
+ *
+ * const result = await BEFORE_TRANSFER_ERC1155_FLAG();
+ *
+ * ```
+ */
+export async function BEFORE_TRANSFER_ERC1155_FLAG(
+  options: BaseTransactionOptions,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/BEFORE_TRANSFER_ERC20_FLAG.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/BEFORE_TRANSFER_ERC20_FLAG.ts
@@ -1,0 +1,53 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x94557b58" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the BEFORE_TRANSFER_ERC20_FLAG function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { decodeBEFORE_TRANSFER_ERC20_FLAGResult } from "thirdweb/extensions/erc721";
+ * const result = decodeBEFORE_TRANSFER_ERC20_FLAGResult("...");
+ * ```
+ */
+export function decodeBEFORE_TRANSFER_ERC20_FLAGResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "BEFORE_TRANSFER_ERC20_FLAG" function on the contract.
+ * @param options - The options for the BEFORE_TRANSFER_ERC20_FLAG function.
+ * @returns The parsed result of the function call.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { BEFORE_TRANSFER_ERC20_FLAG } from "thirdweb/extensions/erc721";
+ *
+ * const result = await BEFORE_TRANSFER_ERC20_FLAG();
+ *
+ * ```
+ */
+export async function BEFORE_TRANSFER_ERC20_FLAG(
+  options: BaseTransactionOptions,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/BEFORE_TRANSFER_ERC721_FLAG.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/BEFORE_TRANSFER_ERC721_FLAG.ts
@@ -1,0 +1,53 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x8c14e60d" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the BEFORE_TRANSFER_ERC721_FLAG function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { decodeBEFORE_TRANSFER_ERC721_FLAGResult } from "thirdweb/extensions/erc721";
+ * const result = decodeBEFORE_TRANSFER_ERC721_FLAGResult("...");
+ * ```
+ */
+export function decodeBEFORE_TRANSFER_ERC721_FLAGResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "BEFORE_TRANSFER_ERC721_FLAG" function on the contract.
+ * @param options - The options for the BEFORE_TRANSFER_ERC721_FLAG function.
+ * @returns The parsed result of the function call.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { BEFORE_TRANSFER_ERC721_FLAG } from "thirdweb/extensions/erc721";
+ *
+ * const result = await BEFORE_TRANSFER_ERC721_FLAG();
+ *
+ * ```
+ */
+export async function BEFORE_TRANSFER_ERC721_FLAG(
+  options: BaseTransactionOptions,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/ON_ROYALTY_INFO_FLAG.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/ON_ROYALTY_INFO_FLAG.ts
@@ -1,0 +1,51 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0xa77ec9bb" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the ON_ROYALTY_INFO_FLAG function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { decodeON_ROYALTY_INFO_FLAGResult } from "thirdweb/extensions/erc721";
+ * const result = decodeON_ROYALTY_INFO_FLAGResult("...");
+ * ```
+ */
+export function decodeON_ROYALTY_INFO_FLAGResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "ON_ROYALTY_INFO_FLAG" function on the contract.
+ * @param options - The options for the ON_ROYALTY_INFO_FLAG function.
+ * @returns The parsed result of the function call.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { ON_ROYALTY_INFO_FLAG } from "thirdweb/extensions/erc721";
+ *
+ * const result = await ON_ROYALTY_INFO_FLAG();
+ *
+ * ```
+ */
+export async function ON_ROYALTY_INFO_FLAG(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/ON_TOKEN_URI_FLAG.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/ON_TOKEN_URI_FLAG.ts
@@ -1,0 +1,51 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0xdcbad62f" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the ON_TOKEN_URI_FLAG function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { decodeON_TOKEN_URI_FLAGResult } from "thirdweb/extensions/erc721";
+ * const result = decodeON_TOKEN_URI_FLAGResult("...");
+ * ```
+ */
+export function decodeON_TOKEN_URI_FLAGResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "ON_TOKEN_URI_FLAG" function on the contract.
+ * @param options - The options for the ON_TOKEN_URI_FLAG function.
+ * @returns The parsed result of the function call.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { ON_TOKEN_URI_FLAG } from "thirdweb/extensions/erc721";
+ *
+ * const result = await ON_TOKEN_URI_FLAG();
+ *
+ * ```
+ */
+export async function ON_TOKEN_URI_FLAG(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/_highestBitToZero.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/_highestBitToZero.ts
@@ -1,0 +1,92 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+/**
+ * Represents the parameters for the "_highestBitToZero" function.
+ */
+export type _highestBitToZeroParams = {
+  value: AbiParameterToPrimitiveType<{
+    name: "_value";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+};
+
+const FN_SELECTOR = "0xc3e2a033" as const;
+const FN_INPUTS = [
+  {
+    name: "_value",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "_highestBitToZero" function.
+ * @param options - The options for the _highestBitToZero function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { encode_highestBitToZeroParams } "thirdweb/extensions/erc721";
+ * const result = encode_highestBitToZeroParams({
+ *  value: ...,
+ * });
+ * ```
+ */
+export function encode_highestBitToZeroParams(
+  options: _highestBitToZeroParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.value]);
+}
+
+/**
+ * Decodes the result of the _highestBitToZero function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { decode_highestBitToZeroResult } from "thirdweb/extensions/erc721";
+ * const result = decode_highestBitToZeroResult("...");
+ * ```
+ */
+export function decode_highestBitToZeroResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "_highestBitToZero" function on the contract.
+ * @param options - The options for the _highestBitToZero function.
+ * @returns The parsed result of the function call.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { _highestBitToZero } from "thirdweb/extensions/erc721";
+ *
+ * const result = await _highestBitToZero({
+ *  value: ...,
+ * });
+ *
+ * ```
+ */
+export async function _highestBitToZero(
+  options: BaseTransactionOptions<_highestBitToZeroParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.value],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/balanceOf.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/balanceOf.ts
@@ -1,0 +1,90 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+/**
+ * Represents the parameters for the "balanceOf" function.
+ */
+export type BalanceOfParams = {
+  owner: AbiParameterToPrimitiveType<{
+    name: "owner";
+    type: "address";
+    internalType: "address";
+  }>;
+};
+
+const FN_SELECTOR = "0x70a08231" as const;
+const FN_INPUTS = [
+  {
+    name: "owner",
+    type: "address",
+    internalType: "address",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "balanceOf" function.
+ * @param options - The options for the balanceOf function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { encodeBalanceOfParams } "thirdweb/extensions/erc721";
+ * const result = encodeBalanceOfParams({
+ *  owner: ...,
+ * });
+ * ```
+ */
+export function encodeBalanceOfParams(options: BalanceOfParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.owner]);
+}
+
+/**
+ * Decodes the result of the balanceOf function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { decodeBalanceOfResult } from "thirdweb/extensions/erc721";
+ * const result = decodeBalanceOfResult("...");
+ * ```
+ */
+export function decodeBalanceOfResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "balanceOf" function on the contract.
+ * @param options - The options for the balanceOf function.
+ * @returns The parsed result of the function call.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { balanceOf } from "thirdweb/extensions/erc721";
+ *
+ * const result = await balanceOf({
+ *  owner: ...,
+ * });
+ *
+ * ```
+ */
+export async function balanceOf(
+  options: BaseTransactionOptions<BalanceOfParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.owner],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/contractURI.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/contractURI.ts
@@ -1,0 +1,51 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0xe8a3d485" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "string",
+    internalType: "string",
+  },
+] as const;
+
+/**
+ * Decodes the result of the contractURI function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { decodeContractURIResult } from "thirdweb/extensions/erc721";
+ * const result = decodeContractURIResult("...");
+ * ```
+ */
+export function decodeContractURIResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "contractURI" function on the contract.
+ * @param options - The options for the contractURI function.
+ * @returns The parsed result of the function call.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { contractURI } from "thirdweb/extensions/erc721";
+ *
+ * const result = await contractURI();
+ *
+ * ```
+ */
+export async function contractURI(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/explicitOwnershipOf.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/explicitOwnershipOf.ts
@@ -1,0 +1,114 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+/**
+ * Represents the parameters for the "explicitOwnershipOf" function.
+ */
+export type ExplicitOwnershipOfParams = {
+  tokenId: AbiParameterToPrimitiveType<{
+    name: "tokenId";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+};
+
+const FN_SELECTOR = "0xc23dc68f" as const;
+const FN_INPUTS = [
+  {
+    name: "tokenId",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "ownership",
+    type: "tuple",
+    internalType: "struct IERC721A.TokenOwnership",
+    components: [
+      {
+        name: "addr",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "startTimestamp",
+        type: "uint64",
+        internalType: "uint64",
+      },
+      {
+        name: "burned",
+        type: "bool",
+        internalType: "bool",
+      },
+      {
+        name: "extraData",
+        type: "uint24",
+        internalType: "uint24",
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "explicitOwnershipOf" function.
+ * @param options - The options for the explicitOwnershipOf function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { encodeExplicitOwnershipOfParams } "thirdweb/extensions/erc721";
+ * const result = encodeExplicitOwnershipOfParams({
+ *  tokenId: ...,
+ * });
+ * ```
+ */
+export function encodeExplicitOwnershipOfParams(
+  options: ExplicitOwnershipOfParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.tokenId]);
+}
+
+/**
+ * Decodes the result of the explicitOwnershipOf function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { decodeExplicitOwnershipOfResult } from "thirdweb/extensions/erc721";
+ * const result = decodeExplicitOwnershipOfResult("...");
+ * ```
+ */
+export function decodeExplicitOwnershipOfResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "explicitOwnershipOf" function on the contract.
+ * @param options - The options for the explicitOwnershipOf function.
+ * @returns The parsed result of the function call.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { explicitOwnershipOf } from "thirdweb/extensions/erc721";
+ *
+ * const result = await explicitOwnershipOf({
+ *  tokenId: ...,
+ * });
+ *
+ * ```
+ */
+export async function explicitOwnershipOf(
+  options: BaseTransactionOptions<ExplicitOwnershipOfParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.tokenId],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/explicitOwnershipsOf.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/explicitOwnershipsOf.ts
@@ -1,0 +1,114 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+/**
+ * Represents the parameters for the "explicitOwnershipsOf" function.
+ */
+export type ExplicitOwnershipsOfParams = {
+  tokenIds: AbiParameterToPrimitiveType<{
+    name: "tokenIds";
+    type: "uint256[]";
+    internalType: "uint256[]";
+  }>;
+};
+
+const FN_SELECTOR = "0x5bbb2177" as const;
+const FN_INPUTS = [
+  {
+    name: "tokenIds",
+    type: "uint256[]",
+    internalType: "uint256[]",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "tuple[]",
+    internalType: "struct IERC721A.TokenOwnership[]",
+    components: [
+      {
+        name: "addr",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "startTimestamp",
+        type: "uint64",
+        internalType: "uint64",
+      },
+      {
+        name: "burned",
+        type: "bool",
+        internalType: "bool",
+      },
+      {
+        name: "extraData",
+        type: "uint24",
+        internalType: "uint24",
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "explicitOwnershipsOf" function.
+ * @param options - The options for the explicitOwnershipsOf function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { encodeExplicitOwnershipsOfParams } "thirdweb/extensions/erc721";
+ * const result = encodeExplicitOwnershipsOfParams({
+ *  tokenIds: ...,
+ * });
+ * ```
+ */
+export function encodeExplicitOwnershipsOfParams(
+  options: ExplicitOwnershipsOfParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.tokenIds]);
+}
+
+/**
+ * Decodes the result of the explicitOwnershipsOf function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { decodeExplicitOwnershipsOfResult } from "thirdweb/extensions/erc721";
+ * const result = decodeExplicitOwnershipsOfResult("...");
+ * ```
+ */
+export function decodeExplicitOwnershipsOfResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "explicitOwnershipsOf" function on the contract.
+ * @param options - The options for the explicitOwnershipsOf function.
+ * @returns The parsed result of the function call.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { explicitOwnershipsOf } from "thirdweb/extensions/erc721";
+ *
+ * const result = await explicitOwnershipsOf({
+ *  tokenIds: ...,
+ * });
+ *
+ * ```
+ */
+export async function explicitOwnershipsOf(
+  options: BaseTransactionOptions<ExplicitOwnershipsOfParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.tokenIds],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/getAllHooks.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/getAllHooks.ts
@@ -1,0 +1,88 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0xfbea28c0" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "hooks",
+    type: "tuple",
+    internalType: "struct IERC721HookInstaller.ERC721Hooks",
+    components: [
+      {
+        name: "beforeMint",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "beforeTransfer",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "beforeBurn",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "beforeApprove",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "beforeApproveForAll",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "tokenURI",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "royaltyInfo",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Decodes the result of the getAllHooks function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { decodeGetAllHooksResult } from "thirdweb/extensions/erc721";
+ * const result = decodeGetAllHooksResult("...");
+ * ```
+ */
+export function decodeGetAllHooksResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "getAllHooks" function on the contract.
+ * @param options - The options for the getAllHooks function.
+ * @returns The parsed result of the function call.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { getAllHooks } from "thirdweb/extensions/erc721";
+ *
+ * const result = await getAllHooks();
+ *
+ * ```
+ */
+export async function getAllHooks(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/getApproved.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/getApproved.ts
@@ -1,0 +1,90 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+/**
+ * Represents the parameters for the "getApproved" function.
+ */
+export type GetApprovedParams = {
+  tokenId: AbiParameterToPrimitiveType<{
+    name: "tokenId";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+};
+
+const FN_SELECTOR = "0x081812fc" as const;
+const FN_INPUTS = [
+  {
+    name: "tokenId",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "address",
+    internalType: "address",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getApproved" function.
+ * @param options - The options for the getApproved function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { encodeGetApprovedParams } "thirdweb/extensions/erc721";
+ * const result = encodeGetApprovedParams({
+ *  tokenId: ...,
+ * });
+ * ```
+ */
+export function encodeGetApprovedParams(options: GetApprovedParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.tokenId]);
+}
+
+/**
+ * Decodes the result of the getApproved function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { decodeGetApprovedResult } from "thirdweb/extensions/erc721";
+ * const result = decodeGetApprovedResult("...");
+ * ```
+ */
+export function decodeGetApprovedResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "getApproved" function on the contract.
+ * @param options - The options for the getApproved function.
+ * @returns The parsed result of the function call.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { getApproved } from "thirdweb/extensions/erc721";
+ *
+ * const result = await getApproved({
+ *  tokenId: ...,
+ * });
+ *
+ * ```
+ */
+export async function getApproved(
+  options: BaseTransactionOptions<GetApprovedParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.tokenId],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/getHookFallbackFunctionCall.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/getHookFallbackFunctionCall.ts
@@ -1,0 +1,109 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+/**
+ * Represents the parameters for the "getHookFallbackFunctionCall" function.
+ */
+export type GetHookFallbackFunctionCallParams = {
+  selector: AbiParameterToPrimitiveType<{
+    name: "_selector";
+    type: "bytes4";
+    internalType: "bytes4";
+  }>;
+};
+
+const FN_SELECTOR = "0x45e56ce0" as const;
+const FN_INPUTS = [
+  {
+    name: "_selector",
+    type: "bytes4",
+    internalType: "bytes4",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "tuple",
+    internalType: "struct IHookInstaller.HookFallbackFunctionCall",
+    components: [
+      {
+        name: "target",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "callType",
+        type: "uint8",
+        internalType: "enum IHookInfo.CallType",
+      },
+      {
+        name: "permissioned",
+        type: "bool",
+        internalType: "bool",
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getHookFallbackFunctionCall" function.
+ * @param options - The options for the getHookFallbackFunctionCall function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { encodeGetHookFallbackFunctionCallParams } "thirdweb/extensions/erc721";
+ * const result = encodeGetHookFallbackFunctionCallParams({
+ *  selector: ...,
+ * });
+ * ```
+ */
+export function encodeGetHookFallbackFunctionCallParams(
+  options: GetHookFallbackFunctionCallParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.selector]);
+}
+
+/**
+ * Decodes the result of the getHookFallbackFunctionCall function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { decodeGetHookFallbackFunctionCallResult } from "thirdweb/extensions/erc721";
+ * const result = decodeGetHookFallbackFunctionCallResult("...");
+ * ```
+ */
+export function decodeGetHookFallbackFunctionCallResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "getHookFallbackFunctionCall" function on the contract.
+ * @param options - The options for the getHookFallbackFunctionCall function.
+ * @returns The parsed result of the function call.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { getHookFallbackFunctionCall } from "thirdweb/extensions/erc721";
+ *
+ * const result = await getHookFallbackFunctionCall({
+ *  selector: ...,
+ * });
+ *
+ * ```
+ */
+export async function getHookFallbackFunctionCall(
+  options: BaseTransactionOptions<GetHookFallbackFunctionCallParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.selector],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/getHookImplementation.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/getHookImplementation.ts
@@ -1,0 +1,92 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+/**
+ * Represents the parameters for the "getHookImplementation" function.
+ */
+export type GetHookImplementationParams = {
+  flag: AbiParameterToPrimitiveType<{
+    name: "_flag";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+};
+
+const FN_SELECTOR = "0x24077953" as const;
+const FN_INPUTS = [
+  {
+    name: "_flag",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "address",
+    internalType: "address",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getHookImplementation" function.
+ * @param options - The options for the getHookImplementation function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { encodeGetHookImplementationParams } "thirdweb/extensions/erc721";
+ * const result = encodeGetHookImplementationParams({
+ *  flag: ...,
+ * });
+ * ```
+ */
+export function encodeGetHookImplementationParams(
+  options: GetHookImplementationParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.flag]);
+}
+
+/**
+ * Decodes the result of the getHookImplementation function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { decodeGetHookImplementationResult } from "thirdweb/extensions/erc721";
+ * const result = decodeGetHookImplementationResult("...");
+ * ```
+ */
+export function decodeGetHookImplementationResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "getHookImplementation" function on the contract.
+ * @param options - The options for the getHookImplementation function.
+ * @returns The parsed result of the function call.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { getHookImplementation } from "thirdweb/extensions/erc721";
+ *
+ * const result = await getHookImplementation({
+ *  flag: ...,
+ * });
+ *
+ * ```
+ */
+export async function getHookImplementation(
+  options: BaseTransactionOptions<GetHookImplementationParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.flag],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/isApprovedForAll.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/isApprovedForAll.ts
@@ -1,0 +1,102 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+/**
+ * Represents the parameters for the "isApprovedForAll" function.
+ */
+export type IsApprovedForAllParams = {
+  owner: AbiParameterToPrimitiveType<{
+    name: "owner";
+    type: "address";
+    internalType: "address";
+  }>;
+  operator: AbiParameterToPrimitiveType<{
+    name: "operator";
+    type: "address";
+    internalType: "address";
+  }>;
+};
+
+const FN_SELECTOR = "0xe985e9c5" as const;
+const FN_INPUTS = [
+  {
+    name: "owner",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "operator",
+    type: "address",
+    internalType: "address",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "bool",
+    internalType: "bool",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "isApprovedForAll" function.
+ * @param options - The options for the isApprovedForAll function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { encodeIsApprovedForAllParams } "thirdweb/extensions/erc721";
+ * const result = encodeIsApprovedForAllParams({
+ *  owner: ...,
+ *  operator: ...,
+ * });
+ * ```
+ */
+export function encodeIsApprovedForAllParams(options: IsApprovedForAllParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.owner, options.operator]);
+}
+
+/**
+ * Decodes the result of the isApprovedForAll function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { decodeIsApprovedForAllResult } from "thirdweb/extensions/erc721";
+ * const result = decodeIsApprovedForAllResult("...");
+ * ```
+ */
+export function decodeIsApprovedForAllResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "isApprovedForAll" function on the contract.
+ * @param options - The options for the isApprovedForAll function.
+ * @returns The parsed result of the function call.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { isApprovedForAll } from "thirdweb/extensions/erc721";
+ *
+ * const result = await isApprovedForAll({
+ *  owner: ...,
+ *  operator: ...,
+ * });
+ *
+ * ```
+ */
+export async function isApprovedForAll(
+  options: BaseTransactionOptions<IsApprovedForAllParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.owner, options.operator],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/name.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/name.ts
@@ -1,0 +1,51 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x06fdde03" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "string",
+    internalType: "string",
+  },
+] as const;
+
+/**
+ * Decodes the result of the name function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { decodeNameResult } from "thirdweb/extensions/erc721";
+ * const result = decodeNameResult("...");
+ * ```
+ */
+export function decodeNameResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "name" function on the contract.
+ * @param options - The options for the name function.
+ * @returns The parsed result of the function call.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { name } from "thirdweb/extensions/erc721";
+ *
+ * const result = await name();
+ *
+ * ```
+ */
+export async function name(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/owner.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/owner.ts
@@ -1,0 +1,51 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x8da5cb5b" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "result",
+    type: "address",
+    internalType: "address",
+  },
+] as const;
+
+/**
+ * Decodes the result of the owner function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { decodeOwnerResult } from "thirdweb/extensions/erc721";
+ * const result = decodeOwnerResult("...");
+ * ```
+ */
+export function decodeOwnerResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "owner" function on the contract.
+ * @param options - The options for the owner function.
+ * @returns The parsed result of the function call.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { owner } from "thirdweb/extensions/erc721";
+ *
+ * const result = await owner();
+ *
+ * ```
+ */
+export async function owner(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/ownerOf.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/ownerOf.ts
@@ -1,0 +1,88 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+/**
+ * Represents the parameters for the "ownerOf" function.
+ */
+export type OwnerOfParams = {
+  tokenId: AbiParameterToPrimitiveType<{
+    name: "tokenId";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+};
+
+const FN_SELECTOR = "0x6352211e" as const;
+const FN_INPUTS = [
+  {
+    name: "tokenId",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "address",
+    internalType: "address",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "ownerOf" function.
+ * @param options - The options for the ownerOf function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { encodeOwnerOfParams } "thirdweb/extensions/erc721";
+ * const result = encodeOwnerOfParams({
+ *  tokenId: ...,
+ * });
+ * ```
+ */
+export function encodeOwnerOfParams(options: OwnerOfParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.tokenId]);
+}
+
+/**
+ * Decodes the result of the ownerOf function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { decodeOwnerOfResult } from "thirdweb/extensions/erc721";
+ * const result = decodeOwnerOfResult("...");
+ * ```
+ */
+export function decodeOwnerOfResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "ownerOf" function on the contract.
+ * @param options - The options for the ownerOf function.
+ * @returns The parsed result of the function call.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { ownerOf } from "thirdweb/extensions/erc721";
+ *
+ * const result = await ownerOf({
+ *  tokenId: ...,
+ * });
+ *
+ * ```
+ */
+export async function ownerOf(options: BaseTransactionOptions<OwnerOfParams>) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.tokenId],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/ownershipHandoverExpiresAt.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/ownershipHandoverExpiresAt.ts
@@ -1,0 +1,92 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+/**
+ * Represents the parameters for the "ownershipHandoverExpiresAt" function.
+ */
+export type OwnershipHandoverExpiresAtParams = {
+  pendingOwner: AbiParameterToPrimitiveType<{
+    name: "pendingOwner";
+    type: "address";
+    internalType: "address";
+  }>;
+};
+
+const FN_SELECTOR = "0xfee81cf4" as const;
+const FN_INPUTS = [
+  {
+    name: "pendingOwner",
+    type: "address",
+    internalType: "address",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "result",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "ownershipHandoverExpiresAt" function.
+ * @param options - The options for the ownershipHandoverExpiresAt function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { encodeOwnershipHandoverExpiresAtParams } "thirdweb/extensions/erc721";
+ * const result = encodeOwnershipHandoverExpiresAtParams({
+ *  pendingOwner: ...,
+ * });
+ * ```
+ */
+export function encodeOwnershipHandoverExpiresAtParams(
+  options: OwnershipHandoverExpiresAtParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.pendingOwner]);
+}
+
+/**
+ * Decodes the result of the ownershipHandoverExpiresAt function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { decodeOwnershipHandoverExpiresAtResult } from "thirdweb/extensions/erc721";
+ * const result = decodeOwnershipHandoverExpiresAtResult("...");
+ * ```
+ */
+export function decodeOwnershipHandoverExpiresAtResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "ownershipHandoverExpiresAt" function on the contract.
+ * @param options - The options for the ownershipHandoverExpiresAt function.
+ * @returns The parsed result of the function call.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { ownershipHandoverExpiresAt } from "thirdweb/extensions/erc721";
+ *
+ * const result = await ownershipHandoverExpiresAt({
+ *  pendingOwner: ...,
+ * });
+ *
+ * ```
+ */
+export async function ownershipHandoverExpiresAt(
+  options: BaseTransactionOptions<OwnershipHandoverExpiresAtParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.pendingOwner],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/royaltyInfo.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/royaltyInfo.ts
@@ -1,0 +1,107 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+/**
+ * Represents the parameters for the "royaltyInfo" function.
+ */
+export type RoyaltyInfoParams = {
+  tokenId: AbiParameterToPrimitiveType<{
+    name: "_tokenId";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+  salePrice: AbiParameterToPrimitiveType<{
+    name: "_salePrice";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+};
+
+const FN_SELECTOR = "0x2a55205a" as const;
+const FN_INPUTS = [
+  {
+    name: "_tokenId",
+    type: "uint256",
+    internalType: "uint256",
+  },
+  {
+    name: "_salePrice",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "royaltyInfo" function.
+ * @param options - The options for the royaltyInfo function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { encodeRoyaltyInfoParams } "thirdweb/extensions/erc721";
+ * const result = encodeRoyaltyInfoParams({
+ *  tokenId: ...,
+ *  salePrice: ...,
+ * });
+ * ```
+ */
+export function encodeRoyaltyInfoParams(options: RoyaltyInfoParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.tokenId, options.salePrice]);
+}
+
+/**
+ * Decodes the result of the royaltyInfo function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { decodeRoyaltyInfoResult } from "thirdweb/extensions/erc721";
+ * const result = decodeRoyaltyInfoResult("...");
+ * ```
+ */
+export function decodeRoyaltyInfoResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result);
+}
+
+/**
+ * Calls the "royaltyInfo" function on the contract.
+ * @param options - The options for the royaltyInfo function.
+ * @returns The parsed result of the function call.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { royaltyInfo } from "thirdweb/extensions/erc721";
+ *
+ * const result = await royaltyInfo({
+ *  tokenId: ...,
+ *  salePrice: ...,
+ * });
+ *
+ * ```
+ */
+export async function royaltyInfo(
+  options: BaseTransactionOptions<RoyaltyInfoParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.tokenId, options.salePrice],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/supportsInterface.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/supportsInterface.ts
@@ -1,0 +1,92 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+/**
+ * Represents the parameters for the "supportsInterface" function.
+ */
+export type SupportsInterfaceParams = {
+  interfaceId: AbiParameterToPrimitiveType<{
+    name: "_interfaceId";
+    type: "bytes4";
+    internalType: "bytes4";
+  }>;
+};
+
+const FN_SELECTOR = "0x01ffc9a7" as const;
+const FN_INPUTS = [
+  {
+    name: "_interfaceId",
+    type: "bytes4",
+    internalType: "bytes4",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "bool",
+    internalType: "bool",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "supportsInterface" function.
+ * @param options - The options for the supportsInterface function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { encodeSupportsInterfaceParams } "thirdweb/extensions/erc721";
+ * const result = encodeSupportsInterfaceParams({
+ *  interfaceId: ...,
+ * });
+ * ```
+ */
+export function encodeSupportsInterfaceParams(
+  options: SupportsInterfaceParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.interfaceId]);
+}
+
+/**
+ * Decodes the result of the supportsInterface function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { decodeSupportsInterfaceResult } from "thirdweb/extensions/erc721";
+ * const result = decodeSupportsInterfaceResult("...");
+ * ```
+ */
+export function decodeSupportsInterfaceResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "supportsInterface" function on the contract.
+ * @param options - The options for the supportsInterface function.
+ * @returns The parsed result of the function call.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { supportsInterface } from "thirdweb/extensions/erc721";
+ *
+ * const result = await supportsInterface({
+ *  interfaceId: ...,
+ * });
+ *
+ * ```
+ */
+export async function supportsInterface(
+  options: BaseTransactionOptions<SupportsInterfaceParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.interfaceId],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/symbol.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/symbol.ts
@@ -1,0 +1,51 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x95d89b41" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "string",
+    internalType: "string",
+  },
+] as const;
+
+/**
+ * Decodes the result of the symbol function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { decodeSymbolResult } from "thirdweb/extensions/erc721";
+ * const result = decodeSymbolResult("...");
+ * ```
+ */
+export function decodeSymbolResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "symbol" function on the contract.
+ * @param options - The options for the symbol function.
+ * @returns The parsed result of the function call.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { symbol } from "thirdweb/extensions/erc721";
+ *
+ * const result = await symbol();
+ *
+ * ```
+ */
+export async function symbol(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/tokenURI.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/tokenURI.ts
@@ -1,0 +1,90 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+/**
+ * Represents the parameters for the "tokenURI" function.
+ */
+export type TokenURIParams = {
+  id: AbiParameterToPrimitiveType<{
+    name: "_id";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+};
+
+const FN_SELECTOR = "0xc87b56dd" as const;
+const FN_INPUTS = [
+  {
+    name: "_id",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "string",
+    internalType: "string",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "tokenURI" function.
+ * @param options - The options for the tokenURI function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { encodeTokenURIParams } "thirdweb/extensions/erc721";
+ * const result = encodeTokenURIParams({
+ *  id: ...,
+ * });
+ * ```
+ */
+export function encodeTokenURIParams(options: TokenURIParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.id]);
+}
+
+/**
+ * Decodes the result of the tokenURI function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { decodeTokenURIResult } from "thirdweb/extensions/erc721";
+ * const result = decodeTokenURIResult("...");
+ * ```
+ */
+export function decodeTokenURIResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "tokenURI" function on the contract.
+ * @param options - The options for the tokenURI function.
+ * @returns The parsed result of the function call.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { tokenURI } from "thirdweb/extensions/erc721";
+ *
+ * const result = await tokenURI({
+ *  id: ...,
+ * });
+ *
+ * ```
+ */
+export async function tokenURI(
+  options: BaseTransactionOptions<TokenURIParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.id],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/tokensOfOwner.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/tokensOfOwner.ts
@@ -1,0 +1,90 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+/**
+ * Represents the parameters for the "tokensOfOwner" function.
+ */
+export type TokensOfOwnerParams = {
+  owner: AbiParameterToPrimitiveType<{
+    name: "owner";
+    type: "address";
+    internalType: "address";
+  }>;
+};
+
+const FN_SELECTOR = "0x8462151c" as const;
+const FN_INPUTS = [
+  {
+    name: "owner",
+    type: "address",
+    internalType: "address",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "uint256[]",
+    internalType: "uint256[]",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "tokensOfOwner" function.
+ * @param options - The options for the tokensOfOwner function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { encodeTokensOfOwnerParams } "thirdweb/extensions/erc721";
+ * const result = encodeTokensOfOwnerParams({
+ *  owner: ...,
+ * });
+ * ```
+ */
+export function encodeTokensOfOwnerParams(options: TokensOfOwnerParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.owner]);
+}
+
+/**
+ * Decodes the result of the tokensOfOwner function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { decodeTokensOfOwnerResult } from "thirdweb/extensions/erc721";
+ * const result = decodeTokensOfOwnerResult("...");
+ * ```
+ */
+export function decodeTokensOfOwnerResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "tokensOfOwner" function on the contract.
+ * @param options - The options for the tokensOfOwner function.
+ * @returns The parsed result of the function call.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { tokensOfOwner } from "thirdweb/extensions/erc721";
+ *
+ * const result = await tokensOfOwner({
+ *  owner: ...,
+ * });
+ *
+ * ```
+ */
+export async function tokensOfOwner(
+  options: BaseTransactionOptions<TokensOfOwnerParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.owner],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/tokensOfOwnerIn.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/tokensOfOwnerIn.ts
@@ -1,0 +1,118 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+/**
+ * Represents the parameters for the "tokensOfOwnerIn" function.
+ */
+export type TokensOfOwnerInParams = {
+  owner: AbiParameterToPrimitiveType<{
+    name: "owner";
+    type: "address";
+    internalType: "address";
+  }>;
+  start: AbiParameterToPrimitiveType<{
+    name: "start";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+  stop: AbiParameterToPrimitiveType<{
+    name: "stop";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+};
+
+const FN_SELECTOR = "0x99a2557a" as const;
+const FN_INPUTS = [
+  {
+    name: "owner",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "start",
+    type: "uint256",
+    internalType: "uint256",
+  },
+  {
+    name: "stop",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "uint256[]",
+    internalType: "uint256[]",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "tokensOfOwnerIn" function.
+ * @param options - The options for the tokensOfOwnerIn function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { encodeTokensOfOwnerInParams } "thirdweb/extensions/erc721";
+ * const result = encodeTokensOfOwnerInParams({
+ *  owner: ...,
+ *  start: ...,
+ *  stop: ...,
+ * });
+ * ```
+ */
+export function encodeTokensOfOwnerInParams(options: TokensOfOwnerInParams) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.owner,
+    options.start,
+    options.stop,
+  ]);
+}
+
+/**
+ * Decodes the result of the tokensOfOwnerIn function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { decodeTokensOfOwnerInResult } from "thirdweb/extensions/erc721";
+ * const result = decodeTokensOfOwnerInResult("...");
+ * ```
+ */
+export function decodeTokensOfOwnerInResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "tokensOfOwnerIn" function on the contract.
+ * @param options - The options for the tokensOfOwnerIn function.
+ * @returns The parsed result of the function call.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { tokensOfOwnerIn } from "thirdweb/extensions/erc721";
+ *
+ * const result = await tokensOfOwnerIn({
+ *  owner: ...,
+ *  start: ...,
+ *  stop: ...,
+ * });
+ *
+ * ```
+ */
+export async function tokensOfOwnerIn(
+  options: BaseTransactionOptions<TokensOfOwnerInParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.owner, options.start, options.stop],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/totalSupply.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/totalSupply.ts
@@ -1,0 +1,51 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x18160ddd" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "result",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the totalSupply function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { decodeTotalSupplyResult } from "thirdweb/extensions/erc721";
+ * const result = decodeTotalSupplyResult("...");
+ * ```
+ */
+export function decodeTotalSupplyResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "totalSupply" function on the contract.
+ * @param options - The options for the totalSupply function.
+ * @returns The parsed result of the function call.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { totalSupply } from "thirdweb/extensions/erc721";
+ *
+ * const result = await totalSupply();
+ *
+ * ```
+ */
+export async function totalSupply(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/write/approve.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/write/approve.ts
@@ -1,0 +1,95 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+
+/**
+ * Represents the parameters for the "approve" function.
+ */
+
+export type ApproveParams = {
+  spender: AbiParameterToPrimitiveType<{
+    name: "_spender";
+    type: "address";
+    internalType: "address";
+  }>;
+  id: AbiParameterToPrimitiveType<{
+    name: "_id";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+};
+
+const FN_SELECTOR = "0x095ea7b3" as const;
+const FN_INPUTS = [
+  {
+    name: "_spender",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "_id",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "approve" function.
+ * @param options - The options for the approve function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { encodeApproveParams } "thirdweb/extensions/erc721";
+ * const result = encodeApproveParams({
+ *  spender: ...,
+ *  id: ...,
+ * });
+ * ```
+ */
+export function encodeApproveParams(options: ApproveParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.spender, options.id]);
+}
+
+/**
+ * Calls the "approve" function on the contract.
+ * @param options - The options for the "approve" function.
+ * @returns A prepared transaction object.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { approve } from "thirdweb/extensions/erc721";
+ *
+ * const transaction = approve({
+ *  contract,
+ *  spender: ...,
+ *  id: ...,
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function approve(
+  options: BaseTransactionOptions<
+    | ApproveParams
+    | {
+        asyncParams: () => Promise<ApproveParams>;
+      }
+  >,
+) {
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params:
+      "asyncParams" in options
+        ? async () => {
+            const resolvedParams = await options.asyncParams();
+            return [resolvedParams.spender, resolvedParams.id] as const;
+          }
+        : [options.spender, options.id],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/write/burn.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/write/burn.ts
@@ -1,0 +1,95 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+
+/**
+ * Represents the parameters for the "burn" function.
+ */
+
+export type BurnParams = {
+  tokenId: AbiParameterToPrimitiveType<{
+    name: "_tokenId";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+  data: AbiParameterToPrimitiveType<{
+    name: "_data";
+    type: "bytes";
+    internalType: "bytes";
+  }>;
+};
+
+const FN_SELECTOR = "0xfe9d9303" as const;
+const FN_INPUTS = [
+  {
+    name: "_tokenId",
+    type: "uint256",
+    internalType: "uint256",
+  },
+  {
+    name: "_data",
+    type: "bytes",
+    internalType: "bytes",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "burn" function.
+ * @param options - The options for the burn function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { encodeBurnParams } "thirdweb/extensions/erc721";
+ * const result = encodeBurnParams({
+ *  tokenId: ...,
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeBurnParams(options: BurnParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.tokenId, options.data]);
+}
+
+/**
+ * Calls the "burn" function on the contract.
+ * @param options - The options for the "burn" function.
+ * @returns A prepared transaction object.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { burn } from "thirdweb/extensions/erc721";
+ *
+ * const transaction = burn({
+ *  contract,
+ *  tokenId: ...,
+ *  data: ...,
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function burn(
+  options: BaseTransactionOptions<
+    | BurnParams
+    | {
+        asyncParams: () => Promise<BurnParams>;
+      }
+  >,
+) {
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params:
+      "asyncParams" in options
+        ? async () => {
+            const resolvedParams = await options.asyncParams();
+            return [resolvedParams.tokenId, resolvedParams.data] as const;
+          }
+        : [options.tokenId, options.data],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/write/cancelOwnershipHandover.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/write/cancelOwnershipHandover.ts
@@ -1,0 +1,29 @@
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+
+const FN_SELECTOR = "0x54d1f13d" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Calls the "cancelOwnershipHandover" function on the contract.
+ * @param options - The options for the "cancelOwnershipHandover" function.
+ * @returns A prepared transaction object.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { cancelOwnershipHandover } from "thirdweb/extensions/erc721";
+ *
+ * const transaction = cancelOwnershipHandover();
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function cancelOwnershipHandover(options: BaseTransactionOptions) {
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/write/completeOwnershipHandover.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/write/completeOwnershipHandover.ts
@@ -1,0 +1,85 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+
+/**
+ * Represents the parameters for the "completeOwnershipHandover" function.
+ */
+
+export type CompleteOwnershipHandoverParams = {
+  pendingOwner: AbiParameterToPrimitiveType<{
+    name: "pendingOwner";
+    type: "address";
+    internalType: "address";
+  }>;
+};
+
+const FN_SELECTOR = "0xf04e283e" as const;
+const FN_INPUTS = [
+  {
+    name: "pendingOwner",
+    type: "address",
+    internalType: "address",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "completeOwnershipHandover" function.
+ * @param options - The options for the completeOwnershipHandover function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { encodeCompleteOwnershipHandoverParams } "thirdweb/extensions/erc721";
+ * const result = encodeCompleteOwnershipHandoverParams({
+ *  pendingOwner: ...,
+ * });
+ * ```
+ */
+export function encodeCompleteOwnershipHandoverParams(
+  options: CompleteOwnershipHandoverParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.pendingOwner]);
+}
+
+/**
+ * Calls the "completeOwnershipHandover" function on the contract.
+ * @param options - The options for the "completeOwnershipHandover" function.
+ * @returns A prepared transaction object.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { completeOwnershipHandover } from "thirdweb/extensions/erc721";
+ *
+ * const transaction = completeOwnershipHandover({
+ *  contract,
+ *  pendingOwner: ...,
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function completeOwnershipHandover(
+  options: BaseTransactionOptions<
+    | CompleteOwnershipHandoverParams
+    | {
+        asyncParams: () => Promise<CompleteOwnershipHandoverParams>;
+      }
+  >,
+) {
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params:
+      "asyncParams" in options
+        ? async () => {
+            const resolvedParams = await options.asyncParams();
+            return [resolvedParams.pendingOwner] as const;
+          }
+        : [options.pendingOwner],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/write/installHook.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/write/installHook.ts
@@ -1,0 +1,105 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+
+/**
+ * Represents the parameters for the "installHook" function.
+ */
+
+export type InstallHookParams = {
+  params: AbiParameterToPrimitiveType<{
+    name: "_params";
+    type: "tuple";
+    internalType: "struct IHookInstaller.InstallHookParams";
+    components: [
+      { name: "hook"; type: "address"; internalType: "contract IHook" },
+      { name: "initCallValue"; type: "uint256"; internalType: "uint256" },
+      { name: "initCalldata"; type: "bytes"; internalType: "bytes" },
+    ];
+  }>;
+};
+
+const FN_SELECTOR = "0xc1b419a5" as const;
+const FN_INPUTS = [
+  {
+    name: "_params",
+    type: "tuple",
+    internalType: "struct IHookInstaller.InstallHookParams",
+    components: [
+      {
+        name: "hook",
+        type: "address",
+        internalType: "contract IHook",
+      },
+      {
+        name: "initCallValue",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "initCalldata",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "installHook" function.
+ * @param options - The options for the installHook function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { encodeInstallHookParams } "thirdweb/extensions/erc721";
+ * const result = encodeInstallHookParams({
+ *  params: ...,
+ * });
+ * ```
+ */
+export function encodeInstallHookParams(options: InstallHookParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.params]);
+}
+
+/**
+ * Calls the "installHook" function on the contract.
+ * @param options - The options for the "installHook" function.
+ * @returns A prepared transaction object.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { installHook } from "thirdweb/extensions/erc721";
+ *
+ * const transaction = installHook({
+ *  contract,
+ *  params: ...,
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function installHook(
+  options: BaseTransactionOptions<
+    | InstallHookParams
+    | {
+        asyncParams: () => Promise<InstallHookParams>;
+      }
+  >,
+) {
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params:
+      "asyncParams" in options
+        ? async () => {
+            const resolvedParams = await options.asyncParams();
+            return [resolvedParams.params] as const;
+          }
+        : [options.params],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/write/mint.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/write/mint.ts
@@ -1,0 +1,115 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+
+/**
+ * Represents the parameters for the "mint" function.
+ */
+
+export type MintParams = {
+  to: AbiParameterToPrimitiveType<{
+    name: "_to";
+    type: "address";
+    internalType: "address";
+  }>;
+  quantity: AbiParameterToPrimitiveType<{
+    name: "_quantity";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+  data: AbiParameterToPrimitiveType<{
+    name: "_data";
+    type: "bytes";
+    internalType: "bytes";
+  }>;
+};
+
+const FN_SELECTOR = "0x94d008ef" as const;
+const FN_INPUTS = [
+  {
+    name: "_to",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "_quantity",
+    type: "uint256",
+    internalType: "uint256",
+  },
+  {
+    name: "_data",
+    type: "bytes",
+    internalType: "bytes",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "mint" function.
+ * @param options - The options for the mint function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { encodeMintParams } "thirdweb/extensions/erc721";
+ * const result = encodeMintParams({
+ *  to: ...,
+ *  quantity: ...,
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeMintParams(options: MintParams) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.to,
+    options.quantity,
+    options.data,
+  ]);
+}
+
+/**
+ * Calls the "mint" function on the contract.
+ * @param options - The options for the "mint" function.
+ * @returns A prepared transaction object.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { mint } from "thirdweb/extensions/erc721";
+ *
+ * const transaction = mint({
+ *  contract,
+ *  to: ...,
+ *  quantity: ...,
+ *  data: ...,
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function mint(
+  options: BaseTransactionOptions<
+    | MintParams
+    | {
+        asyncParams: () => Promise<MintParams>;
+      }
+  >,
+) {
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params:
+      "asyncParams" in options
+        ? async () => {
+            const resolvedParams = await options.asyncParams();
+            return [
+              resolvedParams.to,
+              resolvedParams.quantity,
+              resolvedParams.data,
+            ] as const;
+          }
+        : [options.to, options.quantity, options.data],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/write/multicall.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/write/multicall.ts
@@ -1,0 +1,89 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+
+/**
+ * Represents the parameters for the "multicall" function.
+ */
+
+export type MulticallParams = {
+  data: AbiParameterToPrimitiveType<{
+    name: "data";
+    type: "bytes[]";
+    internalType: "bytes[]";
+  }>;
+};
+
+const FN_SELECTOR = "0xac9650d8" as const;
+const FN_INPUTS = [
+  {
+    name: "data",
+    type: "bytes[]",
+    internalType: "bytes[]",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "bytes[]",
+    internalType: "bytes[]",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "multicall" function.
+ * @param options - The options for the multicall function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { encodeMulticallParams } "thirdweb/extensions/erc721";
+ * const result = encodeMulticallParams({
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeMulticallParams(options: MulticallParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.data]);
+}
+
+/**
+ * Calls the "multicall" function on the contract.
+ * @param options - The options for the "multicall" function.
+ * @returns A prepared transaction object.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { multicall } from "thirdweb/extensions/erc721";
+ *
+ * const transaction = multicall({
+ *  contract,
+ *  data: ...,
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function multicall(
+  options: BaseTransactionOptions<
+    | MulticallParams
+    | {
+        asyncParams: () => Promise<MulticallParams>;
+      }
+  >,
+) {
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params:
+      "asyncParams" in options
+        ? async () => {
+            const resolvedParams = await options.asyncParams();
+            return [resolvedParams.data] as const;
+          }
+        : [options.data],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/write/renounceOwnership.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/write/renounceOwnership.ts
@@ -1,0 +1,29 @@
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+
+const FN_SELECTOR = "0x715018a6" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Calls the "renounceOwnership" function on the contract.
+ * @param options - The options for the "renounceOwnership" function.
+ * @returns A prepared transaction object.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { renounceOwnership } from "thirdweb/extensions/erc721";
+ *
+ * const transaction = renounceOwnership();
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function renounceOwnership(options: BaseTransactionOptions) {
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/write/requestOwnershipHandover.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/write/requestOwnershipHandover.ts
@@ -1,0 +1,29 @@
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+
+const FN_SELECTOR = "0x25692962" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Calls the "requestOwnershipHandover" function on the contract.
+ * @param options - The options for the "requestOwnershipHandover" function.
+ * @returns A prepared transaction object.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { requestOwnershipHandover } from "thirdweb/extensions/erc721";
+ *
+ * const transaction = requestOwnershipHandover();
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function requestOwnershipHandover(options: BaseTransactionOptions) {
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/write/safeTransferFrom.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/write/safeTransferFrom.ts
@@ -1,0 +1,115 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+
+/**
+ * Represents the parameters for the "safeTransferFrom" function.
+ */
+
+export type SafeTransferFromParams = {
+  from: AbiParameterToPrimitiveType<{
+    name: "from";
+    type: "address";
+    internalType: "address";
+  }>;
+  to: AbiParameterToPrimitiveType<{
+    name: "to";
+    type: "address";
+    internalType: "address";
+  }>;
+  tokenId: AbiParameterToPrimitiveType<{
+    name: "tokenId";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+};
+
+const FN_SELECTOR = "0x42842e0e" as const;
+const FN_INPUTS = [
+  {
+    name: "from",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "to",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "tokenId",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "safeTransferFrom" function.
+ * @param options - The options for the safeTransferFrom function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { encodeSafeTransferFromParams } "thirdweb/extensions/erc721";
+ * const result = encodeSafeTransferFromParams({
+ *  from: ...,
+ *  to: ...,
+ *  tokenId: ...,
+ * });
+ * ```
+ */
+export function encodeSafeTransferFromParams(options: SafeTransferFromParams) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.from,
+    options.to,
+    options.tokenId,
+  ]);
+}
+
+/**
+ * Calls the "safeTransferFrom" function on the contract.
+ * @param options - The options for the "safeTransferFrom" function.
+ * @returns A prepared transaction object.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { safeTransferFrom } from "thirdweb/extensions/erc721";
+ *
+ * const transaction = safeTransferFrom({
+ *  contract,
+ *  from: ...,
+ *  to: ...,
+ *  tokenId: ...,
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function safeTransferFrom(
+  options: BaseTransactionOptions<
+    | SafeTransferFromParams
+    | {
+        asyncParams: () => Promise<SafeTransferFromParams>;
+      }
+  >,
+) {
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params:
+      "asyncParams" in options
+        ? async () => {
+            const resolvedParams = await options.asyncParams();
+            return [
+              resolvedParams.from,
+              resolvedParams.to,
+              resolvedParams.tokenId,
+            ] as const;
+          }
+        : [options.from, options.to, options.tokenId],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/write/setApprovalForAll.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/write/setApprovalForAll.ts
@@ -1,0 +1,97 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+
+/**
+ * Represents the parameters for the "setApprovalForAll" function.
+ */
+
+export type SetApprovalForAllParams = {
+  operator: AbiParameterToPrimitiveType<{
+    name: "_operator";
+    type: "address";
+    internalType: "address";
+  }>;
+  approved: AbiParameterToPrimitiveType<{
+    name: "_approved";
+    type: "bool";
+    internalType: "bool";
+  }>;
+};
+
+const FN_SELECTOR = "0xa22cb465" as const;
+const FN_INPUTS = [
+  {
+    name: "_operator",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "_approved",
+    type: "bool",
+    internalType: "bool",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "setApprovalForAll" function.
+ * @param options - The options for the setApprovalForAll function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { encodeSetApprovalForAllParams } "thirdweb/extensions/erc721";
+ * const result = encodeSetApprovalForAllParams({
+ *  operator: ...,
+ *  approved: ...,
+ * });
+ * ```
+ */
+export function encodeSetApprovalForAllParams(
+  options: SetApprovalForAllParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.operator, options.approved]);
+}
+
+/**
+ * Calls the "setApprovalForAll" function on the contract.
+ * @param options - The options for the "setApprovalForAll" function.
+ * @returns A prepared transaction object.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { setApprovalForAll } from "thirdweb/extensions/erc721";
+ *
+ * const transaction = setApprovalForAll({
+ *  contract,
+ *  operator: ...,
+ *  approved: ...,
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function setApprovalForAll(
+  options: BaseTransactionOptions<
+    | SetApprovalForAllParams
+    | {
+        asyncParams: () => Promise<SetApprovalForAllParams>;
+      }
+  >,
+) {
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params:
+      "asyncParams" in options
+        ? async () => {
+            const resolvedParams = await options.asyncParams();
+            return [resolvedParams.operator, resolvedParams.approved] as const;
+          }
+        : [options.operator, options.approved],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/write/setContractURI.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/write/setContractURI.ts
@@ -1,0 +1,83 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+
+/**
+ * Represents the parameters for the "setContractURI" function.
+ */
+
+export type SetContractURIParams = {
+  uri: AbiParameterToPrimitiveType<{
+    name: "_uri";
+    type: "string";
+    internalType: "string";
+  }>;
+};
+
+const FN_SELECTOR = "0x938e3d7b" as const;
+const FN_INPUTS = [
+  {
+    name: "_uri",
+    type: "string",
+    internalType: "string",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "setContractURI" function.
+ * @param options - The options for the setContractURI function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { encodeSetContractURIParams } "thirdweb/extensions/erc721";
+ * const result = encodeSetContractURIParams({
+ *  uri: ...,
+ * });
+ * ```
+ */
+export function encodeSetContractURIParams(options: SetContractURIParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.uri]);
+}
+
+/**
+ * Calls the "setContractURI" function on the contract.
+ * @param options - The options for the "setContractURI" function.
+ * @returns A prepared transaction object.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { setContractURI } from "thirdweb/extensions/erc721";
+ *
+ * const transaction = setContractURI({
+ *  contract,
+ *  uri: ...,
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function setContractURI(
+  options: BaseTransactionOptions<
+    | SetContractURIParams
+    | {
+        asyncParams: () => Promise<SetContractURIParams>;
+      }
+  >,
+) {
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params:
+      "asyncParams" in options
+        ? async () => {
+            const resolvedParams = await options.asyncParams();
+            return [resolvedParams.uri] as const;
+          }
+        : [options.uri],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/write/transferFrom.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/write/transferFrom.ts
@@ -1,0 +1,111 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+
+/**
+ * Represents the parameters for the "transferFrom" function.
+ */
+
+export type TransferFromParams = {
+  from: AbiParameterToPrimitiveType<{
+    name: "_from";
+    type: "address";
+    internalType: "address";
+  }>;
+  to: AbiParameterToPrimitiveType<{
+    name: "_to";
+    type: "address";
+    internalType: "address";
+  }>;
+  id: AbiParameterToPrimitiveType<{
+    name: "_id";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+};
+
+const FN_SELECTOR = "0x23b872dd" as const;
+const FN_INPUTS = [
+  {
+    name: "_from",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "_to",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "_id",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "transferFrom" function.
+ * @param options - The options for the transferFrom function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { encodeTransferFromParams } "thirdweb/extensions/erc721";
+ * const result = encodeTransferFromParams({
+ *  from: ...,
+ *  to: ...,
+ *  id: ...,
+ * });
+ * ```
+ */
+export function encodeTransferFromParams(options: TransferFromParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.from, options.to, options.id]);
+}
+
+/**
+ * Calls the "transferFrom" function on the contract.
+ * @param options - The options for the "transferFrom" function.
+ * @returns A prepared transaction object.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { transferFrom } from "thirdweb/extensions/erc721";
+ *
+ * const transaction = transferFrom({
+ *  contract,
+ *  from: ...,
+ *  to: ...,
+ *  id: ...,
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function transferFrom(
+  options: BaseTransactionOptions<
+    | TransferFromParams
+    | {
+        asyncParams: () => Promise<TransferFromParams>;
+      }
+  >,
+) {
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params:
+      "asyncParams" in options
+        ? async () => {
+            const resolvedParams = await options.asyncParams();
+            return [
+              resolvedParams.from,
+              resolvedParams.to,
+              resolvedParams.id,
+            ] as const;
+          }
+        : [options.from, options.to, options.id],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/write/transferOwnership.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/write/transferOwnership.ts
@@ -1,0 +1,85 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+
+/**
+ * Represents the parameters for the "transferOwnership" function.
+ */
+
+export type TransferOwnershipParams = {
+  newOwner: AbiParameterToPrimitiveType<{
+    name: "newOwner";
+    type: "address";
+    internalType: "address";
+  }>;
+};
+
+const FN_SELECTOR = "0xf2fde38b" as const;
+const FN_INPUTS = [
+  {
+    name: "newOwner",
+    type: "address",
+    internalType: "address",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "transferOwnership" function.
+ * @param options - The options for the transferOwnership function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { encodeTransferOwnershipParams } "thirdweb/extensions/erc721";
+ * const result = encodeTransferOwnershipParams({
+ *  newOwner: ...,
+ * });
+ * ```
+ */
+export function encodeTransferOwnershipParams(
+  options: TransferOwnershipParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.newOwner]);
+}
+
+/**
+ * Calls the "transferOwnership" function on the contract.
+ * @param options - The options for the "transferOwnership" function.
+ * @returns A prepared transaction object.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { transferOwnership } from "thirdweb/extensions/erc721";
+ *
+ * const transaction = transferOwnership({
+ *  contract,
+ *  newOwner: ...,
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function transferOwnership(
+  options: BaseTransactionOptions<
+    | TransferOwnershipParams
+    | {
+        asyncParams: () => Promise<TransferOwnershipParams>;
+      }
+  >,
+) {
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params:
+      "asyncParams" in options
+        ? async () => {
+            const resolvedParams = await options.asyncParams();
+            return [resolvedParams.newOwner] as const;
+          }
+        : [options.newOwner],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/write/uninstallHook.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/write/uninstallHook.ts
@@ -1,0 +1,83 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+
+/**
+ * Represents the parameters for the "uninstallHook" function.
+ */
+
+export type UninstallHookParams = {
+  hooksToUninstall: AbiParameterToPrimitiveType<{
+    name: "_hooksToUninstall";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+};
+
+const FN_SELECTOR = "0x2382b7e6" as const;
+const FN_INPUTS = [
+  {
+    name: "_hooksToUninstall",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "uninstallHook" function.
+ * @param options - The options for the uninstallHook function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { encodeUninstallHookParams } "thirdweb/extensions/erc721";
+ * const result = encodeUninstallHookParams({
+ *  hooksToUninstall: ...,
+ * });
+ * ```
+ */
+export function encodeUninstallHookParams(options: UninstallHookParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.hooksToUninstall]);
+}
+
+/**
+ * Calls the "uninstallHook" function on the contract.
+ * @param options - The options for the "uninstallHook" function.
+ * @returns A prepared transaction object.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { uninstallHook } from "thirdweb/extensions/erc721";
+ *
+ * const transaction = uninstallHook({
+ *  contract,
+ *  hooksToUninstall: ...,
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function uninstallHook(
+  options: BaseTransactionOptions<
+    | UninstallHookParams
+    | {
+        asyncParams: () => Promise<UninstallHookParams>;
+      }
+  >,
+) {
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params:
+      "asyncParams" in options
+        ? async () => {
+            const resolvedParams = await options.asyncParams();
+            return [resolvedParams.hooksToUninstall] as const;
+          }
+        : [options.hooksToUninstall],
+  });
+}

--- a/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/BEFORE_APPROVE_ERC20_FLAG.ts
+++ b/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/BEFORE_APPROVE_ERC20_FLAG.ts
@@ -1,0 +1,53 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x8971e55c" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the BEFORE_APPROVE_ERC20_FLAG function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { decodeBEFORE_APPROVE_ERC20_FLAGResult } from "thirdweb/extensions/hooks";
+ * const result = decodeBEFORE_APPROVE_ERC20_FLAGResult("...");
+ * ```
+ */
+export function decodeBEFORE_APPROVE_ERC20_FLAGResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "BEFORE_APPROVE_ERC20_FLAG" function on the contract.
+ * @param options - The options for the BEFORE_APPROVE_ERC20_FLAG function.
+ * @returns The parsed result of the function call.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { BEFORE_APPROVE_ERC20_FLAG } from "thirdweb/extensions/hooks";
+ *
+ * const result = await BEFORE_APPROVE_ERC20_FLAG();
+ *
+ * ```
+ */
+export async function BEFORE_APPROVE_ERC20_FLAG(
+  options: BaseTransactionOptions,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/BEFORE_APPROVE_ERC721_FLAG.ts
+++ b/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/BEFORE_APPROVE_ERC721_FLAG.ts
@@ -1,0 +1,53 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x64dfcb7f" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the BEFORE_APPROVE_ERC721_FLAG function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { decodeBEFORE_APPROVE_ERC721_FLAGResult } from "thirdweb/extensions/hooks";
+ * const result = decodeBEFORE_APPROVE_ERC721_FLAGResult("...");
+ * ```
+ */
+export function decodeBEFORE_APPROVE_ERC721_FLAGResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "BEFORE_APPROVE_ERC721_FLAG" function on the contract.
+ * @param options - The options for the BEFORE_APPROVE_ERC721_FLAG function.
+ * @returns The parsed result of the function call.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { BEFORE_APPROVE_ERC721_FLAG } from "thirdweb/extensions/hooks";
+ *
+ * const result = await BEFORE_APPROVE_ERC721_FLAG();
+ *
+ * ```
+ */
+export async function BEFORE_APPROVE_ERC721_FLAG(
+  options: BaseTransactionOptions,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/BEFORE_APPROVE_FOR_ALL_FLAG.ts
+++ b/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/BEFORE_APPROVE_FOR_ALL_FLAG.ts
@@ -1,0 +1,53 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0xfcfea892" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the BEFORE_APPROVE_FOR_ALL_FLAG function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { decodeBEFORE_APPROVE_FOR_ALL_FLAGResult } from "thirdweb/extensions/hooks";
+ * const result = decodeBEFORE_APPROVE_FOR_ALL_FLAGResult("...");
+ * ```
+ */
+export function decodeBEFORE_APPROVE_FOR_ALL_FLAGResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "BEFORE_APPROVE_FOR_ALL_FLAG" function on the contract.
+ * @param options - The options for the BEFORE_APPROVE_FOR_ALL_FLAG function.
+ * @returns The parsed result of the function call.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { BEFORE_APPROVE_FOR_ALL_FLAG } from "thirdweb/extensions/hooks";
+ *
+ * const result = await BEFORE_APPROVE_FOR_ALL_FLAG();
+ *
+ * ```
+ */
+export async function BEFORE_APPROVE_FOR_ALL_FLAG(
+  options: BaseTransactionOptions,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/BEFORE_BATCH_TRANSFER_ERC1155_FLAG.ts
+++ b/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/BEFORE_BATCH_TRANSFER_ERC1155_FLAG.ts
@@ -1,0 +1,53 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x044ac9e1" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the BEFORE_BATCH_TRANSFER_ERC1155_FLAG function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { decodeBEFORE_BATCH_TRANSFER_ERC1155_FLAGResult } from "thirdweb/extensions/hooks";
+ * const result = decodeBEFORE_BATCH_TRANSFER_ERC1155_FLAGResult("...");
+ * ```
+ */
+export function decodeBEFORE_BATCH_TRANSFER_ERC1155_FLAGResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "BEFORE_BATCH_TRANSFER_ERC1155_FLAG" function on the contract.
+ * @param options - The options for the BEFORE_BATCH_TRANSFER_ERC1155_FLAG function.
+ * @returns The parsed result of the function call.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { BEFORE_BATCH_TRANSFER_ERC1155_FLAG } from "thirdweb/extensions/hooks";
+ *
+ * const result = await BEFORE_BATCH_TRANSFER_ERC1155_FLAG();
+ *
+ * ```
+ */
+export async function BEFORE_BATCH_TRANSFER_ERC1155_FLAG(
+  options: BaseTransactionOptions,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/BEFORE_BURN_ERC1155_FLAG.ts
+++ b/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/BEFORE_BURN_ERC1155_FLAG.ts
@@ -1,0 +1,53 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0xc42ed21c" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the BEFORE_BURN_ERC1155_FLAG function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { decodeBEFORE_BURN_ERC1155_FLAGResult } from "thirdweb/extensions/hooks";
+ * const result = decodeBEFORE_BURN_ERC1155_FLAGResult("...");
+ * ```
+ */
+export function decodeBEFORE_BURN_ERC1155_FLAGResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "BEFORE_BURN_ERC1155_FLAG" function on the contract.
+ * @param options - The options for the BEFORE_BURN_ERC1155_FLAG function.
+ * @returns The parsed result of the function call.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { BEFORE_BURN_ERC1155_FLAG } from "thirdweb/extensions/hooks";
+ *
+ * const result = await BEFORE_BURN_ERC1155_FLAG();
+ *
+ * ```
+ */
+export async function BEFORE_BURN_ERC1155_FLAG(
+  options: BaseTransactionOptions,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/BEFORE_BURN_ERC20_FLAG.ts
+++ b/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/BEFORE_BURN_ERC20_FLAG.ts
@@ -1,0 +1,51 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x9652b35b" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the BEFORE_BURN_ERC20_FLAG function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { decodeBEFORE_BURN_ERC20_FLAGResult } from "thirdweb/extensions/hooks";
+ * const result = decodeBEFORE_BURN_ERC20_FLAGResult("...");
+ * ```
+ */
+export function decodeBEFORE_BURN_ERC20_FLAGResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "BEFORE_BURN_ERC20_FLAG" function on the contract.
+ * @param options - The options for the BEFORE_BURN_ERC20_FLAG function.
+ * @returns The parsed result of the function call.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { BEFORE_BURN_ERC20_FLAG } from "thirdweb/extensions/hooks";
+ *
+ * const result = await BEFORE_BURN_ERC20_FLAG();
+ *
+ * ```
+ */
+export async function BEFORE_BURN_ERC20_FLAG(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/BEFORE_BURN_ERC721_FLAG.ts
+++ b/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/BEFORE_BURN_ERC721_FLAG.ts
@@ -1,0 +1,51 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x5a928783" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the BEFORE_BURN_ERC721_FLAG function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { decodeBEFORE_BURN_ERC721_FLAGResult } from "thirdweb/extensions/hooks";
+ * const result = decodeBEFORE_BURN_ERC721_FLAGResult("...");
+ * ```
+ */
+export function decodeBEFORE_BURN_ERC721_FLAGResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "BEFORE_BURN_ERC721_FLAG" function on the contract.
+ * @param options - The options for the BEFORE_BURN_ERC721_FLAG function.
+ * @returns The parsed result of the function call.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { BEFORE_BURN_ERC721_FLAG } from "thirdweb/extensions/hooks";
+ *
+ * const result = await BEFORE_BURN_ERC721_FLAG();
+ *
+ * ```
+ */
+export async function BEFORE_BURN_ERC721_FLAG(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/BEFORE_MINT_ERC1155_FLAG.ts
+++ b/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/BEFORE_MINT_ERC1155_FLAG.ts
@@ -1,0 +1,53 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x5a1d92c0" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the BEFORE_MINT_ERC1155_FLAG function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { decodeBEFORE_MINT_ERC1155_FLAGResult } from "thirdweb/extensions/hooks";
+ * const result = decodeBEFORE_MINT_ERC1155_FLAGResult("...");
+ * ```
+ */
+export function decodeBEFORE_MINT_ERC1155_FLAGResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "BEFORE_MINT_ERC1155_FLAG" function on the contract.
+ * @param options - The options for the BEFORE_MINT_ERC1155_FLAG function.
+ * @returns The parsed result of the function call.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { BEFORE_MINT_ERC1155_FLAG } from "thirdweb/extensions/hooks";
+ *
+ * const result = await BEFORE_MINT_ERC1155_FLAG();
+ *
+ * ```
+ */
+export async function BEFORE_MINT_ERC1155_FLAG(
+  options: BaseTransactionOptions,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/BEFORE_MINT_ERC20_FLAG.ts
+++ b/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/BEFORE_MINT_ERC20_FLAG.ts
@@ -1,0 +1,51 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0xe0345fe6" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the BEFORE_MINT_ERC20_FLAG function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { decodeBEFORE_MINT_ERC20_FLAGResult } from "thirdweb/extensions/hooks";
+ * const result = decodeBEFORE_MINT_ERC20_FLAGResult("...");
+ * ```
+ */
+export function decodeBEFORE_MINT_ERC20_FLAGResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "BEFORE_MINT_ERC20_FLAG" function on the contract.
+ * @param options - The options for the BEFORE_MINT_ERC20_FLAG function.
+ * @returns The parsed result of the function call.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { BEFORE_MINT_ERC20_FLAG } from "thirdweb/extensions/hooks";
+ *
+ * const result = await BEFORE_MINT_ERC20_FLAG();
+ *
+ * ```
+ */
+export async function BEFORE_MINT_ERC20_FLAG(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/BEFORE_MINT_ERC721_FLAG.ts
+++ b/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/BEFORE_MINT_ERC721_FLAG.ts
@@ -1,0 +1,51 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0xc44f5ef5" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the BEFORE_MINT_ERC721_FLAG function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { decodeBEFORE_MINT_ERC721_FLAGResult } from "thirdweb/extensions/hooks";
+ * const result = decodeBEFORE_MINT_ERC721_FLAGResult("...");
+ * ```
+ */
+export function decodeBEFORE_MINT_ERC721_FLAGResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "BEFORE_MINT_ERC721_FLAG" function on the contract.
+ * @param options - The options for the BEFORE_MINT_ERC721_FLAG function.
+ * @returns The parsed result of the function call.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { BEFORE_MINT_ERC721_FLAG } from "thirdweb/extensions/hooks";
+ *
+ * const result = await BEFORE_MINT_ERC721_FLAG();
+ *
+ * ```
+ */
+export async function BEFORE_MINT_ERC721_FLAG(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/BEFORE_TRANSFER_ERC1155_FLAG.ts
+++ b/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/BEFORE_TRANSFER_ERC1155_FLAG.ts
@@ -1,0 +1,53 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0xfd87b270" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the BEFORE_TRANSFER_ERC1155_FLAG function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { decodeBEFORE_TRANSFER_ERC1155_FLAGResult } from "thirdweb/extensions/hooks";
+ * const result = decodeBEFORE_TRANSFER_ERC1155_FLAGResult("...");
+ * ```
+ */
+export function decodeBEFORE_TRANSFER_ERC1155_FLAGResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "BEFORE_TRANSFER_ERC1155_FLAG" function on the contract.
+ * @param options - The options for the BEFORE_TRANSFER_ERC1155_FLAG function.
+ * @returns The parsed result of the function call.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { BEFORE_TRANSFER_ERC1155_FLAG } from "thirdweb/extensions/hooks";
+ *
+ * const result = await BEFORE_TRANSFER_ERC1155_FLAG();
+ *
+ * ```
+ */
+export async function BEFORE_TRANSFER_ERC1155_FLAG(
+  options: BaseTransactionOptions,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/BEFORE_TRANSFER_ERC20_FLAG.ts
+++ b/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/BEFORE_TRANSFER_ERC20_FLAG.ts
@@ -1,0 +1,53 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x94557b58" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the BEFORE_TRANSFER_ERC20_FLAG function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { decodeBEFORE_TRANSFER_ERC20_FLAGResult } from "thirdweb/extensions/hooks";
+ * const result = decodeBEFORE_TRANSFER_ERC20_FLAGResult("...");
+ * ```
+ */
+export function decodeBEFORE_TRANSFER_ERC20_FLAGResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "BEFORE_TRANSFER_ERC20_FLAG" function on the contract.
+ * @param options - The options for the BEFORE_TRANSFER_ERC20_FLAG function.
+ * @returns The parsed result of the function call.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { BEFORE_TRANSFER_ERC20_FLAG } from "thirdweb/extensions/hooks";
+ *
+ * const result = await BEFORE_TRANSFER_ERC20_FLAG();
+ *
+ * ```
+ */
+export async function BEFORE_TRANSFER_ERC20_FLAG(
+  options: BaseTransactionOptions,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/BEFORE_TRANSFER_ERC721_FLAG.ts
+++ b/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/BEFORE_TRANSFER_ERC721_FLAG.ts
@@ -1,0 +1,53 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x8c14e60d" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the BEFORE_TRANSFER_ERC721_FLAG function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { decodeBEFORE_TRANSFER_ERC721_FLAGResult } from "thirdweb/extensions/hooks";
+ * const result = decodeBEFORE_TRANSFER_ERC721_FLAGResult("...");
+ * ```
+ */
+export function decodeBEFORE_TRANSFER_ERC721_FLAGResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "BEFORE_TRANSFER_ERC721_FLAG" function on the contract.
+ * @param options - The options for the BEFORE_TRANSFER_ERC721_FLAG function.
+ * @returns The parsed result of the function call.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { BEFORE_TRANSFER_ERC721_FLAG } from "thirdweb/extensions/hooks";
+ *
+ * const result = await BEFORE_TRANSFER_ERC721_FLAG();
+ *
+ * ```
+ */
+export async function BEFORE_TRANSFER_ERC721_FLAG(
+  options: BaseTransactionOptions,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/ON_ROYALTY_INFO_FLAG.ts
+++ b/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/ON_ROYALTY_INFO_FLAG.ts
@@ -1,0 +1,51 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0xa77ec9bb" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the ON_ROYALTY_INFO_FLAG function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { decodeON_ROYALTY_INFO_FLAGResult } from "thirdweb/extensions/hooks";
+ * const result = decodeON_ROYALTY_INFO_FLAGResult("...");
+ * ```
+ */
+export function decodeON_ROYALTY_INFO_FLAGResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "ON_ROYALTY_INFO_FLAG" function on the contract.
+ * @param options - The options for the ON_ROYALTY_INFO_FLAG function.
+ * @returns The parsed result of the function call.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { ON_ROYALTY_INFO_FLAG } from "thirdweb/extensions/hooks";
+ *
+ * const result = await ON_ROYALTY_INFO_FLAG();
+ *
+ * ```
+ */
+export async function ON_ROYALTY_INFO_FLAG(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/ON_TOKEN_URI_FLAG.ts
+++ b/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/ON_TOKEN_URI_FLAG.ts
@@ -1,0 +1,51 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0xdcbad62f" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Decodes the result of the ON_TOKEN_URI_FLAG function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { decodeON_TOKEN_URI_FLAGResult } from "thirdweb/extensions/hooks";
+ * const result = decodeON_TOKEN_URI_FLAGResult("...");
+ * ```
+ */
+export function decodeON_TOKEN_URI_FLAGResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "ON_TOKEN_URI_FLAG" function on the contract.
+ * @param options - The options for the ON_TOKEN_URI_FLAG function.
+ * @returns The parsed result of the function call.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { ON_TOKEN_URI_FLAG } from "thirdweb/extensions/hooks";
+ *
+ * const result = await ON_TOKEN_URI_FLAG();
+ *
+ * ```
+ */
+export async function ON_TOKEN_URI_FLAG(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/allowlistMint.ts
+++ b/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/allowlistMint.ts
@@ -1,0 +1,116 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+/**
+ * Represents the parameters for the "allowlistMint" function.
+ */
+export type AllowlistMintParams = {
+  params: AbiParameterToPrimitiveType<{
+    name: "_params";
+    type: "tuple";
+    internalType: "struct MintHook.ClaimParams";
+    components: [
+      { name: "allowlistProof"; type: "bytes32[]"; internalType: "bytes32[]" },
+      {
+        name: "expectedPricePerUnit";
+        type: "uint256";
+        internalType: "uint256";
+      },
+      { name: "expectedCurrency"; type: "address"; internalType: "address" },
+    ];
+  }>;
+};
+
+const FN_SELECTOR = "0x911e0191" as const;
+const FN_INPUTS = [
+  {
+    name: "_params",
+    type: "tuple",
+    internalType: "struct MintHook.ClaimParams",
+    components: [
+      {
+        name: "allowlistProof",
+        type: "bytes32[]",
+        internalType: "bytes32[]",
+      },
+      {
+        name: "expectedPricePerUnit",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "expectedCurrency",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "bytes",
+    internalType: "bytes",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "allowlistMint" function.
+ * @param options - The options for the allowlistMint function.
+ * @returns The encoded ABI parameters.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { encodeAllowlistMintParams } "thirdweb/extensions/hooks";
+ * const result = encodeAllowlistMintParams({
+ *  params: ...,
+ * });
+ * ```
+ */
+export function encodeAllowlistMintParams(options: AllowlistMintParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.params]);
+}
+
+/**
+ * Decodes the result of the allowlistMint function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { decodeAllowlistMintResult } from "thirdweb/extensions/hooks";
+ * const result = decodeAllowlistMintResult("...");
+ * ```
+ */
+export function decodeAllowlistMintResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "allowlistMint" function on the contract.
+ * @param options - The options for the allowlistMint function.
+ * @returns The parsed result of the function call.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { allowlistMint } from "thirdweb/extensions/hooks";
+ *
+ * const result = await allowlistMint({
+ *  params: ...,
+ * });
+ *
+ * ```
+ */
+export async function allowlistMint(
+  options: BaseTransactionOptions<AllowlistMintParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.params],
+  });
+}

--- a/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/decodeClaimParams.ts
+++ b/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/decodeClaimParams.ts
@@ -1,0 +1,109 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+/**
+ * Represents the parameters for the "decodeClaimParams" function.
+ */
+export type DecodeClaimParamsParams = {
+  data: AbiParameterToPrimitiveType<{
+    name: "_data";
+    type: "bytes";
+    internalType: "bytes";
+  }>;
+};
+
+const FN_SELECTOR = "0x3d94bee5" as const;
+const FN_INPUTS = [
+  {
+    name: "_data",
+    type: "bytes",
+    internalType: "bytes",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "tuple",
+    internalType: "struct MintHook.ClaimParams",
+    components: [
+      {
+        name: "allowlistProof",
+        type: "bytes32[]",
+        internalType: "bytes32[]",
+      },
+      {
+        name: "expectedPricePerUnit",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "expectedCurrency",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "decodeClaimParams" function.
+ * @param options - The options for the decodeClaimParams function.
+ * @returns The encoded ABI parameters.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { encodeDecodeClaimParamsParams } "thirdweb/extensions/hooks";
+ * const result = encodeDecodeClaimParamsParams({
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeDecodeClaimParamsParams(
+  options: DecodeClaimParamsParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.data]);
+}
+
+/**
+ * Decodes the result of the decodeClaimParams function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { decodeDecodeClaimParamsResult } from "thirdweb/extensions/hooks";
+ * const result = decodeDecodeClaimParamsResult("...");
+ * ```
+ */
+export function decodeDecodeClaimParamsResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "decodeClaimParams" function on the contract.
+ * @param options - The options for the decodeClaimParams function.
+ * @returns The parsed result of the function call.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { decodeClaimParams } from "thirdweb/extensions/hooks";
+ *
+ * const result = await decodeClaimParams({
+ *  data: ...,
+ * });
+ *
+ * ```
+ */
+export async function decodeClaimParams(
+  options: BaseTransactionOptions<DecodeClaimParamsParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.data],
+  });
+}

--- a/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/decodeSignatureMintERC1155Params.ts
+++ b/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/decodeSignatureMintERC1155Params.ts
@@ -1,0 +1,151 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+/**
+ * Represents the parameters for the "decodeSignatureMintERC1155Params" function.
+ */
+export type DecodeSignatureMintERC1155ParamsParams = {
+  data: AbiParameterToPrimitiveType<{
+    name: "_data";
+    type: "bytes";
+    internalType: "bytes";
+  }>;
+};
+
+const FN_SELECTOR = "0x2f9d8f67" as const;
+const FN_INPUTS = [
+  {
+    name: "_data",
+    type: "bytes",
+    internalType: "bytes",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "tuple",
+    internalType: "struct MintHook.SignatureMintParamsERC1155",
+    components: [
+      {
+        name: "request",
+        type: "tuple",
+        internalType: "struct MintHook.SignatureMintRequestERC1155",
+        components: [
+          {
+            name: "tokenId",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "token",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "startTimestamp",
+            type: "uint48",
+            internalType: "uint48",
+          },
+          {
+            name: "endTimestamp",
+            type: "uint48",
+            internalType: "uint48",
+          },
+          {
+            name: "recipient",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "quantity",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "currency",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "pricePerUnit",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "uid",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+        ],
+      },
+      {
+        name: "signature",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "decodeSignatureMintERC1155Params" function.
+ * @param options - The options for the decodeSignatureMintERC1155Params function.
+ * @returns The encoded ABI parameters.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { encodeDecodeSignatureMintERC1155ParamsParams } "thirdweb/extensions/hooks";
+ * const result = encodeDecodeSignatureMintERC1155ParamsParams({
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeDecodeSignatureMintERC1155ParamsParams(
+  options: DecodeSignatureMintERC1155ParamsParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.data]);
+}
+
+/**
+ * Decodes the result of the decodeSignatureMintERC1155Params function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { decodeDecodeSignatureMintERC1155ParamsResult } from "thirdweb/extensions/hooks";
+ * const result = decodeDecodeSignatureMintERC1155ParamsResult("...");
+ * ```
+ */
+export function decodeDecodeSignatureMintERC1155ParamsResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "decodeSignatureMintERC1155Params" function on the contract.
+ * @param options - The options for the decodeSignatureMintERC1155Params function.
+ * @returns The parsed result of the function call.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { decodeSignatureMintERC1155Params } from "thirdweb/extensions/hooks";
+ *
+ * const result = await decodeSignatureMintERC1155Params({
+ *  data: ...,
+ * });
+ *
+ * ```
+ */
+export async function decodeSignatureMintERC1155Params(
+  options: BaseTransactionOptions<DecodeSignatureMintERC1155ParamsParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.data],
+  });
+}

--- a/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/decodeSignatureMintERC20Params.ts
+++ b/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/decodeSignatureMintERC20Params.ts
@@ -1,0 +1,146 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+/**
+ * Represents the parameters for the "decodeSignatureMintERC20Params" function.
+ */
+export type DecodeSignatureMintERC20ParamsParams = {
+  data: AbiParameterToPrimitiveType<{
+    name: "_data";
+    type: "bytes";
+    internalType: "bytes";
+  }>;
+};
+
+const FN_SELECTOR = "0x138844e0" as const;
+const FN_INPUTS = [
+  {
+    name: "_data",
+    type: "bytes",
+    internalType: "bytes",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "tuple",
+    internalType: "struct MintHook.SignatureMintParamsERC20",
+    components: [
+      {
+        name: "request",
+        type: "tuple",
+        internalType: "struct MintHook.SignatureMintRequestERC20",
+        components: [
+          {
+            name: "token",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "startTimestamp",
+            type: "uint48",
+            internalType: "uint48",
+          },
+          {
+            name: "endTimestamp",
+            type: "uint48",
+            internalType: "uint48",
+          },
+          {
+            name: "recipient",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "quantity",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "currency",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "pricePerUnit",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "uid",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+        ],
+      },
+      {
+        name: "signature",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "decodeSignatureMintERC20Params" function.
+ * @param options - The options for the decodeSignatureMintERC20Params function.
+ * @returns The encoded ABI parameters.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { encodeDecodeSignatureMintERC20ParamsParams } "thirdweb/extensions/hooks";
+ * const result = encodeDecodeSignatureMintERC20ParamsParams({
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeDecodeSignatureMintERC20ParamsParams(
+  options: DecodeSignatureMintERC20ParamsParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.data]);
+}
+
+/**
+ * Decodes the result of the decodeSignatureMintERC20Params function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { decodeDecodeSignatureMintERC20ParamsResult } from "thirdweb/extensions/hooks";
+ * const result = decodeDecodeSignatureMintERC20ParamsResult("...");
+ * ```
+ */
+export function decodeDecodeSignatureMintERC20ParamsResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "decodeSignatureMintERC20Params" function on the contract.
+ * @param options - The options for the decodeSignatureMintERC20Params function.
+ * @returns The parsed result of the function call.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { decodeSignatureMintERC20Params } from "thirdweb/extensions/hooks";
+ *
+ * const result = await decodeSignatureMintERC20Params({
+ *  data: ...,
+ * });
+ *
+ * ```
+ */
+export async function decodeSignatureMintERC20Params(
+  options: BaseTransactionOptions<DecodeSignatureMintERC20ParamsParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.data],
+  });
+}

--- a/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/decodeSignatureMintERC721Params.ts
+++ b/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/decodeSignatureMintERC721Params.ts
@@ -1,0 +1,146 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+/**
+ * Represents the parameters for the "decodeSignatureMintERC721Params" function.
+ */
+export type DecodeSignatureMintERC721ParamsParams = {
+  data: AbiParameterToPrimitiveType<{
+    name: "_data";
+    type: "bytes";
+    internalType: "bytes";
+  }>;
+};
+
+const FN_SELECTOR = "0xdd462578" as const;
+const FN_INPUTS = [
+  {
+    name: "_data",
+    type: "bytes",
+    internalType: "bytes",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "tuple",
+    internalType: "struct MintHook.SignatureMintParamsERC721",
+    components: [
+      {
+        name: "request",
+        type: "tuple",
+        internalType: "struct MintHook.SignatureMintRequestERC721",
+        components: [
+          {
+            name: "token",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "startTimestamp",
+            type: "uint48",
+            internalType: "uint48",
+          },
+          {
+            name: "endTimestamp",
+            type: "uint48",
+            internalType: "uint48",
+          },
+          {
+            name: "recipient",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "quantity",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "currency",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "pricePerUnit",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "uid",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+        ],
+      },
+      {
+        name: "signature",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "decodeSignatureMintERC721Params" function.
+ * @param options - The options for the decodeSignatureMintERC721Params function.
+ * @returns The encoded ABI parameters.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { encodeDecodeSignatureMintERC721ParamsParams } "thirdweb/extensions/hooks";
+ * const result = encodeDecodeSignatureMintERC721ParamsParams({
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeDecodeSignatureMintERC721ParamsParams(
+  options: DecodeSignatureMintERC721ParamsParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.data]);
+}
+
+/**
+ * Decodes the result of the decodeSignatureMintERC721Params function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { decodeDecodeSignatureMintERC721ParamsResult } from "thirdweb/extensions/hooks";
+ * const result = decodeDecodeSignatureMintERC721ParamsResult("...");
+ * ```
+ */
+export function decodeDecodeSignatureMintERC721ParamsResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "decodeSignatureMintERC721Params" function on the contract.
+ * @param options - The options for the decodeSignatureMintERC721Params function.
+ * @returns The parsed result of the function call.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { decodeSignatureMintERC721Params } from "thirdweb/extensions/hooks";
+ *
+ * const result = await decodeSignatureMintERC721Params({
+ *  data: ...,
+ * });
+ *
+ * ```
+ */
+export async function decodeSignatureMintERC721Params(
+  options: BaseTransactionOptions<DecodeSignatureMintERC721ParamsParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.data],
+  });
+}

--- a/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/eip712Domain.ts
+++ b/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/eip712Domain.ts
@@ -1,0 +1,81 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x84b0196e" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "fields",
+    type: "bytes1",
+    internalType: "bytes1",
+  },
+  {
+    name: "name",
+    type: "string",
+    internalType: "string",
+  },
+  {
+    name: "version",
+    type: "string",
+    internalType: "string",
+  },
+  {
+    name: "chainId",
+    type: "uint256",
+    internalType: "uint256",
+  },
+  {
+    name: "verifyingContract",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "salt",
+    type: "bytes32",
+    internalType: "bytes32",
+  },
+  {
+    name: "extensions",
+    type: "uint256[]",
+    internalType: "uint256[]",
+  },
+] as const;
+
+/**
+ * Decodes the result of the eip712Domain function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { decodeEip712DomainResult } from "thirdweb/extensions/hooks";
+ * const result = decodeEip712DomainResult("...");
+ * ```
+ */
+export function decodeEip712DomainResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result);
+}
+
+/**
+ * Calls the "eip712Domain" function on the contract.
+ * @param options - The options for the eip712Domain function.
+ * @returns The parsed result of the function call.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { eip712Domain } from "thirdweb/extensions/hooks";
+ *
+ * const result = await eip712Domain();
+ *
+ * ```
+ */
+export async function eip712Domain(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/getClaimPhaseERC1155.ts
+++ b/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/getClaimPhaseERC1155.ts
@@ -1,0 +1,136 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+/**
+ * Represents the parameters for the "getClaimPhaseERC1155" function.
+ */
+export type GetClaimPhaseERC1155Params = {
+  token: AbiParameterToPrimitiveType<{
+    name: "_token";
+    type: "address";
+    internalType: "address";
+  }>;
+  id: AbiParameterToPrimitiveType<{
+    name: "_id";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+};
+
+const FN_SELECTOR = "0x2e40479a" as const;
+const FN_INPUTS = [
+  {
+    name: "_token",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "_id",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "claimPhase",
+    type: "tuple",
+    internalType: "struct MintHook.ClaimPhase",
+    components: [
+      {
+        name: "availableSupply",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "allowlistMerkleRoot",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+      {
+        name: "pricePerUnit",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "currency",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "startTimestamp",
+        type: "uint48",
+        internalType: "uint48",
+      },
+      {
+        name: "endTimestamp",
+        type: "uint48",
+        internalType: "uint48",
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getClaimPhaseERC1155" function.
+ * @param options - The options for the getClaimPhaseERC1155 function.
+ * @returns The encoded ABI parameters.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { encodeGetClaimPhaseERC1155Params } "thirdweb/extensions/hooks";
+ * const result = encodeGetClaimPhaseERC1155Params({
+ *  token: ...,
+ *  id: ...,
+ * });
+ * ```
+ */
+export function encodeGetClaimPhaseERC1155Params(
+  options: GetClaimPhaseERC1155Params,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.token, options.id]);
+}
+
+/**
+ * Decodes the result of the getClaimPhaseERC1155 function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { decodeGetClaimPhaseERC1155Result } from "thirdweb/extensions/hooks";
+ * const result = decodeGetClaimPhaseERC1155Result("...");
+ * ```
+ */
+export function decodeGetClaimPhaseERC1155Result(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "getClaimPhaseERC1155" function on the contract.
+ * @param options - The options for the getClaimPhaseERC1155 function.
+ * @returns The parsed result of the function call.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { getClaimPhaseERC1155 } from "thirdweb/extensions/hooks";
+ *
+ * const result = await getClaimPhaseERC1155({
+ *  token: ...,
+ *  id: ...,
+ * });
+ *
+ * ```
+ */
+export async function getClaimPhaseERC1155(
+  options: BaseTransactionOptions<GetClaimPhaseERC1155Params>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.token, options.id],
+  });
+}

--- a/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/getClaimPhaseERC20.ts
+++ b/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/getClaimPhaseERC20.ts
@@ -1,0 +1,124 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+/**
+ * Represents the parameters for the "getClaimPhaseERC20" function.
+ */
+export type GetClaimPhaseERC20Params = {
+  token: AbiParameterToPrimitiveType<{
+    name: "_token";
+    type: "address";
+    internalType: "address";
+  }>;
+};
+
+const FN_SELECTOR = "0x595b92bb" as const;
+const FN_INPUTS = [
+  {
+    name: "_token",
+    type: "address",
+    internalType: "address",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "claimPhase",
+    type: "tuple",
+    internalType: "struct MintHook.ClaimPhase",
+    components: [
+      {
+        name: "availableSupply",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "allowlistMerkleRoot",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+      {
+        name: "pricePerUnit",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "currency",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "startTimestamp",
+        type: "uint48",
+        internalType: "uint48",
+      },
+      {
+        name: "endTimestamp",
+        type: "uint48",
+        internalType: "uint48",
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getClaimPhaseERC20" function.
+ * @param options - The options for the getClaimPhaseERC20 function.
+ * @returns The encoded ABI parameters.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { encodeGetClaimPhaseERC20Params } "thirdweb/extensions/hooks";
+ * const result = encodeGetClaimPhaseERC20Params({
+ *  token: ...,
+ * });
+ * ```
+ */
+export function encodeGetClaimPhaseERC20Params(
+  options: GetClaimPhaseERC20Params,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.token]);
+}
+
+/**
+ * Decodes the result of the getClaimPhaseERC20 function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { decodeGetClaimPhaseERC20Result } from "thirdweb/extensions/hooks";
+ * const result = decodeGetClaimPhaseERC20Result("...");
+ * ```
+ */
+export function decodeGetClaimPhaseERC20Result(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "getClaimPhaseERC20" function on the contract.
+ * @param options - The options for the getClaimPhaseERC20 function.
+ * @returns The parsed result of the function call.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { getClaimPhaseERC20 } from "thirdweb/extensions/hooks";
+ *
+ * const result = await getClaimPhaseERC20({
+ *  token: ...,
+ * });
+ *
+ * ```
+ */
+export async function getClaimPhaseERC20(
+  options: BaseTransactionOptions<GetClaimPhaseERC20Params>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.token],
+  });
+}

--- a/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/getClaimPhaseERC721.ts
+++ b/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/getClaimPhaseERC721.ts
@@ -1,0 +1,124 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+/**
+ * Represents the parameters for the "getClaimPhaseERC721" function.
+ */
+export type GetClaimPhaseERC721Params = {
+  token: AbiParameterToPrimitiveType<{
+    name: "_token";
+    type: "address";
+    internalType: "address";
+  }>;
+};
+
+const FN_SELECTOR = "0xbe906827" as const;
+const FN_INPUTS = [
+  {
+    name: "_token",
+    type: "address",
+    internalType: "address",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "claimPhase",
+    type: "tuple",
+    internalType: "struct MintHook.ClaimPhase",
+    components: [
+      {
+        name: "availableSupply",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "allowlistMerkleRoot",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+      {
+        name: "pricePerUnit",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "currency",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "startTimestamp",
+        type: "uint48",
+        internalType: "uint48",
+      },
+      {
+        name: "endTimestamp",
+        type: "uint48",
+        internalType: "uint48",
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getClaimPhaseERC721" function.
+ * @param options - The options for the getClaimPhaseERC721 function.
+ * @returns The encoded ABI parameters.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { encodeGetClaimPhaseERC721Params } "thirdweb/extensions/hooks";
+ * const result = encodeGetClaimPhaseERC721Params({
+ *  token: ...,
+ * });
+ * ```
+ */
+export function encodeGetClaimPhaseERC721Params(
+  options: GetClaimPhaseERC721Params,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.token]);
+}
+
+/**
+ * Decodes the result of the getClaimPhaseERC721 function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { decodeGetClaimPhaseERC721Result } from "thirdweb/extensions/hooks";
+ * const result = decodeGetClaimPhaseERC721Result("...");
+ * ```
+ */
+export function decodeGetClaimPhaseERC721Result(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "getClaimPhaseERC721" function on the contract.
+ * @param options - The options for the getClaimPhaseERC721 function.
+ * @returns The parsed result of the function call.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { getClaimPhaseERC721 } from "thirdweb/extensions/hooks";
+ *
+ * const result = await getClaimPhaseERC721({
+ *  token: ...,
+ * });
+ *
+ * ```
+ */
+export async function getClaimPhaseERC721(
+  options: BaseTransactionOptions<GetClaimPhaseERC721Params>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.token],
+  });
+}

--- a/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/getHookInfo.ts
+++ b/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/getHookInfo.ts
@@ -1,0 +1,80 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+const FN_SELECTOR = "0x650fb029" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "info",
+    type: "tuple",
+    internalType: "struct IHookInfo.HookInfo",
+    components: [
+      {
+        name: "hookFlags",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "hookFallbackFunctions",
+        type: "tuple[]",
+        internalType: "struct IHookInfo.HookFallbackFunction[]",
+        components: [
+          {
+            name: "functionSelector",
+            type: "bytes4",
+            internalType: "bytes4",
+          },
+          {
+            name: "callType",
+            type: "uint8",
+            internalType: "enum IHookInfo.CallType",
+          },
+          {
+            name: "permissioned",
+            type: "bool",
+            internalType: "bool",
+          },
+        ],
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Decodes the result of the getHookInfo function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { decodeGetHookInfoResult } from "thirdweb/extensions/hooks";
+ * const result = decodeGetHookInfoResult("...");
+ * ```
+ */
+export function decodeGetHookInfoResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "getHookInfo" function on the contract.
+ * @param options - The options for the getHookInfo function.
+ * @returns The parsed result of the function call.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { getHookInfo } from "thirdweb/extensions/hooks";
+ *
+ * const result = await getHookInfo();
+ *
+ * ```
+ */
+export async function getHookInfo(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/getSaleConfig.ts
+++ b/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/getSaleConfig.ts
@@ -1,0 +1,100 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+/**
+ * Represents the parameters for the "getSaleConfig" function.
+ */
+export type GetSaleConfigParams = {
+  token: AbiParameterToPrimitiveType<{
+    name: "_token";
+    type: "address";
+    internalType: "address";
+  }>;
+};
+
+const FN_SELECTOR = "0x320eec5a" as const;
+const FN_INPUTS = [
+  {
+    name: "_token",
+    type: "address",
+    internalType: "address",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "primarySaleRecipient",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "platformFeeRecipient",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "platformFeeBps",
+    type: "uint16",
+    internalType: "uint16",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "getSaleConfig" function.
+ * @param options - The options for the getSaleConfig function.
+ * @returns The encoded ABI parameters.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { encodeGetSaleConfigParams } "thirdweb/extensions/hooks";
+ * const result = encodeGetSaleConfigParams({
+ *  token: ...,
+ * });
+ * ```
+ */
+export function encodeGetSaleConfigParams(options: GetSaleConfigParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.token]);
+}
+
+/**
+ * Decodes the result of the getSaleConfig function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { decodeGetSaleConfigResult } from "thirdweb/extensions/hooks";
+ * const result = decodeGetSaleConfigResult("...");
+ * ```
+ */
+export function decodeGetSaleConfigResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result);
+}
+
+/**
+ * Calls the "getSaleConfig" function on the contract.
+ * @param options - The options for the getSaleConfig function.
+ * @returns The parsed result of the function call.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { getSaleConfig } from "thirdweb/extensions/hooks";
+ *
+ * const result = await getSaleConfig({
+ *  token: ...,
+ * });
+ *
+ * ```
+ */
+export async function getSaleConfig(
+  options: BaseTransactionOptions<GetSaleConfigParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.token],
+  });
+}

--- a/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/signatureMintERC1155.ts
+++ b/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/signatureMintERC1155.ts
@@ -1,0 +1,170 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+/**
+ * Represents the parameters for the "signatureMintERC1155" function.
+ */
+export type SignatureMintERC1155Params = {
+  params: AbiParameterToPrimitiveType<{
+    name: "_params";
+    type: "tuple";
+    internalType: "struct MintHook.SignatureMintParamsERC1155";
+    components: [
+      {
+        name: "request";
+        type: "tuple";
+        internalType: "struct MintHook.SignatureMintRequestERC1155";
+        components: [
+          { name: "tokenId"; type: "uint256"; internalType: "uint256" },
+          { name: "token"; type: "address"; internalType: "address" },
+          { name: "startTimestamp"; type: "uint48"; internalType: "uint48" },
+          { name: "endTimestamp"; type: "uint48"; internalType: "uint48" },
+          { name: "recipient"; type: "address"; internalType: "address" },
+          { name: "quantity"; type: "uint256"; internalType: "uint256" },
+          { name: "currency"; type: "address"; internalType: "address" },
+          { name: "pricePerUnit"; type: "uint256"; internalType: "uint256" },
+          { name: "uid"; type: "bytes32"; internalType: "bytes32" },
+        ];
+      },
+      { name: "signature"; type: "bytes"; internalType: "bytes" },
+    ];
+  }>;
+};
+
+const FN_SELECTOR = "0xf0434a1e" as const;
+const FN_INPUTS = [
+  {
+    name: "_params",
+    type: "tuple",
+    internalType: "struct MintHook.SignatureMintParamsERC1155",
+    components: [
+      {
+        name: "request",
+        type: "tuple",
+        internalType: "struct MintHook.SignatureMintRequestERC1155",
+        components: [
+          {
+            name: "tokenId",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "token",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "startTimestamp",
+            type: "uint48",
+            internalType: "uint48",
+          },
+          {
+            name: "endTimestamp",
+            type: "uint48",
+            internalType: "uint48",
+          },
+          {
+            name: "recipient",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "quantity",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "currency",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "pricePerUnit",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "uid",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+        ],
+      },
+      {
+        name: "signature",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "bytes",
+    internalType: "bytes",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "signatureMintERC1155" function.
+ * @param options - The options for the signatureMintERC1155 function.
+ * @returns The encoded ABI parameters.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { encodeSignatureMintERC1155Params } "thirdweb/extensions/hooks";
+ * const result = encodeSignatureMintERC1155Params({
+ *  params: ...,
+ * });
+ * ```
+ */
+export function encodeSignatureMintERC1155Params(
+  options: SignatureMintERC1155Params,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.params]);
+}
+
+/**
+ * Decodes the result of the signatureMintERC1155 function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { decodeSignatureMintERC1155Result } from "thirdweb/extensions/hooks";
+ * const result = decodeSignatureMintERC1155Result("...");
+ * ```
+ */
+export function decodeSignatureMintERC1155Result(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "signatureMintERC1155" function on the contract.
+ * @param options - The options for the signatureMintERC1155 function.
+ * @returns The parsed result of the function call.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { signatureMintERC1155 } from "thirdweb/extensions/hooks";
+ *
+ * const result = await signatureMintERC1155({
+ *  params: ...,
+ * });
+ *
+ * ```
+ */
+export async function signatureMintERC1155(
+  options: BaseTransactionOptions<SignatureMintERC1155Params>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.params],
+  });
+}

--- a/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/signatureMintERC20.ts
+++ b/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/signatureMintERC20.ts
@@ -1,0 +1,164 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+/**
+ * Represents the parameters for the "signatureMintERC20" function.
+ */
+export type SignatureMintERC20Params = {
+  params: AbiParameterToPrimitiveType<{
+    name: "_params";
+    type: "tuple";
+    internalType: "struct MintHook.SignatureMintParamsERC20";
+    components: [
+      {
+        name: "request";
+        type: "tuple";
+        internalType: "struct MintHook.SignatureMintRequestERC20";
+        components: [
+          { name: "token"; type: "address"; internalType: "address" },
+          { name: "startTimestamp"; type: "uint48"; internalType: "uint48" },
+          { name: "endTimestamp"; type: "uint48"; internalType: "uint48" },
+          { name: "recipient"; type: "address"; internalType: "address" },
+          { name: "quantity"; type: "uint256"; internalType: "uint256" },
+          { name: "currency"; type: "address"; internalType: "address" },
+          { name: "pricePerUnit"; type: "uint256"; internalType: "uint256" },
+          { name: "uid"; type: "bytes32"; internalType: "bytes32" },
+        ];
+      },
+      { name: "signature"; type: "bytes"; internalType: "bytes" },
+    ];
+  }>;
+};
+
+const FN_SELECTOR = "0x5bdb4775" as const;
+const FN_INPUTS = [
+  {
+    name: "_params",
+    type: "tuple",
+    internalType: "struct MintHook.SignatureMintParamsERC20",
+    components: [
+      {
+        name: "request",
+        type: "tuple",
+        internalType: "struct MintHook.SignatureMintRequestERC20",
+        components: [
+          {
+            name: "token",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "startTimestamp",
+            type: "uint48",
+            internalType: "uint48",
+          },
+          {
+            name: "endTimestamp",
+            type: "uint48",
+            internalType: "uint48",
+          },
+          {
+            name: "recipient",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "quantity",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "currency",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "pricePerUnit",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "uid",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+        ],
+      },
+      {
+        name: "signature",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "bytes",
+    internalType: "bytes",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "signatureMintERC20" function.
+ * @param options - The options for the signatureMintERC20 function.
+ * @returns The encoded ABI parameters.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { encodeSignatureMintERC20Params } "thirdweb/extensions/hooks";
+ * const result = encodeSignatureMintERC20Params({
+ *  params: ...,
+ * });
+ * ```
+ */
+export function encodeSignatureMintERC20Params(
+  options: SignatureMintERC20Params,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.params]);
+}
+
+/**
+ * Decodes the result of the signatureMintERC20 function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { decodeSignatureMintERC20Result } from "thirdweb/extensions/hooks";
+ * const result = decodeSignatureMintERC20Result("...");
+ * ```
+ */
+export function decodeSignatureMintERC20Result(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "signatureMintERC20" function on the contract.
+ * @param options - The options for the signatureMintERC20 function.
+ * @returns The parsed result of the function call.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { signatureMintERC20 } from "thirdweb/extensions/hooks";
+ *
+ * const result = await signatureMintERC20({
+ *  params: ...,
+ * });
+ *
+ * ```
+ */
+export async function signatureMintERC20(
+  options: BaseTransactionOptions<SignatureMintERC20Params>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.params],
+  });
+}

--- a/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/signatureMintERC721.ts
+++ b/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/signatureMintERC721.ts
@@ -1,0 +1,164 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+
+/**
+ * Represents the parameters for the "signatureMintERC721" function.
+ */
+export type SignatureMintERC721Params = {
+  params: AbiParameterToPrimitiveType<{
+    name: "_params";
+    type: "tuple";
+    internalType: "struct MintHook.SignatureMintParamsERC721";
+    components: [
+      {
+        name: "request";
+        type: "tuple";
+        internalType: "struct MintHook.SignatureMintRequestERC721";
+        components: [
+          { name: "token"; type: "address"; internalType: "address" },
+          { name: "startTimestamp"; type: "uint48"; internalType: "uint48" },
+          { name: "endTimestamp"; type: "uint48"; internalType: "uint48" },
+          { name: "recipient"; type: "address"; internalType: "address" },
+          { name: "quantity"; type: "uint256"; internalType: "uint256" },
+          { name: "currency"; type: "address"; internalType: "address" },
+          { name: "pricePerUnit"; type: "uint256"; internalType: "uint256" },
+          { name: "uid"; type: "bytes32"; internalType: "bytes32" },
+        ];
+      },
+      { name: "signature"; type: "bytes"; internalType: "bytes" },
+    ];
+  }>;
+};
+
+const FN_SELECTOR = "0xef97a00c" as const;
+const FN_INPUTS = [
+  {
+    name: "_params",
+    type: "tuple",
+    internalType: "struct MintHook.SignatureMintParamsERC721",
+    components: [
+      {
+        name: "request",
+        type: "tuple",
+        internalType: "struct MintHook.SignatureMintRequestERC721",
+        components: [
+          {
+            name: "token",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "startTimestamp",
+            type: "uint48",
+            internalType: "uint48",
+          },
+          {
+            name: "endTimestamp",
+            type: "uint48",
+            internalType: "uint48",
+          },
+          {
+            name: "recipient",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "quantity",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "currency",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "pricePerUnit",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "uid",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+        ],
+      },
+      {
+        name: "signature",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "bytes",
+    internalType: "bytes",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "signatureMintERC721" function.
+ * @param options - The options for the signatureMintERC721 function.
+ * @returns The encoded ABI parameters.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { encodeSignatureMintERC721Params } "thirdweb/extensions/hooks";
+ * const result = encodeSignatureMintERC721Params({
+ *  params: ...,
+ * });
+ * ```
+ */
+export function encodeSignatureMintERC721Params(
+  options: SignatureMintERC721Params,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.params]);
+}
+
+/**
+ * Decodes the result of the signatureMintERC721 function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { decodeSignatureMintERC721Result } from "thirdweb/extensions/hooks";
+ * const result = decodeSignatureMintERC721Result("...");
+ * ```
+ */
+export function decodeSignatureMintERC721Result(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "signatureMintERC721" function on the contract.
+ * @param options - The options for the signatureMintERC721 function.
+ * @returns The parsed result of the function call.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { signatureMintERC721 } from "thirdweb/extensions/hooks";
+ *
+ * const result = await signatureMintERC721({
+ *  params: ...,
+ * });
+ *
+ * ```
+ */
+export async function signatureMintERC721(
+  options: BaseTransactionOptions<SignatureMintERC721Params>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.params],
+  });
+}

--- a/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/write/beforeMintERC1155.ts
+++ b/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/write/beforeMintERC1155.ts
@@ -1,0 +1,137 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+
+/**
+ * Represents the parameters for the "beforeMintERC1155" function.
+ */
+
+export type BeforeMintERC1155Params = {
+  to: AbiParameterToPrimitiveType<{
+    name: "_to";
+    type: "address";
+    internalType: "address";
+  }>;
+  id: AbiParameterToPrimitiveType<{
+    name: "_id";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+  quantity: AbiParameterToPrimitiveType<{
+    name: "_quantity";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+  data: AbiParameterToPrimitiveType<{
+    name: "_data";
+    type: "bytes";
+    internalType: "bytes";
+  }>;
+};
+
+const FN_SELECTOR = "0x1e1dcb18" as const;
+const FN_INPUTS = [
+  {
+    name: "_to",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "_id",
+    type: "uint256",
+    internalType: "uint256",
+  },
+  {
+    name: "_quantity",
+    type: "uint256",
+    internalType: "uint256",
+  },
+  {
+    name: "_data",
+    type: "bytes",
+    internalType: "bytes",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "bytes",
+    internalType: "bytes",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "beforeMintERC1155" function.
+ * @param options - The options for the beforeMintERC1155 function.
+ * @returns The encoded ABI parameters.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { encodeBeforeMintERC1155Params } "thirdweb/extensions/hooks";
+ * const result = encodeBeforeMintERC1155Params({
+ *  to: ...,
+ *  id: ...,
+ *  quantity: ...,
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeBeforeMintERC1155Params(
+  options: BeforeMintERC1155Params,
+) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.to,
+    options.id,
+    options.quantity,
+    options.data,
+  ]);
+}
+
+/**
+ * Calls the "beforeMintERC1155" function on the contract.
+ * @param options - The options for the "beforeMintERC1155" function.
+ * @returns A prepared transaction object.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { beforeMintERC1155 } from "thirdweb/extensions/hooks";
+ *
+ * const transaction = beforeMintERC1155({
+ *  contract,
+ *  to: ...,
+ *  id: ...,
+ *  quantity: ...,
+ *  data: ...,
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function beforeMintERC1155(
+  options: BaseTransactionOptions<
+    | BeforeMintERC1155Params
+    | {
+        asyncParams: () => Promise<BeforeMintERC1155Params>;
+      }
+  >,
+) {
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params:
+      "asyncParams" in options
+        ? async () => {
+            const resolvedParams = await options.asyncParams();
+            return [
+              resolvedParams.to,
+              resolvedParams.id,
+              resolvedParams.quantity,
+              resolvedParams.data,
+            ] as const;
+          }
+        : [options.to, options.id, options.quantity, options.data],
+  });
+}

--- a/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/write/beforeMintERC20.ts
+++ b/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/write/beforeMintERC20.ts
@@ -1,0 +1,121 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+
+/**
+ * Represents the parameters for the "beforeMintERC20" function.
+ */
+
+export type BeforeMintERC20Params = {
+  to: AbiParameterToPrimitiveType<{
+    name: "_to";
+    type: "address";
+    internalType: "address";
+  }>;
+  quantity: AbiParameterToPrimitiveType<{
+    name: "_quantity";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+  data: AbiParameterToPrimitiveType<{
+    name: "_data";
+    type: "bytes";
+    internalType: "bytes";
+  }>;
+};
+
+const FN_SELECTOR = "0x7ce7cf07" as const;
+const FN_INPUTS = [
+  {
+    name: "_to",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "_quantity",
+    type: "uint256",
+    internalType: "uint256",
+  },
+  {
+    name: "_data",
+    type: "bytes",
+    internalType: "bytes",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "bytes",
+    internalType: "bytes",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "beforeMintERC20" function.
+ * @param options - The options for the beforeMintERC20 function.
+ * @returns The encoded ABI parameters.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { encodeBeforeMintERC20Params } "thirdweb/extensions/hooks";
+ * const result = encodeBeforeMintERC20Params({
+ *  to: ...,
+ *  quantity: ...,
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeBeforeMintERC20Params(options: BeforeMintERC20Params) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.to,
+    options.quantity,
+    options.data,
+  ]);
+}
+
+/**
+ * Calls the "beforeMintERC20" function on the contract.
+ * @param options - The options for the "beforeMintERC20" function.
+ * @returns A prepared transaction object.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { beforeMintERC20 } from "thirdweb/extensions/hooks";
+ *
+ * const transaction = beforeMintERC20({
+ *  contract,
+ *  to: ...,
+ *  quantity: ...,
+ *  data: ...,
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function beforeMintERC20(
+  options: BaseTransactionOptions<
+    | BeforeMintERC20Params
+    | {
+        asyncParams: () => Promise<BeforeMintERC20Params>;
+      }
+  >,
+) {
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params:
+      "asyncParams" in options
+        ? async () => {
+            const resolvedParams = await options.asyncParams();
+            return [
+              resolvedParams.to,
+              resolvedParams.quantity,
+              resolvedParams.data,
+            ] as const;
+          }
+        : [options.to, options.quantity, options.data],
+  });
+}

--- a/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/write/beforeMintERC721.ts
+++ b/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/write/beforeMintERC721.ts
@@ -1,0 +1,121 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+
+/**
+ * Represents the parameters for the "beforeMintERC721" function.
+ */
+
+export type BeforeMintERC721Params = {
+  to: AbiParameterToPrimitiveType<{
+    name: "_to";
+    type: "address";
+    internalType: "address";
+  }>;
+  quantity: AbiParameterToPrimitiveType<{
+    name: "_quantity";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+  data: AbiParameterToPrimitiveType<{
+    name: "_data";
+    type: "bytes";
+    internalType: "bytes";
+  }>;
+};
+
+const FN_SELECTOR = "0x592394bf" as const;
+const FN_INPUTS = [
+  {
+    name: "_to",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "_quantity",
+    type: "uint256",
+    internalType: "uint256",
+  },
+  {
+    name: "_data",
+    type: "bytes",
+    internalType: "bytes",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "bytes",
+    internalType: "bytes",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "beforeMintERC721" function.
+ * @param options - The options for the beforeMintERC721 function.
+ * @returns The encoded ABI parameters.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { encodeBeforeMintERC721Params } "thirdweb/extensions/hooks";
+ * const result = encodeBeforeMintERC721Params({
+ *  to: ...,
+ *  quantity: ...,
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeBeforeMintERC721Params(options: BeforeMintERC721Params) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.to,
+    options.quantity,
+    options.data,
+  ]);
+}
+
+/**
+ * Calls the "beforeMintERC721" function on the contract.
+ * @param options - The options for the "beforeMintERC721" function.
+ * @returns A prepared transaction object.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { beforeMintERC721 } from "thirdweb/extensions/hooks";
+ *
+ * const transaction = beforeMintERC721({
+ *  contract,
+ *  to: ...,
+ *  quantity: ...,
+ *  data: ...,
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function beforeMintERC721(
+  options: BaseTransactionOptions<
+    | BeforeMintERC721Params
+    | {
+        asyncParams: () => Promise<BeforeMintERC721Params>;
+      }
+  >,
+) {
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params:
+      "asyncParams" in options
+        ? async () => {
+            const resolvedParams = await options.asyncParams();
+            return [
+              resolvedParams.to,
+              resolvedParams.quantity,
+              resolvedParams.data,
+            ] as const;
+          }
+        : [options.to, options.quantity, options.data],
+  });
+}

--- a/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/write/multicall.ts
+++ b/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/write/multicall.ts
@@ -1,0 +1,89 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+
+/**
+ * Represents the parameters for the "multicall" function.
+ */
+
+export type MulticallParams = {
+  data: AbiParameterToPrimitiveType<{
+    name: "data";
+    type: "bytes[]";
+    internalType: "bytes[]";
+  }>;
+};
+
+const FN_SELECTOR = "0xac9650d8" as const;
+const FN_INPUTS = [
+  {
+    name: "data",
+    type: "bytes[]",
+    internalType: "bytes[]",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "bytes[]",
+    internalType: "bytes[]",
+  },
+] as const;
+
+/**
+ * Encodes the parameters for the "multicall" function.
+ * @param options - The options for the multicall function.
+ * @returns The encoded ABI parameters.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { encodeMulticallParams } "thirdweb/extensions/hooks";
+ * const result = encodeMulticallParams({
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeMulticallParams(options: MulticallParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.data]);
+}
+
+/**
+ * Calls the "multicall" function on the contract.
+ * @param options - The options for the "multicall" function.
+ * @returns A prepared transaction object.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { multicall } from "thirdweb/extensions/hooks";
+ *
+ * const transaction = multicall({
+ *  contract,
+ *  data: ...,
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function multicall(
+  options: BaseTransactionOptions<
+    | MulticallParams
+    | {
+        asyncParams: () => Promise<MulticallParams>;
+      }
+  >,
+) {
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params:
+      "asyncParams" in options
+        ? async () => {
+            const resolvedParams = await options.asyncParams();
+            return [resolvedParams.data] as const;
+          }
+        : [options.data],
+  });
+}

--- a/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/write/setClaimPhaseERC1155.ts
+++ b/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/write/setClaimPhaseERC1155.ts
@@ -1,0 +1,137 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+
+/**
+ * Represents the parameters for the "setClaimPhaseERC1155" function.
+ */
+
+export type SetClaimPhaseERC1155Params = {
+  id: AbiParameterToPrimitiveType<{
+    name: "_id";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+  claimPhase: AbiParameterToPrimitiveType<{
+    name: "_claimPhase";
+    type: "tuple";
+    internalType: "struct MintHook.ClaimPhase";
+    components: [
+      { name: "availableSupply"; type: "uint256"; internalType: "uint256" },
+      { name: "allowlistMerkleRoot"; type: "bytes32"; internalType: "bytes32" },
+      { name: "pricePerUnit"; type: "uint256"; internalType: "uint256" },
+      { name: "currency"; type: "address"; internalType: "address" },
+      { name: "startTimestamp"; type: "uint48"; internalType: "uint48" },
+      { name: "endTimestamp"; type: "uint48"; internalType: "uint48" },
+    ];
+  }>;
+};
+
+const FN_SELECTOR = "0x1ff71e06" as const;
+const FN_INPUTS = [
+  {
+    name: "_id",
+    type: "uint256",
+    internalType: "uint256",
+  },
+  {
+    name: "_claimPhase",
+    type: "tuple",
+    internalType: "struct MintHook.ClaimPhase",
+    components: [
+      {
+        name: "availableSupply",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "allowlistMerkleRoot",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+      {
+        name: "pricePerUnit",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "currency",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "startTimestamp",
+        type: "uint48",
+        internalType: "uint48",
+      },
+      {
+        name: "endTimestamp",
+        type: "uint48",
+        internalType: "uint48",
+      },
+    ],
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "setClaimPhaseERC1155" function.
+ * @param options - The options for the setClaimPhaseERC1155 function.
+ * @returns The encoded ABI parameters.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { encodeSetClaimPhaseERC1155Params } "thirdweb/extensions/hooks";
+ * const result = encodeSetClaimPhaseERC1155Params({
+ *  id: ...,
+ *  claimPhase: ...,
+ * });
+ * ```
+ */
+export function encodeSetClaimPhaseERC1155Params(
+  options: SetClaimPhaseERC1155Params,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.id, options.claimPhase]);
+}
+
+/**
+ * Calls the "setClaimPhaseERC1155" function on the contract.
+ * @param options - The options for the "setClaimPhaseERC1155" function.
+ * @returns A prepared transaction object.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { setClaimPhaseERC1155 } from "thirdweb/extensions/hooks";
+ *
+ * const transaction = setClaimPhaseERC1155({
+ *  contract,
+ *  id: ...,
+ *  claimPhase: ...,
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function setClaimPhaseERC1155(
+  options: BaseTransactionOptions<
+    | SetClaimPhaseERC1155Params
+    | {
+        asyncParams: () => Promise<SetClaimPhaseERC1155Params>;
+      }
+  >,
+) {
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params:
+      "asyncParams" in options
+        ? async () => {
+            const resolvedParams = await options.asyncParams();
+            return [resolvedParams.id, resolvedParams.claimPhase] as const;
+          }
+        : [options.id, options.claimPhase],
+  });
+}

--- a/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/write/setClaimPhaseERC20.ts
+++ b/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/write/setClaimPhaseERC20.ts
@@ -1,0 +1,125 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+
+/**
+ * Represents the parameters for the "setClaimPhaseERC20" function.
+ */
+
+export type SetClaimPhaseERC20Params = {
+  claimPhase: AbiParameterToPrimitiveType<{
+    name: "_claimPhase";
+    type: "tuple";
+    internalType: "struct MintHook.ClaimPhase";
+    components: [
+      { name: "availableSupply"; type: "uint256"; internalType: "uint256" },
+      { name: "allowlistMerkleRoot"; type: "bytes32"; internalType: "bytes32" },
+      { name: "pricePerUnit"; type: "uint256"; internalType: "uint256" },
+      { name: "currency"; type: "address"; internalType: "address" },
+      { name: "startTimestamp"; type: "uint48"; internalType: "uint48" },
+      { name: "endTimestamp"; type: "uint48"; internalType: "uint48" },
+    ];
+  }>;
+};
+
+const FN_SELECTOR = "0x4659f3c0" as const;
+const FN_INPUTS = [
+  {
+    name: "_claimPhase",
+    type: "tuple",
+    internalType: "struct MintHook.ClaimPhase",
+    components: [
+      {
+        name: "availableSupply",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "allowlistMerkleRoot",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+      {
+        name: "pricePerUnit",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "currency",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "startTimestamp",
+        type: "uint48",
+        internalType: "uint48",
+      },
+      {
+        name: "endTimestamp",
+        type: "uint48",
+        internalType: "uint48",
+      },
+    ],
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "setClaimPhaseERC20" function.
+ * @param options - The options for the setClaimPhaseERC20 function.
+ * @returns The encoded ABI parameters.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { encodeSetClaimPhaseERC20Params } "thirdweb/extensions/hooks";
+ * const result = encodeSetClaimPhaseERC20Params({
+ *  claimPhase: ...,
+ * });
+ * ```
+ */
+export function encodeSetClaimPhaseERC20Params(
+  options: SetClaimPhaseERC20Params,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.claimPhase]);
+}
+
+/**
+ * Calls the "setClaimPhaseERC20" function on the contract.
+ * @param options - The options for the "setClaimPhaseERC20" function.
+ * @returns A prepared transaction object.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { setClaimPhaseERC20 } from "thirdweb/extensions/hooks";
+ *
+ * const transaction = setClaimPhaseERC20({
+ *  contract,
+ *  claimPhase: ...,
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function setClaimPhaseERC20(
+  options: BaseTransactionOptions<
+    | SetClaimPhaseERC20Params
+    | {
+        asyncParams: () => Promise<SetClaimPhaseERC20Params>;
+      }
+  >,
+) {
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params:
+      "asyncParams" in options
+        ? async () => {
+            const resolvedParams = await options.asyncParams();
+            return [resolvedParams.claimPhase] as const;
+          }
+        : [options.claimPhase],
+  });
+}

--- a/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/write/setClaimPhaseERC721.ts
+++ b/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/write/setClaimPhaseERC721.ts
@@ -1,0 +1,125 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+
+/**
+ * Represents the parameters for the "setClaimPhaseERC721" function.
+ */
+
+export type SetClaimPhaseERC721Params = {
+  claimPhase: AbiParameterToPrimitiveType<{
+    name: "_claimPhase";
+    type: "tuple";
+    internalType: "struct MintHook.ClaimPhase";
+    components: [
+      { name: "availableSupply"; type: "uint256"; internalType: "uint256" },
+      { name: "allowlistMerkleRoot"; type: "bytes32"; internalType: "bytes32" },
+      { name: "pricePerUnit"; type: "uint256"; internalType: "uint256" },
+      { name: "currency"; type: "address"; internalType: "address" },
+      { name: "startTimestamp"; type: "uint48"; internalType: "uint48" },
+      { name: "endTimestamp"; type: "uint48"; internalType: "uint48" },
+    ];
+  }>;
+};
+
+const FN_SELECTOR = "0x12869c58" as const;
+const FN_INPUTS = [
+  {
+    name: "_claimPhase",
+    type: "tuple",
+    internalType: "struct MintHook.ClaimPhase",
+    components: [
+      {
+        name: "availableSupply",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "allowlistMerkleRoot",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+      {
+        name: "pricePerUnit",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "currency",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "startTimestamp",
+        type: "uint48",
+        internalType: "uint48",
+      },
+      {
+        name: "endTimestamp",
+        type: "uint48",
+        internalType: "uint48",
+      },
+    ],
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "setClaimPhaseERC721" function.
+ * @param options - The options for the setClaimPhaseERC721 function.
+ * @returns The encoded ABI parameters.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { encodeSetClaimPhaseERC721Params } "thirdweb/extensions/hooks";
+ * const result = encodeSetClaimPhaseERC721Params({
+ *  claimPhase: ...,
+ * });
+ * ```
+ */
+export function encodeSetClaimPhaseERC721Params(
+  options: SetClaimPhaseERC721Params,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.claimPhase]);
+}
+
+/**
+ * Calls the "setClaimPhaseERC721" function on the contract.
+ * @param options - The options for the "setClaimPhaseERC721" function.
+ * @returns A prepared transaction object.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { setClaimPhaseERC721 } from "thirdweb/extensions/hooks";
+ *
+ * const transaction = setClaimPhaseERC721({
+ *  contract,
+ *  claimPhase: ...,
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function setClaimPhaseERC721(
+  options: BaseTransactionOptions<
+    | SetClaimPhaseERC721Params
+    | {
+        asyncParams: () => Promise<SetClaimPhaseERC721Params>;
+      }
+  >,
+) {
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params:
+      "asyncParams" in options
+        ? async () => {
+            const resolvedParams = await options.asyncParams();
+            return [resolvedParams.claimPhase] as const;
+          }
+        : [options.claimPhase],
+  });
+}

--- a/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/write/setSaleConfig.ts
+++ b/packages/thirdweb/src/extensions/hooks/__generated__/MintHook/write/setSaleConfig.ts
@@ -1,0 +1,119 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+
+/**
+ * Represents the parameters for the "setSaleConfig" function.
+ */
+
+export type SetSaleConfigParams = {
+  primarySaleRecipient: AbiParameterToPrimitiveType<{
+    name: "_primarySaleRecipient";
+    type: "address";
+    internalType: "address";
+  }>;
+  platformFeeRecipient: AbiParameterToPrimitiveType<{
+    name: "_platformFeeRecipient";
+    type: "address";
+    internalType: "address";
+  }>;
+  platformFeeBps: AbiParameterToPrimitiveType<{
+    name: "_platformFeeBps";
+    type: "uint16";
+    internalType: "uint16";
+  }>;
+};
+
+const FN_SELECTOR = "0x09d3e819" as const;
+const FN_INPUTS = [
+  {
+    name: "_primarySaleRecipient",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "_platformFeeRecipient",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "_platformFeeBps",
+    type: "uint16",
+    internalType: "uint16",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Encodes the parameters for the "setSaleConfig" function.
+ * @param options - The options for the setSaleConfig function.
+ * @returns The encoded ABI parameters.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { encodeSetSaleConfigParams } "thirdweb/extensions/hooks";
+ * const result = encodeSetSaleConfigParams({
+ *  primarySaleRecipient: ...,
+ *  platformFeeRecipient: ...,
+ *  platformFeeBps: ...,
+ * });
+ * ```
+ */
+export function encodeSetSaleConfigParams(options: SetSaleConfigParams) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.primarySaleRecipient,
+    options.platformFeeRecipient,
+    options.platformFeeBps,
+  ]);
+}
+
+/**
+ * Calls the "setSaleConfig" function on the contract.
+ * @param options - The options for the "setSaleConfig" function.
+ * @returns A prepared transaction object.
+ * @extension HOOKS
+ * @example
+ * ```ts
+ * import { setSaleConfig } from "thirdweb/extensions/hooks";
+ *
+ * const transaction = setSaleConfig({
+ *  contract,
+ *  primarySaleRecipient: ...,
+ *  platformFeeRecipient: ...,
+ *  platformFeeBps: ...,
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function setSaleConfig(
+  options: BaseTransactionOptions<
+    | SetSaleConfigParams
+    | {
+        asyncParams: () => Promise<SetSaleConfigParams>;
+      }
+  >,
+) {
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params:
+      "asyncParams" in options
+        ? async () => {
+            const resolvedParams = await options.asyncParams();
+            return [
+              resolvedParams.primarySaleRecipient,
+              resolvedParams.platformFeeRecipient,
+              resolvedParams.platformFeeBps,
+            ] as const;
+          }
+        : [
+            options.primarySaleRecipient,
+            options.platformFeeRecipient,
+            options.platformFeeBps,
+          ],
+  });
+}


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

## Changes made

- [ ] Public API changes: list the public API changes made if any
- [ ] Internal API changes: explain the internal logic changes

## How to test

- [ ] Automated tests: link to unit test file
- [ ] Manual tests: step by step instructions on how to test

## Contributor NFT

Paste in your wallet address below and we will airdrop you a special NFT when your pull request is merged. 

```Address: ```


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds ERC721 extension functions and events for ownership management and hooks in Thirdweb.

### Detailed summary
- Added ERC721 extension functions for ownership management
- Included events for OwnershipTransferred, Transfer, ApprovalForAll, OwnershipHandoverRequested, OwnershipHandoverCanceled, HooksInstalled, and HooksUninstalled

> The following files were skipped due to too many changes: `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/events/Transfer.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/events/Approval.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/name.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/owner.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/symbol.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/events/ConsecutiveTransfer.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/contractURI.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/totalSupply.ts`, `packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/ON_TOKEN_URI_FLAG.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/ON_TOKEN_URI_FLAG.ts`, `packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/ON_ROYALTY_INFO_FLAG.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/ON_ROYALTY_INFO_FLAG.ts`, `packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/BEFORE_BURN_ERC20_FLAG.ts`, `packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/BEFORE_MINT_ERC20_FLAG.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/BEFORE_BURN_ERC20_FLAG.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/BEFORE_MINT_ERC20_FLAG.ts`, `packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/BEFORE_BURN_ERC721_FLAG.ts`, `packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/BEFORE_MINT_ERC721_FLAG.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/BEFORE_BURN_ERC721_FLAG.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/BEFORE_MINT_ERC721_FLAG.ts`, `packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/BEFORE_BURN_ERC1155_FLAG.ts`, `packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/BEFORE_MINT_ERC1155_FLAG.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/BEFORE_BURN_ERC1155_FLAG.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/BEFORE_MINT_ERC1155_FLAG.ts`, `packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/BEFORE_APPROVE_ERC20_FLAG.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/BEFORE_APPROVE_ERC20_FLAG.ts`, `packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/BEFORE_APPROVE_ERC721_FLAG.ts`, `packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/BEFORE_TRANSFER_ERC20_FLAG.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/BEFORE_APPROVE_ERC721_FLAG.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/BEFORE_TRANSFER_ERC20_FLAG.ts`, `packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/BEFORE_APPROVE_FOR_ALL_FLAG.ts`, `packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/BEFORE_TRANSFER_ERC721_FLAG.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/BEFORE_APPROVE_FOR_ALL_FLAG.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/BEFORE_TRANSFER_ERC721_FLAG.ts`, `packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/BEFORE_TRANSFER_ERC1155_FLAG.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/BEFORE_TRANSFER_ERC1155_FLAG.ts`, `packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/BEFORE_BATCH_TRANSFER_ERC1155_FLAG.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/BEFORE_BATCH_TRANSFER_ERC1155_FLAG.ts`, `packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/eip712Domain.ts`, `packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/getHookInfo.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/getAllHooks.ts`, `packages/thirdweb/src/extensions/hooks/__generated__/MintHook/write/multicall.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/write/multicall.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/write/setContractURI.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/write/uninstallHook.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/write/transferOwnership.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/write/burn.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/write/approve.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/write/completeOwnershipHandover.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/tokenURI.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/ownerOf.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/balanceOf.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/getApproved.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/write/setApprovalForAll.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/write/mint.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/tokensOfOwner.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/write/transferFrom.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/_highestBitToZero.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/supportsInterface.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/write/installHook.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/getHookImplementation.ts`, `packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/getSaleConfig.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/write/safeTransferFrom.ts`, `packages/thirdweb/src/extensions/hooks/__generated__/MintHook/write/beforeMintERC20.ts`, `packages/thirdweb/src/extensions/hooks/__generated__/MintHook/write/beforeMintERC721.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/royaltyInfo.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/isApprovedForAll.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/ownershipHandoverExpiresAt.ts`, `packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/decodeClaimParams.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/explicitOwnershipOf.ts`, `packages/thirdweb/src/extensions/hooks/__generated__/MintHook/write/setSaleConfig.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/explicitOwnershipsOf.ts`, `packages/thirdweb/src/extensions/hooks/__generated__/MintHook/write/beforeMintERC1155.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/tokensOfOwnerIn.ts`, `packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/allowlistMint.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ERC721Core/read/getHookFallbackFunctionCall.ts`, `packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/getClaimPhaseERC20.ts`, `packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/getClaimPhaseERC721.ts`, `packages/thirdweb/src/extensions/hooks/__generated__/MintHook/write/setClaimPhaseERC20.ts`, `packages/thirdweb/src/extensions/hooks/__generated__/MintHook/write/setClaimPhaseERC721.ts`, `packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/getClaimPhaseERC1155.ts`, `packages/thirdweb/src/extensions/hooks/__generated__/MintHook/write/setClaimPhaseERC1155.ts`, `packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/decodeSignatureMintERC20Params.ts`, `packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/decodeSignatureMintERC721Params.ts`, `packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/decodeSignatureMintERC1155Params.ts`, `packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/signatureMintERC20.ts`, `packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/signatureMintERC721.ts`, `packages/thirdweb/src/extensions/hooks/__generated__/MintHook/read/signatureMintERC1155.ts`, `packages/thirdweb/scripts/generate/abis/hooks/MintHook.json`, `packages/thirdweb/scripts/generate/abis/erc721/ERC721Core.json`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->