### PR TITLE
[TSv4] Avoid unnecessary fetching for error formatting

### DIFF
--- a/.changeset/strange-dryers-yawn.md
+++ b/.changeset/strange-dryers-yawn.md
@@ -1,0 +1,6 @@
+---
+"@thirdweb-dev/unity-js-bridge": patch
+"@thirdweb-dev/sdk": patch
+---
+
+[TSv4] Avoid unnecessary fetching for error formatting

--- a/legacy_packages/sdk/src/evm/core/classes/internal/contract-wrapper.ts
+++ b/legacy_packages/sdk/src/evm/core/classes/internal/contract-wrapper.ts
@@ -18,7 +18,6 @@ import { computeEOAForwarderAddress } from "../../../common/any-evm-utils/comput
 import { computeForwarderAddress } from "../../../common/any-evm-utils/computeForwarderAddress";
 import { TransactionError, parseRevertReason } from "../../../common/error";
 import { extractFunctionsFromAbi } from "../../../common/feature-detection/extractFunctionsFromAbi";
-import { fetchSourceFilesFromMetadata } from "../../../common/fetchSourceFilesFromMetadata";
 import {
   BiconomyForwarderAbi,
   ChainAwareForwardRequest,
@@ -32,7 +31,7 @@ import { signTypedDataInternal } from "../../../common/sign";
 import { CONTRACT_ADDRESSES } from "../../../constants/addresses/CONTRACT_ADDRESSES";
 import { getContractAddressByChainId } from "../../../constants/addresses/getContractAddressByChainId";
 import { EventType } from "../../../constants/events";
-import { AbiSchema, ContractSource } from "../../../schema/contracts/custom";
+import { AbiSchema } from "../../../schema/contracts/custom";
 import { SDKOptions } from "../../../schema/sdk-options";
 import { Address } from "../../../schema/shared/Address";
 import { CallOverrideSchema } from "../../../schema/shared/CallOverrideSchema";

--- a/legacy_packages/sdk/src/evm/core/classes/internal/contract-wrapper.ts
+++ b/legacy_packages/sdk/src/evm/core/classes/internal/contract-wrapper.ts
@@ -396,10 +396,12 @@ export class ContractWrapper<
             ...(callOverrides.value ? [{ value: callOverrides.value }] : []),
           );
         } catch (staticErr: any) {
-          throw await this.formatError(staticErr, fn, args, callOverrides);
+          // don't do extra work
+          throw new Error("Transaction failed: " + staticErr.message);
         }
 
-        throw await this.formatError(err, fn, args, callOverrides);
+        // don't do extra work
+        throw new Error("Transaction failed");
       }
 
       this.emitTransactionEvent("completed", tx.hash);
@@ -433,9 +435,13 @@ export class ContractWrapper<
             ...args,
             ...(callOverrides.value ? [{ value: callOverrides.value }] : []),
           );
-        } catch (err: any) {
-          throw await this.formatError(err, fn, args, callOverrides);
+        } catch (staticErr: any) {
+          // don't do extra work
+          throw new Error("Transaction estimation failed: " + staticErr.message);
         }
+
+        // don't do extra work
+        throw new Error("Transaction estimation failed");
       }
     }
 
@@ -443,7 +449,8 @@ export class ContractWrapper<
     try {
       return await func(...args, callOverrides);
     } catch (err) {
-      throw await this.formatError(err, fn, args, callOverrides);
+      // don't do extra work
+      throw err;
     }
   }
 

--- a/legacy_packages/sdk/src/evm/core/classes/transactions.ts
+++ b/legacy_packages/sdk/src/evm/core/classes/transactions.ts
@@ -663,7 +663,7 @@ export class Transaction<
     // Parse the revert reason from the error
     const reason = parseRevertReason(error);
 
-    // Get contract sources for stack trace
+    // Get contract metadata for contract name if cached
     let contractName: string | undefined = undefined;
     try {
       const chainId = (await provider.getNetwork()).chainId;

--- a/legacy_packages/unity-js-bridge/src/thirdweb-bridge.ts
+++ b/legacy_packages/unity-js-bridge/src/thirdweb-bridge.ts
@@ -27,6 +27,7 @@ import { EthersWallet } from "@thirdweb-dev/wallets/evm/wallets/ethers";
 import { InjectedWallet } from "@thirdweb-dev/wallets/evm/wallets/injected";
 import { LocalWallet } from "@thirdweb-dev/wallets/evm/wallets/local-wallet";
 import { MetaMaskWallet } from "@thirdweb-dev/wallets/evm/wallets/metamask";
+import { RabbyWallet } from "@thirdweb-dev/wallets/evm/wallets/rabby";
 import { SmartWallet } from "@thirdweb-dev/wallets/evm/wallets/smart-wallet";
 import { WalletConnect } from "@thirdweb-dev/wallets/evm/wallets/wallet-connect";
 import {
@@ -68,6 +69,7 @@ const bigNumberReplacer = (_key: string, value: any) => {
 const SUPPORTED_WALLET_IDS = [
   "injected",
   "metamask",
+  "rabby",
   "walletConnect",
   "coinbase",
   "localWallet",
@@ -232,6 +234,14 @@ class ThirdwebBridge implements TWBridge {
           break;
         case "metamask":
           walletInstance = new MetaMaskWallet({
+            dappMetadata,
+            chains: supportedChains,
+            clientId: sdkOptions.clientId,
+          });
+          break;
+        case "rabby":
+          walletInstance = new RabbyWallet({
+            projectId: sdkOptions.wallet?.walletConnectProjectId,
             dappMetadata,
             chains: supportedChains,
             clientId: sdkOptions.clientId,

--- a/legacy_packages/unity-js-bridge/src/thirdweb-bridge.ts
+++ b/legacy_packages/unity-js-bridge/src/thirdweb-bridge.ts
@@ -171,7 +171,7 @@ class ThirdwebBridge implements TWBridge {
       // biome-ignore lint/suspicious/noExplicitAny: TODO: fix use of any
       (globalThis as any).X_SDK_PLATFORM = "unity";
       // biome-ignore lint/suspicious/noExplicitAny: TODO: fix use of any
-      (globalThis as any).X_SDK_VERSION = "4.15.1";
+      (globalThis as any).X_SDK_VERSION = "4.15.2";
       // biome-ignore lint/suspicious/noExplicitAny: TODO: fix use of any
       (globalThis as any).X_SDK_OS = browser?.os ?? "unknown";
     }


### PR DESCRIPTION
@joaquim-verges @jnsdls this is sub-optimal but works, currently we fetch extra metadata even after a MetaMask user rejection to format this error, can take up to 20-30s in some regions, should be instant from a UX perspective. If there's a way to pass down the abi/metadata if it's available that'd be good, otherwise we can stick to this if you don't see issues with it. Needed for Unity WebGL.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR optimizes error handling and contract metadata retrieval in the EVM SDK. 

### Detailed summary
- Updated error handling for unnecessary fetching
- Added RabbyWallet support
- Updated SDK version to 4.15.2
- Improved contract metadata retrieval efficiency

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->