### PR TITLE
docs(contributing): add instructions for testing React Native SDK changes

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -114,6 +114,51 @@ These are the versions the GH action published to npm for testing purposes. Let'
 
 <br/>
 
+### Test Your Changes (React Native)
+
+The repository does not yet have a React Native playground, so some additional steps are needed to test any React Native SDK changes.
+
+#### Create a Local React Native Project
+
+For ease of setup, we recommend using the React Native SDK template project as a local testing playground. To generate this project, just run `npx thirdweb create --react-native`.
+
+#### Linking Your Local Changes
+
+To use the local version of the SDK while listening for changes in your React Native project, we'll use [wml](https://www.npmjs.com/package/wml). To install wml, run `npm i -g wml`.
+
+Once installed, edit the project's `package.json` so the thirdweb package points to your local version of the repository (rather than a version number). It should look something like this:
+
+```json
+"thirdweb": "/Users/me/Desktop/js/packages/thirdweb/"
+```
+
+Now we'll add a wml link between your React Native project and this local repository:
+
+```bash
+wml add /[Path to this repository on your machine]/packages/thirdweb /[Path to your RN project]/node_modules/thirdweb
+```
+
+Run `wml list` to confirm you've added the connection successfully.
+
+Now run `wml start` to start the connection between your two projects. wml will watch for changes in the first directory you specified and copy them to the second.
+
+However, for this to work you'll also need to setup [watchman](https://facebook.github.io/watchman/) on wml (confusing, I know). First, install watchman with homebrew or another installer.
+
+Once watchman is installed, find where wml's src is. You can normally do this by running `which wml` to find your node directory, then adding `/lib/node_modules/wml/src` from the root path of your current node version. It should look something like this: `/Users/me/.nvm/versions/node/v20.13.0/lib/node_modules/wml/src`
+
+Now, run watchman on this path with `watchman watch /Users/me/.nvm/versions/node/v20.13.0/lib/node_modules/wml/src`
+
+Finally, navigate to the V5 SDK package with `cd packages/thirdweb` and run it in dev mode to rebuild on changes with `pnpm dev:esm`.
+
+You should now have:
+
+1. `wml` running in one terminal window, watching your local SDK and your React Native project
+2. `watchman` set to watch your `wml` src directory
+3. `pnpm dev:esm` running in `packages/thirdweb`
+4. The "thirdweb" dependency in your RN `package.json` pointing to `packages/thirdweb` of your local version of this repository
+
+Try making changes in the SDK to see if they affect your React Native project. If they don't, try deleting your RN project `node_modules`, reinstalling via yarn (the preferred package manager for React Native), and trying again.
+
 ### Publish Your Changes
 
 Once you're satisfied with your changes, you are ready to submit them for review!

--- a/packages/thirdweb/package.json
+++ b/packages/thirdweb/package.json
@@ -117,54 +117,22 @@
   },
   "typesVersions": {
     "*": {
-      "adapters/*": [
-        "./dist/types/exports/adapters/*.d.ts"
-      ],
-      "auth": [
-        "./dist/types/exports/auth.d.ts"
-      ],
-      "chains": [
-        "./dist/types/exports/chains.d.ts"
-      ],
-      "contract": [
-        "./dist/types/exports/contract.d.ts"
-      ],
-      "deploys": [
-        "./dist/types/exports/deploys.d.ts"
-      ],
-      "event": [
-        "./dist/types/exports/event.d.ts"
-      ],
-      "extensions/*": [
-        "./dist/types/exports/extensions/*.d.ts"
-      ],
-      "pay": [
-        "./dist/types/exports/pay.d.ts"
-      ],
-      "react": [
-        "./dist/types/exports/react.d.ts"
-      ],
-      "react-native": [
-        "./dist/types/exports/react-native.d.ts"
-      ],
-      "rpc": [
-        "./dist/types/exports/rpc.d.ts"
-      ],
-      "storage": [
-        "./dist/types/exports/storage.d.ts"
-      ],
-      "transaction": [
-        "./dist/types/exports/transaction.d.ts"
-      ],
-      "utils": [
-        "./dist/types/exports/utils.d.ts"
-      ],
-      "wallets": [
-        "./dist/types/exports/wallets.d.ts"
-      ],
-      "wallets/*": [
-        "./dist/types/exports/wallets/*.d.ts"
-      ]
+      "adapters/*": ["./dist/types/exports/adapters/*.d.ts"],
+      "auth": ["./dist/types/exports/auth.d.ts"],
+      "chains": ["./dist/types/exports/chains.d.ts"],
+      "contract": ["./dist/types/exports/contract.d.ts"],
+      "deploys": ["./dist/types/exports/deploys.d.ts"],
+      "event": ["./dist/types/exports/event.d.ts"],
+      "extensions/*": ["./dist/types/exports/extensions/*.d.ts"],
+      "pay": ["./dist/types/exports/pay.d.ts"],
+      "react": ["./dist/types/exports/react.d.ts"],
+      "react-native": ["./dist/types/exports/react-native.d.ts"],
+      "rpc": ["./dist/types/exports/rpc.d.ts"],
+      "storage": ["./dist/types/exports/storage.d.ts"],
+      "transaction": ["./dist/types/exports/transaction.d.ts"],
+      "utils": ["./dist/types/exports/utils.d.ts"],
+      "wallets": ["./dist/types/exports/wallets.d.ts"],
+      "wallets/*": ["./dist/types/exports/wallets/*.d.ts"]
     }
   },
   "browser": {
@@ -272,6 +240,8 @@
     "build:generate": "bun scripts/generate/generate.ts",
     "build:generate-wallets": "bun scripts/wallets/generate.ts",
     "dev": "tsc --project ./tsconfig.build.json --module es2020 --outDir ./dist/esm --watch",
+    "dev:cjs": "printf '{\"type\":\"commonjs\"}' > ./dist/cjs/package.json && tsc --project ./tsconfig.build.json --module commonjs --outDir ./dist/cjs --verbatimModuleSyntax false --watch",
+    "dev:esm": "printf '{\"type\": \"module\",\"sideEffects\":false}' > ./dist/esm/package.json && tsc --project ./tsconfig.build.json --module es2020 --outDir ./dist/esm --watch",
     "build": "pnpm clean && pnpm build:cjs && pnpm build:esm && pnpm build:types",
     "build:cjs": "tsc --project ./tsconfig.build.json --module commonjs --outDir ./dist/cjs --verbatimModuleSyntax false && printf '{\"type\":\"commonjs\"}' > ./dist/cjs/package.json",
     "build:esm": "tsc --project ./tsconfig.build.json --module es2020 --outDir ./dist/esm && printf '{\"type\": \"module\",\"sideEffects\":false}' > ./dist/esm/package.json",


### PR DESCRIPTION
### TL;DR

This PR adds a section for testing changes in the React Native SDK to the contributing guidelines and updates the formatting of type versions in the `package.json` file.

### What changed?

1. **Contributing Guidelines**: Added detailed instructions for testing React Native changes by creating a local React Native project, linking local changes, and using tools like wml and watchman.

2. **Formatting in `package.json`**: Updated the formatting of type versions to a more compact and readable style.

### How to test?

1. Follow the newly added instructions in the contributing guidelines to create a local React Native project and test changes using wml and watchman.
2. Verify that the `package.json` file's type versions formatting is correct and does not affect the build process.

### Why make this change?

This change aims to provide clearer guidance for contributors who need to test React Native SDK changes and improve the readability of the `package.json` file.

---

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the `package.json` file in the `thirdweb` package and provide detailed instructions for testing React Native changes locally.

### Detailed summary
- Updated the `typesVersions` section in `package.json` for better organization.
- Added instructions for setting up a local React Native project to test SDK changes.
- Included guidance on using `wml` for linking local SDK changes to a React Native project.
- Provided steps for setting up `watchman` and running the SDK in dev mode.
- Added instructions for updating the "thirdweb" dependency in the React Native `package.json`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->