### PR TITLE
Prevent autoConnect from running again on window focus

### DIFF
--- a/.changeset/nasty-pumpkins-chew.md
+++ b/.changeset/nasty-pumpkins-chew.md
@@ -1,0 +1,9 @@
+---
+"thirdweb": patch
+---
+
+Fix in-app wallet sending another verification code on window focus when using ConnectEmbed.
+
+Fix the underlying issue of `useAutoConnect` running again on window focus.
+
+Add `refetchOnWindowFocus: false` on few more `useQuery` instances to avoid unnecessary refetches

--- a/packages/thirdweb/src/react/core/hooks/auth/useSiweAuth.ts
+++ b/packages/thirdweb/src/react/core/hooks/auth/useSiweAuth.ts
@@ -64,6 +64,7 @@ export function useSiweAuth(authOptions?: SiweAuthOptions) {
       }
       return authOptions.isLoggedIn(activeAccount.address);
     },
+    refetchOnWindowFocus: false,
   });
 
   const loginMutation = useMutation({

--- a/packages/thirdweb/src/react/core/hooks/connection/useAutoConnect.ts
+++ b/packages/thirdweb/src/react/core/hooks/connection/useAutoConnect.ts
@@ -134,6 +134,7 @@ export function useAutoConnect(props: AutoConnectProps) {
     queryKey: ["autoConnect", props.client.clientId],
     queryFn: autoConnect,
     refetchOnMount: false,
+    refetchOnWindowFocus: false,
   });
 
   return query;

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/AnyWalletConnectUI.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/AnyWalletConnectUI.tsx
@@ -11,7 +11,6 @@ import { getInstalledWalletProviders } from "../../../../../wallets/injected/mip
 import type { Wallet } from "../../../../../wallets/interfaces/wallet.js";
 import { useConnectUI } from "../../../../core/hooks/others/useWalletConnectionCtx.js";
 import { getInjectedWalletLocale } from "../../../wallets/injected/locale/getInjectedWalletLocale.js";
-import type { InjectedWalletLocale } from "../../../wallets/injected/locale/types.js";
 import { GetStartedScreen } from "../../../wallets/shared/GetStartedScreen.js";
 import { LoadingScreen } from "../../../wallets/shared/LoadingScreen.js";
 import {
@@ -21,6 +20,7 @@ import {
 import { useWalletInfo } from "../../hooks/useWalletInfo.js";
 import { DeepLinkConnectUI } from "./DeepLinkConnectUI.js";
 import { InjectedConnectUI } from "./InjectedConnectUI.js";
+import { useQuery } from "@tanstack/react-query";
 
 const CoinbaseSDKWalletConnectUI = /* @__PURE__ */ lazy(
   () => import("../../../wallets/shared/CoinbaseSDKConnection.js"),
@@ -42,18 +42,23 @@ export function AnyWalletConnectUI(props: {
   const { wallet } = props;
   const walletInfo = useWalletInfo(props.wallet.id);
   const localeId = useConnectUI().locale;
-  const [locale, setLocale] = useState<InjectedWalletLocale | null>(null);
 
-  useEffect(() => {
-    if (!walletInfo.data) {
-      return;
-    }
-    getInjectedWalletLocale(localeId).then((w) => {
-      setLocale(w(walletInfo.data.name));
-    });
-  }, [localeId, walletInfo.data]);
+  const localeQuery = useQuery({
+    queryKey: ["injectedWalletLocale", localeId],
+    queryFn: async () => {
+      if (!walletInfo.data) {
+        throw new Error("Wallet info not available");
+      }
+      const w = await getInjectedWalletLocale(localeId)
+      return w(walletInfo.data.name);
+    },
+    enabled: !!walletInfo.data,
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+  })
 
-  if (!walletInfo.data || !locale) {
+
+  if (!walletInfo.data || !localeQuery.data) {
     return <LoadingScreen />;
   }
 
@@ -65,7 +70,7 @@ export function AnyWalletConnectUI(props: {
   if (screen === "get-started") {
     return (
       <GetStartedScreen
-        locale={locale}
+        locale={localeQuery.data}
         wallet={props.wallet}
         walletInfo={walletInfo.data}
         onBack={() => {
@@ -87,7 +92,7 @@ export function AnyWalletConnectUI(props: {
         wallet={props.wallet as Wallet<InjectedSupportedWalletIds>}
         walletInfo={walletInfo.data}
         deepLinkPrefix={walletInfo.data.deepLink.mobile}
-        locale={locale}
+        locale={localeQuery.data}
         onGetStarted={() => {
           setScreen("get-started");
         }}
@@ -102,7 +107,7 @@ export function AnyWalletConnectUI(props: {
         wallet={props.wallet as Wallet<InjectedSupportedWalletIds>}
         walletInfo={walletInfo.data}
         done={props.done}
-        locale={locale}
+        locale={localeQuery.data}
         onGetStarted={() => {
           setScreen("get-started");
         }}
@@ -116,7 +121,7 @@ export function AnyWalletConnectUI(props: {
     return (
       <Suspense fallback={<LoadingScreen />}>
         <CoinbaseSDKWalletConnectUI
-          locale={locale}
+          locale={localeQuery.data}
           onGetStarted={() => {
             setScreen("get-started");
           }}
@@ -133,7 +138,7 @@ export function AnyWalletConnectUI(props: {
   if (walletInfo.data.mobile.native || walletInfo.data.mobile.universal) {
     return (
       <WalletConnectConnection
-        locale={locale}
+        locale={localeQuery.data}
         onGetStarted={() => {
           setScreen("get-started");
         }}
@@ -149,7 +154,7 @@ export function AnyWalletConnectUI(props: {
   if (props.wallet.id === "walletConnect") {
     return (
       <WalletConnectStandaloneConnection
-        locale={locale}
+        locale={localeQuery.data}
         onBack={props.onBack}
         done={props.done}
         wallet={props.wallet as Wallet<"walletConnect">}
@@ -174,7 +179,7 @@ export function AnyWalletConnectUI(props: {
   // if can't connect in any way - show get started screen
   return (
     <GetStartedScreen
-      locale={locale}
+      locale={localeQuery.data}
       wallet={props.wallet}
       walletInfo={walletInfo.data}
       onBack={() => {

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/AnyWalletConnectUI.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/AnyWalletConnectUI.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { Suspense, lazy, useEffect, useState } from "react";
+import { Suspense, lazy, useState } from "react";
 import { isMobile } from "../../../../../utils/web/isMobile.js";
 import type {
   DeepLinkSupportedWalletIds,

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/AnyWalletConnectUI.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/AnyWalletConnectUI.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { useQuery } from "@tanstack/react-query";
 import { Suspense, lazy, useState } from "react";
 import { isMobile } from "../../../../../utils/web/isMobile.js";
 import type {
@@ -20,7 +21,6 @@ import {
 import { useWalletInfo } from "../../hooks/useWalletInfo.js";
 import { DeepLinkConnectUI } from "./DeepLinkConnectUI.js";
 import { InjectedConnectUI } from "./InjectedConnectUI.js";
-import { useQuery } from "@tanstack/react-query";
 
 const CoinbaseSDKWalletConnectUI = /* @__PURE__ */ lazy(
   () => import("../../../wallets/shared/CoinbaseSDKConnection.js"),
@@ -49,14 +49,13 @@ export function AnyWalletConnectUI(props: {
       if (!walletInfo.data) {
         throw new Error("Wallet info not available");
       }
-      const w = await getInjectedWalletLocale(localeId)
+      const w = await getInjectedWalletLocale(localeId);
       return w(walletInfo.data.name);
     },
     enabled: !!walletInfo.data,
     refetchOnWindowFocus: false,
     refetchOnMount: false,
-  })
-
+  });
 
   if (!walletInfo.data || !localeQuery.data) {
     return <LoadingScreen />;

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/locale/getConnectLocale.ts
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/locale/getConnectLocale.ts
@@ -27,5 +27,7 @@ export function useConnectLocale(localeId: LocaleId) {
     queryFn: async () => {
       return getConnectLocale(localeId);
     },
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
   });
 }

--- a/packages/thirdweb/src/react/web/ui/hooks/useWalletInfo.ts
+++ b/packages/thirdweb/src/react/web/ui/hooks/useWalletInfo.ts
@@ -14,6 +14,8 @@ export function useWalletInfo(id: WalletId) {
       return getWalletInfo(id, false);
     },
     retry: false,
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
   });
 }
 
@@ -28,5 +30,7 @@ export function useWalletImage(id: WalletId) {
       return getWalletInfo(id, true);
     },
     retry: false,
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
   });
 }

--- a/packages/thirdweb/src/react/web/wallets/in-app/InAppWalletConnectUI.tsx
+++ b/packages/thirdweb/src/react/web/wallets/in-app/InAppWalletConnectUI.tsx
@@ -25,10 +25,10 @@ function InAppWalletConnectUI(props: {
   const data = useSelectionData();
   const setSelectionData = useSetSelectionData();
   const state = data as InAppWalletSelectUIState;
-  const locale = useInAppWalletLocale();
+  const localeQuery = useInAppWalletLocale();
   const { connectModal } = useConnectUI();
 
-  if (!locale) {
+  if (!localeQuery.data) {
     return <LoadingScreen />;
   }
 
@@ -49,7 +49,7 @@ function InAppWalletConnectUI(props: {
     return (
       <InAppWalletOTPLoginUI
         userInfo={otpUserInfo}
-        locale={locale}
+        locale={localeQuery.data}
         done={props.done}
         goBack={goBackToMain}
         wallet={props.wallet}
@@ -71,7 +71,7 @@ function InAppWalletConnectUI(props: {
     return (
       <InAppWalletSocialLogin
         socialAuth={state.socialLogin.type}
-        locale={locale}
+        locale={localeQuery.data}
         done={props.done}
         goBack={goBackToMain}
         wallet={props.wallet}
@@ -83,7 +83,7 @@ function InAppWalletConnectUI(props: {
   return (
     <InAppWalletFormUIScreen
       select={() => {}}
-      locale={locale}
+      locale={localeQuery.data}
       done={props.done}
       goBack={props.goBack}
       wallet={props.wallet}

--- a/packages/thirdweb/src/react/web/wallets/in-app/InAppWalletSelectionUI.tsx
+++ b/packages/thirdweb/src/react/web/wallets/in-app/InAppWalletSelectionUI.tsx
@@ -22,7 +22,7 @@ function InAppWalletSelectionUI(props: {
   const { screen } = useScreenContext();
   const { connectModal } = useConnectUI();
   const setData = useSetSelectionData();
-  const locale = useInAppWalletLocale();
+  const localeQuery = useInAppWalletLocale();
 
   // do not show the "selectUI" if
   // modal is compact or
@@ -42,13 +42,13 @@ function InAppWalletSelectionUI(props: {
     );
   }
 
-  if (!locale) {
+  if (!localeQuery.data) {
     return <LoadingScreen height="195px" />;
   }
 
   return (
     <InAppWalletFormUI
-      locale={locale}
+      locale={localeQuery.data}
       wallet={props.wallet}
       done={props.done}
       select={props.select}

--- a/packages/thirdweb/src/react/web/wallets/in-app/useInAppWalletLocale.ts
+++ b/packages/thirdweb/src/react/web/wallets/in-app/useInAppWalletLocale.ts
@@ -1,22 +1,16 @@
-import { useEffect, useState } from "react";
 import { useConnectUI } from "../../../core/hooks/others/useWalletConnectionCtx.js";
 import { getInAppWalletLocale } from "./locale/getInAppWalletLocale.js";
-import type { InAppWalletLocale } from "./locale/types.js";
+import { useQuery } from "@tanstack/react-query";
 
 /**
  * @internal
  */
 export function useInAppWalletLocale() {
   const localeId = useConnectUI().locale;
-  const [locale, setLocale] = useState<InAppWalletLocale | undefined>(
-    undefined,
-  );
-
-  useEffect(() => {
-    getInAppWalletLocale(localeId).then((l) => {
-      setLocale(l);
-    });
-  }, [localeId]);
-
-  return locale;
+  return useQuery({
+    queryKey: ["inAppWalletLocale", localeId],
+    queryFn: () => getInAppWalletLocale(localeId),
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+  });
 }

--- a/packages/thirdweb/src/react/web/wallets/in-app/useInAppWalletLocale.ts
+++ b/packages/thirdweb/src/react/web/wallets/in-app/useInAppWalletLocale.ts
@@ -1,6 +1,6 @@
+import { useQuery } from "@tanstack/react-query";
 import { useConnectUI } from "../../../core/hooks/others/useWalletConnectionCtx.js";
 import { getInAppWalletLocale } from "./locale/getInAppWalletLocale.js";
-import { useQuery } from "@tanstack/react-query";
 
 /**
  * @internal


### PR DESCRIPTION
Fixes - https://linear.app/thirdweb/issue/CNCT-1359/bug-causing-multiple-otp-emails-to-be-received-when-using-the 


Main change is stopping `autoConnect` from running again on window focus

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing unnecessary refetches in `useQuery` instances and preventing re-execution of `useAutoConnect` on window focus. 

### Detailed summary
- Added `refetchOnWindowFocus: false` to multiple `useQuery` instances to prevent unnecessary refetches
- Fixed `useAutoConnect` re-execution on window focus
- Resolved in-app wallet sending extra verification code on window focus

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->