### PR TITLE
test(ts): improve airdrop test robustness

### DIFF
--- a/packages/thirdweb/src/extensions/airdrop/write/airdropERC1155WithSignature.test.ts
+++ b/packages/thirdweb/src/extensions/airdrop/write/airdropERC1155WithSignature.test.ts
@@ -15,7 +15,7 @@ import {
   balanceOf,
   setApprovalForAll,
 } from "../../../exports/extensions/erc1155.js";
-import { sendTransaction } from "../../../transaction/actions/send-transaction.js";
+import { sendAndConfirmTransaction } from "../../../transaction/actions/send-and-confirm-transaction.js";
 import { mintTo } from "../../erc1155/write/mintTo.js";
 import { deployERC1155Contract } from "../../prebuilts/deploy-erc1155.js";
 import { deployPublishedContract } from "../../prebuilts/deploy-published.js";
@@ -26,9 +26,9 @@ import {
 
 // skip this test suite if there is no secret key available to test with
 // TODO: remove reliance on secret key during unit tests entirely
-describe.runIf(process.env.TW_SECRET_KEY)(
-  "generateAirdropSignatureERC11551155",
-  () => {
+describe
+  .runIf(process.env.TW_SECRET_KEY)
+  .sequential("generateAirdropSignatureERC11551155", () => {
     let airdropContract: ThirdwebContract;
     let erc1155TokenContract: ThirdwebContract;
 
@@ -80,7 +80,7 @@ describe.runIf(process.env.TW_SECRET_KEY)(
       ];
 
       for (const tx of mintTransactions) {
-        await sendTransaction({
+        await sendAndConfirmTransaction({
           transaction: tx,
           account: TEST_ACCOUNT_A,
         });
@@ -91,7 +91,7 @@ describe.runIf(process.env.TW_SECRET_KEY)(
         operator: airdropContract.address,
         approved: true,
       });
-      await sendTransaction({
+      await sendAndConfirmTransaction({
         transaction: approvalTx,
         account: TEST_ACCOUNT_A,
       });
@@ -117,7 +117,7 @@ describe.runIf(process.env.TW_SECRET_KEY)(
         req,
         signature,
       });
-      const { transactionHash } = await sendTransaction({
+      const { transactionHash } = await sendAndConfirmTransaction({
         transaction,
         account: TEST_ACCOUNT_A,
       });
@@ -146,5 +146,4 @@ describe.runIf(process.env.TW_SECRET_KEY)(
 
       expect(transactionHash.length).toBe(66);
     });
-  },
-);
+  });

--- a/packages/thirdweb/src/extensions/airdrop/write/airdropERC20WithSignature.test.ts
+++ b/packages/thirdweb/src/extensions/airdrop/write/airdropERC20WithSignature.test.ts
@@ -11,7 +11,7 @@ import {
   type ThirdwebContract,
   getContract,
 } from "../../../contract/contract.js";
-import { sendTransaction } from "../../../transaction/actions/send-transaction.js";
+import { sendAndConfirmTransaction } from "../../../transaction/actions/send-and-confirm-transaction.js";
 import { getBalance } from "../../erc20/read/getBalance.js";
 import { approve } from "../../erc20/write/approve.js";
 import { mintTo } from "../../erc20/write/mintTo.js";
@@ -24,9 +24,9 @@ import {
 
 // skip this test suite if there is no secret key available to test with
 // TODO: remove reliance on secret key during unit tests entirely
-describe.runIf(process.env.TW_SECRET_KEY)(
-  "generateAirdropSignatureERC2020",
-  () => {
+describe
+  .runIf(process.env.TW_SECRET_KEY)
+  .sequential("generateAirdropSignatureERC2020", () => {
     let airdropContract: ThirdwebContract;
     let erc20TokenContract: ThirdwebContract;
 
@@ -62,17 +62,17 @@ describe.runIf(process.env.TW_SECRET_KEY)(
         to: TEST_ACCOUNT_A.address,
         amountWei: 1000n,
       });
-      await sendTransaction({
+      await sendAndConfirmTransaction({
         transaction: mintTx,
         account: TEST_ACCOUNT_A,
       });
 
-      const approvalTx = await approve({
+      const approvalTx = approve({
         contract: erc20TokenContract,
         spender: airdropContract.address,
         amountWei: 1000n,
       });
-      await sendTransaction({
+      await sendAndConfirmTransaction({
         transaction: approvalTx,
         account: TEST_ACCOUNT_A,
       });
@@ -98,7 +98,7 @@ describe.runIf(process.env.TW_SECRET_KEY)(
         req,
         signature,
       });
-      const { transactionHash } = await sendTransaction({
+      const { transactionHash } = await sendAndConfirmTransaction({
         transaction,
         account: TEST_ACCOUNT_A,
       });
@@ -140,5 +140,4 @@ describe.runIf(process.env.TW_SECRET_KEY)(
 
       expect(transactionHash.length).toBe(66);
     });
-  },
-);
+  });

--- a/packages/thirdweb/src/extensions/airdrop/write/airdropERC721WithSignature.test.ts
+++ b/packages/thirdweb/src/extensions/airdrop/write/airdropERC721WithSignature.test.ts
@@ -15,7 +15,7 @@ import {
   ownerOf,
   setApprovalForAll,
 } from "../../../exports/extensions/erc721.js";
-import { sendTransaction } from "../../../transaction/actions/send-transaction.js";
+import { sendAndConfirmTransaction } from "../../../transaction/actions/send-and-confirm-transaction.js";
 import { mintTo } from "../../erc721/write/mintTo.js";
 import { deployERC721Contract } from "../../prebuilts/deploy-erc721.js";
 import { deployPublishedContract } from "../../prebuilts/deploy-published.js";
@@ -27,7 +27,7 @@ import {
 // skip this test suite if there is no secret key available to test with
 // TODO: remove reliance on secret key during unit tests entirely
 describe.runIf(process.env.TW_SECRET_KEY)(
-  "generateAirdropSignatureERC721721",
+  "generateAirdropSignatureERC721",
   () => {
     let airdropContract: ThirdwebContract;
     let erc721TokenContract: ThirdwebContract;
@@ -92,7 +92,7 @@ describe.runIf(process.env.TW_SECRET_KEY)(
       ];
 
       for (const tx of mintTransactions) {
-        await sendTransaction({
+        await sendAndConfirmTransaction({
           transaction: tx,
           account: TEST_ACCOUNT_A,
         });
@@ -103,7 +103,7 @@ describe.runIf(process.env.TW_SECRET_KEY)(
         operator: airdropContract.address,
         approved: true,
       });
-      await sendTransaction({
+      await sendAndConfirmTransaction({
         transaction: approvalTx,
         account: TEST_ACCOUNT_A,
       });
@@ -129,7 +129,7 @@ describe.runIf(process.env.TW_SECRET_KEY)(
         req,
         signature,
       });
-      const { transactionHash } = await sendTransaction({
+      const { transactionHash } = await sendAndConfirmTransaction({
         transaction,
         account: TEST_ACCOUNT_A,
       });

--- a/packages/thirdweb/src/extensions/airdrop/write/claimERC1155.test.ts
+++ b/packages/thirdweb/src/extensions/airdrop/write/claimERC1155.test.ts
@@ -15,7 +15,7 @@ import {
   balanceOf,
   setApprovalForAll,
 } from "../../../exports/extensions/erc1155.js";
-import { sendTransaction } from "../../../transaction/actions/send-transaction.js";
+import { sendAndConfirmTransaction } from "../../../transaction/actions/send-and-confirm-transaction.js";
 import { mintTo } from "../../erc1155/write/mintTo.js";
 import { deployERC1155Contract } from "../../prebuilts/deploy-erc1155.js";
 import { deployPublishedContract } from "../../prebuilts/deploy-published.js";
@@ -79,7 +79,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("claimERC1155", () => {
     ];
 
     for (const tx of mintTransactions) {
-      await sendTransaction({
+      await sendAndConfirmTransaction({
         transaction: tx,
         account: TEST_ACCOUNT_A,
       });
@@ -90,7 +90,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("claimERC1155", () => {
       operator: airdropContract.address,
       approved: true,
     });
-    await sendTransaction({
+    await sendAndConfirmTransaction({
       transaction: approvalTx,
       account: TEST_ACCOUNT_A,
     });
@@ -113,7 +113,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("claimERC1155", () => {
       snapshotUri,
       contract: airdropContract,
     });
-    await sendTransaction({
+    await sendAndConfirmTransaction({
       transaction: saveSnapshotTransaction,
       account: TEST_ACCOUNT_A,
     });
@@ -124,7 +124,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("claimERC1155", () => {
       resetClaimStatus: true,
       contract: airdropContract,
     });
-    await sendTransaction({
+    await sendAndConfirmTransaction({
       transaction: setMerkleRootTransaction,
       account: TEST_ACCOUNT_A,
     });
@@ -134,7 +134,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("claimERC1155", () => {
       recipient: TEST_ACCOUNT_B.address,
       contract: airdropContract,
     });
-    const { transactionHash } = await sendTransaction({
+    const { transactionHash } = await sendAndConfirmTransaction({
       transaction: claimTransaction,
       account: TEST_ACCOUNT_A,
     });

--- a/packages/thirdweb/src/extensions/airdrop/write/claimERC20.test.ts
+++ b/packages/thirdweb/src/extensions/airdrop/write/claimERC20.test.ts
@@ -11,7 +11,7 @@ import {
   type ThirdwebContract,
   getContract,
 } from "../../../contract/contract.js";
-import { sendTransaction } from "../../../transaction/actions/send-transaction.js";
+import { sendAndConfirmTransaction } from "../../../transaction/actions/send-and-confirm-transaction.js";
 import { getBalance } from "../../erc20/read/getBalance.js";
 import { approve } from "../../erc20/write/approve.js";
 import { mintTo } from "../../erc20/write/mintTo.js";
@@ -61,17 +61,17 @@ describe.runIf(process.env.TW_SECRET_KEY)("claimERC20", () => {
       to: TEST_ACCOUNT_A.address,
       amount: 1000,
     });
-    await sendTransaction({
+    await sendAndConfirmTransaction({
       transaction: mintTx,
       account: TEST_ACCOUNT_A,
     });
 
-    const approvalTx = await approve({
+    const approvalTx = approve({
       contract: erc20TokenContract,
       spender: airdropContract.address,
       amount: 1000,
     });
-    await sendTransaction({
+    await sendAndConfirmTransaction({
       transaction: approvalTx,
       account: TEST_ACCOUNT_A,
     });
@@ -94,7 +94,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("claimERC20", () => {
       snapshotUri,
       contract: airdropContract,
     });
-    await sendTransaction({
+    await sendAndConfirmTransaction({
       transaction: saveSnapshotTransaction,
       account: TEST_ACCOUNT_A,
     });
@@ -105,7 +105,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("claimERC20", () => {
       resetClaimStatus: true,
       contract: airdropContract,
     });
-    await sendTransaction({
+    await sendAndConfirmTransaction({
       transaction: setMerkleRootTransaction,
       account: TEST_ACCOUNT_A,
     });
@@ -115,7 +115,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("claimERC20", () => {
       recipient: TEST_ACCOUNT_B.address,
       contract: airdropContract,
     });
-    const { transactionHash } = await sendTransaction({
+    const { transactionHash } = await sendAndConfirmTransaction({
       transaction: claimTransaction,
       account: TEST_ACCOUNT_A,
     });

--- a/packages/thirdweb/src/extensions/airdrop/write/claimERC721.test.ts
+++ b/packages/thirdweb/src/extensions/airdrop/write/claimERC721.test.ts
@@ -15,7 +15,7 @@ import {
   ownerOf,
   setApprovalForAll,
 } from "../../../exports/extensions/erc721.js";
-import { sendTransaction } from "../../../transaction/actions/send-transaction.js";
+import { sendAndConfirmTransaction } from "../../../transaction/actions/send-and-confirm-transaction.js";
 import { mintTo } from "../../erc721/write/mintTo.js";
 import { deployERC721Contract } from "../../prebuilts/deploy-erc721.js";
 import { deployPublishedContract } from "../../prebuilts/deploy-published.js";
@@ -91,7 +91,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("claimERC721", () => {
     ];
 
     for (const tx of mintTransactions) {
-      await sendTransaction({
+      await sendAndConfirmTransaction({
         transaction: tx,
         account: TEST_ACCOUNT_A,
       });
@@ -102,7 +102,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("claimERC721", () => {
       operator: airdropContract.address,
       approved: true,
     });
-    await sendTransaction({
+    await sendAndConfirmTransaction({
       transaction: approvalTx,
       account: TEST_ACCOUNT_A,
     });
@@ -125,7 +125,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("claimERC721", () => {
       snapshotUri,
       contract: airdropContract,
     });
-    await sendTransaction({
+    await sendAndConfirmTransaction({
       transaction: saveSnapshotTransaction,
       account: TEST_ACCOUNT_A,
     });
@@ -136,7 +136,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("claimERC721", () => {
       resetClaimStatus: true,
       contract: airdropContract,
     });
-    await sendTransaction({
+    await sendAndConfirmTransaction({
       transaction: setMerkleRootTransaction,
       account: TEST_ACCOUNT_A,
     });
@@ -146,7 +146,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("claimERC721", () => {
       recipient: TEST_ACCOUNT_B.address,
       contract: airdropContract,
     });
-    const { transactionHash } = await sendTransaction({
+    const { transactionHash } = await sendAndConfirmTransaction({
       transaction: claimTransaction,
       account: TEST_ACCOUNT_A,
     });

--- a/packages/thirdweb/src/rpc/actions/eth_getLogs.test.ts
+++ b/packages/thirdweb/src/rpc/actions/eth_getLogs.test.ts
@@ -13,6 +13,6 @@ const rpcClient = getRpcClient({
 describe.runIf(process.env.TW_SECRET_KEY).skip("eth_getLogs", () => {
   it("should return unparsed logs, without events", async () => {
     const logs = await eth_getLogs(rpcClient);
-    expect(logs).toMatchInlineSnapshot("[]");
+    expect(Array.isArray(logs)).toBe(true);
   });
 });

--- a/packages/thirdweb/test/vitest.config.ts
+++ b/packages/thirdweb/test/vitest.config.ts
@@ -40,7 +40,7 @@ export default defineConfig({
     include: ["src/**/*.test.{ts,tsx}"],
     setupFiles: [join(__dirname, "./reactSetup.ts")],
     globalSetup: [join(__dirname, "./globalSetup.ts")],
-    testTimeout: 60_000,
+    testTimeout: 90_000,
     retry: 0,
     bail: 1,
     // clear any mocks between any tests


### PR DESCRIPTION
This pull request updates multiple test cases to use the `sendAndConfirmTransaction` method instead of the `sendTransaction` method. The tests affected include those for airdropERC1155WithSignature, airdropERC20WithSignature, airdropERC721WithSignature, claimERC1155, claimERC20, and claimERC721. The main goal is to ensure transactions are confirmed within the tests for improved reliability and accuracy.

### TL;DR
Replaced `sendTransaction` with `sendAndConfirmTransaction` in multiple test cases to ensure transactions are confirmed.

### What changed?
- Updated `airdropERC1155WithSignature.test.ts` to use `sendAndConfirmTransaction`
- Updated `airdropERC20WithSignature.test.ts` to use `sendAndConfirmTransaction`
- Updated `airdropERC721WithSignature.test.ts` to use `sendAndConfirmTransaction`
- Updated `claimERC1155.test.ts` to use `sendAndConfirmTransaction`
- Updated `claimERC20.test.ts` to use `sendAndConfirmTransaction`
- Updated `claimERC721.test.ts` to use `sendAndConfirmTransaction`

### How to test?
Run the test suite to ensure all tests pass with the updated method.

### Why make this change?
This change improves the reliability and accuracy of the test cases by ensuring that transactions are confirmed within the tests.

---

<!-- start pr-codex -->

---

## PR-Codex overview
This PR increases test timeout, updates function calls to `sendAndConfirmTransaction`, and refactors test suite descriptions for consistency.

### Detailed summary
- Increased test timeout from 60,000 to 90,000
- Updated function calls to `sendAndConfirmTransaction`
- Refactored test suite descriptions for consistency

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->