### PR TITLE
Move EIP-5792 hooks ro thirdweb/react export to match documentation

### DIFF
--- a/.changeset/short-news-sneeze.md
+++ b/.changeset/short-news-sneeze.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Adds EIP-5792 hook exports to thirdweb/react

--- a/packages/thirdweb/src/exports/react.ts
+++ b/packages/thirdweb/src/exports/react.ts
@@ -140,3 +140,8 @@ export {
   useWalletDetailsModal,
   type UseWalletDetailsModalOptions,
 } from "../react/web/ui/ConnectWallet/Details.js";
+
+// eip5792 hooks
+export { useSendCalls } from "../react/core/hooks/wallets/useSendCalls.js";
+export { useCallsStatus } from "../react/core/hooks/wallets/useCallsStatus.js";
+export { useCapabilities } from "../react/core/hooks/wallets/useCapabilities.js";


### PR DESCRIPTION
Our documentation lists the EIP-5792 hooks as exported from `thirdweb/react`, which is more consistent than the current export from `wallets`

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding EIP-5792 hook exports to `thirdweb/react`.

### Detailed summary
- Added EIP-5792 hook exports to `thirdweb/react`
- Exported `useSendCalls` from `../react/core/hooks/wallets/useSendCalls.js`
- Exported `useCallsStatus` from `../react/core/hooks/wallets/useCallsStatus.js`
- Exported `useCapabilities` from `../react/core/hooks/wallets/useCapabilities.js`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->