### PR TITLE
feature(react): show ecosystem wallet branding regardless of modal size

### DIFF
--- a/.changeset/warm-eyes-invent.md
+++ b/.changeset/warm-eyes-invent.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Show ecosystem wallet branding on wide modal layout

--- a/packages/thirdweb/src/react/web/wallets/ecosystem/EcosystemWalletFormUI.tsx
+++ b/packages/thirdweb/src/react/web/wallets/ecosystem/EcosystemWalletFormUI.tsx
@@ -54,16 +54,12 @@ export function EcosystemWalletFormUIScreen(props: EcosystemWalletFormUIProps) {
         minHeight: "250px",
       }}
     >
-      {isCompact ? (
-        <>
-          <EcosystemWalletHeader
-            client={props.client}
-            onBack={onBack}
-            wallet={props.wallet}
-          />
-          <Spacer y="lg" />
-        </>
-      ) : null}
+      <EcosystemWalletHeader
+        client={props.client}
+        onBack={isCompact ? onBack : undefined}
+        wallet={props.wallet}
+      />
+      <Spacer y="lg" />
 
       <Container
         expand


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on showing ecosystem wallet branding on a wide modal layout.

### Detailed summary
- Updated `EcosystemWalletFormUI.tsx` to display ecosystem wallet branding on wide modal layout
- Removed conditional rendering based on `isCompact` prop

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->