### PR TITLE
[CI, Size] Update release workflow permissions and increase thirdweb size limit

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -27,7 +27,7 @@ jobs:
         id: validate_user
         if: ${{ steps.check.outputs.triggered == 'true' }}
         run: |
-          if [[ "${AUTHOR_ASSOCIATION}" != 'MEMBER' && "${AUTHOR_ASSOCIATION}" != 'OWNER' && "${AUTHOR_ASSOCIATION}" != 'CONTRIBUTOR' ]]
+          if [[ "${AUTHOR_ASSOCIATION}" != 'MEMBER' && "${AUTHOR_ASSOCIATION}" != 'OWNER' ]]
           then
             echo "User authorization failed"
             exit 1

--- a/packages/thirdweb/.size-limit.json
+++ b/packages/thirdweb/.size-limit.json
@@ -2,7 +2,7 @@
   {
     "name": "thirdweb (esm)",
     "path": "./dist/esm/exports/thirdweb.js",
-    "limit": "41 kB",
+    "limit": "45 kB",
     "import": "*"
   },
   {


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

## Changes made

- [ ] Public API changes: list the public API changes made if any
- [ ] Internal API changes: explain the internal logic changes

## How to test

- [ ] Automated tests: link to unit test file
- [ ] Manual tests: step by step instructions on how to test

## Contributor NFT

Paste in your wallet address below and we will airdrop you a special NFT when your pull request is merged. 

```Address: ```


<!-- start pr-codex -->

---

## PR-Codex overview
This PR increases the size limit for the `thirdweb (esm)` package and refines the user authorization check in the release workflow.

### Detailed summary
- Increased size limit for `thirdweb (esm)` to 45 kB
- Refined user authorization check in release workflow to exclude 'CONTRIBUTOR' role

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->