### PR TITLE
Blockscout v2 contract verification

### DIFF
--- a/.changeset/three-lamps-explain.md
+++ b/.changeset/three-lamps-explain.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Blockscout v2 contract verification

--- a/legacy_packages/sdk/src/evm/core/classes/contract-verifier.ts
+++ b/legacy_packages/sdk/src/evm/core/classes/contract-verifier.ts
@@ -2,6 +2,7 @@ import { utils } from "ethers";
 import {
   verifyThirdwebPrebuiltImplementation,
   checkVerificationStatus,
+  ExplorerType,
 } from "../../common/verification";
 import { verify } from "../../common/verification";
 import { SDKOptions } from "../../schema/sdk-options";
@@ -60,6 +61,7 @@ export class ContractVerifier extends RPCConnectionHandler {
     explorerAPIUrl: string,
     explorerAPIKey: string,
     contractVersion: string = "latest",
+    type?: ExplorerType,
     constructorArgs?: ConstructorParamMap,
   ) {
     const chainId = (await this.getProvider().getNetwork()).chainId;
@@ -72,16 +74,19 @@ export class ContractVerifier extends RPCConnectionHandler {
       contractVersion,
       this.options.clientId,
       this.options.secretKey,
+      type,
       constructorArgs,
     );
 
-    console.info("Checking verification status...");
-    const verificationStatus = await checkVerificationStatus(
-      explorerAPIUrl,
-      explorerAPIKey,
-      guid,
-    );
-    console.info(verificationStatus);
+    if(type !== "blockscoutV2") {
+      console.info("Checking verification status...");
+      const verificationStatus = await checkVerificationStatus(
+        explorerAPIUrl,
+        explorerAPIKey,
+        guid,
+      );
+      console.info(verificationStatus);
+    }
   }
 
   /**
@@ -113,6 +118,7 @@ export class ContractVerifier extends RPCConnectionHandler {
     contractAddress: string,
     explorerAPIUrl: string,
     explorerAPIKey: string,
+    type?: ExplorerType,
     constructorArgs?: ConstructorParamMap,
   ) {
     const chainId = (await this.getProvider().getNetwork()).chainId;
@@ -136,15 +142,18 @@ export class ContractVerifier extends RPCConnectionHandler {
       explorerAPIUrl,
       explorerAPIKey,
       this.storage,
+      type,
       encodedArgs,
     );
 
-    console.info("Checking verification status...");
+    if(type !== "blockscoutV2") {
+      console.info("Checking verification status...");
     const verificationStatus = await checkVerificationStatus(
       explorerAPIUrl,
       explorerAPIKey,
       guid,
     );
     console.info(verificationStatus);
+    }
   }
 }


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

## Changes made

- [ ] Public API changes: list the public API changes made if any
- [ ] Internal API changes: explain the internal logic changes

## How to test

- [ ] Automated tests: link to unit test file
- [ ] Manual tests: step by step instructions on how to test

## Contributor NFT

Paste in your wallet address below and we will airdrop you a special NFT when your pull request is merged. 

```Address: ```

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding support for Blockscout v2 contract verification. 

### Detailed summary
- Added `ExplorerType` enum for different explorer types
- Modified functions to check verification status based on explorer type
- Implemented specific verification logic for Blockscout v2
- Updated contract verification process for different explorer types

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->