### PR TITLE
Fix custom theme not used in ConnectEmbed loading screen

### DIFF
--- a/.changeset/strange-hounds-draw.md
+++ b/.changeset/strange-hounds-draw.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix custom theme not used in ConnectEmbed loading screen

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/ConnectEmbed.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/ConnectEmbed.tsx
@@ -5,7 +5,10 @@ import type { ThirdwebClient } from "../../../../../client/client.js";
 import type { Wallet } from "../../../../../wallets/interfaces/wallet.js";
 import type { SmartWalletOptions } from "../../../../../wallets/smart/types.js";
 import type { AppMetadata } from "../../../../../wallets/types.js";
-import { useCustomTheme } from "../../../../core/design-system/CustomThemeProvider.js";
+import {
+  CustomThemeProvider,
+  useCustomTheme,
+} from "../../../../core/design-system/CustomThemeProvider.js";
 import { type Theme, radius } from "../../../../core/design-system/index.js";
 import type { SiweAuthOptions } from "../../../../core/hooks/auth/useSiweAuth.js";
 import { useSiweAuth } from "../../../../core/hooks/auth/useSiweAuth.js";
@@ -374,9 +377,11 @@ export function ConnectEmbed(props: ConnectEmbedProps) {
       return (
         <>
           {autoConnectComp}
-          <EmbedContainer modalSize={modalSize}>
-            <LoadingScreen />
-          </EmbedContainer>
+          <CustomThemeProvider theme={props.theme || "dark"}>
+            <EmbedContainer modalSize={modalSize}>
+              <LoadingScreen />
+            </EmbedContainer>
+          </CustomThemeProvider>
         </>
       );
     }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR fixes the issue where the custom theme was not applied in the ConnectEmbed loading screen in `ConnectEmbed.tsx`.

### Detailed summary
- Fixed custom theme not being applied in ConnectEmbed loading screen
- Added `CustomThemeProvider` import and usage
- Wrapped `EmbedContainer` in `CustomThemeProvider` with the provided theme or default to "dark"

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->