### PR TITLE
fix(ts): properly disconnect wallet connect

### DIFF
--- a/.changeset/fifty-apricots-kneel.md
+++ b/.changeset/fifty-apricots-kneel.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix WalletConnect client disconnections

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/WalletConnectReceiverScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/WalletConnectReceiverScreen.tsx
@@ -48,6 +48,12 @@ export function WalletConnectReceiverScreen(props: {
               queryKey: ["walletConnectSession"],
             });
           },
+          onDisconnect: () => {
+            setLoading(false);
+            queryClient.invalidateQueries({
+              queryKey: ["walletConnectSession"],
+            });
+          },
           onError: (error) => {
             setErrorConnecting(error.message);
             setLoading(false);

--- a/packages/thirdweb/src/wallets/wallet-connect/receiver/index.ts
+++ b/packages/thirdweb/src/wallets/wallet-connect/receiver/index.ts
@@ -249,7 +249,10 @@ export async function createWalletConnectClient(
   // Disconnects can come from the user or the connected app, so we inject the callback to ensure its always triggered
   const _disconnect = walletConnectClient.disconnect;
   walletConnectClient.disconnect = async (args) => {
-    const result = await _disconnect(args);
+    const result = await _disconnect(args).catch(() => {
+      // no-op if already disconnected
+    });
+
     if (onDisconnect) {
       disconnectHook({ topic: args.topic, onDisconnect });
     }
@@ -323,6 +326,8 @@ export async function disconnectWalletConnectSession(options: {
   session: WalletConnectSession;
   walletConnectClient: WalletConnectClient;
 }): Promise<void> {
+  removeSession(options.session);
+
   try {
     await options.walletConnectClient.disconnect({
       topic: options.session.topic,
@@ -331,10 +336,9 @@ export async function disconnectWalletConnectSession(options: {
         message: "Disconnected",
       },
     });
-  } catch {
+  } catch (error) {
     // ignore, the session doesn't exist already
   }
-  removeSession(options.session);
 }
 
 /**
@@ -346,6 +350,7 @@ async function disconnectHook(options: {
 }) {
   const { topic, onDisconnect } = options;
   const sessions = await getSessions();
+
   onDisconnect(
     sessions.find((s) => s.topic === topic) ?? {
       topic,

--- a/packages/thirdweb/src/wallets/wallet-connect/receiver/receiver.test.ts
+++ b/packages/thirdweb/src/wallets/wallet-connect/receiver/receiver.test.ts
@@ -146,6 +146,7 @@ describe("createWalletConnectClient", () => {
     });
 
     await listeners.session_delete?.({ topic: "test" });
+    await new Promise((resolve) => setTimeout(resolve, 300));
     expect(onDisconnect).toHaveBeenCalledWith({ topic: "test" });
   });
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on fixing WalletConnect client disconnections and improving error handling.

### Detailed summary
- Added delay before expecting disconnection in tests
- Improved error handling in `disconnectWalletConnectSession`
- Added `onDisconnect` function in `WalletConnectReceiverScreen`
- Added no-op catch for already disconnected state in `disconnect` function

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->