### PR TITLE
feat(connect-wallet): support custom chains in WalletConnect

### DIFF
--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/Details.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/Details.tsx
@@ -656,6 +656,7 @@ function DetailsModal(props: {
         onBack={() => {
           setScreen("manage-wallet");
         }}
+        chains={props.chains}
         closeModal={closeModal}
         client={client}
       />

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/WalletConnectReceiverScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/WalletConnectReceiverScreen.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { ReloadIcon } from "@radix-ui/react-icons";
 import { useEffect, useState } from "react";
+import type { Chain } from "../../../../../chains/types.js";
 import type { ThirdwebClient } from "../../../../../client/client.js";
 import {
   createWalletConnectClient,
@@ -23,6 +24,7 @@ export function WalletConnectReceiverScreen(props: {
   onBack: () => void;
   closeModal: () => void;
   client: ThirdwebClient;
+  chains?: Chain[];
 }) {
   const [walletConnectClient, setWalletConnectClient] = useState<
     WalletConnectClient | undefined
@@ -36,6 +38,7 @@ export function WalletConnectReceiverScreen(props: {
     createWalletConnectClient({
       wallet: activeWallet,
       client: props.client,
+      chains: props.chains,
       onConnect: () => {
         props.closeModal();
         setLoading(false);
@@ -47,7 +50,13 @@ export function WalletConnectReceiverScreen(props: {
       .catch(() => {
         setErrorConnecting("Failed to establish WalletConnect connection");
       });
-  }, [activeWallet, props.client, props.closeModal, errorConnecting]);
+  }, [
+    activeWallet,
+    props.client,
+    props.closeModal,
+    errorConnecting,
+    props.chains,
+  ]);
 
   return (
     <Container

--- a/packages/thirdweb/src/wallets/wallet-connect/receiver/index.ts
+++ b/packages/thirdweb/src/wallets/wallet-connect/receiver/index.ts
@@ -1,4 +1,5 @@
 import { SignClient } from "@walletconnect/sign-client";
+import type { Chain } from "../../../chains/types.js";
 import type { ThirdwebClient } from "../../../client/client.js";
 import type { Prettify } from "../../../utils/type-utils.js";
 import type { Wallet } from "../../interfaces/wallet.js";
@@ -30,6 +31,11 @@ export type CreateWalletConnectClientOptions = Prettify<
      * The wallet to connect to the WalletConnect URI.
      */
     wallet: Wallet;
+
+    /**
+     * Any chains to enable for the wallet. Apps can request access to specific chains, but this list will always be available for use with the wallet.
+     */
+    chains?: Chain[];
 
     /**
      * Custom RPC handlers to override the defaults. Useful when creating a custom approval UI.
@@ -125,7 +131,7 @@ export const clearWalletConnectClientCache = () => {
 export async function createWalletConnectClient(
   options: CreateWalletConnectClientOptions,
 ): Promise<WalletConnectClient> {
-  const { wallet, requestHandlers, onConnect, onDisconnect } = options;
+  const { wallet, requestHandlers, chains, onConnect, onDisconnect } = options;
 
   if (walletConnectClientCache.has(options.client)) {
     return walletConnectClientCache.get(options.client) as WalletConnectClient;
@@ -152,6 +158,7 @@ export async function createWalletConnectClient(
         wallet,
         walletConnectClient,
         event,
+        chains,
         onConnect,
       });
     },
@@ -173,7 +180,7 @@ export async function createWalletConnectClient(
   walletConnectClient.on(
     "session_event",
     async (_event: WalletConnectSessionEvent) => {
-      // TODO
+      // TODO (accountsChanged, chainChanged)
     },
   );
 

--- a/packages/thirdweb/src/wallets/wallet-connect/receiver/types.ts
+++ b/packages/thirdweb/src/wallets/wallet-connect/receiver/types.ts
@@ -31,7 +31,7 @@ export type WalletConnectSessionProposalEvent = {
         icons: string[];
       };
     };
-    requiredNamespaces: Record<
+    requiredNamespaces?: Record<
       string,
       {
         chains?: string[];


### PR DESCRIPTION
Allows use of chains not explicitly specified on the connecting app but specified by the receiver.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the WalletConnect feature by adding support for custom chains and improving session handling.

### Detailed summary
- Added support for custom chains in WalletConnect feature
- Improved session handling logic for WalletConnect sessions
- Updated types and imports for better clarity and organization

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->