### PR TITLE
Improve connect wallet copy

### DIFF
--- a/packages/thirdweb/src/react/web/wallets/injected/locale/en.ts
+++ b/packages/thirdweb/src/react/web/wallets/injected/locale/en.ts
@@ -16,7 +16,7 @@ const injectedWalletLocaleEn = (wallet: string): InjectedWalletLocale => ({
   scanScreen: {
     instruction: `Scan the QR code with the ${wallet} app to connect`,
   },
-  getStartedLink: `Don't have a ${wallet} wallet?`,
+  getStartedLink: `Don't have ${wallet}?`,
   download: {
     chrome: "Download Chrome Extension",
     android: "Download on Google Play",


### PR DESCRIPTION
Realizing a lot of wallets are named "{something} Wallet", this corrects and typos like "Don't have Coinbase Wallet wallet?"

<!-- start pr-codex -->

---

## PR-Codex overview
This PR simplifies the wallet mention in the UI text and enhances clarity by removing redundancy. 

### Detailed summary
- Updated UI text to remove redundancy in wallet mention
- Improved clarity in the UI text for better user understanding

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->