### PR TITLE
WalletConnect copy link button

### DIFF
--- a/.changeset/sour-ants-doubt.md
+++ b/.changeset/sour-ants-doubt.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": minor
+---
+
+Adds the ability to copy the wallet connect connection link as an alternative to scanning the QR code

--- a/packages/thirdweb/src/react/web/wallets/shared/ScanScreen.tsx
+++ b/packages/thirdweb/src/react/web/wallets/shared/ScanScreen.tsx
@@ -1,3 +1,6 @@
+"use client";
+import { CheckIcon, CopyIcon } from "@radix-ui/react-icons";
+import { useState } from "react";
 import type { WalletId } from "../../../../wallets/wallet-types.js";
 import { useConnectUI } from "../../../core/hooks/others/useWalletConnectionCtx.js";
 import { AccentFailIcon } from "../../ui/ConnectWallet/icons/AccentFailIcon.js";
@@ -28,6 +31,8 @@ export const ScanScreen: React.FC<{
   onRetry: () => void;
 }> = (props) => {
   const { connectModal, client } = useConnectUI();
+  const [linkCopied, setLinkCopied] = useState(false);
+
   return (
     <Container fullHeight flex="column" animate="fadein">
       <Container p="lg">
@@ -66,6 +71,31 @@ export const ScanScreen: React.FC<{
             >
               {props.qrScanInstruction}
             </Text>
+
+            <Spacer y="lg" />
+
+            <Button
+              disabled={props.qrCodeUri === undefined}
+              variant="link"
+              style={{
+                opacity: props.qrCodeUri === undefined ? 0.5 : 1,
+                cursor: props.qrCodeUri === undefined ? "default" : "pointer",
+              }}
+              onClick={() => {
+                navigator.clipboard
+                  .writeText(props.qrCodeUri as string) // should always be string since the button is disabled otherwise
+                  .then(() => {
+                    setLinkCopied(true);
+                    setTimeout(() => setLinkCopied(false), 3000); // reset the check icon after 3 seconds
+                  })
+                  .catch((err) => {
+                    console.error("Failed to copy link to clipboard", err);
+                  });
+              }}
+            >
+              {linkCopied ? <CheckIcon /> : <CopyIcon />}
+              <span style={{ padding: "0 4px" }}>Copy Link</span>
+            </Button>
           </div>
         )}
 

--- a/packages/thirdweb/src/react/web/wallets/shared/ScanScreen.tsx
+++ b/packages/thirdweb/src/react/web/wallets/shared/ScanScreen.tsx
@@ -59,25 +59,13 @@ export const ScanScreen: React.FC<{
               }
             />
 
-            <Spacer y="lg" />
-
-            <Text
-              center
-              multiline
-              balance
-              style={{
-                paddingInline: spacing.lg,
-              }}
-            >
-              {props.qrScanInstruction}
-            </Text>
-
-            <Spacer y="lg" />
+            <Spacer y="xs" />
 
             <Button
               disabled={props.qrCodeUri === undefined}
               variant="link"
               style={{
+                fontSize: "12px",
                 opacity: props.qrCodeUri === undefined ? 0.5 : 1,
                 cursor: props.qrCodeUri === undefined ? "default" : "pointer",
               }}
@@ -93,9 +81,26 @@ export const ScanScreen: React.FC<{
                   });
               }}
             >
-              {linkCopied ? <CheckIcon /> : <CopyIcon />}
+              {linkCopied ? (
+                <CheckIcon width={14} height={14} />
+              ) : (
+                <CopyIcon width={14} height={14} />
+              )}
               <span style={{ padding: "0 4px" }}>Copy Link</span>
             </Button>
+
+            <Spacer y="lg" />
+
+            <Text
+              center
+              multiline
+              balance
+              style={{
+                paddingInline: spacing.lg,
+              }}
+            >
+              {props.qrScanInstruction}
+            </Text>
           </div>
         )}
 


### PR DESCRIPTION

![Screenshot 2024-05-26 at 7 03 05 PM](https://github.com/thirdweb-dev/js/assets/17715009/b1c2db96-8d0f-4991-8f0c-099d0959876d)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds the ability to copy the wallet connect link as an alternative to scanning the QR code.

### Detailed summary
- Added functionality to copy wallet connect link
- Implemented button to copy link to clipboard
- Display check or copy icon based on copy status

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->