### PR TITLE
fix(react): update `ConnectButton` loading spinner to respect custom color style

### DIFF
--- a/.changeset/eleven-dodos-cheer.md
+++ b/.changeset/eleven-dodos-cheer.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fixed `ConnectButton` loading spinner not respecting custom color style

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/ConnectButton.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/ConnectButton.tsx
@@ -89,7 +89,7 @@ export function ConnectButton(props: ConnectButtonProps) {
         }}
       >
         {autoConnectComp}
-        <Spinner size="sm" color="primaryButtonText" />
+        <Spinner size="sm" color="currentColor" />
       </AnimatedButton>
     );
   }
@@ -201,7 +201,7 @@ function ConnectButtonInner(
         data-test="connect-wallet-button"
       >
         {isLoading ? (
-          <Spinner size="sm" color="primaryButtonText" />
+          <Spinner size="sm" color="currentColor" />
         ) : (
           connectButtonLabel
         )}
@@ -226,7 +226,7 @@ function ConnectButtonInner(
             ...props.connectButton?.style,
           }}
         >
-          <Spinner size="sm" color="primaryButtonText" />
+          <Spinner size="sm" color="currentColor" />
         </AnimatedButton>
       );
     }
@@ -247,7 +247,7 @@ function ConnectButtonInner(
             }}
           >
             {siweAuth.isLoggingIn ? (
-              <Spinner size="sm" color="primaryButtonText" />
+              <Spinner size="sm" color="currentColor" />
             ) : (
               <Container flex="row" center="y" gap="sm">
                 <LockIcon size={iconSize.sm} />

--- a/packages/thirdweb/src/react/web/ui/components/Spinner.tsx
+++ b/packages/thirdweb/src/react/web/ui/components/Spinner.tsx
@@ -9,7 +9,7 @@ import { StyledCircle, StyledSvg } from "../design-system/elements.js";
  * @internal
  */
 export const Spinner: React.FC<{
-  color: keyof Theme["colors"];
+  color: keyof Theme["colors"] | "currentColor";
   size: keyof typeof iconSize;
 }> = (props) => {
   const theme = useCustomTheme();
@@ -26,7 +26,11 @@ export const Spinner: React.FC<{
         cy="25"
         r="20"
         fill="none"
-        stroke={theme.colors[props.color]}
+        stroke={
+          props.color === "currentColor"
+            ? props.color
+            : theme.colors[props.color]
+        }
         strokeWidth="4"
       />
     </Svg>


### PR DESCRIPTION
## Problem solved

`Spinner` element on the `ConnectButton` was always rendered with the `primaryButtonText` color, regardless of what `color` style was passed in on the `connectButton.style` props. Updating the prop to allow for a value of `currentColor` makes the custom color style inheritable without changing the default functionality.

Before
https://github.com/thirdweb-dev/js/assets/1013230/2a25ba82-b389-4b3f-9cfe-501e5091d8b0

After
https://github.com/thirdweb-dev/js/assets/1013230/cc4a6144-a527-4460-bb98-374629f99fa9

## Changes made

- [X] Public API changes: list the public API changes made if any
- [ ] Internal API changes: explain the internal logic changes

- Non-breaking change for `Spinner.color` prop type to allow for value of `currentColor`

## How to test

- [ ] Automated tests: link to unit test file
- [X] Manual tests: step by step instructions on how to test

Add the example params to the `StyledConnectButton` example in the playground app and run locally:
```
connectButton={{
  style: {
    color: "#FFFFFF",
    backgroundColor: "#DC2626",
  },
}}
```

<!-- start pr-codex -->

---

## PR-Codex overview
This PR fixes the `ConnectButton` loading spinner to respect custom color styles.

### Detailed summary
- Updated `Spinner` component to accept `currentColor` as a color option
- Modified `ConnectButton` to use `currentColor` for spinner color instead of a specific color

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->