### PR TITLE
fix(dashboard): can update image when no existing one

### DIFF
--- a/.changeset/khaki-penguins-swim.md
+++ b/.changeset/khaki-penguins-swim.md
@@ -1,0 +1,5 @@
+---
+"thirdweb-dashboard": patch
+---
+
+Fixes NFT image updates when no existing image is present

--- a/apps/dashboard/src/contract-ui/tabs/nfts/components/mint-form.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/nfts/components/mint-form.tsx
@@ -573,7 +573,7 @@ export const NFTMintForm: React.FC<NFTMintForm> = ({
           form={MINT_FORM_ID}
           type="submit"
           colorScheme="primary"
-          isDisabled={!isDirty}
+          isDisabled={!isDirty && imageUrl === nft?.metadata.image}
         >
           {sharedMetadataMutation
             ? "Set NFT Metadata"


### PR DESCRIPTION
### TL;DR
Fixes an issue where NFT image updates were not being applied if there was no existing image.

### What changed?
- Modified the `mint-form.tsx` to only disable the submit button if the form is not dirty and the image URL has not changed.

### How to test?
1. Open the mint form for an NFT without an existing image.
2. Attempt to update the image.
3. Ensure the submit button is enabled and the image update is successful.

### Why make this change?
This change ensures that users can update the image for NFTs that do not have an existing image without unnecessary restrictions.

---

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing NFT image updates when no existing image is present in the thirdweb-dashboard.

### Detailed summary
- Fixed issue with NFT image updates when no existing image is present in `mint-form.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->