### PR TITLE
fix: add ts-ignore for react native native libs

### DIFF
--- a/packages/thirdweb/src/wallets/in-app/native/helpers/storage/local.ts
+++ b/packages/thirdweb/src/wallets/in-app/native/helpers/storage/local.ts
@@ -13,14 +13,17 @@ const CONNECTED_AUTH_STRATEGY_LOCAL_STORAGE_NAME =
   "embedded-wallet-connected-auth-params";
 
 const getItemFromAsyncStorage = async (key: string) => {
+  // @ts-ignore - default import buils but ts doesn't like it
   return AsyncStorage.getItem(key);
 };
 
 const setItemInAsyncStorage = async (key: string, value: string) => {
+  // @ts-ignore - default import buils but ts doesn't like it
   await AsyncStorage.setItem(key, value);
 };
 
 const removeItemInAsyncStorage = async (key: string) => {
+  // @ts-ignore - default import buils but ts doesn't like it
   await AsyncStorage.removeItem(key);
 };
 

--- a/packages/thirdweb/src/wallets/in-app/native/helpers/wallet/encryption.ts
+++ b/packages/thirdweb/src/wallets/in-app/native/helpers/wallet/encryption.ts
@@ -21,6 +21,7 @@ export async function getEncryptionKey(
   salt: Uint8Array,
   iterationCounts: number,
 ): Promise<string> {
+  // @ts-ignore - default import buils but ts doesn't like it
   const key: ArrayBuffer = QuickCrypto.pbkdf2Sync(
     pwd,
     salt.buffer as ArrayBuffer,
@@ -50,6 +51,7 @@ export async function encryptShareWeb(
   // biome-ignore lint/suspicious/noExplicitAny: Can't import the types properly
   let encryptedValue: any;
   try {
+    // @ts-ignore - default import buils but ts doesn't like it
     encryptedValue = await AesGcmCrypto.encrypt(share, false, keyBase64);
   } catch (error) {
     throw new Error(`Error encrypting share: ${error}`);
@@ -129,6 +131,7 @@ export async function decryptShareWeb(
   // biome-ignore lint/style/noNonNullAssertion: it's there
   const ivBufferHex = uint8ArrayToHex(base64ToUint8Array(ivBase64!));
 
+  // @ts-ignore - default import buils but ts doesn't like it
   const normalizedShare = await AesGcmCrypto.decrypt(
     originalBase64CipherText,
     key,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces `@ts-ignore` comments to handle TypeScript issues with default imports in AsyncStorage and encryption functions.

### Detailed summary
- Added `@ts-ignore` comments for default imports in AsyncStorage functions.
- Added `@ts-ignore` comments for default imports in encryption functions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->