### PR TITLE
fix: bigint crash on tooltip

### DIFF
--- a/apps/dashboard/README.md
+++ b/apps/dashboard/README.md
@@ -2,20 +2,13 @@
 
 This repo contains the full source for all of thirdweb.com and the thirdweb dashboard.
 
-## Building
+## Starting a local dev server
 
-### Install dependencies
-
-We use `pnpm`.
+Run from the root folder (thirdweb-dev/js):
 
 ```sh
-pnpm install
-```
-
-### Starting local dev server.
-
-```sh
-pnpm dev
+cd <path/to/thirdweb-dev/js>
+pnpm dashboard
 ```
 
 ### Building for production

--- a/apps/dashboard/src/components/engine/contract-subscription/contract-subscriptions-table.tsx
+++ b/apps/dashboard/src/components/engine/contract-subscription/contract-subscriptions-table.tsx
@@ -238,7 +238,7 @@ const ChainLastBlockTimestamp = ({
 }) => {
   // Get the block timestamp to display how delayed the last processed block is.
   const ethBlockQuery = useQuery({
-    queryKey: ["block_timestamp", chainId, blockNumber],
+    queryKey: ["block_timestamp", chainId, Number(blockNumber)],
     // keep the previous data while fetching new data
     keepPreviousData: true,
     queryFn: async () => {


### PR DESCRIPTION
## Problem solved

Fix error: "Do not know how to serialize bigint" by casting bigint to number when used as a string.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the README file in the dashboard app to provide clear instructions for starting a local dev server. It also improves the block timestamp retrieval in the contract-subscriptions-table component.

### Detailed summary
- Updated README.md to include instructions for starting a local dev server
- Improved block timestamp retrieval by converting blockNumber to a number when querying

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->