### PR TITLE
fix: set default recipients in sigMint and update tests

### DIFF
--- a/.changeset/weak-fireants-jam.md
+++ b/.changeset/weak-fireants-jam.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix default sale and royalty recipients for signature mints

--- a/packages/thirdweb/src/extensions/erc721/write/sigMint721.test.ts
+++ b/packages/thirdweb/src/extensions/erc721/write/sigMint721.test.ts
@@ -4,6 +4,7 @@ import { TEST_CLIENT } from "../../../../test/src/test-clients.js";
 import {
   TEST_ACCOUNT_A,
   TEST_ACCOUNT_B,
+  TEST_ACCOUNT_C,
 } from "../../../../test/src/test-wallets.js";
 import { NATIVE_TOKEN_ADDRESS } from "../../../constants/addresses.js";
 import {
@@ -34,6 +35,8 @@ describe.runIf(process.env.TW_SECRET_KEY)(
           params: {
             name: "Test",
             symbol: "TST",
+            royaltyRecipient: TEST_ACCOUNT_C.address,
+            saleRecipient: TEST_ACCOUNT_B.address,
           },
           type: "TokenERC721",
         }),
@@ -93,13 +96,9 @@ describe.runIf(process.env.TW_SECRET_KEY)(
       });
 
       expect(payload.to).toBe("0x70997970C51812dc3A010C7d01b50e0d17dc79C8");
-      expect(payload.royaltyRecipient).toBe(
-        "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-      );
+      expect(payload.royaltyRecipient).toBe(TEST_ACCOUNT_C.address);
       expect(payload.royaltyBps).toBe(0n);
-      expect(payload.primarySaleRecipient).toBe(
-        "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-      );
+      expect(payload.primarySaleRecipient).toBe(TEST_ACCOUNT_B.address);
       expect(payload.uri).toBe("https://example.com/token");
       expect(payload.price).toBe(0n);
       expect(payload.currency).toBe(NATIVE_TOKEN_ADDRESS);
@@ -154,6 +153,29 @@ describe.runIf(process.env.TW_SECRET_KEY)(
       expect(payload.uid).toBe(
         "0x6162636465663132333435363738393000000000000000000000000000000000",
       );
+      expect(signature.length).toBe(132);
+    });
+
+    it("should default sale recipient to the contract's primarySaleRecipient when empty", async () => {
+      const { payload, signature } = await generateMintSignature({
+        mintRequest: {
+          to: TEST_ACCOUNT_B.address,
+          royaltyBps: 500,
+          metadata: "https://example.com/token",
+          price: "0.2",
+          currency: erc20TokenContract.address,
+          validityStartTimestamp: new Date(1635724800),
+          validityEndTimestamp: new Date(1867260800),
+          uid: toHex("abcdef1234567890", { size: 32 }),
+          primarySaleRecipient: "",
+          royaltyRecipient: "",
+        },
+        account: TEST_ACCOUNT_A,
+        contract: erc721Contract,
+      });
+
+      expect(payload.royaltyRecipient).toBe(TEST_ACCOUNT_C.address);
+      expect(payload.primarySaleRecipient).toBe(TEST_ACCOUNT_B.address);
       expect(signature.length).toBe(132);
     });
   },


### PR DESCRIPTION

## PR-Codex overview
The focus of this PR is to update the ERC721 minting process to handle primary and royalty sale recipients dynamically.

### Detailed summary
- Dynamically set sale recipient based on conditions
- Dynamically set royalty recipient based on conditions
- Update tests to reflect changes in sale and royalty recipients

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to fix default sale and royalty recipients for signature mints in the ERC721 extension.

### Detailed summary
- Set default sale and royalty recipients if not provided
- Update tests to reflect changes in default recipients
- Ensure proper handling of empty recipient fields

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->