### PR TITLE
[Chore] Update OG API: Remove redundant <title> elements and add isProd flag

### DIFF
--- a/apps/dashboard/src/pages/api/og/chain/[chainId].tsx
+++ b/apps/dashboard/src/pages/api/og/chain/[chainId].tsx
@@ -1,8 +1,9 @@
 /* eslint-disable @next/next/no-img-element */
 import { ImageResponse } from "@vercel/og";
-import { getAbsoluteUrl } from "lib/vercel-utils";
+// import { getAbsoluteUrl } from "lib/vercel-utils";
 import type { NextRequest } from "next/server";
 import { fetchChain } from "utils/fetchChain";
+import { isProd } from "../../../../constants/rpc";
 
 // Make sure the font exists in the specified path:
 export const config = {
@@ -28,14 +29,14 @@ const inter700_ = fetch(
 ).then((res) => res.arrayBuffer());
 
 const TWLogo: React.FC = () => (
-  <svg
+  // biome-ignore lint/a11y/noSvgWithoutTitle: not needed
+<svg
     width="255"
     height="37"
     viewBox="0 0 255 37"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title>thirdweb</title>
     <g clip-path="url(#clip0_4_1228)">
       <path
         fill-rule="evenodd"
@@ -69,7 +70,7 @@ const TWLogo: React.FC = () => (
   </svg>
 );
 const IPFS_GATEWAY = process.env.API_ROUTES_CLIENT_ID
-  ? `https://${process.env.API_ROUTES_CLIENT_ID}.ipfscdn.io/ipfs/`
+  ? `https://${process.env.API_ROUTES_CLIENT_ID}.${isProd ? "ipfscdn.io/ipfs/": "thirdwebstorage-dev.com/ipfs/"}`
   : "https://ipfs.io/ipfs/";
 
 function replaceAnyIpfsUrlWithGateway(url: string) {
@@ -102,11 +103,11 @@ export default async function handler(req: NextRequest) {
     ? replaceAnyIpfsUrlWithGateway(chain.icon.url)
     : undefined;
 
-  const optimizedIconUrl = iconUrl
-    ? `${getAbsoluteUrl()}/_next/image?url=${encodeURIComponent(
-        iconUrl,
-      )}&w=256&q=75`
-    : undefined;
+  // const optimizedIconUrl = iconUrl
+  //   ? `${getAbsoluteUrl()}/_next/image?url=${encodeURIComponent(
+  //       iconUrl,
+  //     )}&w=256&q=75`
+  //   : undefined;
 
   const [inter400, inter500, inter700, imageData] = await Promise.all([
     inter400_,
@@ -133,10 +134,10 @@ export default async function handler(req: NextRequest) {
       />
       {/* the actual component starts here */}
 
-      {optimizedIconUrl && (
+      {iconUrl && (
         <img
           alt=""
-          src={optimizedIconUrl}
+          src={iconUrl}
           tw="absolute rounded-full"
           style={{
             top: 240,

--- a/apps/dashboard/src/pages/api/og/contract.tsx
+++ b/apps/dashboard/src/pages/api/og/contract.tsx
@@ -2,6 +2,7 @@
 import { ImageResponse } from "@vercel/og";
 import type { NextRequest } from "next/server";
 import { ContractOG } from "og-lib/url-utils";
+import { isProd } from "../../../constants/rpc";
 
 export function shortenString(str: string) {
   return `${str.substring(0, 7)}...${str.substring(str.length - 5)}`;
@@ -23,14 +24,14 @@ const inter700_ = fetch(
 ).then((res) => res.arrayBuffer());
 
 const OgBrandIcon: React.FC = () => (
-  <svg
+  // biome-ignore lint/a11y/noSvgWithoutTitle: not needed
+<svg
     xmlns="http://www.w3.org/2000/svg"
     width="147"
     height="21"
     viewBox="0 0 147 21"
     fill="none"
   >
-    <title>OgBrandIcon</title>
     <path
       fill-rule="evenodd"
       clip-rule="evenodd"
@@ -93,7 +94,7 @@ function textShortener(text: string) {
 }
 
 const IPFS_GATEWAY = process.env.API_ROUTES_CLIENT_ID
-  ? `https://${process.env.API_ROUTES_CLIENT_ID}.ipfscdn.io/ipfs/`
+  ? `https://${process.env.API_ROUTES_CLIENT_ID}.${isProd ? "ipfscdn.io/ipfs/": "thirdwebstorage-dev.com/ipfs/"}`
   : "https://ipfs.io/ipfs/";
 
 function replaceAnyIpfsUrlWithGateway(url: string) {

--- a/apps/dashboard/src/pages/api/og/profile.tsx
+++ b/apps/dashboard/src/pages/api/og/profile.tsx
@@ -2,6 +2,7 @@
 import { ImageResponse } from "@vercel/og";
 import type { NextRequest } from "next/server";
 import { ProfileOG } from "og-lib/url-utils";
+import { isProd } from "../../../constants/rpc";
 
 // Make sure the font exists in the specified path:
 export const config = {
@@ -33,6 +34,7 @@ const ibmPlexMono700_ = fetch(
 ).then((res) => res.arrayBuffer());
 
 const OgBrandIcon: React.FC = () => (
+  // biome-ignore lint/a11y/noSvgWithoutTitle: not needed
   <svg
     xmlns="http://www.w3.org/2000/svg"
     width="59"
@@ -40,7 +42,6 @@ const OgBrandIcon: React.FC = () => (
     viewBox="0 0 59 36"
     fill="none"
   >
-    <title>OgBrandIcon</title>
     <path
       fillRule="evenodd"
       clipRule="evenodd"
@@ -52,6 +53,7 @@ const OgBrandIcon: React.FC = () => (
 );
 
 const PackageIcon: React.FC = () => (
+  // biome-ignore lint/a11y/noSvgWithoutTitle: not needed
   <svg
     xmlns="http://www.w3.org/2000/svg"
     width="36"
@@ -63,7 +65,6 @@ const PackageIcon: React.FC = () => (
     stroke-linecap="round"
     stroke-linejoin="round"
   >
-    <title>PackageIcon</title>
     <line x1="16.5" y1="9.4" x2="7.5" y2="4.21" />
     <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" />
     <polyline points="3.27 6.96 12 12.01 20.73 6.96" />
@@ -99,7 +100,7 @@ function descriptionShortener(description: string) {
 }
 
 const IPFS_GATEWAY = process.env.API_ROUTES_CLIENT_ID
-  ? `https://${process.env.API_ROUTES_CLIENT_ID}.ipfscdn.io/ipfs/`
+  ? `https://${process.env.API_ROUTES_CLIENT_ID}.${isProd ? "ipfscdn.io/ipfs/": "thirdwebstorage-dev.com/ipfs/"}`
   : "https://ipfs.io/ipfs/";
 
 function replaceAnyIpfsUrlWithGateway(url: string) {

--- a/apps/dashboard/src/pages/api/og/publishedContract.tsx
+++ b/apps/dashboard/src/pages/api/og/publishedContract.tsx
@@ -2,6 +2,7 @@
 import { ImageResponse } from "@vercel/og";
 import type { NextRequest } from "next/server";
 import { PublishedContractOG } from "og-lib/url-utils";
+import { isProd } from "../../../constants/rpc";
 
 // Make sure the font exists in the specified path:
 export const config = {
@@ -33,6 +34,7 @@ const ibmPlexMono700_ = fetch(
 ).then((res) => res.arrayBuffer());
 
 const OgBrandIcon: React.FC = () => (
+  // biome-ignore lint/a11y/noSvgWithoutTitle: not needed
   <svg
     xmlns="http://www.w3.org/2000/svg"
     width="59"
@@ -40,7 +42,6 @@ const OgBrandIcon: React.FC = () => (
     viewBox="0 0 59 36"
     fill="none"
   >
-    <title>OgBrandIcon</title>
     <path
       fillRule="evenodd"
       clipRule="evenodd"
@@ -52,6 +53,7 @@ const OgBrandIcon: React.FC = () => (
 );
 
 const PackageIcon: React.FC = () => (
+  // biome-ignore lint/a11y/noSvgWithoutTitle: not needed
   <svg
     xmlns="http://www.w3.org/2000/svg"
     width="24"
@@ -63,7 +65,6 @@ const PackageIcon: React.FC = () => (
     stroke-linecap="round"
     stroke-linejoin="round"
   >
-    <title>PackageIcon</title>
     <line x1="16.5" y1="9.4" x2="7.5" y2="4.21" />
     <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" />
     <polyline points="3.27 6.96 12 12.01 20.73 6.96" />
@@ -72,6 +73,7 @@ const PackageIcon: React.FC = () => (
 );
 
 const FileTextIcon: React.FC = () => (
+  // biome-ignore lint/a11y/noSvgWithoutTitle: not needed
   <svg
     xmlns="http://www.w3.org/2000/svg"
     width="24"
@@ -83,7 +85,6 @@ const FileTextIcon: React.FC = () => (
     stroke-linecap="round"
     stroke-linejoin="round"
   >
-    <title>FileTextIcon</title>
     <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
     <polyline points="14 2 14 8 20 8" />
     <line x1="16" y1="13" x2="8" y2="13" />
@@ -93,6 +94,7 @@ const FileTextIcon: React.FC = () => (
 );
 
 const CalendarIcon: React.FC = () => (
+  // biome-ignore lint/a11y/noSvgWithoutTitle: not needed
   <svg
     xmlns="http://www.w3.org/2000/svg"
     width="24"
@@ -104,7 +106,6 @@ const CalendarIcon: React.FC = () => (
     stroke-linecap="round"
     stroke-linejoin="round"
   >
-    <title>CalendarIcon</title>
     <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
     <line x1="16" y1="2" x2="16" y2="6" />
     <line x1="8" y1="2" x2="8" y2="6" />
@@ -113,6 +114,7 @@ const CalendarIcon: React.FC = () => (
 );
 
 const VersionIcon: React.FC = () => (
+  // biome-ignore lint/a11y/noSvgWithoutTitle: not needed
   <svg
     xmlns="http://www.w3.org/2000/svg"
     width="24"
@@ -124,7 +126,6 @@ const VersionIcon: React.FC = () => (
     stroke-linecap="round"
     stroke-linejoin="round"
   >
-    <title>VersionIcon</title>
     <line x1="6" y1="3" x2="6" y2="15" />
     <circle cx="18" cy="6" r="3" />
     <circle cx="6" cy="18" r="3" />
@@ -160,7 +161,7 @@ function descriptionShortener(description: string) {
 }
 
 const IPFS_GATEWAY = process.env.API_ROUTES_CLIENT_ID
-  ? `https://${process.env.API_ROUTES_CLIENT_ID}.ipfscdn.io/ipfs/`
+  ? `https://${process.env.API_ROUTES_CLIENT_ID}.${isProd ? "ipfscdn.io/ipfs/": "thirdwebstorage-dev.com/ipfs/"}`
   : "https://ipfs.io/ipfs/";
 
 function replaceAnyIpfsUrlWithGateway(url: string) {


### PR DESCRIPTION
### TL;DR

This pull request removes several unused packages and files to improve codebase cleanliness and reduce clutter.

### What changed?

- Removed the `airtable` package from `package.json` and `pnpm-lock.yaml`.
- Deleted `airtable.ts`, `check-verification-status.ts`, `etherscan-fetch.ts`, `verify.ts` from the `api` folder.
- Applied minor formatting changes across various source files for better consistency.

### How to test?

1. Pull the branch.
2. Run `pnpm install` to ensure no missing dependencies.
3. Run the application with `pnpm dev` to confirm it starts correctly.
4. Verify that the deleted endpoints are no longer accessible.

### Why make this change?

The removed packages and files were no longer in use, contributing to unnecessary bloat in the codebase. This change improves maintainability and reduces potential confusion for future developers.

---

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the `isProd` constant to dynamically switch IPFS gateway URLs based on the environment. 

### Detailed summary
- Added `isProd` constant for environment-based URL switching
- Updated IPFS gateway URLs in multiple files based on `isProd` constant

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->