### PR TITLE
feat(cli): add --expo option to CLI for creating Expo projects

### DIFF
--- a/.changeset/dry-jobs-reply.md
+++ b/.changeset/dry-jobs-reply.md
@@ -1,0 +1,6 @@
+---
+"@thirdweb-dev/cli": minor
+"thirdweb": minor
+---
+
+Adds --expo option to cli

--- a/legacy_packages/cli/src/cli/index.ts
+++ b/legacy_packages/cli/src/cli/index.ts
@@ -255,7 +255,8 @@ const main = async () => {
     .option("--extension", "Create a smart contract extension.")
     .option("--next", "Initialize as a Next.js project.")
     .option("--vite", "Initialize as a Vite project.")
-    .option("--react-native", "Initialize as a React Native project.")
+    .option("--react-native", "Initialize as a React Native (Expo) project.")
+    .option("--expo", "Initialize as an Expo project.")
     .option("--node", "Initialize as a Node project.")
     .option(
       "--use-npm",

--- a/legacy_packages/cli/src/create/command.ts
+++ b/legacy_packages/cli/src/create/command.ts
@@ -54,7 +54,7 @@ export async function twCreate(
       framework = "vite";
     }
 
-    if (options.reactNative) {
+    if (options.reactNative || options.expo) {
       projectType = "app";
       framework = "expo";
     }
@@ -72,7 +72,7 @@ export async function twCreate(
     if (options.vite) {
       framework = "vite";
     }
-    if (options.reactNative) {
+    if (options.reactNative || options.expo) {
       framework = "expo";
     }
     if (options.node) {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR enhances the CLI tool by adding support for Expo projects. 

### Detailed summary
- Added `--expo` option to CLI for initializing Expo projects
- Updated projectType and framework conditions to include Expo
- Renamed `--react-native` option to `--react-native (Expo)`
- Added `--expo` option description to CLI commands

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->