### PR TITLE
[ConnectWallet] Include wallet name in injectedWalletLocale query key

### DIFF
--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/AnyWalletConnectUI.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/AnyWalletConnectUI.tsx
@@ -44,7 +44,7 @@ export function AnyWalletConnectUI(props: {
   const localeId = useConnectUI().locale;
 
   const localeQuery = useQuery({
-    queryKey: ["injectedWalletLocale", localeId],
+    queryKey: ["injectedWalletLocale", localeId, walletInfo.data?.name],
     queryFn: async () => {
       if (!walletInfo.data) {
         throw new Error("Wallet info not available");


### PR DESCRIPTION
### TL;DR
Updated the queryKey used in the useQuery hook to also include the walletInfo.data?.name parameter, ensuring that injectedWalletLocale queries are correctly keyed and updated when the wallet name changes.

### What changed?
The queryKey array in the useQuery hook was updated from `["injectedWalletLocale", localeId]` to `["injectedWalletLocale", localeId, walletInfo.data?.name]`.

### How to test?
1. Ensure the application runs without errors.
2. Verify that locale-specific wallet names are correctly handled when displayed in the UI.

### Why make this change?
The change ensures that the locale-based queries are properly identified and updated when the wallet name changes, preventing potential stale data from being used in the UI.

---

 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `AnyWalletConnectUI.tsx` file to include the wallet name in the `queryKey` for `useQuery`.

### Detailed summary
- Added the wallet name to the `queryKey` for `useQuery` in `AnyWalletConnectUI.tsx`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->