### PR TITLE
Add ERC721 extension: updateMetadata & updateBatchBaseURI

### DIFF
--- a/.changeset/slimy-camels-burn.md
+++ b/.changeset/slimy-camels-burn.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Add ERC721 extension: updateMetadata

--- a/packages/thirdweb/scripts/generate/abis/erc721/DropERC721.json
+++ b/packages/thirdweb/scripts/generate/abis/erc721/DropERC721.json
@@ -1,0 +1,5 @@
+[
+  "function updateBatchBaseURI(uint256 _index, string calldata _uri)",
+  "function freezeBatchBaseURI(uint256 _index)",
+  "function setMaxTotalSupply(uint256 _maxTotalSupply)"
+]

--- a/packages/thirdweb/src/exports/extensions/erc721.ts
+++ b/packages/thirdweb/src/exports/extensions/erc721.ts
@@ -163,3 +163,7 @@ export {
   type BatchToReveal,
   getBatchesToReveal,
 } from "../../extensions/erc721/lazyMinting/read/getBatchesToReveal.js";
+export {
+  updateMetadata,
+  type UpdateMetadataParams,
+} from "../../extensions/erc721/drops/write/updateMetadata.js";

--- a/packages/thirdweb/src/extensions/erc721/__generated__/DropERC721/write/freezeBatchBaseURI.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/DropERC721/write/freezeBatchBaseURI.ts
@@ -1,0 +1,141 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "freezeBatchBaseURI" function.
+ */
+export type FreezeBatchBaseURIParams = WithOverrides<{
+  index: AbiParameterToPrimitiveType<{ type: "uint256"; name: "_index" }>;
+}>;
+
+export const FN_SELECTOR = "0xa07ced9e" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_index",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `freezeBatchBaseURI` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `freezeBatchBaseURI` method is supported.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { isFreezeBatchBaseURISupported } from "thirdweb/extensions/erc721";
+ *
+ * const supported = await isFreezeBatchBaseURISupported(contract);
+ * ```
+ */
+export async function isFreezeBatchBaseURISupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "freezeBatchBaseURI" function.
+ * @param options - The options for the freezeBatchBaseURI function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { encodeFreezeBatchBaseURIParams } "thirdweb/extensions/erc721";
+ * const result = encodeFreezeBatchBaseURIParams({
+ *  index: ...,
+ * });
+ * ```
+ */
+export function encodeFreezeBatchBaseURIParams(
+  options: FreezeBatchBaseURIParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.index]);
+}
+
+/**
+ * Encodes the "freezeBatchBaseURI" function into a Hex string with its parameters.
+ * @param options - The options for the freezeBatchBaseURI function.
+ * @returns The encoded hexadecimal string.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { encodeFreezeBatchBaseURI } "thirdweb/extensions/erc721";
+ * const result = encodeFreezeBatchBaseURI({
+ *  index: ...,
+ * });
+ * ```
+ */
+export function encodeFreezeBatchBaseURI(options: FreezeBatchBaseURIParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeFreezeBatchBaseURIParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "freezeBatchBaseURI" function on the contract.
+ * @param options - The options for the "freezeBatchBaseURI" function.
+ * @returns A prepared transaction object.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { freezeBatchBaseURI } from "thirdweb/extensions/erc721";
+ *
+ * const transaction = freezeBatchBaseURI({
+ *  contract,
+ *  index: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function freezeBatchBaseURI(
+  options: BaseTransactionOptions<
+    | FreezeBatchBaseURIParams
+    | {
+        asyncParams: () => Promise<FreezeBatchBaseURIParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.index] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/DropERC721/write/setMaxTotalSupply.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/DropERC721/write/setMaxTotalSupply.ts
@@ -1,0 +1,144 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "setMaxTotalSupply" function.
+ */
+export type SetMaxTotalSupplyParams = WithOverrides<{
+  maxTotalSupply: AbiParameterToPrimitiveType<{
+    type: "uint256";
+    name: "_maxTotalSupply";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0x3f3e4c11" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_maxTotalSupply",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `setMaxTotalSupply` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `setMaxTotalSupply` method is supported.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { isSetMaxTotalSupplySupported } from "thirdweb/extensions/erc721";
+ *
+ * const supported = await isSetMaxTotalSupplySupported(contract);
+ * ```
+ */
+export async function isSetMaxTotalSupplySupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "setMaxTotalSupply" function.
+ * @param options - The options for the setMaxTotalSupply function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { encodeSetMaxTotalSupplyParams } "thirdweb/extensions/erc721";
+ * const result = encodeSetMaxTotalSupplyParams({
+ *  maxTotalSupply: ...,
+ * });
+ * ```
+ */
+export function encodeSetMaxTotalSupplyParams(
+  options: SetMaxTotalSupplyParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.maxTotalSupply]);
+}
+
+/**
+ * Encodes the "setMaxTotalSupply" function into a Hex string with its parameters.
+ * @param options - The options for the setMaxTotalSupply function.
+ * @returns The encoded hexadecimal string.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { encodeSetMaxTotalSupply } "thirdweb/extensions/erc721";
+ * const result = encodeSetMaxTotalSupply({
+ *  maxTotalSupply: ...,
+ * });
+ * ```
+ */
+export function encodeSetMaxTotalSupply(options: SetMaxTotalSupplyParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeSetMaxTotalSupplyParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "setMaxTotalSupply" function on the contract.
+ * @param options - The options for the "setMaxTotalSupply" function.
+ * @returns A prepared transaction object.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { setMaxTotalSupply } from "thirdweb/extensions/erc721";
+ *
+ * const transaction = setMaxTotalSupply({
+ *  contract,
+ *  maxTotalSupply: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function setMaxTotalSupply(
+  options: BaseTransactionOptions<
+    | SetMaxTotalSupplyParams
+    | {
+        asyncParams: () => Promise<SetMaxTotalSupplyParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.maxTotalSupply] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/__generated__/DropERC721/write/updateBatchBaseURI.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/DropERC721/write/updateBatchBaseURI.ts
@@ -1,0 +1,149 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "updateBatchBaseURI" function.
+ */
+export type UpdateBatchBaseURIParams = WithOverrides<{
+  index: AbiParameterToPrimitiveType<{ type: "uint256"; name: "_index" }>;
+  uri: AbiParameterToPrimitiveType<{ type: "string"; name: "_uri" }>;
+}>;
+
+export const FN_SELECTOR = "0xde903ddd" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_index",
+  },
+  {
+    type: "string",
+    name: "_uri",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `updateBatchBaseURI` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `updateBatchBaseURI` method is supported.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { isUpdateBatchBaseURISupported } from "thirdweb/extensions/erc721";
+ *
+ * const supported = await isUpdateBatchBaseURISupported(contract);
+ * ```
+ */
+export async function isUpdateBatchBaseURISupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "updateBatchBaseURI" function.
+ * @param options - The options for the updateBatchBaseURI function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { encodeUpdateBatchBaseURIParams } "thirdweb/extensions/erc721";
+ * const result = encodeUpdateBatchBaseURIParams({
+ *  index: ...,
+ *  uri: ...,
+ * });
+ * ```
+ */
+export function encodeUpdateBatchBaseURIParams(
+  options: UpdateBatchBaseURIParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.index, options.uri]);
+}
+
+/**
+ * Encodes the "updateBatchBaseURI" function into a Hex string with its parameters.
+ * @param options - The options for the updateBatchBaseURI function.
+ * @returns The encoded hexadecimal string.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { encodeUpdateBatchBaseURI } "thirdweb/extensions/erc721";
+ * const result = encodeUpdateBatchBaseURI({
+ *  index: ...,
+ *  uri: ...,
+ * });
+ * ```
+ */
+export function encodeUpdateBatchBaseURI(options: UpdateBatchBaseURIParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeUpdateBatchBaseURIParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "updateBatchBaseURI" function on the contract.
+ * @param options - The options for the "updateBatchBaseURI" function.
+ * @returns A prepared transaction object.
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { updateBatchBaseURI } from "thirdweb/extensions/erc721";
+ *
+ * const transaction = updateBatchBaseURI({
+ *  contract,
+ *  index: ...,
+ *  uri: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function updateBatchBaseURI(
+  options: BaseTransactionOptions<
+    | UpdateBatchBaseURIParams
+    | {
+        asyncParams: () => Promise<UpdateBatchBaseURIParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.index, resolvedOptions.uri] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/erc721/drops/write/updateMetadata.test.ts
+++ b/packages/thirdweb/src/extensions/erc721/drops/write/updateMetadata.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { ANVIL_CHAIN } from "~test/chains.js";
+import { TEST_CLIENT } from "~test/test-clients.js";
+import { TEST_ACCOUNT_A } from "~test/test-wallets.js";
+
+import {
+  type ThirdwebContract,
+  getContract,
+} from "../../../../contract/contract.js";
+import { deployERC721Contract } from "../../../../extensions/prebuilts/deploy-erc721.js";
+import { sendAndConfirmTransaction } from "../../../../transaction/actions/send-and-confirm-transaction.js";
+import type { NFTInput } from "../../../../utils/nft/parseNft.js";
+import { getNFT } from "../../read/getNFT.js";
+import { getNFTs } from "../../read/getNFTs.js";
+import { lazyMint } from "../../write/lazyMint.js";
+import { getUpdateMetadataParams, updateMetadata } from "./updateMetadata.js";
+
+let contract: ThirdwebContract;
+const account = TEST_ACCOUNT_A;
+const client = TEST_CLIENT;
+const chain = ANVIL_CHAIN;
+
+describe("erc721: updateMetadata", () => {
+  beforeEach(async () => {
+    const address = await deployERC721Contract({
+      client,
+      chain,
+      account,
+      type: "DropERC721",
+      params: {
+        name: "NFTDrop",
+      },
+    });
+    contract = getContract({
+      address,
+      client,
+      chain,
+    });
+  });
+
+  it("should update the metadata for the selected token | case 1", async () => {
+    const metadatas: NFTInput[] = [
+      { name: "token 0" },
+      { name: "token 1" },
+      { name: "token 2" },
+    ];
+
+    const lazyMintTx = lazyMint({ contract, nfts: metadatas });
+    await sendAndConfirmTransaction({ transaction: lazyMintTx, account });
+
+    const transaction = updateMetadata({
+      contract,
+      targetTokenId: 0n,
+      newMetadata: { name: "token 0 - updated" },
+      client,
+    });
+    await sendAndConfirmTransaction({ transaction, account });
+    const nfts = await getNFTs({ contract });
+    expect(nfts[0]?.metadata.name).toBe("token 0 - updated");
+
+    // The other tokens should not change
+    expect(nfts[1]?.metadata.name).toBe("token 1");
+    expect(nfts[2]?.metadata.name).toBe("token 2");
+  });
+
+  it("should update the metadata for the selected token | case 2", async () => {
+    const nftBatch1: NFTInput[] = [
+      { name: "token 0" },
+      { name: "token 1" },
+      { name: "token 2" },
+    ];
+
+    const batch1 = lazyMint({ contract, nfts: nftBatch1 });
+    await sendAndConfirmTransaction({ transaction: batch1, account });
+
+    const nftBatch2: NFTInput[] = [
+      { name: "token 3" },
+      { name: "token 4" },
+      { name: "token 5" },
+    ];
+    const batch2 = lazyMint({ contract, nfts: nftBatch2 });
+    await sendAndConfirmTransaction({ transaction: batch2, account });
+
+    // firstly, update the token in the first batch
+    const transaction1 = updateMetadata({
+      contract,
+      targetTokenId: 0n,
+      newMetadata: { name: "token 0 - updated" },
+      client,
+    });
+    await sendAndConfirmTransaction({ transaction: transaction1, account });
+    const nft = await getNFT({ contract, tokenId: 0n });
+    expect(nft.metadata.name).toBe("token 0 - updated");
+
+    const tokenUriAfterUpdatedFirstTime = nft.tokenURI;
+
+    // Update token in the second batch
+    const transaction2 = updateMetadata({
+      contract,
+      targetTokenId: 5n,
+      newMetadata: { name: "token 5 - updated" },
+      client,
+    });
+    await sendAndConfirmTransaction({ transaction: transaction2, account });
+
+    const allNfts = await getNFTs({ contract });
+    expect(allNfts[0]?.metadata.name).toBe("token 0 - updated");
+    expect(allNfts.at(-1)?.metadata.name).toBe("token 5 - updated");
+
+    // The tokenUri of tokenId#0 after the second updateMetadata should still be the same
+    // since it belong to another batch
+    expect(allNfts[0]?.tokenURI).toBe(tokenUriAfterUpdatedFirstTime);
+  });
+
+  it("should throw error if there's no batch", async () => {
+    await expect(() =>
+      getUpdateMetadataParams({
+        contract,
+        targetTokenId: 0n,
+        newMetadata: { name: "token 0 - updated" },
+        client,
+      }),
+    ).rejects.toThrowError(
+      "No base URI set. Please set a base URI before updating metadata",
+    );
+  });
+});

--- a/packages/thirdweb/src/extensions/erc721/drops/write/updateMetadata.ts
+++ b/packages/thirdweb/src/extensions/erc721/drops/write/updateMetadata.ts
@@ -1,0 +1,123 @@
+import type { ThirdwebClient } from "../../../../client/client.js";
+import type { BaseTransactionOptions } from "../../../../transaction/types.js";
+import type { NFT, NFTInput } from "../../../../utils/nft/parseNft.js";
+import {
+  type UpdateBatchBaseURIParams,
+  updateBatchBaseURI,
+} from "../../__generated__/DropERC721/write/updateBatchBaseURI.js";
+import { getBaseURICount } from "../../__generated__/IBatchMintMetadata/read/getBaseURICount.js";
+
+export type UpdateMetadataParams = {
+  targetTokenId: bigint;
+  newMetadata: NFTInput;
+  client: ThirdwebClient;
+};
+
+/**
+ * @internal
+ */
+export async function getUpdateMetadataParams(
+  options: BaseTransactionOptions<UpdateMetadataParams>,
+): Promise<UpdateBatchBaseURIParams> {
+  const { contract, targetTokenId, newMetadata, client } = options;
+  const batchCount = await getBaseURICount(options);
+  if (batchCount === 0n) {
+    throw new Error(
+      "No base URI set. Please set a base URI before updating metadata",
+    );
+  }
+
+  // Look for the batchId & determine the start + end tokenId of the batch
+  const [{ getBatchIdAtIndex }, { getNFT }] = await Promise.all([
+    import("../../__generated__/IBatchMintMetadata/read/getBatchIdAtIndex.js"),
+    import("../../read/getNFT.js"),
+  ]);
+  let startTokenId = 0n;
+  let endTokenId = 0n;
+  let batchIndex = 0n;
+  for (let i = 0n; i < batchCount; i += 1n) {
+    batchIndex = i;
+    endTokenId = await getBatchIdAtIndex({ contract, index: batchIndex });
+    if (endTokenId > targetTokenId) {
+      break;
+    }
+    startTokenId = endTokenId;
+  }
+
+  const range = Array.from(
+    { length: Number(endTokenId - startTokenId) },
+    (_, k) => BigInt(k) + startTokenId,
+  );
+
+  const currentMetadatas = await Promise.all(
+    range.map((id) => getNFT({ contract, tokenId: id, includeOwner: false })),
+  );
+
+  // Abort if any of the items failed to load
+  if (currentMetadatas.some((item) => item === undefined || !item.tokenURI)) {
+    throw new Error(
+      `Failed to load all ${range.length} items from batchIndex: ${batchIndex}`,
+    );
+  }
+
+  const newMetadatas: NFTInput[] = [];
+  for (let i = 0; i < currentMetadatas.length; i++) {
+    const { id, metadata } = currentMetadatas[i] as NFT;
+    if (targetTokenId === id) {
+      newMetadatas.push(newMetadata);
+    } else {
+      newMetadatas.push(metadata);
+    }
+  }
+
+  const { uploadOrExtractURIs } = await import("../../../../utils/ipfs.js");
+  const batchOfUris = await uploadOrExtractURIs(
+    newMetadatas,
+    client,
+    Number(startTokenId),
+  );
+
+  if (!batchOfUris || !batchOfUris.length || !batchOfUris[0]) {
+    throw new Error("Failed to upload batch of new metadatas");
+  }
+
+  const baseUri = batchOfUris[0].substring(0, batchOfUris[0].lastIndexOf("/"));
+
+  // IMPORTANT: The new ipfs URI must have the trailing slash at the end
+  // this is required by the Drop contract
+  const uri = `${baseUri}/`;
+
+  return { index: batchIndex, uri };
+}
+
+/**
+ * Update the metadata of the single token in an NFT Drop (DropERC721) collection
+ * For NFT Collection, please use `setTokenURI`
+ * @param options
+ * @returns the prepared transaction
+ * @extension ERC721
+ * @example
+ * ```ts
+ * import { updateMetadata } from "thirdweb/extensions/erc721";
+ *
+ * const transaction = updateMetadata({
+ *  contract,
+ *  targetTokenId: 0n,
+ *  newMetadata: {
+ *    name: "this is the new nft name",
+ *    description: "...",
+ *    image: "new image uri"
+ *    // ...
+ *  }
+ * });
+ * ```
+ */
+export function updateMetadata(
+  options: BaseTransactionOptions<UpdateMetadataParams>,
+) {
+  const { contract } = options;
+  return updateBatchBaseURI({
+    contract,
+    asyncParams: async () => getUpdateMetadataParams(options),
+  });
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds an ERC721 extension `updateMetadata` for updating NFT metadata in a batch. 

### Detailed summary
- Added `updateMetadata` function to update NFT metadata in ERC721 extension
- Added `getUpdateMetadataParams` function to prepare update metadata parameters
- Added tests for `updateMetadata` function with different scenarios
- Added `FreezeBatchBaseURIParams` and related functions for freezing batch base URI

> The following files were skipped due to too many changes: `packages/thirdweb/src/extensions/erc721/__generated__/DropERC721/write/freezeBatchBaseURI.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/DropERC721/write/setMaxTotalSupply.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/DropERC721/write/updateBatchBaseURI.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->