### PR TITLE
fix(react-native): ensure onClose is called on successful wallet connection in ConnectModal

### DIFF
--- a/packages/thirdweb/src/react/native/ui/connect/ConnectModal.tsx
+++ b/packages/thirdweb/src/react/native/ui/connect/ConnectModal.tsx
@@ -67,7 +67,10 @@ export function ConnectModal(
   const connectMutation = useConnect({
     client,
     accountAbstraction,
-    onConnect,
+    onConnect: (wallet) => {
+      props.onClose?.();
+      onConnect?.(wallet);
+    },
   });
   const wallets = props.wallets || getDefaultWallets(props);
   const [modalState, setModalState] = useState<ModalState>({ screen: "base" });


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update the `onConnect` function in `ConnectModal.tsx` to call `onClose` before calling `onConnect`.

### Detailed summary
- Updated `onConnect` function to call `onClose` before calling `onConnect`
- Improved logic flow for connecting wallets in the ConnectModal component

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->