### PR TITLE
[Fix] Update import paths in engine-explorer and _app.tsx for better modularity

### DIFF
--- a/apps/dashboard/src/components/engine/explorer/engine-explorer.tsx
+++ b/apps/dashboard/src/components/engine/explorer/engine-explorer.tsx
@@ -1,5 +1,6 @@
 import { Box, DarkMode } from "@chakra-ui/react";
 import { ClientOnly } from "components/ClientOnly/ClientOnly";
+import "../../../css/swagger-ui.css";
 import "swagger-ui-react/swagger-ui.css";
 import { useApiAuthToken } from "@3rdweb-sdk/react/hooks/useApi";
 import dynamic from "next/dynamic";

--- a/apps/dashboard/src/pages/_app.tsx
+++ b/apps/dashboard/src/pages/_app.tsx
@@ -1,3 +1,4 @@
+import { Toaster } from "@/components/ui/toaster";
 import { ChakraProvider, useColorMode } from "@chakra-ui/react";
 import { Global, css } from "@emotion/react";
 import type { DehydratedState } from "@tanstack/react-query";
@@ -20,8 +21,6 @@ import { memo, useEffect, useMemo, useRef } from "react";
 import { generateBreakpointTypographyCssVars } from "tw-components/utils/typography";
 import type { ThirdwebNextPage } from "utils/types";
 import { ThemeProvider } from "../@/components/theme-provider";
-import "../css/swagger-ui.css";
-import { Toaster } from "@/components/ui/toaster";
 import chakraTheme from "../theme";
 import "@/styles/globals.css";
 


### PR DESCRIPTION
### TL;DR

Corrected stylesheet imports for `swagger-ui.css` in the Engine Explorer component and added the Toaster component import in the _app.tsx. 

### What changed?

- Added missing `swagger-ui.css` import in `engine-explorer.tsx`
- Removed duplicate `swagger-ui.css` import from `_app.tsx`
- Ensured Toaster component import in `_app.tsx`

### How to test?

- Verify UI for the Engine Explorer relies on the correct styles
- Ensure the Toaster component renders correctly without issues

### Why make this change?

To ensure the correct CSS styles are applied and to improve the maintainability of the import statements.

---

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add a new CSS file for Swagger UI styling and remove unnecessary CSS imports.

### Detailed summary
- Added `apps/dashboard/src/components/engine/explorer/engine-explorer.tsx` with import of `swagger-ui.css`
- Removed import of `css/swagger-ui.css` from `apps/dashboard/src/pages/_app.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->