### PR TITLE
fix: don't throw on erc20 metadata fetch failure

### DIFF
--- a/.changeset/thirty-crabs-tan.md
+++ b/.changeset/thirty-crabs-tan.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fallback to default metadata on failure to fetch erc20 metadata

--- a/packages/thirdweb/src/extensions/erc20/read/getCurrencyMetadata.ts
+++ b/packages/thirdweb/src/extensions/erc20/read/getCurrencyMetadata.ts
@@ -38,9 +38,9 @@ export async function getCurrencyMetadata(
 
   try {
     const [name_, symbol_, decimals_] = await Promise.all([
-      name(options),
-      symbol(options),
-      decimals(options),
+      name(options).catch(() => ""),
+      symbol(options).catch(() => ""),
+      decimals(options).catch(() => 18),
     ]);
 
     return {

--- a/packages/thirdweb/src/extensions/erc20/read/getCurrencyMetadata.ts
+++ b/packages/thirdweb/src/extensions/erc20/read/getCurrencyMetadata.ts
@@ -39,8 +39,8 @@ export async function getCurrencyMetadata(
   try {
     const [name_, symbol_, decimals_] = await Promise.all([
       name(options).catch(() => ""),
-      symbol(options).catch(() => ""),
-      decimals(options).catch(() => 18),
+      symbol(options),
+      decimals(options),
     ]);
 
     return {

--- a/packages/thirdweb/src/wallets/smart/smart-wallet-zksync.test.ts
+++ b/packages/thirdweb/src/wallets/smart/smart-wallet-zksync.test.ts
@@ -44,11 +44,6 @@ describe.runIf(process.env.TW_SECRET_KEY)(
         personalAccount,
       });
       smartWalletAddress = smartAccount.address;
-      accountContract = getContract({
-        address: smartWalletAddress,
-        chain,
-        client,
-      });
     });
 
     it("should send a transactions", async () => {

--- a/packages/thirdweb/src/wallets/smart/smart-wallet-zksync.test.ts
+++ b/packages/thirdweb/src/wallets/smart/smart-wallet-zksync.test.ts
@@ -2,7 +2,7 @@ import { beforeAll, describe, expect, it } from "vitest";
 import { TEST_CLIENT } from "../../../test/src/test-clients.js";
 import { ANVIL_PKEY_C } from "../../../test/src/test-wallets.js";
 import { zkSyncSepolia } from "../../chains/chain-definitions/zksync-sepolia.js";
-import { type ThirdwebContract, getContract } from "../../contract/contract.js";
+import { getContract } from "../../contract/contract.js";
 import { claimTo } from "../../extensions/erc1155/drops/write/claimTo.js";
 import { sendAndConfirmTransaction } from "../../transaction/actions/send-and-confirm-transaction.js";
 import { smartWallet } from "../create-wallet.js";
@@ -13,7 +13,6 @@ let wallet: Wallet;
 let smartAccount: Account;
 let smartWalletAddress: string;
 let personalAccount: Account;
-let accountContract: ThirdwebContract;
 
 const chain = zkSyncSepolia;
 const client = TEST_CLIENT;

--- a/packages/thirdweb/src/wallets/utils/getWalletBalance.test.ts
+++ b/packages/thirdweb/src/wallets/utils/getWalletBalance.test.ts
@@ -57,7 +57,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("getWalletBalance", () => {
     expect(result.displayValue).toBe(amount.toString());
   });
 
-  it("should work for native token", async () => {
+  it("should work for un-named token", async () => {
     const result = await getWalletBalance({
       address: TEST_ACCOUNT_A.address,
       client: TEST_CLIENT,

--- a/packages/thirdweb/src/wallets/utils/getWalletBalance.test.ts
+++ b/packages/thirdweb/src/wallets/utils/getWalletBalance.test.ts
@@ -3,6 +3,7 @@ import { ANVIL_CHAIN } from "~test/chains.js";
 import { TEST_CONTRACT_URI } from "~test/ipfs-uris.js";
 import { TEST_CLIENT } from "~test/test-clients.js";
 import { TEST_ACCOUNT_A } from "~test/test-wallets.js";
+import { defineChain } from "../../chains/utils.js";
 import { getContract } from "../../contract/contract.js";
 import { mintTo } from "../../extensions/erc20/write/mintTo.js";
 import { deployERC20Contract } from "../../extensions/prebuilts/deploy-erc20.js";
@@ -54,5 +55,19 @@ describe.runIf(process.env.TW_SECRET_KEY)("getWalletBalance", () => {
     expect(result.name).toBeDefined();
     expect(result.value).toBe(BigInt(amount) * 10n ** BigInt(expectedDecimal));
     expect(result.displayValue).toBe(amount.toString());
+  });
+
+  it("should work for native token", async () => {
+    const result = await getWalletBalance({
+      address: TEST_ACCOUNT_A.address,
+      client: TEST_CLIENT,
+      chain: defineChain(97),
+      tokenAddress: "0xd66c6B4F0be8CE5b39D52E0Fd1344c389929B378",
+    });
+    expect(result).toBeDefined();
+    expect(result.decimals).toBe(18);
+    expect(result.symbol).toBeDefined();
+    expect(result.value).toBeGreaterThan(0n);
+    expect(result.displayValue).toBeDefined();
   });
 });

--- a/packages/thirdweb/src/wallets/wallet-connect/consumer/consumer.test.ts
+++ b/packages/thirdweb/src/wallets/wallet-connect/consumer/consumer.test.ts
@@ -5,7 +5,6 @@ import { TEST_IN_APP_WALLET_A } from "../../../../test/src/test-wallets.js";
 import { getDefaultAppMetadata } from "../../utils/defaultDappMetadata.js";
 import { DEFAULT_PROJECT_ID } from "../constants.js";
 import {
-  type WalletConnectClient,
   createWalletConnectClient,
   createWalletConnectSession,
   disconnectWalletConnectSession,
@@ -14,6 +13,7 @@ import {
 import * as SessionProposal from "./session-proposal.js";
 import * as SessionRequest from "./session-request.js";
 import * as SessionStore from "./session-store.js";
+import type { WalletConnectClient } from "./types.js";
 
 const TEST_METADATA = {
   name: "test",

--- a/packages/thirdweb/src/wallets/wallet-connect/consumer/session-proposal.test.ts
+++ b/packages/thirdweb/src/wallets/wallet-connect/consumer/session-proposal.test.ts
@@ -5,10 +5,12 @@ import {
   TEST_IN_APP_WALLET_A,
 } from "../../../../test/src/test-wallets.js";
 import { cloneObject } from "../../../../test/src/utils.js";
-import type { WalletConnectClient } from "./index.js";
 import { onSessionProposal } from "./session-proposal.js";
 import * as SessionStore from "./session-store.js";
-import type { WalletConnectSessionProposalEvent } from "./types.js";
+import type {
+  WalletConnectClient,
+  WalletConnectSessionProposalEvent,
+} from "./types.js";
 
 const PROPOSAL_EVENT_MOCK: WalletConnectSessionProposalEvent = {
   id: 1717020142228697,

--- a/packages/thirdweb/src/wallets/wallet-connect/consumer/session-request.test.ts
+++ b/packages/thirdweb/src/wallets/wallet-connect/consumer/session-request.test.ts
@@ -6,9 +6,9 @@ import {
 } from "../../../../test/src/test-wallets.js";
 import { typedData } from "../../../../test/src/typed-data.js";
 import { cloneObject } from "../../../../test/src/utils.js";
-import type { WalletConnectClient } from "./index.js";
 import { fulfillRequest } from "./session-request.js";
 import type {
+  WalletConnectClient,
   WalletConnectRawTransactionRequestParams,
   WalletConnectSessionRequestEvent,
   WalletConnectSignRequestPrams,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on improving error handling and type definitions in the `thirdweb` package related to ERC20 metadata and WalletConnect.

### Detailed summary
- Fallback to default metadata on failure to fetch ERC20 metadata
- Improved error handling for WalletConnect functions
- Updated type definitions for WalletConnectClient
- Removed unused code related to ThirdwebContract in smart wallet tests
- Added a test case for fetching balance of an un-named token

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->