### PR TITLE
[Chore] Add Vercel configuration for auto job cancelation in dashboard and playground-web apps

### DIFF
--- a/apps/dashboard/vercel.json
+++ b/apps/dashboard/vercel.json
@@ -1,0 +1,5 @@
+{
+  "github": {
+    "autoJobCancelation": true
+  }
+}

--- a/apps/playground-web/vercel.json
+++ b/apps/playground-web/vercel.json
@@ -1,0 +1,5 @@
+{
+  "github": {
+    "autoJobCancelation": true
+  }
+}


### PR DESCRIPTION
### TL;DR

Add new `vercel.json` files to the dashboard and playground-web applications for enabling GitHub auto job cancellation.

### What changed?
Two new `vercel.json` files were created and added to the respective applications. These files contain configuration for automatically canceling previous jobs in GitHub actions when new commits are pushed.

### How to test?
1. Navigate to the dashboard and playground-web directories.
2. Check for the presence of the `vercel.json` files.
3. Ensure the config `

---

