### PR TITLE
Fix React warning when clicking copy address button

### DIFF
--- a/.changeset/spotty-parrots-own.md
+++ b/.changeset/spotty-parrots-own.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix React warning when clicking copy address button and layout shift

--- a/packages/thirdweb/src/react/web/ui/components/CopyIcon.tsx
+++ b/packages/thirdweb/src/react/web/ui/components/CopyIcon.tsx
@@ -15,6 +15,7 @@ export const CopyIcon: React.FC<{
   hasCopied?: boolean;
 }> = (props) => {
   const { hasCopied, onCopy } = useClipboard(props.text);
+  const showCheckIcon = props.hasCopied || hasCopied;
 
   return (
     <div
@@ -31,13 +32,11 @@ export const CopyIcon: React.FC<{
       }}
     >
       <ToolTip tip={props.tip} side={props.side} align={props.align}>
-        {props.hasCopied || hasCopied ? (
-          <Container color="success">
-            <CheckIcon />
+        <div>
+          <Container color={showCheckIcon ? "success" : undefined}>
+            {showCheckIcon ? <CheckIcon /> : <CopyIconSVG />}
           </Container>
-        ) : (
-          <CopyIconSVG />
-        )}
+        </div>
       </ToolTip>
     </div>
   );


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR fixes a React warning and layout shift issue when clicking the copy address button in `CopyIcon.tsx`.

### Detailed summary
- Introduces `showCheckIcon` to handle display logic
- Updates conditional rendering of `CheckIcon` and `CopyIconSVG` based on `showCheckIcon`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->