### PR TITLE
Fix eip155 check

### DIFF
--- a/.changeset/smart-avocados-juggle.md
+++ b/.changeset/smart-avocados-juggle.md
@@ -1,0 +1,6 @@
+---
+"@thirdweb-dev/sdk": patch
+"thirdweb": patch
+---
+
+Fix EIP155 check for create2 factory deployment

--- a/legacy_packages/sdk/src/evm/common/any-evm-constants.ts
+++ b/legacy_packages/sdk/src/evm/common/any-evm-constants.ts
@@ -107,7 +107,12 @@ export function matchError(error: string): boolean {
   }
 
   const hasCompositeError = ERROR_SUBSTRINGS_COMPOSITE.some((arr) => {
-    return arr.some((substring) => error.includes(substring));
+    let foundError = true;
+    arr.forEach((substring) => {
+      foundError &&= error.includes(substring);
+    });
+
+    return foundError;
   });
 
   return hasCompositeError;

--- a/packages/thirdweb/src/utils/any-evm/is-eip155-enforced.ts
+++ b/packages/thirdweb/src/utils/any-evm/is-eip155-enforced.ts
@@ -87,6 +87,11 @@ function matchError(error: string): boolean {
 
   // otherwise return true if any of the composite substrings are found
   return ERROR_SUBSTRINGS_COMPOSITE.some((arr) => {
-    return arr.some((substring) => error.includes(substring));
+    let foundError = true;
+
+    for (const substring of arr) {
+      foundError &&= error.includes(substring);
+    }
+    return foundError;
   });
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on fixing the EIP155 check for create2 factory deployment.

### Detailed summary
- Updated error handling logic in `any-evm-constants.ts` and `is-eip155-enforced.ts`
- Replaced `arr.some` with a loop to ensure all substrings are checked before returning true

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->