### PR TITLE
[Fix] Add onClickApply handler to CreditsItem and CreditsButton components

### DIFF
--- a/apps/dashboard/src/components/settings/Account/Billing/CreditsButton.tsx
+++ b/apps/dashboard/src/components/settings/Account/Billing/CreditsButton.tsx
@@ -108,6 +108,9 @@ export const CreditsButton = () => {
                 credit={opCredit}
                 onCreditsButton={true}
                 isOpCreditDefault={true}
+                onClickApply={() => {
+                  onClose();
+                }}
               />
               {restCredits?.map((credit) => (
                 <CreditsItem

--- a/apps/dashboard/src/components/settings/Account/Billing/CreditsItem.tsx
+++ b/apps/dashboard/src/components/settings/Account/Billing/CreditsItem.tsx
@@ -1,11 +1,5 @@
 import { type BillingCredit, useAccount } from "@3rdweb-sdk/react/hooks/useApi";
-import {
-  Alert,
-  AlertDescription,
-  AlertIcon,
-  Flex,
-  useModalContext,
-} from "@chakra-ui/react";
+import { Alert, AlertDescription, AlertIcon, Flex } from "@chakra-ui/react";
 import { Optimism } from "@thirdweb-dev/chains";
 import { ChakraNextImage } from "components/Image";
 import { ChainIcon } from "components/icons/ChainIcon";
@@ -19,16 +13,17 @@ interface CreditsItemProps {
   credit?: BillingCredit;
   onCreditsButton?: true;
   isOpCreditDefault?: boolean;
+  onClickApply?: () => void;
 }
 
 export const CreditsItem: React.FC<CreditsItemProps> = ({
   credit,
   onCreditsButton,
   isOpCreditDefault,
+  onClickApply,
 }) => {
   const trackEvent = useTrack();
   const account = useAccount();
-  const modal = useModalContext();
 
   const [hasAppliedForOpGrant] = useLocalStorage(
     `appliedForOpGrant-${account?.data?.id || ""}`,
@@ -81,7 +76,9 @@ export const CreditsItem: React.FC<CreditsItemProps> = ({
                   action: "click",
                   label: "apply-now",
                 });
-                modal.onClose();
+                if (onClickApply) {
+                  onClickApply();
+                }
               }}
             >
               Apply Now


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to refactor the `CreditsItem` component in the Billing section of the Account settings to include an `onClickApply` callback for applying credits.

### Detailed summary
- Added `onClickApply` callback in `CreditsItem` component
- Removed unused imports in `CreditsItem.tsx`
- Modified `onClickApply` behavior in `CreditsItem` to call the provided function
- Updated `CreditsButton` component to include `onClickApply` callback for closing the modal

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->