### PR TITLE
Use Native wallet link for android in WalletConnect session

### DIFF
--- a/.changeset/flat-teachers-shave.md
+++ b/.changeset/flat-teachers-shave.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Prefer native wallet app link in android as well for WalletConnect session

--- a/packages/thirdweb/src/react/web/wallets/shared/WalletConnectConnection.tsx
+++ b/packages/thirdweb/src/react/web/wallets/shared/WalletConnectConnection.tsx
@@ -40,26 +40,31 @@ export const WalletConnectConnection: React.FC<{
           projectId: walletConnect?.projectId,
           showQrModal: false,
           onDisplayUri(uri) {
-            const platformUris = {
-              ios: walletInfo.mobile.native || "",
-              android: walletInfo.mobile.universal || "",
-              other: walletInfo.mobile.universal || "",
-            };
+            const preferNative =
+              walletInfo.mobile.native || walletInfo.mobile.universal;
 
             setQrCodeUri(uri);
             if (isMobile()) {
               if (isAndroid()) {
-                openWindow(
-                  formatWalletConnectUrl(platformUris.android, uri).redirect,
-                );
+                if (preferNative) {
+                  openWindow(
+                    formatWalletConnectUrl(preferNative, uri).redirect,
+                  );
+                }
               } else if (isIOS()) {
-                openWindow(
-                  formatWalletConnectUrl(platformUris.ios, uri).redirect,
-                );
+                if (preferNative) {
+                  openWindow(
+                    formatWalletConnectUrl(preferNative, uri).redirect,
+                  );
+                }
               } else {
-                openWindow(
-                  formatWalletConnectUrl(platformUris.other, uri).redirect,
-                );
+                const preferUniversal =
+                  walletInfo.mobile.universal || walletInfo.mobile.native;
+                if (preferUniversal) {
+                  openWindow(
+                    formatWalletConnectUrl(preferUniversal, uri).redirect,
+                  );
+                }
               }
             }
           },

--- a/packages/thirdweb/src/wallets/wallet-connect/index.ts
+++ b/packages/thirdweb/src/wallets/wallet-connect/index.ts
@@ -266,20 +266,21 @@ async function initProvider(
         return;
       }
 
-      const preferUniversal =
-        walletInfo.mobile.universal || walletInfo.mobile.native;
       const preferNative =
         walletInfo.mobile.native || walletInfo.mobile.universal;
 
       if (isAndroid()) {
-        if (preferUniversal) {
-          openWindow(preferUniversal);
+        if (preferNative) {
+          openWindow(preferNative);
         }
       } else if (isIOS()) {
         if (preferNative) {
           openWindow(preferNative);
         }
       } else {
+        const preferUniversal =
+          walletInfo.mobile.universal || walletInfo.mobile.native;
+
         if (preferUniversal) {
           openWindow(preferUniversal);
         }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to prefer the native wallet app link in Android for WalletConnect sessions.

### Detailed summary
- Prefer native wallet app link in Android for WalletConnect sessions
- Updated handling of wallet app URLs in different platforms
- Improved logic for displaying QR code modal in mobile devices

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->