### PR TITLE
fix(sepolia): rename Sepolia native currency symbol to ETH

### DIFF
--- a/.changeset/sweet-queens-lie.md
+++ b/.changeset/sweet-queens-lie.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Rename Sepolia native currency symbol to ETH

--- a/packages/thirdweb/src/chains/chain-definitions/sepolia.ts
+++ b/packages/thirdweb/src/chains/chain-definitions/sepolia.ts
@@ -3,7 +3,7 @@ import { defineChain } from "../utils.js";
 export const sepolia = /*@__PURE__*/ defineChain({
   id: 11155111,
   name: "Sepolia",
-  nativeCurrency: { name: "Sepolia Ether", symbol: "SEP", decimals: 18 },
+  nativeCurrency: { name: "Sepolia Ether", symbol: "ETH", decimals: 18 },
   blockExplorers: [
     {
       name: "Etherscan",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to rename the native currency symbol from `SEP` to `ETH` in the Sepolia chain definition.

### Detailed summary
- Renamed Sepolia native currency symbol from `SEP` to `ETH`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->