### PR TITLE
[Multi] Optimize package.json types versions & update ERC4337 factory methods

### DIFF
--- a/.changeset/fluffy-roses-yell.md
+++ b/.changeset/fluffy-roses-yell.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+add missing erc4337 extensions

--- a/packages/thirdweb/package.json
+++ b/packages/thirdweb/package.json
@@ -110,54 +110,22 @@
   },
   "typesVersions": {
     "*": {
-      "adapters/*": [
-        "./dist/types/exports/adapters/*.d.ts"
-      ],
-      "auth": [
-        "./dist/types/exports/auth.d.ts"
-      ],
-      "chains": [
-        "./dist/types/exports/chains.d.ts"
-      ],
-      "contract": [
-        "./dist/types/exports/contract.d.ts"
-      ],
-      "deploys": [
-        "./dist/types/exports/deploys.d.ts"
-      ],
-      "event": [
-        "./dist/types/exports/event.d.ts"
-      ],
-      "extensions/*": [
-        "./dist/types/exports/extensions/*.d.ts"
-      ],
-      "pay": [
-        "./dist/types/exports/pay.d.ts"
-      ],
-      "react": [
-        "./dist/types/exports/react.d.ts"
-      ],
-      "react-native": [
-        "./dist/types/exports/react-native.d.ts"
-      ],
-      "rpc": [
-        "./dist/types/exports/rpc.d.ts"
-      ],
-      "storage": [
-        "./dist/types/exports/storage.d.ts"
-      ],
-      "transaction": [
-        "./dist/types/exports/transaction.d.ts"
-      ],
-      "utils": [
-        "./dist/types/exports/utils.d.ts"
-      ],
-      "wallets": [
-        "./dist/types/exports/wallets.d.ts"
-      ],
-      "wallets/*": [
-        "./dist/types/exports/wallets/*.d.ts"
-      ]
+      "adapters/*": ["./dist/types/exports/adapters/*.d.ts"],
+      "auth": ["./dist/types/exports/auth.d.ts"],
+      "chains": ["./dist/types/exports/chains.d.ts"],
+      "contract": ["./dist/types/exports/contract.d.ts"],
+      "deploys": ["./dist/types/exports/deploys.d.ts"],
+      "event": ["./dist/types/exports/event.d.ts"],
+      "extensions/*": ["./dist/types/exports/extensions/*.d.ts"],
+      "pay": ["./dist/types/exports/pay.d.ts"],
+      "react": ["./dist/types/exports/react.d.ts"],
+      "react-native": ["./dist/types/exports/react-native.d.ts"],
+      "rpc": ["./dist/types/exports/rpc.d.ts"],
+      "storage": ["./dist/types/exports/storage.d.ts"],
+      "transaction": ["./dist/types/exports/transaction.d.ts"],
+      "utils": ["./dist/types/exports/utils.d.ts"],
+      "wallets": ["./dist/types/exports/wallets.d.ts"],
+      "wallets/*": ["./dist/types/exports/wallets/*.d.ts"]
     }
   },
   "browser": {
@@ -258,7 +226,7 @@
   "scripts": {
     "bench:compare": "bun run ./benchmarks/run.ts",
     "bench": "vitest -c ./test/vitest.config.ts bench",
-    "format": "biome format 'src/**/*' --write",
+    "format": "biome format src/ --write",
     "lint": "biome check src/",
     "fix": "biome check src/ --apply",
     "knip": "knip",

--- a/packages/thirdweb/scripts/generate/abis/erc4337/IAccountFactory.json
+++ b/packages/thirdweb/scripts/generate/abis/erc4337/IAccountFactory.json
@@ -7,6 +7,9 @@
   "function getAccountsOfSigner(address signer) view returns (address[] accounts)",
   "function getAddress(address adminSigner, bytes data) view returns (address)",
   "function getAllAccounts() view returns (address[])",
+  "function getAccounts(uint256 start, uint256 end) view returns (address[])",
   "function onSignerAdded(address signer, address creatorAdmin, bytes data)",
-  "function onSignerRemoved(address signer, address creatorAdmin, bytes data)"
+  "function onSignerRemoved(address signer, address creatorAdmin, bytes data)",
+  "function totalAccounts() view returns (uint256)",
+  "function isRegistered(address account) view returns (bool)"
 ]

--- a/packages/thirdweb/scripts/generate/generate.ts
+++ b/packages/thirdweb/scripts/generate/generate.ts
@@ -55,8 +55,9 @@ export async function generateFromAbi(
       events.map(async (e) => {
         await writeFile(
           join(outFolder, extensionFileName, "./events", `${e.name}.ts`),
-          await format(generateEvent(e, extensionName), {
+          format(generateEvent(e, extensionName), {
             parser: "babel-ts",
+            trailingComma: "all",
           }),
           "utf-8",
         );
@@ -73,8 +74,9 @@ export async function generateFromAbi(
       readFunctions.map(async (f) => {
         await writeFile(
           join(outFolder, extensionFileName, "./read", `${f.name}.ts`),
-          await format(generateReadFunction(f, extensionName), {
+          format(generateReadFunction(f, extensionName), {
             parser: "babel-ts",
+            trailingComma: "all",
           }),
           "utf-8",
         );
@@ -91,8 +93,9 @@ export async function generateFromAbi(
       writeFunctions.map(async (f) => {
         await writeFile(
           join(outFolder, extensionFileName, "./write", `${f.name}.ts`),
-          await format(generateWriteFunction(f, extensionName), {
+          format(generateWriteFunction(f, extensionName), {
             parser: "babel-ts",
+            trailingComma: "all",
           }),
           "utf-8",
         );

--- a/packages/thirdweb/src/exports/extensions/erc4337.ts
+++ b/packages/thirdweb/src/exports/extensions/erc4337.ts
@@ -36,6 +36,9 @@ export { signerPermissionsUpdatedEvent } from "../../extensions/erc4337/__genera
 
 // FACTORY
 export { getAllAccounts } from "../../extensions/erc4337/__generated__/IAccountFactory/read/getAllAccounts.js";
+export { getAccounts } from "../../extensions/erc4337/__generated__/IAccountFactory/read/getAccounts.js";
+export { totalAccounts } from "../../extensions/erc4337/__generated__/IAccountFactory/read/totalAccounts.js";
+export { isRegistered } from "../../extensions/erc4337/__generated__/IAccountFactory/read/isRegistered.js";
 export {
   getAccountsOfSigner,
   type GetAccountsOfSignerParams,

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/read/getAccounts.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/read/getAccounts.ts
@@ -1,0 +1,135 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "getAccounts" function.
+ */
+export type GetAccountsParams = {
+  start: AbiParameterToPrimitiveType<{ type: "uint256"; name: "start" }>;
+  end: AbiParameterToPrimitiveType<{ type: "uint256"; name: "end" }>;
+};
+
+export const FN_SELECTOR = "0xe68a7c3b" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "start",
+  },
+  {
+    type: "uint256",
+    name: "end",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "address[]",
+  },
+] as const;
+
+/**
+ * Checks if the `getAccounts` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `getAccounts` method is supported.
+ * @extension ERC4337
+ * @example
+ * ```ts
+ * import { isGetAccountsSupported } from "thirdweb/extensions/erc4337";
+ *
+ * const supported = await isGetAccountsSupported(contract);
+ * ```
+ */
+export async function isGetAccountsSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "getAccounts" function.
+ * @param options - The options for the getAccounts function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC4337
+ * @example
+ * ```ts
+ * import { encodeGetAccountsParams } "thirdweb/extensions/erc4337";
+ * const result = encodeGetAccountsParams({
+ *  start: ...,
+ *  end: ...,
+ * });
+ * ```
+ */
+export function encodeGetAccountsParams(options: GetAccountsParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.start, options.end]);
+}
+
+/**
+ * Encodes the "getAccounts" function into a Hex string with its parameters.
+ * @param options - The options for the getAccounts function.
+ * @returns The encoded hexadecimal string.
+ * @extension ERC4337
+ * @example
+ * ```ts
+ * import { encodeGetAccounts } "thirdweb/extensions/erc4337";
+ * const result = encodeGetAccounts({
+ *  start: ...,
+ *  end: ...,
+ * });
+ * ```
+ */
+export function encodeGetAccounts(options: GetAccountsParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeGetAccountsParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the getAccounts function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC4337
+ * @example
+ * ```ts
+ * import { decodeGetAccountsResult } from "thirdweb/extensions/erc4337";
+ * const result = decodeGetAccountsResult("...");
+ * ```
+ */
+export function decodeGetAccountsResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "getAccounts" function on the contract.
+ * @param options - The options for the getAccounts function.
+ * @returns The parsed result of the function call.
+ * @extension ERC4337
+ * @example
+ * ```ts
+ * import { getAccounts } from "thirdweb/extensions/erc4337";
+ *
+ * const result = await getAccounts({
+ *  contract,
+ *  start: ...,
+ *  end: ...,
+ * });
+ *
+ * ```
+ */
+export async function getAccounts(
+  options: BaseTransactionOptions<GetAccountsParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.start, options.end],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/read/isRegistered.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/read/isRegistered.ts
@@ -1,0 +1,127 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "isRegistered" function.
+ */
+export type IsRegisteredParams = {
+  account: AbiParameterToPrimitiveType<{ type: "address"; name: "account" }>;
+};
+
+export const FN_SELECTOR = "0xc3c5a547" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "account",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bool",
+  },
+] as const;
+
+/**
+ * Checks if the `isRegistered` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `isRegistered` method is supported.
+ * @extension ERC4337
+ * @example
+ * ```ts
+ * import { isIsRegisteredSupported } from "thirdweb/extensions/erc4337";
+ *
+ * const supported = await isIsRegisteredSupported(contract);
+ * ```
+ */
+export async function isIsRegisteredSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "isRegistered" function.
+ * @param options - The options for the isRegistered function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC4337
+ * @example
+ * ```ts
+ * import { encodeIsRegisteredParams } "thirdweb/extensions/erc4337";
+ * const result = encodeIsRegisteredParams({
+ *  account: ...,
+ * });
+ * ```
+ */
+export function encodeIsRegisteredParams(options: IsRegisteredParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.account]);
+}
+
+/**
+ * Encodes the "isRegistered" function into a Hex string with its parameters.
+ * @param options - The options for the isRegistered function.
+ * @returns The encoded hexadecimal string.
+ * @extension ERC4337
+ * @example
+ * ```ts
+ * import { encodeIsRegistered } "thirdweb/extensions/erc4337";
+ * const result = encodeIsRegistered({
+ *  account: ...,
+ * });
+ * ```
+ */
+export function encodeIsRegistered(options: IsRegisteredParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeIsRegisteredParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the isRegistered function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC4337
+ * @example
+ * ```ts
+ * import { decodeIsRegisteredResult } from "thirdweb/extensions/erc4337";
+ * const result = decodeIsRegisteredResult("...");
+ * ```
+ */
+export function decodeIsRegisteredResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "isRegistered" function on the contract.
+ * @param options - The options for the isRegistered function.
+ * @returns The parsed result of the function call.
+ * @extension ERC4337
+ * @example
+ * ```ts
+ * import { isRegistered } from "thirdweb/extensions/erc4337";
+ *
+ * const result = await isRegistered({
+ *  contract,
+ *  account: ...,
+ * });
+ *
+ * ```
+ */
+export async function isRegistered(
+  options: BaseTransactionOptions<IsRegisteredParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.account],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/read/totalAccounts.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/read/totalAccounts.ts
@@ -1,0 +1,74 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0x58451f97" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Checks if the `totalAccounts` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `totalAccounts` method is supported.
+ * @extension ERC4337
+ * @example
+ * ```ts
+ * import { isTotalAccountsSupported } from "thirdweb/extensions/erc4337";
+ *
+ * const supported = await isTotalAccountsSupported(contract);
+ * ```
+ */
+export async function isTotalAccountsSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Decodes the result of the totalAccounts function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC4337
+ * @example
+ * ```ts
+ * import { decodeTotalAccountsResult } from "thirdweb/extensions/erc4337";
+ * const result = decodeTotalAccountsResult("...");
+ * ```
+ */
+export function decodeTotalAccountsResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "totalAccounts" function on the contract.
+ * @param options - The options for the totalAccounts function.
+ * @returns The parsed result of the function call.
+ * @extension ERC4337
+ * @example
+ * ```ts
+ * import { totalAccounts } from "thirdweb/extensions/erc4337";
+ *
+ * const result = await totalAccounts({
+ *  contract,
+ * });
+ *
+ * ```
+ */
+export async function totalAccounts(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds missing ERC4337 extensions to the `thirdweb` package. It includes functions for `getAccounts`, `totalAccounts`, and `isRegistered`.

### Detailed summary
- Added missing ERC4337 extensions to `thirdweb` package
- Included functions for `getAccounts`, `totalAccounts`, and `isRegistered`
- Updated `package.json` with new typesVersions configuration

> The following files were skipped due to too many changes: `packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/read/getAccounts.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->