### PR TITLE
[Fix] Remove IPFS replacement hack in ChainIcon component

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/(chain)/components/server/chain-icon.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/components/server/chain-icon.tsx
@@ -16,9 +16,7 @@ export async function ChainIcon(props: {
     const resolved = resolveScheme({
       client: thirdwebClient,
       uri: props.iconUrl,
-    })
-      // hack to fix this bug: https://github.com/thirdweb-dev/js/pull/3241
-      .replace("ipfs://", "");
+    });
     const res = await fetch(resolved, {
       // revalidate every hour
       next: { revalidate: 60 * 60 },


### PR DESCRIPTION
no longer needed

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `chain-icon.tsx` file in the dashboard app to fix a bug related to the `iconUrl` by removing a specific string.

### Detailed summary
- Fixed a bug related to `iconUrl` by removing "ipfs://" string
- Updated fetch call with revalidate option of 1 hour

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->