### PR TITLE
Fix playground docs link

### DIFF
--- a/apps/playground-web/src/app/connect/sign-in/page.tsx
+++ b/apps/playground-web/src/app/connect/sign-in/page.tsx
@@ -36,7 +36,7 @@ export default function Page() {
               <Button asChild size="lg">
                 <Link
                   target="_blank"
-                  href="https://portal.thirdweb.com/connect/sign-in"
+                  href="https://portal.thirdweb.com/connect/sign-in/overview"
                 >
                   View docs
                 </Link>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the link in the sign-in page to direct users to the new 'overview' section instead of the main sign-in page.

### Detailed summary
- Updated the href attribute of the Link component in `page.tsx` from "/connect/sign-in" to "/connect/sign-in/overview"

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->