### PR TITLE
feat(ts): adds isEcosystemWallet

### DIFF
--- a/packages/thirdweb/src/wallets/ecosystem/is-ecosystem-wallet.test.ts
+++ b/packages/thirdweb/src/wallets/ecosystem/is-ecosystem-wallet.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { isEcosystemWallet } from "./is-ecosystem-wallet.js";
+
+describe("isEcosystemWallet", () => {
+  it('should return true for wallet IDs starting with "ecosystem."', () => {
+    const walletId = "ecosystem.123";
+    expect(isEcosystemWallet(walletId)).toBe(true);
+  });
+
+  it('should return false for wallet IDs not starting with "ecosystem."', () => {
+    const walletId = "com.coinbase.wallet";
+    expect(isEcosystemWallet(walletId)).toBe(false);
+  });
+
+  it("should handle edge cases like empty wallet IDs", () => {
+    const walletId = "";
+    expect(isEcosystemWallet(walletId)).toBe(false);
+  });
+});

--- a/packages/thirdweb/src/wallets/ecosystem/is-ecosystem-wallet.ts
+++ b/packages/thirdweb/src/wallets/ecosystem/is-ecosystem-wallet.ts
@@ -1,0 +1,10 @@
+/**
+ * Checks if the given wallet is an ecosystem wallet.
+ *
+ * @param {string} walletId - The wallet ID to check.
+ * @returns {boolean} True if the wallet is an ecosystem wallet, false otherwise.
+ * @internal
+ */
+export function isEcosystemWallet(walletId: string): boolean {
+  return walletId.startsWith("ecosystem.");
+}


### PR DESCRIPTION
This PR introduces a new function `isEcosystemWallet` into the `thirdweb` repository and updates the exports accordingly. The function checks if the given wallet is an ecosystem wallet by verifying if the wallet ID starts with the prefix `ecosystem.`. Accompanying tests ensure the functionality is accurately validated.

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add a function `isEcosystemWallet` to determine if a wallet is part of the ecosystem.

### Detailed summary
- Added `isEcosystemWallet` function to check ecosystem wallets.
- Included tests for `isEcosystemWallet` with positive and negative cases.
- Handles edge cases like empty wallet IDs.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->