### PR TITLE
fix: always use CustomThemeProvider's theme prop in React

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "generate-snippets": "node ./scripts/generate-snippets/index.mjs",
     "build:release": "pnpm run build --force",
     "dev:playground": "turbo run dev --no-cache --parallel --continue --filter=!./apps/dashboard",
-    "dev:dashboard": "turbo run dev --filter=./apps/dashboard",
+    "dev:dashboard": "turbo run dev --filter=./apps/dashboard --filter=./packages/thirdweb",
     "build:dashboard": "turbo run build --filter=./apps/dashboard",
     "fix:repo": "manypkg fix",
     "lint": "turbo run lint --filter=./packages/*",

--- a/packages/thirdweb/src/react/core/design-system/CustomThemeProvider.tsx
+++ b/packages/thirdweb/src/react/core/design-system/CustomThemeProvider.tsx
@@ -9,7 +9,7 @@ const CustomThemeCtx = /* @__PURE__ */ createContext(darkThemeObj);
  */
 export function CustomThemeProvider(props: {
   children: React.ReactNode;
-  theme: "light" | "dark" | Theme;
+  theme: "light" | "dark" | Theme | undefined;
 }) {
   const { theme, children } = props;
   const themeObj = parseTheme(theme);

--- a/packages/thirdweb/src/react/web/providers/wallet-ui-states-provider.tsx
+++ b/packages/thirdweb/src/react/web/providers/wallet-ui-states-provider.tsx
@@ -30,7 +30,7 @@ export const WalletUIStatesProvider = (
       <SetWalletModalOpen.Provider value={setIsWalletModalOpen}>
         <SelectionUIDataCtx.Provider value={selectionUIData}>
           <SetSelectionUIDataCtx.Provider value={setSelectionUIData}>
-            <CustomThemeProvider theme={props.theme || "dark"}>
+            <CustomThemeProvider theme={props.theme}>
               {props.children}
             </CustomThemeProvider>
           </SetSelectionUIDataCtx.Provider>

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/ConnectEmbed.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/ConnectEmbed.tsx
@@ -383,7 +383,7 @@ export function ConnectEmbed(props: ConnectEmbedProps) {
       return (
         <>
           {autoConnectComp}
-          <CustomThemeProvider theme={props.theme || "dark"}>
+          <CustomThemeProvider theme={props.theme}>
             <EmbedContainer modalSize={modalSize}>
               <LoadingScreen />
             </EmbedContainer>

--- a/packages/thirdweb/src/react/web/ui/TransactionButton/index.tsx
+++ b/packages/thirdweb/src/react/web/ui/TransactionButton/index.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { parseTheme } from "../../../core/design-system/CustomThemeProvider.js";
+import { CustomThemeProvider } from "../../../core/design-system/CustomThemeProvider.js";
 import {
   type TransactionButtonProps,
   useTransactionButtonMutation,
@@ -60,47 +60,48 @@ export function TransactionButton(props: TransactionButtonProps) {
   );
 
   return (
-    <Button
-      gap="xs"
-      disabled={!account || disabled || isPending}
-      variant={"primary"}
-      unstyled={unstyled}
-      data-is-loading={isPending}
-      onClick={() => handleClick()}
-      {...buttonProps}
-      style={
-        !unstyled
-          ? {
-              opacity: !account || disabled ? 0.5 : 1,
-              minWidth: "150px",
-              position: "relative",
-              ...buttonProps.style,
-            }
-          : {
-              position: "relative",
-              ...buttonProps.style,
-            }
-      }
-      theme={parseTheme(props.theme)}
-    >
-      <span style={{ visibility: isPending ? "hidden" : "visible" }}>
-        {children}
-      </span>
-      {isPending && (
-        <div
-          style={{
-            position: "absolute",
-            display: "flex",
-            alignItems: "center",
-            height: "100%",
-            top: 0,
-            bottom: 0,
-            margin: "auto",
-          }}
-        >
-          <Spinner size="md" color="primaryButtonText" />
-        </div>
-      )}
-    </Button>
+    <CustomThemeProvider theme={props.theme}>
+      <Button
+        gap="xs"
+        disabled={!account || disabled || isPending}
+        variant={"primary"}
+        unstyled={unstyled}
+        data-is-loading={isPending}
+        onClick={() => handleClick()}
+        {...buttonProps}
+        style={
+          !unstyled
+            ? {
+                opacity: !account || disabled ? 0.5 : 1,
+                minWidth: "150px",
+                position: "relative",
+                ...buttonProps.style,
+              }
+            : {
+                position: "relative",
+                ...buttonProps.style,
+              }
+        }
+      >
+        <span style={{ visibility: isPending ? "hidden" : "visible" }}>
+          {children}
+        </span>
+        {isPending && (
+          <div
+            style={{
+              position: "absolute",
+              display: "flex",
+              alignItems: "center",
+              height: "100%",
+              top: 0,
+              bottom: 0,
+              margin: "auto",
+            }}
+          >
+            <Spinner size="md" color="primaryButtonText" />
+          </div>
+        )}
+      </Button>
+    </CustomThemeProvider>
   );
 }

--- a/packages/thirdweb/src/react/web/ui/components/buttons.tsx
+++ b/packages/thirdweb/src/react/web/ui/components/buttons.tsx
@@ -1,11 +1,6 @@
 "use client";
+import { useCustomTheme } from "../../../core/design-system/CustomThemeProvider.js";
 import {
-  isValidTheme,
-  parseTheme,
-  useCustomTheme,
-} from "../../../core/design-system/CustomThemeProvider.js";
-import {
-  type Theme,
   fontSize,
   radius,
   spacing,
@@ -14,15 +9,13 @@ import { StyledButton } from "../design-system/elements.js";
 
 export type ButtonProps = {
   variant: "primary" | "secondary" | "link" | "accent" | "outline" | "ghost";
-  theme?: Theme;
   unstyled?: boolean;
   fullWidth?: boolean;
   gap?: keyof typeof spacing;
 };
 
 export const Button = /* @__PURE__ */ StyledButton((props: ButtonProps) => {
-  const _theme = useCustomTheme();
-  const theme = isValidTheme(props.theme) ? parseTheme(props.theme) : _theme;
+  const theme = useCustomTheme();
   if (props.unstyled) {
     return {};
   }


### PR DESCRIPTION
### Main issue

StyledComponents come with their own `theme` prop, overriding our own `theme` prop. So instead of trying to use the `theme` prop in our Button component, always use the `CustomThemeProvider` one.

### TL;DR
This PR introduces a change to ensure that the `CustomThemeProvider` and related components respect an undefined `theme` prop. This is achieved by removing the default fallback to the `dark` theme when the `theme` prop is not provided.

### What changed?
- Updated `CustomThemeProvider` to accept `undefined` as a valid `theme` value.
- Modified components that use `CustomThemeProvider` to pass the `theme` prop directly without defaulting to `dark`.
- Replaced direct import and usage of `parseTheme` in `TransactionButton` with wrapping the button in `CustomThemeProvider`.
- Removed unnecessary imports and streamlined theme handling in the `Button` component to utilize `useCustomTheme`.
- Updated `dev:dashboard` script to also filter `./packages/thirdweb`.

### How to test?
- Verify the application operates correctly when the `theme` prop is explicitly set to `undefined` or not provided.
- Ensure all components render with the default theme correctly without any regressions.

### Why make this change?
This change ensures more flexible theme handling in the application and reduces the assumption that a `dark` theme should always be the fallback. This is particularly useful for dynamic theming use cases where the theme might not always be determinable upfront.

---

 

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the theme handling in various components and improve code structure.

### Detailed summary
- Updated theme handling in `CustomThemeProvider`
- Removed redundant imports in `buttons.tsx`
- Refactored `TransactionButton` to use `CustomThemeProvider`
- Updated scripts in `package.json` to include additional filters

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->