### PR TITLE
[Chore] Add conditional check in ERC721 mintTo test using TW_SECRET_KEY

### DIFF
--- a/packages/thirdweb/src/extensions/erc721/write/mintTo.test.ts
+++ b/packages/thirdweb/src/extensions/erc721/write/mintTo.test.ts
@@ -18,7 +18,7 @@ const account = TEST_ACCOUNT_A;
 const client = TEST_CLIENT;
 const chain = ANVIL_CHAIN;
 
-describe("erc721 mintTo extension", () => {
+describe.runIf(!!process.env.TW_SECRET_KEY)("erc721 mintTo extension", () => {
   beforeEach(async () => {
     const address = await deployERC721Contract({
       client,


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

## Changes made

- [ ] Public API changes: list the public API changes made if any
- [ ] Internal API changes: explain the internal logic changes

## How to test

- [ ] Automated tests: link to unit test file
- [ ] Manual tests: step by step instructions on how to test

## Contributor NFT

Paste in your wallet address below and we will airdrop you a special NFT when your pull request is merged. 

```Address: ```


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a conditional test execution based on the presence of a secret key in the environment variables for the `erc721 mintTo` extension.

### Detailed summary
- Conditionally runs the `erc721 mintTo` extension test based on the existence of a secret key in the environment variables.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->