### PR TITLE
Fixes #3204 - Update Account object properly on Account change in Wallet

### DIFF
--- a/.changeset/metal-goats-pull.md
+++ b/.changeset/metal-goats-pull.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": minor
+---
+
+Fixes #3204 - Account methods not properly updated when account is changed in wallet

--- a/.changeset/metal-goats-pull.md
+++ b/.changeset/metal-goats-pull.md
@@ -1,5 +1,5 @@
 ---
-"thirdweb": minor
+"thirdweb": patch
 ---
 
 Fixes #3204 - Account methods not properly updated when account is changed in wallet

--- a/packages/thirdweb/src/wallets/wallet-connect/controller.ts
+++ b/packages/thirdweb/src/wallets/wallet-connect/controller.ts
@@ -324,12 +324,7 @@ async function initProvider(
   return provider;
 }
 
-function onConnect(
-  address: string,
-  chain: Chain,
-  provider: WCProvider,
-  emitter: WalletEmitter<WCSupportedWalletIds>,
-): [Account, Chain, DisconnectFn, SwitchChainFn] {
+function createAccount(provider: WCProvider, address: string) {
   const account: Account = {
     address,
     async sendTransaction(tx: SendTransactionOption) {
@@ -391,6 +386,17 @@ function onConnect(
     },
   };
 
+  return account;
+}
+
+function onConnect(
+  address: string,
+  chain: Chain,
+  provider: WCProvider,
+  emitter: WalletEmitter<WCSupportedWalletIds>,
+): [Account, Chain, DisconnectFn, SwitchChainFn] {
+  const account = createAccount(provider, address);
+
   async function disconnect() {
     provider.removeListener("accountsChanged", onAccountsChanged);
     provider.removeListener("chainChanged", onChainChanged);
@@ -407,10 +413,7 @@ function onConnect(
 
   function onAccountsChanged(accounts: string[]) {
     if (accounts[0]) {
-      const newAccount: Account = {
-        ...account,
-        address: getAddress(accounts[0]),
-      };
+      const newAccount = createAccount(provider, getAddress(accounts[0]));
       emitter.emit("accountChanged", newAccount);
       emitter.emit("accountsChanged", accounts);
     } else {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates account methods in `wallet-connect`, `coinbaseSDKWallet`, and `injected` wallets when the account changes in the wallet.

### Detailed summary
- Added `createAccount` function to create an account object with `sendTransaction` method
- Refactored `onConnect` functions to use `createAccount` function
- Improved handling of account changes in `onAccountsChanged` functions

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->