### PR TITLE
Fix AutoConnect on MIPD wallets

### DIFF
--- a/packages/thirdweb/src/react/core/hooks/connection/useAutoConnect.ts
+++ b/packages/thirdweb/src/react/core/hooks/connection/useAutoConnect.ts
@@ -1,4 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
+import { createWallet } from "../../../../wallets/create-wallet.js";
+import { getInstalledWalletProviders } from "../../../../wallets/injected/mipdStore.js";
 import type { Wallet } from "../../../../wallets/interfaces/wallet.js";
 import {
   getLastConnectedChain,
@@ -68,8 +70,13 @@ export function useAutoConnect(props: AutoConnectProps) {
       });
     }
 
+    const availableWallets = [
+      ...wallets,
+      ...getInstalledWalletProviders().map((p) => createWallet(p.info.rdns)),
+    ];
     const activeWallet =
-      lastActiveWalletId && wallets.find((w) => w.id === lastActiveWalletId);
+      lastActiveWalletId &&
+      availableWallets.find((w) => w.id === lastActiveWalletId);
 
     if (activeWallet) {
       try {


### PR DESCRIPTION
## Problem solved

AutoConnect was only using user-specified wallets, meaning installed but not specified wallets would not reconnect on refresh

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the `useAutoConnect` hook to use available wallets from installed providers for auto connection.

### Detailed summary
- Added import for `createWallet` and `getInstalledWalletProviders`
- Updated `useAutoConnect` hook to use available wallets from installed providers
- Modified logic to find active wallet using the updated list of available wallets

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->