### PR TITLE
Fix `estimateGas` transaction type resolution

### DIFF
--- a/.changeset/blue-lobsters-turn.md
+++ b/.changeset/blue-lobsters-turn.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix `estimateGas` type resolution

--- a/packages/thirdweb/src/transaction/actions/estimate-gas.ts
+++ b/packages/thirdweb/src/transaction/actions/estimate-gas.ts
@@ -8,7 +8,9 @@ import type { PreparedTransaction } from "../prepare-transaction.js";
 
 export type EstimateGasOptions = Prettify<
   {
-    transaction: PreparedTransaction;
+    // TODO: update this to `Transaction<"prepared">` once the type is available to ensure only prepared transactions are accepted
+    // biome-ignore lint/suspicious/noExplicitAny: library function that accepts any prepared transaction type
+    transaction: PreparedTransaction<any>;
   } & (
     | {
         account: Account;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to fix the type resolution for `estimateGas` by updating the `transaction` type to ensure only prepared transactions are accepted.

### Detailed summary
- Updated `EstimateGasOptions` type in `estimate-gas.ts`
- Updated `transaction` type to `PreparedTransaction<any>` to enforce prepared transactions
- Added a TODO comment for future type update

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->