### PR TITLE
fix: resolveScheme for native apps

### DIFF
--- a/.changeset/shaggy-radios-brake.md
+++ b/.changeset/shaggy-radios-brake.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix resolveScheme for native apps

--- a/packages/thirdweb/src/utils/ipfs.ts
+++ b/packages/thirdweb/src/utils/ipfs.ts
@@ -34,11 +34,18 @@ export function resolveScheme(options: ResolveSchemeOptions) {
     const clientId = options.client.clientId;
     const cid = findIPFSCidFromUri(options.uri);
 
+    let bundleId: string | undefined = undefined;
+    if (typeof globalThis !== "undefined" && "Application" in globalThis) {
+      // shims use wallet connect RN module which injects Application info in globalThis
+      // biome-ignore lint/suspicious/noExplicitAny: get around globalThis typing
+      bundleId = (globalThis as any).Application.applicationId;
+    }
+
     // purposefully using SPLIT here and and not replace for CID to avoid cases where users don't know the schema
     // also only splitting on `/ipfs` to avoid cases where people pass non `/` terminated gateway urls
     return `${
       gateway.replace("{clientId}", clientId).split("/ipfs")[0]
-    }/ipfs/${cid}`;
+    }/ipfs/${cid}${bundleId ? `?bundleId=${bundleId}` : ""}`;
   }
   if (options.uri.startsWith("http")) {
     return options.uri;

--- a/packages/thirdweb/src/wallets/smart/index.ts
+++ b/packages/thirdweb/src/wallets/smart/index.ts
@@ -345,6 +345,7 @@ async function _deployAccount(args: {
     chain: options.chain,
     to: accountContract.address,
     value: 0n,
+    gas: 50000n, // force gas to avoid simulation error
   });
   const deployResult = await sendTransaction({
     transaction: dummyTx,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on fixing `resolveScheme` for native apps in `thirdweb`.

### Detailed summary
- Fixed `resolveScheme` for native apps in `thirdweb`
- Added `bundleId` logic based on `globalThis` for `ipfs.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->