### PR TITLE
[WIP] Allow specifying cost of transaction in ERC20 tokens

### DIFF
--- a/.changeset/wild-snakes-deliver.md
+++ b/.changeset/wild-snakes-deliver.md
@@ -2,27 +2,23 @@
 "thirdweb": minor
 ---
 
-Add `overrideTxCost` option in `payModal` to override the calculated transaction cost to add support for prompting the user to buy ERC-20 tokens via Pay Modal.
+Add `valueERC20` option in `PreparedTransaction` object to specify the transaction cost in ERC20 tokens to allow opening the Pay Modal for ERC20 tokens if user does not have specified ERC20 tokens.
 
 ```tsx
-const sendTx = useSendTransaction({
-  payModal: {
-    // set the transaction cost as 10 USDC
-    overrideTxCost: {
-      value: sendUSDPolygonAmount,
-      token: {
-        address: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
-        name: "USD Coin",
-        symbol: "USDC",
-      },
-    },
-  },
-});
+const sendTx = useSendTransaction();
 
 return (
   <button
     onClick={async () => {
-      await sendTx.mutateAsync({ ... });
+      const someTx = { ... };
+
+      // declare that transaction cost is 10 USDC
+      someTx.valueERC20 = {
+        amount: "10",
+        tokenAddress: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
+      };
+
+      await sendTx.mutateAsync(someTx);
     }}
   >
     send tx
@@ -32,17 +28,17 @@ return (
 
 ```tsx
 <TransactionButton
-  payModal={{
-    overrideTxCost: {
-      value: sendUSDPolygonAmount,
-      token: {
-        address: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
-        name: "USD Coin",
-        symbol: "USDC",
-      },
-    },
+  transaction={() => {
+    const someTx = {...};
+
+    // declare that transaction cost is 10 USDC
+    someTx.valueERC20 = {
+      amount: "10",
+      tokenAddress: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
+    };
+
+    return someTx;
   }}
-  transaction={() => {...}}
 >
   send tx
 </TransactionButton>

--- a/.changeset/wild-snakes-deliver.md
+++ b/.changeset/wild-snakes-deliver.md
@@ -1,0 +1,49 @@
+---
+"thirdweb": minor
+---
+
+Add `overrideTxCost` option in `payModal` to override the calculated transaction cost to add support for prompting the user to buy ERC-20 tokens via Pay Modal.
+
+```tsx
+const sendTx = useSendTransaction({
+  payModal: {
+    // set the transaction cost as 10 USDC
+    overrideTxCost: {
+      value: sendUSDPolygonAmount,
+      token: {
+        address: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
+        name: "USD Coin",
+        symbol: "USDC",
+      },
+    },
+  },
+});
+
+return (
+  <button
+    onClick={async () => {
+      await sendTx.mutateAsync({ ... });
+    }}
+  >
+    send tx
+  </button>
+);
+```
+
+```tsx
+<TransactionButton
+  payModal={{
+    overrideTxCost: {
+      value: sendUSDPolygonAmount,
+      token: {
+        address: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
+        name: "USD Coin",
+        symbol: "USDC",
+      },
+    },
+  }}
+  transaction={() => {...}}
+>
+  send tx
+</TransactionButton>
+```

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx
@@ -5,7 +5,6 @@ import { NATIVE_TOKEN_ADDRESS } from "../../../../../../constants/addresses.js";
 import type { GetBuyWithCryptoQuoteParams } from "../../../../../../pay/buyWithCrypto/getQuote.js";
 import { isSwapRequiredPostOnramp } from "../../../../../../pay/buyWithFiat/isSwapRequiredPostOnramp.js";
 import { formatNumber } from "../../../../../../utils/formatNumber.js";
-import { toEther } from "../../../../../../utils/units.js";
 import type { Account } from "../../../../../../wallets/interfaces/wallet.js";
 import {
   useChainQuery,
@@ -411,9 +410,7 @@ function BuyScreenContent(props: BuyScreenContentProps) {
           {/* Amount needed for Send Tx */}
           {amountNeeded && props.buyForTx ? (
             <BuyForTxUI
-              amountNeeded={String(
-                formatNumber(Number(toEther(amountNeeded)), 4),
-              )}
+              amountNeeded={String(formatNumber(Number(amountNeeded), 4))}
               buyForTx={props.buyForTx}
               client={client}
             />
@@ -911,23 +908,25 @@ function FiatScreenContent(
       )}
 
       {/* Continue */}
-      <Button
-        variant={disableSubmit ? "outline" : "accent"}
-        data-disabled={disableSubmit}
-        disabled={disableSubmit}
-        fullWidth
-        onClick={handleSubmit}
-        gap="xs"
-      >
-        {fiatQuoteQuery.isLoading ? (
-          <>
-            <Spinner size="sm" color="accentText" />
-            Getting price quote
-          </>
-        ) : (
-          "Continue"
-        )}
-      </Button>
+      {!fiatQuoteQuery.error && (
+        <Button
+          variant={disableSubmit ? "outline" : "accent"}
+          data-disabled={disableSubmit}
+          disabled={disableSubmit}
+          fullWidth
+          onClick={handleSubmit}
+          gap="xs"
+        >
+          {fiatQuoteQuery.isLoading ? (
+            <>
+              <Spinner size="sm" color="accentText" />
+              Getting price quote
+            </>
+          ) : (
+            "Continue"
+          )}
+        </Button>
+      )}
     </Container>
   );
 }
@@ -988,7 +987,7 @@ function BuyForTxUI(props: {
         <Text size="sm">Your Balance</Text>
         <Container flex="row" gap="xs">
           <Text color="primaryText" size="sm">
-            {formatNumber(Number(toEther(props.buyForTx.balance)), 4)}{" "}
+            {formatNumber(Number(props.buyForTx.balance), 4)}{" "}
             {props.buyForTx.tokenSymbol}
           </Text>
           <TokenIcon

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/main/types.ts
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/main/types.ts
@@ -1,10 +1,17 @@
 import type { PreparedTransaction } from "../../../../../../../transaction/prepare-transaction.js";
 
 export type BuyForTx = {
-  cost: bigint;
-  balance: bigint;
-  tx: PreparedTransaction;
+  cost: string;
+  balance: string;
   tokenSymbol: string;
+  token?: {
+    name: string;
+    symbol: string;
+    address: string;
+    icon?: string;
+  };
+  tx: PreparedTransaction;
+  isCostOverridden: boolean;
 };
 
 export type SelectedScreen =

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/main/useUISelectionStates.ts
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/main/useUISelectionStates.ts
@@ -2,7 +2,6 @@ import { useState } from "react";
 import { polygon } from "../../../../../../../chains/chain-definitions/polygon.js";
 import type { Chain } from "../../../../../../../chains/types.js";
 import { formatNumber } from "../../../../../../../utils/formatNumber.js";
-import { toEther } from "../../../../../../../utils/units.js";
 import { useActiveWalletChain } from "../../../../../../core/hooks/wallets/wallet-hooks.js";
 import { useDebouncedValue } from "../../../../hooks/useDebouncedValue.js";
 import type { PayUIOptions } from "../../../ConnectButtonProps.js";
@@ -26,7 +25,7 @@ export function useUISelectionStates(options: {
     payOptions.prefillBuy?.amount ||
     (buyForTx
       ? String(
-          formatNumber(Number(toEther(buyForTx.cost - buyForTx.balance)), 4),
+          formatNumber(Number(buyForTx.cost) - Number(buyForTx.balance), 4),
         )
       : "");
 
@@ -50,7 +49,7 @@ export function useUISelectionStates(options: {
   );
 
   const [toToken, setToToken] = useState<ERC20OrNativeToken>(
-    payOptions.prefillBuy?.token || NATIVE_TOKEN,
+    payOptions.prefillBuy?.token || buyForTx?.token || NATIVE_TOKEN,
   );
   // --------------------------------------------------------------------------
 

--- a/packages/thirdweb/src/transaction/prepare-transaction.ts
+++ b/packages/thirdweb/src/transaction/prepare-transaction.ts
@@ -74,6 +74,11 @@ export type PreparedTransaction<
 > = Readonly<options> & {
   __preparedMethod?: () => Promise<PreparedMethod<abiFn>>;
   __contract?: ThirdwebContract<abi>;
+  // additional
+  valueERC20?: {
+    amount: string; // units of tokens
+    tokenAddress: string;
+  };
 };
 
 /**


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds support for specifying transaction cost in ERC20 tokens, enabling users to pay with ERC20 tokens when lacking specified ones.

### Detailed summary
- Added `valueERC20` option in `PreparedTransaction` object
- Updated `BuyForTx` type to include token details
- Modified functions to handle ERC20 token cost
- Updated UI components to display ERC20 token information

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->