### PR TITLE
Reset selection data on wallet selection

### DIFF
--- a/.changeset/hot-donuts-change.md
+++ b/.changeset/hot-donuts-change.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Reset wallet selection data on wallet selection

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/ConnectModalContent.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/ConnectModalContent.tsx
@@ -121,6 +121,7 @@ export const ConnectModalContent = (props: {
         setScreen(reservedScreens.getStarted);
       }}
       selectWallet={(newWallet) => {
+        setSelectionData({});
         if (newWallet.onConnectRequested) {
           newWallet
             .onConnectRequested()

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/WalletSelector.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/WalletSelector.tsx
@@ -17,6 +17,7 @@ import {
   spacing,
 } from "../../../core/design-system/index.js";
 import { genericWalletIcon } from "../../../core/utils/socialIcons.js";
+import { useSetSelectionData } from "../../providers/wallet-ui-states-provider.js";
 import { sortWallets } from "../../utils/sortWallets.js";
 import { LoadingScreen } from "../../wallets/shared/LoadingScreen.js";
 import { Img } from "../components/Img.js";
@@ -569,6 +570,7 @@ const WalletSelection: React.FC<{
   localeId: LocaleId;
 }> = (props) => {
   const wallets = sortWallets(props.wallets, props.recommendedWallets);
+  const selectionData = useSetSelectionData();
 
   return (
     <WalletList
@@ -602,6 +604,7 @@ const WalletSelection: React.FC<{
                 walletId={wallet.id}
                 selectWallet={() => {
                   props.selectWallet(wallet);
+                  selectionData({});
                 }}
                 connectLocale={props.connectLocale}
                 client={props.client}

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/WalletSelector.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/WalletSelector.tsx
@@ -17,7 +17,6 @@ import {
   spacing,
 } from "../../../core/design-system/index.js";
 import { genericWalletIcon } from "../../../core/utils/socialIcons.js";
-import { useSetSelectionData } from "../../providers/wallet-ui-states-provider.js";
 import { sortWallets } from "../../utils/sortWallets.js";
 import { LoadingScreen } from "../../wallets/shared/LoadingScreen.js";
 import { Img } from "../components/Img.js";
@@ -570,7 +569,6 @@ const WalletSelection: React.FC<{
   localeId: LocaleId;
 }> = (props) => {
   const wallets = sortWallets(props.wallets, props.recommendedWallets);
-  const selectionData = useSetSelectionData();
 
   return (
     <WalletList
@@ -604,7 +602,6 @@ const WalletSelection: React.FC<{
                 walletId={wallet.id}
                 selectWallet={() => {
                   props.selectWallet(wallet);
-                  selectionData({});
                 }}
                 connectLocale={props.connectLocale}
                 client={props.client}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on resetting wallet selection data when a wallet is selected in the ConnectModalContent component.

### Detailed summary
- Reset wallet selection data when a wallet is selected in `ConnectModalContent.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->