### PR TITLE
Edition Drop extension: updateMetadata + few others

### DIFF
--- a/.changeset/cyan-chefs-swim.md
+++ b/.changeset/cyan-chefs-swim.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Add updateMetadata extension for Edition Drop (DropERC1155)

--- a/packages/thirdweb/scripts/generate/abis/erc1155/BatchMintMetadata.json
+++ b/packages/thirdweb/scripts/generate/abis/erc1155/BatchMintMetadata.json
@@ -1,0 +1,5 @@
+[
+  "event BatchMetadataUpdate(uint256 _fromTokenId, uint256 _toTokenId)",
+  "function getBaseURICount() public view returns (uint256)",
+  "function getBatchIdAtIndex(uint256 _index) public view returns (uint256)"
+]

--- a/packages/thirdweb/scripts/generate/abis/erc1155/DropERC1155.json
+++ b/packages/thirdweb/scripts/generate/abis/erc1155/DropERC1155.json
@@ -1,0 +1,6 @@
+[
+  "function setMaxTotalSupply(uint256 _tokenId, uint256 _maxTotalSupply)",
+  "function setSaleRecipientForToken(uint256 _tokenId, address _saleRecipient)",
+  "function updateBatchBaseURI(uint256 _index, string calldata _uri)",
+  "function freezeBatchBaseURI(uint256 _index)"
+]

--- a/packages/thirdweb/src/exports/extensions/erc1155.ts
+++ b/packages/thirdweb/src/exports/extensions/erc1155.ts
@@ -94,6 +94,11 @@ export {
   type SetClaimConditionsParams,
 } from "../../extensions/erc1155/drops/write/setClaimConditions.js";
 
+export {
+  updateMetadata,
+  type UpdateMetadataParams,
+} from "../../extensions/erc1155/drops/write/updateMetadata.js";
+
 /**
  * SIGNATURE extension for ERC1155
  */

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/BatchMintMetadata/events/BatchMetadataUpdate.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/BatchMintMetadata/events/BatchMetadataUpdate.ts
@@ -1,0 +1,25 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+
+/**
+ * Creates an event object for the BatchMetadataUpdate event.
+ * @returns The prepared event object.
+ * @extension ERC1155
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { batchMetadataUpdateEvent } from "thirdweb/extensions/erc1155";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  batchMetadataUpdateEvent()
+ * ],
+ * });
+ * ```
+ */
+export function batchMetadataUpdateEvent() {
+  return prepareEvent({
+    signature:
+      "event BatchMetadataUpdate(uint256 _fromTokenId, uint256 _toTokenId)",
+  });
+}

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/BatchMintMetadata/read/getBaseURICount.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/BatchMintMetadata/read/getBaseURICount.ts
@@ -1,0 +1,74 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0x63b45e2d" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Checks if the `getBaseURICount` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `getBaseURICount` method is supported.
+ * @extension ERC1155
+ * @example
+ * ```ts
+ * import { isGetBaseURICountSupported } from "thirdweb/extensions/erc1155";
+ *
+ * const supported = await isGetBaseURICountSupported(contract);
+ * ```
+ */
+export async function isGetBaseURICountSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Decodes the result of the getBaseURICount function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC1155
+ * @example
+ * ```ts
+ * import { decodeGetBaseURICountResult } from "thirdweb/extensions/erc1155";
+ * const result = decodeGetBaseURICountResult("...");
+ * ```
+ */
+export function decodeGetBaseURICountResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "getBaseURICount" function on the contract.
+ * @param options - The options for the getBaseURICount function.
+ * @returns The parsed result of the function call.
+ * @extension ERC1155
+ * @example
+ * ```ts
+ * import { getBaseURICount } from "thirdweb/extensions/erc1155";
+ *
+ * const result = await getBaseURICount({
+ *  contract,
+ * });
+ *
+ * ```
+ */
+export async function getBaseURICount(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/BatchMintMetadata/read/getBatchIdAtIndex.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/BatchMintMetadata/read/getBatchIdAtIndex.ts
@@ -1,0 +1,131 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "getBatchIdAtIndex" function.
+ */
+export type GetBatchIdAtIndexParams = {
+  index: AbiParameterToPrimitiveType<{ type: "uint256"; name: "_index" }>;
+};
+
+export const FN_SELECTOR = "0x2419f51b" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_index",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Checks if the `getBatchIdAtIndex` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `getBatchIdAtIndex` method is supported.
+ * @extension ERC1155
+ * @example
+ * ```ts
+ * import { isGetBatchIdAtIndexSupported } from "thirdweb/extensions/erc1155";
+ *
+ * const supported = await isGetBatchIdAtIndexSupported(contract);
+ * ```
+ */
+export async function isGetBatchIdAtIndexSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "getBatchIdAtIndex" function.
+ * @param options - The options for the getBatchIdAtIndex function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC1155
+ * @example
+ * ```ts
+ * import { encodeGetBatchIdAtIndexParams } "thirdweb/extensions/erc1155";
+ * const result = encodeGetBatchIdAtIndexParams({
+ *  index: ...,
+ * });
+ * ```
+ */
+export function encodeGetBatchIdAtIndexParams(
+  options: GetBatchIdAtIndexParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.index]);
+}
+
+/**
+ * Encodes the "getBatchIdAtIndex" function into a Hex string with its parameters.
+ * @param options - The options for the getBatchIdAtIndex function.
+ * @returns The encoded hexadecimal string.
+ * @extension ERC1155
+ * @example
+ * ```ts
+ * import { encodeGetBatchIdAtIndex } "thirdweb/extensions/erc1155";
+ * const result = encodeGetBatchIdAtIndex({
+ *  index: ...,
+ * });
+ * ```
+ */
+export function encodeGetBatchIdAtIndex(options: GetBatchIdAtIndexParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeGetBatchIdAtIndexParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the getBatchIdAtIndex function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension ERC1155
+ * @example
+ * ```ts
+ * import { decodeGetBatchIdAtIndexResult } from "thirdweb/extensions/erc1155";
+ * const result = decodeGetBatchIdAtIndexResult("...");
+ * ```
+ */
+export function decodeGetBatchIdAtIndexResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "getBatchIdAtIndex" function on the contract.
+ * @param options - The options for the getBatchIdAtIndex function.
+ * @returns The parsed result of the function call.
+ * @extension ERC1155
+ * @example
+ * ```ts
+ * import { getBatchIdAtIndex } from "thirdweb/extensions/erc1155";
+ *
+ * const result = await getBatchIdAtIndex({
+ *  contract,
+ *  index: ...,
+ * });
+ *
+ * ```
+ */
+export async function getBatchIdAtIndex(
+  options: BaseTransactionOptions<GetBatchIdAtIndexParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.index],
+  });
+}

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/DropERC1155/write/freezeBatchBaseURI.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/DropERC1155/write/freezeBatchBaseURI.ts
@@ -1,0 +1,141 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "freezeBatchBaseURI" function.
+ */
+export type FreezeBatchBaseURIParams = WithOverrides<{
+  index: AbiParameterToPrimitiveType<{ type: "uint256"; name: "_index" }>;
+}>;
+
+export const FN_SELECTOR = "0xa07ced9e" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_index",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `freezeBatchBaseURI` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `freezeBatchBaseURI` method is supported.
+ * @extension ERC1155
+ * @example
+ * ```ts
+ * import { isFreezeBatchBaseURISupported } from "thirdweb/extensions/erc1155";
+ *
+ * const supported = await isFreezeBatchBaseURISupported(contract);
+ * ```
+ */
+export async function isFreezeBatchBaseURISupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "freezeBatchBaseURI" function.
+ * @param options - The options for the freezeBatchBaseURI function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC1155
+ * @example
+ * ```ts
+ * import { encodeFreezeBatchBaseURIParams } "thirdweb/extensions/erc1155";
+ * const result = encodeFreezeBatchBaseURIParams({
+ *  index: ...,
+ * });
+ * ```
+ */
+export function encodeFreezeBatchBaseURIParams(
+  options: FreezeBatchBaseURIParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.index]);
+}
+
+/**
+ * Encodes the "freezeBatchBaseURI" function into a Hex string with its parameters.
+ * @param options - The options for the freezeBatchBaseURI function.
+ * @returns The encoded hexadecimal string.
+ * @extension ERC1155
+ * @example
+ * ```ts
+ * import { encodeFreezeBatchBaseURI } "thirdweb/extensions/erc1155";
+ * const result = encodeFreezeBatchBaseURI({
+ *  index: ...,
+ * });
+ * ```
+ */
+export function encodeFreezeBatchBaseURI(options: FreezeBatchBaseURIParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeFreezeBatchBaseURIParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "freezeBatchBaseURI" function on the contract.
+ * @param options - The options for the "freezeBatchBaseURI" function.
+ * @returns A prepared transaction object.
+ * @extension ERC1155
+ * @example
+ * ```ts
+ * import { freezeBatchBaseURI } from "thirdweb/extensions/erc1155";
+ *
+ * const transaction = freezeBatchBaseURI({
+ *  contract,
+ *  index: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function freezeBatchBaseURI(
+  options: BaseTransactionOptions<
+    | FreezeBatchBaseURIParams
+    | {
+        asyncParams: () => Promise<FreezeBatchBaseURIParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.index] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/DropERC1155/write/setMaxTotalSupply.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/DropERC1155/write/setMaxTotalSupply.ts
@@ -1,0 +1,155 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "setMaxTotalSupply" function.
+ */
+export type SetMaxTotalSupplyParams = WithOverrides<{
+  tokenId: AbiParameterToPrimitiveType<{ type: "uint256"; name: "_tokenId" }>;
+  maxTotalSupply: AbiParameterToPrimitiveType<{
+    type: "uint256";
+    name: "_maxTotalSupply";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0x87198cf2" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_tokenId",
+  },
+  {
+    type: "uint256",
+    name: "_maxTotalSupply",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `setMaxTotalSupply` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `setMaxTotalSupply` method is supported.
+ * @extension ERC1155
+ * @example
+ * ```ts
+ * import { isSetMaxTotalSupplySupported } from "thirdweb/extensions/erc1155";
+ *
+ * const supported = await isSetMaxTotalSupplySupported(contract);
+ * ```
+ */
+export async function isSetMaxTotalSupplySupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "setMaxTotalSupply" function.
+ * @param options - The options for the setMaxTotalSupply function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC1155
+ * @example
+ * ```ts
+ * import { encodeSetMaxTotalSupplyParams } "thirdweb/extensions/erc1155";
+ * const result = encodeSetMaxTotalSupplyParams({
+ *  tokenId: ...,
+ *  maxTotalSupply: ...,
+ * });
+ * ```
+ */
+export function encodeSetMaxTotalSupplyParams(
+  options: SetMaxTotalSupplyParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.tokenId,
+    options.maxTotalSupply,
+  ]);
+}
+
+/**
+ * Encodes the "setMaxTotalSupply" function into a Hex string with its parameters.
+ * @param options - The options for the setMaxTotalSupply function.
+ * @returns The encoded hexadecimal string.
+ * @extension ERC1155
+ * @example
+ * ```ts
+ * import { encodeSetMaxTotalSupply } "thirdweb/extensions/erc1155";
+ * const result = encodeSetMaxTotalSupply({
+ *  tokenId: ...,
+ *  maxTotalSupply: ...,
+ * });
+ * ```
+ */
+export function encodeSetMaxTotalSupply(options: SetMaxTotalSupplyParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeSetMaxTotalSupplyParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "setMaxTotalSupply" function on the contract.
+ * @param options - The options for the "setMaxTotalSupply" function.
+ * @returns A prepared transaction object.
+ * @extension ERC1155
+ * @example
+ * ```ts
+ * import { setMaxTotalSupply } from "thirdweb/extensions/erc1155";
+ *
+ * const transaction = setMaxTotalSupply({
+ *  contract,
+ *  tokenId: ...,
+ *  maxTotalSupply: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function setMaxTotalSupply(
+  options: BaseTransactionOptions<
+    | SetMaxTotalSupplyParams
+    | {
+        asyncParams: () => Promise<SetMaxTotalSupplyParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.tokenId, resolvedOptions.maxTotalSupply] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/DropERC1155/write/setSaleRecipientForToken.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/DropERC1155/write/setSaleRecipientForToken.ts
@@ -1,0 +1,157 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "setSaleRecipientForToken" function.
+ */
+export type SetSaleRecipientForTokenParams = WithOverrides<{
+  tokenId: AbiParameterToPrimitiveType<{ type: "uint256"; name: "_tokenId" }>;
+  saleRecipient: AbiParameterToPrimitiveType<{
+    type: "address";
+    name: "_saleRecipient";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0x29c49b9b" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_tokenId",
+  },
+  {
+    type: "address",
+    name: "_saleRecipient",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `setSaleRecipientForToken` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `setSaleRecipientForToken` method is supported.
+ * @extension ERC1155
+ * @example
+ * ```ts
+ * import { isSetSaleRecipientForTokenSupported } from "thirdweb/extensions/erc1155";
+ *
+ * const supported = await isSetSaleRecipientForTokenSupported(contract);
+ * ```
+ */
+export async function isSetSaleRecipientForTokenSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "setSaleRecipientForToken" function.
+ * @param options - The options for the setSaleRecipientForToken function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC1155
+ * @example
+ * ```ts
+ * import { encodeSetSaleRecipientForTokenParams } "thirdweb/extensions/erc1155";
+ * const result = encodeSetSaleRecipientForTokenParams({
+ *  tokenId: ...,
+ *  saleRecipient: ...,
+ * });
+ * ```
+ */
+export function encodeSetSaleRecipientForTokenParams(
+  options: SetSaleRecipientForTokenParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.tokenId,
+    options.saleRecipient,
+  ]);
+}
+
+/**
+ * Encodes the "setSaleRecipientForToken" function into a Hex string with its parameters.
+ * @param options - The options for the setSaleRecipientForToken function.
+ * @returns The encoded hexadecimal string.
+ * @extension ERC1155
+ * @example
+ * ```ts
+ * import { encodeSetSaleRecipientForToken } "thirdweb/extensions/erc1155";
+ * const result = encodeSetSaleRecipientForToken({
+ *  tokenId: ...,
+ *  saleRecipient: ...,
+ * });
+ * ```
+ */
+export function encodeSetSaleRecipientForToken(
+  options: SetSaleRecipientForTokenParams,
+) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeSetSaleRecipientForTokenParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "setSaleRecipientForToken" function on the contract.
+ * @param options - The options for the "setSaleRecipientForToken" function.
+ * @returns A prepared transaction object.
+ * @extension ERC1155
+ * @example
+ * ```ts
+ * import { setSaleRecipientForToken } from "thirdweb/extensions/erc1155";
+ *
+ * const transaction = setSaleRecipientForToken({
+ *  contract,
+ *  tokenId: ...,
+ *  saleRecipient: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function setSaleRecipientForToken(
+  options: BaseTransactionOptions<
+    | SetSaleRecipientForTokenParams
+    | {
+        asyncParams: () => Promise<SetSaleRecipientForTokenParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.tokenId, resolvedOptions.saleRecipient] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/DropERC1155/write/updateBatchBaseURI.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/DropERC1155/write/updateBatchBaseURI.ts
@@ -1,0 +1,149 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "updateBatchBaseURI" function.
+ */
+export type UpdateBatchBaseURIParams = WithOverrides<{
+  index: AbiParameterToPrimitiveType<{ type: "uint256"; name: "_index" }>;
+  uri: AbiParameterToPrimitiveType<{ type: "string"; name: "_uri" }>;
+}>;
+
+export const FN_SELECTOR = "0xde903ddd" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_index",
+  },
+  {
+    type: "string",
+    name: "_uri",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `updateBatchBaseURI` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `updateBatchBaseURI` method is supported.
+ * @extension ERC1155
+ * @example
+ * ```ts
+ * import { isUpdateBatchBaseURISupported } from "thirdweb/extensions/erc1155";
+ *
+ * const supported = await isUpdateBatchBaseURISupported(contract);
+ * ```
+ */
+export async function isUpdateBatchBaseURISupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "updateBatchBaseURI" function.
+ * @param options - The options for the updateBatchBaseURI function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC1155
+ * @example
+ * ```ts
+ * import { encodeUpdateBatchBaseURIParams } "thirdweb/extensions/erc1155";
+ * const result = encodeUpdateBatchBaseURIParams({
+ *  index: ...,
+ *  uri: ...,
+ * });
+ * ```
+ */
+export function encodeUpdateBatchBaseURIParams(
+  options: UpdateBatchBaseURIParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.index, options.uri]);
+}
+
+/**
+ * Encodes the "updateBatchBaseURI" function into a Hex string with its parameters.
+ * @param options - The options for the updateBatchBaseURI function.
+ * @returns The encoded hexadecimal string.
+ * @extension ERC1155
+ * @example
+ * ```ts
+ * import { encodeUpdateBatchBaseURI } "thirdweb/extensions/erc1155";
+ * const result = encodeUpdateBatchBaseURI({
+ *  index: ...,
+ *  uri: ...,
+ * });
+ * ```
+ */
+export function encodeUpdateBatchBaseURI(options: UpdateBatchBaseURIParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeUpdateBatchBaseURIParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "updateBatchBaseURI" function on the contract.
+ * @param options - The options for the "updateBatchBaseURI" function.
+ * @returns A prepared transaction object.
+ * @extension ERC1155
+ * @example
+ * ```ts
+ * import { updateBatchBaseURI } from "thirdweb/extensions/erc1155";
+ *
+ * const transaction = updateBatchBaseURI({
+ *  contract,
+ *  index: ...,
+ *  uri: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function updateBatchBaseURI(
+  options: BaseTransactionOptions<
+    | UpdateBatchBaseURIParams
+    | {
+        asyncParams: () => Promise<UpdateBatchBaseURIParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.index, resolvedOptions.uri] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+  });
+}

--- a/packages/thirdweb/src/extensions/erc1155/drops/write/updateMetadata.test.ts
+++ b/packages/thirdweb/src/extensions/erc1155/drops/write/updateMetadata.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { ANVIL_CHAIN } from "~test/chains.js";
+import { TEST_CLIENT } from "~test/test-clients.js";
+import { TEST_ACCOUNT_A } from "~test/test-wallets.js";
+
+import {
+  type ThirdwebContract,
+  getContract,
+} from "../../../../contract/contract.js";
+import { deployERC1155Contract } from "../../../../extensions/prebuilts/deploy-erc1155.js";
+import { sendAndConfirmTransaction } from "../../../../transaction/actions/send-and-confirm-transaction.js";
+import type { NFTInput } from "../../../../utils/nft/parseNft.js";
+import { getNFT } from "../../read/getNFT.js";
+import { getNFTs } from "../../read/getNFTs.js";
+import { lazyMint } from "../../write/lazyMint.js";
+import { getUpdateMetadataParams, updateMetadata } from "./updateMetadata.js";
+
+let contract: ThirdwebContract;
+const account = TEST_ACCOUNT_A;
+const client = TEST_CLIENT;
+const chain = ANVIL_CHAIN;
+
+describe.runIf(process.env.TW_SECRET_KEY)("erc1155: updateMetadata", () => {
+  beforeEach(async () => {
+    const address = await deployERC1155Contract({
+      client,
+      chain,
+      account,
+      type: "DropERC1155",
+      params: {
+        name: "EditionDrop",
+      },
+    });
+    contract = getContract({
+      address,
+      client,
+      chain,
+    });
+  });
+
+  it("should update the metadata for the selected token | case 1", async () => {
+    const metadatas: NFTInput[] = [
+      { name: "token 0" },
+      { name: "token 1" },
+      { name: "token 2" },
+    ];
+
+    const lazyMintTx = lazyMint({ contract, nfts: metadatas });
+    await sendAndConfirmTransaction({ transaction: lazyMintTx, account });
+
+    const transaction = updateMetadata({
+      contract,
+      targetTokenId: 0n,
+      newMetadata: { name: "token 0 - updated" },
+      client,
+    });
+    await sendAndConfirmTransaction({ transaction, account });
+    const nfts = await getNFTs({ contract });
+    expect(nfts[0]?.metadata.name).toBe("token 0 - updated");
+
+    // The other tokens should not change
+    expect(nfts[1]?.metadata.name).toBe("token 1");
+    expect(nfts[2]?.metadata.name).toBe("token 2");
+  });
+
+  it("should update the metadata for the selected token | case 2", async () => {
+    const nftBatch1: NFTInput[] = [
+      { name: "token 0" },
+      { name: "token 1" },
+      { name: "token 2" },
+    ];
+
+    const batch1 = lazyMint({ contract, nfts: nftBatch1 });
+    await sendAndConfirmTransaction({ transaction: batch1, account });
+
+    const nftBatch2: NFTInput[] = [
+      { name: "token 3" },
+      { name: "token 4" },
+      { name: "token 5" },
+    ];
+    const batch2 = lazyMint({ contract, nfts: nftBatch2 });
+    await sendAndConfirmTransaction({ transaction: batch2, account });
+
+    // firstly, update the token in the first batch
+    const transaction1 = updateMetadata({
+      contract,
+      targetTokenId: 0n,
+      newMetadata: { name: "token 0 - updated" },
+      client,
+    });
+    await sendAndConfirmTransaction({ transaction: transaction1, account });
+    const nft = await getNFT({ contract, tokenId: 0n });
+    expect(nft.metadata.name).toBe("token 0 - updated");
+
+    const tokenUriAfterUpdatedFirstTime = nft.tokenURI;
+
+    // Update token in the second batch
+    const transaction2 = updateMetadata({
+      contract,
+      targetTokenId: 5n,
+      newMetadata: { name: "token 5 - updated" },
+      client,
+    });
+    await sendAndConfirmTransaction({ transaction: transaction2, account });
+
+    const allNfts = await getNFTs({ contract });
+    expect(allNfts[0]?.metadata.name).toBe("token 0 - updated");
+    expect(allNfts.at(-1)?.metadata.name).toBe("token 5 - updated");
+
+    // The tokenUri of tokenId#0 after the second updateMetadata should still be the same
+    // since it belong to another batch
+    expect(allNfts[0]?.tokenURI).toBe(tokenUriAfterUpdatedFirstTime);
+  });
+
+  it("should throw error if there's no batch", async () => {
+    await expect(() =>
+      getUpdateMetadataParams({
+        contract,
+        targetTokenId: 0n,
+        newMetadata: { name: "token 0 - updated" },
+        client,
+      }),
+    ).rejects.toThrowError(
+      "No base URI set. Please set a base URI before updating metadata",
+    );
+  });
+});

--- a/packages/thirdweb/src/extensions/erc1155/drops/write/updateMetadata.ts
+++ b/packages/thirdweb/src/extensions/erc1155/drops/write/updateMetadata.ts
@@ -1,0 +1,125 @@
+import { getBaseURICount } from "../../../erc721/__generated__/IBatchMintMetadata/read/getBaseURICount.js";
+import {
+  type UpdateBatchBaseURIParams,
+  updateBatchBaseURI,
+} from "../../__generated__/DropERC1155/write/updateBatchBaseURI.js";
+
+import type { ThirdwebClient } from "../../../../client/client.js";
+import type { BaseTransactionOptions } from "../../../../transaction/types.js";
+import type { NFT, NFTInput } from "../../../../utils/nft/parseNft.js";
+
+export type UpdateMetadataParams = {
+  targetTokenId: bigint;
+  newMetadata: NFTInput;
+  client: ThirdwebClient;
+};
+
+/**
+ * @internal
+ */
+export async function getUpdateMetadataParams(
+  options: BaseTransactionOptions<UpdateMetadataParams>,
+): Promise<UpdateBatchBaseURIParams> {
+  const { contract, targetTokenId, newMetadata, client } = options;
+  const batchCount = await getBaseURICount(options);
+  if (batchCount === 0n) {
+    throw new Error(
+      "No base URI set. Please set a base URI before updating metadata",
+    );
+  }
+
+  // Look for the batchId & determine the start + end tokenId of the batch
+  const [{ getBatchIdAtIndex }, { getNFT }] = await Promise.all([
+    import("../../__generated__/BatchMintMetadata/read/getBatchIdAtIndex.js"),
+    import("../../read/getNFT.js"),
+  ]);
+
+  let startTokenId = 0n;
+  let endTokenId = 0n;
+  let batchIndex = 0n;
+  for (let i = 0n; i < batchCount; i += 1n) {
+    batchIndex = i;
+    endTokenId = await getBatchIdAtIndex({ contract, index: batchIndex });
+    if (endTokenId > targetTokenId) {
+      break;
+    }
+    startTokenId = endTokenId;
+  }
+
+  const range = Array.from(
+    { length: Number(endTokenId - startTokenId) },
+    (_, k) => BigInt(k) + startTokenId,
+  );
+
+  const currentMetadatas = await Promise.all(
+    range.map((id) => getNFT({ contract, tokenId: id })),
+  );
+
+  // Abort if any of the items failed to load
+  if (currentMetadatas.some((item) => item === undefined || !item.tokenURI)) {
+    throw new Error(
+      `Failed to load all ${range.length} items from batchIndex: ${batchIndex}`,
+    );
+  }
+
+  const newMetadatas: NFTInput[] = [];
+  for (let i = 0; i < currentMetadatas.length; i++) {
+    const { id, metadata } = currentMetadatas[i] as NFT;
+    if (targetTokenId === id) {
+      newMetadatas.push(newMetadata);
+    } else {
+      newMetadatas.push(metadata);
+    }
+  }
+
+  const { uploadOrExtractURIs } = await import("../../../../utils/ipfs.js");
+  const batchOfUris = await uploadOrExtractURIs(
+    newMetadatas,
+    client,
+    Number(startTokenId),
+  );
+
+  if (!batchOfUris || !batchOfUris.length || !batchOfUris[0]) {
+    throw new Error("Failed to upload batch of new metadatas");
+  }
+
+  const baseUri = batchOfUris[0].substring(0, batchOfUris[0].lastIndexOf("/"));
+
+  // IMPORTANT: The new ipfs URI must have the trailing slash at the end
+  // this is required by the Drop contract
+  const uri = `${baseUri}/`;
+
+  return { index: batchIndex, uri };
+}
+
+/**
+ * Update the metadata of the single token in an Edition Drop (DropERC1155) collection
+ * For Edition contracts, use `setTokenURI`
+ * @param options
+ * @returns the prepared transaction
+ * @extension ERC1155
+ * @example
+ * ```ts
+ * import { updateMetadata } from "thirdweb/extensions/erc1155";
+ *
+ * const transaction = updateMetadata({
+ *  contract,
+ *  targetTokenId: 0n,
+ *  newMetadata: {
+ *    name: "this is the new nft name",
+ *    description: "...",
+ *    image: "new image uri"
+ *    // ...
+ *  }
+ * });
+ * ```
+ */
+export function updateMetadata(
+  options: BaseTransactionOptions<UpdateMetadataParams>,
+) {
+  const { contract } = options;
+  return updateBatchBaseURI({
+    contract,
+    asyncParams: async () => getUpdateMetadataParams(options),
+  });
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds an `updateMetadata` extension for Edition Drop (DropERC1155).

### Detailed summary
- Added `updateMetadata` extension for DropERC1155
- Updated event handling for BatchMetadataUpdate
- Added functions for decoding and calling `getBaseURICount`
- Implemented logic for updating metadata in ERC1155 collections

> The following files were skipped due to too many changes: `packages/thirdweb/src/extensions/erc1155/drops/write/updateMetadata.test.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/BatchMintMetadata/read/getBatchIdAtIndex.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/DropERC1155/write/freezeBatchBaseURI.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/DropERC1155/write/updateBatchBaseURI.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/DropERC1155/write/setMaxTotalSupply.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/DropERC1155/write/setSaleRecipientForToken.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->