### PR TITLE
fix(auth): add warning and improve parameter checks in verifySignature

### DIFF
--- a/packages/thirdweb/src/auth/verifySignature.ts
+++ b/packages/thirdweb/src/auth/verifySignature.ts
@@ -124,6 +124,7 @@ export type VerifySignatureParams = Prettify<
  * ```
  * @auth
  */
+let warningTriggered = false;
 export async function verifySignature(options: VerifySignatureParams) {
   try {
     const isValidEOASig = await verifyEOASignature(options);
@@ -139,6 +140,15 @@ export async function verifySignature(options: VerifySignatureParams) {
     } catch {
       // no-op we skip to return false
     }
+  } else if (!warningTriggered) {
+    // We only trigger this warning once
+    warningTriggered = true;
+    console.error(`
+      Failed to verify EOA signature and no chain or client provided.
+
+      If you mean to use a smart account, please provide a chain and client.
+      For more information on how to setup a smart account with Auth, see https://portal.thirdweb.com/connect/auth
+    `);
   }
   // if we reach here, we have no way to verify the signature
   return false;
@@ -147,5 +157,10 @@ export async function verifySignature(options: VerifySignatureParams) {
 function isVerifyContractWalletSignatureParams(
   options: VerifySignatureParams,
 ): options is VerifyContractWalletSignatureParams {
-  return "chain" in options && "client" in options;
+  return (
+    "chain" in options &&
+    options.chain !== undefined &&
+    "client" in options &&
+    options.client !== undefined
+  );
 }


### PR DESCRIPTION
### TL;DR
Added a warning that gets triggered once when the EOA signature verification fails and neither the chain nor the client parameter is provided in the verifySignature function. This is crucial to guide users on setting up smart accounts properly.

### What changed?
- Introduced a `warningTriggered` flag to ensure the warning is only logged once.
- Added a warning message to notify about missing chain and client parameters when EOA signature verification fails.
- Updated `isVerifyContractWalletSignatureParams` to explicitly check for undefined values in chain and client parameters.

### How to test?
1. Call the `verifySignature` function without providing the `chain` and `client` parameters.
2. Observe the console for the warning message.
3. Ensure the warning triggers only once even with multiple calls to `verifySignature` without the required parameters.

### Why make this change?
This change improves the developer experience by providing clear guidance when critical parameters are missing for using smart accounts with the Auth module. This helps in debugging and ensures proper setup for smart accounts.

---

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add a warning message when failing to verify EOA signature without chain or client provided.

### Detailed summary
- Added a warning message when failing to verify EOA signature without chain or client
- Updated `isVerifyContractWalletSignatureParams` function to check for `undefined` values

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->