### PR TITLE
fix(wallets): cache walletConnectClient

### DIFF
--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/WalletConnectReceiverScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/WalletConnectReceiverScreen.tsx
@@ -45,7 +45,6 @@ export function WalletConnectReceiverScreen(props: {
         setWalletConnectClient(wcClient);
       })
       .catch(() => {
-        console.log("Failed to establish WalletConnect connection");
         setErrorConnecting("Failed to establish WalletConnect connection");
       });
   }, [activeWallet, props.client, props.closeModal, errorConnecting]);

--- a/packages/thirdweb/src/wallets/wallet-connect/receiver/receiver.test.ts
+++ b/packages/thirdweb/src/wallets/wallet-connect/receiver/receiver.test.ts
@@ -5,6 +5,7 @@ import { TEST_IN_APP_WALLET_A } from "../../../../test/src/test-wallets.js";
 import { getDefaultAppMetadata } from "../../utils/defaultDappMetadata.js";
 import { DEFAULT_PROJECT_ID } from "../constants.js";
 import {
+  clearWalletConnectClientCache,
   createWalletConnectClient,
   createWalletConnectSession,
   disconnectWalletConnectSession,
@@ -64,6 +65,10 @@ beforeEach(() => {
 });
 
 describe("createWalletConnectClient", () => {
+  beforeEach(() => {
+    clearWalletConnectClientCache();
+  });
+
   it("creates a client with provided metadata", async () => {
     const client = await createWalletConnectClient({
       projectId: "test",


### PR DESCRIPTION
### TL;DR

Implemented a caching mechanism for WalletConnect clients to improve performance and added error messaging for failed connections.

### What changed?

- Introduced a caching mechanism for WalletConnect clients using a WeakMap to store instances.
- Removed redundant console.log error message in WalletConnectReceiverScreen.tsx.
- Updated disconnect message to "Disconnected".

### How to test?

1. Trigger multiple WalletConnect sessions and ensure that the client is retrieved from the cache after the initial creation.
2. Test error handling by forcing a connection failure and verifying that the error message is set correctly.
3. Disconnect a WalletConnect session and ensure the disconnect message is accurate.

### Why make this change?

This change enhances the performance by reducing redundant WalletConnect client creations and improves the clarity of error and disconnect messages.

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to optimize the WalletConnect client caching mechanism and improve error handling in the WalletConnect receiver module.

### Detailed summary
- Added a caching mechanism for WalletConnect clients to improve performance.
- Updated error message handling in WalletConnect receiver.
- Improved testing setup by clearing the WalletConnect client cache before each test.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->