### PR TITLE
Add support for cb wallet in react native

### DIFF
--- a/.changeset/fast-toys-remember.md
+++ b/.changeset/fast-toys-remember.md
@@ -1,0 +1,6 @@
+---
+"@thirdweb-dev/react-native-adapter": patch
+"thirdweb": patch
+---
+
+Add support for CB wallet in react native

--- a/packages/react-native-adapter/package.json
+++ b/packages/react-native-adapter/package.json
@@ -33,6 +33,7 @@
   },
   "peerDependencies": {
     "typescript": ">=5.0.4",
+    "@coinbase/wallet-mobile-sdk": "^1",
     "@react-native-async-storage/async-storage": "^1",
     "@react-native-community/netinfo": "^11",
     "amazon-cognito-identity-js": "^6",

--- a/packages/thirdweb/package.json
+++ b/packages/thirdweb/package.json
@@ -110,54 +110,22 @@
   },
   "typesVersions": {
     "*": {
-      "adapters/*": [
-        "./dist/types/exports/adapters/*.d.ts"
-      ],
-      "auth": [
-        "./dist/types/exports/auth.d.ts"
-      ],
-      "chains": [
-        "./dist/types/exports/chains.d.ts"
-      ],
-      "contract": [
-        "./dist/types/exports/contract.d.ts"
-      ],
-      "deploys": [
-        "./dist/types/exports/deploys.d.ts"
-      ],
-      "event": [
-        "./dist/types/exports/event.d.ts"
-      ],
-      "extensions/*": [
-        "./dist/types/exports/extensions/*.d.ts"
-      ],
-      "pay": [
-        "./dist/types/exports/pay.d.ts"
-      ],
-      "react": [
-        "./dist/types/exports/react.d.ts"
-      ],
-      "react-native": [
-        "./dist/types/exports/react-native.d.ts"
-      ],
-      "rpc": [
-        "./dist/types/exports/rpc.d.ts"
-      ],
-      "storage": [
-        "./dist/types/exports/storage.d.ts"
-      ],
-      "transaction": [
-        "./dist/types/exports/transaction.d.ts"
-      ],
-      "utils": [
-        "./dist/types/exports/utils.d.ts"
-      ],
-      "wallets": [
-        "./dist/types/exports/wallets.d.ts"
-      ],
-      "wallets/*": [
-        "./dist/types/exports/wallets/*.d.ts"
-      ]
+      "adapters/*": ["./dist/types/exports/adapters/*.d.ts"],
+      "auth": ["./dist/types/exports/auth.d.ts"],
+      "chains": ["./dist/types/exports/chains.d.ts"],
+      "contract": ["./dist/types/exports/contract.d.ts"],
+      "deploys": ["./dist/types/exports/deploys.d.ts"],
+      "event": ["./dist/types/exports/event.d.ts"],
+      "extensions/*": ["./dist/types/exports/extensions/*.d.ts"],
+      "pay": ["./dist/types/exports/pay.d.ts"],
+      "react": ["./dist/types/exports/react.d.ts"],
+      "react-native": ["./dist/types/exports/react-native.d.ts"],
+      "rpc": ["./dist/types/exports/rpc.d.ts"],
+      "storage": ["./dist/types/exports/storage.d.ts"],
+      "transaction": ["./dist/types/exports/transaction.d.ts"],
+      "utils": ["./dist/types/exports/utils.d.ts"],
+      "wallets": ["./dist/types/exports/wallets.d.ts"],
+      "wallets/*": ["./dist/types/exports/wallets/*.d.ts"]
     }
   },
   "browser": {
@@ -201,6 +169,7 @@
   "peerDependencies": {
     "@aws-sdk/client-lambda": "^3",
     "@aws-sdk/credential-providers": "^3",
+    "@coinbase/wallet-mobile-sdk": "^1",
     "@react-native-async-storage/async-storage": "^1",
     "amazon-cognito-identity-js": "^6",
     "aws-amplify": "^5",
@@ -282,6 +251,7 @@
   "devDependencies": {
     "@aws-sdk/client-lambda": "3.577.0",
     "@aws-sdk/credential-providers": "3.577.0",
+    "@coinbase/wallet-mobile-sdk": "1.0.13",
     "@react-native-async-storage/async-storage": "^1.23.1",
     "@testing-library/jest-dom": "^6.4.5",
     "@testing-library/react": "^15.0.6",

--- a/packages/thirdweb/src/wallets/coinbase/coinbaseMobileSDK.ts
+++ b/packages/thirdweb/src/wallets/coinbase/coinbaseMobileSDK.ts
@@ -1,0 +1,33 @@
+import { configure } from "@coinbase/wallet-mobile-sdk";
+import type { Chain } from "../../chains/types.js";
+
+export async function initMobileProvider(args: {
+  chain?: Chain;
+  callbackURL?: string;
+  hostURL?: string;
+  hostPackageName?: string;
+}) {
+  configure({
+    callbackURL: new URL(args.callbackURL || "https://thirdweb.com/wsegue"),
+    hostURL: new URL(args.hostURL || "https://wallet.coinbase.com/wsegue"),
+    hostPackageName: args.hostPackageName || "org.toshi",
+  });
+  let CoinbaseWalletMobileSDK = (
+    await import("@coinbase/wallet-mobile-sdk/build/WalletMobileSDKEVMProvider")
+  ).WalletMobileSDKEVMProvider;
+  if (
+    typeof CoinbaseWalletMobileSDK !== "function" &&
+    // @ts-expect-error This import error is not visible to TypeScript
+    typeof CoinbaseWalletMobileSDK.default === "function"
+  ) {
+    CoinbaseWalletMobileSDK = (
+      CoinbaseWalletMobileSDK as unknown as {
+        default: typeof CoinbaseWalletMobileSDK;
+      }
+    ).default;
+  }
+  return new CoinbaseWalletMobileSDK({
+    jsonRpcUrl: args.chain?.rpc,
+    chainId: args.chain?.id,
+  });
+}

--- a/packages/thirdweb/src/wallets/coinbase/coinbaseSDKWallet.ts
+++ b/packages/thirdweb/src/wallets/coinbase/coinbaseSDKWallet.ts
@@ -27,6 +27,7 @@ import {
   stringToHex,
   uint8ArrayToHex,
 } from "../../utils/encoding/hex.js";
+import { isReactNative } from "../../utils/platform.js";
 import { parseTypedData } from "../../utils/signatures/helpers/parseTypedData.js";
 import { COINBASE } from "../constants.js";
 import type {
@@ -87,6 +88,15 @@ export type CoinbaseWalletCreationOptions =
        * }
        */
       chains?: Chain[];
+
+      mobileConfig?: {
+        /**
+         * The univeral callback URL to redirect the user to after they have completed the wallet connection with the cb wallet app.
+         * This needs to be setup as a Universal link for iOS https://docs.cdp.coinbase.com/wallet-sdk/docs/ios-setup/
+         * and App link on Android https://docs.cdp.coinbase.com/wallet-sdk/docs/android-setup/
+         */
+        callbackURL?: string;
+      };
     }
   | undefined;
 
@@ -123,6 +133,16 @@ async function getCoinbaseProvider(
   options?: CreateWalletArgs<typeof COINBASE>[1],
 ): Promise<ProviderInterface> {
   if (!_provider) {
+    if (isReactNative()) {
+      const { initMobileProvider } = require("./coinbaseMobileSDK.js");
+      const mobileProvider = initMobileProvider({
+        chain: options?.chains ? options.chains[0] : undefined,
+        ...options?.mobileConfig,
+      });
+      _provider = mobileProvider;
+      return mobileProvider;
+    }
+
     const client = new CoinbaseWalletSDK({
       appName: options?.appMetadata?.name || getDefaultAppMetadata().name,
       appChainIds: options?.chains

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1530,6 +1530,9 @@ importers:
       '@aws-sdk/credential-providers':
         specifier: 3.577.0
         version: 3.577.0(@aws-sdk/client-sso-oidc@3.577.0)
+      '@coinbase/wallet-mobile-sdk':
+        specifier: ^1
+        version: 1.0.13(expo@51.0.5)(react-native@0.74.1)(react@18.2.0)
       '@react-native-async-storage/async-storage':
         specifier: ^1
         version: 1.23.1(react-native@0.74.1)
@@ -1676,6 +1679,9 @@ importers:
       '@aws-sdk/credential-providers':
         specifier: 3.577.0
         version: 3.577.0(@aws-sdk/client-sso-oidc@3.577.0)
+      '@coinbase/wallet-mobile-sdk':
+        specifier: 1.0.13
+        version: 1.0.13(expo@51.0.5)(react-native@0.74.1)(react@18.2.0)
       '@react-native-async-storage/async-storage':
         specifier: ^1.23.1
         version: 1.23.1(react-native@0.74.1)
@@ -5794,6 +5800,23 @@ packages:
         optional: true
     dev: false
 
+  /@coinbase/wallet-mobile-sdk@1.0.13(expo@51.0.5)(react-native@0.74.1)(react@18.2.0):
+    resolution: {integrity: sha512-sK7G31jiT6yS4Dp7XzhCqB6uQJHAH2eDGZLkRtwVURMgBdg8+l5OnPK3l3O4Y8HNnJ3Qdn3PIKAqzCtHfIKXkw==}
+    peerDependencies:
+      expo: '*'
+      react: '*'
+      react-native: '*'
+    dependencies:
+      '@metamask/safe-event-emitter': 2.0.0
+      bn.js: 5.2.1
+      buffer: 6.0.3
+      eth-rpc-errors: 4.0.3
+      events: 3.3.0
+      expo: 51.0.5(@babel/core@7.24.5)(@babel/preset-env@7.24.5)
+      react: 18.2.0
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.5)(@types/react@18.2.17)(react@18.2.0)
+      react-native-mmkv: 2.11.0(react-native@0.74.1)(react@18.2.0)
+
   /@coinbase/wallet-sdk@3.9.3:
     resolution: {integrity: sha512-N/A2DRIf0Y3PHc1XAMvbBUu4zisna6qAdqABMZwBMNEfWrXpAwx16pZGkYCLGE+Rvv1edbcB2LYDRnACNcmCiw==}
     dependencies:
@@ -7945,7 +7968,6 @@ packages:
 
   /@metamask/safe-event-emitter@2.0.0:
     resolution: {integrity: sha512-/kSXhY692qiV1MXu6EeOZvg5nECLclxNXcKCxJ3cXQgYuRymRHpdx/t7JXfsK+JLjwA1e1c1/SBrlQYpusC29Q==}
-    dev: false
 
   /@metamask/safe-event-emitter@3.1.1:
     resolution: {integrity: sha512-ihb3B0T/wJm1eUuArYP4lCTSEoZsClHhuWyfo/kMX3m/odpqNcPfsz5O2A3NT7dXCAgWPGDQGPqygCpgeniKMw==}
@@ -17055,7 +17077,6 @@ packages:
     resolution: {integrity: sha512-Z3ymjopaoft7JDoxZcEb3pwdGh7yiYMhOwm2doUt6ASXlMavpNlK6Cre0+IMl2VSGyEU9rkiperQhp5iRxn5Pg==}
     dependencies:
       fast-safe-stringify: 2.1.1
-    dev: false
 
   /ethereum-bloom-filters@1.1.0:
     resolution: {integrity: sha512-J1gDRkLpuGNvWYzWslBQR9cDV4nd4kfvVTE/Wy4Kkm4yb3EYRSlyi0eB/inTsSTTVyA0+HyzHgbr95Fn/Z1fSw==}
@@ -18281,6 +18302,7 @@ packages:
 
   /glob@6.0.4:
     resolution: {integrity: sha512-MKZeRNyYZAVVVG1oZeLaWie1uweH40m9AZwIwxyPbTSX4hHrVYSzLg0Ro5Z5R7XKkIX+Cc6oD1rqeDJnwsB8/A==}
+    deprecated: Glob versions prior to v9 are no longer supported
     requiresBuild: true
     dependencies:
       inflight: 1.0.6
@@ -18292,6 +18314,7 @@ packages:
 
   /glob@7.1.6:
     resolution: {integrity: sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==}
+    deprecated: Glob versions prior to v9 are no longer supported
     dependencies:
       fs.realpath: 1.0.0
       inflight: 1.0.6
@@ -22994,6 +23017,15 @@ packages:
       fast-base64-decode: 1.0.0
       react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.5)(@types/react@18.2.17)(react@18.2.0)
 
+  /react-native-mmkv@2.11.0(react-native@0.74.1)(react@18.2.0):
+    resolution: {integrity: sha512-28PdUHjZJmAw3q+8zJDAAdohnZMpDC7WgRUJxACOMkcmJeqS3u5cKS/lSq2bhf1CvaeIiHYHUWiyatUjMRCDQQ==}
+    peerDependencies:
+      react: '*'
+      react-native: '>=0.71.0'
+    dependencies:
+      react: 18.2.0
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.5)(@types/react@18.2.17)(react@18.2.0)
+
   /react-native-quick-base64@2.1.2(react-native@0.74.1)(react@18.2.0):
     resolution: {integrity: sha512-xghaXpWdB0ji8OwYyo0fWezRroNxiNFCNFpGUIyE7+qc4gA/IGWnysIG5L0MbdoORv8FkTKUvfd6yCUN5R2VFA==}
     peerDependencies:
@@ -23614,6 +23646,7 @@ packages:
 
   /rimraf@2.4.5:
     resolution: {integrity: sha512-J5xnxTyqaiw06JjMftq7L9ouA448dw/E7dKghkP9WpKNuwmARNNg+Gk8/u5ryb9N/Yo2+z3MCwuqFK/+qPOPfQ==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
     requiresBuild: true
     dependencies:


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds support for the CB wallet in React Native by implementing the Coinbase wallet SDK. 

### Detailed summary
- Added support for CB wallet in React Native
- Updated dependencies for Coinbase wallet SDK
- Implemented `initMobileProvider` function for CB wallet integration
- Added `mobileConfig` option for CB wallet callback URL
- Updated `package.json` and `changeset` files for the changes

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->