### PR TITLE
Adds signMessage test for viem adapter

### DIFF
--- a/packages/thirdweb/src/adapters/viem.test.ts
+++ b/packages/thirdweb/src/adapters/viem.test.ts
@@ -1,4 +1,4 @@
-import { zeroAddress } from "viem";
+import { type Account as ViemAccount, zeroAddress } from "viem";
 import { beforeAll, describe, expect, test } from "vitest";
 import { ANVIL_PKEY_A } from "~test/test-wallets.js";
 import { typedData } from "~test/typed-data.js";
@@ -85,5 +85,16 @@ describe("walletClient.toViem", () => {
     const address = await walletClient.getAddresses();
     expect(address[0]).toBeDefined();
     expect(address[0]).toBe(account.address);
+  });
+
+  test("should match thirdweb account signature", async () => {
+    const message = "testing123";
+    const twSignature = await account.signMessage({ message });
+    const viemSignature = await walletClient.signMessage({
+      message,
+      account: walletClient.account as ViemAccount,
+    });
+
+    expect(viemSignature).toEqual(twSignature);
   });
 });

--- a/packages/thirdweb/src/adapters/viem.test.ts
+++ b/packages/thirdweb/src/adapters/viem.test.ts
@@ -1,4 +1,5 @@
 import { type Account as ViemAccount, zeroAddress } from "viem";
+import { privateKeyToAccount as viemPrivateKeyToAccount } from "viem/accounts";
 import { beforeAll, describe, expect, test } from "vitest";
 import { ANVIL_PKEY_A } from "~test/test-wallets.js";
 import { typedData } from "~test/typed-data.js";
@@ -89,12 +90,16 @@ describe("walletClient.toViem", () => {
 
   test("should match thirdweb account signature", async () => {
     const message = "testing123";
+
+    const rawViemAccount = viemPrivateKeyToAccount(ANVIL_PKEY_A);
     const twSignature = await account.signMessage({ message });
-    const viemSignature = await walletClient.signMessage({
+    const viemTwSignature = await walletClient.signMessage({
       message,
       account: walletClient.account as ViemAccount,
     });
+    const viemSignature = await rawViemAccount.signMessage({ message });
 
     expect(viemSignature).toEqual(twSignature);
+    expect(viemTwSignature).toEqual(twSignature);
   });
 });


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to add a test to match the account signature between a Viem account and a thirdweb account.

### Detailed summary
- Added import of Viem account related functions
- Added test to match signatures between Viem and thirdweb accounts

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->