### PR TITLE
fix(utils): correct filter condition for recommended wallets

### DIFF
--- a/.changeset/spotty-kids-shave.md
+++ b/.changeset/spotty-kids-shave.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix recommended wallet ordering

--- a/packages/thirdweb/src/react/web/utils/sortWallets.ts
+++ b/packages/thirdweb/src/react/web/utils/sortWallets.ts
@@ -27,8 +27,8 @@ export function sortWallets<T extends { id: string }>(
       })
       // show the recommended wallets even before that
       .sort((a, b) => {
-        const aIsRecommended = recommendedWallets?.find((w) => w === a);
-        const bIsRecommended = recommendedWallets?.find((w) => w === b);
+        const aIsRecommended = recommendedWallets?.find((w) => w.id === a.id);
+        const bIsRecommended = recommendedWallets?.find((w) => w.id === b.id);
 
         if (aIsRecommended && !bIsRecommended) {
           return -1;
@@ -38,7 +38,7 @@ export function sortWallets<T extends { id: string }>(
         }
         return 0;
       })
-      // show wallets with select ui first ( currently only in-app )
+      // show in-app wallets first
       .sort((a, b) => {
         const aIsInApp = a.id === "inApp" || a.id === "embedded";
         const bIsInApp = b.id === "inApp" || b.id === "embedded";


### PR DESCRIPTION
## Problem solved

Recommended wallets were being compared for object equality when sorting, which caused confusion when using inline `createWallet` to set the recommended wallets. This PR updates sorting to compare the recommended wallets by ID (installed providers already work this way)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the recommended wallet ordering in the `sortWallets.ts` file.

### Detailed summary
- Updated logic to check recommended wallets based on `id` instead of object reference
- Changed ordering to prioritize in-app wallets over others

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->