### PR TITLE
feat(react): add ability to pass ReactNode for ConnectButton label

### DIFF
--- a/.changeset/twelve-ads-hope.md
+++ b/.changeset/twelve-ads-hope.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/react": patch
+---
+
+Updated the `ConnectButton` `label` prop to be of type `ReactNode`

--- a/.changeset/twelve-ads-hope.md
+++ b/.changeset/twelve-ads-hope.md
@@ -1,5 +1,5 @@
 ---
-"@thirdweb-dev/react": patch
+"thirdweb": patch
 ---
 
 Updated the `ConnectButton` `label` prop to be of type `ReactNode`

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/ConnectButton.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/ConnectButton.tsx
@@ -193,7 +193,9 @@ function ConnectButtonInner(
         aria-label={
           connectionStatus === "connecting"
             ? locale.connecting
-            : connectButtonLabel
+            : typeof connectButtonLabel === "string"
+              ? connectButtonLabel
+              : locale.defaultButtonTitle
         }
         onClick={() => {
           setIsWalletModalOpen(true);

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/ConnectButtonProps.ts
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/ConnectButtonProps.ts
@@ -90,7 +90,7 @@ export type ConnectButton_connectButtonOptions = {
    * }} />
    * ```
    */
-  label?: string;
+  label?: React.ReactNode;
 
   /**
    * CSS class to apply to the button element


### PR DESCRIPTION
## Problem solved

Updates the `ConnectButton`'s `label` prop to be of type `ReactNode` so that consumers have more flexibility with the button contents. For example, adding an icon:

<img width="183" alt="Screenshot 2024-06-12 at 3 40 35 PM" src="https://github.com/thirdweb-dev/js/assets/1013230/3a5e9c36-d005-46d7-8f0c-1b2e960a53af">

## Changes made

- [X] Public API changes: list the public API changes made if any
- [ ] Internal API changes: explain the internal logic changes

- `ConnectButton.label` type becomes `ReactNode`. This is a non-breaking change because it was previously `string`, which is compatible with `ReactNode`.

## How to test

- [ ] Automated tests: link to unit test file
- [X] Manual tests: step by step instructions on how to test

Add the example params to the `StyledConnectButton` example in the playground app and run locally:
```
connectButton={{
  label: (
    <>
      <SparklesIcon />
      <span className="ml-1">Connect</span>
    </>
  ),
}}
```

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `ConnectButton` component in `thirdweb` package to accept `ReactNode` type for the `label` prop.

### Detailed summary
- Updated `ConnectButton` `label` prop to accept `ReactNode` type instead of just string
- Adjusted logic in `ConnectButton.tsx` to use `connectButtonLabel` if it's a string, otherwise default to `locale.defaultButtonTitle`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->