### PR TITLE
[Tests] Conditionally run updateMetadata test based on TW_SECRET_KEY environment variable

### DIFF
--- a/packages/thirdweb/src/extensions/erc721/drops/write/updateMetadata.test.ts
+++ b/packages/thirdweb/src/extensions/erc721/drops/write/updateMetadata.test.ts
@@ -20,7 +20,7 @@ const account = TEST_ACCOUNT_A;
 const client = TEST_CLIENT;
 const chain = ANVIL_CHAIN;
 
-describe("erc721: updateMetadata", () => {
+describe.runIf(process.env.TW_SECRET_KEY)("erc721: updateMetadata", () => {
   beforeEach(async () => {
     const address = await deployERC721Contract({
       client,


### PR DESCRIPTION
### TL;DR

The change ensures that the `erc721: updateMetadata` test suite is conditionally executed only if the `TW_SECRET_KEY` environment variable is set.

### What changed?

- Updated the `updateMetadata.test.ts` file to conditionally run the `erc721: updateMetadata` test suite based on the `TW_SECRET_KEY` environment variable.

### How to test?

1. Set the `TW_SECRET_KEY` environment variable.
2. Run the test suite.
3. Observe that the `erc721: updateMetadata` tests are executed only if the environment variable is set.

### Why make this change?

This change ensures that sensitive tests which require a secret key are only executed in appropriate environments, thereby enhancing test reliability and security.

---



<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to conditionally run the test suite based on the presence of a secret key.

### Detailed summary
- Updated the test suite to run only if a secret key is provided in the environment variables.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->