### PR TITLE
feat(wallets): add watchAsset functionality to wallet API

### DIFF
--- a/.changeset/hip-bears-repeat.md
+++ b/.changeset/hip-bears-repeat.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": minor
+---
+
+Adds watchAsset support in injected wallet accounts

--- a/packages/thirdweb/src/wallets/injected/index.ts
+++ b/packages/thirdweb/src/wallets/injected/index.ts
@@ -196,6 +196,16 @@ function createAccount(provider: Ethereum, address: string) {
         params: [account.address, stringifiedData],
       });
     },
+    async watchAsset(asset) {
+      const result = await provider.request(
+        {
+          method: "wallet_watchAsset",
+          params: asset,
+        },
+        { retryCount: 0 },
+      );
+      return result;
+    },
   };
 
   return account;

--- a/packages/thirdweb/src/wallets/interfaces/wallet.ts
+++ b/packages/thirdweb/src/wallets/interfaces/wallet.ts
@@ -26,6 +26,16 @@ export type SendRawTransactionOptions = {
   chainId: number;
 };
 
+export type WatchAssetParams = {
+  type: "ERC20";
+  options: {
+    address: Address;
+    symbol: string;
+    decimals: number;
+    image?: string | undefined;
+  };
+};
+
 /**
  * Wallet interface
  */
@@ -238,4 +248,16 @@ export type Account = {
     // biome-ignore lint/suspicious/noExplicitAny: any transaction type is allowed here
     transaction: PreparedTransaction<any>,
   ) => Promise<void>;
+  /**
+   * Add an asset to the wallet's watchlist.
+   * @param asset - The asset to watch.
+   *
+   * @example
+   * ```ts
+   * if (account.watchAsset) {
+   *  const success = await account.watchAsset({ type: "ERC20", options: { address: "0x...", symbol: "...", decimals: 18 } });
+   * }
+   * ```
+   */
+  watchAsset?: (asset: WatchAssetParams) => Promise<boolean>;
 };


### PR DESCRIPTION
### TL;DR
This pull request introduces the `watchAsset` functionality to the injected wallets in the thirdweb package.

### What changed?
A new method `watchAsset` is added to the `createAccount` function and `Account` type. This method allows users to add an ERC-20 asset to their wallet's watchlist.

### How to test?
1. Create an account using the `createAccount` function.
2. Call the `watchAsset` method with appropriate parameters to watch an ERC-20 asset.
3. Verify if the asset is added to the wallet's watchlist.

### Why make this change?
This change is made to enhance the functionality of the injected wallets by allowing users to easily add ERC-20 assets to their watchlist, improving the user experience and making asset management more convenient.

---

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for watching assets in injected wallet accounts in `thirdweb`.

### Detailed summary
- Added `watchAsset` method in injected wallet accounts
- Defined `WatchAssetParams` type for asset watching
- Updated `Wallet` interface with `watchAsset` method
- Provided example usage for `watchAsset` in comments

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->