### PR TITLE
don't pass from in estimateGas

### DIFF
--- a/packages/thirdweb/src/transaction/actions/estimate-gas.ts
+++ b/packages/thirdweb/src/transaction/actions/estimate-gas.ts
@@ -88,7 +88,8 @@ export async function estimateGas(
     // 1. the user specified from address
     // 2. the passed in account address
     // 3. the passed in wallet's account address
-    const from = options.from ?? options.account?.address ?? undefined;
+    // TODO investigate Base RPC reverting when the sender has no gas money
+    const from = undefined; // options.from ?? options.account?.address ?? undefined;
     try {
       let gas = await eth_estimateGas(
         rpcRequest,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on investigating issues with gas money by setting `from` to `undefined` temporarily.

### Detailed summary
- Temporarily set `from` to `undefined` to investigate Base RPC gas money issue.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->