### PR TITLE
refactor: Update imports for AsyncStorage and encryption libraries

### DIFF
--- a/packages/thirdweb/src/wallets/in-app/native/helpers/storage/local.ts
+++ b/packages/thirdweb/src/wallets/in-app/native/helpers/storage/local.ts
@@ -1,4 +1,3 @@
-import AsyncStorage from "@react-native-async-storage/async-storage";
 import type { AuthArgsType } from "../../../core/authentication/type.js";
 import {
   AUTH_TOKEN_LOCAL_STORAGE_NAME,
@@ -13,15 +12,15 @@ const CONNECTED_AUTH_STRATEGY_LOCAL_STORAGE_NAME =
   "embedded-wallet-connected-auth-params";
 
 const getItemFromAsyncStorage = async (key: string) => {
-  return AsyncStorage.getItem(key);
+  return require("@react-native-async-storage/async-storage").getItem(key);
 };
 
 const setItemInAsyncStorage = async (key: string, value: string) => {
-  await AsyncStorage.setItem(key, value);
+  require("@react-native-async-storage/async-storage").setItem(key, value);
 };
 
 const removeItemInAsyncStorage = async (key: string) => {
-  await AsyncStorage.removeItem(key);
+  require("@react-native-async-storage/async-storage").removeItem(key);
 };
 
 export async function getConnectedEmail() {

--- a/packages/thirdweb/src/wallets/in-app/native/helpers/wallet/encryption.ts
+++ b/packages/thirdweb/src/wallets/in-app/native/helpers/wallet/encryption.ts
@@ -1,5 +1,4 @@
-import AesGcmCrypto from "react-native-aes-gcm-crypto";
-import QuickCrypto from "react-native-quick-crypto";
+import type { EncryptedData } from "react-native-aes-gcm-crypto";
 import { concat } from "viem/utils";
 import {
   hexToUint8Array,
@@ -21,7 +20,7 @@ export async function getEncryptionKey(
   salt: Uint8Array,
   iterationCounts: number,
 ): Promise<string> {
-  const key: ArrayBuffer = QuickCrypto.pbkdf2Sync(
+  const key: ArrayBuffer = require("react-native-quick-crypto").pbkdf2Sync(
     pwd,
     salt.buffer as ArrayBuffer,
     iterationCounts,
@@ -47,10 +46,13 @@ export async function encryptShareWeb(
 
   const keyBase64 = await getEncryptionKey(pwd, salt, iterationCount);
 
-  // biome-ignore lint/suspicious/noExplicitAny: Can't import the types properly
-  let encryptedValue: any;
+  let encryptedValue: EncryptedData;
   try {
-    encryptedValue = await AesGcmCrypto.encrypt(share, false, keyBase64);
+    encryptedValue = await require("react-native-aes-gcm-crypto").encrypt(
+      share,
+      false,
+      keyBase64,
+    );
   } catch (error) {
     throw new Error(`Error encrypting share: ${error}`);
   }
@@ -129,7 +131,7 @@ export async function decryptShareWeb(
   // biome-ignore lint/style/noNonNullAssertion: it's there
   const ivBufferHex = uint8ArrayToHex(base64ToUint8Array(ivBase64!));
 
-  const normalizedShare = await AesGcmCrypto.decrypt(
+  const normalizedShare = await require("react-native-aes-gcm-crypto").decrypt(
     originalBase64CipherText,
     key,
     ivBufferHex.slice(2), // lib expects hex with no


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to replace direct imports with `require` statements for AsyncStorage and encryption libraries in the `thirdweb` package.

### Detailed summary
- Replaced direct imports with `require` for AsyncStorage in `local.ts`
- Replaced `react-native-quick-crypto` import with `require` in `encryption.ts`
- Updated encryption functions to use `react-native-aes-gcm-crypto`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->