### PR TITLE
[Chore] Remove markdown formatter configuration from VSCode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,9 +6,6 @@
     "quickfix.biome": "explicit"
   },
   "editor.defaultFormatter": "biomejs.biome",
-  "[markdown]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
-  },
   "typescript.preferences.autoImportFileExcludePatterns": [
     "./packages/thirdweb/src/exports"
   ]


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

## Changes made

- [ ] Public API changes: list the public API changes made if any
- [ ] Internal API changes: explain the internal logic changes

## How to test

- [ ] Automated tests: link to unit test file
- [ ] Manual tests: step by step instructions on how to test

## Contributor NFT

Paste in your wallet address below and we will airdrop you a special NFT when your pull request is merged. 

```Address: ```


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the default code formatter to `biomejs.biome` and configures TypeScript preferences to exclude auto imports from a specific directory.

### Detailed summary
- Updated `editor.defaultFormatter` to `biomejs.biome`
- Removed `editor.defaultFormatter` setting for markdown files
- Added exclusion pattern for auto imports in TypeScript preferences

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->