### PR TITLE
[V4 SDK] Adds ethers-compatible _signTypedData to legacy GCP KMS wallet

### DIFF
--- a/.changeset/grumpy-turtles-try.md
+++ b/.changeset/grumpy-turtles-try.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/wallets": patch
+---
+
+Adds missing \_signTypedData method to GCP KMS wallets

--- a/legacy_packages/wallets/src/evm/connectors/gcp-kms/signer.ts
+++ b/legacy_packages/wallets/src/evm/connectors/gcp-kms/signer.ts
@@ -15,7 +15,7 @@ import {
   TypedDataUtils,
 } from "@metamask/eth-sig-util";
 
-import { ethers, UnsignedTransaction } from "ethers";
+import { ethers, TypedDataDomain, TypedDataField, UnsignedTransaction } from "ethers";
 import { bufferToHex } from "ethereumjs-util";
 import {
   getPublicKey,
@@ -134,6 +134,15 @@ export class GcpKmsSigner extends ethers.Signer {
       messageSignature = this._signDigest(bufferToHex(eip712Hash));
     }
     return messageSignature;
+  }
+
+  async _signTypedData(domain: TypedDataDomain, types: Record<string, Array<TypedDataField>>, value: Record<string, any>) {
+    const hash = ethers.utils._TypedDataEncoder.hash(
+      domain,
+      types,
+      value,
+    );
+    return this._signDigest(hash);
   }
 
   async signTransaction(


### PR DESCRIPTION
We're running into some issues with GCP KMS signatures in engine, one of the root problems was found to be this missing method on the GCP wallets (it exists on AWS KMS).

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds the `_signTypedData` method to GCP KMS wallets for signing typed data using Ethereum's Ethers library.

### Detailed summary
- Added `_signTypedData` method to GCP KMS Signer class
- Imported `TypedDataDomain` and `TypedDataField` from Ethers
- Implemented `_signTypedData` for hashing and signing typed data

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->