### PR TITLE
[Fix] Prevent overriding gasLimit and maxFeePerGas settings if already present

### DIFF
--- a/.changeset/smart-bears-breathe.md
+++ b/.changeset/smart-bears-breathe.md
@@ -1,0 +1,6 @@
+---
+"@thirdweb-dev/wallets": patch
+"@thirdweb-dev/sdk": patch
+---
+
+respect gas overrides if they are passed in

--- a/legacy_packages/sdk/src/evm/core/classes/transactions.ts
+++ b/legacy_packages/sdk/src/evm/core/classes/transactions.ts
@@ -216,6 +216,14 @@ abstract class TransactionContext {
     if (isBrowser()) {
       return {};
     }
+    // if we already have a gasLimit set, don't override it
+    if (this.overrides.gasLimit) {
+     return {};
+    }
+    // if we already have maxFeePerGas && maxPriorityFeePerGas set, don't override it
+    if (this.overrides.maxFeePerGas && this.overrides.maxPriorityFeePerGas) {
+      return {};
+    }
     return getDefaultGasOverrides(this.provider);
   }
 }

--- a/legacy_packages/sdk/src/evm/core/wallet/user-wallet.ts
+++ b/legacy_packages/sdk/src/evm/core/wallet/user-wallet.ts
@@ -1,15 +1,15 @@
 import type { BlockTag } from "@ethersproject/abstract-provider";
 import type { IERC20 } from "@thirdweb-dev/contracts-js";
-import { ThirdwebStorage, isBrowser } from "@thirdweb-dev/storage";
+import { type ThirdwebStorage, isBrowser } from "@thirdweb-dev/storage";
 import {
-  BigNumber,
-  Wallet,
-  utils,
+  type BigNumber,
   type BigNumberish,
+  type ContractInterface,
   type Signer,
   type TypedDataField,
+  Wallet,
   type providers,
-  ContractInterface,
+  utils,
 } from "ethers";
 import EventEmitter from "eventemitter3";
 import invariant from "tiny-invariant";
@@ -17,19 +17,19 @@ import { fetchCurrencyValue } from "../../common/currency/fetchCurrencyValue";
 import { isNativeToken } from "../../common/currency/isNativeToken";
 import { normalizePriceValue } from "../../common/currency/normalizePriceValue";
 import { resolveAddress } from "../../common/ens/resolveAddress";
-import { EIP712Domain, signTypedDataInternal } from "../../common/sign";
+import { getDefaultGasOverrides } from "../../common/gas-price";
+import { type EIP712Domain, signTypedDataInternal } from "../../common/sign";
 import { LOCAL_NODE_PKEY } from "../../constants/addresses/LOCAL_NODE_PKEY";
 import { ChainId } from "../../constants/chains/ChainId";
 import { NATIVE_TOKEN_ADDRESS } from "../../constants/currency";
 import { getChainProvider } from "../../constants/urls";
-import { SDKOptions } from "../../schema/sdk-options";
-import { Address } from "../../schema/shared/Address";
-import { AddressOrEns } from "../../schema/shared/AddressOrEnsSchema";
+import type { SDKOptions } from "../../schema/sdk-options";
+import type { Address } from "../../schema/shared/Address";
+import type { AddressOrEns } from "../../schema/shared/AddressOrEnsSchema";
 import type { Amount, CurrencyValue } from "../../types/currency";
 import { ContractWrapper } from "../classes/internal/contract-wrapper";
 import { RPCConnectionHandler } from "../classes/internal/rpc-connection-handler";
-import { NetworkInput, TransactionResult } from "../types";
-import { getDefaultGasOverrides } from "../../common/gas-price";
+import type { NetworkInput, TransactionResult } from "../types";
 /**
  *
  * {@link UserWallet} events that you can subscribe to using `sdk.wallet.events`.
@@ -298,8 +298,10 @@ export class UserWallet {
     transactionRequest: providers.TransactionRequest,
   ): Promise<providers.TransactionResponse> {
     const signer = this.requireWallet();
-    // set default gas values
+    // set default gas values (except for if they are already set in the transactionRequest)
     const gasOverrides = isBrowser()
+    || transactionRequest.gasLimit
+    || (transactionRequest.maxFeePerGas && transactionRequest.maxPriorityFeePerGas)
       ? {}
       : await getDefaultGasOverrides(this.connection.getProvider());
     transactionRequest = {

--- a/legacy_packages/wallets/src/evm/connectors/embedded-wallet/implementations/lib/core/signer.ts
+++ b/legacy_packages/wallets/src/evm/connectors/embedded-wallet/implementations/lib/core/signer.ts
@@ -1,11 +1,11 @@
 import {
-  Bytes,
+  type Bytes,
   Signer,
-  TypedDataDomain,
-  TypedDataField,
-  providers,
+  type TypedDataDomain,
+  type TypedDataField,
+  type providers,
 } from "ethers";
-import { Deferrable, defineReadOnly } from "ethers/lib/utils";
+import { type Deferrable, defineReadOnly } from "ethers/lib/utils";
 import type { ClientIdWithQuerierType } from "../../interfaces/embedded-wallets/embedded-wallets";
 import type {
   GetAddressReturnType,
@@ -14,9 +14,9 @@ import type {
   SignedTypedDataReturnType,
 } from "../../interfaces/embedded-wallets/signer";
 
-import Provider from "ethereum-provider";
-import type { EmbeddedWalletIframeCommunicator } from "../../utils/iFrameCommunication/EmbeddedWalletIframeCommunicator";
 import { getDefaultGasOverrides } from "@thirdweb-dev/sdk";
+import type Provider from "ethereum-provider";
+import type { EmbeddedWalletIframeCommunicator } from "../../utils/iFrameCommunication/EmbeddedWalletIframeCommunicator";
 
 export type SignerProcedureTypes = {
   getAddress: void;
@@ -105,7 +105,15 @@ export class EthersSigner extends Signer {
     if (!this.provider) {
       throw new Error("Provider not found");
     }
-    const gas = await getDefaultGasOverrides(this.provider);
+    let gas = {};
+    // only set overrides if we don't have values already
+    if (
+      !transaction.gasLimit &&
+      !(transaction.maxFeePerGas && transaction.maxPriorityFeePerGas)
+    ) {
+      gas = await getDefaultGasOverrides(this.provider);
+    }
+
     const txWithGas = {
       ...gas,
       ...transaction,

--- a/legacy_packages/wallets/src/evm/connectors/local-wallet/wrapped-signer.ts
+++ b/legacy_packages/wallets/src/evm/connectors/local-wallet/wrapped-signer.ts
@@ -1,13 +1,13 @@
 import { getDefaultGasOverrides } from "@thirdweb-dev/sdk";
 import {
-  Bytes,
+  type Bytes,
   Signer,
-  providers,
-  TypedDataDomain,
-  TypedDataField,
-  Wallet,
+  type TypedDataDomain,
+  type TypedDataField,
+  type Wallet,
+  type providers,
 } from "ethers";
-import { Deferrable, defineReadOnly } from "ethers/lib/utils";
+import { type Deferrable, defineReadOnly } from "ethers/lib/utils";
 
 export class WrappedSigner extends Signer {
   constructor(private signer: Wallet) {
@@ -47,7 +47,15 @@ export class WrappedSigner extends Signer {
     if (!this.provider) {
       throw new Error("Provider not found");
     }
-    const gas = await getDefaultGasOverrides(this.provider);
+    let gas = {};
+    // only set overrides if we don't have values already
+    if (
+      !transaction.gasLimit &&
+      !(transaction.maxFeePerGas && transaction.maxPriorityFeePerGas)
+    ) {
+      gas = await getDefaultGasOverrides(this.provider);
+    }
+
     const txWithGas = {
       ...gas,
       ...transaction,


### PR DESCRIPTION
Respect gas overrides if they are passed in both the SDK and various wallet implementations by checking if gasLimit, maxFeePerGas, and maxPriorityFeePerGas are already set before applying default values. Added necessary type annotations and improved import statements for better code clarity.

---

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to respect gas overrides in transactions and improve type annotations in the codebase.

### Detailed summary
- Respect gas overrides in transactions
- Improved type annotations for various objects and functions

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->