### PR TITLE
fix: update chain import paths

### DIFF
--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/ConnectButtonProps.ts
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/ConnectButtonProps.ts
@@ -459,7 +459,7 @@ export type ConnectButtonProps = {
    * At minimum, you need to pass the `id` of the blockchain to `defineChain` function to create a `Chain` object.
    * @example
    * ```tsx
-   * import { polygon } from "thirdweb/wallets";
+   * import { polygon } from "thirdweb/chains";
    *
    * function Example() {
    *  return <div> <ConnectButton chain={polygon} /> </div>
@@ -486,7 +486,7 @@ export type ConnectButtonProps = {
    * At minimum, you need to pass the `id` of the blockchain to `defineChain` function to create a `Chain` object.
    *
    * ```tsx
-   * import { defineChain } from "thirdweb/react";
+   * import { defineChain } from "thirdweb/chains";
    *
    * const polygon = defineChain({
    *   id: 137,


### PR DESCRIPTION
## Problem solved

Some of the examples in the `ConnectButtonProps` comments are incorrect and may misguide developers (I was misguided). So, I made changes to correct them

<pre><code><del>import { polygon } from "thirdweb/wallets";</del>
import { polygon } from "thirdweb/chains";
</code></pre>

## Changes made

- [ ] Public API changes: list the public API changes made if any
- [ ] Internal API changes: explain the internal logic changes

## How to test

- [ ] Automated tests: link to unit test file
- [ ] Manual tests: step by step instructions on how to test

## Contributor NFT

Paste in your wallet address below and we will airdrop you a special NFT when your pull request is merged. 

```Address: 0x66fe4806cD41BcD308c9d2f6815AEf6b2e38f9a3```


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update import paths related to blockchain functionality from `thirdweb/wallets` to `thirdweb/chains`.

### Detailed summary
- Updated import path from `thirdweb/wallets` to `thirdweb/chains` in `ConnectButtonProps.ts`
- Updated import path from `thirdweb/react` to `thirdweb/chains`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->