### PR TITLE
Add announcement for Onchain Olympics

### DIFF
--- a/apps/dashboard/src/components/notices/AnnouncementBanner.tsx
+++ b/apps/dashboard/src/components/notices/AnnouncementBanner.tsx
@@ -27,9 +27,9 @@ export const AnnouncementBanner = () => {
       >
         <Box display={{ base: "none", md: "block" }} />
         <TrackedLink
-          href="https://blog.thirdweb.com/welcoming-blocktorch/"
+          href="https://onchainolympics.com"
           category="announcement"
-          label="blocktorch"
+          label="onchain-olympics"
           isExternal
         >
           <Container maxW="container.page" display="flex" px={0}>
@@ -47,8 +47,8 @@ export const AnnouncementBanner = () => {
                 color="white"
                 fontWeight={500}
               >
-                thirdweb acquires Blocktorch, a leading web3 observability
-                platform.
+                The Onchain Olympics ⛓️🏅 — Mint an NFT on your preferred chain
+                to unlock builder perks on thirdweb
               </Heading>
               <Icon display={{ base: "none", md: "block" }} as={FiArrowRight} />
             </Flex>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update the AnnouncementBanner component with a new link and label for the Onchain Olympics event, along with revised text content.

### Detailed summary
- Updated TrackedLink href to "https://onchainolympics.com" and label to "onchain-olympics"
- Changed announcement text to promote the Onchain Olympics event and NFT minting.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->