### PR TITLE
[dashboard] Add copy button for chain id

### DIFF
--- a/apps/dashboard/src/@/components/ui/CopyAddressButton.tsx
+++ b/apps/dashboard/src/@/components/ui/CopyAddressButton.tsx
@@ -1,10 +1,6 @@
 "use client";
 
-import { CheckIcon, CopyIcon } from "lucide-react";
-import { useState } from "react";
-import { cn } from "../../lib/utils";
-import { Button } from "./button";
-import { ToolTipLabel } from "./tooltip";
+import { CopyTextButton } from "./CopyTextButton";
 
 export function CopyAddressButton(props: {
   address: string;
@@ -17,36 +13,18 @@ export function CopyAddressButton(props: {
     | "outline"
     | "secondary"
     | "ghost";
+  copyIconPosition: "left" | "right";
 }) {
-  const [isCopied, setIsCopied] = useState(false);
   const shortenedAddress = `${props.address.slice(0, 6)}...${props.address.slice(0, 4)}`;
 
   return (
-    <ToolTipLabel label="Copy address">
-      <Button
-        variant={props.variant || "outline"}
-        aria-label="Copy"
-        className={cn(
-          "h-auto w-auto px-2.5 py-1.5 flex gap-2 text-xs rounded-lg font-mono text-foreground",
-          props.className,
-        )}
-        onClick={() => {
-          navigator.clipboard.writeText(props.address);
-          setIsCopied(true);
-          setTimeout(() => setIsCopied(false), 1000);
-        }}
-      >
-        {isCopied ? (
-          <CheckIcon
-            className={cn("size-3 text-green-500", props.iconClassName)}
-          />
-        ) : (
-          <CopyIcon
-            className={cn("size-3 text-muted-foreground", props.iconClassName)}
-          />
-        )}
-        {shortenedAddress}
-      </Button>
-    </ToolTipLabel>
+    <CopyTextButton
+      textToCopy={props.address}
+      textToShow={shortenedAddress}
+      tooltip="Copy Address"
+      className="font-mono text-sm"
+      variant={props.variant}
+      copyIconPosition={props.copyIconPosition}
+    />
   );
 }

--- a/apps/dashboard/src/@/components/ui/CopyTextButton.tsx
+++ b/apps/dashboard/src/@/components/ui/CopyTextButton.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { CheckIcon, CopyIcon } from "lucide-react";
+import { useState } from "react";
+import { cn } from "../../lib/utils";
+import { Button } from "./button";
+import { ToolTipLabel } from "./tooltip";
+
+export function CopyTextButton(props: {
+  textToShow: string;
+  textToCopy: string;
+  tooltip: string;
+  className?: string;
+  iconClassName?: string;
+  variant?:
+    | "primary"
+    | "default"
+    | "destructive"
+    | "outline"
+    | "secondary"
+    | "ghost";
+  copyIconPosition: "left" | "right";
+}) {
+  const [isCopied, setIsCopied] = useState(false);
+  const copyButton = isCopied ? (
+    <CheckIcon className={cn("size-3 text-green-500", props.iconClassName)} />
+  ) : (
+    <CopyIcon
+      className={cn("size-3 text-muted-foreground", props.iconClassName)}
+    />
+  );
+
+  return (
+    <ToolTipLabel label={props.tooltip}>
+      <Button
+        variant={props.variant || "outline"}
+        aria-label={props.tooltip}
+        className={cn(
+          "h-auto w-auto px-2.5 py-1.5 flex gap-2 rounded-lg text-foreground",
+          props.className,
+        )}
+        onClick={() => {
+          navigator.clipboard.writeText(props.textToCopy);
+          setIsCopied(true);
+          setTimeout(() => setIsCopied(false), 1000);
+        }}
+      >
+        {props.copyIconPosition === "right" ? (
+          <>
+            {props.textToShow}
+            {copyButton}
+          </>
+        ) : (
+          <>
+            {copyButton}
+            {props.textToShow}
+          </>
+        )}
+      </Button>
+    </ToolTipLabel>
+  );
+}

--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/layout.tsx
@@ -11,6 +11,7 @@ import {
 import type { Metadata } from "next";
 import Link from "next/link";
 import { redirect } from "next/navigation";
+import { CopyTextButton } from "../../../../@/components/ui/CopyTextButton";
 import { StarButton } from "../components/client/star-button";
 import { ChainIcon } from "../components/server/chain-icon";
 import { getChain, getChainMetadata } from "../utils";
@@ -205,7 +206,14 @@ export default async function ChainPageLayout({
 
               {/* Chain Id */}
               <PrimaryInfoItem title="Chain ID">
-                <div className="text-lg">{chain.chainId}</div>
+                <CopyTextButton
+                  textToCopy={chain.chainId.toString()}
+                  textToShow={chain.chainId.toString()}
+                  tooltip="Copy Chain ID"
+                  variant="ghost"
+                  className="text-lg -translate-x-2 py-0.5"
+                  copyIconPosition="right"
+                />
               </PrimaryInfoItem>
 
               {/* Native token */}

--- a/apps/dashboard/src/app/(dashboard)/(chain)/chainlist/components/server/chainlist-card.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/chainlist/components/server/chainlist-card.tsx
@@ -1,6 +1,7 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { CircleAlertIcon, TicketCheckIcon } from "lucide-react";
 import Link from "next/link";
+import { CopyTextButton } from "../../../../../../@/components/ui/CopyTextButton";
 import { ChainIcon } from "../../../components/server/chain-icon";
 import type { ChainSupportedService } from "../../../types/chain";
 import { getChainMetadata } from "../../../utils";
@@ -48,25 +49,42 @@ export async function ChainListCard({
         <CardContent className="pt-0 px-4 pb-4">
           {/* table of `chain id` `native token` `managed support`, header row on left value row on right */}
           <table className="w-full">
-            <tbody className="[&_td]:py-0.5 text-sm">
+            <tbody className="[&_td>*]:min-h-[25px] text-sm">
               <tr>
                 <th className="text-left font-normal text-secondary-foreground">
                   Chain ID
                 </th>
-                <td className="text-right">{chainId}</td>
+                <td className="text-right">
+                  <CopyTextButton
+                    textToCopy={chainId.toString()}
+                    textToShow={chainId.toString()}
+                    tooltip="Copy Chain ID"
+                    className="inline-flex z-10 relative text-base translate-x-2 py-0.5"
+                    variant="ghost"
+                    copyIconPosition="left"
+                  />
+                </td>
               </tr>
               <tr>
                 <th className="text-left font-normal text-secondary-foreground">
                   Native Token
                 </th>
-                <td className="text-right">{currencySymbol}</td>
+                <td className="text-right">
+                  <div className="inline-flex items-center">
+                    {currencySymbol}
+                  </div>
+                </td>
               </tr>
               <tr>
                 <th className="text-left font-normal text-secondary-foreground">
                   Available Services
                 </th>
 
-                <td className="text-right">{enabledServices.length}</td>
+                <td className="text-right">
+                  <div className="inline-flex items-center">
+                    {enabledServices.length}
+                  </div>
+                </td>
               </tr>
             </tbody>
           </table>
@@ -75,7 +93,7 @@ export async function ChainListCard({
             <div className="mt-5 flex gap-5 border-t pt-4">
               {!isDeprecated && chainMetadata?.gasSponsored && (
                 <div className="gap-1.5 flex items-center">
-                  <TicketCheckIcon className="text-primary-foreground size-5" />
+                  <TicketCheckIcon className="text-foreground size-5" />
                   <p className="text-sm">Gas Sponsored</p>
                 </div>
               )}

--- a/apps/dashboard/src/app/(dashboard)/(chain)/chainlist/components/server/chainlist-row.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/chainlist/components/server/chainlist-row.tsx
@@ -7,6 +7,7 @@ import {
   XIcon,
 } from "lucide-react";
 import Link from "next/link";
+import { CopyTextButton } from "../../../../../../@/components/ui/CopyTextButton";
 import { ChainIcon } from "../../../components/server/chain-icon";
 import { products } from "../../../components/server/products";
 import type { ChainSupportedService } from "../../../types/chain";
@@ -64,7 +65,16 @@ export async function ChainListRow({
         </div>
       </TableData>
 
-      <TableData>{chainId}</TableData>
+      <TableData>
+        <CopyTextButton
+          textToCopy={chainId.toString()}
+          textToShow={chainId.toString()}
+          tooltip="Copy Chain ID"
+          className="z-10 relative text-base"
+          variant="ghost"
+          copyIconPosition="right"
+        />
+      </TableData>
 
       <TableData>{currencySymbol}</TableData>
 

--- a/apps/dashboard/src/components/pay/PayAnalytics/components/PayCustomersTable.tsx
+++ b/apps/dashboard/src/components/pay/PayAnalytics/components/PayCustomersTable.tsx
@@ -217,6 +217,7 @@ function CustomerTableRow(props: {
                 address={v}
                 variant="ghost"
                 className="text-secondary-foreground"
+                copyIconPosition="left"
               />
             );
           }}

--- a/apps/dashboard/src/components/pay/PayAnalytics/components/PaymentHistory.tsx
+++ b/apps/dashboard/src/components/pay/PayAnalytics/components/PaymentHistory.tsx
@@ -234,6 +234,7 @@ function TableRow(props: { purchase: PayPurchasesData["purchases"][0] }) {
           address={purchase.fromAddress}
           variant="ghost"
           className="text-secondary-foreground"
+          copyIconPosition="left"
         />
       </TableData>
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to add a `CopyTextButton` component with copy functionality to various parts of the application for easy text copying.

### Detailed summary
- Added `CopyTextButton` component for copying text with customizable icon position.
- Implemented the `CopyTextButton` in multiple components for copying chain IDs and addresses.
- Updated styles and functionality for text copying in different parts of the application.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->