### PR TITLE
fix(transaction): update EIP721 to EIP712 naming in getEip721Domain and prepare-transaction

### DIFF
--- a/packages/thirdweb/src/transaction/actions/zksync/getEip721Domain.ts
+++ b/packages/thirdweb/src/transaction/actions/zksync/getEip721Domain.ts
@@ -1,13 +1,13 @@
 import type { TransactionSerializable } from "viem";
 import type { Address } from "../../../utils/address.js";
 import type {
-  EIP721SerializedTransaction,
-  EIP721TransactionOptions,
+  EIP712SerializedTransaction,
+  EIP712TransactionOptions,
 } from "../../prepare-transaction.js";
 
 export type EIP721TransactionSerializable = TransactionSerializable & {
   from: Address;
-} & EIP721TransactionOptions;
+} & EIP712TransactionOptions;
 export const gasPerPubdataDefault = 50000n;
 
 export const getEip712Domain = (transaction: EIP721TransactionSerializable) => {
@@ -43,7 +43,7 @@ export const getEip712Domain = (transaction: EIP721TransactionSerializable) => {
 
 function transactionToMessage(
   transaction: EIP721TransactionSerializable,
-): EIP721SerializedTransaction {
+): EIP712SerializedTransaction {
   const {
     gas,
     nonce,

--- a/packages/thirdweb/src/transaction/prepare-transaction.ts
+++ b/packages/thirdweb/src/transaction/prepare-transaction.ts
@@ -19,13 +19,13 @@ export type StaticPrepareTransactionOptions = {
   nonce?: number | undefined;
   extraGas?: bigint | undefined;
   // zksync specific
-  eip712?: EIP721TransactionOptions | undefined;
+  eip712?: EIP712TransactionOptions | undefined;
   // tw specific
   chain: Chain;
   client: ThirdwebClient;
 };
 
-export type EIP721TransactionOptions = {
+export type EIP712TransactionOptions = {
   // constant or user input
   gasPerPubdata?: bigint | undefined;
   // optional signature, generated
@@ -38,7 +38,7 @@ export type EIP721TransactionOptions = {
   paymasterInput?: Hex | undefined;
 };
 
-export type EIP721SerializedTransaction = {
+export type EIP712SerializedTransaction = {
   txType: bigint;
   from: bigint;
   to: bigint;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates transaction options and serialization names from EIP721 to EIP712 for clarity and consistency.

### Detailed summary
- Renamed `EIP721TransactionOptions` to `EIP712TransactionOptions`
- Renamed `EIP721SerializedTransaction` to `EIP712SerializedTransaction`
- Updated references in `prepare-transaction.ts` and `getEip721Domain.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->