### PR TITLE
fix: sign typed data using inAppWalelt with salt in domain

### DIFF
--- a/.changeset/cuddly-falcons-film.md
+++ b/.changeset/cuddly-falcons-film.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix sign typed data with inAppWallet when the domain contains a salt param

--- a/packages/thirdweb/src/wallets/in-app/web/lib/in-app-account.ts
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/in-app-account.ts
@@ -257,15 +257,19 @@ export class IFrameWallet {
         if (parsedTypedData.types?.EIP712Domain) {
           parsedTypedData.types.EIP712Domain = undefined;
         }
-        // biome-ignore lint/suspicious/noExplicitAny: TODO: fix later
-        const chainId = Number((parsedTypedData.domain as any)?.chainId || 1);
+        const domain = parsedTypedData.domain as TypedDataDefinition["domain"];
+        const chainId = domain?.chainId || 1;
 
         const { signedTypedData } =
           await querier.call<SignedTypedDataReturnType>({
             procedureName: "signTypedDataV4",
             params: {
-              // biome-ignore lint/suspicious/noExplicitAny: TODO: fix later
-              domain: parsedTypedData.domain as any,
+              domain: {
+                chainId: chainId,
+                verifyingContract: domain?.verifyingContract,
+                name: domain?.name,
+                version: domain?.version,
+              },
               types:
                 parsedTypedData.types as SignerProcedureTypes["signTypedDataV4"]["types"],
               message:


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on fixing sign typed data in the in-app wallet when the domain contains a salt param.

### Detailed summary
- Updated handling of `chainId` to use `TypedDataDefinition["domain"]`
- Refactored `domain` object assignment to include specific properties like `verifyingContract`, `name`, and `version`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->