### PR TITLE
[v4 & v5] zkCandy Sepolia AA Support

### DIFF
--- a/.changeset/bright-ants-reply.md
+++ b/.changeset/bright-ants-reply.md
@@ -1,0 +1,8 @@
+---
+"@thirdweb-dev/unity-js-bridge": patch
+"@thirdweb-dev/wallets": patch
+"@thirdweb-dev/sdk": patch
+"thirdweb": patch
+---
+
+[v4 & v5] zkCandy Sepolia AA Support

--- a/legacy_packages/sdk/src/evm/contracts/index.ts
+++ b/legacy_packages/sdk/src/evm/contracts/index.ts
@@ -230,7 +230,8 @@ export const MarketplaceV3Initializer = {
     options?: SDKOptions,
   ) => {
     const chainId = (await provider.getNetwork()).chainId;
-    const isZkSync = chainId === 280 || chainId === 324;
+    const isZkSync =
+      chainId === 280 || chainId === 300 || chainId === 324 || chainId === 302;
 
     // Can't resolve IPFS hash from plugin bytecode on ZkSync
     // Thus, pull the composite ABI from the release page

--- a/legacy_packages/unity-js-bridge/src/thirdweb-bridge.ts
+++ b/legacy_packages/unity-js-bridge/src/thirdweb-bridge.ts
@@ -173,7 +173,7 @@ class ThirdwebBridge implements TWBridge {
       // biome-ignore lint/suspicious/noExplicitAny: TODO: fix use of any
       (globalThis as any).X_SDK_PLATFORM = "unity";
       // biome-ignore lint/suspicious/noExplicitAny: TODO: fix use of any
-      (globalThis as any).X_SDK_VERSION = "4.16.2";
+      (globalThis as any).X_SDK_VERSION = "4.16.3";
       // biome-ignore lint/suspicious/noExplicitAny: TODO: fix use of any
       (globalThis as any).X_SDK_OS = browser?.os ?? "unknown";
     }

--- a/legacy_packages/wallets/src/evm/connectors/smart-wallet/lib/http-rpc-client.ts
+++ b/legacy_packages/wallets/src/evm/connectors/smart-wallet/lib/http-rpc-client.ts
@@ -9,6 +9,7 @@ import {
   ZkTransactionInput,
 } from "../types";
 import { MANAGED_ACCOUNT_GAS_BUFFER } from "./constants";
+import { isZkSyncChain } from "../utils";
 
 export const DEBUG = false; // TODO set as public flag
 
@@ -89,7 +90,7 @@ export class HttpRpcClient {
   }
 
   async validateChainId(): Promise<void> {
-    if (this.chainId === 300 || this.chainId === 324) {
+    if (await isZkSyncChain(this.chainId)) {
       return;
     }
     // validate chainId is in sync with expected chainid

--- a/legacy_packages/wallets/src/evm/connectors/smart-wallet/utils.ts
+++ b/legacy_packages/wallets/src/evm/connectors/smart-wallet/utils.ts
@@ -7,7 +7,6 @@ import {
 import { BytesLike } from "ethers";
 import { ENTRYPOINT_ADDRESS } from "./lib/constants";
 import { EntryPoint__factory } from "@account-abstraction/contracts";
-import { Zksync, ZksyncSepoliaTestnet } from "@thirdweb-dev/chains";
 
 export type AccessibleSmartWallets = {
   owned: string;
@@ -111,7 +110,7 @@ export async function isZkSyncChain(
     secretKey,
   });
   const chainId = (await provider.getNetwork()).chainId;
-  return chainId === Zksync.chainId || chainId === ZksyncSepoliaTestnet.chainId;
+  return chainId === 324 || chainId === 300 || chainId === 302;
 }
 
 /**

--- a/legacy_packages/wallets/src/evm/connectors/smart-wallet/zk-connector.ts
+++ b/legacy_packages/wallets/src/evm/connectors/smart-wallet/zk-connector.ts
@@ -6,6 +6,7 @@ import { EVMWallet } from "../../interfaces";
 import { HttpRpcClient } from "./lib/http-rpc-client";
 import { ENTRYPOINT_ADDRESS } from "./lib/constants";
 import { ZkWrappedSigner } from "./zk-wrapped-signer";
+import { isZkSyncChain } from "./utils";
 
 export class ZkSyncConnector extends Connector<SmartWalletConnectionArgs> {
   protected config: SmartWalletConfig;
@@ -23,7 +24,7 @@ export class ZkSyncConnector extends Connector<SmartWalletConnectionArgs> {
   ): Promise<string> {
     this.personalWallet = args.personalWallet;
     this.chainId = await (await this.personalWallet.getSigner()).getChainId();
-    if (this.chainId !== 300 && this.chainId !== 324) {
+    if (!(await isZkSyncChain(this.chainId))) {
       throw new Error("Invalid zksync chain id");
     }
     const bundlerUrl =

--- a/legacy_packages/wallets/src/evm/wallets/smart-wallet.ts
+++ b/legacy_packages/wallets/src/evm/wallets/smart-wallet.ts
@@ -580,10 +580,10 @@ export class SmartWallet extends AbstractClientWallet<
    * @returns `true` if the smart wallet contract is deployed
    */
   async isDeployed(): Promise<boolean> {
-    if (this.connector?.chainId === 300 || this.connector?.chainId === 324) {
+    const connector = await this.getConnector();
+    if (connector.chainId && (await isZkSyncChain(connector.chainId))) {
       return true;
     }
-    const connector = await this.getConnector();
     return connector.isDeployed();
   }
 

--- a/legacy_packages/wallets/test/zk-smart-wallet-integration.test.ts
+++ b/legacy_packages/wallets/test/zk-smart-wallet-integration.test.ts
@@ -1,7 +1,10 @@
 /* eslint-disable better-tree-shaking/no-top-level-side-effects */
 import { SmartWallet } from "../src/evm/wallets/smart-wallet";
 import { LocalWallet } from "../src/evm/wallets/local-wallet";
-import { ZksyncSepoliaTestnet } from "@thirdweb-dev/chains";
+import {
+  ZkcandySepoliaTestnet,
+  ZksyncSepoliaTestnet,
+} from "@thirdweb-dev/chains";
 import { ThirdwebSDK } from "@thirdweb-dev/sdk";
 import { describe, it, expect, beforeAll } from "vitest";
 
@@ -70,6 +73,35 @@ describeIf(!!SECRET_KEY)("SmartWallet core tests", () => {
       );
       console.log(approveTx.receipt.transactionHash);
       expect(approveTx.receipt.transactionHash).toHaveLength(66);
+    },
+  );
+
+  it(
+    "can execute zkcandy tx via SDK",
+    {
+      timeout: 120_000,
+    },
+    async () => {
+      const zkCandysmartWallet = new SmartWallet({
+        chain: 302,
+        gasless: true,
+        secretKey: SECRET_KEY,
+      });
+      const zkCandyPersonalWallet = new LocalWallet({
+        chain: ZkcandySepoliaTestnet,
+        secretKey: SECRET_KEY,
+      });
+      await zkCandyPersonalWallet.generate();
+      await zkCandyPersonalWallet.connect();
+      const zkCandyWalletAddress = await zkCandysmartWallet.connect({
+        personalWallet: zkCandyPersonalWallet,
+      });
+      const zkCandySdk = await ThirdwebSDK.fromWallet(zkCandysmartWallet, 302, {
+        secretKey: SECRET_KEY,
+      });
+      const tx = await zkCandySdk.wallet.transfer(zkCandyWalletAddress, 0);
+      expect(tx.receipt.transactionHash).toHaveLength(66);
+      console.log(tx.receipt.transactionHash);
     },
   );
 });

--- a/packages/thirdweb/src/wallets/smart/lib/utils.ts
+++ b/packages/thirdweb/src/wallets/smart/lib/utils.ts
@@ -1,6 +1,4 @@
 import { concat } from "viem";
-import { zkSyncSepolia } from "../../../chains/chain-definitions/zksync-sepolia.js";
-import { zkSync } from "../../../chains/chain-definitions/zksync.js";
 import type { Chain } from "../../../chains/types.js";
 import { isHex, numberToHex, toHex } from "../../../utils/encoding/hex.js";
 import type { UserOperation, UserOperationHexed } from "../types.js";
@@ -45,5 +43,5 @@ export function hexlifyUserOp(userOp: UserOperation): UserOperationHexed {
 }
 
 export function isNativeAAChain(chain: Chain) {
-  return chain.id === zkSync.id || chain.id === zkSyncSepolia.id;
+  return chain.id === 324 || chain.id === 300 || chain.id === 302;
 }

--- a/packages/thirdweb/src/wallets/smart/smart-wallet-zksync.test.ts
+++ b/packages/thirdweb/src/wallets/smart/smart-wallet-zksync.test.ts
@@ -2,9 +2,11 @@ import { beforeAll, describe, expect, it } from "vitest";
 import { TEST_CLIENT } from "../../../test/src/test-clients.js";
 import { ANVIL_PKEY_C } from "../../../test/src/test-wallets.js";
 import { zkSyncSepolia } from "../../chains/chain-definitions/zksync-sepolia.js";
+import { defineChain } from "../../chains/utils.js";
 import { getContract } from "../../contract/contract.js";
 import { claimTo } from "../../extensions/erc1155/drops/write/claimTo.js";
 import { sendTransaction } from "../../transaction/actions/send-transaction.js";
+import { prepareTransaction } from "../../transaction/prepare-transaction.js";
 import { smartWallet } from "../create-wallet.js";
 import type { Account, Wallet } from "../interfaces/wallet.js";
 import { privateKeyToAccount } from "../private-key.js";
@@ -55,6 +57,31 @@ describe.runIf(process.env.TW_SECRET_KEY)(
           tokenId: 0n,
         }),
         account: smartAccount,
+      });
+      expect(tx.transactionHash.length).toBe(66);
+    });
+
+    it("should send a transaction on zkcandy", async () => {
+      const zkCandy = defineChain(302);
+      const zkCandySmartWallet = smartWallet({
+        chain: zkCandy,
+        gasless: true,
+      });
+      const zkCandySmartAccount = await zkCandySmartWallet.connect({
+        client: TEST_CLIENT,
+        personalAccount,
+      });
+      const zkCandySmartWalletAddress = zkCandySmartAccount.address;
+      const preparedTx = await prepareTransaction({
+        chain: defineChain(302),
+        client: client,
+        to: zkCandySmartWalletAddress,
+        value: BigInt(0),
+        data: "0x",
+      });
+      const tx = await sendTransaction({
+        transaction: preparedTx,
+        account: zkCandySmartAccount,
       });
       expect(tx.transactionHash.length).toBe(66);
     });


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds support for zkCandy Sepolia AA and updates chain IDs for ZkSync. 

### Detailed summary
- Updated chain IDs for ZkSync support
- Added zkCandy Sepolia AA support
- Updated SDK version to 4.16.3
- Refactored chain ID validation logic to use `isZkSyncChain` function
- Added tests for zkCandy transactions via SDK

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->