### PR TITLE
show connect button if disconnected in pay playground

### DIFF
--- a/apps/playground-web/src/components/styled-pay-transaction.tsx
+++ b/apps/playground-web/src/components/styled-pay-transaction.tsx
@@ -6,6 +6,7 @@ import { getContract } from "thirdweb";
 import { polygon } from "thirdweb/chains";
 import { claimTo } from "thirdweb/extensions/erc1155";
 import { TransactionButton, useActiveAccount } from "thirdweb/react";
+import { StyledConnectButton } from "./styled-connect-button";
 
 const contract = getContract({
   address: "0x96B30d36f783c7BC68535De23147e2ce65788e93",
@@ -17,7 +18,7 @@ export function StyledPayTransaction() {
   const account = useActiveAccount();
   const { theme } = useTheme();
 
-  return (
+  return account ? (
     <TransactionButton
       transaction={() => {
         if (!account) throw new Error("No active account");
@@ -34,5 +35,7 @@ export function StyledPayTransaction() {
     >
       Buy for 10 MATIC
     </TransactionButton>
+  ) : (
+    <StyledConnectButton />
   );
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to add a styled connect button component for handling account connection in the pay transaction feature.

### Detailed summary
- Added import for `StyledConnectButton`
- Conditionally render `TransactionButton` or `StyledConnectButton` based on active account status

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->