### PR TITLE
[Feature] Add session transaction storage

### DIFF
--- a/.changeset/cuddly-dots-fry.md
+++ b/.changeset/cuddly-dots-fry.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": minor
+---
+
+Adds `getTransactionStore` to retrieve a transaction store for a given address

--- a/packages/thirdweb/src/exports/transaction.ts
+++ b/packages/thirdweb/src/exports/transaction.ts
@@ -55,6 +55,7 @@ export {
   toSerializableTransaction,
   type ToSerializableTransactionOptions,
 } from "../transaction/actions/to-serializable-transaction.js";
+export { getTransactionStore } from "../transaction/transaction-store.js";
 
 //types & utils
 export {

--- a/packages/thirdweb/src/transaction/actions/send-transaction.test.ts
+++ b/packages/thirdweb/src/transaction/actions/send-transaction.test.ts
@@ -1,10 +1,16 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { TEST_WALLET_B } from "../../../test/src/addresses.js";
 import { ANVIL_CHAIN } from "../../../test/src/chains.js";
 import { TEST_CLIENT } from "../../../test/src/test-clients.js";
 import { TEST_ACCOUNT_A } from "../../../test/src/test-wallets.js";
 import { prepareTransaction } from "../prepare-transaction.js";
+import * as TransactionStore from "../transaction-store.js";
 import { sendTransaction } from "./send-transaction.js";
+
+const addTransactionToStore = vi.spyOn(
+  TransactionStore,
+  "addTransactionToStore",
+);
 
 describe("sendTransaction", () => {
   it("should send transaction", async () => {
@@ -20,5 +26,20 @@ describe("sendTransaction", () => {
     });
 
     expect(res.transactionHash.length).toBe(66);
+  });
+
+  it("should add transaction to session", async () => {
+    const transaction = prepareTransaction({
+      chain: ANVIL_CHAIN,
+      client: TEST_CLIENT,
+      value: 100n,
+      to: TEST_WALLET_B,
+    });
+    await sendTransaction({
+      account: TEST_ACCOUNT_A,
+      transaction,
+    });
+
+    expect(addTransactionToStore).toHaveBeenCalled();
   });
 });

--- a/packages/thirdweb/src/transaction/actions/send-transaction.ts
+++ b/packages/thirdweb/src/transaction/actions/send-transaction.ts
@@ -1,5 +1,6 @@
 import type { Account } from "../../wallets/interfaces/wallet.js";
 import type { PreparedTransaction } from "../prepare-transaction.js";
+import { addTransactionToStore } from "../transaction-store.js";
 import type { GaslessOptions } from "./gasless/types.js";
 import { toSerializableTransaction } from "./to-serializable-transaction.js";
 import type { WaitForReceiptOptions } from "./wait-for-tx-receipt.js";
@@ -57,5 +58,11 @@ export async function sendTransaction(
   }
 
   const result = await account.sendTransaction(serializableTransaction);
+  // Store the transaction
+  addTransactionToStore({
+    address: account.address,
+    transactionHash: result.transactionHash,
+    chainId: transaction.chain.id,
+  });
   return { ...result, chain: transaction.chain, client: transaction.client };
 }

--- a/packages/thirdweb/src/transaction/transaction-store.test.ts
+++ b/packages/thirdweb/src/transaction/transaction-store.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { ANVIL_CHAIN } from "../../test/src/chains.js";
+import { TEST_ACCOUNT_A } from "../../test/src/test-wallets.js";
+import type { Address } from "../utils/address.js";
+import {
+  addTransactionToStore,
+  getTransactionStore,
+} from "./transaction-store.js";
+
+const MOCK_TX_HASH = "0x1234567890abcdef";
+
+describe("transaction-store", () => {
+  it("should return no transactions initially", async () => {
+    const transactions = getTransactionStore(TEST_ACCOUNT_A.address as Address);
+    expect(transactions.getValue()).toEqual([]);
+  });
+
+  it("should update transactions on completion", async () => {
+    addTransactionToStore({
+      address: TEST_ACCOUNT_A.address as Address,
+      transactionHash: MOCK_TX_HASH,
+      chainId: ANVIL_CHAIN.id,
+    });
+
+    const transactions = getTransactionStore(TEST_ACCOUNT_A.address as Address);
+    expect(transactions.getValue()).toEqual([
+      {
+        transactionHash: MOCK_TX_HASH,
+        chainId: ANVIL_CHAIN.id,
+      },
+    ]);
+
+    addTransactionToStore({
+      address: TEST_ACCOUNT_A.address,
+      transactionHash: "0xabc",
+      chainId: 1,
+    });
+
+    const transactions2 = getTransactionStore(TEST_ACCOUNT_A.address);
+    expect(transactions2.getValue()).toEqual([
+      {
+        transactionHash: MOCK_TX_HASH,
+        chainId: ANVIL_CHAIN.id,
+      },
+      {
+        transactionHash: "0xabc",
+        chainId: 1,
+      },
+    ]);
+  });
+});

--- a/packages/thirdweb/src/transaction/transaction-store.ts
+++ b/packages/thirdweb/src/transaction/transaction-store.ts
@@ -1,0 +1,46 @@
+import { type Store, createStore } from "../reactive/store.js";
+import type { Hex } from "../utils/encoding/hex.js";
+
+type StoredTransaction = {
+  transactionHash: Hex;
+  chainId: number;
+};
+
+const transactionsByAddress = new Map<string, Store<StoredTransaction[]>>();
+
+/**
+ * Retrieve the transaction store for a given address.
+ * @param address - The address to retrieve the transaction store for.
+ * @returns A store of transactions for the given account to subscribe to.
+ */
+export function getTransactionStore(
+  address: string,
+): Store<StoredTransaction[]> {
+  const existingStore = transactionsByAddress.get(address);
+  if (existingStore) {
+    return existingStore;
+  }
+
+  const newStore = createStore<StoredTransaction[]>([]);
+  transactionsByAddress.set(address, newStore);
+  return newStore;
+}
+
+/**
+ * @internal
+ */
+export function addTransactionToStore(options: {
+  address: string;
+  transactionHash: Hex;
+  chainId: number;
+}) {
+  const { address, transactionHash, chainId } = options;
+  const tranasctionStore = getTransactionStore(address);
+
+  tranasctionStore.setValue([
+    ...tranasctionStore.getValue(),
+    { transactionHash, chainId },
+  ]);
+
+  transactionsByAddress.set(address, tranasctionStore);
+}

--- a/packages/thirdweb/src/wallets/in-app/web/utils/Storage/LocalStorage.ts
+++ b/packages/thirdweb/src/wallets/in-app/web/utils/Storage/LocalStorage.ts
@@ -21,7 +21,10 @@ export class LocalStorage {
   constructor({
     clientId,
     ecosystemId,
-  }: { clientId: string; ecosystemId?: EcosystemWalletId }) {
+  }: {
+    clientId: string;
+    ecosystemId?: EcosystemWalletId;
+  }) {
     this.isSupported = typeof window !== "undefined" && !!window.localStorage;
     this.key = getLocalStorageKey(clientId, ecosystemId);
   }


### PR DESCRIPTION
https://linear.app/thirdweb/issue/CNCT-1398/ts-sdk-store-in-session-transactions-in-wallet

This update introduces the ability to track transactions during a "session" within the thirdweb SDK. The key additions and changes are:

1. Exporting `getSessionTransactions` from `transaction-store.js`.
2. Adding calls to `addTransactionToSession` in `send-gasless-transaction.ts` and `send-transaction.ts`.
3. Creating a new test file `transaction-store.test.ts` to cover the transaction session functionalities.
4. Including new constants in `settings.ts` specific to session storage keys.
5. Extending `LocalStorage` class functionalities to handle transaction session data.

These changes will act as the foundation of the v1 "transactions" page in the react SDK

---

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a `getTransactionStore` function to retrieve transaction stores by address and enhances transaction handling with a store.

### Detailed summary
- Added `getTransactionStore` function to retrieve transaction stores by address
- Implemented `addTransactionToStore` to store transactions for an address
- Updated `sendTransaction` to store transactions after sending
- Added tests for transaction store functionality

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->