### PR TITLE
fix: unit price conversion for ERC20 claimTo

### DIFF
--- a/packages/thirdweb/src/extensions/erc1155/drop1155.test.ts
+++ b/packages/thirdweb/src/extensions/erc1155/drop1155.test.ts
@@ -8,6 +8,8 @@ import {
 } from "../../../test/src/test-wallets.js";
 import { type ThirdwebContract, getContract } from "../../contract/contract.js";
 import { sendAndConfirmTransaction } from "../../transaction/actions/send-and-confirm-transaction.js";
+import { resolvePromisedValue } from "../../utils/promise/resolve-promised-value.js";
+import { toEther } from "../../utils/units.js";
 import { getContractMetadata } from "../common/read/getContractMetadata.js";
 import { deployERC1155Contract } from "../prebuilts/deploy-erc1155.js";
 import { balanceOf } from "./__generated__/IERC1155/read/balanceOf.js";
@@ -135,6 +137,11 @@ describe.runIf(process.env.TW_SECRET_KEY)(
         tokenId: 0n,
         quantity: 1n,
       });
+      // assert value is set correctly
+      const value = await resolvePromisedValue(claimTx.value);
+      expect(value).toBeDefined();
+      if (!value) throw new Error("value is undefined");
+      expect(toEther(value)).toBe("0.001");
       await sendAndConfirmTransaction({
         transaction: claimTx,
         account: TEST_ACCOUNT_A,

--- a/packages/thirdweb/src/utils/extensions/drops/get-claim-params.ts
+++ b/packages/thirdweb/src/utils/extensions/drops/get-claim-params.ts
@@ -59,6 +59,8 @@ export async function getClaimParams(options: GetClaimParamsOptions) {
     });
   })();
 
+  const tokenDecimals = options.type === "erc20" ? options.tokenDecimals : 0; // nfts have no decimals
+
   // compute the allowListProof in an iife
   const allowlistProof = await (async () => {
     // early exit if no merkle root is set
@@ -79,7 +81,7 @@ export async function getClaimParams(options: GetClaimParamsOptions) {
       contract: options.contract,
       claimer: options.from || options.to, // receiver and claimer can be different, always prioritize the claimer for allowlists
       merkleRoot: cc.merkleRoot,
-      tokenDecimals: options.type === "erc20" ? options.tokenDecimals : 0, // nfts have no decimals
+      tokenDecimals,
     });
     // if no proof is found, we'll try the empty proof
     if (!allowListProof) {
@@ -116,7 +118,7 @@ export async function getClaimParams(options: GetClaimParamsOptions) {
     data: "0x" as Hex,
     overrides: {
       value: isNativeTokenAddress(currency)
-        ? pricePerToken * BigInt(options.quantity)
+        ? (pricePerToken * options.quantity) / BigInt(10 ** tokenDecimals)
         : 0n,
     },
   };


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to enhance ERC1155, ERC721, and ERC20 drop tests by adding the ability to claim tokens with specific values.

### Detailed summary
- Added `resolvePromisedValue` and `toEther` functions for value assertion
- Updated value calculation logic for ERC1155 and ERC20 tokens
- Added `TEST_ACCOUNT_C` for testing purposes

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->