### PR TITLE
fix(ens): enhance ENS resolution tests and error handling

### DIFF
--- a/.changeset/shiny-tables-remember.md
+++ b/.changeset/shiny-tables-remember.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+resolveName returns null if no ENS exists for an address

--- a/packages/thirdweb/src/extensions/ens/resolve-name.test.ts
+++ b/packages/thirdweb/src/extensions/ens/resolve-name.test.ts
@@ -6,11 +6,19 @@ import { resolveName } from "./resolve-name.js";
 // TODO: remove reliance on secret key during unit tests entirely
 describe.runIf(process.env.TW_SECRET_KEY)("ENS:resolve-name", () => {
   it("should resolve ENS", async () => {
-    const address = await resolveName({
+    const ens = await resolveName({
       client: TEST_CLIENT,
       // vitalik.eth
       address: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
     });
-    expect(address).toBe("vitalik.eth");
+    expect(ens).toBe("vitalik.eth");
+  });
+
+  it("should return null if no ENS exists for the address", async () => {
+    const ens = await resolveName({
+      client: TEST_CLIENT,
+      address: "0xc6248746A9CA5935ae722E2061347A5897548c03",
+    });
+    expect(ens).toBeNull();
   });
 });

--- a/packages/thirdweb/src/extensions/ens/resolve-name.ts
+++ b/packages/thirdweb/src/extensions/ens/resolve-name.ts
@@ -45,7 +45,15 @@ export async function resolveName(options: ResolveNameOptions) {
         packetToBytes(`${address.toLowerCase().substring(2)}.addr.reverse`),
       );
 
-      const [name, resolvedAddress] = await reverse({ contract, reverseName });
+      const [name, resolvedAddress] = await reverse({
+        contract,
+        reverseName,
+      }).catch((e) => {
+        if ("data" in e && e.data === "0x7199966d") {
+          return [null, address] as const;
+        }
+        throw e;
+      });
 
       if (address.toLowerCase() !== resolvedAddress.toLowerCase()) {
         return null;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR enhances the ENS resolution functionality by handling cases where no ENS exists for an address. 

### Detailed summary
- Updated `resolve-name.ts` to return `null` if no ENS exists for an address
- Added a test in `resolve-name.test.ts` to validate the new functionality

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->