### PR TITLE
refactor: respect Coinbase wallet optons when preloading

### DIFF
--- a/.changeset/giant-phones-mix.md
+++ b/.changeset/giant-phones-mix.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Respect coinbase wallet create settings when preloading the provider

--- a/packages/thirdweb/src/react/web/utils/usePreloadWalletProviders.ts
+++ b/packages/thirdweb/src/react/web/utils/usePreloadWalletProviders.ts
@@ -2,6 +2,7 @@ import { useQueries } from "@tanstack/react-query";
 import type { ThirdwebClient } from "../../../client/client.js";
 import { COINBASE } from "../../../wallets/constants.js";
 import type { Wallet } from "../../../wallets/interfaces/wallet.js";
+import type { CreateWalletArgs } from "../../../wallets/wallet-types.js";
 
 export function usePreloadWalletProviders({
   client,
@@ -18,7 +19,9 @@ export function usePreloadWalletProviders({
               const { getCoinbaseWebProvider } = await import(
                 "../../../wallets/coinbase/coinbaseWebSDK.js"
               );
-              await getCoinbaseWebProvider();
+              await getCoinbaseWebProvider(
+                w.getConfig() as CreateWalletArgs<typeof COINBASE>[1],
+              );
               // return _something_
               return true;
             }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to respect the coinbase wallet create settings when preloading the provider.

### Detailed summary
- Updated the `usePreloadWalletProviders` function to pass create wallet arguments when preloading the Coinbase provider.
- Added import for `CreateWalletArgs` from `wallet-types.js`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->