### PR TITLE
Modular Contracts: token minting API integration

### DIFF
--- a/.changeset/brave-cherries-occur.md
+++ b/.changeset/brave-cherries-occur.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix sign raw message through ethers 5/6 adapters

--- a/packages/thirdweb/package.json
+++ b/packages/thirdweb/package.json
@@ -113,26 +113,66 @@
       "import": "./dist/esm/exports/wallets/*.js",
       "default": "./dist/cjs/exports/wallets/*.js"
     },
+    "./modular/*": {
+      "types": "./dist/types/exports/modular/*.d.ts",
+      "import": "./dist/esm/exports/modular/*.js",
+      "default": "./dist/cjs/exports/modular/*.js"
+    },
     "./package.json": "./package.json"
   },
   "typesVersions": {
     "*": {
-      "adapters/*": ["./dist/types/exports/adapters/*.d.ts"],
-      "auth": ["./dist/types/exports/auth.d.ts"],
-      "chains": ["./dist/types/exports/chains.d.ts"],
-      "contract": ["./dist/types/exports/contract.d.ts"],
-      "deploys": ["./dist/types/exports/deploys.d.ts"],
-      "event": ["./dist/types/exports/event.d.ts"],
-      "extensions/*": ["./dist/types/exports/extensions/*.d.ts"],
-      "pay": ["./dist/types/exports/pay.d.ts"],
-      "react": ["./dist/types/exports/react.d.ts"],
-      "react-native": ["./dist/types/exports/react-native.d.ts"],
-      "rpc": ["./dist/types/exports/rpc.d.ts"],
-      "storage": ["./dist/types/exports/storage.d.ts"],
-      "transaction": ["./dist/types/exports/transaction.d.ts"],
-      "utils": ["./dist/types/exports/utils.d.ts"],
-      "wallets": ["./dist/types/exports/wallets.d.ts"],
-      "wallets/*": ["./dist/types/exports/wallets/*.d.ts"]
+      "adapters/*": [
+        "./dist/types/exports/adapters/*.d.ts"
+      ],
+      "auth": [
+        "./dist/types/exports/auth.d.ts"
+      ],
+      "chains": [
+        "./dist/types/exports/chains.d.ts"
+      ],
+      "contract": [
+        "./dist/types/exports/contract.d.ts"
+      ],
+      "deploys": [
+        "./dist/types/exports/deploys.d.ts"
+      ],
+      "event": [
+        "./dist/types/exports/event.d.ts"
+      ],
+      "extensions/*": [
+        "./dist/types/exports/extensions/*.d.ts"
+      ],
+      "pay": [
+        "./dist/types/exports/pay.d.ts"
+      ],
+      "react": [
+        "./dist/types/exports/react.d.ts"
+      ],
+      "react-native": [
+        "./dist/types/exports/react-native.d.ts"
+      ],
+      "rpc": [
+        "./dist/types/exports/rpc.d.ts"
+      ],
+      "storage": [
+        "./dist/types/exports/storage.d.ts"
+      ],
+      "transaction": [
+        "./dist/types/exports/transaction.d.ts"
+      ],
+      "utils": [
+        "./dist/types/exports/utils.d.ts"
+      ],
+      "wallets": [
+        "./dist/types/exports/wallets.d.ts"
+      ],
+      "wallets/*": [
+        "./dist/types/exports/wallets/*.d.ts"
+      ],
+      "modular/*": [
+        "./dist/types/exports/modular/*.d.ts"
+      ]
     }
   },
   "browser": {

--- a/packages/thirdweb/scripts/generate/abis/modular/ERC1155Core.json
+++ b/packages/thirdweb/scripts/generate/abis/modular/ERC1155Core.json
@@ -1,0 +1,703 @@
+[
+    {
+      "type": "constructor",
+      "inputs": [
+        { "name": "name", "type": "string", "internalType": "string" },
+        { "name": "symbol", "type": "string", "internalType": "string" },
+        { "name": "contractURI", "type": "string", "internalType": "string" },
+        { "name": "owner", "type": "address", "internalType": "address" },
+        {
+          "name": "extensions",
+          "type": "address[]",
+          "internalType": "address[]"
+        },
+        {
+          "name": "extensionInstallData",
+          "type": "bytes[]",
+          "internalType": "bytes[]"
+        }
+      ],
+      "stateMutability": "payable"
+    },
+    { "type": "fallback", "stateMutability": "payable" },
+    { "type": "receive", "stateMutability": "payable" },
+    {
+      "type": "function",
+      "name": "balanceOf",
+      "inputs": [
+        { "name": "owner", "type": "address", "internalType": "address" },
+        { "name": "id", "type": "uint256", "internalType": "uint256" }
+      ],
+      "outputs": [
+        { "name": "result", "type": "uint256", "internalType": "uint256" }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "balanceOfBatch",
+      "inputs": [
+        { "name": "owners", "type": "address[]", "internalType": "address[]" },
+        { "name": "ids", "type": "uint256[]", "internalType": "uint256[]" }
+      ],
+      "outputs": [
+        { "name": "balances", "type": "uint256[]", "internalType": "uint256[]" }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "burn",
+      "inputs": [
+        { "name": "from", "type": "address", "internalType": "address" },
+        { "name": "tokenId", "type": "uint256", "internalType": "uint256" },
+        { "name": "value", "type": "uint256", "internalType": "uint256" },
+        { "name": "data", "type": "bytes", "internalType": "bytes" }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "cancelOwnershipHandover",
+      "inputs": [],
+      "outputs": [],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "completeOwnershipHandover",
+      "inputs": [
+        { "name": "pendingOwner", "type": "address", "internalType": "address" }
+      ],
+      "outputs": [],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "contractURI",
+      "inputs": [],
+      "outputs": [{ "name": "", "type": "string", "internalType": "string" }],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getInstalledExtensions",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "_installedExtensions",
+          "type": "tuple[]",
+          "internalType": "struct IModularCore.InstalledExtension[]",
+          "components": [
+            {
+              "name": "implementation",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "config",
+              "type": "tuple",
+              "internalType": "struct IExtensionConfig.ExtensionConfig",
+              "components": [
+                {
+                  "name": "requiredInterfaceId",
+                  "type": "bytes4",
+                  "internalType": "bytes4"
+                },
+                {
+                  "name": "registerInstallationCallback",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "supportedInterfaces",
+                  "type": "bytes4[]",
+                  "internalType": "bytes4[]"
+                },
+                {
+                  "name": "callbackFunctions",
+                  "type": "tuple[]",
+                  "internalType": "struct IExtensionConfig.CallbackFunction[]",
+                  "components": [
+                    {
+                      "name": "selector",
+                      "type": "bytes4",
+                      "internalType": "bytes4"
+                    }
+                  ]
+                },
+                {
+                  "name": "fallbackFunctions",
+                  "type": "tuple[]",
+                  "internalType": "struct IExtensionConfig.FallbackFunction[]",
+                  "components": [
+                    {
+                      "name": "selector",
+                      "type": "bytes4",
+                      "internalType": "bytes4"
+                    },
+                    {
+                      "name": "permissionBits",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getSupportedCallbackFunctions",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "supportedCallbackFunctions",
+          "type": "tuple[]",
+          "internalType": "struct IModularCore.SupportedCallbackFunction[]",
+          "components": [
+            { "name": "selector", "type": "bytes4", "internalType": "bytes4" },
+            {
+              "name": "mode",
+              "type": "uint8",
+              "internalType": "enum IModularCore.CallbackMode"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "pure"
+    },
+    {
+      "type": "function",
+      "name": "grantRoles",
+      "inputs": [
+        { "name": "user", "type": "address", "internalType": "address" },
+        { "name": "roles", "type": "uint256", "internalType": "uint256" }
+      ],
+      "outputs": [],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "hasAllRoles",
+      "inputs": [
+        { "name": "user", "type": "address", "internalType": "address" },
+        { "name": "roles", "type": "uint256", "internalType": "uint256" }
+      ],
+      "outputs": [{ "name": "", "type": "bool", "internalType": "bool" }],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "hasAnyRole",
+      "inputs": [
+        { "name": "user", "type": "address", "internalType": "address" },
+        { "name": "roles", "type": "uint256", "internalType": "uint256" }
+      ],
+      "outputs": [{ "name": "", "type": "bool", "internalType": "bool" }],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "installExtension",
+      "inputs": [
+        { "name": "_extension", "type": "address", "internalType": "address" },
+        { "name": "_data", "type": "bytes", "internalType": "bytes" }
+      ],
+      "outputs": [],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "isApprovedForAll",
+      "inputs": [
+        { "name": "owner", "type": "address", "internalType": "address" },
+        { "name": "operator", "type": "address", "internalType": "address" }
+      ],
+      "outputs": [{ "name": "result", "type": "bool", "internalType": "bool" }],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "mint",
+      "inputs": [
+        { "name": "to", "type": "address", "internalType": "address" },
+        { "name": "tokenId", "type": "uint256", "internalType": "uint256" },
+        { "name": "value", "type": "uint256", "internalType": "uint256" },
+        { "name": "data", "type": "bytes", "internalType": "bytes" }
+      ],
+      "outputs": [],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "multicall",
+      "inputs": [
+        { "name": "data", "type": "bytes[]", "internalType": "bytes[]" }
+      ],
+      "outputs": [{ "name": "", "type": "bytes[]", "internalType": "bytes[]" }],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "name",
+      "inputs": [],
+      "outputs": [{ "name": "", "type": "string", "internalType": "string" }],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "owner",
+      "inputs": [],
+      "outputs": [
+        { "name": "result", "type": "address", "internalType": "address" }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "ownershipHandoverExpiresAt",
+      "inputs": [
+        { "name": "pendingOwner", "type": "address", "internalType": "address" }
+      ],
+      "outputs": [
+        { "name": "result", "type": "uint256", "internalType": "uint256" }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "renounceOwnership",
+      "inputs": [],
+      "outputs": [],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "renounceRoles",
+      "inputs": [
+        { "name": "roles", "type": "uint256", "internalType": "uint256" }
+      ],
+      "outputs": [],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "requestOwnershipHandover",
+      "inputs": [],
+      "outputs": [],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "revokeRoles",
+      "inputs": [
+        { "name": "user", "type": "address", "internalType": "address" },
+        { "name": "roles", "type": "uint256", "internalType": "uint256" }
+      ],
+      "outputs": [],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "rolesOf",
+      "inputs": [
+        { "name": "user", "type": "address", "internalType": "address" }
+      ],
+      "outputs": [
+        { "name": "roles", "type": "uint256", "internalType": "uint256" }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "safeBatchTransferFrom",
+      "inputs": [
+        { "name": "from", "type": "address", "internalType": "address" },
+        { "name": "to", "type": "address", "internalType": "address" },
+        {
+          "name": "tokenIds",
+          "type": "uint256[]",
+          "internalType": "uint256[]"
+        },
+        { "name": "values", "type": "uint256[]", "internalType": "uint256[]" },
+        { "name": "data", "type": "bytes", "internalType": "bytes" }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "safeTransferFrom",
+      "inputs": [
+        { "name": "from", "type": "address", "internalType": "address" },
+        { "name": "to", "type": "address", "internalType": "address" },
+        { "name": "tokenId", "type": "uint256", "internalType": "uint256" },
+        { "name": "value", "type": "uint256", "internalType": "uint256" },
+        { "name": "data", "type": "bytes", "internalType": "bytes" }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setApprovalForAll",
+      "inputs": [
+        { "name": "operator", "type": "address", "internalType": "address" },
+        { "name": "approved", "type": "bool", "internalType": "bool" }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setContractURI",
+      "inputs": [{ "name": "uri", "type": "string", "internalType": "string" }],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "supportsInterface",
+      "inputs": [
+        { "name": "interfaceId", "type": "bytes4", "internalType": "bytes4" }
+      ],
+      "outputs": [{ "name": "", "type": "bool", "internalType": "bool" }],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "symbol",
+      "inputs": [],
+      "outputs": [{ "name": "", "type": "string", "internalType": "string" }],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "totalSupply",
+      "inputs": [
+        { "name": "tokenId", "type": "uint256", "internalType": "uint256" }
+      ],
+      "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "transferOwnership",
+      "inputs": [
+        { "name": "newOwner", "type": "address", "internalType": "address" }
+      ],
+      "outputs": [],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "uninstallExtension",
+      "inputs": [
+        { "name": "_extension", "type": "address", "internalType": "address" },
+        { "name": "_data", "type": "bytes", "internalType": "bytes" }
+      ],
+      "outputs": [],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "uri",
+      "inputs": [
+        { "name": "tokenId", "type": "uint256", "internalType": "uint256" }
+      ],
+      "outputs": [{ "name": "", "type": "string", "internalType": "string" }],
+      "stateMutability": "view"
+    },
+    {
+      "type": "event",
+      "name": "ApprovalForAll",
+      "inputs": [
+        {
+          "name": "owner",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "operator",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "isApproved",
+          "type": "bool",
+          "indexed": false,
+          "internalType": "bool"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ContractURIUpdated",
+      "inputs": [],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ExtensionInstalled",
+      "inputs": [
+        {
+          "name": "sender",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        },
+        {
+          "name": "implementation",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        },
+        {
+          "name": "installedExtension",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ExtensionUninstalled",
+      "inputs": [
+        {
+          "name": "sender",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        },
+        {
+          "name": "implementation",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        },
+        {
+          "name": "installedExtension",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "OwnershipHandoverCanceled",
+      "inputs": [
+        {
+          "name": "pendingOwner",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "OwnershipHandoverRequested",
+      "inputs": [
+        {
+          "name": "pendingOwner",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "OwnershipTransferred",
+      "inputs": [
+        {
+          "name": "oldOwner",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "newOwner",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "RolesUpdated",
+      "inputs": [
+        {
+          "name": "user",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "roles",
+          "type": "uint256",
+          "indexed": true,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "TransferBatch",
+      "inputs": [
+        {
+          "name": "operator",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "from",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "to",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "ids",
+          "type": "uint256[]",
+          "indexed": false,
+          "internalType": "uint256[]"
+        },
+        {
+          "name": "amounts",
+          "type": "uint256[]",
+          "indexed": false,
+          "internalType": "uint256[]"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "TransferSingle",
+      "inputs": [
+        {
+          "name": "operator",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "from",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "to",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "id",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "amount",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "URI",
+      "inputs": [
+        {
+          "name": "value",
+          "type": "string",
+          "indexed": false,
+          "internalType": "string"
+        },
+        {
+          "name": "id",
+          "type": "uint256",
+          "indexed": true,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    { "type": "error", "name": "AccountBalanceOverflow", "inputs": [] },
+    { "type": "error", "name": "AlreadyInitialized", "inputs": [] },
+    { "type": "error", "name": "ArrayLengthsMismatch", "inputs": [] },
+    { "type": "error", "name": "CallbackExecutionReverted", "inputs": [] },
+    {
+      "type": "error",
+      "name": "CallbackFunctionAlreadyInstalled",
+      "inputs": []
+    },
+    { "type": "error", "name": "CallbackFunctionNotSupported", "inputs": [] },
+    { "type": "error", "name": "CallbackFunctionRequired", "inputs": [] },
+    {
+      "type": "error",
+      "name": "CallbackFunctionUnauthorizedCall",
+      "inputs": []
+    },
+    { "type": "error", "name": "ExtensionAlreadyInstalled", "inputs": [] },
+    {
+      "type": "error",
+      "name": "ExtensionInterfaceNotCompatible",
+      "inputs": [
+        {
+          "name": "requiredInterfaceId",
+          "type": "bytes4",
+          "internalType": "bytes4"
+        }
+      ]
+    },
+    { "type": "error", "name": "ExtensionNotInstalled", "inputs": [] },
+    { "type": "error", "name": "ExtensionOutOfSync", "inputs": [] },
+    {
+      "type": "error",
+      "name": "FallbackFunctionAlreadyInstalled",
+      "inputs": []
+    },
+    { "type": "error", "name": "FallbackFunctionNotInstalled", "inputs": [] },
+    { "type": "error", "name": "IndexOutOfBounds", "inputs": [] },
+    { "type": "error", "name": "InsufficientBalance", "inputs": [] },
+    { "type": "error", "name": "NewOwnerIsZeroAddress", "inputs": [] },
+    { "type": "error", "name": "NoHandoverRequest", "inputs": [] },
+    { "type": "error", "name": "NotOwnerNorApproved", "inputs": [] },
+    {
+      "type": "error",
+      "name": "TransferToNonERC1155ReceiverImplementer",
+      "inputs": []
+    },
+    { "type": "error", "name": "TransferToZeroAddress", "inputs": [] },
+    { "type": "error", "name": "Unauthorized", "inputs": [] }
+]

--- a/packages/thirdweb/scripts/generate/abis/modular/ERC20Core.json
+++ b/packages/thirdweb/scripts/generate/abis/modular/ERC20Core.json
@@ -1,0 +1,645 @@
+[
+    {
+      "type": "constructor",
+      "inputs": [
+        { "name": "name", "type": "string", "internalType": "string" },
+        { "name": "symbol", "type": "string", "internalType": "string" },
+        { "name": "contractURI", "type": "string", "internalType": "string" },
+        { "name": "owner", "type": "address", "internalType": "address" },
+        {
+          "name": "extensions",
+          "type": "address[]",
+          "internalType": "address[]"
+        },
+        {
+          "name": "extensionInstallData",
+          "type": "bytes[]",
+          "internalType": "bytes[]"
+        }
+      ],
+      "stateMutability": "payable"
+    },
+    { "type": "fallback", "stateMutability": "payable" },
+    { "type": "receive", "stateMutability": "payable" },
+    {
+      "type": "function",
+      "name": "DOMAIN_SEPARATOR",
+      "inputs": [],
+      "outputs": [
+        { "name": "result", "type": "bytes32", "internalType": "bytes32" }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "allowance",
+      "inputs": [
+        { "name": "owner", "type": "address", "internalType": "address" },
+        { "name": "spender", "type": "address", "internalType": "address" }
+      ],
+      "outputs": [
+        { "name": "result", "type": "uint256", "internalType": "uint256" }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "approve",
+      "inputs": [
+        { "name": "spender", "type": "address", "internalType": "address" },
+        { "name": "amount", "type": "uint256", "internalType": "uint256" }
+      ],
+      "outputs": [{ "name": "", "type": "bool", "internalType": "bool" }],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "balanceOf",
+      "inputs": [
+        { "name": "owner", "type": "address", "internalType": "address" }
+      ],
+      "outputs": [
+        { "name": "result", "type": "uint256", "internalType": "uint256" }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "burn",
+      "inputs": [
+        { "name": "from", "type": "address", "internalType": "address" },
+        { "name": "amount", "type": "uint256", "internalType": "uint256" },
+        { "name": "data", "type": "bytes", "internalType": "bytes" }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "cancelOwnershipHandover",
+      "inputs": [],
+      "outputs": [],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "completeOwnershipHandover",
+      "inputs": [
+        { "name": "pendingOwner", "type": "address", "internalType": "address" }
+      ],
+      "outputs": [],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "contractURI",
+      "inputs": [],
+      "outputs": [{ "name": "", "type": "string", "internalType": "string" }],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "decimals",
+      "inputs": [],
+      "outputs": [{ "name": "", "type": "uint8", "internalType": "uint8" }],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getInstalledExtensions",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "_installedExtensions",
+          "type": "tuple[]",
+          "internalType": "struct IModularCore.InstalledExtension[]",
+          "components": [
+            {
+              "name": "implementation",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "config",
+              "type": "tuple",
+              "internalType": "struct IExtensionConfig.ExtensionConfig",
+              "components": [
+                {
+                  "name": "requiredInterfaceId",
+                  "type": "bytes4",
+                  "internalType": "bytes4"
+                },
+                {
+                  "name": "registerInstallationCallback",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "supportedInterfaces",
+                  "type": "bytes4[]",
+                  "internalType": "bytes4[]"
+                },
+                {
+                  "name": "callbackFunctions",
+                  "type": "tuple[]",
+                  "internalType": "struct IExtensionConfig.CallbackFunction[]",
+                  "components": [
+                    {
+                      "name": "selector",
+                      "type": "bytes4",
+                      "internalType": "bytes4"
+                    }
+                  ]
+                },
+                {
+                  "name": "fallbackFunctions",
+                  "type": "tuple[]",
+                  "internalType": "struct IExtensionConfig.FallbackFunction[]",
+                  "components": [
+                    {
+                      "name": "selector",
+                      "type": "bytes4",
+                      "internalType": "bytes4"
+                    },
+                    {
+                      "name": "permissionBits",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getSupportedCallbackFunctions",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "supportedCallbackFunctions",
+          "type": "tuple[]",
+          "internalType": "struct IModularCore.SupportedCallbackFunction[]",
+          "components": [
+            { "name": "selector", "type": "bytes4", "internalType": "bytes4" },
+            {
+              "name": "mode",
+              "type": "uint8",
+              "internalType": "enum IModularCore.CallbackMode"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "pure"
+    },
+    {
+      "type": "function",
+      "name": "grantRoles",
+      "inputs": [
+        { "name": "user", "type": "address", "internalType": "address" },
+        { "name": "roles", "type": "uint256", "internalType": "uint256" }
+      ],
+      "outputs": [],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "hasAllRoles",
+      "inputs": [
+        { "name": "user", "type": "address", "internalType": "address" },
+        { "name": "roles", "type": "uint256", "internalType": "uint256" }
+      ],
+      "outputs": [{ "name": "", "type": "bool", "internalType": "bool" }],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "hasAnyRole",
+      "inputs": [
+        { "name": "user", "type": "address", "internalType": "address" },
+        { "name": "roles", "type": "uint256", "internalType": "uint256" }
+      ],
+      "outputs": [{ "name": "", "type": "bool", "internalType": "bool" }],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "installExtension",
+      "inputs": [
+        { "name": "_extension", "type": "address", "internalType": "address" },
+        { "name": "_data", "type": "bytes", "internalType": "bytes" }
+      ],
+      "outputs": [],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "mint",
+      "inputs": [
+        { "name": "to", "type": "address", "internalType": "address" },
+        { "name": "amount", "type": "uint256", "internalType": "uint256" },
+        { "name": "data", "type": "bytes", "internalType": "bytes" }
+      ],
+      "outputs": [],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "multicall",
+      "inputs": [
+        { "name": "data", "type": "bytes[]", "internalType": "bytes[]" }
+      ],
+      "outputs": [{ "name": "", "type": "bytes[]", "internalType": "bytes[]" }],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "name",
+      "inputs": [],
+      "outputs": [{ "name": "", "type": "string", "internalType": "string" }],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "nonces",
+      "inputs": [
+        { "name": "owner", "type": "address", "internalType": "address" }
+      ],
+      "outputs": [
+        { "name": "result", "type": "uint256", "internalType": "uint256" }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "owner",
+      "inputs": [],
+      "outputs": [
+        { "name": "result", "type": "address", "internalType": "address" }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "ownershipHandoverExpiresAt",
+      "inputs": [
+        { "name": "pendingOwner", "type": "address", "internalType": "address" }
+      ],
+      "outputs": [
+        { "name": "result", "type": "uint256", "internalType": "uint256" }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "permit",
+      "inputs": [
+        { "name": "owner", "type": "address", "internalType": "address" },
+        { "name": "spender", "type": "address", "internalType": "address" },
+        { "name": "value", "type": "uint256", "internalType": "uint256" },
+        { "name": "deadline", "type": "uint256", "internalType": "uint256" },
+        { "name": "v", "type": "uint8", "internalType": "uint8" },
+        { "name": "r", "type": "bytes32", "internalType": "bytes32" },
+        { "name": "s", "type": "bytes32", "internalType": "bytes32" }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "renounceOwnership",
+      "inputs": [],
+      "outputs": [],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "renounceRoles",
+      "inputs": [
+        { "name": "roles", "type": "uint256", "internalType": "uint256" }
+      ],
+      "outputs": [],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "requestOwnershipHandover",
+      "inputs": [],
+      "outputs": [],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "revokeRoles",
+      "inputs": [
+        { "name": "user", "type": "address", "internalType": "address" },
+        { "name": "roles", "type": "uint256", "internalType": "uint256" }
+      ],
+      "outputs": [],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "rolesOf",
+      "inputs": [
+        { "name": "user", "type": "address", "internalType": "address" }
+      ],
+      "outputs": [
+        { "name": "roles", "type": "uint256", "internalType": "uint256" }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "setContractURI",
+      "inputs": [
+        { "name": "contractURI", "type": "string", "internalType": "string" }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "supportsInterface",
+      "inputs": [
+        { "name": "interfaceId", "type": "bytes4", "internalType": "bytes4" }
+      ],
+      "outputs": [{ "name": "", "type": "bool", "internalType": "bool" }],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "symbol",
+      "inputs": [],
+      "outputs": [{ "name": "", "type": "string", "internalType": "string" }],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "totalSupply",
+      "inputs": [],
+      "outputs": [
+        { "name": "result", "type": "uint256", "internalType": "uint256" }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "transfer",
+      "inputs": [
+        { "name": "to", "type": "address", "internalType": "address" },
+        { "name": "amount", "type": "uint256", "internalType": "uint256" }
+      ],
+      "outputs": [{ "name": "", "type": "bool", "internalType": "bool" }],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "transferFrom",
+      "inputs": [
+        { "name": "from", "type": "address", "internalType": "address" },
+        { "name": "to", "type": "address", "internalType": "address" },
+        { "name": "amount", "type": "uint256", "internalType": "uint256" }
+      ],
+      "outputs": [{ "name": "", "type": "bool", "internalType": "bool" }],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "transferOwnership",
+      "inputs": [
+        { "name": "newOwner", "type": "address", "internalType": "address" }
+      ],
+      "outputs": [],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "uninstallExtension",
+      "inputs": [
+        { "name": "_extension", "type": "address", "internalType": "address" },
+        { "name": "_data", "type": "bytes", "internalType": "bytes" }
+      ],
+      "outputs": [],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "event",
+      "name": "Approval",
+      "inputs": [
+        {
+          "name": "owner",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "spender",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "amount",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ContractURIUpdated",
+      "inputs": [],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ExtensionInstalled",
+      "inputs": [
+        {
+          "name": "sender",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        },
+        {
+          "name": "implementation",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        },
+        {
+          "name": "installedExtension",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ExtensionUninstalled",
+      "inputs": [
+        {
+          "name": "sender",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        },
+        {
+          "name": "implementation",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        },
+        {
+          "name": "installedExtension",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "OwnershipHandoverCanceled",
+      "inputs": [
+        {
+          "name": "pendingOwner",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "OwnershipHandoverRequested",
+      "inputs": [
+        {
+          "name": "pendingOwner",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "OwnershipTransferred",
+      "inputs": [
+        {
+          "name": "oldOwner",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "newOwner",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "RolesUpdated",
+      "inputs": [
+        {
+          "name": "user",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "roles",
+          "type": "uint256",
+          "indexed": true,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "Transfer",
+      "inputs": [
+        {
+          "name": "from",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "to",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "amount",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    { "type": "error", "name": "AllowanceOverflow", "inputs": [] },
+    { "type": "error", "name": "AllowanceUnderflow", "inputs": [] },
+    { "type": "error", "name": "AlreadyInitialized", "inputs": [] },
+    { "type": "error", "name": "CallbackExecutionReverted", "inputs": [] },
+    {
+      "type": "error",
+      "name": "CallbackFunctionAlreadyInstalled",
+      "inputs": []
+    },
+    { "type": "error", "name": "CallbackFunctionNotSupported", "inputs": [] },
+    { "type": "error", "name": "CallbackFunctionRequired", "inputs": [] },
+    {
+      "type": "error",
+      "name": "CallbackFunctionUnauthorizedCall",
+      "inputs": []
+    },
+    { "type": "error", "name": "ExtensionAlreadyInstalled", "inputs": [] },
+    {
+      "type": "error",
+      "name": "ExtensionInterfaceNotCompatible",
+      "inputs": [
+        {
+          "name": "requiredInterfaceId",
+          "type": "bytes4",
+          "internalType": "bytes4"
+        }
+      ]
+    },
+    { "type": "error", "name": "ExtensionNotInstalled", "inputs": [] },
+    { "type": "error", "name": "ExtensionOutOfSync", "inputs": [] },
+    {
+      "type": "error",
+      "name": "FallbackFunctionAlreadyInstalled",
+      "inputs": []
+    },
+    { "type": "error", "name": "FallbackFunctionNotInstalled", "inputs": [] },
+    { "type": "error", "name": "IndexOutOfBounds", "inputs": [] },
+    { "type": "error", "name": "InsufficientAllowance", "inputs": [] },
+    { "type": "error", "name": "InsufficientBalance", "inputs": [] },
+    { "type": "error", "name": "InvalidPermit", "inputs": [] },
+    { "type": "error", "name": "NewOwnerIsZeroAddress", "inputs": [] },
+    { "type": "error", "name": "NoHandoverRequest", "inputs": [] },
+    { "type": "error", "name": "PermitExpired", "inputs": [] },
+    { "type": "error", "name": "TotalSupplyOverflow", "inputs": [] },
+    { "type": "error", "name": "Unauthorized", "inputs": [] }
+]

--- a/packages/thirdweb/scripts/generate/abis/modular/ERC721Core.json
+++ b/packages/thirdweb/scripts/generate/abis/modular/ERC721Core.json
@@ -1,0 +1,826 @@
+[
+  {
+    "type": "constructor",
+    "inputs": [
+      { "name": "name", "type": "string", "internalType": "string" },
+      { "name": "symbol", "type": "string", "internalType": "string" },
+      { "name": "contractURI", "type": "string", "internalType": "string" },
+      { "name": "owner", "type": "address", "internalType": "address" },
+      {
+        "name": "extensions",
+        "type": "address[]",
+        "internalType": "address[]"
+      },
+      {
+        "name": "extensionInstallData",
+        "type": "bytes[]",
+        "internalType": "bytes[]"
+      }
+    ],
+    "stateMutability": "payable"
+  },
+  { "type": "fallback", "stateMutability": "payable" },
+  { "type": "receive", "stateMutability": "payable" },
+  {
+    "type": "function",
+    "name": "approve",
+    "inputs": [
+      { "name": "spender", "type": "address", "internalType": "address" },
+      { "name": "id", "type": "uint256", "internalType": "uint256" }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "balanceOf",
+    "inputs": [
+      { "name": "owner", "type": "address", "internalType": "address" }
+    ],
+    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "burn",
+    "inputs": [
+      { "name": "tokenId", "type": "uint256", "internalType": "uint256" },
+      { "name": "data", "type": "bytes", "internalType": "bytes" }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "cancelOwnershipHandover",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "completeOwnershipHandover",
+    "inputs": [
+      { "name": "pendingOwner", "type": "address", "internalType": "address" }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "contractURI",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "string", "internalType": "string" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "explicitOwnershipOf",
+    "inputs": [
+      { "name": "tokenId", "type": "uint256", "internalType": "uint256" }
+    ],
+    "outputs": [
+      {
+        "name": "ownership",
+        "type": "tuple",
+        "internalType": "struct IERC721A.TokenOwnership",
+        "components": [
+          { "name": "addr", "type": "address", "internalType": "address" },
+          {
+            "name": "startTimestamp",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          { "name": "burned", "type": "bool", "internalType": "bool" },
+          { "name": "extraData", "type": "uint24", "internalType": "uint24" }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "explicitOwnershipsOf",
+    "inputs": [
+      { "name": "tokenIds", "type": "uint256[]", "internalType": "uint256[]" }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple[]",
+        "internalType": "struct IERC721A.TokenOwnership[]",
+        "components": [
+          { "name": "addr", "type": "address", "internalType": "address" },
+          {
+            "name": "startTimestamp",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          { "name": "burned", "type": "bool", "internalType": "bool" },
+          { "name": "extraData", "type": "uint24", "internalType": "uint24" }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getApproved",
+    "inputs": [
+      { "name": "tokenId", "type": "uint256", "internalType": "uint256" }
+    ],
+    "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getInstalledExtensions",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "_installedExtensions",
+        "type": "tuple[]",
+        "internalType": "struct IModularCore.InstalledExtension[]",
+        "components": [
+          {
+            "name": "implementation",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "config",
+            "type": "tuple",
+            "internalType": "struct IExtensionConfig.ExtensionConfig",
+            "components": [
+              {
+                "name": "requiredInterfaceId",
+                "type": "bytes4",
+                "internalType": "bytes4"
+              },
+              {
+                "name": "registerInstallationCallback",
+                "type": "bool",
+                "internalType": "bool"
+              },
+              {
+                "name": "supportedInterfaces",
+                "type": "bytes4[]",
+                "internalType": "bytes4[]"
+              },
+              {
+                "name": "callbackFunctions",
+                "type": "tuple[]",
+                "internalType": "struct IExtensionConfig.CallbackFunction[]",
+                "components": [
+                  {
+                    "name": "selector",
+                    "type": "bytes4",
+                    "internalType": "bytes4"
+                  }
+                ]
+              },
+              {
+                "name": "fallbackFunctions",
+                "type": "tuple[]",
+                "internalType": "struct IExtensionConfig.FallbackFunction[]",
+                "components": [
+                  {
+                    "name": "selector",
+                    "type": "bytes4",
+                    "internalType": "bytes4"
+                  },
+                  {
+                    "name": "permissionBits",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getSupportedCallbackFunctions",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "supportedCallbackFunctions",
+        "type": "tuple[]",
+        "internalType": "struct IModularCore.SupportedCallbackFunction[]",
+        "components": [
+          { "name": "selector", "type": "bytes4", "internalType": "bytes4" },
+          {
+            "name": "mode",
+            "type": "uint8",
+            "internalType": "enum IModularCore.CallbackMode"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "grantRoles",
+    "inputs": [
+      { "name": "user", "type": "address", "internalType": "address" },
+      { "name": "roles", "type": "uint256", "internalType": "uint256" }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "hasAllRoles",
+    "inputs": [
+      { "name": "user", "type": "address", "internalType": "address" },
+      { "name": "roles", "type": "uint256", "internalType": "uint256" }
+    ],
+    "outputs": [{ "name": "", "type": "bool", "internalType": "bool" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "hasAnyRole",
+    "inputs": [
+      { "name": "user", "type": "address", "internalType": "address" },
+      { "name": "roles", "type": "uint256", "internalType": "uint256" }
+    ],
+    "outputs": [{ "name": "", "type": "bool", "internalType": "bool" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "installExtension",
+    "inputs": [
+      { "name": "_extension", "type": "address", "internalType": "address" },
+      { "name": "_data", "type": "bytes", "internalType": "bytes" }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "isApprovedForAll",
+    "inputs": [
+      { "name": "owner", "type": "address", "internalType": "address" },
+      { "name": "operator", "type": "address", "internalType": "address" }
+    ],
+    "outputs": [{ "name": "", "type": "bool", "internalType": "bool" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "mint",
+    "inputs": [
+      { "name": "to", "type": "address", "internalType": "address" },
+      { "name": "quantity", "type": "uint256", "internalType": "uint256" },
+      { "name": "data", "type": "bytes", "internalType": "bytes" }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "multicall",
+    "inputs": [
+      { "name": "data", "type": "bytes[]", "internalType": "bytes[]" }
+    ],
+    "outputs": [{ "name": "", "type": "bytes[]", "internalType": "bytes[]" }],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "name",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "string", "internalType": "string" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "owner",
+    "inputs": [],
+    "outputs": [
+      { "name": "result", "type": "address", "internalType": "address" }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "ownerOf",
+    "inputs": [
+      { "name": "tokenId", "type": "uint256", "internalType": "uint256" }
+    ],
+    "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "ownershipHandoverExpiresAt",
+    "inputs": [
+      { "name": "pendingOwner", "type": "address", "internalType": "address" }
+    ],
+    "outputs": [
+      { "name": "result", "type": "uint256", "internalType": "uint256" }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "renounceOwnership",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "renounceRoles",
+    "inputs": [
+      { "name": "roles", "type": "uint256", "internalType": "uint256" }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "requestOwnershipHandover",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "revokeRoles",
+    "inputs": [
+      { "name": "user", "type": "address", "internalType": "address" },
+      { "name": "roles", "type": "uint256", "internalType": "uint256" }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "rolesOf",
+    "inputs": [
+      { "name": "user", "type": "address", "internalType": "address" }
+    ],
+    "outputs": [
+      { "name": "roles", "type": "uint256", "internalType": "uint256" }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "safeTransferFrom",
+    "inputs": [
+      { "name": "from", "type": "address", "internalType": "address" },
+      { "name": "to", "type": "address", "internalType": "address" },
+      { "name": "tokenId", "type": "uint256", "internalType": "uint256" }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "safeTransferFrom",
+    "inputs": [
+      { "name": "from", "type": "address", "internalType": "address" },
+      { "name": "to", "type": "address", "internalType": "address" },
+      { "name": "tokenId", "type": "uint256", "internalType": "uint256" },
+      { "name": "_data", "type": "bytes", "internalType": "bytes" }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "setApprovalForAll",
+    "inputs": [
+      { "name": "operator", "type": "address", "internalType": "address" },
+      { "name": "approved", "type": "bool", "internalType": "bool" }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setContractURI",
+    "inputs": [{ "name": "uri", "type": "string", "internalType": "string" }],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "startTokenId",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "supportsInterface",
+    "inputs": [
+      { "name": "interfaceId", "type": "bytes4", "internalType": "bytes4" }
+    ],
+    "outputs": [{ "name": "", "type": "bool", "internalType": "bool" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "symbol",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "string", "internalType": "string" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "tokenURI",
+    "inputs": [
+      { "name": "id", "type": "uint256", "internalType": "uint256" }
+    ],
+    "outputs": [{ "name": "", "type": "string", "internalType": "string" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "tokensOfOwner",
+    "inputs": [
+      { "name": "owner", "type": "address", "internalType": "address" }
+    ],
+    "outputs": [
+      { "name": "", "type": "uint256[]", "internalType": "uint256[]" }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "tokensOfOwnerIn",
+    "inputs": [
+      { "name": "owner", "type": "address", "internalType": "address" },
+      { "name": "start", "type": "uint256", "internalType": "uint256" },
+      { "name": "stop", "type": "uint256", "internalType": "uint256" }
+    ],
+    "outputs": [
+      { "name": "", "type": "uint256[]", "internalType": "uint256[]" }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "totalMinted",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "totalSupply",
+    "inputs": [],
+    "outputs": [
+      { "name": "result", "type": "uint256", "internalType": "uint256" }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "transferFrom",
+    "inputs": [
+      { "name": "from", "type": "address", "internalType": "address" },
+      { "name": "to", "type": "address", "internalType": "address" },
+      { "name": "id", "type": "uint256", "internalType": "uint256" }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "transferOwnership",
+    "inputs": [
+      { "name": "newOwner", "type": "address", "internalType": "address" }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "uninstallExtension",
+    "inputs": [
+      { "name": "_extension", "type": "address", "internalType": "address" },
+      { "name": "_data", "type": "bytes", "internalType": "bytes" }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "event",
+    "name": "Approval",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "approved",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ApprovalForAll",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "approved",
+        "type": "bool",
+        "indexed": false,
+        "internalType": "bool"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ConsecutiveTransfer",
+    "inputs": [
+      {
+        "name": "fromTokenId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "toTokenId",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "from",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ContractURIUpdated",
+    "inputs": [],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ExtensionInstalled",
+    "inputs": [
+      {
+        "name": "caller",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "installedExtension",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ExtensionUninstalled",
+    "inputs": [
+      {
+        "name": "caller",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "installedExtension",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipHandoverCanceled",
+    "inputs": [
+      {
+        "name": "pendingOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipHandoverRequested",
+    "inputs": [
+      {
+        "name": "pendingOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipTransferred",
+    "inputs": [
+      {
+        "name": "oldOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RolesUpdated",
+    "inputs": [
+      {
+        "name": "user",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "roles",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Transfer",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  { "type": "error", "name": "AlreadyInitialized", "inputs": [] },
+  {
+    "type": "error",
+    "name": "ApprovalCallerNotOwnerNorApproved",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ApprovalQueryForNonexistentToken",
+    "inputs": []
+  },
+  { "type": "error", "name": "BalanceQueryForZeroAddress", "inputs": [] },
+  { "type": "error", "name": "CallbackExecutionReverted", "inputs": [] },
+  {
+    "type": "error",
+    "name": "CallbackFunctionAlreadyInstalled",
+    "inputs": []
+  },
+  { "type": "error", "name": "CallbackFunctionNotSupported", "inputs": [] },
+  { "type": "error", "name": "CallbackFunctionRequired", "inputs": [] },
+  {
+    "type": "error",
+    "name": "CallbackFunctionUnauthorizedCall",
+    "inputs": []
+  },
+  { "type": "error", "name": "ExtensionAlreadyInstalled", "inputs": [] },
+  {
+    "type": "error",
+    "name": "ExtensionInterfaceNotCompatible",
+    "inputs": [
+      {
+        "name": "requiredInterfaceId",
+        "type": "bytes4",
+        "internalType": "bytes4"
+      }
+    ]
+  },
+  { "type": "error", "name": "ExtensionNotInstalled", "inputs": [] },
+  { "type": "error", "name": "ExtensionOutOfSync", "inputs": [] },
+  {
+    "type": "error",
+    "name": "FallbackFunctionAlreadyInstalled",
+    "inputs": []
+  },
+  { "type": "error", "name": "FallbackFunctionNotInstalled", "inputs": [] },
+  { "type": "error", "name": "IndexOutOfBounds", "inputs": [] },
+  { "type": "error", "name": "InvalidQueryRange", "inputs": [] },
+  {
+    "type": "error",
+    "name": "MintERC2309QuantityExceedsLimit",
+    "inputs": []
+  },
+  { "type": "error", "name": "MintToZeroAddress", "inputs": [] },
+  { "type": "error", "name": "MintZeroQuantity", "inputs": [] },
+  { "type": "error", "name": "NewOwnerIsZeroAddress", "inputs": [] },
+  { "type": "error", "name": "NoHandoverRequest", "inputs": [] },
+  { "type": "error", "name": "NotCompatibleWithSpotMints", "inputs": [] },
+  { "type": "error", "name": "OwnerQueryForNonexistentToken", "inputs": [] },
+  {
+    "type": "error",
+    "name": "OwnershipNotInitializedForExtraData",
+    "inputs": []
+  },
+  { "type": "error", "name": "SequentialMintExceedsLimit", "inputs": [] },
+  { "type": "error", "name": "SequentialUpToTooSmall", "inputs": [] },
+  { "type": "error", "name": "SpotMintTokenIdTooSmall", "inputs": [] },
+  { "type": "error", "name": "TokenAlreadyExists", "inputs": [] },
+  {
+    "type": "error",
+    "name": "TransferCallerNotOwnerNorApproved",
+    "inputs": []
+  },
+  { "type": "error", "name": "TransferFromIncorrectOwner", "inputs": [] },
+  {
+    "type": "error",
+    "name": "TransferToNonERC721ReceiverImplementer",
+    "inputs": []
+  },
+  { "type": "error", "name": "TransferToZeroAddress", "inputs": [] },
+  { "type": "error", "name": "URIQueryForNonexistentToken", "inputs": [] },
+  { "type": "error", "name": "Unauthorized", "inputs": [] }
+]

--- a/packages/thirdweb/scripts/generate/abis/modular/MintableERC1155.json
+++ b/packages/thirdweb/scripts/generate/abis/modular/MintableERC1155.json
@@ -1,0 +1,5 @@
+[
+    "function mint(((uint48 startTimestamp,uint48 endTimestamp,address recipient,uint256 quantity,address currency,uint256 pricePerUnit,string metadataURI, bytes32 uid) request, bytes signature, string metadataURI) params) view",
+    "function setSaleConfig(address _primarySaleRecipient)",
+    "function grantRoles(address user, uint256 roles) payable"
+]

--- a/packages/thirdweb/scripts/generate/abis/modular/MintableERC20.json
+++ b/packages/thirdweb/scripts/generate/abis/modular/MintableERC20.json
@@ -1,0 +1,5 @@
+[
+  "function mint(((uint48 startTimestamp,uint48 endTimestamp,address recipient,uint256 quantity,address currency,uint256 pricePerUnit,bytes32 uid) request, bytes signature) params) view",
+  "function setSaleConfig(address _primarySaleRecipient)",
+  "function grantRoles(address user, uint256 roles) payable"
+]

--- a/packages/thirdweb/scripts/generate/abis/modular/MintableERC721.json
+++ b/packages/thirdweb/scripts/generate/abis/modular/MintableERC721.json
@@ -1,0 +1,5 @@
+[
+    "function mint(((uint48 startTimestamp,uint48 endTimestamp,address recipient,uint256 quantity,address currency,uint256 pricePerUnit,string baseURI, bytes32 uid) request, bytes signature, string baseURI) params) view",
+    "function setSaleConfig(address _primarySaleRecipient)",
+    "function grantRoles(address user, uint256 roles) payable"
+]

--- a/packages/thirdweb/src/exports/modular/erc1155.ts
+++ b/packages/thirdweb/src/exports/modular/erc1155.ts
@@ -1,0 +1,5 @@
+export {
+  mintWithPermissions,
+  mintWithSignature,
+  generateMintSignature,
+} from "../../extensions/modular/write/mintableERC1155.js";

--- a/packages/thirdweb/src/exports/modular/erc20.ts
+++ b/packages/thirdweb/src/exports/modular/erc20.ts
@@ -1,0 +1,8 @@
+export {
+  mintWithPermissions,
+  mintWithSignature,
+  generateMintSignature,
+} from "../../extensions/modular/write/mintableERC20.js";
+
+export { setSaleConfig } from "../../extensions/modular/__generated__/MintableERC20/write/setSaleConfig.js";
+export { grantMinterRole } from "../../extensions/modular/write/grantMinterRole.js";

--- a/packages/thirdweb/src/exports/modular/erc721.ts
+++ b/packages/thirdweb/src/exports/modular/erc721.ts
@@ -1,0 +1,5 @@
+export {
+  mintWithPermissions,
+  mintWithSignature,
+  generateMintSignature,
+} from "../../extensions/modular/write/mintableERC721.js";

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/events/ApprovalForAll.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/events/ApprovalForAll.ts
@@ -1,0 +1,49 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+import type { AbiParameterToPrimitiveType } from "abitype";
+
+/**
+ * Represents the filters for the "ApprovalForAll" event.
+ */
+export type ApprovalForAllEventFilters = Partial<{
+  owner: AbiParameterToPrimitiveType<{
+    name: "owner";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+  operator: AbiParameterToPrimitiveType<{
+    name: "operator";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+}>;
+
+/**
+ * Creates an event object for the ApprovalForAll event.
+ * @param filters - Optional filters to apply to the event.
+ * @returns The prepared event object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { approvalForAllEvent } from "thirdweb/extensions/modular";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  approvalForAllEvent({
+ *  owner: ...,
+ *  operator: ...,
+ * })
+ * ],
+ * });
+ * ```
+ */
+export function approvalForAllEvent(filters: ApprovalForAllEventFilters = {}) {
+  return prepareEvent({
+    signature:
+      "event ApprovalForAll(address indexed owner, address indexed operator, bool isApproved)",
+    filters,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/events/ContractURIUpdated.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/events/ContractURIUpdated.ts
@@ -1,0 +1,24 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+
+/**
+ * Creates an event object for the ContractURIUpdated event.
+ * @returns The prepared event object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { contractURIUpdatedEvent } from "thirdweb/extensions/modular";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  contractURIUpdatedEvent()
+ * ],
+ * });
+ * ```
+ */
+export function contractURIUpdatedEvent() {
+  return prepareEvent({
+    signature: "event ContractURIUpdated()",
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/events/ExtensionInstalled.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/events/ExtensionInstalled.ts
@@ -1,0 +1,25 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+
+/**
+ * Creates an event object for the ExtensionInstalled event.
+ * @returns The prepared event object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { extensionInstalledEvent } from "thirdweb/extensions/modular";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  extensionInstalledEvent()
+ * ],
+ * });
+ * ```
+ */
+export function extensionInstalledEvent() {
+  return prepareEvent({
+    signature:
+      "event ExtensionInstalled(address sender, address implementation, address installedExtension)",
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/events/ExtensionUninstalled.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/events/ExtensionUninstalled.ts
@@ -1,0 +1,25 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+
+/**
+ * Creates an event object for the ExtensionUninstalled event.
+ * @returns The prepared event object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { extensionUninstalledEvent } from "thirdweb/extensions/modular";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  extensionUninstalledEvent()
+ * ],
+ * });
+ * ```
+ */
+export function extensionUninstalledEvent() {
+  return prepareEvent({
+    signature:
+      "event ExtensionUninstalled(address sender, address implementation, address installedExtension)",
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/events/OwnershipHandoverCanceled.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/events/OwnershipHandoverCanceled.ts
@@ -1,0 +1,43 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+import type { AbiParameterToPrimitiveType } from "abitype";
+
+/**
+ * Represents the filters for the "OwnershipHandoverCanceled" event.
+ */
+export type OwnershipHandoverCanceledEventFilters = Partial<{
+  pendingOwner: AbiParameterToPrimitiveType<{
+    name: "pendingOwner";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+}>;
+
+/**
+ * Creates an event object for the OwnershipHandoverCanceled event.
+ * @param filters - Optional filters to apply to the event.
+ * @returns The prepared event object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { ownershipHandoverCanceledEvent } from "thirdweb/extensions/modular";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  ownershipHandoverCanceledEvent({
+ *  pendingOwner: ...,
+ * })
+ * ],
+ * });
+ * ```
+ */
+export function ownershipHandoverCanceledEvent(
+  filters: OwnershipHandoverCanceledEventFilters = {},
+) {
+  return prepareEvent({
+    signature: "event OwnershipHandoverCanceled(address indexed pendingOwner)",
+    filters,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/events/OwnershipHandoverRequested.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/events/OwnershipHandoverRequested.ts
@@ -1,0 +1,43 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+import type { AbiParameterToPrimitiveType } from "abitype";
+
+/**
+ * Represents the filters for the "OwnershipHandoverRequested" event.
+ */
+export type OwnershipHandoverRequestedEventFilters = Partial<{
+  pendingOwner: AbiParameterToPrimitiveType<{
+    name: "pendingOwner";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+}>;
+
+/**
+ * Creates an event object for the OwnershipHandoverRequested event.
+ * @param filters - Optional filters to apply to the event.
+ * @returns The prepared event object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { ownershipHandoverRequestedEvent } from "thirdweb/extensions/modular";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  ownershipHandoverRequestedEvent({
+ *  pendingOwner: ...,
+ * })
+ * ],
+ * });
+ * ```
+ */
+export function ownershipHandoverRequestedEvent(
+  filters: OwnershipHandoverRequestedEventFilters = {},
+) {
+  return prepareEvent({
+    signature: "event OwnershipHandoverRequested(address indexed pendingOwner)",
+    filters,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/events/OwnershipTransferred.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/events/OwnershipTransferred.ts
@@ -1,0 +1,51 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+import type { AbiParameterToPrimitiveType } from "abitype";
+
+/**
+ * Represents the filters for the "OwnershipTransferred" event.
+ */
+export type OwnershipTransferredEventFilters = Partial<{
+  oldOwner: AbiParameterToPrimitiveType<{
+    name: "oldOwner";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+  newOwner: AbiParameterToPrimitiveType<{
+    name: "newOwner";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+}>;
+
+/**
+ * Creates an event object for the OwnershipTransferred event.
+ * @param filters - Optional filters to apply to the event.
+ * @returns The prepared event object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { ownershipTransferredEvent } from "thirdweb/extensions/modular";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  ownershipTransferredEvent({
+ *  oldOwner: ...,
+ *  newOwner: ...,
+ * })
+ * ],
+ * });
+ * ```
+ */
+export function ownershipTransferredEvent(
+  filters: OwnershipTransferredEventFilters = {},
+) {
+  return prepareEvent({
+    signature:
+      "event OwnershipTransferred(address indexed oldOwner, address indexed newOwner)",
+    filters,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/events/RolesUpdated.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/events/RolesUpdated.ts
@@ -1,0 +1,49 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+import type { AbiParameterToPrimitiveType } from "abitype";
+
+/**
+ * Represents the filters for the "RolesUpdated" event.
+ */
+export type RolesUpdatedEventFilters = Partial<{
+  user: AbiParameterToPrimitiveType<{
+    name: "user";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+  roles: AbiParameterToPrimitiveType<{
+    name: "roles";
+    type: "uint256";
+    indexed: true;
+    internalType: "uint256";
+  }>;
+}>;
+
+/**
+ * Creates an event object for the RolesUpdated event.
+ * @param filters - Optional filters to apply to the event.
+ * @returns The prepared event object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { rolesUpdatedEvent } from "thirdweb/extensions/modular";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  rolesUpdatedEvent({
+ *  user: ...,
+ *  roles: ...,
+ * })
+ * ],
+ * });
+ * ```
+ */
+export function rolesUpdatedEvent(filters: RolesUpdatedEventFilters = {}) {
+  return prepareEvent({
+    signature:
+      "event RolesUpdated(address indexed user, uint256 indexed roles)",
+    filters,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/events/TransferBatch.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/events/TransferBatch.ts
@@ -1,0 +1,56 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+import type { AbiParameterToPrimitiveType } from "abitype";
+
+/**
+ * Represents the filters for the "TransferBatch" event.
+ */
+export type TransferBatchEventFilters = Partial<{
+  operator: AbiParameterToPrimitiveType<{
+    name: "operator";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+  from: AbiParameterToPrimitiveType<{
+    name: "from";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+  to: AbiParameterToPrimitiveType<{
+    name: "to";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+}>;
+
+/**
+ * Creates an event object for the TransferBatch event.
+ * @param filters - Optional filters to apply to the event.
+ * @returns The prepared event object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { transferBatchEvent } from "thirdweb/extensions/modular";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  transferBatchEvent({
+ *  operator: ...,
+ *  from: ...,
+ *  to: ...,
+ * })
+ * ],
+ * });
+ * ```
+ */
+export function transferBatchEvent(filters: TransferBatchEventFilters = {}) {
+  return prepareEvent({
+    signature:
+      "event TransferBatch(address indexed operator, address indexed from, address indexed to, uint256[] ids, uint256[] amounts)",
+    filters,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/events/TransferSingle.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/events/TransferSingle.ts
@@ -1,0 +1,56 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+import type { AbiParameterToPrimitiveType } from "abitype";
+
+/**
+ * Represents the filters for the "TransferSingle" event.
+ */
+export type TransferSingleEventFilters = Partial<{
+  operator: AbiParameterToPrimitiveType<{
+    name: "operator";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+  from: AbiParameterToPrimitiveType<{
+    name: "from";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+  to: AbiParameterToPrimitiveType<{
+    name: "to";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+}>;
+
+/**
+ * Creates an event object for the TransferSingle event.
+ * @param filters - Optional filters to apply to the event.
+ * @returns The prepared event object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { transferSingleEvent } from "thirdweb/extensions/modular";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  transferSingleEvent({
+ *  operator: ...,
+ *  from: ...,
+ *  to: ...,
+ * })
+ * ],
+ * });
+ * ```
+ */
+export function transferSingleEvent(filters: TransferSingleEventFilters = {}) {
+  return prepareEvent({
+    signature:
+      "event TransferSingle(address indexed operator, address indexed from, address indexed to, uint256 id, uint256 amount)",
+    filters,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/events/URI.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/events/URI.ts
@@ -1,0 +1,41 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+import type { AbiParameterToPrimitiveType } from "abitype";
+
+/**
+ * Represents the filters for the "URI" event.
+ */
+export type URIEventFilters = Partial<{
+  id: AbiParameterToPrimitiveType<{
+    name: "id";
+    type: "uint256";
+    indexed: true;
+    internalType: "uint256";
+  }>;
+}>;
+
+/**
+ * Creates an event object for the URI event.
+ * @param filters - Optional filters to apply to the event.
+ * @returns The prepared event object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { uRIEvent } from "thirdweb/extensions/modular";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  uRIEvent({
+ *  id: ...,
+ * })
+ * ],
+ * });
+ * ```
+ */
+export function uRIEvent(filters: URIEventFilters = {}) {
+  return prepareEvent({
+    signature: "event URI(string value, uint256 indexed id)",
+    filters,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/balanceOf.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/balanceOf.ts
@@ -1,0 +1,147 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "balanceOf" function.
+ */
+export type BalanceOfParams = {
+  owner: AbiParameterToPrimitiveType<{
+    name: "owner";
+    type: "address";
+    internalType: "address";
+  }>;
+  id: AbiParameterToPrimitiveType<{
+    name: "id";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+};
+
+export const FN_SELECTOR = "0x00fdd58e" as const;
+const FN_INPUTS = [
+  {
+    name: "owner",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "id",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "result",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Checks if the `balanceOf` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `balanceOf` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isBalanceOfSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isBalanceOfSupported(contract);
+ * ```
+ */
+export async function isBalanceOfSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "balanceOf" function.
+ * @param options - The options for the balanceOf function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeBalanceOfParams } "thirdweb/extensions/modular";
+ * const result = encodeBalanceOfParams({
+ *  owner: ...,
+ *  id: ...,
+ * });
+ * ```
+ */
+export function encodeBalanceOfParams(options: BalanceOfParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.owner, options.id]);
+}
+
+/**
+ * Encodes the "balanceOf" function into a Hex string with its parameters.
+ * @param options - The options for the balanceOf function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeBalanceOf } "thirdweb/extensions/modular";
+ * const result = encodeBalanceOf({
+ *  owner: ...,
+ *  id: ...,
+ * });
+ * ```
+ */
+export function encodeBalanceOf(options: BalanceOfParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeBalanceOfParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the balanceOf function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeBalanceOfResult } from "thirdweb/extensions/modular";
+ * const result = decodeBalanceOfResult("...");
+ * ```
+ */
+export function decodeBalanceOfResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "balanceOf" function on the contract.
+ * @param options - The options for the balanceOf function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { balanceOf } from "thirdweb/extensions/modular";
+ *
+ * const result = await balanceOf({
+ *  contract,
+ *  owner: ...,
+ *  id: ...,
+ * });
+ *
+ * ```
+ */
+export async function balanceOf(
+  options: BaseTransactionOptions<BalanceOfParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.owner, options.id],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/balanceOfBatch.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/balanceOfBatch.ts
@@ -1,0 +1,149 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "balanceOfBatch" function.
+ */
+export type BalanceOfBatchParams = {
+  owners: AbiParameterToPrimitiveType<{
+    name: "owners";
+    type: "address[]";
+    internalType: "address[]";
+  }>;
+  ids: AbiParameterToPrimitiveType<{
+    name: "ids";
+    type: "uint256[]";
+    internalType: "uint256[]";
+  }>;
+};
+
+export const FN_SELECTOR = "0x4e1273f4" as const;
+const FN_INPUTS = [
+  {
+    name: "owners",
+    type: "address[]",
+    internalType: "address[]",
+  },
+  {
+    name: "ids",
+    type: "uint256[]",
+    internalType: "uint256[]",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "balances",
+    type: "uint256[]",
+    internalType: "uint256[]",
+  },
+] as const;
+
+/**
+ * Checks if the `balanceOfBatch` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `balanceOfBatch` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isBalanceOfBatchSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isBalanceOfBatchSupported(contract);
+ * ```
+ */
+export async function isBalanceOfBatchSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "balanceOfBatch" function.
+ * @param options - The options for the balanceOfBatch function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeBalanceOfBatchParams } "thirdweb/extensions/modular";
+ * const result = encodeBalanceOfBatchParams({
+ *  owners: ...,
+ *  ids: ...,
+ * });
+ * ```
+ */
+export function encodeBalanceOfBatchParams(options: BalanceOfBatchParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.owners, options.ids]);
+}
+
+/**
+ * Encodes the "balanceOfBatch" function into a Hex string with its parameters.
+ * @param options - The options for the balanceOfBatch function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeBalanceOfBatch } "thirdweb/extensions/modular";
+ * const result = encodeBalanceOfBatch({
+ *  owners: ...,
+ *  ids: ...,
+ * });
+ * ```
+ */
+export function encodeBalanceOfBatch(options: BalanceOfBatchParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeBalanceOfBatchParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the balanceOfBatch function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeBalanceOfBatchResult } from "thirdweb/extensions/modular";
+ * const result = decodeBalanceOfBatchResult("...");
+ * ```
+ */
+export function decodeBalanceOfBatchResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "balanceOfBatch" function on the contract.
+ * @param options - The options for the balanceOfBatch function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { balanceOfBatch } from "thirdweb/extensions/modular";
+ *
+ * const result = await balanceOfBatch({
+ *  contract,
+ *  owners: ...,
+ *  ids: ...,
+ * });
+ *
+ * ```
+ */
+export async function balanceOfBatch(
+  options: BaseTransactionOptions<BalanceOfBatchParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.owners, options.ids],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/contractURI.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/contractURI.ts
@@ -1,0 +1,74 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0xe8a3d485" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "string",
+    internalType: "string",
+  },
+] as const;
+
+/**
+ * Checks if the `contractURI` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `contractURI` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isContractURISupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isContractURISupported(contract);
+ * ```
+ */
+export async function isContractURISupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Decodes the result of the contractURI function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeContractURIResult } from "thirdweb/extensions/modular";
+ * const result = decodeContractURIResult("...");
+ * ```
+ */
+export function decodeContractURIResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "contractURI" function on the contract.
+ * @param options - The options for the contractURI function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { contractURI } from "thirdweb/extensions/modular";
+ *
+ * const result = await contractURI({
+ *  contract,
+ * });
+ *
+ * ```
+ */
+export async function contractURI(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/getInstalledExtensions.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/getInstalledExtensions.ts
@@ -1,0 +1,134 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0x5357aa5e" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "_installedExtensions",
+    type: "tuple[]",
+    internalType: "struct IModularCore.InstalledExtension[]",
+    components: [
+      {
+        name: "implementation",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "config",
+        type: "tuple",
+        internalType: "struct IExtensionConfig.ExtensionConfig",
+        components: [
+          {
+            name: "requiredInterfaceId",
+            type: "bytes4",
+            internalType: "bytes4",
+          },
+          {
+            name: "registerInstallationCallback",
+            type: "bool",
+            internalType: "bool",
+          },
+          {
+            name: "supportedInterfaces",
+            type: "bytes4[]",
+            internalType: "bytes4[]",
+          },
+          {
+            name: "callbackFunctions",
+            type: "tuple[]",
+            internalType: "struct IExtensionConfig.CallbackFunction[]",
+            components: [
+              {
+                name: "selector",
+                type: "bytes4",
+                internalType: "bytes4",
+              },
+            ],
+          },
+          {
+            name: "fallbackFunctions",
+            type: "tuple[]",
+            internalType: "struct IExtensionConfig.FallbackFunction[]",
+            components: [
+              {
+                name: "selector",
+                type: "bytes4",
+                internalType: "bytes4",
+              },
+              {
+                name: "permissionBits",
+                type: "uint256",
+                internalType: "uint256",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Checks if the `getInstalledExtensions` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `getInstalledExtensions` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isGetInstalledExtensionsSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isGetInstalledExtensionsSupported(contract);
+ * ```
+ */
+export async function isGetInstalledExtensionsSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Decodes the result of the getInstalledExtensions function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeGetInstalledExtensionsResult } from "thirdweb/extensions/modular";
+ * const result = decodeGetInstalledExtensionsResult("...");
+ * ```
+ */
+export function decodeGetInstalledExtensionsResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "getInstalledExtensions" function on the contract.
+ * @param options - The options for the getInstalledExtensions function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { getInstalledExtensions } from "thirdweb/extensions/modular";
+ *
+ * const result = await getInstalledExtensions({
+ *  contract,
+ * });
+ *
+ * ```
+ */
+export async function getInstalledExtensions(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/getSupportedCallbackFunctions.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/getSupportedCallbackFunctions.ts
@@ -1,0 +1,90 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0xf147db8a" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "supportedCallbackFunctions",
+    type: "tuple[]",
+    internalType: "struct IModularCore.SupportedCallbackFunction[]",
+    components: [
+      {
+        name: "selector",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+      {
+        name: "mode",
+        type: "uint8",
+        internalType: "enum IModularCore.CallbackMode",
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Checks if the `getSupportedCallbackFunctions` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `getSupportedCallbackFunctions` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isGetSupportedCallbackFunctionsSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isGetSupportedCallbackFunctionsSupported(contract);
+ * ```
+ */
+export async function isGetSupportedCallbackFunctionsSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Decodes the result of the getSupportedCallbackFunctions function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeGetSupportedCallbackFunctionsResult } from "thirdweb/extensions/modular";
+ * const result = decodeGetSupportedCallbackFunctionsResult("...");
+ * ```
+ */
+export function decodeGetSupportedCallbackFunctionsResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "getSupportedCallbackFunctions" function on the contract.
+ * @param options - The options for the getSupportedCallbackFunctions function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { getSupportedCallbackFunctions } from "thirdweb/extensions/modular";
+ *
+ * const result = await getSupportedCallbackFunctions({
+ *  contract,
+ * });
+ *
+ * ```
+ */
+export async function getSupportedCallbackFunctions(
+  options: BaseTransactionOptions,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/hasAllRoles.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/hasAllRoles.ts
@@ -1,0 +1,147 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "hasAllRoles" function.
+ */
+export type HasAllRolesParams = {
+  user: AbiParameterToPrimitiveType<{
+    name: "user";
+    type: "address";
+    internalType: "address";
+  }>;
+  roles: AbiParameterToPrimitiveType<{
+    name: "roles";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+};
+
+export const FN_SELECTOR = "0x1cd64df4" as const;
+const FN_INPUTS = [
+  {
+    name: "user",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "roles",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "bool",
+    internalType: "bool",
+  },
+] as const;
+
+/**
+ * Checks if the `hasAllRoles` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `hasAllRoles` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isHasAllRolesSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isHasAllRolesSupported(contract);
+ * ```
+ */
+export async function isHasAllRolesSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "hasAllRoles" function.
+ * @param options - The options for the hasAllRoles function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeHasAllRolesParams } "thirdweb/extensions/modular";
+ * const result = encodeHasAllRolesParams({
+ *  user: ...,
+ *  roles: ...,
+ * });
+ * ```
+ */
+export function encodeHasAllRolesParams(options: HasAllRolesParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.user, options.roles]);
+}
+
+/**
+ * Encodes the "hasAllRoles" function into a Hex string with its parameters.
+ * @param options - The options for the hasAllRoles function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeHasAllRoles } "thirdweb/extensions/modular";
+ * const result = encodeHasAllRoles({
+ *  user: ...,
+ *  roles: ...,
+ * });
+ * ```
+ */
+export function encodeHasAllRoles(options: HasAllRolesParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeHasAllRolesParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the hasAllRoles function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeHasAllRolesResult } from "thirdweb/extensions/modular";
+ * const result = decodeHasAllRolesResult("...");
+ * ```
+ */
+export function decodeHasAllRolesResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "hasAllRoles" function on the contract.
+ * @param options - The options for the hasAllRoles function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { hasAllRoles } from "thirdweb/extensions/modular";
+ *
+ * const result = await hasAllRoles({
+ *  contract,
+ *  user: ...,
+ *  roles: ...,
+ * });
+ *
+ * ```
+ */
+export async function hasAllRoles(
+  options: BaseTransactionOptions<HasAllRolesParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.user, options.roles],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/hasAnyRole.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/hasAnyRole.ts
@@ -1,0 +1,147 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "hasAnyRole" function.
+ */
+export type HasAnyRoleParams = {
+  user: AbiParameterToPrimitiveType<{
+    name: "user";
+    type: "address";
+    internalType: "address";
+  }>;
+  roles: AbiParameterToPrimitiveType<{
+    name: "roles";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+};
+
+export const FN_SELECTOR = "0x514e62fc" as const;
+const FN_INPUTS = [
+  {
+    name: "user",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "roles",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "bool",
+    internalType: "bool",
+  },
+] as const;
+
+/**
+ * Checks if the `hasAnyRole` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `hasAnyRole` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isHasAnyRoleSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isHasAnyRoleSupported(contract);
+ * ```
+ */
+export async function isHasAnyRoleSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "hasAnyRole" function.
+ * @param options - The options for the hasAnyRole function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeHasAnyRoleParams } "thirdweb/extensions/modular";
+ * const result = encodeHasAnyRoleParams({
+ *  user: ...,
+ *  roles: ...,
+ * });
+ * ```
+ */
+export function encodeHasAnyRoleParams(options: HasAnyRoleParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.user, options.roles]);
+}
+
+/**
+ * Encodes the "hasAnyRole" function into a Hex string with its parameters.
+ * @param options - The options for the hasAnyRole function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeHasAnyRole } "thirdweb/extensions/modular";
+ * const result = encodeHasAnyRole({
+ *  user: ...,
+ *  roles: ...,
+ * });
+ * ```
+ */
+export function encodeHasAnyRole(options: HasAnyRoleParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeHasAnyRoleParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the hasAnyRole function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeHasAnyRoleResult } from "thirdweb/extensions/modular";
+ * const result = decodeHasAnyRoleResult("...");
+ * ```
+ */
+export function decodeHasAnyRoleResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "hasAnyRole" function on the contract.
+ * @param options - The options for the hasAnyRole function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { hasAnyRole } from "thirdweb/extensions/modular";
+ *
+ * const result = await hasAnyRole({
+ *  contract,
+ *  user: ...,
+ *  roles: ...,
+ * });
+ *
+ * ```
+ */
+export async function hasAnyRole(
+  options: BaseTransactionOptions<HasAnyRoleParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.user, options.roles],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/isApprovedForAll.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/isApprovedForAll.ts
@@ -1,0 +1,149 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "isApprovedForAll" function.
+ */
+export type IsApprovedForAllParams = {
+  owner: AbiParameterToPrimitiveType<{
+    name: "owner";
+    type: "address";
+    internalType: "address";
+  }>;
+  operator: AbiParameterToPrimitiveType<{
+    name: "operator";
+    type: "address";
+    internalType: "address";
+  }>;
+};
+
+export const FN_SELECTOR = "0xe985e9c5" as const;
+const FN_INPUTS = [
+  {
+    name: "owner",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "operator",
+    type: "address",
+    internalType: "address",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "result",
+    type: "bool",
+    internalType: "bool",
+  },
+] as const;
+
+/**
+ * Checks if the `isApprovedForAll` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `isApprovedForAll` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isIsApprovedForAllSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isIsApprovedForAllSupported(contract);
+ * ```
+ */
+export async function isIsApprovedForAllSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "isApprovedForAll" function.
+ * @param options - The options for the isApprovedForAll function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeIsApprovedForAllParams } "thirdweb/extensions/modular";
+ * const result = encodeIsApprovedForAllParams({
+ *  owner: ...,
+ *  operator: ...,
+ * });
+ * ```
+ */
+export function encodeIsApprovedForAllParams(options: IsApprovedForAllParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.owner, options.operator]);
+}
+
+/**
+ * Encodes the "isApprovedForAll" function into a Hex string with its parameters.
+ * @param options - The options for the isApprovedForAll function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeIsApprovedForAll } "thirdweb/extensions/modular";
+ * const result = encodeIsApprovedForAll({
+ *  owner: ...,
+ *  operator: ...,
+ * });
+ * ```
+ */
+export function encodeIsApprovedForAll(options: IsApprovedForAllParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeIsApprovedForAllParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the isApprovedForAll function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeIsApprovedForAllResult } from "thirdweb/extensions/modular";
+ * const result = decodeIsApprovedForAllResult("...");
+ * ```
+ */
+export function decodeIsApprovedForAllResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "isApprovedForAll" function on the contract.
+ * @param options - The options for the isApprovedForAll function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isApprovedForAll } from "thirdweb/extensions/modular";
+ *
+ * const result = await isApprovedForAll({
+ *  contract,
+ *  owner: ...,
+ *  operator: ...,
+ * });
+ *
+ * ```
+ */
+export async function isApprovedForAll(
+  options: BaseTransactionOptions<IsApprovedForAllParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.owner, options.operator],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/name.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/name.ts
@@ -1,0 +1,74 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0x06fdde03" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "string",
+    internalType: "string",
+  },
+] as const;
+
+/**
+ * Checks if the `name` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `name` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isNameSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isNameSupported(contract);
+ * ```
+ */
+export async function isNameSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Decodes the result of the name function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeNameResult } from "thirdweb/extensions/modular";
+ * const result = decodeNameResult("...");
+ * ```
+ */
+export function decodeNameResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "name" function on the contract.
+ * @param options - The options for the name function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { name } from "thirdweb/extensions/modular";
+ *
+ * const result = await name({
+ *  contract,
+ * });
+ *
+ * ```
+ */
+export async function name(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/owner.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/owner.ts
@@ -1,0 +1,74 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0x8da5cb5b" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "result",
+    type: "address",
+    internalType: "address",
+  },
+] as const;
+
+/**
+ * Checks if the `owner` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `owner` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isOwnerSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isOwnerSupported(contract);
+ * ```
+ */
+export async function isOwnerSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Decodes the result of the owner function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeOwnerResult } from "thirdweb/extensions/modular";
+ * const result = decodeOwnerResult("...");
+ * ```
+ */
+export function decodeOwnerResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "owner" function on the contract.
+ * @param options - The options for the owner function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { owner } from "thirdweb/extensions/modular";
+ *
+ * const result = await owner({
+ *  contract,
+ * });
+ *
+ * ```
+ */
+export async function owner(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/ownershipHandoverExpiresAt.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/ownershipHandoverExpiresAt.ts
@@ -1,0 +1,140 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "ownershipHandoverExpiresAt" function.
+ */
+export type OwnershipHandoverExpiresAtParams = {
+  pendingOwner: AbiParameterToPrimitiveType<{
+    name: "pendingOwner";
+    type: "address";
+    internalType: "address";
+  }>;
+};
+
+export const FN_SELECTOR = "0xfee81cf4" as const;
+const FN_INPUTS = [
+  {
+    name: "pendingOwner",
+    type: "address",
+    internalType: "address",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "result",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Checks if the `ownershipHandoverExpiresAt` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `ownershipHandoverExpiresAt` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isOwnershipHandoverExpiresAtSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isOwnershipHandoverExpiresAtSupported(contract);
+ * ```
+ */
+export async function isOwnershipHandoverExpiresAtSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "ownershipHandoverExpiresAt" function.
+ * @param options - The options for the ownershipHandoverExpiresAt function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeOwnershipHandoverExpiresAtParams } "thirdweb/extensions/modular";
+ * const result = encodeOwnershipHandoverExpiresAtParams({
+ *  pendingOwner: ...,
+ * });
+ * ```
+ */
+export function encodeOwnershipHandoverExpiresAtParams(
+  options: OwnershipHandoverExpiresAtParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.pendingOwner]);
+}
+
+/**
+ * Encodes the "ownershipHandoverExpiresAt" function into a Hex string with its parameters.
+ * @param options - The options for the ownershipHandoverExpiresAt function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeOwnershipHandoverExpiresAt } "thirdweb/extensions/modular";
+ * const result = encodeOwnershipHandoverExpiresAt({
+ *  pendingOwner: ...,
+ * });
+ * ```
+ */
+export function encodeOwnershipHandoverExpiresAt(
+  options: OwnershipHandoverExpiresAtParams,
+) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeOwnershipHandoverExpiresAtParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the ownershipHandoverExpiresAt function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeOwnershipHandoverExpiresAtResult } from "thirdweb/extensions/modular";
+ * const result = decodeOwnershipHandoverExpiresAtResult("...");
+ * ```
+ */
+export function decodeOwnershipHandoverExpiresAtResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "ownershipHandoverExpiresAt" function on the contract.
+ * @param options - The options for the ownershipHandoverExpiresAt function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { ownershipHandoverExpiresAt } from "thirdweb/extensions/modular";
+ *
+ * const result = await ownershipHandoverExpiresAt({
+ *  contract,
+ *  pendingOwner: ...,
+ * });
+ *
+ * ```
+ */
+export async function ownershipHandoverExpiresAt(
+  options: BaseTransactionOptions<OwnershipHandoverExpiresAtParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.pendingOwner],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/rolesOf.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/rolesOf.ts
@@ -1,0 +1,130 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "rolesOf" function.
+ */
+export type RolesOfParams = {
+  user: AbiParameterToPrimitiveType<{
+    name: "user";
+    type: "address";
+    internalType: "address";
+  }>;
+};
+
+export const FN_SELECTOR = "0x2de94807" as const;
+const FN_INPUTS = [
+  {
+    name: "user",
+    type: "address",
+    internalType: "address",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "roles",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Checks if the `rolesOf` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `rolesOf` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isRolesOfSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isRolesOfSupported(contract);
+ * ```
+ */
+export async function isRolesOfSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "rolesOf" function.
+ * @param options - The options for the rolesOf function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeRolesOfParams } "thirdweb/extensions/modular";
+ * const result = encodeRolesOfParams({
+ *  user: ...,
+ * });
+ * ```
+ */
+export function encodeRolesOfParams(options: RolesOfParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.user]);
+}
+
+/**
+ * Encodes the "rolesOf" function into a Hex string with its parameters.
+ * @param options - The options for the rolesOf function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeRolesOf } "thirdweb/extensions/modular";
+ * const result = encodeRolesOf({
+ *  user: ...,
+ * });
+ * ```
+ */
+export function encodeRolesOf(options: RolesOfParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeRolesOfParams(options).slice(2)) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the rolesOf function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeRolesOfResult } from "thirdweb/extensions/modular";
+ * const result = decodeRolesOfResult("...");
+ * ```
+ */
+export function decodeRolesOfResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "rolesOf" function on the contract.
+ * @param options - The options for the rolesOf function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { rolesOf } from "thirdweb/extensions/modular";
+ *
+ * const result = await rolesOf({
+ *  contract,
+ *  user: ...,
+ * });
+ *
+ * ```
+ */
+export async function rolesOf(options: BaseTransactionOptions<RolesOfParams>) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.user],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/supportsInterface.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/supportsInterface.ts
@@ -1,0 +1,138 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "supportsInterface" function.
+ */
+export type SupportsInterfaceParams = {
+  interfaceId: AbiParameterToPrimitiveType<{
+    name: "interfaceId";
+    type: "bytes4";
+    internalType: "bytes4";
+  }>;
+};
+
+export const FN_SELECTOR = "0x01ffc9a7" as const;
+const FN_INPUTS = [
+  {
+    name: "interfaceId",
+    type: "bytes4",
+    internalType: "bytes4",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "bool",
+    internalType: "bool",
+  },
+] as const;
+
+/**
+ * Checks if the `supportsInterface` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `supportsInterface` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isSupportsInterfaceSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isSupportsInterfaceSupported(contract);
+ * ```
+ */
+export async function isSupportsInterfaceSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "supportsInterface" function.
+ * @param options - The options for the supportsInterface function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeSupportsInterfaceParams } "thirdweb/extensions/modular";
+ * const result = encodeSupportsInterfaceParams({
+ *  interfaceId: ...,
+ * });
+ * ```
+ */
+export function encodeSupportsInterfaceParams(
+  options: SupportsInterfaceParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.interfaceId]);
+}
+
+/**
+ * Encodes the "supportsInterface" function into a Hex string with its parameters.
+ * @param options - The options for the supportsInterface function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeSupportsInterface } "thirdweb/extensions/modular";
+ * const result = encodeSupportsInterface({
+ *  interfaceId: ...,
+ * });
+ * ```
+ */
+export function encodeSupportsInterface(options: SupportsInterfaceParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeSupportsInterfaceParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the supportsInterface function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeSupportsInterfaceResult } from "thirdweb/extensions/modular";
+ * const result = decodeSupportsInterfaceResult("...");
+ * ```
+ */
+export function decodeSupportsInterfaceResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "supportsInterface" function on the contract.
+ * @param options - The options for the supportsInterface function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { supportsInterface } from "thirdweb/extensions/modular";
+ *
+ * const result = await supportsInterface({
+ *  contract,
+ *  interfaceId: ...,
+ * });
+ *
+ * ```
+ */
+export async function supportsInterface(
+  options: BaseTransactionOptions<SupportsInterfaceParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.interfaceId],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/symbol.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/symbol.ts
@@ -1,0 +1,74 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0x95d89b41" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "string",
+    internalType: "string",
+  },
+] as const;
+
+/**
+ * Checks if the `symbol` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `symbol` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isSymbolSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isSymbolSupported(contract);
+ * ```
+ */
+export async function isSymbolSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Decodes the result of the symbol function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeSymbolResult } from "thirdweb/extensions/modular";
+ * const result = decodeSymbolResult("...");
+ * ```
+ */
+export function decodeSymbolResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "symbol" function on the contract.
+ * @param options - The options for the symbol function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { symbol } from "thirdweb/extensions/modular";
+ *
+ * const result = await symbol({
+ *  contract,
+ * });
+ *
+ * ```
+ */
+export async function symbol(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/totalSupply.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/totalSupply.ts
@@ -1,0 +1,134 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "totalSupply" function.
+ */
+export type TotalSupplyParams = {
+  tokenId: AbiParameterToPrimitiveType<{
+    name: "tokenId";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+};
+
+export const FN_SELECTOR = "0xbd85b039" as const;
+const FN_INPUTS = [
+  {
+    name: "tokenId",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Checks if the `totalSupply` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `totalSupply` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isTotalSupplySupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isTotalSupplySupported(contract);
+ * ```
+ */
+export async function isTotalSupplySupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "totalSupply" function.
+ * @param options - The options for the totalSupply function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeTotalSupplyParams } "thirdweb/extensions/modular";
+ * const result = encodeTotalSupplyParams({
+ *  tokenId: ...,
+ * });
+ * ```
+ */
+export function encodeTotalSupplyParams(options: TotalSupplyParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.tokenId]);
+}
+
+/**
+ * Encodes the "totalSupply" function into a Hex string with its parameters.
+ * @param options - The options for the totalSupply function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeTotalSupply } "thirdweb/extensions/modular";
+ * const result = encodeTotalSupply({
+ *  tokenId: ...,
+ * });
+ * ```
+ */
+export function encodeTotalSupply(options: TotalSupplyParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeTotalSupplyParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the totalSupply function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeTotalSupplyResult } from "thirdweb/extensions/modular";
+ * const result = decodeTotalSupplyResult("...");
+ * ```
+ */
+export function decodeTotalSupplyResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "totalSupply" function on the contract.
+ * @param options - The options for the totalSupply function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { totalSupply } from "thirdweb/extensions/modular";
+ *
+ * const result = await totalSupply({
+ *  contract,
+ *  tokenId: ...,
+ * });
+ *
+ * ```
+ */
+export async function totalSupply(
+  options: BaseTransactionOptions<TotalSupplyParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.tokenId],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/uri.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/uri.ts
@@ -1,0 +1,130 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "uri" function.
+ */
+export type UriParams = {
+  tokenId: AbiParameterToPrimitiveType<{
+    name: "tokenId";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+};
+
+export const FN_SELECTOR = "0x0e89341c" as const;
+const FN_INPUTS = [
+  {
+    name: "tokenId",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "string",
+    internalType: "string",
+  },
+] as const;
+
+/**
+ * Checks if the `uri` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `uri` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isUriSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isUriSupported(contract);
+ * ```
+ */
+export async function isUriSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "uri" function.
+ * @param options - The options for the uri function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeUriParams } "thirdweb/extensions/modular";
+ * const result = encodeUriParams({
+ *  tokenId: ...,
+ * });
+ * ```
+ */
+export function encodeUriParams(options: UriParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.tokenId]);
+}
+
+/**
+ * Encodes the "uri" function into a Hex string with its parameters.
+ * @param options - The options for the uri function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeUri } "thirdweb/extensions/modular";
+ * const result = encodeUri({
+ *  tokenId: ...,
+ * });
+ * ```
+ */
+export function encodeUri(options: UriParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeUriParams(options).slice(2)) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the uri function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeUriResult } from "thirdweb/extensions/modular";
+ * const result = decodeUriResult("...");
+ * ```
+ */
+export function decodeUriResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "uri" function on the contract.
+ * @param options - The options for the uri function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { uri } from "thirdweb/extensions/modular";
+ *
+ * const result = await uri({
+ *  contract,
+ *  tokenId: ...,
+ * });
+ *
+ * ```
+ */
+export async function uri(options: BaseTransactionOptions<UriParams>) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.tokenId],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/burn.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/burn.ts
@@ -1,0 +1,189 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "burn" function.
+ */
+export type BurnParams = WithOverrides<{
+  from: AbiParameterToPrimitiveType<{
+    name: "from";
+    type: "address";
+    internalType: "address";
+  }>;
+  tokenId: AbiParameterToPrimitiveType<{
+    name: "tokenId";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+  value: AbiParameterToPrimitiveType<{
+    name: "value";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+  data: AbiParameterToPrimitiveType<{
+    name: "data";
+    type: "bytes";
+    internalType: "bytes";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0x8a94b05f" as const;
+const FN_INPUTS = [
+  {
+    name: "from",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "tokenId",
+    type: "uint256",
+    internalType: "uint256",
+  },
+  {
+    name: "value",
+    type: "uint256",
+    internalType: "uint256",
+  },
+  {
+    name: "data",
+    type: "bytes",
+    internalType: "bytes",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `burn` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `burn` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isBurnSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isBurnSupported(contract);
+ * ```
+ */
+export async function isBurnSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "burn" function.
+ * @param options - The options for the burn function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeBurnParams } "thirdweb/extensions/modular";
+ * const result = encodeBurnParams({
+ *  from: ...,
+ *  tokenId: ...,
+ *  value: ...,
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeBurnParams(options: BurnParams) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.from,
+    options.tokenId,
+    options.value,
+    options.data,
+  ]);
+}
+
+/**
+ * Encodes the "burn" function into a Hex string with its parameters.
+ * @param options - The options for the burn function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeBurn } "thirdweb/extensions/modular";
+ * const result = encodeBurn({
+ *  from: ...,
+ *  tokenId: ...,
+ *  value: ...,
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeBurn(options: BurnParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeBurnParams(options).slice(2)) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "burn" function on the contract.
+ * @param options - The options for the "burn" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { burn } from "thirdweb/extensions/modular";
+ *
+ * const transaction = burn({
+ *  contract,
+ *  from: ...,
+ *  tokenId: ...,
+ *  value: ...,
+ *  data: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function burn(
+  options: BaseTransactionOptions<
+    | BurnParams
+    | {
+        asyncParams: () => Promise<BurnParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [
+        resolvedOptions.from,
+        resolvedOptions.tokenId,
+        resolvedOptions.value,
+        resolvedOptions.data,
+      ] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/cancelOwnershipHandover.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/cancelOwnershipHandover.ts
@@ -1,0 +1,53 @@
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0x54d1f13d" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `cancelOwnershipHandover` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `cancelOwnershipHandover` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isCancelOwnershipHandoverSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isCancelOwnershipHandoverSupported(contract);
+ * ```
+ */
+export async function isCancelOwnershipHandoverSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Prepares a transaction to call the "cancelOwnershipHandover" function on the contract.
+ * @param options - The options for the "cancelOwnershipHandover" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { cancelOwnershipHandover } from "thirdweb/extensions/modular";
+ *
+ * const transaction = cancelOwnershipHandover();
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function cancelOwnershipHandover(options: BaseTransactionOptions) {
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/completeOwnershipHandover.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/completeOwnershipHandover.ts
@@ -1,0 +1,148 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "completeOwnershipHandover" function.
+ */
+export type CompleteOwnershipHandoverParams = WithOverrides<{
+  pendingOwner: AbiParameterToPrimitiveType<{
+    name: "pendingOwner";
+    type: "address";
+    internalType: "address";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0xf04e283e" as const;
+const FN_INPUTS = [
+  {
+    name: "pendingOwner",
+    type: "address",
+    internalType: "address",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `completeOwnershipHandover` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `completeOwnershipHandover` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isCompleteOwnershipHandoverSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isCompleteOwnershipHandoverSupported(contract);
+ * ```
+ */
+export async function isCompleteOwnershipHandoverSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "completeOwnershipHandover" function.
+ * @param options - The options for the completeOwnershipHandover function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeCompleteOwnershipHandoverParams } "thirdweb/extensions/modular";
+ * const result = encodeCompleteOwnershipHandoverParams({
+ *  pendingOwner: ...,
+ * });
+ * ```
+ */
+export function encodeCompleteOwnershipHandoverParams(
+  options: CompleteOwnershipHandoverParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.pendingOwner]);
+}
+
+/**
+ * Encodes the "completeOwnershipHandover" function into a Hex string with its parameters.
+ * @param options - The options for the completeOwnershipHandover function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeCompleteOwnershipHandover } "thirdweb/extensions/modular";
+ * const result = encodeCompleteOwnershipHandover({
+ *  pendingOwner: ...,
+ * });
+ * ```
+ */
+export function encodeCompleteOwnershipHandover(
+  options: CompleteOwnershipHandoverParams,
+) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeCompleteOwnershipHandoverParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "completeOwnershipHandover" function on the contract.
+ * @param options - The options for the "completeOwnershipHandover" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { completeOwnershipHandover } from "thirdweb/extensions/modular";
+ *
+ * const transaction = completeOwnershipHandover({
+ *  contract,
+ *  pendingOwner: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function completeOwnershipHandover(
+  options: BaseTransactionOptions<
+    | CompleteOwnershipHandoverParams
+    | {
+        asyncParams: () => Promise<CompleteOwnershipHandoverParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.pendingOwner] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/grantRoles.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/grantRoles.ts
@@ -1,0 +1,155 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "grantRoles" function.
+ */
+export type GrantRolesParams = WithOverrides<{
+  user: AbiParameterToPrimitiveType<{
+    name: "user";
+    type: "address";
+    internalType: "address";
+  }>;
+  roles: AbiParameterToPrimitiveType<{
+    name: "roles";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0x1c10893f" as const;
+const FN_INPUTS = [
+  {
+    name: "user",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "roles",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `grantRoles` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `grantRoles` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isGrantRolesSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isGrantRolesSupported(contract);
+ * ```
+ */
+export async function isGrantRolesSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "grantRoles" function.
+ * @param options - The options for the grantRoles function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeGrantRolesParams } "thirdweb/extensions/modular";
+ * const result = encodeGrantRolesParams({
+ *  user: ...,
+ *  roles: ...,
+ * });
+ * ```
+ */
+export function encodeGrantRolesParams(options: GrantRolesParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.user, options.roles]);
+}
+
+/**
+ * Encodes the "grantRoles" function into a Hex string with its parameters.
+ * @param options - The options for the grantRoles function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeGrantRoles } "thirdweb/extensions/modular";
+ * const result = encodeGrantRoles({
+ *  user: ...,
+ *  roles: ...,
+ * });
+ * ```
+ */
+export function encodeGrantRoles(options: GrantRolesParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeGrantRolesParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "grantRoles" function on the contract.
+ * @param options - The options for the "grantRoles" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { grantRoles } from "thirdweb/extensions/modular";
+ *
+ * const transaction = grantRoles({
+ *  contract,
+ *  user: ...,
+ *  roles: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function grantRoles(
+  options: BaseTransactionOptions<
+    | GrantRolesParams
+    | {
+        asyncParams: () => Promise<GrantRolesParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.user, resolvedOptions.roles] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/installExtension.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/installExtension.ts
@@ -1,0 +1,157 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "installExtension" function.
+ */
+export type InstallExtensionParams = WithOverrides<{
+  extension: AbiParameterToPrimitiveType<{
+    name: "_extension";
+    type: "address";
+    internalType: "address";
+  }>;
+  data: AbiParameterToPrimitiveType<{
+    name: "_data";
+    type: "bytes";
+    internalType: "bytes";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0xaca696f5" as const;
+const FN_INPUTS = [
+  {
+    name: "_extension",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "_data",
+    type: "bytes",
+    internalType: "bytes",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `installExtension` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `installExtension` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isInstallExtensionSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isInstallExtensionSupported(contract);
+ * ```
+ */
+export async function isInstallExtensionSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "installExtension" function.
+ * @param options - The options for the installExtension function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeInstallExtensionParams } "thirdweb/extensions/modular";
+ * const result = encodeInstallExtensionParams({
+ *  extension: ...,
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeInstallExtensionParams(options: InstallExtensionParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.extension, options.data]);
+}
+
+/**
+ * Encodes the "installExtension" function into a Hex string with its parameters.
+ * @param options - The options for the installExtension function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeInstallExtension } "thirdweb/extensions/modular";
+ * const result = encodeInstallExtension({
+ *  extension: ...,
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeInstallExtension(options: InstallExtensionParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeInstallExtensionParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "installExtension" function on the contract.
+ * @param options - The options for the "installExtension" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { installExtension } from "thirdweb/extensions/modular";
+ *
+ * const transaction = installExtension({
+ *  contract,
+ *  extension: ...,
+ *  data: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function installExtension(
+  options: BaseTransactionOptions<
+    | InstallExtensionParams
+    | {
+        asyncParams: () => Promise<InstallExtensionParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.extension, resolvedOptions.data] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/mint.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/mint.ts
@@ -1,0 +1,189 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "mint" function.
+ */
+export type MintParams = WithOverrides<{
+  to: AbiParameterToPrimitiveType<{
+    name: "to";
+    type: "address";
+    internalType: "address";
+  }>;
+  tokenId: AbiParameterToPrimitiveType<{
+    name: "tokenId";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+  value: AbiParameterToPrimitiveType<{
+    name: "value";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+  data: AbiParameterToPrimitiveType<{
+    name: "data";
+    type: "bytes";
+    internalType: "bytes";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0x731133e9" as const;
+const FN_INPUTS = [
+  {
+    name: "to",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "tokenId",
+    type: "uint256",
+    internalType: "uint256",
+  },
+  {
+    name: "value",
+    type: "uint256",
+    internalType: "uint256",
+  },
+  {
+    name: "data",
+    type: "bytes",
+    internalType: "bytes",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `mint` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `mint` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isMintSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isMintSupported(contract);
+ * ```
+ */
+export async function isMintSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "mint" function.
+ * @param options - The options for the mint function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeMintParams } "thirdweb/extensions/modular";
+ * const result = encodeMintParams({
+ *  to: ...,
+ *  tokenId: ...,
+ *  value: ...,
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeMintParams(options: MintParams) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.to,
+    options.tokenId,
+    options.value,
+    options.data,
+  ]);
+}
+
+/**
+ * Encodes the "mint" function into a Hex string with its parameters.
+ * @param options - The options for the mint function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeMint } "thirdweb/extensions/modular";
+ * const result = encodeMint({
+ *  to: ...,
+ *  tokenId: ...,
+ *  value: ...,
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeMint(options: MintParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeMintParams(options).slice(2)) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "mint" function on the contract.
+ * @param options - The options for the "mint" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { mint } from "thirdweb/extensions/modular";
+ *
+ * const transaction = mint({
+ *  contract,
+ *  to: ...,
+ *  tokenId: ...,
+ *  value: ...,
+ *  data: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function mint(
+  options: BaseTransactionOptions<
+    | MintParams
+    | {
+        asyncParams: () => Promise<MintParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [
+        resolvedOptions.to,
+        resolvedOptions.tokenId,
+        resolvedOptions.value,
+        resolvedOptions.data,
+      ] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/multicall.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/multicall.ts
@@ -1,0 +1,148 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "multicall" function.
+ */
+export type MulticallParams = WithOverrides<{
+  data: AbiParameterToPrimitiveType<{
+    name: "data";
+    type: "bytes[]";
+    internalType: "bytes[]";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0xac9650d8" as const;
+const FN_INPUTS = [
+  {
+    name: "data",
+    type: "bytes[]",
+    internalType: "bytes[]",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "bytes[]",
+    internalType: "bytes[]",
+  },
+] as const;
+
+/**
+ * Checks if the `multicall` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `multicall` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isMulticallSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isMulticallSupported(contract);
+ * ```
+ */
+export async function isMulticallSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "multicall" function.
+ * @param options - The options for the multicall function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeMulticallParams } "thirdweb/extensions/modular";
+ * const result = encodeMulticallParams({
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeMulticallParams(options: MulticallParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.data]);
+}
+
+/**
+ * Encodes the "multicall" function into a Hex string with its parameters.
+ * @param options - The options for the multicall function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeMulticall } "thirdweb/extensions/modular";
+ * const result = encodeMulticall({
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeMulticall(options: MulticallParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeMulticallParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "multicall" function on the contract.
+ * @param options - The options for the "multicall" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { multicall } from "thirdweb/extensions/modular";
+ *
+ * const transaction = multicall({
+ *  contract,
+ *  data: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function multicall(
+  options: BaseTransactionOptions<
+    | MulticallParams
+    | {
+        asyncParams: () => Promise<MulticallParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.data] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/renounceOwnership.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/renounceOwnership.ts
@@ -1,0 +1,53 @@
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0x715018a6" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `renounceOwnership` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `renounceOwnership` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isRenounceOwnershipSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isRenounceOwnershipSupported(contract);
+ * ```
+ */
+export async function isRenounceOwnershipSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Prepares a transaction to call the "renounceOwnership" function on the contract.
+ * @param options - The options for the "renounceOwnership" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { renounceOwnership } from "thirdweb/extensions/modular";
+ *
+ * const transaction = renounceOwnership();
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function renounceOwnership(options: BaseTransactionOptions) {
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/renounceRoles.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/renounceRoles.ts
@@ -1,0 +1,144 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "renounceRoles" function.
+ */
+export type RenounceRolesParams = WithOverrides<{
+  roles: AbiParameterToPrimitiveType<{
+    name: "roles";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0x183a4f6e" as const;
+const FN_INPUTS = [
+  {
+    name: "roles",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `renounceRoles` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `renounceRoles` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isRenounceRolesSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isRenounceRolesSupported(contract);
+ * ```
+ */
+export async function isRenounceRolesSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "renounceRoles" function.
+ * @param options - The options for the renounceRoles function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeRenounceRolesParams } "thirdweb/extensions/modular";
+ * const result = encodeRenounceRolesParams({
+ *  roles: ...,
+ * });
+ * ```
+ */
+export function encodeRenounceRolesParams(options: RenounceRolesParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.roles]);
+}
+
+/**
+ * Encodes the "renounceRoles" function into a Hex string with its parameters.
+ * @param options - The options for the renounceRoles function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeRenounceRoles } "thirdweb/extensions/modular";
+ * const result = encodeRenounceRoles({
+ *  roles: ...,
+ * });
+ * ```
+ */
+export function encodeRenounceRoles(options: RenounceRolesParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeRenounceRolesParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "renounceRoles" function on the contract.
+ * @param options - The options for the "renounceRoles" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { renounceRoles } from "thirdweb/extensions/modular";
+ *
+ * const transaction = renounceRoles({
+ *  contract,
+ *  roles: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function renounceRoles(
+  options: BaseTransactionOptions<
+    | RenounceRolesParams
+    | {
+        asyncParams: () => Promise<RenounceRolesParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.roles] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/requestOwnershipHandover.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/requestOwnershipHandover.ts
@@ -1,0 +1,53 @@
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0x25692962" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `requestOwnershipHandover` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `requestOwnershipHandover` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isRequestOwnershipHandoverSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isRequestOwnershipHandoverSupported(contract);
+ * ```
+ */
+export async function isRequestOwnershipHandoverSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Prepares a transaction to call the "requestOwnershipHandover" function on the contract.
+ * @param options - The options for the "requestOwnershipHandover" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { requestOwnershipHandover } from "thirdweb/extensions/modular";
+ *
+ * const transaction = requestOwnershipHandover();
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function requestOwnershipHandover(options: BaseTransactionOptions) {
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/revokeRoles.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/revokeRoles.ts
@@ -1,0 +1,155 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "revokeRoles" function.
+ */
+export type RevokeRolesParams = WithOverrides<{
+  user: AbiParameterToPrimitiveType<{
+    name: "user";
+    type: "address";
+    internalType: "address";
+  }>;
+  roles: AbiParameterToPrimitiveType<{
+    name: "roles";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0x4a4ee7b1" as const;
+const FN_INPUTS = [
+  {
+    name: "user",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "roles",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `revokeRoles` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `revokeRoles` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isRevokeRolesSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isRevokeRolesSupported(contract);
+ * ```
+ */
+export async function isRevokeRolesSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "revokeRoles" function.
+ * @param options - The options for the revokeRoles function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeRevokeRolesParams } "thirdweb/extensions/modular";
+ * const result = encodeRevokeRolesParams({
+ *  user: ...,
+ *  roles: ...,
+ * });
+ * ```
+ */
+export function encodeRevokeRolesParams(options: RevokeRolesParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.user, options.roles]);
+}
+
+/**
+ * Encodes the "revokeRoles" function into a Hex string with its parameters.
+ * @param options - The options for the revokeRoles function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeRevokeRoles } "thirdweb/extensions/modular";
+ * const result = encodeRevokeRoles({
+ *  user: ...,
+ *  roles: ...,
+ * });
+ * ```
+ */
+export function encodeRevokeRoles(options: RevokeRolesParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeRevokeRolesParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "revokeRoles" function on the contract.
+ * @param options - The options for the "revokeRoles" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { revokeRoles } from "thirdweb/extensions/modular";
+ *
+ * const transaction = revokeRoles({
+ *  contract,
+ *  user: ...,
+ *  roles: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function revokeRoles(
+  options: BaseTransactionOptions<
+    | RevokeRolesParams
+    | {
+        asyncParams: () => Promise<RevokeRolesParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.user, resolvedOptions.roles] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/safeBatchTransferFrom.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/safeBatchTransferFrom.ts
@@ -1,0 +1,212 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "safeBatchTransferFrom" function.
+ */
+export type SafeBatchTransferFromParams = WithOverrides<{
+  from: AbiParameterToPrimitiveType<{
+    name: "from";
+    type: "address";
+    internalType: "address";
+  }>;
+  to: AbiParameterToPrimitiveType<{
+    name: "to";
+    type: "address";
+    internalType: "address";
+  }>;
+  tokenIds: AbiParameterToPrimitiveType<{
+    name: "tokenIds";
+    type: "uint256[]";
+    internalType: "uint256[]";
+  }>;
+  values: AbiParameterToPrimitiveType<{
+    name: "values";
+    type: "uint256[]";
+    internalType: "uint256[]";
+  }>;
+  data: AbiParameterToPrimitiveType<{
+    name: "data";
+    type: "bytes";
+    internalType: "bytes";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0x2eb2c2d6" as const;
+const FN_INPUTS = [
+  {
+    name: "from",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "to",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "tokenIds",
+    type: "uint256[]",
+    internalType: "uint256[]",
+  },
+  {
+    name: "values",
+    type: "uint256[]",
+    internalType: "uint256[]",
+  },
+  {
+    name: "data",
+    type: "bytes",
+    internalType: "bytes",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `safeBatchTransferFrom` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `safeBatchTransferFrom` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isSafeBatchTransferFromSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isSafeBatchTransferFromSupported(contract);
+ * ```
+ */
+export async function isSafeBatchTransferFromSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "safeBatchTransferFrom" function.
+ * @param options - The options for the safeBatchTransferFrom function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeSafeBatchTransferFromParams } "thirdweb/extensions/modular";
+ * const result = encodeSafeBatchTransferFromParams({
+ *  from: ...,
+ *  to: ...,
+ *  tokenIds: ...,
+ *  values: ...,
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeSafeBatchTransferFromParams(
+  options: SafeBatchTransferFromParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.from,
+    options.to,
+    options.tokenIds,
+    options.values,
+    options.data,
+  ]);
+}
+
+/**
+ * Encodes the "safeBatchTransferFrom" function into a Hex string with its parameters.
+ * @param options - The options for the safeBatchTransferFrom function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeSafeBatchTransferFrom } "thirdweb/extensions/modular";
+ * const result = encodeSafeBatchTransferFrom({
+ *  from: ...,
+ *  to: ...,
+ *  tokenIds: ...,
+ *  values: ...,
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeSafeBatchTransferFrom(
+  options: SafeBatchTransferFromParams,
+) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeSafeBatchTransferFromParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "safeBatchTransferFrom" function on the contract.
+ * @param options - The options for the "safeBatchTransferFrom" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { safeBatchTransferFrom } from "thirdweb/extensions/modular";
+ *
+ * const transaction = safeBatchTransferFrom({
+ *  contract,
+ *  from: ...,
+ *  to: ...,
+ *  tokenIds: ...,
+ *  values: ...,
+ *  data: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function safeBatchTransferFrom(
+  options: BaseTransactionOptions<
+    | SafeBatchTransferFromParams
+    | {
+        asyncParams: () => Promise<SafeBatchTransferFromParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [
+        resolvedOptions.from,
+        resolvedOptions.to,
+        resolvedOptions.tokenIds,
+        resolvedOptions.values,
+        resolvedOptions.data,
+      ] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/safeTransferFrom.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/safeTransferFrom.ts
@@ -1,0 +1,208 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "safeTransferFrom" function.
+ */
+export type SafeTransferFromParams = WithOverrides<{
+  from: AbiParameterToPrimitiveType<{
+    name: "from";
+    type: "address";
+    internalType: "address";
+  }>;
+  to: AbiParameterToPrimitiveType<{
+    name: "to";
+    type: "address";
+    internalType: "address";
+  }>;
+  tokenId: AbiParameterToPrimitiveType<{
+    name: "tokenId";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+  value: AbiParameterToPrimitiveType<{
+    name: "value";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+  data: AbiParameterToPrimitiveType<{
+    name: "data";
+    type: "bytes";
+    internalType: "bytes";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0xf242432a" as const;
+const FN_INPUTS = [
+  {
+    name: "from",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "to",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "tokenId",
+    type: "uint256",
+    internalType: "uint256",
+  },
+  {
+    name: "value",
+    type: "uint256",
+    internalType: "uint256",
+  },
+  {
+    name: "data",
+    type: "bytes",
+    internalType: "bytes",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `safeTransferFrom` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `safeTransferFrom` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isSafeTransferFromSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isSafeTransferFromSupported(contract);
+ * ```
+ */
+export async function isSafeTransferFromSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "safeTransferFrom" function.
+ * @param options - The options for the safeTransferFrom function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeSafeTransferFromParams } "thirdweb/extensions/modular";
+ * const result = encodeSafeTransferFromParams({
+ *  from: ...,
+ *  to: ...,
+ *  tokenId: ...,
+ *  value: ...,
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeSafeTransferFromParams(options: SafeTransferFromParams) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.from,
+    options.to,
+    options.tokenId,
+    options.value,
+    options.data,
+  ]);
+}
+
+/**
+ * Encodes the "safeTransferFrom" function into a Hex string with its parameters.
+ * @param options - The options for the safeTransferFrom function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeSafeTransferFrom } "thirdweb/extensions/modular";
+ * const result = encodeSafeTransferFrom({
+ *  from: ...,
+ *  to: ...,
+ *  tokenId: ...,
+ *  value: ...,
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeSafeTransferFrom(options: SafeTransferFromParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeSafeTransferFromParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "safeTransferFrom" function on the contract.
+ * @param options - The options for the "safeTransferFrom" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { safeTransferFrom } from "thirdweb/extensions/modular";
+ *
+ * const transaction = safeTransferFrom({
+ *  contract,
+ *  from: ...,
+ *  to: ...,
+ *  tokenId: ...,
+ *  value: ...,
+ *  data: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function safeTransferFrom(
+  options: BaseTransactionOptions<
+    | SafeTransferFromParams
+    | {
+        asyncParams: () => Promise<SafeTransferFromParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [
+        resolvedOptions.from,
+        resolvedOptions.to,
+        resolvedOptions.tokenId,
+        resolvedOptions.value,
+        resolvedOptions.data,
+      ] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/setApprovalForAll.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/setApprovalForAll.ts
@@ -1,0 +1,159 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "setApprovalForAll" function.
+ */
+export type SetApprovalForAllParams = WithOverrides<{
+  operator: AbiParameterToPrimitiveType<{
+    name: "operator";
+    type: "address";
+    internalType: "address";
+  }>;
+  approved: AbiParameterToPrimitiveType<{
+    name: "approved";
+    type: "bool";
+    internalType: "bool";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0xa22cb465" as const;
+const FN_INPUTS = [
+  {
+    name: "operator",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "approved",
+    type: "bool",
+    internalType: "bool",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `setApprovalForAll` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `setApprovalForAll` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isSetApprovalForAllSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isSetApprovalForAllSupported(contract);
+ * ```
+ */
+export async function isSetApprovalForAllSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "setApprovalForAll" function.
+ * @param options - The options for the setApprovalForAll function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeSetApprovalForAllParams } "thirdweb/extensions/modular";
+ * const result = encodeSetApprovalForAllParams({
+ *  operator: ...,
+ *  approved: ...,
+ * });
+ * ```
+ */
+export function encodeSetApprovalForAllParams(
+  options: SetApprovalForAllParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.operator, options.approved]);
+}
+
+/**
+ * Encodes the "setApprovalForAll" function into a Hex string with its parameters.
+ * @param options - The options for the setApprovalForAll function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeSetApprovalForAll } "thirdweb/extensions/modular";
+ * const result = encodeSetApprovalForAll({
+ *  operator: ...,
+ *  approved: ...,
+ * });
+ * ```
+ */
+export function encodeSetApprovalForAll(options: SetApprovalForAllParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeSetApprovalForAllParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "setApprovalForAll" function on the contract.
+ * @param options - The options for the "setApprovalForAll" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { setApprovalForAll } from "thirdweb/extensions/modular";
+ *
+ * const transaction = setApprovalForAll({
+ *  contract,
+ *  operator: ...,
+ *  approved: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function setApprovalForAll(
+  options: BaseTransactionOptions<
+    | SetApprovalForAllParams
+    | {
+        asyncParams: () => Promise<SetApprovalForAllParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.operator, resolvedOptions.approved] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/setContractURI.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/setContractURI.ts
@@ -1,0 +1,144 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "setContractURI" function.
+ */
+export type SetContractURIParams = WithOverrides<{
+  uri: AbiParameterToPrimitiveType<{
+    name: "uri";
+    type: "string";
+    internalType: "string";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0x938e3d7b" as const;
+const FN_INPUTS = [
+  {
+    name: "uri",
+    type: "string",
+    internalType: "string",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `setContractURI` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `setContractURI` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isSetContractURISupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isSetContractURISupported(contract);
+ * ```
+ */
+export async function isSetContractURISupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "setContractURI" function.
+ * @param options - The options for the setContractURI function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeSetContractURIParams } "thirdweb/extensions/modular";
+ * const result = encodeSetContractURIParams({
+ *  uri: ...,
+ * });
+ * ```
+ */
+export function encodeSetContractURIParams(options: SetContractURIParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.uri]);
+}
+
+/**
+ * Encodes the "setContractURI" function into a Hex string with its parameters.
+ * @param options - The options for the setContractURI function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeSetContractURI } "thirdweb/extensions/modular";
+ * const result = encodeSetContractURI({
+ *  uri: ...,
+ * });
+ * ```
+ */
+export function encodeSetContractURI(options: SetContractURIParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeSetContractURIParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "setContractURI" function on the contract.
+ * @param options - The options for the "setContractURI" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { setContractURI } from "thirdweb/extensions/modular";
+ *
+ * const transaction = setContractURI({
+ *  contract,
+ *  uri: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function setContractURI(
+  options: BaseTransactionOptions<
+    | SetContractURIParams
+    | {
+        asyncParams: () => Promise<SetContractURIParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.uri] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/transferOwnership.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/transferOwnership.ts
@@ -1,0 +1,146 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "transferOwnership" function.
+ */
+export type TransferOwnershipParams = WithOverrides<{
+  newOwner: AbiParameterToPrimitiveType<{
+    name: "newOwner";
+    type: "address";
+    internalType: "address";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0xf2fde38b" as const;
+const FN_INPUTS = [
+  {
+    name: "newOwner",
+    type: "address",
+    internalType: "address",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `transferOwnership` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `transferOwnership` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isTransferOwnershipSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isTransferOwnershipSupported(contract);
+ * ```
+ */
+export async function isTransferOwnershipSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "transferOwnership" function.
+ * @param options - The options for the transferOwnership function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeTransferOwnershipParams } "thirdweb/extensions/modular";
+ * const result = encodeTransferOwnershipParams({
+ *  newOwner: ...,
+ * });
+ * ```
+ */
+export function encodeTransferOwnershipParams(
+  options: TransferOwnershipParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.newOwner]);
+}
+
+/**
+ * Encodes the "transferOwnership" function into a Hex string with its parameters.
+ * @param options - The options for the transferOwnership function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeTransferOwnership } "thirdweb/extensions/modular";
+ * const result = encodeTransferOwnership({
+ *  newOwner: ...,
+ * });
+ * ```
+ */
+export function encodeTransferOwnership(options: TransferOwnershipParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeTransferOwnershipParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "transferOwnership" function on the contract.
+ * @param options - The options for the "transferOwnership" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { transferOwnership } from "thirdweb/extensions/modular";
+ *
+ * const transaction = transferOwnership({
+ *  contract,
+ *  newOwner: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function transferOwnership(
+  options: BaseTransactionOptions<
+    | TransferOwnershipParams
+    | {
+        asyncParams: () => Promise<TransferOwnershipParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.newOwner] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/uninstallExtension.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/uninstallExtension.ts
@@ -1,0 +1,159 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "uninstallExtension" function.
+ */
+export type UninstallExtensionParams = WithOverrides<{
+  extension: AbiParameterToPrimitiveType<{
+    name: "_extension";
+    type: "address";
+    internalType: "address";
+  }>;
+  data: AbiParameterToPrimitiveType<{
+    name: "_data";
+    type: "bytes";
+    internalType: "bytes";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0x42b7d0c8" as const;
+const FN_INPUTS = [
+  {
+    name: "_extension",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "_data",
+    type: "bytes",
+    internalType: "bytes",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `uninstallExtension` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `uninstallExtension` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isUninstallExtensionSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isUninstallExtensionSupported(contract);
+ * ```
+ */
+export async function isUninstallExtensionSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "uninstallExtension" function.
+ * @param options - The options for the uninstallExtension function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeUninstallExtensionParams } "thirdweb/extensions/modular";
+ * const result = encodeUninstallExtensionParams({
+ *  extension: ...,
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeUninstallExtensionParams(
+  options: UninstallExtensionParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.extension, options.data]);
+}
+
+/**
+ * Encodes the "uninstallExtension" function into a Hex string with its parameters.
+ * @param options - The options for the uninstallExtension function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeUninstallExtension } "thirdweb/extensions/modular";
+ * const result = encodeUninstallExtension({
+ *  extension: ...,
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeUninstallExtension(options: UninstallExtensionParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeUninstallExtensionParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "uninstallExtension" function on the contract.
+ * @param options - The options for the "uninstallExtension" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { uninstallExtension } from "thirdweb/extensions/modular";
+ *
+ * const transaction = uninstallExtension({
+ *  contract,
+ *  extension: ...,
+ *  data: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function uninstallExtension(
+  options: BaseTransactionOptions<
+    | UninstallExtensionParams
+    | {
+        asyncParams: () => Promise<UninstallExtensionParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.extension, resolvedOptions.data] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/events/Approval.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/events/Approval.ts
@@ -1,0 +1,49 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+import type { AbiParameterToPrimitiveType } from "abitype";
+
+/**
+ * Represents the filters for the "Approval" event.
+ */
+export type ApprovalEventFilters = Partial<{
+  owner: AbiParameterToPrimitiveType<{
+    name: "owner";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+  spender: AbiParameterToPrimitiveType<{
+    name: "spender";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+}>;
+
+/**
+ * Creates an event object for the Approval event.
+ * @param filters - Optional filters to apply to the event.
+ * @returns The prepared event object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { approvalEvent } from "thirdweb/extensions/modular";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  approvalEvent({
+ *  owner: ...,
+ *  spender: ...,
+ * })
+ * ],
+ * });
+ * ```
+ */
+export function approvalEvent(filters: ApprovalEventFilters = {}) {
+  return prepareEvent({
+    signature:
+      "event Approval(address indexed owner, address indexed spender, uint256 amount)",
+    filters,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/events/ContractURIUpdated.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/events/ContractURIUpdated.ts
@@ -1,0 +1,24 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+
+/**
+ * Creates an event object for the ContractURIUpdated event.
+ * @returns The prepared event object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { contractURIUpdatedEvent } from "thirdweb/extensions/modular";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  contractURIUpdatedEvent()
+ * ],
+ * });
+ * ```
+ */
+export function contractURIUpdatedEvent() {
+  return prepareEvent({
+    signature: "event ContractURIUpdated()",
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/events/ExtensionInstalled.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/events/ExtensionInstalled.ts
@@ -1,0 +1,25 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+
+/**
+ * Creates an event object for the ExtensionInstalled event.
+ * @returns The prepared event object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { extensionInstalledEvent } from "thirdweb/extensions/modular";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  extensionInstalledEvent()
+ * ],
+ * });
+ * ```
+ */
+export function extensionInstalledEvent() {
+  return prepareEvent({
+    signature:
+      "event ExtensionInstalled(address sender, address implementation, address installedExtension)",
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/events/ExtensionUninstalled.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/events/ExtensionUninstalled.ts
@@ -1,0 +1,25 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+
+/**
+ * Creates an event object for the ExtensionUninstalled event.
+ * @returns The prepared event object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { extensionUninstalledEvent } from "thirdweb/extensions/modular";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  extensionUninstalledEvent()
+ * ],
+ * });
+ * ```
+ */
+export function extensionUninstalledEvent() {
+  return prepareEvent({
+    signature:
+      "event ExtensionUninstalled(address sender, address implementation, address installedExtension)",
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/events/OwnershipHandoverCanceled.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/events/OwnershipHandoverCanceled.ts
@@ -1,0 +1,43 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+import type { AbiParameterToPrimitiveType } from "abitype";
+
+/**
+ * Represents the filters for the "OwnershipHandoverCanceled" event.
+ */
+export type OwnershipHandoverCanceledEventFilters = Partial<{
+  pendingOwner: AbiParameterToPrimitiveType<{
+    name: "pendingOwner";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+}>;
+
+/**
+ * Creates an event object for the OwnershipHandoverCanceled event.
+ * @param filters - Optional filters to apply to the event.
+ * @returns The prepared event object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { ownershipHandoverCanceledEvent } from "thirdweb/extensions/modular";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  ownershipHandoverCanceledEvent({
+ *  pendingOwner: ...,
+ * })
+ * ],
+ * });
+ * ```
+ */
+export function ownershipHandoverCanceledEvent(
+  filters: OwnershipHandoverCanceledEventFilters = {},
+) {
+  return prepareEvent({
+    signature: "event OwnershipHandoverCanceled(address indexed pendingOwner)",
+    filters,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/events/OwnershipHandoverRequested.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/events/OwnershipHandoverRequested.ts
@@ -1,0 +1,43 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+import type { AbiParameterToPrimitiveType } from "abitype";
+
+/**
+ * Represents the filters for the "OwnershipHandoverRequested" event.
+ */
+export type OwnershipHandoverRequestedEventFilters = Partial<{
+  pendingOwner: AbiParameterToPrimitiveType<{
+    name: "pendingOwner";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+}>;
+
+/**
+ * Creates an event object for the OwnershipHandoverRequested event.
+ * @param filters - Optional filters to apply to the event.
+ * @returns The prepared event object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { ownershipHandoverRequestedEvent } from "thirdweb/extensions/modular";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  ownershipHandoverRequestedEvent({
+ *  pendingOwner: ...,
+ * })
+ * ],
+ * });
+ * ```
+ */
+export function ownershipHandoverRequestedEvent(
+  filters: OwnershipHandoverRequestedEventFilters = {},
+) {
+  return prepareEvent({
+    signature: "event OwnershipHandoverRequested(address indexed pendingOwner)",
+    filters,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/events/OwnershipTransferred.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/events/OwnershipTransferred.ts
@@ -1,0 +1,51 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+import type { AbiParameterToPrimitiveType } from "abitype";
+
+/**
+ * Represents the filters for the "OwnershipTransferred" event.
+ */
+export type OwnershipTransferredEventFilters = Partial<{
+  oldOwner: AbiParameterToPrimitiveType<{
+    name: "oldOwner";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+  newOwner: AbiParameterToPrimitiveType<{
+    name: "newOwner";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+}>;
+
+/**
+ * Creates an event object for the OwnershipTransferred event.
+ * @param filters - Optional filters to apply to the event.
+ * @returns The prepared event object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { ownershipTransferredEvent } from "thirdweb/extensions/modular";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  ownershipTransferredEvent({
+ *  oldOwner: ...,
+ *  newOwner: ...,
+ * })
+ * ],
+ * });
+ * ```
+ */
+export function ownershipTransferredEvent(
+  filters: OwnershipTransferredEventFilters = {},
+) {
+  return prepareEvent({
+    signature:
+      "event OwnershipTransferred(address indexed oldOwner, address indexed newOwner)",
+    filters,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/events/RolesUpdated.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/events/RolesUpdated.ts
@@ -1,0 +1,49 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+import type { AbiParameterToPrimitiveType } from "abitype";
+
+/**
+ * Represents the filters for the "RolesUpdated" event.
+ */
+export type RolesUpdatedEventFilters = Partial<{
+  user: AbiParameterToPrimitiveType<{
+    name: "user";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+  roles: AbiParameterToPrimitiveType<{
+    name: "roles";
+    type: "uint256";
+    indexed: true;
+    internalType: "uint256";
+  }>;
+}>;
+
+/**
+ * Creates an event object for the RolesUpdated event.
+ * @param filters - Optional filters to apply to the event.
+ * @returns The prepared event object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { rolesUpdatedEvent } from "thirdweb/extensions/modular";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  rolesUpdatedEvent({
+ *  user: ...,
+ *  roles: ...,
+ * })
+ * ],
+ * });
+ * ```
+ */
+export function rolesUpdatedEvent(filters: RolesUpdatedEventFilters = {}) {
+  return prepareEvent({
+    signature:
+      "event RolesUpdated(address indexed user, uint256 indexed roles)",
+    filters,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/events/Transfer.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/events/Transfer.ts
@@ -1,0 +1,49 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+import type { AbiParameterToPrimitiveType } from "abitype";
+
+/**
+ * Represents the filters for the "Transfer" event.
+ */
+export type TransferEventFilters = Partial<{
+  from: AbiParameterToPrimitiveType<{
+    name: "from";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+  to: AbiParameterToPrimitiveType<{
+    name: "to";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+}>;
+
+/**
+ * Creates an event object for the Transfer event.
+ * @param filters - Optional filters to apply to the event.
+ * @returns The prepared event object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { transferEvent } from "thirdweb/extensions/modular";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  transferEvent({
+ *  from: ...,
+ *  to: ...,
+ * })
+ * ],
+ * });
+ * ```
+ */
+export function transferEvent(filters: TransferEventFilters = {}) {
+  return prepareEvent({
+    signature:
+      "event Transfer(address indexed from, address indexed to, uint256 amount)",
+    filters,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/DOMAIN_SEPARATOR.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/DOMAIN_SEPARATOR.ts
@@ -1,0 +1,76 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0x3644e515" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "result",
+    type: "bytes32",
+    internalType: "bytes32",
+  },
+] as const;
+
+/**
+ * Checks if the `DOMAIN_SEPARATOR` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `DOMAIN_SEPARATOR` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isDOMAIN_SEPARATORSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isDOMAIN_SEPARATORSupported(contract);
+ * ```
+ */
+export async function isDOMAIN_SEPARATORSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Decodes the result of the DOMAIN_SEPARATOR function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeDOMAIN_SEPARATORResult } from "thirdweb/extensions/modular";
+ * const result = decodeDOMAIN_SEPARATORResult("...");
+ * ```
+ */
+export function decodeDOMAIN_SEPARATORResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "DOMAIN_SEPARATOR" function on the contract.
+ * @param options - The options for the DOMAIN_SEPARATOR function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { DOMAIN_SEPARATOR } from "thirdweb/extensions/modular";
+ *
+ * const result = await DOMAIN_SEPARATOR({
+ *  contract,
+ * });
+ *
+ * ```
+ */
+export async function DOMAIN_SEPARATOR(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/allowance.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/allowance.ts
@@ -1,0 +1,147 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "allowance" function.
+ */
+export type AllowanceParams = {
+  owner: AbiParameterToPrimitiveType<{
+    name: "owner";
+    type: "address";
+    internalType: "address";
+  }>;
+  spender: AbiParameterToPrimitiveType<{
+    name: "spender";
+    type: "address";
+    internalType: "address";
+  }>;
+};
+
+export const FN_SELECTOR = "0xdd62ed3e" as const;
+const FN_INPUTS = [
+  {
+    name: "owner",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "spender",
+    type: "address",
+    internalType: "address",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "result",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Checks if the `allowance` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `allowance` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isAllowanceSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isAllowanceSupported(contract);
+ * ```
+ */
+export async function isAllowanceSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "allowance" function.
+ * @param options - The options for the allowance function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeAllowanceParams } "thirdweb/extensions/modular";
+ * const result = encodeAllowanceParams({
+ *  owner: ...,
+ *  spender: ...,
+ * });
+ * ```
+ */
+export function encodeAllowanceParams(options: AllowanceParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.owner, options.spender]);
+}
+
+/**
+ * Encodes the "allowance" function into a Hex string with its parameters.
+ * @param options - The options for the allowance function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeAllowance } "thirdweb/extensions/modular";
+ * const result = encodeAllowance({
+ *  owner: ...,
+ *  spender: ...,
+ * });
+ * ```
+ */
+export function encodeAllowance(options: AllowanceParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeAllowanceParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the allowance function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeAllowanceResult } from "thirdweb/extensions/modular";
+ * const result = decodeAllowanceResult("...");
+ * ```
+ */
+export function decodeAllowanceResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "allowance" function on the contract.
+ * @param options - The options for the allowance function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { allowance } from "thirdweb/extensions/modular";
+ *
+ * const result = await allowance({
+ *  contract,
+ *  owner: ...,
+ *  spender: ...,
+ * });
+ *
+ * ```
+ */
+export async function allowance(
+  options: BaseTransactionOptions<AllowanceParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.owner, options.spender],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/balanceOf.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/balanceOf.ts
@@ -1,0 +1,134 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "balanceOf" function.
+ */
+export type BalanceOfParams = {
+  owner: AbiParameterToPrimitiveType<{
+    name: "owner";
+    type: "address";
+    internalType: "address";
+  }>;
+};
+
+export const FN_SELECTOR = "0x70a08231" as const;
+const FN_INPUTS = [
+  {
+    name: "owner",
+    type: "address",
+    internalType: "address",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "result",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Checks if the `balanceOf` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `balanceOf` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isBalanceOfSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isBalanceOfSupported(contract);
+ * ```
+ */
+export async function isBalanceOfSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "balanceOf" function.
+ * @param options - The options for the balanceOf function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeBalanceOfParams } "thirdweb/extensions/modular";
+ * const result = encodeBalanceOfParams({
+ *  owner: ...,
+ * });
+ * ```
+ */
+export function encodeBalanceOfParams(options: BalanceOfParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.owner]);
+}
+
+/**
+ * Encodes the "balanceOf" function into a Hex string with its parameters.
+ * @param options - The options for the balanceOf function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeBalanceOf } "thirdweb/extensions/modular";
+ * const result = encodeBalanceOf({
+ *  owner: ...,
+ * });
+ * ```
+ */
+export function encodeBalanceOf(options: BalanceOfParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeBalanceOfParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the balanceOf function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeBalanceOfResult } from "thirdweb/extensions/modular";
+ * const result = decodeBalanceOfResult("...");
+ * ```
+ */
+export function decodeBalanceOfResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "balanceOf" function on the contract.
+ * @param options - The options for the balanceOf function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { balanceOf } from "thirdweb/extensions/modular";
+ *
+ * const result = await balanceOf({
+ *  contract,
+ *  owner: ...,
+ * });
+ *
+ * ```
+ */
+export async function balanceOf(
+  options: BaseTransactionOptions<BalanceOfParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.owner],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/contractURI.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/contractURI.ts
@@ -1,0 +1,74 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0xe8a3d485" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "string",
+    internalType: "string",
+  },
+] as const;
+
+/**
+ * Checks if the `contractURI` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `contractURI` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isContractURISupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isContractURISupported(contract);
+ * ```
+ */
+export async function isContractURISupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Decodes the result of the contractURI function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeContractURIResult } from "thirdweb/extensions/modular";
+ * const result = decodeContractURIResult("...");
+ * ```
+ */
+export function decodeContractURIResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "contractURI" function on the contract.
+ * @param options - The options for the contractURI function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { contractURI } from "thirdweb/extensions/modular";
+ *
+ * const result = await contractURI({
+ *  contract,
+ * });
+ *
+ * ```
+ */
+export async function contractURI(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/decimals.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/decimals.ts
@@ -1,0 +1,74 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0x313ce567" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "uint8",
+    internalType: "uint8",
+  },
+] as const;
+
+/**
+ * Checks if the `decimals` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `decimals` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isDecimalsSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isDecimalsSupported(contract);
+ * ```
+ */
+export async function isDecimalsSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Decodes the result of the decimals function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeDecimalsResult } from "thirdweb/extensions/modular";
+ * const result = decodeDecimalsResult("...");
+ * ```
+ */
+export function decodeDecimalsResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "decimals" function on the contract.
+ * @param options - The options for the decimals function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decimals } from "thirdweb/extensions/modular";
+ *
+ * const result = await decimals({
+ *  contract,
+ * });
+ *
+ * ```
+ */
+export async function decimals(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/getInstalledExtensions.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/getInstalledExtensions.ts
@@ -1,0 +1,134 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0x5357aa5e" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "_installedExtensions",
+    type: "tuple[]",
+    internalType: "struct IModularCore.InstalledExtension[]",
+    components: [
+      {
+        name: "implementation",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "config",
+        type: "tuple",
+        internalType: "struct IExtensionConfig.ExtensionConfig",
+        components: [
+          {
+            name: "requiredInterfaceId",
+            type: "bytes4",
+            internalType: "bytes4",
+          },
+          {
+            name: "registerInstallationCallback",
+            type: "bool",
+            internalType: "bool",
+          },
+          {
+            name: "supportedInterfaces",
+            type: "bytes4[]",
+            internalType: "bytes4[]",
+          },
+          {
+            name: "callbackFunctions",
+            type: "tuple[]",
+            internalType: "struct IExtensionConfig.CallbackFunction[]",
+            components: [
+              {
+                name: "selector",
+                type: "bytes4",
+                internalType: "bytes4",
+              },
+            ],
+          },
+          {
+            name: "fallbackFunctions",
+            type: "tuple[]",
+            internalType: "struct IExtensionConfig.FallbackFunction[]",
+            components: [
+              {
+                name: "selector",
+                type: "bytes4",
+                internalType: "bytes4",
+              },
+              {
+                name: "permissionBits",
+                type: "uint256",
+                internalType: "uint256",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Checks if the `getInstalledExtensions` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `getInstalledExtensions` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isGetInstalledExtensionsSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isGetInstalledExtensionsSupported(contract);
+ * ```
+ */
+export async function isGetInstalledExtensionsSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Decodes the result of the getInstalledExtensions function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeGetInstalledExtensionsResult } from "thirdweb/extensions/modular";
+ * const result = decodeGetInstalledExtensionsResult("...");
+ * ```
+ */
+export function decodeGetInstalledExtensionsResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "getInstalledExtensions" function on the contract.
+ * @param options - The options for the getInstalledExtensions function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { getInstalledExtensions } from "thirdweb/extensions/modular";
+ *
+ * const result = await getInstalledExtensions({
+ *  contract,
+ * });
+ *
+ * ```
+ */
+export async function getInstalledExtensions(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/getSupportedCallbackFunctions.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/getSupportedCallbackFunctions.ts
@@ -1,0 +1,90 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0xf147db8a" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "supportedCallbackFunctions",
+    type: "tuple[]",
+    internalType: "struct IModularCore.SupportedCallbackFunction[]",
+    components: [
+      {
+        name: "selector",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+      {
+        name: "mode",
+        type: "uint8",
+        internalType: "enum IModularCore.CallbackMode",
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Checks if the `getSupportedCallbackFunctions` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `getSupportedCallbackFunctions` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isGetSupportedCallbackFunctionsSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isGetSupportedCallbackFunctionsSupported(contract);
+ * ```
+ */
+export async function isGetSupportedCallbackFunctionsSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Decodes the result of the getSupportedCallbackFunctions function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeGetSupportedCallbackFunctionsResult } from "thirdweb/extensions/modular";
+ * const result = decodeGetSupportedCallbackFunctionsResult("...");
+ * ```
+ */
+export function decodeGetSupportedCallbackFunctionsResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "getSupportedCallbackFunctions" function on the contract.
+ * @param options - The options for the getSupportedCallbackFunctions function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { getSupportedCallbackFunctions } from "thirdweb/extensions/modular";
+ *
+ * const result = await getSupportedCallbackFunctions({
+ *  contract,
+ * });
+ *
+ * ```
+ */
+export async function getSupportedCallbackFunctions(
+  options: BaseTransactionOptions,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/hasAllRoles.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/hasAllRoles.ts
@@ -1,0 +1,147 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "hasAllRoles" function.
+ */
+export type HasAllRolesParams = {
+  user: AbiParameterToPrimitiveType<{
+    name: "user";
+    type: "address";
+    internalType: "address";
+  }>;
+  roles: AbiParameterToPrimitiveType<{
+    name: "roles";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+};
+
+export const FN_SELECTOR = "0x1cd64df4" as const;
+const FN_INPUTS = [
+  {
+    name: "user",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "roles",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "bool",
+    internalType: "bool",
+  },
+] as const;
+
+/**
+ * Checks if the `hasAllRoles` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `hasAllRoles` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isHasAllRolesSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isHasAllRolesSupported(contract);
+ * ```
+ */
+export async function isHasAllRolesSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "hasAllRoles" function.
+ * @param options - The options for the hasAllRoles function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeHasAllRolesParams } "thirdweb/extensions/modular";
+ * const result = encodeHasAllRolesParams({
+ *  user: ...,
+ *  roles: ...,
+ * });
+ * ```
+ */
+export function encodeHasAllRolesParams(options: HasAllRolesParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.user, options.roles]);
+}
+
+/**
+ * Encodes the "hasAllRoles" function into a Hex string with its parameters.
+ * @param options - The options for the hasAllRoles function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeHasAllRoles } "thirdweb/extensions/modular";
+ * const result = encodeHasAllRoles({
+ *  user: ...,
+ *  roles: ...,
+ * });
+ * ```
+ */
+export function encodeHasAllRoles(options: HasAllRolesParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeHasAllRolesParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the hasAllRoles function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeHasAllRolesResult } from "thirdweb/extensions/modular";
+ * const result = decodeHasAllRolesResult("...");
+ * ```
+ */
+export function decodeHasAllRolesResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "hasAllRoles" function on the contract.
+ * @param options - The options for the hasAllRoles function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { hasAllRoles } from "thirdweb/extensions/modular";
+ *
+ * const result = await hasAllRoles({
+ *  contract,
+ *  user: ...,
+ *  roles: ...,
+ * });
+ *
+ * ```
+ */
+export async function hasAllRoles(
+  options: BaseTransactionOptions<HasAllRolesParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.user, options.roles],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/hasAnyRole.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/hasAnyRole.ts
@@ -1,0 +1,147 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "hasAnyRole" function.
+ */
+export type HasAnyRoleParams = {
+  user: AbiParameterToPrimitiveType<{
+    name: "user";
+    type: "address";
+    internalType: "address";
+  }>;
+  roles: AbiParameterToPrimitiveType<{
+    name: "roles";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+};
+
+export const FN_SELECTOR = "0x514e62fc" as const;
+const FN_INPUTS = [
+  {
+    name: "user",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "roles",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "bool",
+    internalType: "bool",
+  },
+] as const;
+
+/**
+ * Checks if the `hasAnyRole` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `hasAnyRole` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isHasAnyRoleSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isHasAnyRoleSupported(contract);
+ * ```
+ */
+export async function isHasAnyRoleSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "hasAnyRole" function.
+ * @param options - The options for the hasAnyRole function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeHasAnyRoleParams } "thirdweb/extensions/modular";
+ * const result = encodeHasAnyRoleParams({
+ *  user: ...,
+ *  roles: ...,
+ * });
+ * ```
+ */
+export function encodeHasAnyRoleParams(options: HasAnyRoleParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.user, options.roles]);
+}
+
+/**
+ * Encodes the "hasAnyRole" function into a Hex string with its parameters.
+ * @param options - The options for the hasAnyRole function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeHasAnyRole } "thirdweb/extensions/modular";
+ * const result = encodeHasAnyRole({
+ *  user: ...,
+ *  roles: ...,
+ * });
+ * ```
+ */
+export function encodeHasAnyRole(options: HasAnyRoleParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeHasAnyRoleParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the hasAnyRole function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeHasAnyRoleResult } from "thirdweb/extensions/modular";
+ * const result = decodeHasAnyRoleResult("...");
+ * ```
+ */
+export function decodeHasAnyRoleResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "hasAnyRole" function on the contract.
+ * @param options - The options for the hasAnyRole function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { hasAnyRole } from "thirdweb/extensions/modular";
+ *
+ * const result = await hasAnyRole({
+ *  contract,
+ *  user: ...,
+ *  roles: ...,
+ * });
+ *
+ * ```
+ */
+export async function hasAnyRole(
+  options: BaseTransactionOptions<HasAnyRoleParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.user, options.roles],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/name.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/name.ts
@@ -1,0 +1,74 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0x06fdde03" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "string",
+    internalType: "string",
+  },
+] as const;
+
+/**
+ * Checks if the `name` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `name` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isNameSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isNameSupported(contract);
+ * ```
+ */
+export async function isNameSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Decodes the result of the name function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeNameResult } from "thirdweb/extensions/modular";
+ * const result = decodeNameResult("...");
+ * ```
+ */
+export function decodeNameResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "name" function on the contract.
+ * @param options - The options for the name function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { name } from "thirdweb/extensions/modular";
+ *
+ * const result = await name({
+ *  contract,
+ * });
+ *
+ * ```
+ */
+export async function name(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/nonces.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/nonces.ts
@@ -1,0 +1,130 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "nonces" function.
+ */
+export type NoncesParams = {
+  owner: AbiParameterToPrimitiveType<{
+    name: "owner";
+    type: "address";
+    internalType: "address";
+  }>;
+};
+
+export const FN_SELECTOR = "0x7ecebe00" as const;
+const FN_INPUTS = [
+  {
+    name: "owner",
+    type: "address",
+    internalType: "address",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "result",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Checks if the `nonces` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `nonces` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isNoncesSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isNoncesSupported(contract);
+ * ```
+ */
+export async function isNoncesSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "nonces" function.
+ * @param options - The options for the nonces function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeNoncesParams } "thirdweb/extensions/modular";
+ * const result = encodeNoncesParams({
+ *  owner: ...,
+ * });
+ * ```
+ */
+export function encodeNoncesParams(options: NoncesParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.owner]);
+}
+
+/**
+ * Encodes the "nonces" function into a Hex string with its parameters.
+ * @param options - The options for the nonces function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeNonces } "thirdweb/extensions/modular";
+ * const result = encodeNonces({
+ *  owner: ...,
+ * });
+ * ```
+ */
+export function encodeNonces(options: NoncesParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeNoncesParams(options).slice(2)) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the nonces function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeNoncesResult } from "thirdweb/extensions/modular";
+ * const result = decodeNoncesResult("...");
+ * ```
+ */
+export function decodeNoncesResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "nonces" function on the contract.
+ * @param options - The options for the nonces function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { nonces } from "thirdweb/extensions/modular";
+ *
+ * const result = await nonces({
+ *  contract,
+ *  owner: ...,
+ * });
+ *
+ * ```
+ */
+export async function nonces(options: BaseTransactionOptions<NoncesParams>) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.owner],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/owner.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/owner.ts
@@ -1,0 +1,74 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0x8da5cb5b" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "result",
+    type: "address",
+    internalType: "address",
+  },
+] as const;
+
+/**
+ * Checks if the `owner` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `owner` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isOwnerSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isOwnerSupported(contract);
+ * ```
+ */
+export async function isOwnerSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Decodes the result of the owner function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeOwnerResult } from "thirdweb/extensions/modular";
+ * const result = decodeOwnerResult("...");
+ * ```
+ */
+export function decodeOwnerResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "owner" function on the contract.
+ * @param options - The options for the owner function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { owner } from "thirdweb/extensions/modular";
+ *
+ * const result = await owner({
+ *  contract,
+ * });
+ *
+ * ```
+ */
+export async function owner(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/ownershipHandoverExpiresAt.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/ownershipHandoverExpiresAt.ts
@@ -1,0 +1,140 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "ownershipHandoverExpiresAt" function.
+ */
+export type OwnershipHandoverExpiresAtParams = {
+  pendingOwner: AbiParameterToPrimitiveType<{
+    name: "pendingOwner";
+    type: "address";
+    internalType: "address";
+  }>;
+};
+
+export const FN_SELECTOR = "0xfee81cf4" as const;
+const FN_INPUTS = [
+  {
+    name: "pendingOwner",
+    type: "address",
+    internalType: "address",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "result",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Checks if the `ownershipHandoverExpiresAt` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `ownershipHandoverExpiresAt` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isOwnershipHandoverExpiresAtSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isOwnershipHandoverExpiresAtSupported(contract);
+ * ```
+ */
+export async function isOwnershipHandoverExpiresAtSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "ownershipHandoverExpiresAt" function.
+ * @param options - The options for the ownershipHandoverExpiresAt function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeOwnershipHandoverExpiresAtParams } "thirdweb/extensions/modular";
+ * const result = encodeOwnershipHandoverExpiresAtParams({
+ *  pendingOwner: ...,
+ * });
+ * ```
+ */
+export function encodeOwnershipHandoverExpiresAtParams(
+  options: OwnershipHandoverExpiresAtParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.pendingOwner]);
+}
+
+/**
+ * Encodes the "ownershipHandoverExpiresAt" function into a Hex string with its parameters.
+ * @param options - The options for the ownershipHandoverExpiresAt function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeOwnershipHandoverExpiresAt } "thirdweb/extensions/modular";
+ * const result = encodeOwnershipHandoverExpiresAt({
+ *  pendingOwner: ...,
+ * });
+ * ```
+ */
+export function encodeOwnershipHandoverExpiresAt(
+  options: OwnershipHandoverExpiresAtParams,
+) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeOwnershipHandoverExpiresAtParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the ownershipHandoverExpiresAt function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeOwnershipHandoverExpiresAtResult } from "thirdweb/extensions/modular";
+ * const result = decodeOwnershipHandoverExpiresAtResult("...");
+ * ```
+ */
+export function decodeOwnershipHandoverExpiresAtResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "ownershipHandoverExpiresAt" function on the contract.
+ * @param options - The options for the ownershipHandoverExpiresAt function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { ownershipHandoverExpiresAt } from "thirdweb/extensions/modular";
+ *
+ * const result = await ownershipHandoverExpiresAt({
+ *  contract,
+ *  pendingOwner: ...,
+ * });
+ *
+ * ```
+ */
+export async function ownershipHandoverExpiresAt(
+  options: BaseTransactionOptions<OwnershipHandoverExpiresAtParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.pendingOwner],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/rolesOf.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/rolesOf.ts
@@ -1,0 +1,130 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "rolesOf" function.
+ */
+export type RolesOfParams = {
+  user: AbiParameterToPrimitiveType<{
+    name: "user";
+    type: "address";
+    internalType: "address";
+  }>;
+};
+
+export const FN_SELECTOR = "0x2de94807" as const;
+const FN_INPUTS = [
+  {
+    name: "user",
+    type: "address",
+    internalType: "address",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "roles",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Checks if the `rolesOf` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `rolesOf` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isRolesOfSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isRolesOfSupported(contract);
+ * ```
+ */
+export async function isRolesOfSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "rolesOf" function.
+ * @param options - The options for the rolesOf function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeRolesOfParams } "thirdweb/extensions/modular";
+ * const result = encodeRolesOfParams({
+ *  user: ...,
+ * });
+ * ```
+ */
+export function encodeRolesOfParams(options: RolesOfParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.user]);
+}
+
+/**
+ * Encodes the "rolesOf" function into a Hex string with its parameters.
+ * @param options - The options for the rolesOf function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeRolesOf } "thirdweb/extensions/modular";
+ * const result = encodeRolesOf({
+ *  user: ...,
+ * });
+ * ```
+ */
+export function encodeRolesOf(options: RolesOfParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeRolesOfParams(options).slice(2)) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the rolesOf function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeRolesOfResult } from "thirdweb/extensions/modular";
+ * const result = decodeRolesOfResult("...");
+ * ```
+ */
+export function decodeRolesOfResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "rolesOf" function on the contract.
+ * @param options - The options for the rolesOf function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { rolesOf } from "thirdweb/extensions/modular";
+ *
+ * const result = await rolesOf({
+ *  contract,
+ *  user: ...,
+ * });
+ *
+ * ```
+ */
+export async function rolesOf(options: BaseTransactionOptions<RolesOfParams>) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.user],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/supportsInterface.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/supportsInterface.ts
@@ -1,0 +1,138 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "supportsInterface" function.
+ */
+export type SupportsInterfaceParams = {
+  interfaceId: AbiParameterToPrimitiveType<{
+    name: "interfaceId";
+    type: "bytes4";
+    internalType: "bytes4";
+  }>;
+};
+
+export const FN_SELECTOR = "0x01ffc9a7" as const;
+const FN_INPUTS = [
+  {
+    name: "interfaceId",
+    type: "bytes4",
+    internalType: "bytes4",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "bool",
+    internalType: "bool",
+  },
+] as const;
+
+/**
+ * Checks if the `supportsInterface` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `supportsInterface` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isSupportsInterfaceSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isSupportsInterfaceSupported(contract);
+ * ```
+ */
+export async function isSupportsInterfaceSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "supportsInterface" function.
+ * @param options - The options for the supportsInterface function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeSupportsInterfaceParams } "thirdweb/extensions/modular";
+ * const result = encodeSupportsInterfaceParams({
+ *  interfaceId: ...,
+ * });
+ * ```
+ */
+export function encodeSupportsInterfaceParams(
+  options: SupportsInterfaceParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.interfaceId]);
+}
+
+/**
+ * Encodes the "supportsInterface" function into a Hex string with its parameters.
+ * @param options - The options for the supportsInterface function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeSupportsInterface } "thirdweb/extensions/modular";
+ * const result = encodeSupportsInterface({
+ *  interfaceId: ...,
+ * });
+ * ```
+ */
+export function encodeSupportsInterface(options: SupportsInterfaceParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeSupportsInterfaceParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the supportsInterface function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeSupportsInterfaceResult } from "thirdweb/extensions/modular";
+ * const result = decodeSupportsInterfaceResult("...");
+ * ```
+ */
+export function decodeSupportsInterfaceResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "supportsInterface" function on the contract.
+ * @param options - The options for the supportsInterface function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { supportsInterface } from "thirdweb/extensions/modular";
+ *
+ * const result = await supportsInterface({
+ *  contract,
+ *  interfaceId: ...,
+ * });
+ *
+ * ```
+ */
+export async function supportsInterface(
+  options: BaseTransactionOptions<SupportsInterfaceParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.interfaceId],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/symbol.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/symbol.ts
@@ -1,0 +1,74 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0x95d89b41" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "string",
+    internalType: "string",
+  },
+] as const;
+
+/**
+ * Checks if the `symbol` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `symbol` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isSymbolSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isSymbolSupported(contract);
+ * ```
+ */
+export async function isSymbolSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Decodes the result of the symbol function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeSymbolResult } from "thirdweb/extensions/modular";
+ * const result = decodeSymbolResult("...");
+ * ```
+ */
+export function decodeSymbolResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "symbol" function on the contract.
+ * @param options - The options for the symbol function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { symbol } from "thirdweb/extensions/modular";
+ *
+ * const result = await symbol({
+ *  contract,
+ * });
+ *
+ * ```
+ */
+export async function symbol(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/totalSupply.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/totalSupply.ts
@@ -1,0 +1,74 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0x18160ddd" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "result",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Checks if the `totalSupply` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `totalSupply` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isTotalSupplySupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isTotalSupplySupported(contract);
+ * ```
+ */
+export async function isTotalSupplySupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Decodes the result of the totalSupply function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeTotalSupplyResult } from "thirdweb/extensions/modular";
+ * const result = decodeTotalSupplyResult("...");
+ * ```
+ */
+export function decodeTotalSupplyResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "totalSupply" function on the contract.
+ * @param options - The options for the totalSupply function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { totalSupply } from "thirdweb/extensions/modular";
+ *
+ * const result = await totalSupply({
+ *  contract,
+ * });
+ *
+ * ```
+ */
+export async function totalSupply(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/approve.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/approve.ts
@@ -1,0 +1,159 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "approve" function.
+ */
+export type ApproveParams = WithOverrides<{
+  spender: AbiParameterToPrimitiveType<{
+    name: "spender";
+    type: "address";
+    internalType: "address";
+  }>;
+  amount: AbiParameterToPrimitiveType<{
+    name: "amount";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0x095ea7b3" as const;
+const FN_INPUTS = [
+  {
+    name: "spender",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "amount",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "bool",
+    internalType: "bool",
+  },
+] as const;
+
+/**
+ * Checks if the `approve` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `approve` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isApproveSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isApproveSupported(contract);
+ * ```
+ */
+export async function isApproveSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "approve" function.
+ * @param options - The options for the approve function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeApproveParams } "thirdweb/extensions/modular";
+ * const result = encodeApproveParams({
+ *  spender: ...,
+ *  amount: ...,
+ * });
+ * ```
+ */
+export function encodeApproveParams(options: ApproveParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.spender, options.amount]);
+}
+
+/**
+ * Encodes the "approve" function into a Hex string with its parameters.
+ * @param options - The options for the approve function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeApprove } "thirdweb/extensions/modular";
+ * const result = encodeApprove({
+ *  spender: ...,
+ *  amount: ...,
+ * });
+ * ```
+ */
+export function encodeApprove(options: ApproveParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeApproveParams(options).slice(2)) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "approve" function on the contract.
+ * @param options - The options for the "approve" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { approve } from "thirdweb/extensions/modular";
+ *
+ * const transaction = approve({
+ *  contract,
+ *  spender: ...,
+ *  amount: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function approve(
+  options: BaseTransactionOptions<
+    | ApproveParams
+    | {
+        asyncParams: () => Promise<ApproveParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.spender, resolvedOptions.amount] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/burn.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/burn.ts
@@ -1,0 +1,174 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "burn" function.
+ */
+export type BurnParams = WithOverrides<{
+  from: AbiParameterToPrimitiveType<{
+    name: "from";
+    type: "address";
+    internalType: "address";
+  }>;
+  amount: AbiParameterToPrimitiveType<{
+    name: "amount";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+  data: AbiParameterToPrimitiveType<{
+    name: "data";
+    type: "bytes";
+    internalType: "bytes";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0x44d17187" as const;
+const FN_INPUTS = [
+  {
+    name: "from",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "amount",
+    type: "uint256",
+    internalType: "uint256",
+  },
+  {
+    name: "data",
+    type: "bytes",
+    internalType: "bytes",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `burn` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `burn` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isBurnSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isBurnSupported(contract);
+ * ```
+ */
+export async function isBurnSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "burn" function.
+ * @param options - The options for the burn function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeBurnParams } "thirdweb/extensions/modular";
+ * const result = encodeBurnParams({
+ *  from: ...,
+ *  amount: ...,
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeBurnParams(options: BurnParams) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.from,
+    options.amount,
+    options.data,
+  ]);
+}
+
+/**
+ * Encodes the "burn" function into a Hex string with its parameters.
+ * @param options - The options for the burn function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeBurn } "thirdweb/extensions/modular";
+ * const result = encodeBurn({
+ *  from: ...,
+ *  amount: ...,
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeBurn(options: BurnParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeBurnParams(options).slice(2)) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "burn" function on the contract.
+ * @param options - The options for the "burn" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { burn } from "thirdweb/extensions/modular";
+ *
+ * const transaction = burn({
+ *  contract,
+ *  from: ...,
+ *  amount: ...,
+ *  data: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function burn(
+  options: BaseTransactionOptions<
+    | BurnParams
+    | {
+        asyncParams: () => Promise<BurnParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [
+        resolvedOptions.from,
+        resolvedOptions.amount,
+        resolvedOptions.data,
+      ] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/cancelOwnershipHandover.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/cancelOwnershipHandover.ts
@@ -1,0 +1,53 @@
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0x54d1f13d" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `cancelOwnershipHandover` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `cancelOwnershipHandover` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isCancelOwnershipHandoverSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isCancelOwnershipHandoverSupported(contract);
+ * ```
+ */
+export async function isCancelOwnershipHandoverSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Prepares a transaction to call the "cancelOwnershipHandover" function on the contract.
+ * @param options - The options for the "cancelOwnershipHandover" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { cancelOwnershipHandover } from "thirdweb/extensions/modular";
+ *
+ * const transaction = cancelOwnershipHandover();
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function cancelOwnershipHandover(options: BaseTransactionOptions) {
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/completeOwnershipHandover.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/completeOwnershipHandover.ts
@@ -1,0 +1,148 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "completeOwnershipHandover" function.
+ */
+export type CompleteOwnershipHandoverParams = WithOverrides<{
+  pendingOwner: AbiParameterToPrimitiveType<{
+    name: "pendingOwner";
+    type: "address";
+    internalType: "address";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0xf04e283e" as const;
+const FN_INPUTS = [
+  {
+    name: "pendingOwner",
+    type: "address",
+    internalType: "address",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `completeOwnershipHandover` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `completeOwnershipHandover` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isCompleteOwnershipHandoverSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isCompleteOwnershipHandoverSupported(contract);
+ * ```
+ */
+export async function isCompleteOwnershipHandoverSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "completeOwnershipHandover" function.
+ * @param options - The options for the completeOwnershipHandover function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeCompleteOwnershipHandoverParams } "thirdweb/extensions/modular";
+ * const result = encodeCompleteOwnershipHandoverParams({
+ *  pendingOwner: ...,
+ * });
+ * ```
+ */
+export function encodeCompleteOwnershipHandoverParams(
+  options: CompleteOwnershipHandoverParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.pendingOwner]);
+}
+
+/**
+ * Encodes the "completeOwnershipHandover" function into a Hex string with its parameters.
+ * @param options - The options for the completeOwnershipHandover function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeCompleteOwnershipHandover } "thirdweb/extensions/modular";
+ * const result = encodeCompleteOwnershipHandover({
+ *  pendingOwner: ...,
+ * });
+ * ```
+ */
+export function encodeCompleteOwnershipHandover(
+  options: CompleteOwnershipHandoverParams,
+) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeCompleteOwnershipHandoverParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "completeOwnershipHandover" function on the contract.
+ * @param options - The options for the "completeOwnershipHandover" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { completeOwnershipHandover } from "thirdweb/extensions/modular";
+ *
+ * const transaction = completeOwnershipHandover({
+ *  contract,
+ *  pendingOwner: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function completeOwnershipHandover(
+  options: BaseTransactionOptions<
+    | CompleteOwnershipHandoverParams
+    | {
+        asyncParams: () => Promise<CompleteOwnershipHandoverParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.pendingOwner] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/grantRoles.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/grantRoles.ts
@@ -1,0 +1,155 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "grantRoles" function.
+ */
+export type GrantRolesParams = WithOverrides<{
+  user: AbiParameterToPrimitiveType<{
+    name: "user";
+    type: "address";
+    internalType: "address";
+  }>;
+  roles: AbiParameterToPrimitiveType<{
+    name: "roles";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0x1c10893f" as const;
+const FN_INPUTS = [
+  {
+    name: "user",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "roles",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `grantRoles` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `grantRoles` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isGrantRolesSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isGrantRolesSupported(contract);
+ * ```
+ */
+export async function isGrantRolesSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "grantRoles" function.
+ * @param options - The options for the grantRoles function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeGrantRolesParams } "thirdweb/extensions/modular";
+ * const result = encodeGrantRolesParams({
+ *  user: ...,
+ *  roles: ...,
+ * });
+ * ```
+ */
+export function encodeGrantRolesParams(options: GrantRolesParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.user, options.roles]);
+}
+
+/**
+ * Encodes the "grantRoles" function into a Hex string with its parameters.
+ * @param options - The options for the grantRoles function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeGrantRoles } "thirdweb/extensions/modular";
+ * const result = encodeGrantRoles({
+ *  user: ...,
+ *  roles: ...,
+ * });
+ * ```
+ */
+export function encodeGrantRoles(options: GrantRolesParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeGrantRolesParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "grantRoles" function on the contract.
+ * @param options - The options for the "grantRoles" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { grantRoles } from "thirdweb/extensions/modular";
+ *
+ * const transaction = grantRoles({
+ *  contract,
+ *  user: ...,
+ *  roles: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function grantRoles(
+  options: BaseTransactionOptions<
+    | GrantRolesParams
+    | {
+        asyncParams: () => Promise<GrantRolesParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.user, resolvedOptions.roles] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/installExtension.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/installExtension.ts
@@ -1,0 +1,157 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "installExtension" function.
+ */
+export type InstallExtensionParams = WithOverrides<{
+  extension: AbiParameterToPrimitiveType<{
+    name: "_extension";
+    type: "address";
+    internalType: "address";
+  }>;
+  data: AbiParameterToPrimitiveType<{
+    name: "_data";
+    type: "bytes";
+    internalType: "bytes";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0xaca696f5" as const;
+const FN_INPUTS = [
+  {
+    name: "_extension",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "_data",
+    type: "bytes",
+    internalType: "bytes",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `installExtension` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `installExtension` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isInstallExtensionSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isInstallExtensionSupported(contract);
+ * ```
+ */
+export async function isInstallExtensionSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "installExtension" function.
+ * @param options - The options for the installExtension function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeInstallExtensionParams } "thirdweb/extensions/modular";
+ * const result = encodeInstallExtensionParams({
+ *  extension: ...,
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeInstallExtensionParams(options: InstallExtensionParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.extension, options.data]);
+}
+
+/**
+ * Encodes the "installExtension" function into a Hex string with its parameters.
+ * @param options - The options for the installExtension function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeInstallExtension } "thirdweb/extensions/modular";
+ * const result = encodeInstallExtension({
+ *  extension: ...,
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeInstallExtension(options: InstallExtensionParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeInstallExtensionParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "installExtension" function on the contract.
+ * @param options - The options for the "installExtension" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { installExtension } from "thirdweb/extensions/modular";
+ *
+ * const transaction = installExtension({
+ *  contract,
+ *  extension: ...,
+ *  data: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function installExtension(
+  options: BaseTransactionOptions<
+    | InstallExtensionParams
+    | {
+        asyncParams: () => Promise<InstallExtensionParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.extension, resolvedOptions.data] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/mint.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/mint.ts
@@ -1,0 +1,174 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "mint" function.
+ */
+export type MintParams = WithOverrides<{
+  to: AbiParameterToPrimitiveType<{
+    name: "to";
+    type: "address";
+    internalType: "address";
+  }>;
+  amount: AbiParameterToPrimitiveType<{
+    name: "amount";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+  data: AbiParameterToPrimitiveType<{
+    name: "data";
+    type: "bytes";
+    internalType: "bytes";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0x94d008ef" as const;
+const FN_INPUTS = [
+  {
+    name: "to",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "amount",
+    type: "uint256",
+    internalType: "uint256",
+  },
+  {
+    name: "data",
+    type: "bytes",
+    internalType: "bytes",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `mint` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `mint` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isMintSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isMintSupported(contract);
+ * ```
+ */
+export async function isMintSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "mint" function.
+ * @param options - The options for the mint function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeMintParams } "thirdweb/extensions/modular";
+ * const result = encodeMintParams({
+ *  to: ...,
+ *  amount: ...,
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeMintParams(options: MintParams) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.to,
+    options.amount,
+    options.data,
+  ]);
+}
+
+/**
+ * Encodes the "mint" function into a Hex string with its parameters.
+ * @param options - The options for the mint function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeMint } "thirdweb/extensions/modular";
+ * const result = encodeMint({
+ *  to: ...,
+ *  amount: ...,
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeMint(options: MintParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeMintParams(options).slice(2)) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "mint" function on the contract.
+ * @param options - The options for the "mint" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { mint } from "thirdweb/extensions/modular";
+ *
+ * const transaction = mint({
+ *  contract,
+ *  to: ...,
+ *  amount: ...,
+ *  data: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function mint(
+  options: BaseTransactionOptions<
+    | MintParams
+    | {
+        asyncParams: () => Promise<MintParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [
+        resolvedOptions.to,
+        resolvedOptions.amount,
+        resolvedOptions.data,
+      ] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/multicall.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/multicall.ts
@@ -1,0 +1,148 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "multicall" function.
+ */
+export type MulticallParams = WithOverrides<{
+  data: AbiParameterToPrimitiveType<{
+    name: "data";
+    type: "bytes[]";
+    internalType: "bytes[]";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0xac9650d8" as const;
+const FN_INPUTS = [
+  {
+    name: "data",
+    type: "bytes[]",
+    internalType: "bytes[]",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "bytes[]",
+    internalType: "bytes[]",
+  },
+] as const;
+
+/**
+ * Checks if the `multicall` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `multicall` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isMulticallSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isMulticallSupported(contract);
+ * ```
+ */
+export async function isMulticallSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "multicall" function.
+ * @param options - The options for the multicall function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeMulticallParams } "thirdweb/extensions/modular";
+ * const result = encodeMulticallParams({
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeMulticallParams(options: MulticallParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.data]);
+}
+
+/**
+ * Encodes the "multicall" function into a Hex string with its parameters.
+ * @param options - The options for the multicall function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeMulticall } "thirdweb/extensions/modular";
+ * const result = encodeMulticall({
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeMulticall(options: MulticallParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeMulticallParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "multicall" function on the contract.
+ * @param options - The options for the "multicall" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { multicall } from "thirdweb/extensions/modular";
+ *
+ * const transaction = multicall({
+ *  contract,
+ *  data: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function multicall(
+  options: BaseTransactionOptions<
+    | MulticallParams
+    | {
+        asyncParams: () => Promise<MulticallParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.data] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/permit.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/permit.ts
@@ -1,0 +1,234 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "permit" function.
+ */
+export type PermitParams = WithOverrides<{
+  owner: AbiParameterToPrimitiveType<{
+    name: "owner";
+    type: "address";
+    internalType: "address";
+  }>;
+  spender: AbiParameterToPrimitiveType<{
+    name: "spender";
+    type: "address";
+    internalType: "address";
+  }>;
+  value: AbiParameterToPrimitiveType<{
+    name: "value";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+  deadline: AbiParameterToPrimitiveType<{
+    name: "deadline";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+  v: AbiParameterToPrimitiveType<{
+    name: "v";
+    type: "uint8";
+    internalType: "uint8";
+  }>;
+  r: AbiParameterToPrimitiveType<{
+    name: "r";
+    type: "bytes32";
+    internalType: "bytes32";
+  }>;
+  s: AbiParameterToPrimitiveType<{
+    name: "s";
+    type: "bytes32";
+    internalType: "bytes32";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0xd505accf" as const;
+const FN_INPUTS = [
+  {
+    name: "owner",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "spender",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "value",
+    type: "uint256",
+    internalType: "uint256",
+  },
+  {
+    name: "deadline",
+    type: "uint256",
+    internalType: "uint256",
+  },
+  {
+    name: "v",
+    type: "uint8",
+    internalType: "uint8",
+  },
+  {
+    name: "r",
+    type: "bytes32",
+    internalType: "bytes32",
+  },
+  {
+    name: "s",
+    type: "bytes32",
+    internalType: "bytes32",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `permit` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `permit` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isPermitSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isPermitSupported(contract);
+ * ```
+ */
+export async function isPermitSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "permit" function.
+ * @param options - The options for the permit function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodePermitParams } "thirdweb/extensions/modular";
+ * const result = encodePermitParams({
+ *  owner: ...,
+ *  spender: ...,
+ *  value: ...,
+ *  deadline: ...,
+ *  v: ...,
+ *  r: ...,
+ *  s: ...,
+ * });
+ * ```
+ */
+export function encodePermitParams(options: PermitParams) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.owner,
+    options.spender,
+    options.value,
+    options.deadline,
+    options.v,
+    options.r,
+    options.s,
+  ]);
+}
+
+/**
+ * Encodes the "permit" function into a Hex string with its parameters.
+ * @param options - The options for the permit function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodePermit } "thirdweb/extensions/modular";
+ * const result = encodePermit({
+ *  owner: ...,
+ *  spender: ...,
+ *  value: ...,
+ *  deadline: ...,
+ *  v: ...,
+ *  r: ...,
+ *  s: ...,
+ * });
+ * ```
+ */
+export function encodePermit(options: PermitParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodePermitParams(options).slice(2)) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "permit" function on the contract.
+ * @param options - The options for the "permit" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { permit } from "thirdweb/extensions/modular";
+ *
+ * const transaction = permit({
+ *  contract,
+ *  owner: ...,
+ *  spender: ...,
+ *  value: ...,
+ *  deadline: ...,
+ *  v: ...,
+ *  r: ...,
+ *  s: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function permit(
+  options: BaseTransactionOptions<
+    | PermitParams
+    | {
+        asyncParams: () => Promise<PermitParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [
+        resolvedOptions.owner,
+        resolvedOptions.spender,
+        resolvedOptions.value,
+        resolvedOptions.deadline,
+        resolvedOptions.v,
+        resolvedOptions.r,
+        resolvedOptions.s,
+      ] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/renounceOwnership.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/renounceOwnership.ts
@@ -1,0 +1,53 @@
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0x715018a6" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `renounceOwnership` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `renounceOwnership` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isRenounceOwnershipSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isRenounceOwnershipSupported(contract);
+ * ```
+ */
+export async function isRenounceOwnershipSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Prepares a transaction to call the "renounceOwnership" function on the contract.
+ * @param options - The options for the "renounceOwnership" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { renounceOwnership } from "thirdweb/extensions/modular";
+ *
+ * const transaction = renounceOwnership();
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function renounceOwnership(options: BaseTransactionOptions) {
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/renounceRoles.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/renounceRoles.ts
@@ -1,0 +1,144 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "renounceRoles" function.
+ */
+export type RenounceRolesParams = WithOverrides<{
+  roles: AbiParameterToPrimitiveType<{
+    name: "roles";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0x183a4f6e" as const;
+const FN_INPUTS = [
+  {
+    name: "roles",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `renounceRoles` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `renounceRoles` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isRenounceRolesSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isRenounceRolesSupported(contract);
+ * ```
+ */
+export async function isRenounceRolesSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "renounceRoles" function.
+ * @param options - The options for the renounceRoles function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeRenounceRolesParams } "thirdweb/extensions/modular";
+ * const result = encodeRenounceRolesParams({
+ *  roles: ...,
+ * });
+ * ```
+ */
+export function encodeRenounceRolesParams(options: RenounceRolesParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.roles]);
+}
+
+/**
+ * Encodes the "renounceRoles" function into a Hex string with its parameters.
+ * @param options - The options for the renounceRoles function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeRenounceRoles } "thirdweb/extensions/modular";
+ * const result = encodeRenounceRoles({
+ *  roles: ...,
+ * });
+ * ```
+ */
+export function encodeRenounceRoles(options: RenounceRolesParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeRenounceRolesParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "renounceRoles" function on the contract.
+ * @param options - The options for the "renounceRoles" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { renounceRoles } from "thirdweb/extensions/modular";
+ *
+ * const transaction = renounceRoles({
+ *  contract,
+ *  roles: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function renounceRoles(
+  options: BaseTransactionOptions<
+    | RenounceRolesParams
+    | {
+        asyncParams: () => Promise<RenounceRolesParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.roles] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/requestOwnershipHandover.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/requestOwnershipHandover.ts
@@ -1,0 +1,53 @@
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0x25692962" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `requestOwnershipHandover` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `requestOwnershipHandover` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isRequestOwnershipHandoverSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isRequestOwnershipHandoverSupported(contract);
+ * ```
+ */
+export async function isRequestOwnershipHandoverSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Prepares a transaction to call the "requestOwnershipHandover" function on the contract.
+ * @param options - The options for the "requestOwnershipHandover" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { requestOwnershipHandover } from "thirdweb/extensions/modular";
+ *
+ * const transaction = requestOwnershipHandover();
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function requestOwnershipHandover(options: BaseTransactionOptions) {
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/revokeRoles.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/revokeRoles.ts
@@ -1,0 +1,155 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "revokeRoles" function.
+ */
+export type RevokeRolesParams = WithOverrides<{
+  user: AbiParameterToPrimitiveType<{
+    name: "user";
+    type: "address";
+    internalType: "address";
+  }>;
+  roles: AbiParameterToPrimitiveType<{
+    name: "roles";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0x4a4ee7b1" as const;
+const FN_INPUTS = [
+  {
+    name: "user",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "roles",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `revokeRoles` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `revokeRoles` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isRevokeRolesSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isRevokeRolesSupported(contract);
+ * ```
+ */
+export async function isRevokeRolesSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "revokeRoles" function.
+ * @param options - The options for the revokeRoles function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeRevokeRolesParams } "thirdweb/extensions/modular";
+ * const result = encodeRevokeRolesParams({
+ *  user: ...,
+ *  roles: ...,
+ * });
+ * ```
+ */
+export function encodeRevokeRolesParams(options: RevokeRolesParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.user, options.roles]);
+}
+
+/**
+ * Encodes the "revokeRoles" function into a Hex string with its parameters.
+ * @param options - The options for the revokeRoles function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeRevokeRoles } "thirdweb/extensions/modular";
+ * const result = encodeRevokeRoles({
+ *  user: ...,
+ *  roles: ...,
+ * });
+ * ```
+ */
+export function encodeRevokeRoles(options: RevokeRolesParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeRevokeRolesParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "revokeRoles" function on the contract.
+ * @param options - The options for the "revokeRoles" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { revokeRoles } from "thirdweb/extensions/modular";
+ *
+ * const transaction = revokeRoles({
+ *  contract,
+ *  user: ...,
+ *  roles: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function revokeRoles(
+  options: BaseTransactionOptions<
+    | RevokeRolesParams
+    | {
+        asyncParams: () => Promise<RevokeRolesParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.user, resolvedOptions.roles] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/setContractURI.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/setContractURI.ts
@@ -1,0 +1,144 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "setContractURI" function.
+ */
+export type SetContractURIParams = WithOverrides<{
+  contractURI: AbiParameterToPrimitiveType<{
+    name: "contractURI";
+    type: "string";
+    internalType: "string";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0x938e3d7b" as const;
+const FN_INPUTS = [
+  {
+    name: "contractURI",
+    type: "string",
+    internalType: "string",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `setContractURI` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `setContractURI` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isSetContractURISupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isSetContractURISupported(contract);
+ * ```
+ */
+export async function isSetContractURISupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "setContractURI" function.
+ * @param options - The options for the setContractURI function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeSetContractURIParams } "thirdweb/extensions/modular";
+ * const result = encodeSetContractURIParams({
+ *  contractURI: ...,
+ * });
+ * ```
+ */
+export function encodeSetContractURIParams(options: SetContractURIParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.contractURI]);
+}
+
+/**
+ * Encodes the "setContractURI" function into a Hex string with its parameters.
+ * @param options - The options for the setContractURI function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeSetContractURI } "thirdweb/extensions/modular";
+ * const result = encodeSetContractURI({
+ *  contractURI: ...,
+ * });
+ * ```
+ */
+export function encodeSetContractURI(options: SetContractURIParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeSetContractURIParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "setContractURI" function on the contract.
+ * @param options - The options for the "setContractURI" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { setContractURI } from "thirdweb/extensions/modular";
+ *
+ * const transaction = setContractURI({
+ *  contract,
+ *  contractURI: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function setContractURI(
+  options: BaseTransactionOptions<
+    | SetContractURIParams
+    | {
+        asyncParams: () => Promise<SetContractURIParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.contractURI] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/transfer.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/transfer.ts
@@ -1,0 +1,159 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "transfer" function.
+ */
+export type TransferParams = WithOverrides<{
+  to: AbiParameterToPrimitiveType<{
+    name: "to";
+    type: "address";
+    internalType: "address";
+  }>;
+  amount: AbiParameterToPrimitiveType<{
+    name: "amount";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0xa9059cbb" as const;
+const FN_INPUTS = [
+  {
+    name: "to",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "amount",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "bool",
+    internalType: "bool",
+  },
+] as const;
+
+/**
+ * Checks if the `transfer` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `transfer` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isTransferSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isTransferSupported(contract);
+ * ```
+ */
+export async function isTransferSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "transfer" function.
+ * @param options - The options for the transfer function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeTransferParams } "thirdweb/extensions/modular";
+ * const result = encodeTransferParams({
+ *  to: ...,
+ *  amount: ...,
+ * });
+ * ```
+ */
+export function encodeTransferParams(options: TransferParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.to, options.amount]);
+}
+
+/**
+ * Encodes the "transfer" function into a Hex string with its parameters.
+ * @param options - The options for the transfer function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeTransfer } "thirdweb/extensions/modular";
+ * const result = encodeTransfer({
+ *  to: ...,
+ *  amount: ...,
+ * });
+ * ```
+ */
+export function encodeTransfer(options: TransferParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeTransferParams(options).slice(2)) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "transfer" function on the contract.
+ * @param options - The options for the "transfer" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { transfer } from "thirdweb/extensions/modular";
+ *
+ * const transaction = transfer({
+ *  contract,
+ *  to: ...,
+ *  amount: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function transfer(
+  options: BaseTransactionOptions<
+    | TransferParams
+    | {
+        asyncParams: () => Promise<TransferParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.to, resolvedOptions.amount] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/transferFrom.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/transferFrom.ts
@@ -1,0 +1,182 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "transferFrom" function.
+ */
+export type TransferFromParams = WithOverrides<{
+  from: AbiParameterToPrimitiveType<{
+    name: "from";
+    type: "address";
+    internalType: "address";
+  }>;
+  to: AbiParameterToPrimitiveType<{
+    name: "to";
+    type: "address";
+    internalType: "address";
+  }>;
+  amount: AbiParameterToPrimitiveType<{
+    name: "amount";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0x23b872dd" as const;
+const FN_INPUTS = [
+  {
+    name: "from",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "to",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "amount",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "bool",
+    internalType: "bool",
+  },
+] as const;
+
+/**
+ * Checks if the `transferFrom` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `transferFrom` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isTransferFromSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isTransferFromSupported(contract);
+ * ```
+ */
+export async function isTransferFromSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "transferFrom" function.
+ * @param options - The options for the transferFrom function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeTransferFromParams } "thirdweb/extensions/modular";
+ * const result = encodeTransferFromParams({
+ *  from: ...,
+ *  to: ...,
+ *  amount: ...,
+ * });
+ * ```
+ */
+export function encodeTransferFromParams(options: TransferFromParams) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.from,
+    options.to,
+    options.amount,
+  ]);
+}
+
+/**
+ * Encodes the "transferFrom" function into a Hex string with its parameters.
+ * @param options - The options for the transferFrom function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeTransferFrom } "thirdweb/extensions/modular";
+ * const result = encodeTransferFrom({
+ *  from: ...,
+ *  to: ...,
+ *  amount: ...,
+ * });
+ * ```
+ */
+export function encodeTransferFrom(options: TransferFromParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeTransferFromParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "transferFrom" function on the contract.
+ * @param options - The options for the "transferFrom" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { transferFrom } from "thirdweb/extensions/modular";
+ *
+ * const transaction = transferFrom({
+ *  contract,
+ *  from: ...,
+ *  to: ...,
+ *  amount: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function transferFrom(
+  options: BaseTransactionOptions<
+    | TransferFromParams
+    | {
+        asyncParams: () => Promise<TransferFromParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [
+        resolvedOptions.from,
+        resolvedOptions.to,
+        resolvedOptions.amount,
+      ] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/transferOwnership.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/transferOwnership.ts
@@ -1,0 +1,146 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "transferOwnership" function.
+ */
+export type TransferOwnershipParams = WithOverrides<{
+  newOwner: AbiParameterToPrimitiveType<{
+    name: "newOwner";
+    type: "address";
+    internalType: "address";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0xf2fde38b" as const;
+const FN_INPUTS = [
+  {
+    name: "newOwner",
+    type: "address",
+    internalType: "address",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `transferOwnership` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `transferOwnership` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isTransferOwnershipSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isTransferOwnershipSupported(contract);
+ * ```
+ */
+export async function isTransferOwnershipSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "transferOwnership" function.
+ * @param options - The options for the transferOwnership function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeTransferOwnershipParams } "thirdweb/extensions/modular";
+ * const result = encodeTransferOwnershipParams({
+ *  newOwner: ...,
+ * });
+ * ```
+ */
+export function encodeTransferOwnershipParams(
+  options: TransferOwnershipParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.newOwner]);
+}
+
+/**
+ * Encodes the "transferOwnership" function into a Hex string with its parameters.
+ * @param options - The options for the transferOwnership function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeTransferOwnership } "thirdweb/extensions/modular";
+ * const result = encodeTransferOwnership({
+ *  newOwner: ...,
+ * });
+ * ```
+ */
+export function encodeTransferOwnership(options: TransferOwnershipParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeTransferOwnershipParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "transferOwnership" function on the contract.
+ * @param options - The options for the "transferOwnership" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { transferOwnership } from "thirdweb/extensions/modular";
+ *
+ * const transaction = transferOwnership({
+ *  contract,
+ *  newOwner: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function transferOwnership(
+  options: BaseTransactionOptions<
+    | TransferOwnershipParams
+    | {
+        asyncParams: () => Promise<TransferOwnershipParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.newOwner] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/uninstallExtension.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/uninstallExtension.ts
@@ -1,0 +1,159 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "uninstallExtension" function.
+ */
+export type UninstallExtensionParams = WithOverrides<{
+  extension: AbiParameterToPrimitiveType<{
+    name: "_extension";
+    type: "address";
+    internalType: "address";
+  }>;
+  data: AbiParameterToPrimitiveType<{
+    name: "_data";
+    type: "bytes";
+    internalType: "bytes";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0x42b7d0c8" as const;
+const FN_INPUTS = [
+  {
+    name: "_extension",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "_data",
+    type: "bytes",
+    internalType: "bytes",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `uninstallExtension` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `uninstallExtension` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isUninstallExtensionSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isUninstallExtensionSupported(contract);
+ * ```
+ */
+export async function isUninstallExtensionSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "uninstallExtension" function.
+ * @param options - The options for the uninstallExtension function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeUninstallExtensionParams } "thirdweb/extensions/modular";
+ * const result = encodeUninstallExtensionParams({
+ *  extension: ...,
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeUninstallExtensionParams(
+  options: UninstallExtensionParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.extension, options.data]);
+}
+
+/**
+ * Encodes the "uninstallExtension" function into a Hex string with its parameters.
+ * @param options - The options for the uninstallExtension function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeUninstallExtension } "thirdweb/extensions/modular";
+ * const result = encodeUninstallExtension({
+ *  extension: ...,
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeUninstallExtension(options: UninstallExtensionParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeUninstallExtensionParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "uninstallExtension" function on the contract.
+ * @param options - The options for the "uninstallExtension" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { uninstallExtension } from "thirdweb/extensions/modular";
+ *
+ * const transaction = uninstallExtension({
+ *  contract,
+ *  extension: ...,
+ *  data: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function uninstallExtension(
+  options: BaseTransactionOptions<
+    | UninstallExtensionParams
+    | {
+        asyncParams: () => Promise<UninstallExtensionParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.extension, resolvedOptions.data] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/events/Approval.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/events/Approval.ts
@@ -1,0 +1,56 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+import type { AbiParameterToPrimitiveType } from "abitype";
+
+/**
+ * Represents the filters for the "Approval" event.
+ */
+export type ApprovalEventFilters = Partial<{
+  owner: AbiParameterToPrimitiveType<{
+    name: "owner";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+  approved: AbiParameterToPrimitiveType<{
+    name: "approved";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+  tokenId: AbiParameterToPrimitiveType<{
+    name: "tokenId";
+    type: "uint256";
+    indexed: true;
+    internalType: "uint256";
+  }>;
+}>;
+
+/**
+ * Creates an event object for the Approval event.
+ * @param filters - Optional filters to apply to the event.
+ * @returns The prepared event object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { approvalEvent } from "thirdweb/extensions/modular";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  approvalEvent({
+ *  owner: ...,
+ *  approved: ...,
+ *  tokenId: ...,
+ * })
+ * ],
+ * });
+ * ```
+ */
+export function approvalEvent(filters: ApprovalEventFilters = {}) {
+  return prepareEvent({
+    signature:
+      "event Approval(address indexed owner, address indexed approved, uint256 indexed tokenId)",
+    filters,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/events/ApprovalForAll.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/events/ApprovalForAll.ts
@@ -1,0 +1,49 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+import type { AbiParameterToPrimitiveType } from "abitype";
+
+/**
+ * Represents the filters for the "ApprovalForAll" event.
+ */
+export type ApprovalForAllEventFilters = Partial<{
+  owner: AbiParameterToPrimitiveType<{
+    name: "owner";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+  operator: AbiParameterToPrimitiveType<{
+    name: "operator";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+}>;
+
+/**
+ * Creates an event object for the ApprovalForAll event.
+ * @param filters - Optional filters to apply to the event.
+ * @returns The prepared event object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { approvalForAllEvent } from "thirdweb/extensions/modular";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  approvalForAllEvent({
+ *  owner: ...,
+ *  operator: ...,
+ * })
+ * ],
+ * });
+ * ```
+ */
+export function approvalForAllEvent(filters: ApprovalForAllEventFilters = {}) {
+  return prepareEvent({
+    signature:
+      "event ApprovalForAll(address indexed owner, address indexed operator, bool approved)",
+    filters,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/events/ConsecutiveTransfer.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/events/ConsecutiveTransfer.ts
@@ -1,0 +1,58 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+import type { AbiParameterToPrimitiveType } from "abitype";
+
+/**
+ * Represents the filters for the "ConsecutiveTransfer" event.
+ */
+export type ConsecutiveTransferEventFilters = Partial<{
+  fromTokenId: AbiParameterToPrimitiveType<{
+    name: "fromTokenId";
+    type: "uint256";
+    indexed: true;
+    internalType: "uint256";
+  }>;
+  from: AbiParameterToPrimitiveType<{
+    name: "from";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+  to: AbiParameterToPrimitiveType<{
+    name: "to";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+}>;
+
+/**
+ * Creates an event object for the ConsecutiveTransfer event.
+ * @param filters - Optional filters to apply to the event.
+ * @returns The prepared event object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { consecutiveTransferEvent } from "thirdweb/extensions/modular";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  consecutiveTransferEvent({
+ *  fromTokenId: ...,
+ *  from: ...,
+ *  to: ...,
+ * })
+ * ],
+ * });
+ * ```
+ */
+export function consecutiveTransferEvent(
+  filters: ConsecutiveTransferEventFilters = {},
+) {
+  return prepareEvent({
+    signature:
+      "event ConsecutiveTransfer(uint256 indexed fromTokenId, uint256 toTokenId, address indexed from, address indexed to)",
+    filters,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/events/ContractURIUpdated.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/events/ContractURIUpdated.ts
@@ -1,0 +1,24 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+
+/**
+ * Creates an event object for the ContractURIUpdated event.
+ * @returns The prepared event object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { contractURIUpdatedEvent } from "thirdweb/extensions/modular";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  contractURIUpdatedEvent()
+ * ],
+ * });
+ * ```
+ */
+export function contractURIUpdatedEvent() {
+  return prepareEvent({
+    signature: "event ContractURIUpdated()",
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/events/ExtensionInstalled.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/events/ExtensionInstalled.ts
@@ -1,0 +1,25 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+
+/**
+ * Creates an event object for the ExtensionInstalled event.
+ * @returns The prepared event object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { extensionInstalledEvent } from "thirdweb/extensions/modular";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  extensionInstalledEvent()
+ * ],
+ * });
+ * ```
+ */
+export function extensionInstalledEvent() {
+  return prepareEvent({
+    signature:
+      "event ExtensionInstalled(address caller, address implementation, address installedExtension)",
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/events/ExtensionUninstalled.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/events/ExtensionUninstalled.ts
@@ -1,0 +1,25 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+
+/**
+ * Creates an event object for the ExtensionUninstalled event.
+ * @returns The prepared event object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { extensionUninstalledEvent } from "thirdweb/extensions/modular";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  extensionUninstalledEvent()
+ * ],
+ * });
+ * ```
+ */
+export function extensionUninstalledEvent() {
+  return prepareEvent({
+    signature:
+      "event ExtensionUninstalled(address caller, address implementation, address installedExtension)",
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/events/OwnershipHandoverCanceled.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/events/OwnershipHandoverCanceled.ts
@@ -1,0 +1,43 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+import type { AbiParameterToPrimitiveType } from "abitype";
+
+/**
+ * Represents the filters for the "OwnershipHandoverCanceled" event.
+ */
+export type OwnershipHandoverCanceledEventFilters = Partial<{
+  pendingOwner: AbiParameterToPrimitiveType<{
+    name: "pendingOwner";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+}>;
+
+/**
+ * Creates an event object for the OwnershipHandoverCanceled event.
+ * @param filters - Optional filters to apply to the event.
+ * @returns The prepared event object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { ownershipHandoverCanceledEvent } from "thirdweb/extensions/modular";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  ownershipHandoverCanceledEvent({
+ *  pendingOwner: ...,
+ * })
+ * ],
+ * });
+ * ```
+ */
+export function ownershipHandoverCanceledEvent(
+  filters: OwnershipHandoverCanceledEventFilters = {},
+) {
+  return prepareEvent({
+    signature: "event OwnershipHandoverCanceled(address indexed pendingOwner)",
+    filters,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/events/OwnershipHandoverRequested.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/events/OwnershipHandoverRequested.ts
@@ -1,0 +1,43 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+import type { AbiParameterToPrimitiveType } from "abitype";
+
+/**
+ * Represents the filters for the "OwnershipHandoverRequested" event.
+ */
+export type OwnershipHandoverRequestedEventFilters = Partial<{
+  pendingOwner: AbiParameterToPrimitiveType<{
+    name: "pendingOwner";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+}>;
+
+/**
+ * Creates an event object for the OwnershipHandoverRequested event.
+ * @param filters - Optional filters to apply to the event.
+ * @returns The prepared event object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { ownershipHandoverRequestedEvent } from "thirdweb/extensions/modular";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  ownershipHandoverRequestedEvent({
+ *  pendingOwner: ...,
+ * })
+ * ],
+ * });
+ * ```
+ */
+export function ownershipHandoverRequestedEvent(
+  filters: OwnershipHandoverRequestedEventFilters = {},
+) {
+  return prepareEvent({
+    signature: "event OwnershipHandoverRequested(address indexed pendingOwner)",
+    filters,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/events/OwnershipTransferred.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/events/OwnershipTransferred.ts
@@ -1,0 +1,51 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+import type { AbiParameterToPrimitiveType } from "abitype";
+
+/**
+ * Represents the filters for the "OwnershipTransferred" event.
+ */
+export type OwnershipTransferredEventFilters = Partial<{
+  oldOwner: AbiParameterToPrimitiveType<{
+    name: "oldOwner";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+  newOwner: AbiParameterToPrimitiveType<{
+    name: "newOwner";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+}>;
+
+/**
+ * Creates an event object for the OwnershipTransferred event.
+ * @param filters - Optional filters to apply to the event.
+ * @returns The prepared event object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { ownershipTransferredEvent } from "thirdweb/extensions/modular";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  ownershipTransferredEvent({
+ *  oldOwner: ...,
+ *  newOwner: ...,
+ * })
+ * ],
+ * });
+ * ```
+ */
+export function ownershipTransferredEvent(
+  filters: OwnershipTransferredEventFilters = {},
+) {
+  return prepareEvent({
+    signature:
+      "event OwnershipTransferred(address indexed oldOwner, address indexed newOwner)",
+    filters,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/events/RolesUpdated.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/events/RolesUpdated.ts
@@ -1,0 +1,49 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+import type { AbiParameterToPrimitiveType } from "abitype";
+
+/**
+ * Represents the filters for the "RolesUpdated" event.
+ */
+export type RolesUpdatedEventFilters = Partial<{
+  user: AbiParameterToPrimitiveType<{
+    name: "user";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+  roles: AbiParameterToPrimitiveType<{
+    name: "roles";
+    type: "uint256";
+    indexed: true;
+    internalType: "uint256";
+  }>;
+}>;
+
+/**
+ * Creates an event object for the RolesUpdated event.
+ * @param filters - Optional filters to apply to the event.
+ * @returns The prepared event object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { rolesUpdatedEvent } from "thirdweb/extensions/modular";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  rolesUpdatedEvent({
+ *  user: ...,
+ *  roles: ...,
+ * })
+ * ],
+ * });
+ * ```
+ */
+export function rolesUpdatedEvent(filters: RolesUpdatedEventFilters = {}) {
+  return prepareEvent({
+    signature:
+      "event RolesUpdated(address indexed user, uint256 indexed roles)",
+    filters,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/events/Transfer.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/events/Transfer.ts
@@ -1,0 +1,56 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+import type { AbiParameterToPrimitiveType } from "abitype";
+
+/**
+ * Represents the filters for the "Transfer" event.
+ */
+export type TransferEventFilters = Partial<{
+  from: AbiParameterToPrimitiveType<{
+    name: "from";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+  to: AbiParameterToPrimitiveType<{
+    name: "to";
+    type: "address";
+    indexed: true;
+    internalType: "address";
+  }>;
+  tokenId: AbiParameterToPrimitiveType<{
+    name: "tokenId";
+    type: "uint256";
+    indexed: true;
+    internalType: "uint256";
+  }>;
+}>;
+
+/**
+ * Creates an event object for the Transfer event.
+ * @param filters - Optional filters to apply to the event.
+ * @returns The prepared event object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { transferEvent } from "thirdweb/extensions/modular";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  transferEvent({
+ *  from: ...,
+ *  to: ...,
+ *  tokenId: ...,
+ * })
+ * ],
+ * });
+ * ```
+ */
+export function transferEvent(filters: TransferEventFilters = {}) {
+  return prepareEvent({
+    signature:
+      "event Transfer(address indexed from, address indexed to, uint256 indexed tokenId)",
+    filters,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/balanceOf.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/balanceOf.ts
@@ -1,0 +1,134 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "balanceOf" function.
+ */
+export type BalanceOfParams = {
+  owner: AbiParameterToPrimitiveType<{
+    name: "owner";
+    type: "address";
+    internalType: "address";
+  }>;
+};
+
+export const FN_SELECTOR = "0x70a08231" as const;
+const FN_INPUTS = [
+  {
+    name: "owner",
+    type: "address",
+    internalType: "address",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Checks if the `balanceOf` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `balanceOf` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isBalanceOfSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isBalanceOfSupported(contract);
+ * ```
+ */
+export async function isBalanceOfSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "balanceOf" function.
+ * @param options - The options for the balanceOf function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeBalanceOfParams } "thirdweb/extensions/modular";
+ * const result = encodeBalanceOfParams({
+ *  owner: ...,
+ * });
+ * ```
+ */
+export function encodeBalanceOfParams(options: BalanceOfParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.owner]);
+}
+
+/**
+ * Encodes the "balanceOf" function into a Hex string with its parameters.
+ * @param options - The options for the balanceOf function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeBalanceOf } "thirdweb/extensions/modular";
+ * const result = encodeBalanceOf({
+ *  owner: ...,
+ * });
+ * ```
+ */
+export function encodeBalanceOf(options: BalanceOfParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeBalanceOfParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the balanceOf function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeBalanceOfResult } from "thirdweb/extensions/modular";
+ * const result = decodeBalanceOfResult("...");
+ * ```
+ */
+export function decodeBalanceOfResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "balanceOf" function on the contract.
+ * @param options - The options for the balanceOf function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { balanceOf } from "thirdweb/extensions/modular";
+ *
+ * const result = await balanceOf({
+ *  contract,
+ *  owner: ...,
+ * });
+ *
+ * ```
+ */
+export async function balanceOf(
+  options: BaseTransactionOptions<BalanceOfParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.owner],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/contractURI.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/contractURI.ts
@@ -1,0 +1,74 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0xe8a3d485" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "string",
+    internalType: "string",
+  },
+] as const;
+
+/**
+ * Checks if the `contractURI` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `contractURI` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isContractURISupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isContractURISupported(contract);
+ * ```
+ */
+export async function isContractURISupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Decodes the result of the contractURI function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeContractURIResult } from "thirdweb/extensions/modular";
+ * const result = decodeContractURIResult("...");
+ * ```
+ */
+export function decodeContractURIResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "contractURI" function on the contract.
+ * @param options - The options for the contractURI function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { contractURI } from "thirdweb/extensions/modular";
+ *
+ * const result = await contractURI({
+ *  contract,
+ * });
+ *
+ * ```
+ */
+export async function contractURI(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/explicitOwnershipOf.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/explicitOwnershipOf.ts
@@ -1,0 +1,160 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "explicitOwnershipOf" function.
+ */
+export type ExplicitOwnershipOfParams = {
+  tokenId: AbiParameterToPrimitiveType<{
+    name: "tokenId";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+};
+
+export const FN_SELECTOR = "0xc23dc68f" as const;
+const FN_INPUTS = [
+  {
+    name: "tokenId",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "ownership",
+    type: "tuple",
+    internalType: "struct IERC721A.TokenOwnership",
+    components: [
+      {
+        name: "addr",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "startTimestamp",
+        type: "uint64",
+        internalType: "uint64",
+      },
+      {
+        name: "burned",
+        type: "bool",
+        internalType: "bool",
+      },
+      {
+        name: "extraData",
+        type: "uint24",
+        internalType: "uint24",
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Checks if the `explicitOwnershipOf` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `explicitOwnershipOf` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isExplicitOwnershipOfSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isExplicitOwnershipOfSupported(contract);
+ * ```
+ */
+export async function isExplicitOwnershipOfSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "explicitOwnershipOf" function.
+ * @param options - The options for the explicitOwnershipOf function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeExplicitOwnershipOfParams } "thirdweb/extensions/modular";
+ * const result = encodeExplicitOwnershipOfParams({
+ *  tokenId: ...,
+ * });
+ * ```
+ */
+export function encodeExplicitOwnershipOfParams(
+  options: ExplicitOwnershipOfParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.tokenId]);
+}
+
+/**
+ * Encodes the "explicitOwnershipOf" function into a Hex string with its parameters.
+ * @param options - The options for the explicitOwnershipOf function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeExplicitOwnershipOf } "thirdweb/extensions/modular";
+ * const result = encodeExplicitOwnershipOf({
+ *  tokenId: ...,
+ * });
+ * ```
+ */
+export function encodeExplicitOwnershipOf(options: ExplicitOwnershipOfParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeExplicitOwnershipOfParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the explicitOwnershipOf function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeExplicitOwnershipOfResult } from "thirdweb/extensions/modular";
+ * const result = decodeExplicitOwnershipOfResult("...");
+ * ```
+ */
+export function decodeExplicitOwnershipOfResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "explicitOwnershipOf" function on the contract.
+ * @param options - The options for the explicitOwnershipOf function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { explicitOwnershipOf } from "thirdweb/extensions/modular";
+ *
+ * const result = await explicitOwnershipOf({
+ *  contract,
+ *  tokenId: ...,
+ * });
+ *
+ * ```
+ */
+export async function explicitOwnershipOf(
+  options: BaseTransactionOptions<ExplicitOwnershipOfParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.tokenId],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/explicitOwnershipsOf.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/explicitOwnershipsOf.ts
@@ -1,0 +1,162 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "explicitOwnershipsOf" function.
+ */
+export type ExplicitOwnershipsOfParams = {
+  tokenIds: AbiParameterToPrimitiveType<{
+    name: "tokenIds";
+    type: "uint256[]";
+    internalType: "uint256[]";
+  }>;
+};
+
+export const FN_SELECTOR = "0x5bbb2177" as const;
+const FN_INPUTS = [
+  {
+    name: "tokenIds",
+    type: "uint256[]",
+    internalType: "uint256[]",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "tuple[]",
+    internalType: "struct IERC721A.TokenOwnership[]",
+    components: [
+      {
+        name: "addr",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "startTimestamp",
+        type: "uint64",
+        internalType: "uint64",
+      },
+      {
+        name: "burned",
+        type: "bool",
+        internalType: "bool",
+      },
+      {
+        name: "extraData",
+        type: "uint24",
+        internalType: "uint24",
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Checks if the `explicitOwnershipsOf` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `explicitOwnershipsOf` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isExplicitOwnershipsOfSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isExplicitOwnershipsOfSupported(contract);
+ * ```
+ */
+export async function isExplicitOwnershipsOfSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "explicitOwnershipsOf" function.
+ * @param options - The options for the explicitOwnershipsOf function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeExplicitOwnershipsOfParams } "thirdweb/extensions/modular";
+ * const result = encodeExplicitOwnershipsOfParams({
+ *  tokenIds: ...,
+ * });
+ * ```
+ */
+export function encodeExplicitOwnershipsOfParams(
+  options: ExplicitOwnershipsOfParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.tokenIds]);
+}
+
+/**
+ * Encodes the "explicitOwnershipsOf" function into a Hex string with its parameters.
+ * @param options - The options for the explicitOwnershipsOf function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeExplicitOwnershipsOf } "thirdweb/extensions/modular";
+ * const result = encodeExplicitOwnershipsOf({
+ *  tokenIds: ...,
+ * });
+ * ```
+ */
+export function encodeExplicitOwnershipsOf(
+  options: ExplicitOwnershipsOfParams,
+) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeExplicitOwnershipsOfParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the explicitOwnershipsOf function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeExplicitOwnershipsOfResult } from "thirdweb/extensions/modular";
+ * const result = decodeExplicitOwnershipsOfResult("...");
+ * ```
+ */
+export function decodeExplicitOwnershipsOfResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "explicitOwnershipsOf" function on the contract.
+ * @param options - The options for the explicitOwnershipsOf function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { explicitOwnershipsOf } from "thirdweb/extensions/modular";
+ *
+ * const result = await explicitOwnershipsOf({
+ *  contract,
+ *  tokenIds: ...,
+ * });
+ *
+ * ```
+ */
+export async function explicitOwnershipsOf(
+  options: BaseTransactionOptions<ExplicitOwnershipsOfParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.tokenIds],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/getApproved.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/getApproved.ts
@@ -1,0 +1,134 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "getApproved" function.
+ */
+export type GetApprovedParams = {
+  tokenId: AbiParameterToPrimitiveType<{
+    name: "tokenId";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+};
+
+export const FN_SELECTOR = "0x081812fc" as const;
+const FN_INPUTS = [
+  {
+    name: "tokenId",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "address",
+    internalType: "address",
+  },
+] as const;
+
+/**
+ * Checks if the `getApproved` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `getApproved` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isGetApprovedSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isGetApprovedSupported(contract);
+ * ```
+ */
+export async function isGetApprovedSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "getApproved" function.
+ * @param options - The options for the getApproved function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeGetApprovedParams } "thirdweb/extensions/modular";
+ * const result = encodeGetApprovedParams({
+ *  tokenId: ...,
+ * });
+ * ```
+ */
+export function encodeGetApprovedParams(options: GetApprovedParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.tokenId]);
+}
+
+/**
+ * Encodes the "getApproved" function into a Hex string with its parameters.
+ * @param options - The options for the getApproved function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeGetApproved } "thirdweb/extensions/modular";
+ * const result = encodeGetApproved({
+ *  tokenId: ...,
+ * });
+ * ```
+ */
+export function encodeGetApproved(options: GetApprovedParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeGetApprovedParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the getApproved function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeGetApprovedResult } from "thirdweb/extensions/modular";
+ * const result = decodeGetApprovedResult("...");
+ * ```
+ */
+export function decodeGetApprovedResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "getApproved" function on the contract.
+ * @param options - The options for the getApproved function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { getApproved } from "thirdweb/extensions/modular";
+ *
+ * const result = await getApproved({
+ *  contract,
+ *  tokenId: ...,
+ * });
+ *
+ * ```
+ */
+export async function getApproved(
+  options: BaseTransactionOptions<GetApprovedParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.tokenId],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/getInstalledExtensions.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/getInstalledExtensions.ts
@@ -1,0 +1,134 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0x5357aa5e" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "_installedExtensions",
+    type: "tuple[]",
+    internalType: "struct IModularCore.InstalledExtension[]",
+    components: [
+      {
+        name: "implementation",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "config",
+        type: "tuple",
+        internalType: "struct IExtensionConfig.ExtensionConfig",
+        components: [
+          {
+            name: "requiredInterfaceId",
+            type: "bytes4",
+            internalType: "bytes4",
+          },
+          {
+            name: "registerInstallationCallback",
+            type: "bool",
+            internalType: "bool",
+          },
+          {
+            name: "supportedInterfaces",
+            type: "bytes4[]",
+            internalType: "bytes4[]",
+          },
+          {
+            name: "callbackFunctions",
+            type: "tuple[]",
+            internalType: "struct IExtensionConfig.CallbackFunction[]",
+            components: [
+              {
+                name: "selector",
+                type: "bytes4",
+                internalType: "bytes4",
+              },
+            ],
+          },
+          {
+            name: "fallbackFunctions",
+            type: "tuple[]",
+            internalType: "struct IExtensionConfig.FallbackFunction[]",
+            components: [
+              {
+                name: "selector",
+                type: "bytes4",
+                internalType: "bytes4",
+              },
+              {
+                name: "permissionBits",
+                type: "uint256",
+                internalType: "uint256",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Checks if the `getInstalledExtensions` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `getInstalledExtensions` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isGetInstalledExtensionsSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isGetInstalledExtensionsSupported(contract);
+ * ```
+ */
+export async function isGetInstalledExtensionsSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Decodes the result of the getInstalledExtensions function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeGetInstalledExtensionsResult } from "thirdweb/extensions/modular";
+ * const result = decodeGetInstalledExtensionsResult("...");
+ * ```
+ */
+export function decodeGetInstalledExtensionsResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "getInstalledExtensions" function on the contract.
+ * @param options - The options for the getInstalledExtensions function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { getInstalledExtensions } from "thirdweb/extensions/modular";
+ *
+ * const result = await getInstalledExtensions({
+ *  contract,
+ * });
+ *
+ * ```
+ */
+export async function getInstalledExtensions(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/getSupportedCallbackFunctions.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/getSupportedCallbackFunctions.ts
@@ -1,0 +1,90 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0xf147db8a" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "supportedCallbackFunctions",
+    type: "tuple[]",
+    internalType: "struct IModularCore.SupportedCallbackFunction[]",
+    components: [
+      {
+        name: "selector",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+      {
+        name: "mode",
+        type: "uint8",
+        internalType: "enum IModularCore.CallbackMode",
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Checks if the `getSupportedCallbackFunctions` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `getSupportedCallbackFunctions` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isGetSupportedCallbackFunctionsSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isGetSupportedCallbackFunctionsSupported(contract);
+ * ```
+ */
+export async function isGetSupportedCallbackFunctionsSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Decodes the result of the getSupportedCallbackFunctions function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeGetSupportedCallbackFunctionsResult } from "thirdweb/extensions/modular";
+ * const result = decodeGetSupportedCallbackFunctionsResult("...");
+ * ```
+ */
+export function decodeGetSupportedCallbackFunctionsResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "getSupportedCallbackFunctions" function on the contract.
+ * @param options - The options for the getSupportedCallbackFunctions function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { getSupportedCallbackFunctions } from "thirdweb/extensions/modular";
+ *
+ * const result = await getSupportedCallbackFunctions({
+ *  contract,
+ * });
+ *
+ * ```
+ */
+export async function getSupportedCallbackFunctions(
+  options: BaseTransactionOptions,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/hasAllRoles.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/hasAllRoles.ts
@@ -1,0 +1,147 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "hasAllRoles" function.
+ */
+export type HasAllRolesParams = {
+  user: AbiParameterToPrimitiveType<{
+    name: "user";
+    type: "address";
+    internalType: "address";
+  }>;
+  roles: AbiParameterToPrimitiveType<{
+    name: "roles";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+};
+
+export const FN_SELECTOR = "0x1cd64df4" as const;
+const FN_INPUTS = [
+  {
+    name: "user",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "roles",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "bool",
+    internalType: "bool",
+  },
+] as const;
+
+/**
+ * Checks if the `hasAllRoles` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `hasAllRoles` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isHasAllRolesSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isHasAllRolesSupported(contract);
+ * ```
+ */
+export async function isHasAllRolesSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "hasAllRoles" function.
+ * @param options - The options for the hasAllRoles function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeHasAllRolesParams } "thirdweb/extensions/modular";
+ * const result = encodeHasAllRolesParams({
+ *  user: ...,
+ *  roles: ...,
+ * });
+ * ```
+ */
+export function encodeHasAllRolesParams(options: HasAllRolesParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.user, options.roles]);
+}
+
+/**
+ * Encodes the "hasAllRoles" function into a Hex string with its parameters.
+ * @param options - The options for the hasAllRoles function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeHasAllRoles } "thirdweb/extensions/modular";
+ * const result = encodeHasAllRoles({
+ *  user: ...,
+ *  roles: ...,
+ * });
+ * ```
+ */
+export function encodeHasAllRoles(options: HasAllRolesParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeHasAllRolesParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the hasAllRoles function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeHasAllRolesResult } from "thirdweb/extensions/modular";
+ * const result = decodeHasAllRolesResult("...");
+ * ```
+ */
+export function decodeHasAllRolesResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "hasAllRoles" function on the contract.
+ * @param options - The options for the hasAllRoles function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { hasAllRoles } from "thirdweb/extensions/modular";
+ *
+ * const result = await hasAllRoles({
+ *  contract,
+ *  user: ...,
+ *  roles: ...,
+ * });
+ *
+ * ```
+ */
+export async function hasAllRoles(
+  options: BaseTransactionOptions<HasAllRolesParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.user, options.roles],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/hasAnyRole.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/hasAnyRole.ts
@@ -1,0 +1,147 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "hasAnyRole" function.
+ */
+export type HasAnyRoleParams = {
+  user: AbiParameterToPrimitiveType<{
+    name: "user";
+    type: "address";
+    internalType: "address";
+  }>;
+  roles: AbiParameterToPrimitiveType<{
+    name: "roles";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+};
+
+export const FN_SELECTOR = "0x514e62fc" as const;
+const FN_INPUTS = [
+  {
+    name: "user",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "roles",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "bool",
+    internalType: "bool",
+  },
+] as const;
+
+/**
+ * Checks if the `hasAnyRole` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `hasAnyRole` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isHasAnyRoleSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isHasAnyRoleSupported(contract);
+ * ```
+ */
+export async function isHasAnyRoleSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "hasAnyRole" function.
+ * @param options - The options for the hasAnyRole function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeHasAnyRoleParams } "thirdweb/extensions/modular";
+ * const result = encodeHasAnyRoleParams({
+ *  user: ...,
+ *  roles: ...,
+ * });
+ * ```
+ */
+export function encodeHasAnyRoleParams(options: HasAnyRoleParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.user, options.roles]);
+}
+
+/**
+ * Encodes the "hasAnyRole" function into a Hex string with its parameters.
+ * @param options - The options for the hasAnyRole function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeHasAnyRole } "thirdweb/extensions/modular";
+ * const result = encodeHasAnyRole({
+ *  user: ...,
+ *  roles: ...,
+ * });
+ * ```
+ */
+export function encodeHasAnyRole(options: HasAnyRoleParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeHasAnyRoleParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the hasAnyRole function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeHasAnyRoleResult } from "thirdweb/extensions/modular";
+ * const result = decodeHasAnyRoleResult("...");
+ * ```
+ */
+export function decodeHasAnyRoleResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "hasAnyRole" function on the contract.
+ * @param options - The options for the hasAnyRole function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { hasAnyRole } from "thirdweb/extensions/modular";
+ *
+ * const result = await hasAnyRole({
+ *  contract,
+ *  user: ...,
+ *  roles: ...,
+ * });
+ *
+ * ```
+ */
+export async function hasAnyRole(
+  options: BaseTransactionOptions<HasAnyRoleParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.user, options.roles],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/isApprovedForAll.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/isApprovedForAll.ts
@@ -1,0 +1,149 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "isApprovedForAll" function.
+ */
+export type IsApprovedForAllParams = {
+  owner: AbiParameterToPrimitiveType<{
+    name: "owner";
+    type: "address";
+    internalType: "address";
+  }>;
+  operator: AbiParameterToPrimitiveType<{
+    name: "operator";
+    type: "address";
+    internalType: "address";
+  }>;
+};
+
+export const FN_SELECTOR = "0xe985e9c5" as const;
+const FN_INPUTS = [
+  {
+    name: "owner",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "operator",
+    type: "address",
+    internalType: "address",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "bool",
+    internalType: "bool",
+  },
+] as const;
+
+/**
+ * Checks if the `isApprovedForAll` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `isApprovedForAll` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isIsApprovedForAllSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isIsApprovedForAllSupported(contract);
+ * ```
+ */
+export async function isIsApprovedForAllSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "isApprovedForAll" function.
+ * @param options - The options for the isApprovedForAll function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeIsApprovedForAllParams } "thirdweb/extensions/modular";
+ * const result = encodeIsApprovedForAllParams({
+ *  owner: ...,
+ *  operator: ...,
+ * });
+ * ```
+ */
+export function encodeIsApprovedForAllParams(options: IsApprovedForAllParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.owner, options.operator]);
+}
+
+/**
+ * Encodes the "isApprovedForAll" function into a Hex string with its parameters.
+ * @param options - The options for the isApprovedForAll function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeIsApprovedForAll } "thirdweb/extensions/modular";
+ * const result = encodeIsApprovedForAll({
+ *  owner: ...,
+ *  operator: ...,
+ * });
+ * ```
+ */
+export function encodeIsApprovedForAll(options: IsApprovedForAllParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeIsApprovedForAllParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the isApprovedForAll function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeIsApprovedForAllResult } from "thirdweb/extensions/modular";
+ * const result = decodeIsApprovedForAllResult("...");
+ * ```
+ */
+export function decodeIsApprovedForAllResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "isApprovedForAll" function on the contract.
+ * @param options - The options for the isApprovedForAll function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isApprovedForAll } from "thirdweb/extensions/modular";
+ *
+ * const result = await isApprovedForAll({
+ *  contract,
+ *  owner: ...,
+ *  operator: ...,
+ * });
+ *
+ * ```
+ */
+export async function isApprovedForAll(
+  options: BaseTransactionOptions<IsApprovedForAllParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.owner, options.operator],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/name.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/name.ts
@@ -1,0 +1,74 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0x06fdde03" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "string",
+    internalType: "string",
+  },
+] as const;
+
+/**
+ * Checks if the `name` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `name` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isNameSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isNameSupported(contract);
+ * ```
+ */
+export async function isNameSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Decodes the result of the name function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeNameResult } from "thirdweb/extensions/modular";
+ * const result = decodeNameResult("...");
+ * ```
+ */
+export function decodeNameResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "name" function on the contract.
+ * @param options - The options for the name function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { name } from "thirdweb/extensions/modular";
+ *
+ * const result = await name({
+ *  contract,
+ * });
+ *
+ * ```
+ */
+export async function name(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/owner.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/owner.ts
@@ -1,0 +1,74 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0x8da5cb5b" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "result",
+    type: "address",
+    internalType: "address",
+  },
+] as const;
+
+/**
+ * Checks if the `owner` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `owner` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isOwnerSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isOwnerSupported(contract);
+ * ```
+ */
+export async function isOwnerSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Decodes the result of the owner function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeOwnerResult } from "thirdweb/extensions/modular";
+ * const result = decodeOwnerResult("...");
+ * ```
+ */
+export function decodeOwnerResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "owner" function on the contract.
+ * @param options - The options for the owner function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { owner } from "thirdweb/extensions/modular";
+ *
+ * const result = await owner({
+ *  contract,
+ * });
+ *
+ * ```
+ */
+export async function owner(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/ownerOf.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/ownerOf.ts
@@ -1,0 +1,130 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "ownerOf" function.
+ */
+export type OwnerOfParams = {
+  tokenId: AbiParameterToPrimitiveType<{
+    name: "tokenId";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+};
+
+export const FN_SELECTOR = "0x6352211e" as const;
+const FN_INPUTS = [
+  {
+    name: "tokenId",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "address",
+    internalType: "address",
+  },
+] as const;
+
+/**
+ * Checks if the `ownerOf` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `ownerOf` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isOwnerOfSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isOwnerOfSupported(contract);
+ * ```
+ */
+export async function isOwnerOfSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "ownerOf" function.
+ * @param options - The options for the ownerOf function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeOwnerOfParams } "thirdweb/extensions/modular";
+ * const result = encodeOwnerOfParams({
+ *  tokenId: ...,
+ * });
+ * ```
+ */
+export function encodeOwnerOfParams(options: OwnerOfParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.tokenId]);
+}
+
+/**
+ * Encodes the "ownerOf" function into a Hex string with its parameters.
+ * @param options - The options for the ownerOf function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeOwnerOf } "thirdweb/extensions/modular";
+ * const result = encodeOwnerOf({
+ *  tokenId: ...,
+ * });
+ * ```
+ */
+export function encodeOwnerOf(options: OwnerOfParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeOwnerOfParams(options).slice(2)) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the ownerOf function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeOwnerOfResult } from "thirdweb/extensions/modular";
+ * const result = decodeOwnerOfResult("...");
+ * ```
+ */
+export function decodeOwnerOfResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "ownerOf" function on the contract.
+ * @param options - The options for the ownerOf function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { ownerOf } from "thirdweb/extensions/modular";
+ *
+ * const result = await ownerOf({
+ *  contract,
+ *  tokenId: ...,
+ * });
+ *
+ * ```
+ */
+export async function ownerOf(options: BaseTransactionOptions<OwnerOfParams>) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.tokenId],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/ownershipHandoverExpiresAt.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/ownershipHandoverExpiresAt.ts
@@ -1,0 +1,140 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "ownershipHandoverExpiresAt" function.
+ */
+export type OwnershipHandoverExpiresAtParams = {
+  pendingOwner: AbiParameterToPrimitiveType<{
+    name: "pendingOwner";
+    type: "address";
+    internalType: "address";
+  }>;
+};
+
+export const FN_SELECTOR = "0xfee81cf4" as const;
+const FN_INPUTS = [
+  {
+    name: "pendingOwner",
+    type: "address",
+    internalType: "address",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "result",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Checks if the `ownershipHandoverExpiresAt` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `ownershipHandoverExpiresAt` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isOwnershipHandoverExpiresAtSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isOwnershipHandoverExpiresAtSupported(contract);
+ * ```
+ */
+export async function isOwnershipHandoverExpiresAtSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "ownershipHandoverExpiresAt" function.
+ * @param options - The options for the ownershipHandoverExpiresAt function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeOwnershipHandoverExpiresAtParams } "thirdweb/extensions/modular";
+ * const result = encodeOwnershipHandoverExpiresAtParams({
+ *  pendingOwner: ...,
+ * });
+ * ```
+ */
+export function encodeOwnershipHandoverExpiresAtParams(
+  options: OwnershipHandoverExpiresAtParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.pendingOwner]);
+}
+
+/**
+ * Encodes the "ownershipHandoverExpiresAt" function into a Hex string with its parameters.
+ * @param options - The options for the ownershipHandoverExpiresAt function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeOwnershipHandoverExpiresAt } "thirdweb/extensions/modular";
+ * const result = encodeOwnershipHandoverExpiresAt({
+ *  pendingOwner: ...,
+ * });
+ * ```
+ */
+export function encodeOwnershipHandoverExpiresAt(
+  options: OwnershipHandoverExpiresAtParams,
+) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeOwnershipHandoverExpiresAtParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the ownershipHandoverExpiresAt function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeOwnershipHandoverExpiresAtResult } from "thirdweb/extensions/modular";
+ * const result = decodeOwnershipHandoverExpiresAtResult("...");
+ * ```
+ */
+export function decodeOwnershipHandoverExpiresAtResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "ownershipHandoverExpiresAt" function on the contract.
+ * @param options - The options for the ownershipHandoverExpiresAt function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { ownershipHandoverExpiresAt } from "thirdweb/extensions/modular";
+ *
+ * const result = await ownershipHandoverExpiresAt({
+ *  contract,
+ *  pendingOwner: ...,
+ * });
+ *
+ * ```
+ */
+export async function ownershipHandoverExpiresAt(
+  options: BaseTransactionOptions<OwnershipHandoverExpiresAtParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.pendingOwner],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/rolesOf.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/rolesOf.ts
@@ -1,0 +1,130 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "rolesOf" function.
+ */
+export type RolesOfParams = {
+  user: AbiParameterToPrimitiveType<{
+    name: "user";
+    type: "address";
+    internalType: "address";
+  }>;
+};
+
+export const FN_SELECTOR = "0x2de94807" as const;
+const FN_INPUTS = [
+  {
+    name: "user",
+    type: "address",
+    internalType: "address",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "roles",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Checks if the `rolesOf` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `rolesOf` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isRolesOfSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isRolesOfSupported(contract);
+ * ```
+ */
+export async function isRolesOfSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "rolesOf" function.
+ * @param options - The options for the rolesOf function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeRolesOfParams } "thirdweb/extensions/modular";
+ * const result = encodeRolesOfParams({
+ *  user: ...,
+ * });
+ * ```
+ */
+export function encodeRolesOfParams(options: RolesOfParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.user]);
+}
+
+/**
+ * Encodes the "rolesOf" function into a Hex string with its parameters.
+ * @param options - The options for the rolesOf function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeRolesOf } "thirdweb/extensions/modular";
+ * const result = encodeRolesOf({
+ *  user: ...,
+ * });
+ * ```
+ */
+export function encodeRolesOf(options: RolesOfParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeRolesOfParams(options).slice(2)) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the rolesOf function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeRolesOfResult } from "thirdweb/extensions/modular";
+ * const result = decodeRolesOfResult("...");
+ * ```
+ */
+export function decodeRolesOfResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "rolesOf" function on the contract.
+ * @param options - The options for the rolesOf function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { rolesOf } from "thirdweb/extensions/modular";
+ *
+ * const result = await rolesOf({
+ *  contract,
+ *  user: ...,
+ * });
+ *
+ * ```
+ */
+export async function rolesOf(options: BaseTransactionOptions<RolesOfParams>) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.user],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/startTokenId.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/startTokenId.ts
@@ -1,0 +1,74 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0xe6798baa" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Checks if the `startTokenId` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `startTokenId` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isStartTokenIdSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isStartTokenIdSupported(contract);
+ * ```
+ */
+export async function isStartTokenIdSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Decodes the result of the startTokenId function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeStartTokenIdResult } from "thirdweb/extensions/modular";
+ * const result = decodeStartTokenIdResult("...");
+ * ```
+ */
+export function decodeStartTokenIdResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "startTokenId" function on the contract.
+ * @param options - The options for the startTokenId function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { startTokenId } from "thirdweb/extensions/modular";
+ *
+ * const result = await startTokenId({
+ *  contract,
+ * });
+ *
+ * ```
+ */
+export async function startTokenId(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/supportsInterface.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/supportsInterface.ts
@@ -1,0 +1,138 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "supportsInterface" function.
+ */
+export type SupportsInterfaceParams = {
+  interfaceId: AbiParameterToPrimitiveType<{
+    name: "interfaceId";
+    type: "bytes4";
+    internalType: "bytes4";
+  }>;
+};
+
+export const FN_SELECTOR = "0x01ffc9a7" as const;
+const FN_INPUTS = [
+  {
+    name: "interfaceId",
+    type: "bytes4",
+    internalType: "bytes4",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "bool",
+    internalType: "bool",
+  },
+] as const;
+
+/**
+ * Checks if the `supportsInterface` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `supportsInterface` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isSupportsInterfaceSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isSupportsInterfaceSupported(contract);
+ * ```
+ */
+export async function isSupportsInterfaceSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "supportsInterface" function.
+ * @param options - The options for the supportsInterface function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeSupportsInterfaceParams } "thirdweb/extensions/modular";
+ * const result = encodeSupportsInterfaceParams({
+ *  interfaceId: ...,
+ * });
+ * ```
+ */
+export function encodeSupportsInterfaceParams(
+  options: SupportsInterfaceParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.interfaceId]);
+}
+
+/**
+ * Encodes the "supportsInterface" function into a Hex string with its parameters.
+ * @param options - The options for the supportsInterface function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeSupportsInterface } "thirdweb/extensions/modular";
+ * const result = encodeSupportsInterface({
+ *  interfaceId: ...,
+ * });
+ * ```
+ */
+export function encodeSupportsInterface(options: SupportsInterfaceParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeSupportsInterfaceParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the supportsInterface function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeSupportsInterfaceResult } from "thirdweb/extensions/modular";
+ * const result = decodeSupportsInterfaceResult("...");
+ * ```
+ */
+export function decodeSupportsInterfaceResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "supportsInterface" function on the contract.
+ * @param options - The options for the supportsInterface function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { supportsInterface } from "thirdweb/extensions/modular";
+ *
+ * const result = await supportsInterface({
+ *  contract,
+ *  interfaceId: ...,
+ * });
+ *
+ * ```
+ */
+export async function supportsInterface(
+  options: BaseTransactionOptions<SupportsInterfaceParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.interfaceId],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/symbol.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/symbol.ts
@@ -1,0 +1,74 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0x95d89b41" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "string",
+    internalType: "string",
+  },
+] as const;
+
+/**
+ * Checks if the `symbol` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `symbol` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isSymbolSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isSymbolSupported(contract);
+ * ```
+ */
+export async function isSymbolSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Decodes the result of the symbol function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeSymbolResult } from "thirdweb/extensions/modular";
+ * const result = decodeSymbolResult("...");
+ * ```
+ */
+export function decodeSymbolResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "symbol" function on the contract.
+ * @param options - The options for the symbol function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { symbol } from "thirdweb/extensions/modular";
+ *
+ * const result = await symbol({
+ *  contract,
+ * });
+ *
+ * ```
+ */
+export async function symbol(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/tokenURI.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/tokenURI.ts
@@ -1,0 +1,132 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "tokenURI" function.
+ */
+export type TokenURIParams = {
+  id: AbiParameterToPrimitiveType<{
+    name: "id";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+};
+
+export const FN_SELECTOR = "0xc87b56dd" as const;
+const FN_INPUTS = [
+  {
+    name: "id",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "string",
+    internalType: "string",
+  },
+] as const;
+
+/**
+ * Checks if the `tokenURI` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `tokenURI` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isTokenURISupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isTokenURISupported(contract);
+ * ```
+ */
+export async function isTokenURISupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "tokenURI" function.
+ * @param options - The options for the tokenURI function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeTokenURIParams } "thirdweb/extensions/modular";
+ * const result = encodeTokenURIParams({
+ *  id: ...,
+ * });
+ * ```
+ */
+export function encodeTokenURIParams(options: TokenURIParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.id]);
+}
+
+/**
+ * Encodes the "tokenURI" function into a Hex string with its parameters.
+ * @param options - The options for the tokenURI function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeTokenURI } "thirdweb/extensions/modular";
+ * const result = encodeTokenURI({
+ *  id: ...,
+ * });
+ * ```
+ */
+export function encodeTokenURI(options: TokenURIParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeTokenURIParams(options).slice(2)) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the tokenURI function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeTokenURIResult } from "thirdweb/extensions/modular";
+ * const result = decodeTokenURIResult("...");
+ * ```
+ */
+export function decodeTokenURIResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "tokenURI" function on the contract.
+ * @param options - The options for the tokenURI function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { tokenURI } from "thirdweb/extensions/modular";
+ *
+ * const result = await tokenURI({
+ *  contract,
+ *  id: ...,
+ * });
+ *
+ * ```
+ */
+export async function tokenURI(
+  options: BaseTransactionOptions<TokenURIParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.id],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/tokensOfOwner.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/tokensOfOwner.ts
@@ -1,0 +1,136 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "tokensOfOwner" function.
+ */
+export type TokensOfOwnerParams = {
+  owner: AbiParameterToPrimitiveType<{
+    name: "owner";
+    type: "address";
+    internalType: "address";
+  }>;
+};
+
+export const FN_SELECTOR = "0x8462151c" as const;
+const FN_INPUTS = [
+  {
+    name: "owner",
+    type: "address",
+    internalType: "address",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "uint256[]",
+    internalType: "uint256[]",
+  },
+] as const;
+
+/**
+ * Checks if the `tokensOfOwner` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `tokensOfOwner` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isTokensOfOwnerSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isTokensOfOwnerSupported(contract);
+ * ```
+ */
+export async function isTokensOfOwnerSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "tokensOfOwner" function.
+ * @param options - The options for the tokensOfOwner function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeTokensOfOwnerParams } "thirdweb/extensions/modular";
+ * const result = encodeTokensOfOwnerParams({
+ *  owner: ...,
+ * });
+ * ```
+ */
+export function encodeTokensOfOwnerParams(options: TokensOfOwnerParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.owner]);
+}
+
+/**
+ * Encodes the "tokensOfOwner" function into a Hex string with its parameters.
+ * @param options - The options for the tokensOfOwner function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeTokensOfOwner } "thirdweb/extensions/modular";
+ * const result = encodeTokensOfOwner({
+ *  owner: ...,
+ * });
+ * ```
+ */
+export function encodeTokensOfOwner(options: TokensOfOwnerParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeTokensOfOwnerParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the tokensOfOwner function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeTokensOfOwnerResult } from "thirdweb/extensions/modular";
+ * const result = decodeTokensOfOwnerResult("...");
+ * ```
+ */
+export function decodeTokensOfOwnerResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "tokensOfOwner" function on the contract.
+ * @param options - The options for the tokensOfOwner function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { tokensOfOwner } from "thirdweb/extensions/modular";
+ *
+ * const result = await tokensOfOwner({
+ *  contract,
+ *  owner: ...,
+ * });
+ *
+ * ```
+ */
+export async function tokensOfOwner(
+  options: BaseTransactionOptions<TokensOfOwnerParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.owner],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/tokensOfOwnerIn.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/tokensOfOwnerIn.ts
@@ -1,0 +1,166 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "tokensOfOwnerIn" function.
+ */
+export type TokensOfOwnerInParams = {
+  owner: AbiParameterToPrimitiveType<{
+    name: "owner";
+    type: "address";
+    internalType: "address";
+  }>;
+  start: AbiParameterToPrimitiveType<{
+    name: "start";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+  stop: AbiParameterToPrimitiveType<{
+    name: "stop";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+};
+
+export const FN_SELECTOR = "0x99a2557a" as const;
+const FN_INPUTS = [
+  {
+    name: "owner",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "start",
+    type: "uint256",
+    internalType: "uint256",
+  },
+  {
+    name: "stop",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "uint256[]",
+    internalType: "uint256[]",
+  },
+] as const;
+
+/**
+ * Checks if the `tokensOfOwnerIn` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `tokensOfOwnerIn` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isTokensOfOwnerInSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isTokensOfOwnerInSupported(contract);
+ * ```
+ */
+export async function isTokensOfOwnerInSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "tokensOfOwnerIn" function.
+ * @param options - The options for the tokensOfOwnerIn function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeTokensOfOwnerInParams } "thirdweb/extensions/modular";
+ * const result = encodeTokensOfOwnerInParams({
+ *  owner: ...,
+ *  start: ...,
+ *  stop: ...,
+ * });
+ * ```
+ */
+export function encodeTokensOfOwnerInParams(options: TokensOfOwnerInParams) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.owner,
+    options.start,
+    options.stop,
+  ]);
+}
+
+/**
+ * Encodes the "tokensOfOwnerIn" function into a Hex string with its parameters.
+ * @param options - The options for the tokensOfOwnerIn function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeTokensOfOwnerIn } "thirdweb/extensions/modular";
+ * const result = encodeTokensOfOwnerIn({
+ *  owner: ...,
+ *  start: ...,
+ *  stop: ...,
+ * });
+ * ```
+ */
+export function encodeTokensOfOwnerIn(options: TokensOfOwnerInParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeTokensOfOwnerInParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the tokensOfOwnerIn function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeTokensOfOwnerInResult } from "thirdweb/extensions/modular";
+ * const result = decodeTokensOfOwnerInResult("...");
+ * ```
+ */
+export function decodeTokensOfOwnerInResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "tokensOfOwnerIn" function on the contract.
+ * @param options - The options for the tokensOfOwnerIn function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { tokensOfOwnerIn } from "thirdweb/extensions/modular";
+ *
+ * const result = await tokensOfOwnerIn({
+ *  contract,
+ *  owner: ...,
+ *  start: ...,
+ *  stop: ...,
+ * });
+ *
+ * ```
+ */
+export async function tokensOfOwnerIn(
+  options: BaseTransactionOptions<TokensOfOwnerInParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.owner, options.start, options.stop],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/totalMinted.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/totalMinted.ts
@@ -1,0 +1,74 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0xa2309ff8" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Checks if the `totalMinted` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `totalMinted` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isTotalMintedSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isTotalMintedSupported(contract);
+ * ```
+ */
+export async function isTotalMintedSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Decodes the result of the totalMinted function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeTotalMintedResult } from "thirdweb/extensions/modular";
+ * const result = decodeTotalMintedResult("...");
+ * ```
+ */
+export function decodeTotalMintedResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "totalMinted" function on the contract.
+ * @param options - The options for the totalMinted function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { totalMinted } from "thirdweb/extensions/modular";
+ *
+ * const result = await totalMinted({
+ *  contract,
+ * });
+ *
+ * ```
+ */
+export async function totalMinted(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/totalSupply.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/totalSupply.ts
@@ -1,0 +1,74 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0x18160ddd" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    name: "result",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+
+/**
+ * Checks if the `totalSupply` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `totalSupply` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isTotalSupplySupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isTotalSupplySupported(contract);
+ * ```
+ */
+export async function isTotalSupplySupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Decodes the result of the totalSupply function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { decodeTotalSupplyResult } from "thirdweb/extensions/modular";
+ * const result = decodeTotalSupplyResult("...");
+ * ```
+ */
+export function decodeTotalSupplyResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "totalSupply" function on the contract.
+ * @param options - The options for the totalSupply function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { totalSupply } from "thirdweb/extensions/modular";
+ *
+ * const result = await totalSupply({
+ *  contract,
+ * });
+ *
+ * ```
+ */
+export async function totalSupply(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/approve.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/approve.ts
@@ -1,0 +1,153 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "approve" function.
+ */
+export type ApproveParams = WithOverrides<{
+  spender: AbiParameterToPrimitiveType<{
+    name: "spender";
+    type: "address";
+    internalType: "address";
+  }>;
+  id: AbiParameterToPrimitiveType<{
+    name: "id";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0x095ea7b3" as const;
+const FN_INPUTS = [
+  {
+    name: "spender",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "id",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `approve` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `approve` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isApproveSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isApproveSupported(contract);
+ * ```
+ */
+export async function isApproveSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "approve" function.
+ * @param options - The options for the approve function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeApproveParams } "thirdweb/extensions/modular";
+ * const result = encodeApproveParams({
+ *  spender: ...,
+ *  id: ...,
+ * });
+ * ```
+ */
+export function encodeApproveParams(options: ApproveParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.spender, options.id]);
+}
+
+/**
+ * Encodes the "approve" function into a Hex string with its parameters.
+ * @param options - The options for the approve function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeApprove } "thirdweb/extensions/modular";
+ * const result = encodeApprove({
+ *  spender: ...,
+ *  id: ...,
+ * });
+ * ```
+ */
+export function encodeApprove(options: ApproveParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeApproveParams(options).slice(2)) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "approve" function on the contract.
+ * @param options - The options for the "approve" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { approve } from "thirdweb/extensions/modular";
+ *
+ * const transaction = approve({
+ *  contract,
+ *  spender: ...,
+ *  id: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function approve(
+  options: BaseTransactionOptions<
+    | ApproveParams
+    | {
+        asyncParams: () => Promise<ApproveParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.spender, resolvedOptions.id] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/burn.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/burn.ts
@@ -1,0 +1,153 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "burn" function.
+ */
+export type BurnParams = WithOverrides<{
+  tokenId: AbiParameterToPrimitiveType<{
+    name: "tokenId";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+  data: AbiParameterToPrimitiveType<{
+    name: "data";
+    type: "bytes";
+    internalType: "bytes";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0xfe9d9303" as const;
+const FN_INPUTS = [
+  {
+    name: "tokenId",
+    type: "uint256",
+    internalType: "uint256",
+  },
+  {
+    name: "data",
+    type: "bytes",
+    internalType: "bytes",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `burn` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `burn` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isBurnSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isBurnSupported(contract);
+ * ```
+ */
+export async function isBurnSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "burn" function.
+ * @param options - The options for the burn function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeBurnParams } "thirdweb/extensions/modular";
+ * const result = encodeBurnParams({
+ *  tokenId: ...,
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeBurnParams(options: BurnParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.tokenId, options.data]);
+}
+
+/**
+ * Encodes the "burn" function into a Hex string with its parameters.
+ * @param options - The options for the burn function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeBurn } "thirdweb/extensions/modular";
+ * const result = encodeBurn({
+ *  tokenId: ...,
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeBurn(options: BurnParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeBurnParams(options).slice(2)) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "burn" function on the contract.
+ * @param options - The options for the "burn" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { burn } from "thirdweb/extensions/modular";
+ *
+ * const transaction = burn({
+ *  contract,
+ *  tokenId: ...,
+ *  data: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function burn(
+  options: BaseTransactionOptions<
+    | BurnParams
+    | {
+        asyncParams: () => Promise<BurnParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.tokenId, resolvedOptions.data] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/cancelOwnershipHandover.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/cancelOwnershipHandover.ts
@@ -1,0 +1,53 @@
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0x54d1f13d" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `cancelOwnershipHandover` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `cancelOwnershipHandover` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isCancelOwnershipHandoverSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isCancelOwnershipHandoverSupported(contract);
+ * ```
+ */
+export async function isCancelOwnershipHandoverSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Prepares a transaction to call the "cancelOwnershipHandover" function on the contract.
+ * @param options - The options for the "cancelOwnershipHandover" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { cancelOwnershipHandover } from "thirdweb/extensions/modular";
+ *
+ * const transaction = cancelOwnershipHandover();
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function cancelOwnershipHandover(options: BaseTransactionOptions) {
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/completeOwnershipHandover.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/completeOwnershipHandover.ts
@@ -1,0 +1,148 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "completeOwnershipHandover" function.
+ */
+export type CompleteOwnershipHandoverParams = WithOverrides<{
+  pendingOwner: AbiParameterToPrimitiveType<{
+    name: "pendingOwner";
+    type: "address";
+    internalType: "address";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0xf04e283e" as const;
+const FN_INPUTS = [
+  {
+    name: "pendingOwner",
+    type: "address",
+    internalType: "address",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `completeOwnershipHandover` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `completeOwnershipHandover` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isCompleteOwnershipHandoverSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isCompleteOwnershipHandoverSupported(contract);
+ * ```
+ */
+export async function isCompleteOwnershipHandoverSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "completeOwnershipHandover" function.
+ * @param options - The options for the completeOwnershipHandover function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeCompleteOwnershipHandoverParams } "thirdweb/extensions/modular";
+ * const result = encodeCompleteOwnershipHandoverParams({
+ *  pendingOwner: ...,
+ * });
+ * ```
+ */
+export function encodeCompleteOwnershipHandoverParams(
+  options: CompleteOwnershipHandoverParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.pendingOwner]);
+}
+
+/**
+ * Encodes the "completeOwnershipHandover" function into a Hex string with its parameters.
+ * @param options - The options for the completeOwnershipHandover function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeCompleteOwnershipHandover } "thirdweb/extensions/modular";
+ * const result = encodeCompleteOwnershipHandover({
+ *  pendingOwner: ...,
+ * });
+ * ```
+ */
+export function encodeCompleteOwnershipHandover(
+  options: CompleteOwnershipHandoverParams,
+) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeCompleteOwnershipHandoverParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "completeOwnershipHandover" function on the contract.
+ * @param options - The options for the "completeOwnershipHandover" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { completeOwnershipHandover } from "thirdweb/extensions/modular";
+ *
+ * const transaction = completeOwnershipHandover({
+ *  contract,
+ *  pendingOwner: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function completeOwnershipHandover(
+  options: BaseTransactionOptions<
+    | CompleteOwnershipHandoverParams
+    | {
+        asyncParams: () => Promise<CompleteOwnershipHandoverParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.pendingOwner] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/grantRoles.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/grantRoles.ts
@@ -1,0 +1,155 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "grantRoles" function.
+ */
+export type GrantRolesParams = WithOverrides<{
+  user: AbiParameterToPrimitiveType<{
+    name: "user";
+    type: "address";
+    internalType: "address";
+  }>;
+  roles: AbiParameterToPrimitiveType<{
+    name: "roles";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0x1c10893f" as const;
+const FN_INPUTS = [
+  {
+    name: "user",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "roles",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `grantRoles` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `grantRoles` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isGrantRolesSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isGrantRolesSupported(contract);
+ * ```
+ */
+export async function isGrantRolesSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "grantRoles" function.
+ * @param options - The options for the grantRoles function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeGrantRolesParams } "thirdweb/extensions/modular";
+ * const result = encodeGrantRolesParams({
+ *  user: ...,
+ *  roles: ...,
+ * });
+ * ```
+ */
+export function encodeGrantRolesParams(options: GrantRolesParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.user, options.roles]);
+}
+
+/**
+ * Encodes the "grantRoles" function into a Hex string with its parameters.
+ * @param options - The options for the grantRoles function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeGrantRoles } "thirdweb/extensions/modular";
+ * const result = encodeGrantRoles({
+ *  user: ...,
+ *  roles: ...,
+ * });
+ * ```
+ */
+export function encodeGrantRoles(options: GrantRolesParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeGrantRolesParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "grantRoles" function on the contract.
+ * @param options - The options for the "grantRoles" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { grantRoles } from "thirdweb/extensions/modular";
+ *
+ * const transaction = grantRoles({
+ *  contract,
+ *  user: ...,
+ *  roles: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function grantRoles(
+  options: BaseTransactionOptions<
+    | GrantRolesParams
+    | {
+        asyncParams: () => Promise<GrantRolesParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.user, resolvedOptions.roles] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/installExtension.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/installExtension.ts
@@ -1,0 +1,157 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "installExtension" function.
+ */
+export type InstallExtensionParams = WithOverrides<{
+  extension: AbiParameterToPrimitiveType<{
+    name: "_extension";
+    type: "address";
+    internalType: "address";
+  }>;
+  data: AbiParameterToPrimitiveType<{
+    name: "_data";
+    type: "bytes";
+    internalType: "bytes";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0xaca696f5" as const;
+const FN_INPUTS = [
+  {
+    name: "_extension",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "_data",
+    type: "bytes",
+    internalType: "bytes",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `installExtension` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `installExtension` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isInstallExtensionSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isInstallExtensionSupported(contract);
+ * ```
+ */
+export async function isInstallExtensionSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "installExtension" function.
+ * @param options - The options for the installExtension function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeInstallExtensionParams } "thirdweb/extensions/modular";
+ * const result = encodeInstallExtensionParams({
+ *  extension: ...,
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeInstallExtensionParams(options: InstallExtensionParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.extension, options.data]);
+}
+
+/**
+ * Encodes the "installExtension" function into a Hex string with its parameters.
+ * @param options - The options for the installExtension function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeInstallExtension } "thirdweb/extensions/modular";
+ * const result = encodeInstallExtension({
+ *  extension: ...,
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeInstallExtension(options: InstallExtensionParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeInstallExtensionParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "installExtension" function on the contract.
+ * @param options - The options for the "installExtension" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { installExtension } from "thirdweb/extensions/modular";
+ *
+ * const transaction = installExtension({
+ *  contract,
+ *  extension: ...,
+ *  data: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function installExtension(
+  options: BaseTransactionOptions<
+    | InstallExtensionParams
+    | {
+        asyncParams: () => Promise<InstallExtensionParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.extension, resolvedOptions.data] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/mint.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/mint.ts
@@ -1,0 +1,174 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "mint" function.
+ */
+export type MintParams = WithOverrides<{
+  to: AbiParameterToPrimitiveType<{
+    name: "to";
+    type: "address";
+    internalType: "address";
+  }>;
+  quantity: AbiParameterToPrimitiveType<{
+    name: "quantity";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+  data: AbiParameterToPrimitiveType<{
+    name: "data";
+    type: "bytes";
+    internalType: "bytes";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0x94d008ef" as const;
+const FN_INPUTS = [
+  {
+    name: "to",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "quantity",
+    type: "uint256",
+    internalType: "uint256",
+  },
+  {
+    name: "data",
+    type: "bytes",
+    internalType: "bytes",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `mint` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `mint` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isMintSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isMintSupported(contract);
+ * ```
+ */
+export async function isMintSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "mint" function.
+ * @param options - The options for the mint function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeMintParams } "thirdweb/extensions/modular";
+ * const result = encodeMintParams({
+ *  to: ...,
+ *  quantity: ...,
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeMintParams(options: MintParams) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.to,
+    options.quantity,
+    options.data,
+  ]);
+}
+
+/**
+ * Encodes the "mint" function into a Hex string with its parameters.
+ * @param options - The options for the mint function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeMint } "thirdweb/extensions/modular";
+ * const result = encodeMint({
+ *  to: ...,
+ *  quantity: ...,
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeMint(options: MintParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeMintParams(options).slice(2)) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "mint" function on the contract.
+ * @param options - The options for the "mint" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { mint } from "thirdweb/extensions/modular";
+ *
+ * const transaction = mint({
+ *  contract,
+ *  to: ...,
+ *  quantity: ...,
+ *  data: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function mint(
+  options: BaseTransactionOptions<
+    | MintParams
+    | {
+        asyncParams: () => Promise<MintParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [
+        resolvedOptions.to,
+        resolvedOptions.quantity,
+        resolvedOptions.data,
+      ] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/multicall.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/multicall.ts
@@ -1,0 +1,148 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "multicall" function.
+ */
+export type MulticallParams = WithOverrides<{
+  data: AbiParameterToPrimitiveType<{
+    name: "data";
+    type: "bytes[]";
+    internalType: "bytes[]";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0xac9650d8" as const;
+const FN_INPUTS = [
+  {
+    name: "data",
+    type: "bytes[]",
+    internalType: "bytes[]",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    name: "",
+    type: "bytes[]",
+    internalType: "bytes[]",
+  },
+] as const;
+
+/**
+ * Checks if the `multicall` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `multicall` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isMulticallSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isMulticallSupported(contract);
+ * ```
+ */
+export async function isMulticallSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "multicall" function.
+ * @param options - The options for the multicall function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeMulticallParams } "thirdweb/extensions/modular";
+ * const result = encodeMulticallParams({
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeMulticallParams(options: MulticallParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.data]);
+}
+
+/**
+ * Encodes the "multicall" function into a Hex string with its parameters.
+ * @param options - The options for the multicall function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeMulticall } "thirdweb/extensions/modular";
+ * const result = encodeMulticall({
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeMulticall(options: MulticallParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeMulticallParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "multicall" function on the contract.
+ * @param options - The options for the "multicall" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { multicall } from "thirdweb/extensions/modular";
+ *
+ * const transaction = multicall({
+ *  contract,
+ *  data: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function multicall(
+  options: BaseTransactionOptions<
+    | MulticallParams
+    | {
+        asyncParams: () => Promise<MulticallParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.data] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/renounceOwnership.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/renounceOwnership.ts
@@ -1,0 +1,53 @@
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0x715018a6" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `renounceOwnership` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `renounceOwnership` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isRenounceOwnershipSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isRenounceOwnershipSupported(contract);
+ * ```
+ */
+export async function isRenounceOwnershipSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Prepares a transaction to call the "renounceOwnership" function on the contract.
+ * @param options - The options for the "renounceOwnership" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { renounceOwnership } from "thirdweb/extensions/modular";
+ *
+ * const transaction = renounceOwnership();
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function renounceOwnership(options: BaseTransactionOptions) {
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/renounceRoles.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/renounceRoles.ts
@@ -1,0 +1,144 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "renounceRoles" function.
+ */
+export type RenounceRolesParams = WithOverrides<{
+  roles: AbiParameterToPrimitiveType<{
+    name: "roles";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0x183a4f6e" as const;
+const FN_INPUTS = [
+  {
+    name: "roles",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `renounceRoles` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `renounceRoles` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isRenounceRolesSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isRenounceRolesSupported(contract);
+ * ```
+ */
+export async function isRenounceRolesSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "renounceRoles" function.
+ * @param options - The options for the renounceRoles function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeRenounceRolesParams } "thirdweb/extensions/modular";
+ * const result = encodeRenounceRolesParams({
+ *  roles: ...,
+ * });
+ * ```
+ */
+export function encodeRenounceRolesParams(options: RenounceRolesParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.roles]);
+}
+
+/**
+ * Encodes the "renounceRoles" function into a Hex string with its parameters.
+ * @param options - The options for the renounceRoles function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeRenounceRoles } "thirdweb/extensions/modular";
+ * const result = encodeRenounceRoles({
+ *  roles: ...,
+ * });
+ * ```
+ */
+export function encodeRenounceRoles(options: RenounceRolesParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeRenounceRolesParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "renounceRoles" function on the contract.
+ * @param options - The options for the "renounceRoles" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { renounceRoles } from "thirdweb/extensions/modular";
+ *
+ * const transaction = renounceRoles({
+ *  contract,
+ *  roles: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function renounceRoles(
+  options: BaseTransactionOptions<
+    | RenounceRolesParams
+    | {
+        asyncParams: () => Promise<RenounceRolesParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.roles] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/requestOwnershipHandover.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/requestOwnershipHandover.ts
@@ -1,0 +1,53 @@
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0x25692962" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `requestOwnershipHandover` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `requestOwnershipHandover` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isRequestOwnershipHandoverSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isRequestOwnershipHandoverSupported(contract);
+ * ```
+ */
+export async function isRequestOwnershipHandoverSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Prepares a transaction to call the "requestOwnershipHandover" function on the contract.
+ * @param options - The options for the "requestOwnershipHandover" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { requestOwnershipHandover } from "thirdweb/extensions/modular";
+ *
+ * const transaction = requestOwnershipHandover();
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function requestOwnershipHandover(options: BaseTransactionOptions) {
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/revokeRoles.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/revokeRoles.ts
@@ -1,0 +1,155 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "revokeRoles" function.
+ */
+export type RevokeRolesParams = WithOverrides<{
+  user: AbiParameterToPrimitiveType<{
+    name: "user";
+    type: "address";
+    internalType: "address";
+  }>;
+  roles: AbiParameterToPrimitiveType<{
+    name: "roles";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0x4a4ee7b1" as const;
+const FN_INPUTS = [
+  {
+    name: "user",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "roles",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `revokeRoles` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `revokeRoles` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isRevokeRolesSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isRevokeRolesSupported(contract);
+ * ```
+ */
+export async function isRevokeRolesSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "revokeRoles" function.
+ * @param options - The options for the revokeRoles function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeRevokeRolesParams } "thirdweb/extensions/modular";
+ * const result = encodeRevokeRolesParams({
+ *  user: ...,
+ *  roles: ...,
+ * });
+ * ```
+ */
+export function encodeRevokeRolesParams(options: RevokeRolesParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.user, options.roles]);
+}
+
+/**
+ * Encodes the "revokeRoles" function into a Hex string with its parameters.
+ * @param options - The options for the revokeRoles function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeRevokeRoles } "thirdweb/extensions/modular";
+ * const result = encodeRevokeRoles({
+ *  user: ...,
+ *  roles: ...,
+ * });
+ * ```
+ */
+export function encodeRevokeRoles(options: RevokeRolesParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeRevokeRolesParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "revokeRoles" function on the contract.
+ * @param options - The options for the "revokeRoles" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { revokeRoles } from "thirdweb/extensions/modular";
+ *
+ * const transaction = revokeRoles({
+ *  contract,
+ *  user: ...,
+ *  roles: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function revokeRoles(
+  options: BaseTransactionOptions<
+    | RevokeRolesParams
+    | {
+        asyncParams: () => Promise<RevokeRolesParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.user, resolvedOptions.roles] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/safeTransferFrom.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/safeTransferFrom.ts
@@ -1,0 +1,178 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "safeTransferFrom" function.
+ */
+export type SafeTransferFromParams = WithOverrides<{
+  from: AbiParameterToPrimitiveType<{
+    name: "from";
+    type: "address";
+    internalType: "address";
+  }>;
+  to: AbiParameterToPrimitiveType<{
+    name: "to";
+    type: "address";
+    internalType: "address";
+  }>;
+  tokenId: AbiParameterToPrimitiveType<{
+    name: "tokenId";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0x42842e0e" as const;
+const FN_INPUTS = [
+  {
+    name: "from",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "to",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "tokenId",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `safeTransferFrom` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `safeTransferFrom` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isSafeTransferFromSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isSafeTransferFromSupported(contract);
+ * ```
+ */
+export async function isSafeTransferFromSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "safeTransferFrom" function.
+ * @param options - The options for the safeTransferFrom function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeSafeTransferFromParams } "thirdweb/extensions/modular";
+ * const result = encodeSafeTransferFromParams({
+ *  from: ...,
+ *  to: ...,
+ *  tokenId: ...,
+ * });
+ * ```
+ */
+export function encodeSafeTransferFromParams(options: SafeTransferFromParams) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.from,
+    options.to,
+    options.tokenId,
+  ]);
+}
+
+/**
+ * Encodes the "safeTransferFrom" function into a Hex string with its parameters.
+ * @param options - The options for the safeTransferFrom function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeSafeTransferFrom } "thirdweb/extensions/modular";
+ * const result = encodeSafeTransferFrom({
+ *  from: ...,
+ *  to: ...,
+ *  tokenId: ...,
+ * });
+ * ```
+ */
+export function encodeSafeTransferFrom(options: SafeTransferFromParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeSafeTransferFromParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "safeTransferFrom" function on the contract.
+ * @param options - The options for the "safeTransferFrom" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { safeTransferFrom } from "thirdweb/extensions/modular";
+ *
+ * const transaction = safeTransferFrom({
+ *  contract,
+ *  from: ...,
+ *  to: ...,
+ *  tokenId: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function safeTransferFrom(
+  options: BaseTransactionOptions<
+    | SafeTransferFromParams
+    | {
+        asyncParams: () => Promise<SafeTransferFromParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [
+        resolvedOptions.from,
+        resolvedOptions.to,
+        resolvedOptions.tokenId,
+      ] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/setApprovalForAll.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/setApprovalForAll.ts
@@ -1,0 +1,159 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "setApprovalForAll" function.
+ */
+export type SetApprovalForAllParams = WithOverrides<{
+  operator: AbiParameterToPrimitiveType<{
+    name: "operator";
+    type: "address";
+    internalType: "address";
+  }>;
+  approved: AbiParameterToPrimitiveType<{
+    name: "approved";
+    type: "bool";
+    internalType: "bool";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0xa22cb465" as const;
+const FN_INPUTS = [
+  {
+    name: "operator",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "approved",
+    type: "bool",
+    internalType: "bool",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `setApprovalForAll` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `setApprovalForAll` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isSetApprovalForAllSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isSetApprovalForAllSupported(contract);
+ * ```
+ */
+export async function isSetApprovalForAllSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "setApprovalForAll" function.
+ * @param options - The options for the setApprovalForAll function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeSetApprovalForAllParams } "thirdweb/extensions/modular";
+ * const result = encodeSetApprovalForAllParams({
+ *  operator: ...,
+ *  approved: ...,
+ * });
+ * ```
+ */
+export function encodeSetApprovalForAllParams(
+  options: SetApprovalForAllParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.operator, options.approved]);
+}
+
+/**
+ * Encodes the "setApprovalForAll" function into a Hex string with its parameters.
+ * @param options - The options for the setApprovalForAll function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeSetApprovalForAll } "thirdweb/extensions/modular";
+ * const result = encodeSetApprovalForAll({
+ *  operator: ...,
+ *  approved: ...,
+ * });
+ * ```
+ */
+export function encodeSetApprovalForAll(options: SetApprovalForAllParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeSetApprovalForAllParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "setApprovalForAll" function on the contract.
+ * @param options - The options for the "setApprovalForAll" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { setApprovalForAll } from "thirdweb/extensions/modular";
+ *
+ * const transaction = setApprovalForAll({
+ *  contract,
+ *  operator: ...,
+ *  approved: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function setApprovalForAll(
+  options: BaseTransactionOptions<
+    | SetApprovalForAllParams
+    | {
+        asyncParams: () => Promise<SetApprovalForAllParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.operator, resolvedOptions.approved] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/setContractURI.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/setContractURI.ts
@@ -1,0 +1,144 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "setContractURI" function.
+ */
+export type SetContractURIParams = WithOverrides<{
+  uri: AbiParameterToPrimitiveType<{
+    name: "uri";
+    type: "string";
+    internalType: "string";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0x938e3d7b" as const;
+const FN_INPUTS = [
+  {
+    name: "uri",
+    type: "string",
+    internalType: "string",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `setContractURI` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `setContractURI` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isSetContractURISupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isSetContractURISupported(contract);
+ * ```
+ */
+export async function isSetContractURISupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "setContractURI" function.
+ * @param options - The options for the setContractURI function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeSetContractURIParams } "thirdweb/extensions/modular";
+ * const result = encodeSetContractURIParams({
+ *  uri: ...,
+ * });
+ * ```
+ */
+export function encodeSetContractURIParams(options: SetContractURIParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.uri]);
+}
+
+/**
+ * Encodes the "setContractURI" function into a Hex string with its parameters.
+ * @param options - The options for the setContractURI function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeSetContractURI } "thirdweb/extensions/modular";
+ * const result = encodeSetContractURI({
+ *  uri: ...,
+ * });
+ * ```
+ */
+export function encodeSetContractURI(options: SetContractURIParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeSetContractURIParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "setContractURI" function on the contract.
+ * @param options - The options for the "setContractURI" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { setContractURI } from "thirdweb/extensions/modular";
+ *
+ * const transaction = setContractURI({
+ *  contract,
+ *  uri: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function setContractURI(
+  options: BaseTransactionOptions<
+    | SetContractURIParams
+    | {
+        asyncParams: () => Promise<SetContractURIParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.uri] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/transferFrom.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/transferFrom.ts
@@ -1,0 +1,172 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "transferFrom" function.
+ */
+export type TransferFromParams = WithOverrides<{
+  from: AbiParameterToPrimitiveType<{
+    name: "from";
+    type: "address";
+    internalType: "address";
+  }>;
+  to: AbiParameterToPrimitiveType<{
+    name: "to";
+    type: "address";
+    internalType: "address";
+  }>;
+  id: AbiParameterToPrimitiveType<{
+    name: "id";
+    type: "uint256";
+    internalType: "uint256";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0x23b872dd" as const;
+const FN_INPUTS = [
+  {
+    name: "from",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "to",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "id",
+    type: "uint256",
+    internalType: "uint256",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `transferFrom` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `transferFrom` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isTransferFromSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isTransferFromSupported(contract);
+ * ```
+ */
+export async function isTransferFromSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "transferFrom" function.
+ * @param options - The options for the transferFrom function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeTransferFromParams } "thirdweb/extensions/modular";
+ * const result = encodeTransferFromParams({
+ *  from: ...,
+ *  to: ...,
+ *  id: ...,
+ * });
+ * ```
+ */
+export function encodeTransferFromParams(options: TransferFromParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.from, options.to, options.id]);
+}
+
+/**
+ * Encodes the "transferFrom" function into a Hex string with its parameters.
+ * @param options - The options for the transferFrom function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeTransferFrom } "thirdweb/extensions/modular";
+ * const result = encodeTransferFrom({
+ *  from: ...,
+ *  to: ...,
+ *  id: ...,
+ * });
+ * ```
+ */
+export function encodeTransferFrom(options: TransferFromParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeTransferFromParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "transferFrom" function on the contract.
+ * @param options - The options for the "transferFrom" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { transferFrom } from "thirdweb/extensions/modular";
+ *
+ * const transaction = transferFrom({
+ *  contract,
+ *  from: ...,
+ *  to: ...,
+ *  id: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function transferFrom(
+  options: BaseTransactionOptions<
+    | TransferFromParams
+    | {
+        asyncParams: () => Promise<TransferFromParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [
+        resolvedOptions.from,
+        resolvedOptions.to,
+        resolvedOptions.id,
+      ] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/transferOwnership.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/transferOwnership.ts
@@ -1,0 +1,146 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "transferOwnership" function.
+ */
+export type TransferOwnershipParams = WithOverrides<{
+  newOwner: AbiParameterToPrimitiveType<{
+    name: "newOwner";
+    type: "address";
+    internalType: "address";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0xf2fde38b" as const;
+const FN_INPUTS = [
+  {
+    name: "newOwner",
+    type: "address",
+    internalType: "address",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `transferOwnership` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `transferOwnership` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isTransferOwnershipSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isTransferOwnershipSupported(contract);
+ * ```
+ */
+export async function isTransferOwnershipSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "transferOwnership" function.
+ * @param options - The options for the transferOwnership function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeTransferOwnershipParams } "thirdweb/extensions/modular";
+ * const result = encodeTransferOwnershipParams({
+ *  newOwner: ...,
+ * });
+ * ```
+ */
+export function encodeTransferOwnershipParams(
+  options: TransferOwnershipParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.newOwner]);
+}
+
+/**
+ * Encodes the "transferOwnership" function into a Hex string with its parameters.
+ * @param options - The options for the transferOwnership function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeTransferOwnership } "thirdweb/extensions/modular";
+ * const result = encodeTransferOwnership({
+ *  newOwner: ...,
+ * });
+ * ```
+ */
+export function encodeTransferOwnership(options: TransferOwnershipParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeTransferOwnershipParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "transferOwnership" function on the contract.
+ * @param options - The options for the "transferOwnership" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { transferOwnership } from "thirdweb/extensions/modular";
+ *
+ * const transaction = transferOwnership({
+ *  contract,
+ *  newOwner: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function transferOwnership(
+  options: BaseTransactionOptions<
+    | TransferOwnershipParams
+    | {
+        asyncParams: () => Promise<TransferOwnershipParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.newOwner] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/uninstallExtension.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/uninstallExtension.ts
@@ -1,0 +1,159 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "uninstallExtension" function.
+ */
+export type UninstallExtensionParams = WithOverrides<{
+  extension: AbiParameterToPrimitiveType<{
+    name: "_extension";
+    type: "address";
+    internalType: "address";
+  }>;
+  data: AbiParameterToPrimitiveType<{
+    name: "_data";
+    type: "bytes";
+    internalType: "bytes";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0x42b7d0c8" as const;
+const FN_INPUTS = [
+  {
+    name: "_extension",
+    type: "address",
+    internalType: "address",
+  },
+  {
+    name: "_data",
+    type: "bytes",
+    internalType: "bytes",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `uninstallExtension` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `uninstallExtension` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isUninstallExtensionSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isUninstallExtensionSupported(contract);
+ * ```
+ */
+export async function isUninstallExtensionSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "uninstallExtension" function.
+ * @param options - The options for the uninstallExtension function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeUninstallExtensionParams } "thirdweb/extensions/modular";
+ * const result = encodeUninstallExtensionParams({
+ *  extension: ...,
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeUninstallExtensionParams(
+  options: UninstallExtensionParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.extension, options.data]);
+}
+
+/**
+ * Encodes the "uninstallExtension" function into a Hex string with its parameters.
+ * @param options - The options for the uninstallExtension function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeUninstallExtension } "thirdweb/extensions/modular";
+ * const result = encodeUninstallExtension({
+ *  extension: ...,
+ *  data: ...,
+ * });
+ * ```
+ */
+export function encodeUninstallExtension(options: UninstallExtensionParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeUninstallExtensionParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "uninstallExtension" function on the contract.
+ * @param options - The options for the "uninstallExtension" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { uninstallExtension } from "thirdweb/extensions/modular";
+ *
+ * const transaction = uninstallExtension({
+ *  contract,
+ *  extension: ...,
+ *  data: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function uninstallExtension(
+  options: BaseTransactionOptions<
+    | UninstallExtensionParams
+    | {
+        asyncParams: () => Promise<UninstallExtensionParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.extension, resolvedOptions.data] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/MintableERC1155/read/mint.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/MintableERC1155/read/mint.ts
@@ -1,0 +1,172 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "mint" function.
+ */
+export type MintParams = {
+  params: AbiParameterToPrimitiveType<{
+    type: "tuple";
+    name: "params";
+    components: [
+      {
+        type: "tuple";
+        name: "request";
+        components: [
+          { type: "uint48"; name: "startTimestamp" },
+          { type: "uint48"; name: "endTimestamp" },
+          { type: "address"; name: "recipient" },
+          { type: "uint256"; name: "quantity" },
+          { type: "address"; name: "currency" },
+          { type: "uint256"; name: "pricePerUnit" },
+          { type: "string"; name: "metadataURI" },
+          { type: "bytes32"; name: "uid" },
+        ];
+      },
+      { type: "bytes"; name: "signature" },
+      { type: "string"; name: "metadataURI" },
+    ];
+  }>;
+};
+
+export const FN_SELECTOR = "0xee6d6e23" as const;
+const FN_INPUTS = [
+  {
+    type: "tuple",
+    name: "params",
+    components: [
+      {
+        type: "tuple",
+        name: "request",
+        components: [
+          {
+            type: "uint48",
+            name: "startTimestamp",
+          },
+          {
+            type: "uint48",
+            name: "endTimestamp",
+          },
+          {
+            type: "address",
+            name: "recipient",
+          },
+          {
+            type: "uint256",
+            name: "quantity",
+          },
+          {
+            type: "address",
+            name: "currency",
+          },
+          {
+            type: "uint256",
+            name: "pricePerUnit",
+          },
+          {
+            type: "string",
+            name: "metadataURI",
+          },
+          {
+            type: "bytes32",
+            name: "uid",
+          },
+        ],
+      },
+      {
+        type: "bytes",
+        name: "signature",
+      },
+      {
+        type: "string",
+        name: "metadataURI",
+      },
+    ],
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `mint` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `mint` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isMintSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isMintSupported(contract);
+ * ```
+ */
+export async function isMintSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "mint" function.
+ * @param options - The options for the mint function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeMintParams } "thirdweb/extensions/modular";
+ * const result = encodeMintParams({
+ *  params: ...,
+ * });
+ * ```
+ */
+export function encodeMintParams(options: MintParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.params]);
+}
+
+/**
+ * Encodes the "mint" function into a Hex string with its parameters.
+ * @param options - The options for the mint function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeMint } "thirdweb/extensions/modular";
+ * const result = encodeMint({
+ *  params: ...,
+ * });
+ * ```
+ */
+export function encodeMint(options: MintParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeMintParams(options).slice(2)) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Calls the "mint" function on the contract.
+ * @param options - The options for the mint function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { mint } from "thirdweb/extensions/modular";
+ *
+ * const result = await mint({
+ *  contract,
+ *  params: ...,
+ * });
+ *
+ * ```
+ */
+export async function mint(options: BaseTransactionOptions<MintParams>) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.params],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/MintableERC1155/write/grantRoles.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/MintableERC1155/write/grantRoles.ts
@@ -1,0 +1,145 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "grantRoles" function.
+ */
+export type GrantRolesParams = WithOverrides<{
+  user: AbiParameterToPrimitiveType<{ type: "address"; name: "user" }>;
+  roles: AbiParameterToPrimitiveType<{ type: "uint256"; name: "roles" }>;
+}>;
+
+export const FN_SELECTOR = "0x1c10893f" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "user",
+  },
+  {
+    type: "uint256",
+    name: "roles",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `grantRoles` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `grantRoles` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isGrantRolesSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isGrantRolesSupported(contract);
+ * ```
+ */
+export async function isGrantRolesSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "grantRoles" function.
+ * @param options - The options for the grantRoles function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeGrantRolesParams } "thirdweb/extensions/modular";
+ * const result = encodeGrantRolesParams({
+ *  user: ...,
+ *  roles: ...,
+ * });
+ * ```
+ */
+export function encodeGrantRolesParams(options: GrantRolesParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.user, options.roles]);
+}
+
+/**
+ * Encodes the "grantRoles" function into a Hex string with its parameters.
+ * @param options - The options for the grantRoles function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeGrantRoles } "thirdweb/extensions/modular";
+ * const result = encodeGrantRoles({
+ *  user: ...,
+ *  roles: ...,
+ * });
+ * ```
+ */
+export function encodeGrantRoles(options: GrantRolesParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeGrantRolesParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "grantRoles" function on the contract.
+ * @param options - The options for the "grantRoles" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { grantRoles } from "thirdweb/extensions/modular";
+ *
+ * const transaction = grantRoles({
+ *  contract,
+ *  user: ...,
+ *  roles: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function grantRoles(
+  options: BaseTransactionOptions<
+    | GrantRolesParams
+    | {
+        asyncParams: () => Promise<GrantRolesParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.user, resolvedOptions.roles] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/MintableERC1155/write/setSaleConfig.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/MintableERC1155/write/setSaleConfig.ts
@@ -1,0 +1,142 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "setSaleConfig" function.
+ */
+export type SetSaleConfigParams = WithOverrides<{
+  primarySaleRecipient: AbiParameterToPrimitiveType<{
+    type: "address";
+    name: "_primarySaleRecipient";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0xd29a3628" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "_primarySaleRecipient",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `setSaleConfig` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `setSaleConfig` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isSetSaleConfigSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isSetSaleConfigSupported(contract);
+ * ```
+ */
+export async function isSetSaleConfigSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "setSaleConfig" function.
+ * @param options - The options for the setSaleConfig function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeSetSaleConfigParams } "thirdweb/extensions/modular";
+ * const result = encodeSetSaleConfigParams({
+ *  primarySaleRecipient: ...,
+ * });
+ * ```
+ */
+export function encodeSetSaleConfigParams(options: SetSaleConfigParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.primarySaleRecipient]);
+}
+
+/**
+ * Encodes the "setSaleConfig" function into a Hex string with its parameters.
+ * @param options - The options for the setSaleConfig function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeSetSaleConfig } "thirdweb/extensions/modular";
+ * const result = encodeSetSaleConfig({
+ *  primarySaleRecipient: ...,
+ * });
+ * ```
+ */
+export function encodeSetSaleConfig(options: SetSaleConfigParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeSetSaleConfigParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "setSaleConfig" function on the contract.
+ * @param options - The options for the "setSaleConfig" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { setSaleConfig } from "thirdweb/extensions/modular";
+ *
+ * const transaction = setSaleConfig({
+ *  contract,
+ *  primarySaleRecipient: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function setSaleConfig(
+  options: BaseTransactionOptions<
+    | SetSaleConfigParams
+    | {
+        asyncParams: () => Promise<SetSaleConfigParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.primarySaleRecipient] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/MintableERC20/read/mint.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/MintableERC20/read/mint.ts
@@ -1,0 +1,162 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "mint" function.
+ */
+export type MintParams = {
+  params: AbiParameterToPrimitiveType<{
+    type: "tuple";
+    name: "params";
+    components: [
+      {
+        type: "tuple";
+        name: "request";
+        components: [
+          { type: "uint48"; name: "startTimestamp" },
+          { type: "uint48"; name: "endTimestamp" },
+          { type: "address"; name: "recipient" },
+          { type: "uint256"; name: "quantity" },
+          { type: "address"; name: "currency" },
+          { type: "uint256"; name: "pricePerUnit" },
+          { type: "bytes32"; name: "uid" },
+        ];
+      },
+      { type: "bytes"; name: "signature" },
+    ];
+  }>;
+};
+
+export const FN_SELECTOR = "0xa0581627" as const;
+const FN_INPUTS = [
+  {
+    type: "tuple",
+    name: "params",
+    components: [
+      {
+        type: "tuple",
+        name: "request",
+        components: [
+          {
+            type: "uint48",
+            name: "startTimestamp",
+          },
+          {
+            type: "uint48",
+            name: "endTimestamp",
+          },
+          {
+            type: "address",
+            name: "recipient",
+          },
+          {
+            type: "uint256",
+            name: "quantity",
+          },
+          {
+            type: "address",
+            name: "currency",
+          },
+          {
+            type: "uint256",
+            name: "pricePerUnit",
+          },
+          {
+            type: "bytes32",
+            name: "uid",
+          },
+        ],
+      },
+      {
+        type: "bytes",
+        name: "signature",
+      },
+    ],
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `mint` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `mint` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isMintSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isMintSupported(contract);
+ * ```
+ */
+export async function isMintSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "mint" function.
+ * @param options - The options for the mint function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeMintParams } "thirdweb/extensions/modular";
+ * const result = encodeMintParams({
+ *  params: ...,
+ * });
+ * ```
+ */
+export function encodeMintParams(options: MintParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.params]);
+}
+
+/**
+ * Encodes the "mint" function into a Hex string with its parameters.
+ * @param options - The options for the mint function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeMint } "thirdweb/extensions/modular";
+ * const result = encodeMint({
+ *  params: ...,
+ * });
+ * ```
+ */
+export function encodeMint(options: MintParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeMintParams(options).slice(2)) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Calls the "mint" function on the contract.
+ * @param options - The options for the mint function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { mint } from "thirdweb/extensions/modular";
+ *
+ * const result = await mint({
+ *  contract,
+ *  params: ...,
+ * });
+ *
+ * ```
+ */
+export async function mint(options: BaseTransactionOptions<MintParams>) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.params],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/MintableERC20/write/grantRoles.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/MintableERC20/write/grantRoles.ts
@@ -1,0 +1,145 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "grantRoles" function.
+ */
+export type GrantRolesParams = WithOverrides<{
+  user: AbiParameterToPrimitiveType<{ type: "address"; name: "user" }>;
+  roles: AbiParameterToPrimitiveType<{ type: "uint256"; name: "roles" }>;
+}>;
+
+export const FN_SELECTOR = "0x1c10893f" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "user",
+  },
+  {
+    type: "uint256",
+    name: "roles",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `grantRoles` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `grantRoles` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isGrantRolesSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isGrantRolesSupported(contract);
+ * ```
+ */
+export async function isGrantRolesSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "grantRoles" function.
+ * @param options - The options for the grantRoles function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeGrantRolesParams } "thirdweb/extensions/modular";
+ * const result = encodeGrantRolesParams({
+ *  user: ...,
+ *  roles: ...,
+ * });
+ * ```
+ */
+export function encodeGrantRolesParams(options: GrantRolesParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.user, options.roles]);
+}
+
+/**
+ * Encodes the "grantRoles" function into a Hex string with its parameters.
+ * @param options - The options for the grantRoles function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeGrantRoles } "thirdweb/extensions/modular";
+ * const result = encodeGrantRoles({
+ *  user: ...,
+ *  roles: ...,
+ * });
+ * ```
+ */
+export function encodeGrantRoles(options: GrantRolesParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeGrantRolesParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "grantRoles" function on the contract.
+ * @param options - The options for the "grantRoles" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { grantRoles } from "thirdweb/extensions/modular";
+ *
+ * const transaction = grantRoles({
+ *  contract,
+ *  user: ...,
+ *  roles: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function grantRoles(
+  options: BaseTransactionOptions<
+    | GrantRolesParams
+    | {
+        asyncParams: () => Promise<GrantRolesParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.user, resolvedOptions.roles] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/MintableERC20/write/setSaleConfig.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/MintableERC20/write/setSaleConfig.ts
@@ -1,0 +1,142 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "setSaleConfig" function.
+ */
+export type SetSaleConfigParams = WithOverrides<{
+  primarySaleRecipient: AbiParameterToPrimitiveType<{
+    type: "address";
+    name: "_primarySaleRecipient";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0xd29a3628" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "_primarySaleRecipient",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `setSaleConfig` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `setSaleConfig` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isSetSaleConfigSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isSetSaleConfigSupported(contract);
+ * ```
+ */
+export async function isSetSaleConfigSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "setSaleConfig" function.
+ * @param options - The options for the setSaleConfig function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeSetSaleConfigParams } "thirdweb/extensions/modular";
+ * const result = encodeSetSaleConfigParams({
+ *  primarySaleRecipient: ...,
+ * });
+ * ```
+ */
+export function encodeSetSaleConfigParams(options: SetSaleConfigParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.primarySaleRecipient]);
+}
+
+/**
+ * Encodes the "setSaleConfig" function into a Hex string with its parameters.
+ * @param options - The options for the setSaleConfig function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeSetSaleConfig } "thirdweb/extensions/modular";
+ * const result = encodeSetSaleConfig({
+ *  primarySaleRecipient: ...,
+ * });
+ * ```
+ */
+export function encodeSetSaleConfig(options: SetSaleConfigParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeSetSaleConfigParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "setSaleConfig" function on the contract.
+ * @param options - The options for the "setSaleConfig" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { setSaleConfig } from "thirdweb/extensions/modular";
+ *
+ * const transaction = setSaleConfig({
+ *  contract,
+ *  primarySaleRecipient: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function setSaleConfig(
+  options: BaseTransactionOptions<
+    | SetSaleConfigParams
+    | {
+        asyncParams: () => Promise<SetSaleConfigParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.primarySaleRecipient] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/MintableERC721/read/mint.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/MintableERC721/read/mint.ts
@@ -1,0 +1,172 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "mint" function.
+ */
+export type MintParams = {
+  params: AbiParameterToPrimitiveType<{
+    type: "tuple";
+    name: "params";
+    components: [
+      {
+        type: "tuple";
+        name: "request";
+        components: [
+          { type: "uint48"; name: "startTimestamp" },
+          { type: "uint48"; name: "endTimestamp" },
+          { type: "address"; name: "recipient" },
+          { type: "uint256"; name: "quantity" },
+          { type: "address"; name: "currency" },
+          { type: "uint256"; name: "pricePerUnit" },
+          { type: "string"; name: "baseURI" },
+          { type: "bytes32"; name: "uid" },
+        ];
+      },
+      { type: "bytes"; name: "signature" },
+      { type: "string"; name: "baseURI" },
+    ];
+  }>;
+};
+
+export const FN_SELECTOR = "0xee6d6e23" as const;
+const FN_INPUTS = [
+  {
+    type: "tuple",
+    name: "params",
+    components: [
+      {
+        type: "tuple",
+        name: "request",
+        components: [
+          {
+            type: "uint48",
+            name: "startTimestamp",
+          },
+          {
+            type: "uint48",
+            name: "endTimestamp",
+          },
+          {
+            type: "address",
+            name: "recipient",
+          },
+          {
+            type: "uint256",
+            name: "quantity",
+          },
+          {
+            type: "address",
+            name: "currency",
+          },
+          {
+            type: "uint256",
+            name: "pricePerUnit",
+          },
+          {
+            type: "string",
+            name: "baseURI",
+          },
+          {
+            type: "bytes32",
+            name: "uid",
+          },
+        ],
+      },
+      {
+        type: "bytes",
+        name: "signature",
+      },
+      {
+        type: "string",
+        name: "baseURI",
+      },
+    ],
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `mint` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `mint` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isMintSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isMintSupported(contract);
+ * ```
+ */
+export async function isMintSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "mint" function.
+ * @param options - The options for the mint function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeMintParams } "thirdweb/extensions/modular";
+ * const result = encodeMintParams({
+ *  params: ...,
+ * });
+ * ```
+ */
+export function encodeMintParams(options: MintParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.params]);
+}
+
+/**
+ * Encodes the "mint" function into a Hex string with its parameters.
+ * @param options - The options for the mint function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeMint } "thirdweb/extensions/modular";
+ * const result = encodeMint({
+ *  params: ...,
+ * });
+ * ```
+ */
+export function encodeMint(options: MintParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeMintParams(options).slice(2)) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Calls the "mint" function on the contract.
+ * @param options - The options for the mint function.
+ * @returns The parsed result of the function call.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { mint } from "thirdweb/extensions/modular";
+ *
+ * const result = await mint({
+ *  contract,
+ *  params: ...,
+ * });
+ *
+ * ```
+ */
+export async function mint(options: BaseTransactionOptions<MintParams>) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.params],
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/MintableERC721/write/grantRoles.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/MintableERC721/write/grantRoles.ts
@@ -1,0 +1,145 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "grantRoles" function.
+ */
+export type GrantRolesParams = WithOverrides<{
+  user: AbiParameterToPrimitiveType<{ type: "address"; name: "user" }>;
+  roles: AbiParameterToPrimitiveType<{ type: "uint256"; name: "roles" }>;
+}>;
+
+export const FN_SELECTOR = "0x1c10893f" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "user",
+  },
+  {
+    type: "uint256",
+    name: "roles",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `grantRoles` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `grantRoles` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isGrantRolesSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isGrantRolesSupported(contract);
+ * ```
+ */
+export async function isGrantRolesSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "grantRoles" function.
+ * @param options - The options for the grantRoles function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeGrantRolesParams } "thirdweb/extensions/modular";
+ * const result = encodeGrantRolesParams({
+ *  user: ...,
+ *  roles: ...,
+ * });
+ * ```
+ */
+export function encodeGrantRolesParams(options: GrantRolesParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.user, options.roles]);
+}
+
+/**
+ * Encodes the "grantRoles" function into a Hex string with its parameters.
+ * @param options - The options for the grantRoles function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeGrantRoles } "thirdweb/extensions/modular";
+ * const result = encodeGrantRoles({
+ *  user: ...,
+ *  roles: ...,
+ * });
+ * ```
+ */
+export function encodeGrantRoles(options: GrantRolesParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeGrantRolesParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "grantRoles" function on the contract.
+ * @param options - The options for the "grantRoles" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { grantRoles } from "thirdweb/extensions/modular";
+ *
+ * const transaction = grantRoles({
+ *  contract,
+ *  user: ...,
+ *  roles: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function grantRoles(
+  options: BaseTransactionOptions<
+    | GrantRolesParams
+    | {
+        asyncParams: () => Promise<GrantRolesParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.user, resolvedOptions.roles] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/__generated__/MintableERC721/write/setSaleConfig.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/MintableERC721/write/setSaleConfig.ts
@@ -1,0 +1,142 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "setSaleConfig" function.
+ */
+export type SetSaleConfigParams = WithOverrides<{
+  primarySaleRecipient: AbiParameterToPrimitiveType<{
+    type: "address";
+    name: "_primarySaleRecipient";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0xd29a3628" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "_primarySaleRecipient",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `setSaleConfig` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `setSaleConfig` method is supported.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { isSetSaleConfigSupported } from "thirdweb/extensions/modular";
+ *
+ * const supported = await isSetSaleConfigSupported(contract);
+ * ```
+ */
+export async function isSetSaleConfigSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "setSaleConfig" function.
+ * @param options - The options for the setSaleConfig function.
+ * @returns The encoded ABI parameters.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeSetSaleConfigParams } "thirdweb/extensions/modular";
+ * const result = encodeSetSaleConfigParams({
+ *  primarySaleRecipient: ...,
+ * });
+ * ```
+ */
+export function encodeSetSaleConfigParams(options: SetSaleConfigParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.primarySaleRecipient]);
+}
+
+/**
+ * Encodes the "setSaleConfig" function into a Hex string with its parameters.
+ * @param options - The options for the setSaleConfig function.
+ * @returns The encoded hexadecimal string.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { encodeSetSaleConfig } "thirdweb/extensions/modular";
+ * const result = encodeSetSaleConfig({
+ *  primarySaleRecipient: ...,
+ * });
+ * ```
+ */
+export function encodeSetSaleConfig(options: SetSaleConfigParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeSetSaleConfigParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "setSaleConfig" function on the contract.
+ * @param options - The options for the "setSaleConfig" function.
+ * @returns A prepared transaction object.
+ * @extension MODULAR
+ * @example
+ * ```ts
+ * import { setSaleConfig } from "thirdweb/extensions/modular";
+ *
+ * const transaction = setSaleConfig({
+ *  contract,
+ *  primarySaleRecipient: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function setSaleConfig(
+  options: BaseTransactionOptions<
+    | SetSaleConfigParams
+    | {
+        asyncParams: () => Promise<SetSaleConfigParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.primarySaleRecipient] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/write/grantMinterRole.ts
+++ b/packages/thirdweb/src/extensions/modular/write/grantMinterRole.ts
@@ -1,0 +1,23 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type { BaseTransactionOptions } from "../../../transaction/types.js";
+import { grantRoles } from "../__generated__/MintableERC20/write/grantRoles.js";
+
+const MINTER_ROLE = 1n;
+
+export type GrantMinterRoleParams = {
+  user: AbiParameterToPrimitiveType<{
+    name: "user";
+    type: "address";
+    internalType: "address";
+  }>;
+};
+
+export function grantMinterRole(
+  options: BaseTransactionOptions<GrantMinterRoleParams>,
+) {
+  return grantRoles({
+    contract: options.contract,
+    user: options.user,
+    roles: MINTER_ROLE,
+  });
+}

--- a/packages/thirdweb/src/extensions/modular/write/mintableERC1155.ts
+++ b/packages/thirdweb/src/extensions/modular/write/mintableERC1155.ts
@@ -1,0 +1,216 @@
+import { mint as generatedMint } from "../__generated__/ERC1155Core/write/mint.js";
+import { encodeMintParams } from "../__generated__/MintableERC1155/read/mint.js";
+
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { ADDRESS_ZERO } from "../../../constants/addresses.js";
+import { NATIVE_TOKEN_ADDRESS } from "../../../constants/addresses.js";
+import type { ThirdwebContract } from "../../../contract/contract.js";
+import type { BaseTransactionOptions } from "../../../transaction/types.js";
+import type { Address } from "../../../utils/address.js";
+import { dateToSeconds, tenYearsFromNow } from "../../../utils/date.js";
+import type { Hex } from "../../../utils/encoding/hex.js";
+import {
+  getBaseUriFromBatch,
+  uploadOrExtractURIs,
+} from "../../../utils/ipfs.js";
+import type { NFTInput } from "../../../utils/nft/parseNft.js";
+import { randomBytesHex } from "../../../utils/random.js";
+import type { Account } from "../../../wallets/interfaces/wallet.js";
+
+export type EditionMintParams = {
+  to: Address;
+  tokenId: bigint;
+  amount: bigint;
+  nft: NFTInput | string;
+};
+
+export type NFTSignatureMintParams = {
+  to: Address;
+  nfts: (NFTInput | string)[];
+};
+
+export function mintWithPermissions(
+  options: BaseTransactionOptions<EditionMintParams>,
+) {
+  return generatedMint({
+    contract: options.contract,
+    asyncParams: async () => {
+      const batchOfUris = await uploadOrExtractURIs(
+        [options.nft],
+        options.contract.client,
+        0,
+      );
+
+      const baseURI = getBaseUriFromBatch(batchOfUris);
+
+      const emptyPayload = {
+        tokenId: options.tokenId,
+        pricePerUnit: 0n,
+        quantity: 0n,
+        uid: randomBytesHex(),
+        currency: ADDRESS_ZERO,
+        recipient: ADDRESS_ZERO,
+        startTimestamp: 0,
+        endTimestamp: 0,
+        metadataURI: "",
+      };
+
+      return {
+        to: options.to,
+        tokenId: options.tokenId,
+        value: options.amount,
+        data: encodeMintParams({
+          params: {
+            request: emptyPayload,
+            signature: "0x",
+            metadataURI: `${baseURI}0`,
+          },
+        }),
+      };
+    },
+  });
+}
+
+export function mintWithSignature(
+  options: BaseTransactionOptions<GenerateMintSignatureOptions>,
+) {
+  return generatedMint({
+    contract: options.contract,
+    asyncParams: async () => {
+      const { payload, signature, metadataURI } =
+        await generateMintSignature(options);
+
+      return {
+        to: payload.recipient,
+        tokenId: payload.tokenId,
+        value: BigInt(payload.quantity),
+        data: encodeMintParams({
+          params: {
+            request: payload,
+            signature,
+            metadataURI,
+          },
+        }),
+      };
+    },
+  });
+}
+
+export type GenerateMintSignatureOptions = {
+  account: Account;
+  contract: ThirdwebContract;
+  nft: NFTInput | string;
+  mintRequest: GeneratePayloadInput;
+};
+
+/**
+ * Generates the payload and signature for minting an ERC1155 token.
+ * @param options - The options for the minting process.
+ * @example
+ * ```ts
+ * import { mintWithSignature, generateMintSignature } from "thirdweb/extensions/ERC1155";
+ *
+ * const { payload, signature } = await generateMintSignature({
+ *   account,
+ *   contract,
+ *   mintRequest: {
+ *     recipient: "0x...",
+ *     quantity: "10",
+ *   },
+ * });
+ *
+ * const transaction = mintWithSignature({
+ *   contract,
+ *   payload,
+ *   signature,
+ * });
+ * await sendTransaction({ transaction, account });
+ * ```
+ * @extension ERC1155
+ * @returns A promise that resolves to the payload and signature.
+ */
+export async function generateMintSignature(
+  options: GenerateMintSignatureOptions,
+) {
+  const { mintRequest, account, contract } = options;
+  const currency = mintRequest.currency || NATIVE_TOKEN_ADDRESS;
+  const [pricePerUnit, uid] = await Promise.all([
+    // price per token in wei
+    (async () => {
+      // if priceInWei is provided, use it
+      if ("priceInWei" in mintRequest && mintRequest.priceInWei) {
+        return mintRequest.priceInWei;
+      }
+
+      // if neither price nor priceInWei is provided, default to 0
+      return 0n;
+    })(),
+    // uid computation
+    mintRequest.uid || (await randomBytesHex()),
+  ]);
+
+  const startTime = mintRequest.validityStartTimestamp || new Date(0);
+  const endTime = mintRequest.validityEndTimestamp || tenYearsFromNow();
+
+  const batchOfUris = await uploadOrExtractURIs(
+    [options.nft],
+    options.contract.client,
+    0,
+  );
+
+  const metadataURI = `${getBaseUriFromBatch(batchOfUris)}0`;
+
+  const payload: PayloadType = {
+    pricePerUnit,
+    uid,
+    currency,
+    tokenId: mintRequest.tokenId,
+    recipient: mintRequest.recipient,
+    quantity: mintRequest.quantity,
+    startTimestamp: Number(dateToSeconds(startTime)),
+    endTimestamp: Number(dateToSeconds(endTime)),
+    metadataURI: metadataURI,
+  };
+
+  const signature = await account.signTypedData({
+    domain: {
+      name: "MintableERC1155",
+      version: "1",
+      chainId: contract.chain.id,
+      verifyingContract: contract.address as Hex,
+    },
+    types: { MintRequestERC1155: MintRequestERC1155 },
+    primaryType: "MintRequestERC1155",
+    message: payload,
+  });
+  return { payload, signature, metadataURI };
+}
+
+type PayloadType = AbiParameterToPrimitiveType<{
+  type: "tuple";
+  name: "payload";
+  components: typeof MintRequestERC1155;
+}>;
+
+type GeneratePayloadInput = {
+  recipient: Address;
+  tokenId: bigint;
+  quantity: bigint;
+  currency?: Address;
+  priceInWei?: bigint;
+  uid?: Hex;
+  validityStartTimestamp?: Date;
+  validityEndTimestamp?: Date;
+};
+
+export const MintRequestERC1155 = [
+  { name: "tokenId", type: "uint256" },
+  { name: "startTimestamp", type: "uint48" },
+  { name: "endTimestamp", type: "uint48" },
+  { name: "recipient", type: "address" },
+  { name: "quantity", type: "uint256" },
+  { name: "currency", type: "address" },
+  { name: "pricePerUnit", type: "uint256" },
+  { name: "metadataURI", type: "string" },
+  { name: "uid", type: "bytes32" },
+] as const;

--- a/packages/thirdweb/src/extensions/modular/write/mintableERC20.ts
+++ b/packages/thirdweb/src/extensions/modular/write/mintableERC20.ts
@@ -1,0 +1,207 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { ADDRESS_ZERO } from "../../../constants/addresses.js";
+import { NATIVE_TOKEN_ADDRESS } from "../../../constants/addresses.js";
+import type { ThirdwebContract } from "../../../contract/contract.js";
+import type { BaseTransactionOptions } from "../../../transaction/types.js";
+import type { Address } from "../../../utils/address.js";
+import { dateToSeconds, tenYearsFromNow } from "../../../utils/date.js";
+import type { Hex } from "../../../utils/encoding/hex.js";
+import { randomBytesHex } from "../../../utils/random.js";
+import type { Account } from "../../../wallets/interfaces/wallet.js";
+import { mint as generatedMint } from "../__generated__/ERC20Core/write/mint.js";
+import { encodeMintParams } from "../__generated__/MintableERC20/read/mint.js";
+
+export type TokenMintParams = {
+  to: Address;
+} & ({ quantity: string } | { quantityWei: bigint });
+
+export function mintWithPermissions(
+  options: BaseTransactionOptions<TokenMintParams>,
+) {
+  return generatedMint({
+    contract: options.contract,
+    asyncParams: async () => {
+      let amount = 0n;
+
+      // if the quantity is already passed in wei, use it
+      if ("quantityWei" in options) {
+        amount = options.quantityWei;
+      } else if ("quantity" in options) {
+        // otherwise convert the quantity to wei using the contract's OWN decimals
+        const { convertErc20Amount } = await import(
+          "../../../utils/extensions/convert-erc20-amount.js"
+        );
+        amount = await convertErc20Amount({
+          amount: options.quantity,
+          client: options.contract.client,
+          chain: options.contract.chain,
+          erc20Address: options.contract.address,
+        });
+      }
+
+      const emptyPayload = {
+        pricePerUnit: 0n,
+        quantity: 0n,
+        uid: randomBytesHex(),
+        currency: ADDRESS_ZERO,
+        recipient: ADDRESS_ZERO,
+        startTimestamp: 0,
+        endTimestamp: 0,
+      };
+
+      return {
+        to: options.to,
+        amount: BigInt(amount),
+        data: encodeMintParams({
+          params: {
+            request: emptyPayload,
+            signature: "0x",
+          },
+        }),
+      };
+    },
+  });
+}
+
+export function mintWithSignature(
+  options: BaseTransactionOptions<GenerateMintSignatureOptions>,
+) {
+  return generatedMint({
+    contract: options.contract,
+    asyncParams: async () => {
+      const { payload, signature } = await generateMintSignature(options);
+
+      return {
+        to: payload.recipient,
+        amount: BigInt(payload.quantity),
+        data: encodeMintParams({
+          params: {
+            request: payload,
+            signature,
+          },
+        }),
+      };
+    },
+  });
+}
+
+export type GenerateMintSignatureOptions = {
+  account: Account;
+  contract: ThirdwebContract;
+  mintRequest: GeneratePayloadInput;
+};
+
+/**
+ * Generates the payload and signature for minting an ERC20 token.
+ * @param options - The options for the minting process.
+ * @example
+ * ```ts
+ * import { mintWithSignature, generateMintSignature } from "thirdweb/extensions/erc20";
+ *
+ * const { payload, signature } = await generateMintSignature({
+ *   account,
+ *   contract,
+ *   mintRequest: {
+ *     recipient: "0x...",
+ *     quantity: "10",
+ *   },
+ * });
+ *
+ * const transaction = mintWithSignature({
+ *   contract,
+ *   payload,
+ *   signature,
+ * });
+ * await sendTransaction({ transaction, account });
+ * ```
+ * @extension ERC20
+ * @returns A promise that resolves to the payload and signature.
+ */
+export async function generateMintSignature(
+  options: GenerateMintSignatureOptions,
+) {
+  const { mintRequest, account, contract } = options;
+  const currency = mintRequest.currency || NATIVE_TOKEN_ADDRESS;
+  const [pricePerUnit, quantity, uid] = await Promise.all([
+    // price per token in wei
+    (async () => {
+      // if priceInWei is provided, use it
+      if ("priceInWei" in mintRequest && mintRequest.priceInWei) {
+        return mintRequest.priceInWei;
+      }
+
+      // if neither price nor priceInWei is provided, default to 0
+      return 0n;
+    })(),
+    // quantity in wei
+    (async () => {
+      // if the quantity is already passed in wei, use it
+      if ("quantityWei" in mintRequest) {
+        return mintRequest.quantityWei;
+      }
+      // otherwise convert the quantity to wei using the contract's OWN decimals
+      const { convertErc20Amount } = await import(
+        "../../../utils/extensions/convert-erc20-amount.js"
+      );
+      return await convertErc20Amount({
+        amount: mintRequest.quantity,
+        client: contract.client,
+        chain: contract.chain,
+        erc20Address: contract.address,
+      });
+    })(),
+    // uid computation
+    mintRequest.uid || (await randomBytesHex()),
+  ]);
+
+  const startTime = mintRequest.validityStartTimestamp || new Date(0);
+  const endTime = mintRequest.validityEndTimestamp || tenYearsFromNow();
+
+  const payload: PayloadType = {
+    pricePerUnit,
+    quantity,
+    uid,
+    currency,
+    recipient: mintRequest.recipient,
+    startTimestamp: Number(dateToSeconds(startTime)),
+    endTimestamp: Number(dateToSeconds(endTime)),
+  };
+
+  const signature = await account.signTypedData({
+    domain: {
+      name: "MintableERC20",
+      version: "1",
+      chainId: contract.chain.id,
+      verifyingContract: contract.address as Hex,
+    },
+    types: { MintRequestERC20: MintRequestERC20 },
+    primaryType: "MintRequestERC20",
+    message: payload,
+  });
+  return { payload, signature };
+}
+
+type PayloadType = AbiParameterToPrimitiveType<{
+  type: "tuple";
+  name: "payload";
+  components: typeof MintRequestERC20;
+}>;
+
+type GeneratePayloadInput = {
+  validityStartTimestamp?: Date;
+  validityEndTimestamp?: Date;
+  recipient: Address;
+  currency?: Address;
+  priceInWei?: bigint;
+  uid?: Hex;
+} & ({ quantity: string } | { quantityWei: bigint });
+
+export const MintRequestERC20 = [
+  { name: "startTimestamp", type: "uint48" },
+  { name: "endTimestamp", type: "uint48" },
+  { name: "recipient", type: "address" },
+  { name: "quantity", type: "uint256" },
+  { name: "currency", type: "address" },
+  { name: "pricePerUnit", type: "uint256" },
+  { name: "uid", type: "bytes32" },
+] as const;

--- a/packages/thirdweb/src/extensions/modular/write/mintableERC721.ts
+++ b/packages/thirdweb/src/extensions/modular/write/mintableERC721.ts
@@ -1,0 +1,218 @@
+import { startTokenId } from "../__generated__/ERC721Core/read/startTokenId.js";
+import { totalMinted } from "../__generated__/ERC721Core/read/totalMinted.js";
+import { mint as generatedMint } from "../__generated__/ERC721Core/write/mint.js";
+import { encodeMintParams } from "../__generated__/MintableERC721/read/mint.js";
+
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { ADDRESS_ZERO } from "../../../constants/addresses.js";
+import { NATIVE_TOKEN_ADDRESS } from "../../../constants/addresses.js";
+import type { ThirdwebContract } from "../../../contract/contract.js";
+import type { BaseTransactionOptions } from "../../../transaction/types.js";
+import type { Address } from "../../../utils/address.js";
+import { dateToSeconds, tenYearsFromNow } from "../../../utils/date.js";
+import type { Hex } from "../../../utils/encoding/hex.js";
+import {
+  getBaseUriFromBatch,
+  uploadOrExtractURIs,
+} from "../../../utils/ipfs.js";
+import type { NFTInput } from "../../../utils/nft/parseNft.js";
+import { randomBytesHex } from "../../../utils/random.js";
+import type { Account } from "../../../wallets/interfaces/wallet.js";
+
+export type NFTMintParams = {
+  to: Address;
+  nfts: (NFTInput | string)[];
+};
+
+export type NFTSignatureMintParams = {
+  to: Address;
+  nfts: (NFTInput | string)[];
+};
+
+export function mintWithPermissions(
+  options: BaseTransactionOptions<NFTMintParams>,
+) {
+  return generatedMint({
+    contract: options.contract,
+    asyncParams: async () => {
+      const start = await startTokenId({ contract: options.contract });
+      const minted = await totalMinted({ contract: options.contract });
+      const nextIdToMint = start + minted;
+
+      const batchOfUris = await uploadOrExtractURIs(
+        options.nfts,
+        options.contract.client,
+        Number(nextIdToMint),
+      );
+      const baseURI = getBaseUriFromBatch(batchOfUris);
+
+      const emptyPayload = {
+        pricePerUnit: 0n,
+        quantity: 0n,
+        uid: randomBytesHex(),
+        currency: ADDRESS_ZERO,
+        recipient: ADDRESS_ZERO,
+        startTimestamp: 0,
+        endTimestamp: 0,
+        baseURI: "",
+      };
+
+      return {
+        to: options.to,
+        quantity: BigInt(options.nfts.length),
+        data: encodeMintParams({
+          params: {
+            request: emptyPayload,
+            signature: "0x",
+            baseURI,
+          },
+        }),
+      };
+    },
+  });
+}
+
+export function mintWithSignature(
+  options: BaseTransactionOptions<GenerateMintSignatureOptions>,
+) {
+  return generatedMint({
+    contract: options.contract,
+    asyncParams: async () => {
+      const { payload, signature, baseURI } =
+        await generateMintSignature(options);
+
+      return {
+        to: payload.recipient,
+        quantity: BigInt(options.nfts.length),
+        data: encodeMintParams({
+          params: {
+            request: payload,
+            signature,
+            baseURI,
+          },
+        }),
+      };
+    },
+  });
+}
+
+export type GenerateMintSignatureOptions = {
+  account: Account;
+  contract: ThirdwebContract;
+  nfts: (NFTInput | string)[];
+  mintRequest: GeneratePayloadInput;
+};
+
+/**
+ * Generates the payload and signature for minting an ERC721 token.
+ * @param options - The options for the minting process.
+ * @example
+ * ```ts
+ * import { mintWithSignature, generateMintSignature } from "thirdweb/extensions/ERC721";
+ *
+ * const { payload, signature } = await generateMintSignature({
+ *   account,
+ *   contract,
+ *   mintRequest: {
+ *     recipient: "0x...",
+ *     quantity: "10",
+ *   },
+ * });
+ *
+ * const transaction = mintWithSignature({
+ *   contract,
+ *   payload,
+ *   signature,
+ * });
+ * await sendTransaction({ transaction, account });
+ * ```
+ * @extension ERC721
+ * @returns A promise that resolves to the payload and signature.
+ */
+export async function generateMintSignature(
+  options: GenerateMintSignatureOptions,
+) {
+  const { mintRequest, account, contract } = options;
+  const currency = mintRequest.currency || NATIVE_TOKEN_ADDRESS;
+  const [pricePerUnit, quantity, uid] = await Promise.all([
+    // price per token in wei
+    (async () => {
+      // if priceInWei is provided, use it
+      if ("priceInWei" in mintRequest && mintRequest.priceInWei) {
+        return mintRequest.priceInWei;
+      }
+
+      // if neither price nor priceInWei is provided, default to 0
+      return 0n;
+    })(),
+    (async () => {
+      return BigInt(options.nfts.length);
+    })(),
+    // uid computation
+    mintRequest.uid || (await randomBytesHex()),
+  ]);
+
+  const startTime = mintRequest.validityStartTimestamp || new Date(0);
+  const endTime = mintRequest.validityEndTimestamp || tenYearsFromNow();
+
+  const start = await startTokenId({ contract: options.contract });
+  const minted = await totalMinted({ contract: options.contract });
+  const nextIdToMint = start + minted;
+
+  const batchOfUris = await uploadOrExtractURIs(
+    options.nfts,
+    options.contract.client,
+    Number(nextIdToMint),
+  );
+  const baseURI = getBaseUriFromBatch(batchOfUris);
+
+  const payload: PayloadType = {
+    pricePerUnit,
+    quantity,
+    uid,
+    currency,
+    recipient: mintRequest.recipient,
+    startTimestamp: Number(dateToSeconds(startTime)),
+    endTimestamp: Number(dateToSeconds(endTime)),
+    baseURI: baseURI,
+  };
+
+  const signature = await account.signTypedData({
+    domain: {
+      name: "MintableERC721",
+      version: "1",
+      chainId: contract.chain.id,
+      verifyingContract: contract.address as Hex,
+    },
+    types: { MintRequestERC721: MintRequestERC721 },
+    primaryType: "MintRequestERC721",
+    message: payload,
+  });
+  return { payload, signature, baseURI };
+}
+
+type PayloadType = AbiParameterToPrimitiveType<{
+  type: "tuple";
+  name: "payload";
+  components: typeof MintRequestERC721;
+}>;
+
+type GeneratePayloadInput = {
+  recipient: Address;
+  currency?: Address;
+  priceInWei?: bigint;
+  uid?: Hex;
+  validityStartTimestamp?: Date;
+  validityEndTimestamp?: Date;
+};
+
+export const MintRequestERC721 = [
+  { name: "startTimestamp", type: "uint48" },
+  { name: "endTimestamp", type: "uint48" },
+  { name: "recipient", type: "address" },
+  { name: "quantity", type: "uint256" },
+  { name: "currency", type: "address" },
+  { name: "pricePerUnit", type: "uint256" },
+  { name: "baseURI", type: "string" },
+  { name: "uid", type: "bytes32" },
+] as const;


### PR DESCRIPTION
## Problem solved

Integration for Modular Contracts. Specifically, ERC-20, ERC-721 and ERC-1155 core contracts and MintableERCxxx extension contracts.

## Changes made

- [ ] Public API changes: list the public API changes made if any

```typescript
import { mintWithSignature, mintWithPermissions } from "thirdweb/modular/erc20";
import { mintWithSignature, mintWithPermissions } from "thirdweb/modular/erc721";
import { mintWithSignature, mintWithPermissions } from "thirdweb/modular/erc1155";
```

- [ ] Internal API changes: explain the internal logic changes

## How to test

- [ ] Automated tests: link to unit test file
- [ ] Manual tests: step by step instructions on how to test

## Contributor NFT

Paste in your wallet address below and we will airdrop you a special NFT when your pull request is merged. 

```0x8dff5c0ef4A8c86d4eD8Cb20a14FEe7efa080e09```

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing sign raw message issues through ethers 5/6 adapters and adding modular functionalities for ERC721, ERC1155, and ERC20.

### Detailed summary
- Fixed sign raw message issues through ethers 5/6 adapters
- Added modular functionalities for ERC721, ERC1155, and ERC20
- Updated event objects for ContractURIUpdated, ExtensionInstalled, ExtensionUninstalled, URI, and Transfer

> The following files were skipped due to too many changes: `packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/events/Transfer.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/events/Approval.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/events/OwnershipHandoverCanceled.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/events/OwnershipHandoverCanceled.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/events/OwnershipHandoverCanceled.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/events/RolesUpdated.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/events/RolesUpdated.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/events/RolesUpdated.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/events/OwnershipHandoverRequested.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/events/OwnershipHandoverRequested.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/events/OwnershipHandoverRequested.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/events/ApprovalForAll.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/events/ApprovalForAll.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/events/OwnershipTransferred.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/events/OwnershipTransferred.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/events/OwnershipTransferred.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/events/Transfer.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/events/Approval.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/events/TransferBatch.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/events/TransferSingle.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/events/ConsecutiveTransfer.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/renounceOwnership.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/renounceOwnership.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/renounceOwnership.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/cancelOwnershipHandover.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/cancelOwnershipHandover.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/cancelOwnershipHandover.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/requestOwnershipHandover.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/requestOwnershipHandover.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/requestOwnershipHandover.ts`, `packages/thirdweb/package.json`, `packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/name.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/name.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/name.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/owner.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/owner.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/owner.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/symbol.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/symbol.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/symbol.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/decimals.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/contractURI.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/contractURI.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/contractURI.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/totalMinted.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/totalSupply.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/totalSupply.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/startTokenId.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/DOMAIN_SEPARATOR.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/getSupportedCallbackFunctions.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/getSupportedCallbackFunctions.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/getSupportedCallbackFunctions.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/getInstalledExtensions.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/getInstalledExtensions.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/getInstalledExtensions.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/uri.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/nonces.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/rolesOf.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/rolesOf.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/rolesOf.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/tokenURI.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/ownerOf.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/balanceOf.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/balanceOf.ts`, `packages/thirdweb/src/extensions/modular/__generated__/MintableERC20/read/mint.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/getApproved.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/totalSupply.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/tokensOfOwner.ts`, `packages/thirdweb/src/extensions/modular/__generated__/MintableERC721/read/mint.ts`, `packages/thirdweb/src/extensions/modular/__generated__/MintableERC1155/read/mint.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/balanceOf.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/hasAnyRole.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/hasAnyRole.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/hasAnyRole.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/allowance.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/hasAllRoles.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/supportsInterface.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/hasAllRoles.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/supportsInterface.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/hasAllRoles.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/supportsInterface.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/balanceOfBatch.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/multicall.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/multicall.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/multicall.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/isApprovedForAll.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/isApprovedForAll.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/burn.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/renounceRoles.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/renounceRoles.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/renounceRoles.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/setContractURI.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/setContractURI.ts`, `packages/thirdweb/src/extensions/modular/__generated__/MintableERC20/write/grantRoles.ts`, `packages/thirdweb/src/extensions/modular/__generated__/MintableERC721/write/grantRoles.ts`, `packages/thirdweb/src/extensions/modular/__generated__/MintableERC1155/write/grantRoles.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/approve.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/setContractURI.ts`, `packages/thirdweb/src/extensions/modular/__generated__/MintableERC20/write/setSaleConfig.ts`, `packages/thirdweb/src/extensions/modular/__generated__/MintableERC721/write/setSaleConfig.ts`, `packages/thirdweb/src/extensions/modular/__generated__/MintableERC1155/write/setSaleConfig.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/read/ownershipHandoverExpiresAt.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/ownershipHandoverExpiresAt.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/read/ownershipHandoverExpiresAt.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/transferOwnership.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/transferOwnership.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/transferOwnership.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/transfer.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/explicitOwnershipOf.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/grantRoles.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/approve.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/grantRoles.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/grantRoles.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/revokeRoles.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/tokensOfOwnerIn.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/revokeRoles.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/revokeRoles.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/read/explicitOwnershipsOf.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/mint.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/burn.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/mint.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/installExtension.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/installExtension.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/installExtension.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/completeOwnershipHandover.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/completeOwnershipHandover.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/completeOwnershipHandover.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/setApprovalForAll.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/setApprovalForAll.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/uninstallExtension.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/uninstallExtension.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/uninstallExtension.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/transferFrom.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/mint.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/burn.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/transferFrom.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC721Core/write/safeTransferFrom.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/safeTransferFrom.ts`, `packages/thirdweb/src/extensions/modular/write/mintableERC1155.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC1155Core/write/safeBatchTransferFrom.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ERC20Core/write/permit.ts`, `packages/thirdweb/src/extensions/modular/write/mintableERC20.ts`, `packages/thirdweb/src/extensions/modular/write/mintableERC721.ts`, `packages/thirdweb/scripts/generate/abis/modular/ERC20Core.json`, `packages/thirdweb/scripts/generate/abis/modular/ERC1155Core.json`, `packages/thirdweb/scripts/generate/abis/modular/ERC721Core.json`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->