### PR TITLE
fix(dashboard): renames NFT Properties to Attributes in UI to match metadata

### DIFF
--- a/.changeset/chilly-phones-sort.md
+++ b/.changeset/chilly-phones-sort.md
@@ -1,0 +1,5 @@
+---
+"thirdweb-dashboard": patch
+---
+
+Renames 'Properties' to 'Attributes' in dashboard UI

--- a/apps/dashboard/src/components/contract-pages/forms/properties.shared.tsx
+++ b/apps/dashboard/src/components/contract-pages/forms/properties.shared.tsx
@@ -68,7 +68,7 @@ export const PropertiesFormControl = <
   return (
     <Stack spacing={4}>
       <Flex justify="space-between" align="center" direction="row">
-        <FormLabel m={0}>Properties</FormLabel>
+        <FormLabel m={0}>Attributes</FormLabel>
         <Button
           rightIcon={<Icon as={FiSlash} />}
           variant="outline"

--- a/apps/dashboard/src/contract-ui/tabs/listings/components/listing-drawer.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/listings/components/listing-drawer.tsx
@@ -97,7 +97,7 @@ export const ListingDrawer: React.FC<NFTDrawerProps> = ({
             </Card>
             {data?.asset.attributes || data?.asset.properties ? (
               <Card as={Flex} flexDir="column" gap={4}>
-                <Heading size="label.md">Properties</Heading>
+                <Heading size="label.md">Attributes</Heading>
                 <CodeBlock
                   code={
                     JSON.stringify(

--- a/apps/dashboard/src/contract-ui/tabs/nfts/components/token-id.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/nfts/components/token-id.tsx
@@ -238,7 +238,7 @@ export const TokenIdPage: React.FC<TokenIdPageProps> = ({
             </Card>
             {properties ? (
               <Card as={Flex} flexDir="column" gap={4}>
-                <Heading size="label.md">Properties</Heading>
+                <Heading size="label.md">Attributes</Heading>
                 {Array.isArray(properties) &&
                 String(properties[0]?.value) !== "undefined" ? (
                   <SimpleGrid columns={{ base: 2, md: 4 }} gap={2}>

--- a/apps/dashboard/src/contract-ui/tabs/shared-components/listing-drawer.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/shared-components/listing-drawer.tsx
@@ -109,7 +109,7 @@ export const ListingDrawer: React.FC<NFTDrawerProps> = ({
             </Card>
             {data?.asset.metadata.properties ? (
               <Card as={Flex} flexDir="column" gap={4}>
-                <Heading size="label.md">Properties</Heading>
+                <Heading size="label.md">Attributes</Heading>
                 <CodeBlock
                   code={
                     JSON.stringify(data.asset.metadata.properties, null, 2) ||

--- a/apps/dashboard/src/core-ui/batch-upload/batch-table.tsx
+++ b/apps/dashboard/src/core-ui/batch-upload/batch-table.tsx
@@ -107,7 +107,7 @@ export const BatchTable: React.FC<BatchTableProps> = ({
         accessor: (row) => parseDescription(row.description),
       },
       {
-        Header: "Properties",
+        Header: "Attributes",
         accessor: (row) => row.attributes || row.properties,
         Cell: ({ cell }: { cell: any }) =>
           cell.value ? (


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR renames 'Properties' to 'Attributes' in multiple UI components for consistency and clarity.

### Detailed summary
- Renamed 'Properties' to 'Attributes' in dashboard UI components
- Updated labels and references in various files for consistency

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->