### PR TITLE
[Fix] Handle special case for localhost in development environment in isThirdwebUrl function

### DIFF
--- a/.changeset/brown-comics-unite.md
+++ b/.changeset/brown-comics-unite.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+do not consider localhost a thirdweb url (except for dev mode)

--- a/packages/thirdweb/src/utils/fetch.ts
+++ b/packages/thirdweb/src/utils/fetch.ts
@@ -99,9 +99,18 @@ export function isThirdwebUrl(url: string): boolean {
   }
   try {
     const { hostname } = new URL(url);
-    const is =
-      THIRDWEB_DOMAINS.some((domain) => hostname.endsWith(domain)) ||
-      hostname === "localhost";
+
+    try {
+      // special case for localhost in development only
+      if (process.env.NODE_ENV === "development") {
+        if (hostname === "localhost") {
+          IS_THIRDWEB_URL_CACHE.set(url, true);
+          return true;
+        }
+      }
+    } catch {}
+
+    const is = THIRDWEB_DOMAINS.some((domain) => hostname.endsWith(domain));
     IS_THIRDWEB_URL_CACHE.set(url, is);
     return is;
   } catch {


### PR DESCRIPTION
fixes: CNCT-1370

### TL;DR

This PR updates the `isThirdwebUrl` function to properly handle the `localhost` hostname in the development environment. 

### What changed?

- Added a check to see if `process.env.NODE_ENV` is set to `development`
- If in development, it checks if the hostname is `localhost` and treats it as a Thirdweb URL

### How to test?

- Ensure the application runs in both development and production environments
- In development, verify URLs with `localhost` return `true` for `isThirdwebUrl`
- In production, verify URLs with `localhost` return `false` for `isThirdwebUrl`

### Why make this change?

This change was made to correctly classify `localhost` as a Thirdweb URL when running in a development environment, allowing for better development workflow and environment parity.

---



<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to exclude localhost from being considered a thirdweb URL, except in development mode.

### Detailed summary
- Excludes localhost from thirdweb URL check in `fetch.ts` except in development mode.
- Adds special handling for localhost in development environment.
- Improves accuracy of identifying thirdweb URLs.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->