### PR TITLE
Revert text alignment change done in ModalHeader

### DIFF
--- a/packages/thirdweb/src/react/web/ui/components/basic.tsx
+++ b/packages/thirdweb/src/react/web/ui/components/basic.tsx
@@ -42,7 +42,7 @@ export function ModalHeader(props: {
       style={{
         display: "flex",
         alignItems: "center",
-        justifyContent: onBack ? "center" : "flex-start",
+        justifyContent: "center",
         position: "relative",
       }}
     >


### PR DESCRIPTION
Revert change done in https://github.com/thirdweb-dev/js/pull/2912/files#diff-849ef1af6c857eb1434631e3cb25ffc35cb3e283d37b94fc5ac9edf0f22ce363 

ModalHeader is for centered title only ( with or without back button ). Use `<Text size="lg" />` for left aligned titles

<!-- start pr-codex -->

---

## PR-Codex overview
This PR centers the `justifyContent` property in a component, removing conditional logic for alignment.

### Detailed summary
- Centered `justifyContent` property in a component
- Removed conditional logic for alignment based on `onBack` prop

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->