### PR TITLE
[Fix] Ensure proper awaiting of the format function in generate script

### DIFF
--- a/packages/thirdweb/scripts/generate/generate.ts
+++ b/packages/thirdweb/scripts/generate/generate.ts
@@ -55,7 +55,7 @@ export async function generateFromAbi(
       events.map(async (e) => {
         await writeFile(
           join(outFolder, extensionFileName, "./events", `${e.name}.ts`),
-          format(generateEvent(e, extensionName), {
+          await format(generateEvent(e, extensionName), {
             parser: "babel-ts",
             trailingComma: "all",
           }),
@@ -74,7 +74,7 @@ export async function generateFromAbi(
       readFunctions.map(async (f) => {
         await writeFile(
           join(outFolder, extensionFileName, "./read", `${f.name}.ts`),
-          format(generateReadFunction(f, extensionName), {
+          await format(generateReadFunction(f, extensionName), {
             parser: "babel-ts",
             trailingComma: "all",
           }),
@@ -93,7 +93,7 @@ export async function generateFromAbi(
       writeFunctions.map(async (f) => {
         await writeFile(
           join(outFolder, extensionFileName, "./write", `${f.name}.ts`),
-          format(generateWriteFunction(f, extensionName), {
+          await format(generateWriteFunction(f, extensionName), {
             parser: "babel-ts",
             trailingComma: "all",
           }),


### PR DESCRIPTION
### TL;DR

This PR modifies the `generateFromAbi` function to ensure that the `format` function from Prettier is properly awaited. This solves issues with file writing inconsistencies.

### What changed?

- Added `await` to the `format` function calls within `generateFromAbi`.

### How to test?

1. Run the `generateFromAbi` script.
2. Ensure that generated files are consistently formatted.

### Why make this change?

This change ensures that the Prettier formatting is correctly applied before the files are written, resolving any inconsistencies and potential bugs caused by non-awaited formatting.

---



<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the code to use `await` when formatting generated events and functions. 

### Detailed summary
- Updated `generate.ts` to use `await` when formatting generated events and functions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->