### PR TITLE
fix: signing raw messages in ethers adapter

### DIFF
--- a/.changeset/brave-cherries-occur.md
+++ b/.changeset/brave-cherries-occur.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix sign raw message through ethers 5/6 adapters

--- a/packages/thirdweb/src/adapters/ethers5.test.ts
+++ b/packages/thirdweb/src/adapters/ethers5.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "vitest";
 import { ANVIL_CHAIN } from "../../test/src/chains.js";
 import { TEST_CLIENT } from "../../test/src/test-clients.js";
 import { ANVIL_PKEY_A, TEST_ACCOUNT_B } from "../../test/src/test-wallets.js";
+import { randomBytesBuffer } from "../utils/random.js";
 import { privateKeyToAccount } from "../wallets/private-key.js";
 import { toEthersSigner } from "./ethers5.js";
 
@@ -32,6 +33,19 @@ describe("ethers5 adapter", () => {
     );
     const expectedSig = await account.signMessage({ message: "hello world" });
     const sig = await signer.signMessage("hello world");
+    expect(sig).toBe(expectedSig);
+  });
+
+  test("should sign raw message", async () => {
+    const signer = await toEthersSigner(
+      ethers5,
+      TEST_CLIENT,
+      account,
+      ANVIL_CHAIN,
+    );
+    const bytes = randomBytesBuffer(32);
+    const expectedSig = await account.signMessage({ message: { raw: bytes } });
+    const sig = await signer.signMessage(bytes);
     expect(sig).toBe(expectedSig);
   });
 

--- a/packages/thirdweb/src/adapters/ethers5.ts
+++ b/packages/thirdweb/src/adapters/ethers5.ts
@@ -10,7 +10,7 @@ import { type ThirdwebContract, getContract } from "../contract/contract.js";
 import { sendTransaction } from "../transaction/actions/send-transaction.js";
 import { waitForReceipt } from "../transaction/actions/wait-for-tx-receipt.js";
 import { prepareTransaction } from "../transaction/prepare-transaction.js";
-import { toHex, uint8ArrayToHex } from "../utils/encoding/hex.js";
+import { toHex } from "../utils/encoding/hex.js";
 import type { Account } from "../wallets/interfaces/wallet.js";
 
 type Ethers5 = typeof ethers5;
@@ -306,8 +306,7 @@ export async function toEthersSigner(
         throw new Error("Account not found");
       }
       return account.signMessage({
-        message:
-          typeof message === "string" ? message : uint8ArrayToHex(message),
+        message: typeof message === "string" ? message : { raw: message },
       });
     }
     /**

--- a/packages/thirdweb/src/adapters/ethers6.test.ts
+++ b/packages/thirdweb/src/adapters/ethers6.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "vitest";
 import { ANVIL_CHAIN } from "../../test/src/chains.js";
 import { TEST_CLIENT } from "../../test/src/test-clients.js";
 import { ANVIL_PKEY_A, TEST_ACCOUNT_B } from "../../test/src/test-wallets.js";
+import { randomBytesBuffer } from "../utils/random.js";
 import { privateKeyToAccount } from "../wallets/private-key.js";
 import { toEthersSigner } from "./ethers6.js";
 
@@ -24,14 +25,17 @@ describe("toEthersSigner", () => {
   });
 
   test("should sign message", async () => {
-    const signer = await toEthersSigner(
-      ethers6,
-      TEST_CLIENT,
-      account,
-      ANVIL_CHAIN,
-    );
+    const signer = toEthersSigner(ethers6, TEST_CLIENT, account, ANVIL_CHAIN);
     const expectedSig = await account.signMessage({ message: "hello world" });
     const sig = await signer.signMessage("hello world");
+    expect(sig).toBe(expectedSig);
+  });
+
+  test("should sign raw message", async () => {
+    const signer = toEthersSigner(ethers6, TEST_CLIENT, account, ANVIL_CHAIN);
+    const bytes = randomBytesBuffer(32);
+    const expectedSig = await account.signMessage({ message: { raw: bytes } });
+    const sig = await signer.signMessage(bytes);
     expect(sig).toBe(expectedSig);
   });
 

--- a/packages/thirdweb/src/adapters/ethers6.ts
+++ b/packages/thirdweb/src/adapters/ethers6.ts
@@ -9,7 +9,7 @@ import type { ThirdwebClient } from "../client/client.js";
 import { type ThirdwebContract, getContract } from "../contract/contract.js";
 import { toSerializableTransaction } from "../transaction/actions/to-serializable-transaction.js";
 import type { PreparedTransaction } from "../transaction/prepare-transaction.js";
-import { toHex, uint8ArrayToHex } from "../utils/encoding/hex.js";
+import { toHex } from "../utils/encoding/hex.js";
 import { resolvePromisedValue } from "../utils/promise/resolve-promised-value.js";
 import type { Account } from "../wallets/interfaces/wallet.js";
 import { normalizeChainId } from "../wallets/utils/normalizeChainId.js";
@@ -376,8 +376,7 @@ export function toEthersSigner(
         throw new Error("Account not found");
       }
       return account.signMessage({
-        message:
-          typeof message === "string" ? message : uint8ArrayToHex(message),
+        message: typeof message === "string" ? message : { raw: message },
       });
     }
 

--- a/packages/thirdweb/src/adapters/viem.test.ts
+++ b/packages/thirdweb/src/adapters/viem.test.ts
@@ -11,6 +11,7 @@ import { typedData } from "~test/typed-data.js";
 
 import { ANVIL_CHAIN, FORKED_ETHEREUM_CHAIN } from "../../test/src/chains.js";
 import { TEST_CLIENT } from "../../test/src/test-clients.js";
+import { randomBytesBuffer } from "../utils/random.js";
 import { privateKeyToAccount } from "../wallets/private-key.js";
 import { toViemContract, viemAdapter } from "./viem.js";
 
@@ -33,6 +34,31 @@ describe("walletClient.toViem", () => {
   test("should return an viem wallet client", async () => {
     expect(walletClient).toBeDefined();
     expect(walletClient.signMessage).toBeDefined();
+  });
+
+  test("should sign message", async () => {
+    if (!walletClient.account) {
+      throw new Error("Account not found");
+    }
+    const expectedSig = await account.signMessage({ message: "hello world" });
+    const sig = await walletClient.signMessage({
+      account: walletClient.account,
+      message: "hello world",
+    });
+    expect(sig).toBe(expectedSig);
+  });
+
+  test("should sign raw message", async () => {
+    if (!walletClient.account) {
+      throw new Error("Account not found");
+    }
+    const bytes = randomBytesBuffer(32);
+    const expectedSig = await account.signMessage({ message: { raw: bytes } });
+    const sig = await walletClient.signMessage({
+      account: walletClient.account,
+      message: { raw: bytes },
+    });
+    expect(sig).toBe(expectedSig);
   });
 
   test("should sign typed data", async () => {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on fixing the signing of raw messages through ethers 5/6 adapters.

### Detailed summary
- Updated message signing logic in ethers 5 and 6 adapters to handle raw messages correctly
- Added tests for signing raw messages in ethers 5 and 6 adapters
- Added functionality to sign raw messages in viem adapter

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->