### PR TITLE
Jd/fix ipfs reolve scheme bug

### DIFF
--- a/.changeset/soft-meals-invite.md
+++ b/.changeset/soft-meals-invite.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+fix ipfs `resolveScheme` bug for v1 ipfs schemes

--- a/packages/thirdweb/src/utils/ipfs.test.ts
+++ b/packages/thirdweb/src/utils/ipfs.test.ts
@@ -12,6 +12,18 @@ describe("resolveScheme", () => {
     expect(url).toMatchInlineSnapshot(`"https://test.ipfscdn.io/ipfs/Qm..."`);
   });
 
+  it("should resolve ipfs scheme", () => {
+    const client = createThirdwebClient({
+      clientId: "test",
+    });
+    const uri =
+      "ipfs://bafkreidi5y7afj5z4xrz7uz5rkg2mcsv2p2n4ui4g7q4k4ecdz65i2agou";
+    const url = resolveScheme({ client, uri });
+    expect(url).toMatchInlineSnapshot(
+      `"https://test.ipfscdn.io/ipfs/bafkreidi5y7afj5z4xrz7uz5rkg2mcsv2p2n4ui4g7q4k4ecdz65i2agou"`,
+    );
+  });
+
   it("should resolve ipfs scheme when passing a gateway override", () => {
     const client = createThirdwebClient({
       clientId: "test",

--- a/packages/thirdweb/src/utils/ipfs.ts
+++ b/packages/thirdweb/src/utils/ipfs.ts
@@ -63,7 +63,7 @@ export function findIPFSCidFromUri(uri: string) {
   }
 
   // first index of `/Qm` or `/bafy` in the uri (case insensitive)
-  const firstIndex = uri.search(/\/(Qm|bafy)/i);
+  const firstIndex = uri.search(/\/(Qm|baf)/i);
   // we start one character after the first `/` to avoid including it in the CID
   return uri.slice(firstIndex + 1);
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR fixes a bug in the `resolveScheme` function for v1 IPFS schemes in the `thirdweb` package.

### Detailed summary
- Updated regex pattern to fix IPFS scheme resolution bug
- Added a test case for resolving IPFS scheme with client and URI
- Modified the expected URL in the test case to match the resolved IPFS scheme

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->