### PR TITLE
refactor(constants): rename ADDRESS_ZERO to ZERO_ADDRESS and deprecate older name

### DIFF
--- a/packages/thirdweb/src/constants/addresses.ts
+++ b/packages/thirdweb/src/constants/addresses.ts
@@ -14,4 +14,9 @@ export function isNativeTokenAddress(address: string) {
 /**
  * The zero address in Ethereum, represented as a hexadecimal string.
  */
-export const ADDRESS_ZERO = "0x0000000000000000000000000000000000000000";
+export const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+/**
+ * @deprecated Use {@link ZERO_ADDRESS}.
+ */
+export const ADDRESS_ZERO = ZERO_ADDRESS;

--- a/packages/thirdweb/src/exports/thirdweb.ts
+++ b/packages/thirdweb/src/exports/thirdweb.ts
@@ -8,7 +8,11 @@ declare module "abitype" {
 /**
  * CONSTANTS
  */
-export { ADDRESS_ZERO, NATIVE_TOKEN_ADDRESS } from "../constants/addresses.js";
+export {
+  ADDRESS_ZERO,
+  ZERO_ADDRESS,
+  NATIVE_TOKEN_ADDRESS,
+} from "../constants/addresses.js";
 
 /**
  * CLIENT


### PR DESCRIPTION
### TL;DR

This PR refactors the constant `ADDRESS_ZERO` to `ZERO_ADDRESS` for better clarity and maintainability. The original `ADDRESS_ZERO` constant is retained but marked as deprecated.

### What changed?

- Renamed `ADDRESS_ZERO` to `ZERO_ADDRESS` in `packages/thirdweb/src/constants/addresses.ts`
- Updated exports in `packages/thirdweb/src/exports/thirdweb.ts` to include both `ADDRESS_ZERO` (deprecated) and `ZERO_ADDRESS`

### How to test?

- Ensure that all instances of `ADDRESS_ZERO` correctly map to `ZERO_ADDRESS`
- Check for any breaking changes in the application where `ADDRESS_ZERO` was previously used

### Why make this change?

The renaming provides better clarity and consistency in the codebase, aiding in maintainability and readability by clearly distinguishing the zero address constant.
