### PR TITLE
fix(transaction): export StoredTransaction type from transaction-store.js

### DIFF
--- a/.changeset/gold-hairs-heal.md
+++ b/.changeset/gold-hairs-heal.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": minor
+---
+
+Adds StoredTransaction type

--- a/packages/thirdweb/src/exports/transaction.ts
+++ b/packages/thirdweb/src/exports/transaction.ts
@@ -55,7 +55,10 @@ export {
   toSerializableTransaction,
   type ToSerializableTransactionOptions,
 } from "../transaction/actions/to-serializable-transaction.js";
-export { getTransactionStore } from "../transaction/transaction-store.js";
+export {
+  type StoredTransaction,
+  getTransactionStore,
+} from "../transaction/transaction-store.js";
 
 //types & utils
 export {

--- a/packages/thirdweb/src/transaction/transaction-store.ts
+++ b/packages/thirdweb/src/transaction/transaction-store.ts
@@ -1,7 +1,7 @@
 import { type Store, createStore } from "../reactive/store.js";
 import type { Hex } from "../utils/encoding/hex.js";
 
-type StoredTransaction = {
+export type StoredTransaction = {
   transactionHash: Hex;
   chainId: number;
 };


### PR DESCRIPTION
### TL;DR

This pull request modifies the `transaction-store.ts` module by exporting the type `StoredTransaction`, making it available for external use.

### What changed?

- The type `StoredTransaction` was exported from `transaction-store.ts`
- Updated the export statement for `StoredTransaction` in `transaction.ts`

### How to test?

1. Ensure that the module `transaction-store.ts` exports the type `StoredTransaction`.
2. Verify that importing `StoredTransaction` from the module works correctly in another file.

### Why make this change?

This change was made to facilitate the external utilization of the `StoredTransaction` type.

---

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add a new `StoredTransaction` type to the `thirdweb` package.

### Detailed summary
- Added `StoredTransaction` type to `transaction-store.ts`
- Exported `StoredTransaction` type in `transaction.ts` for wider use

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->