### PR TITLE
Unity 4.16.5

### DIFF
--- a/.changeset/flat-houses-talk.md
+++ b/.changeset/flat-houses-talk.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/unity-js-bridge": patch
+---
+
+Unity 4.16.5

--- a/legacy_packages/unity-js-bridge/src/thirdweb-bridge.ts
+++ b/legacy_packages/unity-js-bridge/src/thirdweb-bridge.ts
@@ -173,7 +173,7 @@ class ThirdwebBridge implements TWBridge {
       // biome-ignore lint/suspicious/noExplicitAny: TODO: fix use of any
       (globalThis as any).X_SDK_PLATFORM = "unity";
       // biome-ignore lint/suspicious/noExplicitAny: TODO: fix use of any
-      (globalThis as any).X_SDK_VERSION = "4.16.4";
+      (globalThis as any).X_SDK_VERSION = "4.16.5";
       // biome-ignore lint/suspicious/noExplicitAny: TODO: fix use of any
       (globalThis as any).X_SDK_OS = browser?.os ?? "unknown";
     }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the Unity JS Bridge package to version 4.16.5, changing the X_SDK_VERSION accordingly.

### Detailed summary
- Updated Unity JS Bridge package to version 4.16.5
- Updated X_SDK_VERSION from "4.16.4" to "4.16.5"

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->