### PR TITLE
feat(wallets): add support for wallet_addEthereumChain and wallet_switchEthereumChain

### DIFF
--- a/packages/thirdweb/src/wallets/wallet-connect/receiver/request-handlers/sign.ts
+++ b/packages/thirdweb/src/wallets/wallet-connect/receiver/request-handlers/sign.ts
@@ -13,5 +13,5 @@ export async function handleSignRequest(options: {
   const { account, params } = options;
 
   validateAccountAddress(account, params[1]);
-  return account.signMessage({ message: params[0] });
+  return account.signMessage({ message: { raw: params[0] as Hex } });
 }

--- a/packages/thirdweb/src/wallets/wallet-connect/receiver/request-handlers/switch-chain.ts
+++ b/packages/thirdweb/src/wallets/wallet-connect/receiver/request-handlers/switch-chain.ts
@@ -1,0 +1,21 @@
+import { defineChain } from "../../../../chains/utils.js";
+import { type Hex, hexToNumber } from "../../../../utils/encoding/hex.js";
+import type { Wallet } from "../../../interfaces/wallet.js";
+import type { WalletConnectSwitchEthereumChainRequestParams } from "../types.js";
+
+/**
+ * @internal
+ */
+export async function handleSwitchChain(options: {
+  wallet: Wallet;
+  params: WalletConnectSwitchEthereumChainRequestParams;
+}): Promise<Hex> {
+  const { wallet, params } = options;
+
+  if (wallet.getChain()?.id === hexToNumber(params[0].chainId)) {
+    return "0x1";
+  } else {
+    await wallet.switchChain(defineChain(hexToNumber(params[0].chainId)));
+    return "0x1";
+  }
+}

--- a/packages/thirdweb/src/wallets/wallet-connect/receiver/session-request.ts
+++ b/packages/thirdweb/src/wallets/wallet-connect/receiver/session-request.ts
@@ -1,6 +1,10 @@
 import type { Hex } from "../../../utils/encoding/hex.js";
 import type { Wallet } from "../../interfaces/wallet.js";
-import type { WalletConnectClient } from "./types.js";
+import type {
+  WalletConnectAddEthereumChainRequestParams,
+  WalletConnectClient,
+  WalletConnectSwitchEthereumChainRequestParams,
+} from "./types.js";
 import type {
   WalletConnectRawTransactionRequestParams,
   WalletConnectRequestError,
@@ -147,6 +151,40 @@ export async function fulfillRequest(options: {
             account,
             chainId,
             params: request.params as WalletConnectRawTransactionRequestParams,
+          });
+        }
+        break;
+      }
+      case "wallet_addEthereumChain": {
+        if (handlers?.wallet_addEthereumChain) {
+          result = await handlers.wallet_addEthereumChain({
+            wallet,
+            params:
+              request.params as WalletConnectAddEthereumChainRequestParams,
+          });
+        } else {
+          throw new Error(
+            "[WalletConnect] wallet_addEthereumChain is not supported",
+          );
+        }
+        break;
+      }
+      case "wallet_switchEthereumChain": {
+        if (handlers?.wallet_switchEthereumChain) {
+          result = await handlers.wallet_switchEthereumChain({
+            wallet,
+            params:
+              request.params as WalletConnectSwitchEthereumChainRequestParams,
+          });
+        } else {
+          const { handleSwitchChain } = await import(
+            "./request-handlers/switch-chain.js"
+          );
+
+          result = await handleSwitchChain({
+            wallet,
+            params:
+              request.params as WalletConnectSwitchEthereumChainRequestParams,
           });
         }
         break;

--- a/packages/thirdweb/src/wallets/wallet-connect/receiver/types.ts
+++ b/packages/thirdweb/src/wallets/wallet-connect/receiver/types.ts
@@ -3,7 +3,7 @@ import type { TypedDataDefinition } from "viem";
 import type { Address } from "../../../utils/address.js";
 import type { Hex } from "../../../utils/encoding/hex.js";
 import type { Prettify } from "../../../utils/type-utils.js";
-import type { Account } from "../../interfaces/wallet.js";
+import type { Account, Wallet } from "../../interfaces/wallet.js";
 
 export type { WalletConnectConfig } from "../types.js"; // re-exporting for use in this module
 export type WalletConnectSession = {
@@ -96,6 +96,14 @@ export type WalletConnectRequestHandlers = Prettify<
       chainId: number;
       params: WalletConnectTransactionRequestParams;
     }) => Promise<Hex | WalletConnectRequestError>;
+    wallet_addEthereumChain?: (_: {
+      wallet: Wallet;
+      params: WalletConnectAddEthereumChainRequestParams;
+    }) => Promise<Hex>;
+    wallet_switchEthereumChain?: (_: {
+      wallet: Wallet;
+      params: WalletConnectSwitchEthereumChainRequestParams;
+    }) => Promise<Hex>;
   } & {
     [code: string]: (_: {
       account: Account;
@@ -114,7 +122,9 @@ type WalletConnectRequestParams =
   | WalletConnectSignRequestPrams
   | WalletConnectSignTypedDataRequestParams
   | WalletConnectTransactionRequestParams
-  | WalletConnectRawTransactionRequestParams;
+  | WalletConnectRawTransactionRequestParams
+  | WalletConnectAddEthereumChainRequestParams
+  | WalletConnectSwitchEthereumChainRequestParams;
 
 export type WalletConnectSessionRequestEvent = {
   id: number;
@@ -146,3 +156,17 @@ export type WalletConnectTransactionRequestParams = [
   },
 ];
 export type WalletConnectRawTransactionRequestParams = [Hex];
+
+export type WalletConnectAddEthereumChainRequestParams = {
+  chainId: string;
+  blockExplorerUrls: string[];
+  chainName: string;
+  nativeCurrency: {
+    name: string;
+    symbol: string;
+    decimals: number;
+  };
+  rpcUrls: string[];
+}[];
+
+export type WalletConnectSwitchEthereumChainRequestParams = [{ chainId: Hex }];

--- a/packages/thirdweb/src/wallets/wallet-connect/receiver/utils.ts
+++ b/packages/thirdweb/src/wallets/wallet-connect/receiver/utils.ts
@@ -1,11 +1,11 @@
-import type { Address } from "../../../utils/address.js";
+import { type Address, checksumAddress } from "../../../utils/address.js";
 import type { Account } from "../../interfaces/wallet.js";
 
 /**
  * @internal
  */
 export function validateAccountAddress(account: Account, address: Address) {
-  if (account.address !== address) {
+  if (checksumAddress(account.address) !== checksumAddress(address)) {
     throw new Error(
       `[WalletConnect] Failed to validate account address (${account.address}), differs from ${address}`,
     );


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR enhances the WalletConnect integration by adding support for validating account addresses, switching Ethereum chains, and handling chain-related requests.

### Detailed summary
- Added support for validating account addresses with checksum
- Implemented handling of switching Ethereum chains
- Updated request handlers for adding and switching Ethereum chains
- Added tests for wallet_addEthereumChain and wallet_switchEthereumChain requests

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->