### PR TITLE
Unity 4.13.3

### DIFF
--- a/.changeset/quiet-rings-flow.md
+++ b/.changeset/quiet-rings-flow.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/unity-js-bridge": patch
+---
+
+Unity 4.13.3

--- a/legacy_packages/unity-js-bridge/src/thirdweb-bridge.ts
+++ b/legacy_packages/unity-js-bridge/src/thirdweb-bridge.ts
@@ -171,7 +171,7 @@ class ThirdwebBridge implements TWBridge {
       // biome-ignore lint/suspicious/noExplicitAny: TODO: fix use of any
       (globalThis as any).X_SDK_PLATFORM = "unity";
       // biome-ignore lint/suspicious/noExplicitAny: TODO: fix use of any
-      (globalThis as any).X_SDK_VERSION = "4.13.2";
+      (globalThis as any).X_SDK_VERSION = "4.13.3";
       // biome-ignore lint/suspicious/noExplicitAny: TODO: fix use of any
       (globalThis as any).X_SDK_OS = browser?.os ?? "unknown";
     }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the Unity SDK version to 4.13.3 and makes minor adjustments in the `thirdweb-bridge.ts` file related to the SDK platform and version.

### Detailed summary
- Updated Unity SDK version to 4.13.3
- Set SDK platform to "unity"
- Updated SDK version to "4.13.3"
- Set SDK OS to browser's OS or "unknown"

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->