### PR TITLE
Override contract publish id on CLI

### DIFF
--- a/.changeset/fuzzy-dolphins-fail.md
+++ b/.changeset/fuzzy-dolphins-fail.md
@@ -1,0 +1,6 @@
+---
+"@thirdweb-dev/cli": patch
+"@thirdweb-dev/sdk": patch
+---
+
+Override contract publish id on CLI

--- a/legacy_packages/cli/src/cli/index.ts
+++ b/legacy_packages/cli/src/cli/index.ts
@@ -373,6 +373,7 @@ const main = async () => {
     .option("-d, --debug", "show debug logs")
     .option("--ci", "Continuous Integration mode")
     .option("--zksync", "Publish with ZKSync settings")
+    .option("--customid", "Override contract name with a custom ID")
     .option(
       "--link-lib <library:address...>",
       "Specify library names and addresses",

--- a/legacy_packages/cli/src/common/processor.ts
+++ b/legacy_packages/cli/src/common/processor.ts
@@ -28,6 +28,7 @@ import {
   ExtensionFunction,
   ExtensionMetadata,
 } from "../core/interfaces/Extension";
+import prompts from "prompts";
 
 export async function processProject(
   options: any,
@@ -250,6 +251,23 @@ export async function processProject(
     );
     process.exit(1);
   }
+
+  if(options.customid) {
+    for (const contract of selectedContracts) {
+      const modifyResponse = await prompts({
+          type: 'text',
+          name: 'contractId',
+          message: `Enter contractId for ${contract.name} (or press enter to use current name):`,
+          initial: contract.name,
+          validate: name => /^[\w-]+$/.test(name) ? true : 'Name must only contain letters, numbers, underscores, or hyphens'
+      });
+    
+      if (modifyResponse.contractId) {
+        contract.name = modifyResponse.contractId;
+      }
+    }
+  }
+
 
   let zkSelectedContracts: ContractPayload[] = [];
   if (options.zksync) {

--- a/legacy_packages/sdk/src/evm/common/feature-detection/fetchPreDeployMetadata.ts
+++ b/legacy_packages/sdk/src/evm/common/feature-detection/fetchPreDeployMetadata.ts
@@ -72,6 +72,7 @@ export async function fetchPreDeployMetadata(
   return PreDeployMetadataFetchedSchema.parse({
     ...rawMeta,
     ...parsedMeta,
+    name: rawMeta.name,
     bytecode: await deployBytecode.text(),
     fetchedMetadataUri: metadataUri,
     fetchedBytecodeUri: bytecodeUri,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the CLI to allow overriding contract names with custom IDs.

### Detailed summary
- Added option to override contract names with custom IDs in CLI
- Added prompts package for user input handling
- Updated contract name modification logic based on user input

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->