### PR TITLE
[TSv4] Fix caching logic, avoid fetch when abi passed

### DIFF
--- a/.changeset/sweet-shoes-sit.md
+++ b/.changeset/sweet-shoes-sit.md
@@ -1,0 +1,6 @@
+---
+"@thirdweb-dev/unity-js-bridge": patch
+"@thirdweb-dev/sdk": patch
+---
+
+Fix caching logic for getContract/getContractFromAbi

--- a/legacy_packages/sdk/src/evm/core/sdk.ts
+++ b/legacy_packages/sdk/src/evm/core/sdk.ts
@@ -587,7 +587,13 @@ export class ThirdwebSDK extends RPCConnectionHandler {
           );
         newContract = await this.getContractFromAbi(
           resolvedAddress,
-          metadata.abi,
+          await getCompositeABI(
+            resolvedAddress,
+            AbiSchema.parse(metadata.abi),
+            this.getProvider(),
+            this.options,
+            this.storage,
+          ),
         );
       } catch (e) {
         // fallback to
@@ -601,7 +607,13 @@ export class ThirdwebSDK extends RPCConnectionHandler {
           ].getAbi(resolvedAddress, this.getProvider(), this.storage);
           newContract = await this.getContractFromAbi(
             resolvedAddress,
-            contractAbi,
+            await getCompositeABI(
+              resolvedAddress,
+              AbiSchema.parse(contractAbi),
+              this.getProvider(),
+              this.options,
+              this.storage,
+            ),
           );
         } else {
           // we cant fetch the ABI, and we don't know the contract type, throw the original error
@@ -843,13 +855,7 @@ export class ThirdwebSDK extends RPCConnectionHandler {
     const contract = new SmartContract(
       this.getSignerOrProvider(),
       resolvedAddress,
-      await getCompositeABI(
-        resolvedAddress,
-        AbiSchema.parse(parsedABI),
-        provider,
-        this.options,
-        this.storage,
-      ),
+      parsedABI,
       this.storageHandler,
       this.options,
       (await provider.getNetwork()).chainId,

--- a/legacy_packages/unity-js-bridge/src/thirdweb-bridge.ts
+++ b/legacy_packages/unity-js-bridge/src/thirdweb-bridge.ts
@@ -570,7 +570,7 @@ class ThirdwebBridge implements TWBridge {
     // contract tx
     if (addrOrSDK.startsWith("0x")) {
       let typeOrAbi: string | ContractInterface | undefined;
-      let isAbi: boolean = false;
+      let isAbi = false;
       if (firstArg.length > 1) {
         try {
           typeOrAbi = JSON.parse(firstArg[1]); // try to parse ABI

--- a/legacy_packages/unity-js-bridge/src/thirdweb-bridge.ts
+++ b/legacy_packages/unity-js-bridge/src/thirdweb-bridge.ts
@@ -171,7 +171,7 @@ class ThirdwebBridge implements TWBridge {
       // biome-ignore lint/suspicious/noExplicitAny: TODO: fix use of any
       (globalThis as any).X_SDK_PLATFORM = "unity";
       // biome-ignore lint/suspicious/noExplicitAny: TODO: fix use of any
-      (globalThis as any).X_SDK_VERSION = "4.15.0";
+      (globalThis as any).X_SDK_VERSION = "4.15.1";
       // biome-ignore lint/suspicious/noExplicitAny: TODO: fix use of any
       (globalThis as any).X_SDK_OS = browser?.os ?? "unknown";
     }

--- a/legacy_packages/unity-js-bridge/src/thirdweb-bridge.ts
+++ b/legacy_packages/unity-js-bridge/src/thirdweb-bridge.ts
@@ -321,7 +321,6 @@ class ThirdwebBridge implements TWBridge {
   }
 
   public async connect(
-    // biome-ignore lint/style/useDefaultParameterLast: would change the order of parameters to fix this
     wallet: string,
     chainId: string,
     password?: string,
@@ -575,7 +574,7 @@ class ThirdwebBridge implements TWBridge {
         try {
           typeOrAbi = JSON.parse(firstArg[1]); // try to parse ABI
         } catch (e) {
-          throw new Error("Invalid ABI: " + firstArg[1]);
+          typeOrAbi = firstArg[1];
         }
       }
 

--- a/legacy_packages/unity-js-bridge/src/thirdweb-bridge.ts
+++ b/legacy_packages/unity-js-bridge/src/thirdweb-bridge.ts
@@ -570,16 +570,21 @@ class ThirdwebBridge implements TWBridge {
     // contract tx
     if (addrOrSDK.startsWith("0x")) {
       let typeOrAbi: string | ContractInterface | undefined;
+      let isAbi: boolean = false;
       if (firstArg.length > 1) {
         try {
           typeOrAbi = JSON.parse(firstArg[1]); // try to parse ABI
+          isAbi = true;
         } catch (e) {
           typeOrAbi = firstArg[1];
+          isAbi = false;
         }
       }
 
       const contract = typeOrAbi
-        ? await this.activeSDK.getContractFromAbi(addrOrSDK, typeOrAbi)
+        ? isAbi
+          ? await this.activeSDK.getContractFromAbi(addrOrSDK, typeOrAbi)
+          : await this.activeSDK.getContract(addrOrSDK, typeOrAbi)
         : await this.activeSDK.getContract(addrOrSDK);
 
       // tx

--- a/legacy_packages/unity-js-bridge/src/thirdweb-bridge.ts
+++ b/legacy_packages/unity-js-bridge/src/thirdweb-bridge.ts
@@ -528,7 +528,8 @@ class ThirdwebBridge implements TWBridge {
         return arg;
       }
     });
-    // console.debug("thirdwebSDK call:", route, parsedArgs);
+
+    // console.log("thirdwebSDK call:", route, parsedArgs);
 
     // wallet call
     if (addrOrSDK.startsWith("sdk")) {
@@ -574,11 +575,12 @@ class ThirdwebBridge implements TWBridge {
         try {
           typeOrAbi = JSON.parse(firstArg[1]); // try to parse ABI
         } catch (e) {
-          typeOrAbi = firstArg[1];
+          throw new Error("Invalid ABI: " + firstArg[1]);
         }
       }
+
       const contract = typeOrAbi
-        ? await this.activeSDK.getContract(addrOrSDK, typeOrAbi)
+        ? await this.activeSDK.getContractFromAbi(addrOrSDK, typeOrAbi)
         : await this.activeSDK.getContract(addrOrSDK);
 
       // tx


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR improves caching logic in `ThirdwebSDK` for contract handling. 

### Detailed summary
- Fixed caching logic for `getContract` and `getContractFromAbi`
- Updated version to "4.15.1" in `ThirdwebBridge`
- Refactored `connect` method in `ThirdwebBridge`
- Enhanced contract handling in `ThirdwebBridge`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->