### PR TITLE
CommonJS import on RN lazy load

### DIFF
--- a/packages/thirdweb/src/wallets/in-app/core/authentication/index.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/authentication/index.ts
@@ -32,9 +32,9 @@ async function getInAppWalletConnector(client: ThirdwebClient) {
       client: client,
     });
   } else if (isReactNative()) {
-    const { InAppNativeConnector } = await import(
-      "../../native/native-connector.js"
-    );
+    const {
+      InAppNativeConnector,
+    } = require("../../native/native-connector.js");
     ewSDK = new InAppNativeConnector({
       client,
     });


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the way `InAppNativeConnector` is imported in the authentication module for React Native.

### Detailed summary
- Changed import of `InAppNativeConnector` from dynamic import to `require`
- Updated object destructuring for `InAppNativeConnector`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->