### PR TITLE
feature(ts): unpin files from ipfs

### DIFF
--- a/.changeset/eighty-actors-hear.md
+++ b/.changeset/eighty-actors-hear.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": minor
+---
+
+Adds storage unpin function

--- a/packages/thirdweb/src/exports/storage.ts
+++ b/packages/thirdweb/src/exports/storage.ts
@@ -4,6 +4,7 @@ export {
   type UploadMobileOptions,
 } from "../storage/uploadMobile.js";
 export { download, type DownloadOptions } from "../storage/download.js";
+export { unpin, type UnpinOptions } from "../storage/unpin.js";
 export { resolveScheme, type ResolveSchemeOptions } from "../utils/ipfs.js";
 export {
   resolveArweaveScheme,

--- a/packages/thirdweb/src/storage/unpin.ts
+++ b/packages/thirdweb/src/storage/unpin.ts
@@ -1,0 +1,52 @@
+import type { ThirdwebClient } from "../client/client.js";
+import { getThirdwebDomains } from "../utils/domains.js";
+import { getClientFetch } from "../utils/fetch.js";
+
+export type UnpinOptions = {
+  client: ThirdwebClient;
+  cid: string;
+};
+
+/**
+ * Unpins a file from IPFS.
+ * @note For security purposes, this method requires a secret key to be set in the ThirdwebClient instance.
+ * @param options - The options for unpinning the file.
+ * @param options.client - The Thirdweb client instance.
+ * @param options.cid - The content identifier (CID) of the file to unpin.
+ * @throws Will throw an error if the client does not have a secret key or if the unpinning fails.
+ * @example
+ * ```ts
+ * import { unpin } from "thirdweb";
+ *
+ * const result = await unpin({
+ *   client: thirdwebClient,
+ *   cid: "QmTzQ1N1z1Q1N1z1Q1N1z1Q1N1z1Q1N1z1Q1N1z1Q1N1z1",
+ * });
+ *
+ * ```
+ */
+
+export async function unpin(options: UnpinOptions) {
+  if (!options.client.secretKey) {
+    throw new Error(
+      "Unauthorized - Your client must have a secret key to unpin files.",
+    );
+  }
+
+  const res = await getClientFetch(options.client)(
+    `https://${getThirdwebDomains().storage}/ipfs/pinned/${options.cid}`,
+    {
+      method: "DELETE",
+    },
+  );
+
+  if (!res.ok) {
+    res.body?.cancel();
+    if (res.status === 401) {
+      throw new Error(
+        "Unauthorized - You don't have permission to use this service.",
+      );
+    }
+    throw new Error(`Failed to unpin file - ${res.status} - ${res.statusText}`);
+  }
+}

--- a/packages/thirdweb/src/wallets/interfaces/wallet.ts
+++ b/packages/thirdweb/src/wallets/interfaces/wallet.ts
@@ -203,7 +203,7 @@ export type Account = {
   /**
    * Sign the given transaction and return the signature
    *
-   * This method is not available for on all wallets. This method will be `undefined` if the wallet does not support it.
+   * This method is not available on all wallets. This method will be `undefined` if the wallet does not support it.
    * @example
    * ```ts
    * if (account.signTransaction) {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to add a new function `unpin` for unpinning files from IPFS in the `thirdweb` package.

### Detailed summary
- Added `unpin` function to unpin files from IPFS
- New `UnpinOptions` type for specifying client and CID
- Function checks for client's secret key before unpinning
- Throws errors for unauthorized access or unpinning failure

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->