### PR TITLE
Add cross-platform support for crypto in randomBytesBuffer function

### DIFF
--- a/packages/thirdweb/src/auth/core/generate-login-payload.ts
+++ b/packages/thirdweb/src/auth/core/generate-login-payload.ts
@@ -35,10 +35,9 @@ export function generateLoginPayload(options: AuthOptions) {
       // use the user passed nonce generator or fall back to generationg uuid
       nonce: await (
         options.login?.nonce?.generate ||
-        (() =>
-          import("../../utils/random.js").then(({ randomBytesHex }) =>
-            randomBytesHex(),
-          ))
+        (() => import("../../utils/random.js").then(({ randomBytesHex }) =>
+          randomBytesHex()
+        ))
       )(),
       statement: options.login?.statement || DEFAULT_LOGIN_STATEMENT,
       version: options.login?.version || DEFAULT_LOGIN_VERSION,

--- a/packages/thirdweb/src/utils/random.ts
+++ b/packages/thirdweb/src/utils/random.ts
@@ -11,5 +11,7 @@ export function randomBytesHex(length = 32) {
  * @internal
  */
 export function randomBytesBuffer(length = 32) {
-  return globalThis.crypto.getRandomValues(new Uint8Array(length));
+  return (typeof globalThis.crypto !== 'undefined'
+    ? globalThis.crypto
+    : (await import('crypto')).webcrypto).getRandomValues(new Uint8Array(length));
 }

--- a/packages/thirdweb/src/utils/random.ts
+++ b/packages/thirdweb/src/utils/random.ts
@@ -3,14 +3,14 @@ import { uint8ArrayToHex } from "./encoding/hex.js";
 /**
  * @internal
  */
-export function randomBytesHex(length = 32) {
-  return uint8ArrayToHex(randomBytesBuffer(length));
+export async function randomBytesHex(length = 32) {
+  return uint8ArrayToHex(await randomBytesBuffer(length));
 }
 
 /**
  * @internal
  */
-export function randomBytesBuffer(length = 32) {
+export async function randomBytesBuffer(length = 32) {
   return (typeof globalThis.crypto !== 'undefined'
     ? globalThis.crypto
     : (await import('crypto')).webcrypto).getRandomValues(new Uint8Array(length));

--- a/packages/thirdweb/src/wallets/in-app/native/helpers/api/fetchers.ts
+++ b/packages/thirdweb/src/wallets/in-app/native/helpers/api/fetchers.ts
@@ -26,9 +26,9 @@ const PAPER_CLIENT_ID_HEADER = "x-thirdweb-client-id";
 
 let sessionNonce: Hex | undefined = undefined;
 
-export function getSessionHeaders() {
+export async function getSessionHeaders() {
   if (!sessionNonce) {
-    sessionNonce = randomBytesHex(16);
+    sessionNonce = await randomBytesHex(16);
   }
   return {
     "Content-Type": "application/json",
@@ -40,7 +40,7 @@ export const verifyClientId = async (client: ThirdwebClient) => {
   const resp = await getClientFetch(client)(ROUTE_VERIFY_THIRDWEB_CLIENT_ID, {
     method: "POST",
     headers: {
-      ...getSessionHeaders(),
+      ...await getSessionHeaders(),
     },
     body: JSON.stringify({ clientId: client.clientId, parentDomain: "" }),
   });
@@ -69,14 +69,14 @@ export const authFetchEmbeddedWalletUser = async (
           authTokenClient || ""
         }`,
         [PAPER_CLIENT_ID_HEADER]: client.clientId,
-        ...getSessionHeaders(),
+        ...await getSessionHeaders(),
       }
     : {
         Authorization: `Bearer ${EMBEDDED_WALLET_TOKEN_HEADER}:${
           authTokenClient || ""
         }`,
         [PAPER_CLIENT_ID_HEADER]: client.clientId,
-        ...getSessionHeaders(),
+        ...await getSessionHeaders(),
       };
   return getClientFetch(client)(url, params);
 };
@@ -112,7 +112,7 @@ export async function generateAuthTokenFromCognitoEmailOtp(
   const resp = await fetch(ROUTE_VERIFY_COGNITO_OTP, {
     method: "POST",
     headers: {
-      ...getSessionHeaders(),
+      ...await getSessionHeaders(),
     },
     body: JSON.stringify({
       access_token: session.getAccessToken().getJwtToken(),
@@ -136,7 +136,7 @@ export async function sendUserManagedEmailOtp(email: string, clientId: string) {
   const resp = await fetch(ROUTE_USER_MANAGED_OTP, {
     method: "POST",
     headers: {
-      ...getSessionHeaders(),
+      ...await getSessionHeaders(),
     },
     body: JSON.stringify({
       email,
@@ -161,7 +161,7 @@ export async function validateUserManagedEmailOtp(options: {
   const resp = await fetch(ROUTE_VALIDATE_USER_MANAGED_OTP, {
     method: "POST",
     headers: {
-      ...getSessionHeaders(),
+      ...await getSessionHeaders(),
     },
     body: JSON.stringify({
       email: options.email,
@@ -186,7 +186,7 @@ export async function isValidUserManagedEmailOtp(options: {
   const resp = await fetch(ROUTE_IS_VALID_USER_MANAGED_OTP, {
     method: "POST",
     headers: {
-      ...getSessionHeaders(),
+      ...await getSessionHeaders(),
     },
     body: JSON.stringify({
       email: options.email,

--- a/packages/thirdweb/src/wallets/in-app/native/helpers/auth/cognitoAuth.ts
+++ b/packages/thirdweb/src/wallets/in-app/native/helpers/auth/cognitoAuth.ts
@@ -18,7 +18,7 @@ Amplify.configure({
 export async function cognitoEmailSignUp(email: string, clientId: string) {
   await Auth.signUp({
     username: `${email}:email:${clientId}`,
-    password: randomBytesHex(30),
+    password: await randomBytesHex(30),
     attributes: {
       email,
     },
@@ -47,7 +47,7 @@ export async function cognitoPhoneSignUp(
 ) {
   await Auth.signUp({
     username: `${phoneNumber}:sms:${clientId}`,
-    password: randomBytesHex(30),
+    password: await randomBytesHex(30),
     attributes: {
       // ! This is a placeholder email, it will not be used for anything. We simply need this to satisfy the Cognito API.
       email: "cognito@thirdweb.com",


### PR DESCRIPTION
## Problem solved

This function is used in the `generatePayload` method when generating the payload in the login route to implement SIWE authorization on the server side. Currently, the function only works in the browser, but this fix will allow it to execute on the server as well, enabling it to generate the login payload without errors.

### How to test

Just call `thirdwebAuth.generatePayload` method and you'll get an error without the fix:
```js
TypeError: Cannot read properties of undefined (reading 'getRandomValues')
```

If the fix is applied, there will be no error.

Ref: https://portal.thirdweb.com/connect/auth/frameworks/react-express

## Changes made

- [ ] Public API changes: list the public API changes made if any
- [x] Internal API changes: explain the internal logic changes

## How to test

- [ ] Automated tests: link to unit test file
- [x] Manual tests: step by step instructions on how to test

## Contributor NFT

Paste in your wallet address below and we will airdrop you a special NFT when your pull request is merged. 

```Address: 0x6047ec2435C5906241AeAcC13b09D3c0eb09Cb45```

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to convert synchronous operations to asynchronous in the authentication and random generation processes.

### Detailed summary
- Converted `randomBytesHex` and `randomBytesBuffer` functions to be asynchronous.
- Updated functions in `cognitoAuth.ts` and `fetchers.ts` to use `await` for `randomBytesHex`.
- Modified functions in various files to await `getSessionHeaders` calls for nonce generation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->