### PR TITLE
fix(wallets): don't serialize eip5792 calls

### DIFF
--- a/packages/thirdweb/src/wallets/eip5792/send-calls.ts
+++ b/packages/thirdweb/src/wallets/eip5792/send-calls.ts
@@ -2,11 +2,14 @@ import type { Abi, AbiFunction } from "abitype";
 import type { WalletSendCallsParameters as ViemWalletSendCallsParameters } from "viem";
 import type { Chain } from "../../chains/types.js";
 import type { ThirdwebClient } from "../../client/client.js";
-import { toSerializableTransaction } from "../../transaction/actions/to-serializable-transaction.js";
+import { encode } from "../../transaction/actions/encode.js";
 import type { PreparedTransaction } from "../../transaction/prepare-transaction.js";
 import { type Address, getAddress } from "../../utils/address.js";
 import { type Hex, numberToHex } from "../../utils/encoding/hex.js";
-import type { PromisedObject } from "../../utils/promise/resolve-promised-value.js";
+import {
+  type PromisedObject,
+  resolvePromisedValue,
+} from "../../utils/promise/resolve-promised-value.js";
 import type { OneOf } from "../../utils/type-utils.js";
 import { isCoinbaseSDKWallet } from "../coinbase/coinbaseSDKWallet.js";
 import { isInAppWallet } from "../in-app/core/wallet/index.js";
@@ -144,22 +147,23 @@ export async function sendCalls<const ID extends WalletId>(
 
   const preparedCalls: EIP5792Call[] = await Promise.all(
     calls.map(async (call) => {
-      const serializableTransaction = await toSerializableTransaction({
-        transaction: call,
-        from: account.address,
-      });
-
-      const { to, data, value } = serializableTransaction;
-      if (to === undefined && data === undefined) {
+      const { to, value } = call;
+      if (to === undefined && call.data === undefined) {
         throw new Error("Cannot send call, `to` or `data` must be provided.");
       }
 
+      const [_to, _data, _value] = await Promise.all([
+        resolvePromisedValue(to),
+        encode(call),
+        resolvePromisedValue(value),
+      ]);
+
       return {
-        to: to as Address,
-        data: data as Hex,
+        to: _to as Address,
+        data: _data as Hex,
         value:
-          typeof value === "bigint" || typeof value === "number"
-            ? numberToHex(value)
+          typeof _value === "bigint" || typeof _value === "number"
+            ? numberToHex(_value)
             : undefined,
       };
     }),

--- a/packages/thirdweb/src/wallets/in-app/core/eip5972/in-app-wallet-calls.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/eip5972/in-app-wallet-calls.ts
@@ -37,7 +37,7 @@ export async function inAppWalletSendCalls(args: {
   const { account, calls } = args;
 
   const hashes: Hex[] = [];
-  const bundleId = await randomBytesHex(65);
+  const bundleId = randomBytesHex(65);
   bundlesToTransactions.set(bundleId, hashes);
   if (account.sendBatchTransaction) {
     const receipt = await sendBatchTransaction({


### PR DESCRIPTION
This PR refactors the EIP-5792 calls preparation logic in `send-calls.ts` by removing the `toSerializableTransaction` function call and simplifying the `preparedCalls` mapping. Additionally, it updates the `in-app-wallet-calls.ts` to fix the `randomBytesHex` function usage.

---

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to refactor and optimize the code related to sending calls in the in-app wallet functionality.

### Detailed summary
- Refactored `bundleId` generation in `in-app-wallet-calls.ts`
- Renamed `toSerializableTransaction` to `encode` in `send-calls.ts`
- Improved handling of transaction data and values in `sendCalls` function

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->