### PR TITLE
fix(ts): in-app wallet user op signatures

### DIFF
--- a/packages/thirdweb/src/wallets/in-app/web/lib/in-app-account.ts
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/in-app-account.ts
@@ -7,7 +7,6 @@ import { getRpcClient } from "../../../../rpc/rpc.js";
 import { type Hex, hexToString } from "../../../../utils/encoding/hex.js";
 import { parseTypedData } from "../../../../utils/signatures/helpers/parseTypedData.js";
 import type { Prettify } from "../../../../utils/type-utils.js";
-import { uint8ArrayToString } from "../../../../utils/uint8-array.js";
 import { getEcosystemPartnerPermissions } from "../../../ecosystem/get-ecosystem-partner-permissions.js";
 import type {
   Account,
@@ -279,7 +278,7 @@ export class IFrameWallet {
             return message;
           }
           if (message.raw instanceof Uint8Array) {
-            return uint8ArrayToString(message.raw);
+            return message.raw;
           }
           return hexToString(message.raw);
         })();
@@ -287,7 +286,8 @@ export class IFrameWallet {
         const { signedMessage } = await querier.call<SignMessageReturnType>({
           procedureName: "signMessage",
           params: {
-            message: messageDecoded, // always a string
+            // biome-ignore lint/suspicious/noExplicitAny: ethers tx transformation
+            message: messageDecoded as any, // needs bytes or string
             partnerId,
             chainId: 1, // TODO check if we need this
           },


### PR DESCRIPTION
### TL;DR

This PR updates the message handling in the in-app-account module of the thirdweb package. Specifically, it modifies the message decoding process and removes an unused import.

### What changed?

- Modified the IFrameWallet class to handle messages that are bytes or strings.
- Removed the `uint8ArrayToString` import which was no longer needed.

### How to test?

1. Run the existing test suite to ensure all tests pass.
2. Manually test the in-app wallet functionality to validate the message handling changes.

### Why make this change?

To improve the robustness and maintainability of the in-app-account module in the thirdweb package by cleaning up the code and ensuring proper handling of different message types.

---

 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `IFrameWallet` class in `in-app-account.ts` for message handling and signing. 

### Detailed summary
- Removed `uint8ArrayToString` function call
- Adjusted message type handling for `signMessage` procedure

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->