### PR TITLE
[Chore] Add conditional check in PayEmbed-disconnected test using TW_SECRET_KEY

### DIFF
--- a/packages/thirdweb/src/react/web/ui/PayEmbed-disconnected.test.tsx
+++ b/packages/thirdweb/src/react/web/ui/PayEmbed-disconnected.test.tsx
@@ -3,12 +3,13 @@ import { render } from "../../../../test/src/react-render.js";
 import { TEST_CLIENT } from "../../../../test/src/test-clients.js";
 import { PayEmbed } from "./PayEmbed.js";
 
-describe("PayEmbed: Disconnected state", () => {
-  it("renders a connect wallet button when a wallet is not connected", async () => {
-    const { findByText } = render(<PayEmbed client={TEST_CLIENT} />);
-    const connectWalletButton = await findByText("Connect Wallet", undefined, {
-      timeout: 10000,
+describe.runIf(process.env.TW_SECRET_KEY)(
+  "PayEmbed: Disconnected state",
+  () => {
+    it("renders a connect wallet button when a wallet is not connected", async () => {
+      const { findByText } = render(<PayEmbed client={TEST_CLIENT} />);
+      const connectWalletButton = await findByText("Connect Wallet");
+      expect(connectWalletButton).toBeInTheDocument();
     });
-    expect(connectWalletButton).toBeInTheDocument();
-  });
-});
+  },
+);

--- a/packages/thirdweb/src/react/web/ui/PayEmbed.test.tsx
+++ b/packages/thirdweb/src/react/web/ui/PayEmbed.test.tsx
@@ -4,31 +4,34 @@ import { render } from "../../../../test/src/react-render.js";
 import { TEST_CLIENT } from "../../../../test/src/test-clients.js";
 import { PayEmbed } from "./PayEmbed.js";
 
-describe("PayEmbed - Connected state", async () => {
-  const { findByRole } = render(<PayEmbed client={TEST_CLIENT} />, {
-    setConnectedWallet: true,
-  });
+describe.runIf(process.env.TW_SECRET_KEY)(
+  "PayEmbed - Connected state",
+  async () => {
+    const { findByRole } = render(<PayEmbed client={TEST_CLIENT} />, {
+      setConnectedWallet: true,
+    });
 
-  // continue button is shown
-  const connectWalletButton = await findByRole("button", {
-    name: "Continue",
-  });
+    // continue button is shown
+    const connectWalletButton = await findByRole("button", {
+      name: "Continue",
+    });
 
-  it("continue button is disabled if no token amount is set", async () => {
-    // continue button is disabled when no amount is entered
-    expect(connectWalletButton).toBeDisabled();
+    it("continue button is disabled if no token amount is set", async () => {
+      // continue button is disabled when no amount is entered
+      expect(connectWalletButton).toBeDisabled();
 
-    // user enters an amount
-    const tokenInput = await findByRole("textbox");
-    await userEvent.type(tokenInput, "1");
+      // user enters an amount
+      const tokenInput = await findByRole("textbox");
+      await userEvent.type(tokenInput, "1");
 
-    // continue button is enabled
-    expect(connectWalletButton).not.toBeDisabled();
+      // continue button is enabled
+      expect(connectWalletButton).not.toBeDisabled();
 
-    // user clears the amount
-    await userEvent.clear(tokenInput);
+      // user clears the amount
+      await userEvent.clear(tokenInput);
 
-    // continue button is disabled again
-    expect(connectWalletButton).toBeDisabled();
-  });
-});
+      // continue button is disabled again
+      expect(connectWalletButton).toBeDisabled();
+    });
+  },
+);


### PR DESCRIPTION
### TL;DR
Update PayEmbed and PayEmbed-disconnected tests to include conditional running based on TW_SECRET_KEY.

### What changed?
- Added conditional checks for TW_SECRET_KEY in PayEmbed-disconnected.test.tsx and PayEmbed.test.tsx
- Ensured tests run only if TW_SECRET_KEY is defined

### How to test?
1. Ensure TW_SECRET_KEY is set in your environment
2. Run the updated tests
3. Verify that the tests only execute if TW_SECRET_KEY is present

### Why make this change?
To add more robust control over test execution based on the presence of secret keys.

---

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to refactor test files in `PayEmbed` component to use conditional test execution based on a secret key.

### Detailed summary
- Refactored test descriptions to use conditional test execution based on a secret key.
- Updated test assertions and cleanup in `PayEmbed-disconnected.test.tsx` and `PayEmbed.test.tsx`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->