### PR TITLE
fix(wallets): always pass a string for in-app wallet signatures

### DIFF
--- a/.changeset/fast-bats-mate.md
+++ b/.changeset/fast-bats-mate.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix hex-based signatures for in-app wallets


### PR DESCRIPTION
### TL;DR

Updated the in-app wallet's `signMessage` function to properly handle different message formats. The function now decodes a message from a string, a `Uint8Array`, or a hex format into a string before signing.

### What changed?

- Imported `uint8ArrayToString` and `hexToString` utilities.
- Updated the `signMessage` method to decode messages from multiple formats (string, `Uint8Array`, and hex).
- Adjusted the type annotations and added in-line comments for clarity.

### How to test?

1. Attempt to sign a message with the in-app wallet using different message formats.
2. Verify that the message is correctly signed in each case without errors.

### Why make this change?

This update ensures that the in-app wallet can handle and correctly process various message formats, improving interoperability and user experience.

---

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing hex-based signatures for in-app wallets. 

### Detailed summary
- Updated `in-app-account.ts` to handle hex-based signatures correctly
- Added `uint8ArrayToString` import for converting Uint8Array to string
- Modified message decoding logic to handle different message types
- Removed unnecessary type casting for message parameter

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->