### PR TITLE
Expose useWalletBalance in react native

### DIFF
--- a/.changeset/cold-clocks-yawn.md
+++ b/.changeset/cold-clocks-yawn.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Expose useWalletBalance in react native

--- a/packages/thirdweb/scripts/typedoc.mjs
+++ b/packages/thirdweb/scripts/typedoc.mjs
@@ -4,6 +4,7 @@ import { typedoc } from "typedoc-gen";
 typedoc({
   entryPoints: ["src/exports/**/*.ts"],
   exclude: [
+    "src/exports/react-native.ts",
     "test/**/*",
     "src/**/*.test.ts",
     "src/**/*.test.tsx",

--- a/packages/thirdweb/src/exports/react-native.ts
+++ b/packages/thirdweb/src/exports/react-native.ts
@@ -14,6 +14,7 @@ export {
   useSetActiveWalletConnectionStatus,
   useIsAutoConnecting,
 } from "../react/core/hooks/wallets/wallet-hooks.js";
+export { useWalletBalance } from "../react/core/hooks/others/useWalletBalance.js";
 
 // contract related
 export { useReadContract } from "../react/core/hooks/contract/useReadContract.js";


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR exposes `useWalletBalance` in React Native and updates typedoc configuration to exclude `react-native.ts`.

### Detailed summary
- Exposed `useWalletBalance` in React Native
- Updated typedoc to exclude `react-native.ts` file

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->