### PR TITLE
refactor: update mobile upload to use getClientFetch for fetching

### DIFF
--- a/.changeset/lucky-birds-wink.md
+++ b/.changeset/lucky-birds-wink.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix uploadMobile function not respecting bundleId

--- a/packages/thirdweb/src/storage/upload/mobile.ts
+++ b/packages/thirdweb/src/storage/upload/mobile.ts
@@ -1,6 +1,6 @@
 import type { ThirdwebClient } from "../../client/client.js";
 import { getThirdwebDomains } from "../../utils/domains.js";
-import { getPlatformHeaders } from "../../utils/fetch.js";
+import { getClientFetch, getPlatformHeaders } from "../../utils/fetch.js";
 import type { UploadMobileOptions } from "../uploadMobile.js";
 import { isFileBufferOrStringEqual } from "./helpers.js";
 import type { UploadFile } from "./types.js";
@@ -9,7 +9,7 @@ const METADATA_NAME = "Storage React Native SDK";
 
 export async function uploadBatchMobile(
   client: ThirdwebClient,
-  data: (UploadFile | Record<string, unknown>)[],
+  data: UploadFile[],
   options?: UploadMobileOptions,
 ): Promise<string[]> {
   if (!data || data.length === 0 || !data[0]) {
@@ -144,14 +144,12 @@ export async function uploadBatchMobile(
   });
 
   try {
-    const res = await fetch(
+    const res = await getClientFetch(client)(
       `https://${getThirdwebDomains().storage}/ipfs/batch-pin-json`,
       {
         method: "POST",
         headers: {
-          ...(client.clientId ? { "x-client-id": client.clientId } : {}),
           "Content-Type": "application/json",
-          ...getPlatformHeaders(),
         },
         body: fetchBody,
       },

--- a/packages/thirdweb/src/storage/upload/types.ts
+++ b/packages/thirdweb/src/storage/upload/types.ts
@@ -30,7 +30,9 @@ export type UploadOptions<TFiles extends UploadableFile[]> = {
   files: TFiles;
 } & BuildFormDataOptions;
 
-export type UploadFile = { name?: string; type?: string; uri: string };
+export type UploadFile =
+  | { name?: string; type?: string; uri: string }
+  | Record<string, unknown>;
 
 export type InternalUploadMobileOptions = {
   files: UploadFile[];

--- a/packages/thirdweb/src/storage/uploadMobile.ts
+++ b/packages/thirdweb/src/storage/uploadMobile.ts
@@ -20,7 +20,7 @@ export type UploadMobileOptions = InternalUploadMobileOptions & {
  *      if (!uri) {
  *        throw new Error('No uri');
  *      }
- *      const resp = await storage.upload({
+ *      const resp = await uploadMobile({
  *        uri,
  *        type,
  *        name: fileName,
@@ -33,20 +33,20 @@ export type UploadMobileOptions = InternalUploadMobileOptions & {
  *  { name: "JSON 1", text: "Hello World" },
  *  { name: "JSON 2", trait: "Awesome" },
  * ];
- * const jsonUris = await storage.uploadBatch(objects);
+ * const jsonUris = await uploadMobile(objects);
  * ```
  * @storage
  */
-export async function uploadMobile(options?: UploadMobileOptions) {
+export async function uploadMobile(options: UploadMobileOptions) {
   if (!options) {
     return [];
   }
 
-  const data = options?.files.filter((item) => item !== undefined);
+  const data = options.files.filter((item) => item !== undefined);
 
   if (!data?.length) {
     return [];
   }
 
-  return await uploadBatchMobile(options?.client, data, options);
+  return await uploadBatchMobile(options.client, data, options);
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR fixes the `uploadMobile` function in `thirdweb` package to properly handle `bundleId`.

### Detailed summary
- Updated `UploadFile` type to allow for additional properties
- Modified `uploadMobile` function to require `UploadMobileOptions`
- Refactored `uploadBatchMobile` function to use `UploadFile` type directly

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->