### PR TITLE
fix(react): return type on useConnectModal.connect

### DIFF
--- a/.changeset/weak-months-repeat.md
+++ b/.changeset/weak-months-repeat.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fixed return type for useConnectModal.connect

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/useConnectModal.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/useConnectModal.tsx
@@ -55,7 +55,7 @@ export function useConnectModal() {
         setRootEl(undefined);
       }
 
-      return new Promise((resolve, reject) => {
+      return new Promise<Wallet>((resolve, reject) => {
         setIsConnecting(true);
         getConnectLocale(props.locale || "en_US")
           .then((locale) => {


### PR DESCRIPTION
## Problem solved

Fixes the return type of the `connect` field in the `useConnectModal` hook because TypeScript was not inferring the `Promise` result

Before
<img width="638" alt="Screenshot 2024-06-18 at 2 07 08 PM" src="https://github.com/thirdweb-dev/js/assets/1013230/e5b3d616-943c-4f9a-9184-34ddf1d971b5">

After
<img width="628" alt="Screenshot 2024-06-18 at 2 07 31 PM" src="https://github.com/thirdweb-dev/js/assets/1013230/8e7e647b-cf99-4c43-8925-2137cb14b207">

## Changes made

- [X] Public API changes: list the public API changes made if any
- [ ] Internal API changes: explain the internal logic changes

Explicitly return `Promise<Wallet>` from the `useConnectModal.connect` function

## How to test

- [ ] Automated tests: link to unit test file
- [X] Manual tests: step by step instructions on how to test

Observe types shown in IDE

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the return type for `useConnectModal.connect` in the `useConnectModal.tsx` file.

### Detailed summary
- Updated return type for `useConnectModal.connect` to `Promise<Wallet>`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->