### PR TITLE
[Unity] fix tx builder type parsing

### DIFF
--- a/.changeset/moody-parents-sip.md
+++ b/.changeset/moody-parents-sip.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/unity-js-bridge": patch
+---
+
+[Unity] fix tx builder type parsing

--- a/legacy_packages/unity-js-bridge/src/thirdweb-bridge.ts
+++ b/legacy_packages/unity-js-bridge/src/thirdweb-bridge.ts
@@ -173,7 +173,7 @@ class ThirdwebBridge implements TWBridge {
       // biome-ignore lint/suspicious/noExplicitAny: TODO: fix use of any
       (globalThis as any).X_SDK_PLATFORM = "unity";
       // biome-ignore lint/suspicious/noExplicitAny: TODO: fix use of any
-      (globalThis as any).X_SDK_VERSION = "4.16.3";
+      (globalThis as any).X_SDK_VERSION = "4.16.4";
       // biome-ignore lint/suspicious/noExplicitAny: TODO: fix use of any
       (globalThis as any).X_SDK_OS = browser?.os ?? "unknown";
     }
@@ -610,7 +610,9 @@ class ThirdwebBridge implements TWBridge {
           maxFeePerGas: txInput?.maxFeePerGas,
           maxPriorityFeePerGas: txInput?.maxPriorityFeePerGas,
           nonce: txInput?.nonce,
-          type: txInput?.type?.toNumber(),
+          type: txInput?.type
+            ? BigNumber.from(txInput.type).toNumber()
+            : undefined,
           accessList: txInput?.accessList,
           // customData: txInput.data,
           // ccipReadEnabled: txInput.ccipReadEnabled,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `unity-js-bridge` package to fix transaction builder type parsing for Unity SDK version 4.16.4.

### Detailed summary
- Updated `X_SDK_VERSION` in Unity SDK to "4.16.4"
- Improved transaction type parsing in `ThirdwebBridge` class

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->