### PR TITLE
feat(wallets): adds getEcosystemWalletMetadata

### DIFF
--- a/packages/thirdweb/src/wallets/ecosystem/get-ecosystem-wallet-info.test.ts
+++ b/packages/thirdweb/src/wallets/ecosystem/get-ecosystem-wallet-info.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+import { getEcosystemWalletInfo } from "./get-ecosystem-wallet-info.js";
+
+const mocks = vi.hoisted(() => ({
+  getThirdwebBaseUrl: vi.fn(),
+}));
+
+vi.mock("../../utils/domains", () => ({
+  getThirdwebBaseUrl: mocks.getThirdwebBaseUrl,
+}));
+
+describe("getEcosystemWalletInfo", () => {
+  it("should fetch wallet metadata successfully", async () => {
+    const walletId = "ecosystem.123";
+    const mockResponse = {
+      name: "Test Wallet",
+      imageUrl: "http://example.com/image.png",
+      homepage: "http://example.com",
+    };
+    const fetchMock = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve(mockResponse),
+    });
+    global.fetch = fetchMock;
+    mocks.getThirdwebBaseUrl.mockReturnValue("http://baseurl.com");
+
+    const result = await getEcosystemWalletInfo(walletId);
+
+    expect(fetchMock).toHaveBeenCalled();
+    expect(result).toEqual({
+      id: walletId,
+      name: "Test Wallet",
+      image_id: "http://example.com/image.png",
+      homepage: "http://example.com",
+      rdns: null,
+      app: {
+        browser: null,
+        ios: null,
+        android: null,
+        mac: null,
+        windows: null,
+        linux: null,
+        opera: null,
+        chrome: null,
+        firefox: null,
+        safari: null,
+        edge: null,
+      },
+      mobile: {
+        native: null,
+        universal: null,
+      },
+      desktop: {
+        native: null,
+        universal: null,
+      },
+    });
+  });
+});

--- a/packages/thirdweb/src/wallets/ecosystem/get-ecosystem-wallet-info.ts
+++ b/packages/thirdweb/src/wallets/ecosystem/get-ecosystem-wallet-info.ts
@@ -1,0 +1,55 @@
+import { getThirdwebBaseUrl } from "../../utils/domains.js";
+import type { Prettify } from "../../utils/type-utils.js";
+import type { WalletInfo } from "../wallet-info.js";
+import type { EcosystemWalletId } from "../wallet-types.js";
+
+/**
+ * Fetches metadata for a given ecosystem wallet.
+ *
+ * @param {EcosystemWalletId} walletId - The ecosystem wallet ID.
+ * @returns {Promise<{ imageUrl: string | undefined, name: string | undefined }>} A promise that resolves to an object containing the wallet's image URL and name.
+ * @throws {Error} Throws an error if no partner ID is provided in the wallet configuration.
+ * @internal
+ */
+export async function getEcosystemWalletInfo(
+  walletId: EcosystemWalletId,
+): Promise<Prettify<WalletInfo>> {
+  const headers = new Headers();
+  headers.set("x-ecosystem-id", walletId);
+  const res = await fetch(
+    `${getThirdwebBaseUrl("inAppWallet")}/api/2024-05-05/ecosystem-wallet`,
+    {
+      headers,
+    },
+  );
+
+  const data = await res.json();
+  return {
+    id: walletId,
+    name: data.name as string,
+    image_id: data.imageUrl as string,
+    homepage: data.homepage as string,
+    rdns: null,
+    app: {
+      browser: null,
+      ios: null,
+      android: null,
+      mac: null,
+      windows: null,
+      linux: null,
+      opera: null,
+      chrome: null,
+      firefox: null,
+      safari: null,
+      edge: null,
+    },
+    mobile: {
+      native: null,
+      universal: null,
+    },
+    desktop: {
+      native: null,
+      universal: null,
+    },
+  };
+}

--- a/packages/thirdweb/src/wallets/ecosystem/is-ecosystem-wallet.test.ts
+++ b/packages/thirdweb/src/wallets/ecosystem/is-ecosystem-wallet.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { isEcosystemWallet } from "./is-ecosystem-wallet.js";
+
+describe("isEcosystemWallet", () => {
+  it('should return true for wallet IDs starting with "ecosystem."', () => {
+    const walletId = "ecosystem.123";
+    expect(isEcosystemWallet(walletId)).toBe(true);
+  });
+
+  it('should return false for wallet IDs not starting with "ecosystem."', () => {
+    const walletId = "com.coinbase.wallet";
+    expect(isEcosystemWallet(walletId)).toBe(false);
+  });
+
+  it("should handle edge cases like empty wallet IDs", () => {
+    const walletId = "";
+    expect(isEcosystemWallet(walletId)).toBe(false);
+  });
+});

--- a/packages/thirdweb/src/wallets/ecosystem/is-ecosystem-wallet.ts
+++ b/packages/thirdweb/src/wallets/ecosystem/is-ecosystem-wallet.ts
@@ -1,0 +1,10 @@
+/**
+ * Checks if the given wallet is an ecosystem wallet.
+ *
+ * @param {string} walletId - The wallet ID to check.
+ * @returns {boolean} True if the wallet is an ecosystem wallet, false otherwise.
+ * @internal
+ */
+export function isEcosystemWallet(walletId: string): boolean {
+  return walletId.startsWith("ecosystem.");
+}


### PR DESCRIPTION
The PR introduces a new feature to the TypeScript codebase, adding a method to fetch metadata for ecosystem wallets. A helper function `getEcosystemWalletMetadata` is added in `packages/thirdweb/src/wallets/ecosystem/get-metadata.ts` to fetch and return wallet name and image URL based on the provided integrator ID.

---

## Problem solved

Short description of the bug fixed or feature added

## Changes made

- [ ] Public API changes: list the public API changes made if any
- [ ] Internal API changes: explain the internal logic changes

## How to test

- [ ] Automated tests: link to unit test file
- [ ] Manual tests: step by step instructions on how to test

## Contributor NFT

Paste in your wallet address below and we will airdrop you a special NFT when your pull request is merged. 

```Address: ```

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add functions for checking and fetching information about ecosystem wallets.

### Detailed summary
- Added `isEcosystemWallet` function to check if a wallet is ecosystem
- Added tests for `isEcosystemWallet` function
- Added `getEcosystemWalletInfo` function to fetch metadata for ecosystem wallets
- Added tests for `getEcosystemWalletInfo` function
- Imported necessary types and modules

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->