### PR TITLE
Support localhost in Pay domains

### DIFF
--- a/.changeset/sweet-badgers-bake.md
+++ b/.changeset/sweet-badgers-bake.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Support localhost as a domain override option for the Pay service

--- a/packages/thirdweb/src/pay/utils/definitions.ts
+++ b/packages/thirdweb/src/pay/utils/definitions.ts
@@ -1,59 +1,66 @@
 import { getThirdwebDomains } from "../../utils/domains.js";
 
+export const getPayBaseUrl = () => {
+  const payDomain: string = getThirdwebDomains().pay;
+  return payDomain.startsWith("localhost")
+    ? `http://${payDomain}`
+    : `https://${payDomain}`;
+};
+
 /**
  * Endpoint to get the status of a "Buy with Crypto" quote.
  * @internal
  */
 export const getPayBuyWithCryptoStatusUrl = () =>
-  `https://${getThirdwebDomains().pay}/buy-with-crypto/status/v1`;
+  `${getPayBaseUrl()}/buy-with-crypto/status/v1`;
 /**
  * Endpoint to get "Buy with Crypto" quote.
  * @internal
  */
 export const getPayBuyWithCryptoQuoteEndpoint = () =>
-  `https://${getThirdwebDomains().pay}/buy-with-crypto/quote/v1`;
+  `${getPayBaseUrl()}/buy-with-crypto/quote/v1`;
 
 /**
  * Endpoint to get a "Buy with Fiat" quote.
  * @internal
  */
 export const getPayBuyWithFiatQuoteEndpoint = () =>
-  `https://${getThirdwebDomains().pay}/buy-with-fiat/quote/v1`;
+  `${getPayBaseUrl()}/buy-with-fiat/quote/v1`;
 
 /**
  * Endpoint to get the status of a "Buy with Fiat" transaction status.
  * @internal
  */
 export const getPayBuyWithFiatStatusEndpoint = () =>
-  `https://${getThirdwebDomains().pay}/buy-with-fiat/status/v1`;
+  `${getPayBaseUrl()}/buy-with-fiat/status/v1`;
 
 /**
  * Endpoint to get history of "Buy with Fiat" transactions for given wallet address.
  * @internal
  */
 export const getPayBuyWithFiatHistoryEndpoint = () =>
-  `https://${getThirdwebDomains().pay}/buy-with-fiat/history/v1`;
+  `${getPayBaseUrl()}/buy-with-fiat/history/v1`;
 
 /**
  * Endpoint to get a "Buy with Crypto" transaction history for a given wallet address.
  * @internal
  */
 export const getPayBuyWithCryptoHistoryEndpoint = () =>
-  `https://${getThirdwebDomains().pay}/buy-with-crypto/history/v1`;
+  `${getPayBaseUrl()}/buy-with-crypto/history/v1`;
 
 /**
  * Endpoint to get a list of supported destination chains and tokens for thirdweb pay.
  * @internal
  */
 export const getPaySupportedDestinations = () =>
-  `https://${getThirdwebDomains().pay}/destination-tokens/v1`;
+  `${getPayBaseUrl()}/destination-tokens/v1`;
 
 /**
  * Endpoint to get a list of supported source chains + tokens for thirdweb pay.
  * @internal
  */
 export const getPaySupportedSources = () =>
-  `https://${getThirdwebDomains().pay}/buy-with-crypto/source-tokens/v1`;
+  `${getPayBaseUrl()}/buy-with-crypto/source-tokens/v1`;
 
 /**
  * Endpoint to get buy history for a given wallet address.
@@ -61,4 +68,4 @@ export const getPaySupportedSources = () =>
  * @internal
  */
 export const getPayBuyHistoryEndpoint = () =>
-  `https://${getThirdwebDomains().pay}/wallet/history/v1`;
+  `${getPayBaseUrl()}/wallet/history/v1`;


### PR DESCRIPTION
## Problem solved

Use "http://" if localhost domain used for thirdweb Pay

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for using localhost as a domain override option for the Pay service.

### Detailed summary
- Added support for localhost as a domain override option in the Pay service
- Updated functions to use the `getPayBaseUrl` function for constructing URLs
- Updated various endpoints to use the `getPayBaseUrl` function for consistency

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->