### PR TITLE
fix(react): use custom title and icon in compact Connect modal

### DIFF
--- a/.changeset/afraid-mirrors-develop.md
+++ b/.changeset/afraid-mirrors-develop.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/react": patch
+---
+
+Fixed Connect modal title not using custom title and icon in compact mode

--- a/.changeset/afraid-mirrors-develop.md
+++ b/.changeset/afraid-mirrors-develop.md
@@ -1,5 +1,5 @@
 ---
-"@thirdweb-dev/react": patch
+"thirdweb": patch
 ---
 
 Fixed Connect modal title not using custom title and icon in compact mode

--- a/packages/thirdweb/src/react/web/ui/components/basic.tsx
+++ b/packages/thirdweb/src/react/web/ui/components/basic.tsx
@@ -42,7 +42,7 @@ export function ModalHeader(props: {
       style={{
         display: "flex",
         alignItems: "center",
-        justifyContent: "center",
+        justifyContent: onBack ? "center" : "flex-start",
         position: "relative",
       }}
     >
@@ -56,7 +56,7 @@ export function ModalHeader(props: {
           }}
         />
       )}
-      <Container flex="row" gap="xs" center="both">
+      <Container flex="row" gap="xs" center={"both"}>
         {typeof title === "string" ? <ModalTitle>{title}</ModalTitle> : title}
       </Container>
     </div>

--- a/packages/thirdweb/src/react/web/wallets/in-app/InAppWalletFormUI.tsx
+++ b/packages/thirdweb/src/react/web/wallets/in-app/InAppWalletFormUI.tsx
@@ -28,6 +28,7 @@ import { Spacer } from "../../ui/components/Spacer.js";
 import { TextDivider } from "../../ui/components/TextDivider.js";
 import { Container, ModalHeader } from "../../ui/components/basic.js";
 import { Button } from "../../ui/components/buttons.js";
+import { ModalTitle } from "../../ui/components/modalElements.js";
 import { InputSelectionUI } from "./InputSelectionUI.js";
 import type { InAppWalletLocale } from "./locale/types.js";
 import { openOauthSignInWindow } from "./openOauthSignInWindow.js";
@@ -336,7 +337,7 @@ export const InAppWalletFormUI = (props: InAppWalletFormUIProps) => {
  */
 export function InAppWalletFormUIScreen(props: InAppWalletFormUIProps) {
   const locale = props.locale.emailLoginScreen;
-  const { connectModal } = useConnectUI();
+  const { connectModal, client } = useConnectUI();
   const isCompact = connectModal.size === "compact";
   const { initialScreen, screen } = useScreenContext();
 
@@ -357,7 +358,22 @@ export function InAppWalletFormUIScreen(props: InAppWalletFormUIProps) {
     >
       {isCompact ? (
         <>
-          <ModalHeader onBack={onBack} title={locale.title} />
+          <ModalHeader
+            onBack={onBack}
+            title={
+              <>
+                {!connectModal.titleIcon ? null : (
+                  <Img
+                    src={connectModal.titleIcon}
+                    width={iconSize.md}
+                    height={iconSize.md}
+                    client={client}
+                  />
+                )}
+                <ModalTitle>{connectModal.title ?? locale.title}</ModalTitle>
+              </>
+            }
+          />
           <Spacer y="sm" />
         </>
       ) : null}

--- a/packages/thirdweb/src/react/web/wallets/in-app/InAppWalletFormUI.tsx
+++ b/packages/thirdweb/src/react/web/wallets/in-app/InAppWalletFormUI.tsx
@@ -374,7 +374,7 @@ export function InAppWalletFormUIScreen(props: InAppWalletFormUIProps) {
               </>
             }
           />
-          <Spacer y="sm" />
+          <Spacer y="lg" />
         </>
       ) : null}
 


### PR DESCRIPTION
## Problem solved

Fixes the Connect button's `connectModal` props for custom title and icon not being respected when the modal is displayed in compact mode.

Example params:
```
connectModal={{
  size: "compact",
  title: "Connect to Zeeverse",
  titleIcon: "https://images.treasure.lol/tdk/login/zeeverse_icon.png",
  showThirdwebBranding: false,
}}
```

Before
<img width="388" alt="Screenshot 2024-06-12 at 11 02 45 AM" src="https://github.com/thirdweb-dev/js/assets/1013230/0b6019b1-5b72-44ad-b158-d819e9e5fcc2">

After
<img width="394" alt="Screenshot 2024-06-12 at 11 02 23 AM" src="https://github.com/thirdweb-dev/js/assets/1013230/da072af1-2455-4908-bc14-5c3aaa813c5e">

## Changes made

- [ ] Public API changes: list the public API changes made if any
- [ ] Internal API changes: explain the internal logic changes

## How to test

- [ ] Automated tests: link to unit test file
- [X] Manual tests: step by step instructions on how to test

Add the example params above to the `StyledConnectButton` example in the playground app and run locally

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to fix the issue where the Connect modal title was not using custom title and icon in compact mode.

### Detailed summary
- Fixed Connect modal title not using custom title and icon in compact mode
- Added `ModalTitle` component import in `InAppWalletFormUI.tsx`
- Modified `ModalHeader` component in `InAppWalletFormUIScreen` to display custom title and icon in compact mode

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->