### PR TITLE
Add react native to thirdweb create CLI

### DIFF
--- a/.changeset/three-pans-learn.md
+++ b/.changeset/three-pans-learn.md
@@ -1,0 +1,6 @@
+---
+"@thirdweb-dev/cli": minor
+"thirdweb": minor
+---
+
+Adds React Native to the thirdweb create CLI

--- a/legacy_packages/cli/src/cli/index.ts
+++ b/legacy_packages/cli/src/cli/index.ts
@@ -255,6 +255,7 @@ const main = async () => {
     .option("--extension", "Create a smart contract extension.")
     .option("--next", "Initialize as a Next.js project.")
     .option("--vite", "Initialize as a Vite project.")
+    .option("--react-native", "Initialize as a React Native project.")
     .option("--node", "Initialize as a Node project.")
     .option(
       "--use-npm",

--- a/legacy_packages/cli/src/create/command.ts
+++ b/legacy_packages/cli/src/create/command.ts
@@ -54,6 +54,11 @@ export async function twCreate(
       framework = "vite";
     }
 
+    if (options.reactNative) {
+      projectType = "app";
+      framework = "expo";
+    }
+
     if (options.node) {
       projectType = "app";
       framework = "node";
@@ -66,6 +71,9 @@ export async function twCreate(
     }
     if (options.vite) {
       framework = "vite";
+    }
+    if (options.reactNative) {
+      framework = "expo";
     }
     if (options.node) {
       framework = "node";
@@ -212,6 +220,7 @@ export async function twCreate(
           choices: [
             { title: "Next.js", value: "next" },
             { title: "Vite", value: "vite" },
+            { title: "React Native", value: "expo" },
           ],
         });
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR enhances the `thirdweb create` CLI by adding support for initializing React Native projects. 

### Detailed summary
- Added support for initializing React Native projects in the CLI
- Updated project type and framework based on user selection
- Included React Native as a project choice in the CLI prompt

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->