### PR TITLE
Update 30731.ts

### DIFF
--- a/legacy_packages/chains/chains/30731.ts
+++ b/legacy_packages/chains/chains/30731.ts
@@ -1,7 +1,7 @@
 import type { Chain } from "../src/types";
 export default {
   "chain": "MOVE",
-  "chainId": 30731,
+  "chainId": 336,
   "explorers": [
     {
       "name": "mevm explorer",
@@ -23,8 +23,10 @@ export default {
     "symbol": "MOVE",
     "decimals": 18
   },
-  "networkId": 30731,
-  "rpc": [],
+  "networkId": 336,
+  "rpc": [
+    "https://mevm.devnet.m1.movementlabs.xyz"
+  ],
   "shortName": "movedev",
   "slug": "movement-evm-devnet",
   "status": "incubating",


### PR DESCRIPTION
Please confirm correct information. I am currently developing a project on movement. I have provided the correct movement devnet rpc and chainid information.

## Problem solved

Short description of the bug fixed or feature added

## Changes made

- [ ] Public API changes: list the public API changes made if any
- [ ] Internal API changes: explain the internal logic changes

## How to test

- [ ] Automated tests: link to unit test file
- [ ] Manual tests: step by step instructions on how to test

## Contributor NFT

Paste in your wallet address below and we will airdrop you a special NFT when your pull request is merged. 

```Address: 0x76914803b100Df11D1329e7F916F83B72bb4A508```


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `chainId` and `networkId` in the `MOVE` chain configuration from 30731 to 336, and adds an RPC endpoint for the MEVM devnet.

### Detailed summary
- Updated `chainId` and `networkId` to 336 in the `MOVE` chain configuration
- Added an RPC endpoint for the MEVM devnet

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->