### PR TITLE
feat(connect-modal): Integrate NFT support into connect modal

### DIFF
--- a/.changeset/healthy-pugs-tickle.md
+++ b/.changeset/healthy-pugs-tickle.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": minor
+---
+
+Adds NFTs to the connect modal, specified with supportedNFTs

--- a/apps/playground-web/src/components/in-app-wallet/connect-button.tsx
+++ b/apps/playground-web/src/components/in-app-wallet/connect-button.tsx
@@ -2,6 +2,7 @@
 
 import { THIRDWEB_CLIENT } from "@/lib/client";
 import { useTheme } from "next-themes";
+import { baseSepolia } from "thirdweb/chains";
 import { ConnectButton } from "thirdweb/react";
 import type { ConnectButtonProps } from "thirdweb/react";
 import { inAppWallet } from "thirdweb/wallets/in-app";
@@ -18,6 +19,9 @@ export function InAppConnectButton(
       theme={theme === "light" ? "light" : "dark"}
       connectButton={{
         label: "Sign in",
+      }}
+      supportedNFTs={{
+        "84532": ["0x638263e3eAa3917a53630e61B1fBa685308024fa"],
       }}
       wallets={[
         inAppWallet({

--- a/apps/playground-web/src/components/styled-connect-button.tsx
+++ b/apps/playground-web/src/components/styled-connect-button.tsx
@@ -12,6 +12,9 @@ export function StyledConnectButton(
 
   return (
     <ConnectButton
+      supportedNFTs={{
+        "84532": ["0x638263e3eAa3917a53630e61B1fBa685308024fa"],
+      }}
       client={THIRDWEB_CLIENT}
       theme={theme === "light" ? "light" : "dark"}
       {...props}

--- a/packages/thirdweb/src/react/core/hooks/connection/ConnectButtonProps.ts
+++ b/packages/thirdweb/src/react/core/hooks/connection/ConnectButtonProps.ts
@@ -7,7 +7,10 @@ import type { NetworkSelectorProps } from "../../../web/ui/ConnectWallet/Network
 import type { WelcomeScreen } from "../../../web/ui/ConnectWallet/screens/types.js";
 import type { LocaleId } from "../../../web/ui/types.js";
 import type { Theme } from "../../design-system/index.js";
-import type { SupportedTokens } from "../../utils/defaultTokens.js";
+import type {
+  SupportedNFTs,
+  SupportedTokens,
+} from "../../utils/defaultTokens.js";
 import type { SiweAuthOptions } from "../auth/useSiweAuth.js";
 
 export type PayUIOptions = {
@@ -673,6 +676,31 @@ export type ConnectButtonProps = {
    * ```
    */
   supportedTokens?: SupportedTokens;
+
+  /**
+   * Customize the NFTs shown in the "View Funds" screen in Details Modal for various networks.
+   *
+   * By default, The "View Funds" screen shows a few popular tokens for default chains and the native token. For other chains it only shows the native token.
+   * @example
+   *
+   * supportedTokens prop allows you to customize this list as shown below which shows "Pudgy Penguins" help when users wallet is connected to Ethereum mainnet.
+   *
+   * ```tsx
+   * import { ConnectButton } from 'thirdweb/react';
+   *
+   * function Example() {
+   *   return (
+   * 		<ConnectButton
+   * 			supportedNFTs={{
+   *        // when connected to Ethereum mainnet - show Pudgy Penguins
+   * 				1: ['0xBd3531dA5CF5857e7CfAA92426877b022e612cf8'],
+   * 			}}
+   * 		/>
+   * 	);
+   * }
+   * ```
+   */
+  supportedNFTs?: SupportedNFTs;
 
   /**
    * Called on connection of a wallet - including auto connect.

--- a/packages/thirdweb/src/react/core/utils/defaultTokens.ts
+++ b/packages/thirdweb/src/react/core/utils/defaultTokens.ts
@@ -1,3 +1,5 @@
+import type { Address } from "../../../utils/address.js";
+
 export type TokenInfo = {
   name: string;
   symbol: string;
@@ -30,6 +32,7 @@ const fantomIcon =
   "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB2aWV3Qm94PSIwIDAgMzIgMzIiPjxkZWZzPjxzdHlsZT4uY2xzLTF7ZmlsbDojZmZmO2ZpbGwtcnVsZTpldmVub2RkO30uY2xzLTJ7ZmlsbDojMTNiNWVjO30uY2xzLTN7bWFzazp1cmwoI21hc2spO308L3N0eWxlPjxtYXNrIGlkPSJtYXNrIiB4PSIxMCIgeT0iNiIgd2lkdGg9IjkzLjEiIGhlaWdodD0iMjAiIG1hc2tVbml0cz0idXNlclNwYWNlT25Vc2UiPjxnIGlkPSJhIj48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik0xMCw2aDkzLjFWMjZIMTBaIi8+PC9nPjwvbWFzaz48L2RlZnM+PHRpdGxlPmZhPC90aXRsZT48ZyBpZD0iTGF5ZXJfMiIgZGF0YS1uYW1lPSJMYXllciAyIj48ZyBpZD0iTGF5ZXJfMS0yIiBkYXRhLW5hbWU9IkxheWVyIDEiPjxjaXJjbGUgY2xhc3M9ImNscy0yIiBjeD0iMTYiIGN5PSIxNiIgcj0iMTYiLz48ZyBjbGFzcz0iY2xzLTMiPjxwYXRoIGNsYXNzPSJjbHMtMSIgZD0iTTE3LjIsMTIuOWwzLjYtMi4xVjE1Wm0zLjYsOUwxNiwyNC43bC00LjgtMi44VjE3TDE2LDE5LjgsMjAuOCwxN1pNMTEuMiwxMC44bDMuNiwyLjFMMTEuMiwxNVptNS40LDMuMUwyMC4yLDE2bC0zLjYsMi4xWm0tMS4yLDQuMkwxMS44LDE2bDMuNi0yLjFabTQuOC04LjNMMTYsMTIuMiwxMS44LDkuOCwxNiw3LjNaTTEwLDkuNFYyMi41bDYsMy40LDYtMy40VjkuNEwxNiw2WiIvPjwvZz48L2c+PC9nPjwvc3ZnPg==";
 
 export type SupportedTokens = Record<number, TokenInfo[]>;
+export type SupportedNFTs = Record<number, Address[]>;
 
 /**
  * Default tokens shown in [`ConnectButton`](https://portal.thirdweb.com/react/v4/components/ConnectButton)'s SendFunds screen for each network.

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/ConnectButton.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/ConnectButton.tsx
@@ -292,6 +292,7 @@ function ConnectButtonInner(
       detailsButton={props.detailsButton}
       detailsModal={props.detailsModal}
       supportedTokens={supportedTokens}
+      supportedNFTs={props.supportedNFTs}
       onDisconnect={(info) => {
         // logout on explicit disconnect!
         if (siweAuth.requiresAuth) {

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/icons/ImageIcon.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/icons/ImageIcon.tsx
@@ -1,0 +1,25 @@
+import type { IconFC } from "./types.js";
+
+/**
+ * @internal
+ */
+export const ImageIcon: IconFC = (props) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={props.size}
+      height={props.size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      role="presentation"
+    >
+      <rect width="18" height="18" x="3" y="3" rx="2" ry="2" />
+      <circle cx="9" cy="9" r="2" />
+      <path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21" />
+    </svg>
+  );
+};

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/ViewFunds.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/ViewFunds.tsx
@@ -1,43 +1,27 @@
-import type { Chain } from "../../../../../chains/types.js";
 import type { ThirdwebClient } from "../../../../../client/client.js";
-import { fontSize } from "../../../../core/design-system/index.js";
-import { useWalletBalance } from "../../../../core/hooks/others/useWalletBalance.js";
-import {
-  type SupportedTokens,
-  defaultTokens,
+import { fontSize, iconSize } from "../../../../core/design-system/index.js";
+import type {
+  SupportedNFTs,
+  SupportedTokens,
 } from "../../../../core/utils/defaultTokens.js";
-import { useActiveAccount } from "../../../hooks/wallets/useActiveAccount.js";
-import { useActiveWalletChain } from "../../../hooks/wallets/useActiveWalletChain.js";
-import { Skeleton } from "../../components/Skeleton.js";
 import { Spacer } from "../../components/Spacer.js";
-import { TokenIcon } from "../../components/TokenIcon.js";
 import { Container, Line, ModalHeader } from "../../components/basic.js";
 import { Text } from "../../components/text.js";
-import { formatTokenBalance } from "./formatTokenBalance.js";
-import {
-  type ERC20OrNativeToken,
-  NATIVE_TOKEN,
-  isNativeToken,
-} from "./nativeToken.js";
+import { MenuButton } from "../MenuButton.js";
+import { CoinsIcon } from "../icons/CoinsIcon.js";
+import { ImageIcon } from "../icons/ImageIcon.js";
+import type { WalletDetailsModalScreen } from "./types.js";
 
 /**
  * @internal
  */
 export function ViewFunds(props: {
   supportedTokens?: SupportedTokens;
+  supportedNFTs?: SupportedNFTs;
   onBack: () => void;
+  setScreen: (screen: WalletDetailsModalScreen) => void;
   client: ThirdwebClient;
 }) {
-  const activeChain = useActiveWalletChain();
-  const supportedTokens = props.supportedTokens || defaultTokens;
-
-  if (!activeChain) {
-    return null;
-  }
-
-  const tokenList =
-    (activeChain?.id ? supportedTokens[activeChain.id] : undefined) || [];
-
   return (
     <Container
       style={{
@@ -57,68 +41,29 @@ export function ViewFunds(props: {
       >
         <Spacer y="md" />
 
-        <TokenInfo
-          token={NATIVE_TOKEN}
-          chain={activeChain}
-          client={props.client}
-        />
-
-        {tokenList.map((token) => {
-          return (
-            <TokenInfo
-              token={token}
-              key={token.address}
-              chain={activeChain}
-              client={props.client}
-            />
-          );
-        })}
+        <MenuButton
+          onClick={() => {
+            props.setScreen("view-tokens");
+          }}
+          style={{
+            fontSize: fontSize.sm,
+          }}
+        >
+          <CoinsIcon size={iconSize.md} />
+          <Text color="primaryText">View Tokens</Text>
+        </MenuButton>
+        <MenuButton
+          onClick={() => {
+            props.setScreen("view-nfts");
+          }}
+          style={{
+            fontSize: fontSize.sm,
+          }}
+        >
+          <ImageIcon size={iconSize.md} />
+          <Text color="primaryText">View NFTs</Text>
+        </MenuButton>
         <Spacer y="lg" />
-      </Container>
-    </Container>
-  );
-}
-
-function TokenInfo(props: {
-  token: ERC20OrNativeToken;
-  chain: Chain;
-  client: ThirdwebClient;
-}) {
-  const account = useActiveAccount();
-  const tokenBalanceQuery = useWalletBalance({
-    address: account?.address,
-    chain: props.chain,
-    tokenAddress: isNativeToken(props.token) ? undefined : props.token.address,
-    client: props.client,
-  });
-
-  const tokenName = isNativeToken(props.token)
-    ? tokenBalanceQuery.data?.name
-    : props.token.name;
-
-  return (
-    <Container flex="row" gap="sm" p="sm">
-      <TokenIcon
-        token={props.token}
-        chain={props.chain}
-        size="lg"
-        client={props.client}
-      />
-
-      <Container flex="column" gap="xxs">
-        {tokenName ? (
-          <Text size="sm" color="primaryText">
-            {tokenName}
-          </Text>
-        ) : (
-          <Skeleton height={fontSize.md} width="150px" />
-        )}
-
-        {tokenBalanceQuery.data ? (
-          <Text size="xs"> {formatTokenBalance(tokenBalanceQuery.data)}</Text>
-        ) : (
-          <Skeleton height={fontSize.xs} width="100px" />
-        )}
       </Container>
     </Container>
   );

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/ViewNFTs.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/ViewNFTs.tsx
@@ -1,0 +1,255 @@
+import { useQueries } from "@tanstack/react-query";
+import { useMemo } from "react";
+import type { Chain } from "../../../../../chains/types.js";
+import { getCachedChain } from "../../../../../chains/utils.js";
+import type { ThirdwebClient } from "../../../../../client/client.js";
+import { getContract } from "../../../../../contract/contract.js";
+import { getOwnedNFTs as getErc721OwnedNFTs } from "../../../../../extensions/erc721/read/getOwnedNFTs.js";
+import { isERC721 } from "../../../../../extensions/erc721/read/isERC721.js";
+import { getOwnedNFTs as getErc1155OwnedNFTs } from "../../../../../extensions/erc1155/read/getOwnedNFTs.js";
+import { isERC1155 } from "../../../../../extensions/erc1155/read/isERC1155.js";
+import type { Theme } from "../../../../core/design-system/index.js";
+import type { SupportedNFTs } from "../../../../core/utils/defaultTokens.js";
+import { useActiveAccount } from "../../../hooks/wallets/useActiveAccount.js";
+import { useActiveWalletChain } from "../../../hooks/wallets/useActiveWalletChain.js";
+import { MediaRenderer } from "../../MediaRenderer/MediaRenderer.js";
+import { Skeleton } from "../../components/Skeleton.js";
+import { Spacer } from "../../components/Spacer.js";
+import { Container, Line, ModalHeader } from "../../components/basic.js";
+
+const fetchNFTs = async (
+  client: ThirdwebClient,
+  chain: Chain,
+  nftAddress: string,
+  owner: string,
+) => {
+  const contract = getContract({
+    address: nftAddress,
+    chain,
+    client,
+  });
+
+  const erc721 = await isERC721({ contract }).catch(() => {
+    throw new Error(
+      `Failed to read contract bytecode for NFT ${nftAddress} on ${chain.name || chain.id}, is this NFT on the correct chain?`,
+    );
+  });
+  if (erc721) {
+    const result = await getErc721OwnedNFTs({
+      contract,
+      owner: owner,
+    });
+    return result.map((nft) => ({
+      ...nft,
+      quantityOwned: BigInt(1),
+      address: contract.address,
+      chain,
+    }));
+  }
+
+  const erc1155 = await isERC1155({ contract }).catch(() => false);
+  if (erc1155) {
+    const result = await getErc1155OwnedNFTs({
+      contract,
+      address: owner,
+    });
+    return result.map((nft) => ({ ...nft, address: contract.address, chain }));
+  }
+
+  throw new Error(
+    `NFT at ${nftAddress} on chain ${chain.id} is not ERC721 or ERC1155, or does not properly identify itself as supporting either interface`,
+  );
+};
+
+/**
+ * @internal
+ */
+export function ViewNFTs(props: {
+  supportedNFTs?: SupportedNFTs;
+  theme: Theme | "light" | "dark";
+  onBack: () => void;
+  client: ThirdwebClient;
+}) {
+  const activeAccount = useActiveAccount();
+  const activeChain = useActiveWalletChain();
+
+  if (!activeChain?.id || !activeAccount?.address) {
+    return null;
+  }
+
+  const nftList = useMemo(() => {
+    const nfts = [];
+    if (!props.supportedNFTs) return [];
+    for (const chainId in props.supportedNFTs) {
+      if (props.supportedNFTs[chainId]) {
+        nfts.push(
+          ...props.supportedNFTs[chainId].map((address) => ({
+            address,
+            chain: getCachedChain(Number.parseInt(chainId)),
+          })),
+        );
+      }
+    }
+    return nfts;
+  }, [props.supportedNFTs]);
+
+  const results = useQueries({
+    queries: nftList.map((nft) => ({
+      queryKey: ["readContract", nft.chain.id, nft.address],
+      queryFn: () =>
+        fetchNFTs(props.client, nft.chain, nft.address, activeAccount?.address),
+    })),
+  });
+
+  return (
+    <Container
+      style={{
+        minHeight: "300px",
+      }}
+    >
+      <Container p="lg">
+        <ModalHeader title="View NFTs" onBack={props.onBack} />
+      </Container>
+      <Line />
+      <Container
+        px="sm"
+        scrollY
+        style={{
+          maxHeight: "500px",
+        }}
+      >
+        <Spacer y="md" />
+        <Container
+          style={{
+            display: "grid",
+            gridTemplateColumns: "1fr 1fr",
+            gap: "12px",
+          }}
+        >
+          {results.map((result, index) => {
+            if (result.error) {
+              console.error(result.error);
+              return null;
+            }
+            return result.isLoading || !result.data ? (
+              <Skeleton
+                key={`${nftList[index]?.chain?.id}:${nftList[index]?.address}`}
+                height="160px"
+                width="160px"
+              />
+            ) : (
+              result.data.map((nft) => (
+                <NftCard
+                  key={`${nft.chain.id}:${nft.address}:${nft.id}`}
+                  {...nft}
+                  client={props.client}
+                  chain={nft.chain}
+                  theme={props.theme}
+                />
+              ))
+            );
+          })}
+        </Container>
+        <Spacer y="lg" />
+      </Container>
+    </Container>
+  );
+}
+
+function NftCard(
+  props: Awaited<ReturnType<typeof fetchNFTs>>[number] & {
+    client: ThirdwebClient;
+    chain: Chain;
+    theme: Theme | "light" | "dark";
+  },
+) {
+  const theme =
+    typeof props.theme === "string" ? props.theme : props.theme.type;
+  const themeObject = typeof props.theme === "string" ? undefined : props.theme;
+  const content = (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "4px",
+        alignItems: "center",
+      }}
+    >
+      <div
+        style={{
+          position: "relative",
+          display: "flex",
+          flexShrink: 0,
+          alignItems: "center",
+          width: "160px",
+          height: "160px",
+          borderRadius: "8px",
+          overflow: "hidden",
+          background:
+            theme === "light" ? "rgba(0, 0, 0, 0.10)" : "rgba(0, 0, 0, 0.20)",
+        }}
+      >
+        {props.metadata.image && (
+          <MediaRenderer
+            src={props.metadata.image}
+            style={{
+              width: "100%",
+              height: "100%",
+            }}
+            client={props.client}
+          />
+        )}
+        {props.quantityOwned > 1 && (
+          <div
+            style={{
+              position: "absolute",
+              bottom: "4px",
+              right: "4px",
+              background:
+                themeObject?.colors?.modalBg ??
+                (theme === "light" ? "white" : "black"),
+              fontSize: "10px",
+              padding: "4px 4px",
+              width: "20px",
+              height: "20px",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              borderRadius: "100%",
+            }}
+          >
+            {props.quantityOwned.toString()}
+          </div>
+        )}
+        {props.chain.icon && (
+          <img
+            alt={props.chain.name}
+            style={{
+              position: "absolute",
+              bottom: "4px",
+              left: "4px",
+              width: "20px",
+              height: "20px",
+            }}
+            src={props.chain.icon.url}
+          />
+        )}
+      </div>
+      <span style={{ fontWeight: 600 }}>{props.metadata.name}</span>
+    </div>
+  );
+
+  if (props.chain.name) {
+    return (
+      <a
+        href={`https://thirdweb.com/${props.chain.id}/${props.address}/nfts/${props.id}`}
+        target="_blank"
+        rel="noreferrer"
+      >
+        {content}
+      </a>
+    );
+  }
+
+  return content;
+}

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/ViewTokens.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/ViewTokens.tsx
@@ -1,0 +1,125 @@
+import type { Chain } from "../../../../../chains/types.js";
+import type { ThirdwebClient } from "../../../../../client/client.js";
+import { fontSize } from "../../../../core/design-system/index.js";
+import { useWalletBalance } from "../../../../core/hooks/others/useWalletBalance.js";
+import {
+  type SupportedTokens,
+  defaultTokens,
+} from "../../../../core/utils/defaultTokens.js";
+import { useActiveAccount } from "../../../hooks/wallets/useActiveAccount.js";
+import { useActiveWalletChain } from "../../../hooks/wallets/useActiveWalletChain.js";
+import { Skeleton } from "../../components/Skeleton.js";
+import { Spacer } from "../../components/Spacer.js";
+import { TokenIcon } from "../../components/TokenIcon.js";
+import { Container, Line, ModalHeader } from "../../components/basic.js";
+import { Text } from "../../components/text.js";
+import { formatTokenBalance } from "./formatTokenBalance.js";
+import {
+  type ERC20OrNativeToken,
+  NATIVE_TOKEN,
+  isNativeToken,
+} from "./nativeToken.js";
+
+/**
+ * @internal
+ */
+export function ViewTokens(props: {
+  supportedTokens?: SupportedTokens;
+  onBack: () => void;
+  client: ThirdwebClient;
+}) {
+  const activeChain = useActiveWalletChain();
+  const supportedTokens = props.supportedTokens || defaultTokens;
+
+  if (!activeChain) {
+    return null;
+  }
+
+  const tokenList =
+    (activeChain?.id ? supportedTokens[activeChain.id] : undefined) || [];
+
+  return (
+    <Container
+      style={{
+        minHeight: "300px",
+      }}
+    >
+      <Container p="lg">
+        <ModalHeader title="View Funds" onBack={props.onBack} />
+      </Container>
+      <Line />
+      <Container
+        px="sm"
+        scrollY
+        style={{
+          maxHeight: "500px",
+        }}
+      >
+        <Spacer y="md" />
+
+        <TokenInfo
+          token={NATIVE_TOKEN}
+          chain={activeChain}
+          client={props.client}
+        />
+
+        {tokenList.map((token) => {
+          return (
+            <TokenInfo
+              token={token}
+              key={token.address}
+              chain={activeChain}
+              client={props.client}
+            />
+          );
+        })}
+        <Spacer y="lg" />
+      </Container>
+    </Container>
+  );
+}
+
+function TokenInfo(props: {
+  token: ERC20OrNativeToken;
+  chain: Chain;
+  client: ThirdwebClient;
+}) {
+  const account = useActiveAccount();
+  const tokenBalanceQuery = useWalletBalance({
+    address: account?.address,
+    chain: props.chain,
+    tokenAddress: isNativeToken(props.token) ? undefined : props.token.address,
+    client: props.client,
+  });
+
+  const tokenName = isNativeToken(props.token)
+    ? tokenBalanceQuery.data?.name
+    : props.token.name;
+
+  return (
+    <Container flex="row" gap="sm" p="sm">
+      <TokenIcon
+        token={props.token}
+        chain={props.chain}
+        size="lg"
+        client={props.client}
+      />
+
+      <Container flex="column" gap="xxs">
+        {tokenName ? (
+          <Text size="sm" color="primaryText">
+            {tokenName}
+          </Text>
+        ) : (
+          <Skeleton height={fontSize.md} width="150px" />
+        )}
+
+        {tokenBalanceQuery.data ? (
+          <Text size="xs"> {formatTokenBalance(tokenBalanceQuery.data)}</Text>
+        ) : (
+          <Skeleton height={fontSize.xs} width="100px" />
+        )}
+      </Container>
+    </Container>
+  );
+}

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/types.ts
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/types.ts
@@ -68,6 +68,8 @@ export type WalletDetailsModalScreen =
   | "network-switcher"
   | "pending-tx"
   | "view-funds"
+  | "view-tokens"
+  | "view-nfts"
   | "private-key"
   | "manage-wallet"
   | "wallet-connect-receiver"


### PR DESCRIPTION
This PR introduces the ability to add NFTs to the connect modal in the thirdweb package. By using the `supportedNFTs` configuration, users can customize which NFTs are shown in the 'View Funds' section within the details modal. This update includes modifications to several TypeScript files to support the new functionality, adjustments in the UI components to handle NFT displays, and updates to hooks and utility functions to fetch and display owned NFTs.

---

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add support for NFTs in the connect modal and customize the NFTs shown in the "View Funds" screen.

### Detailed summary
- Added support for NFTs in the connect modal with `supportedNFTs`
- Customized NFTs shown in the "View Funds" screen
- Updated components and types related to NFTs
- Refactored token-related functionality to support NFTs

> The following files were skipped due to too many changes: `packages/thirdweb/src/react/web/ui/ConnectWallet/screens/ViewFunds.tsx`, `packages/thirdweb/src/react/web/ui/ConnectWallet/Details.tsx`, `packages/thirdweb/src/react/web/ui/ConnectWallet/screens/ViewNFTs.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->