### PR TITLE
Adds options refetchInterval and retry params to useReadContract

### DIFF
--- a/.changeset/dry-roses-cross.md
+++ b/.changeset/dry-roses-cross.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": minor
+---
+
+Adds options refetchInterval and retry params to useReadContract

--- a/packages/thirdweb/src/react/core/hooks/contract/useReadContract.ts
+++ b/packages/thirdweb/src/react/core/hooks/contract/useReadContract.ts
@@ -18,8 +18,14 @@ import type {
 import type { PreparedMethod } from "../../../../utils/abi/prepare-method.js";
 import { getFunctionId } from "../../../../utils/function-id.js";
 import { stringify } from "../../../../utils/json.js";
+import type { Prettify } from "../../../../utils/type-utils.js";
 
-type PickedQueryOptions = Pick<UseQueryOptions, "enabled">;
+type PickedQueryOptions = Prettify<
+  Pick<UseQueryOptions, "enabled"> & {
+    refetchInterval?: number;
+    retry?: number;
+  }
+>;
 
 /**
  * A hook to read from a contract.


### PR DESCRIPTION
## Problem solved

This PR addresses the need for more flexible configuration options when using the `useReadContract` hook. By adding `refetchInterval` and `retry` parameters, users can customize the frequency of refetching data and the number of retry attempts on failure, respectively. These options improve the robustness and flexibility of the `useReadContract` hook when interacting with contracts.

## Changes made

- [ ] Public API changes: `useReadContract` now accepts `refetchInterval` and `retry` as optional parameters.
- [ ] Internal API changes: The `PickedQueryOptions` type has been updated to include the new parameters.

## How to test

- [ ] Automated tests: Adjust or add unit tests covering the new parameters in the appropriate test file.
- [ ] Manual tests: Configure `useReadContract` with different values for `refetchInterval` and `retry` and verify it behaves as expected.
