### PR TITLE
`onDisconnect` callback on `<ConnectButton />`

### DIFF
--- a/.changeset/wicked-clocks-talk.md
+++ b/.changeset/wicked-clocks-talk.md
@@ -1,0 +1,15 @@
+---
+"thirdweb": minor
+---
+
+Adds onDisconnect callback to connect button
+
+### Usage
+
+```tsx
+<ConnectButton
+  client={THIRDWEB_CLIENT}
+  onDisconnect={() => console.log("disconnect")}
+  theme={theme === "light" ? "light" : "dark"}
+/>
+```

--- a/packages/thirdweb/src/react/core/providers/wallet-connection.tsx
+++ b/packages/thirdweb/src/react/core/providers/wallet-connection.tsx
@@ -25,6 +25,7 @@ export const ConnectUIContext = /* @__PURE__ */ createContext<{
   accountAbstraction?: SmartWalletOptions;
   showAllWallets?: boolean;
   onConnect?: (wallet: Wallet) => void;
+  onDisconnect?: () => void;
   isEmbed: boolean;
   connectModal: Omit<ConnectButton_connectModalOptions, "size"> & {
     size: "compact" | "wide";

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/ConnectButton.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/ConnectButton.tsx
@@ -117,6 +117,7 @@ export function ConnectButton(props: ConnectButtonProps) {
               : props.connectModal?.size || "wide",
         },
         onConnect: props.onConnect,
+        onDisconnect: props.onDisconnect,
         auth: props.auth,
       }}
     >
@@ -285,6 +286,9 @@ function ConnectButtonInner(
         // logout on explicit disconnect!
         if (siweAuth.requiresAuth) {
           siweAuth.doLogout();
+        }
+        if (props.onDisconnect) {
+          props.onDisconnect();
         }
       }}
       chains={props?.chains || []}

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/ConnectButtonProps.ts
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/ConnectButtonProps.ts
@@ -649,8 +649,8 @@ export type ConnectButtonProps = {
   supportedTokens?: SupportedTokens;
 
   /**
-   * Callback to be called on successful connection of wallet - including auto connect.
-   * The callback is called with the connected wallet
+   * Called on connection of a wallet - including auto connect.
+   * The callback is called with the connected wallet as an argument.
    *
    * ```tsx
    * <ConnectButton
@@ -661,6 +661,19 @@ export type ConnectButtonProps = {
    * ```
    */
   onConnect?: (wallet: Wallet) => void;
+
+  /**
+   * Called when a wallet is disconnected.
+   *
+   * ```tsx
+   * <ConnectButton
+   *  onDisconnect={() => {
+   *    console.log("disconnected")
+   *  }}
+   * />
+   * ```
+   */
+  onDisconnect?: () => void;
 
   /**
    * Configure options for WalletConnect


### PR DESCRIPTION
Adds onDisconnect callback to connect button

### Usage

```tsx
<ConnectButton
  client={THIRDWEB_CLIENT}
  onDisconnect={() => console.log("disconnect")}
  theme={theme === "light" ? "light" : "dark"}
/>
```


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds an `onDisconnect` callback to the ConnectButton component in the thirdweb package for handling wallet disconnections.

### Detailed summary
- Added `onDisconnect` callback to `ConnectButton` component
- Updated `ConnectButtonProps` type definition
- Modified `wallet-connection.tsx` to include `onDisconnect` prop
- Updated usage documentation in `wicked-clocks-talk.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->