### PR TITLE
fix(dashboard): update to use new THIRDWEB_API_HOST in dashboard ecosystem components

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/[slug]/(active)/hooks/use-ecosystem.ts
+++ b/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/[slug]/(active)/hooks/use-ecosystem.ts
@@ -1,5 +1,6 @@
 import { useLoggedInUser } from "@3rdweb-sdk/react/hooks/useLoggedInUser";
 import { useQuery } from "@tanstack/react-query";
+import { THIRDWEB_API_HOST } from "../../../../../../../../constants/urls";
 import { FetchError } from "../../../../../../../../utils/error";
 import type { Ecosystem } from "../../../types";
 
@@ -14,7 +15,7 @@ export function useEcosystem({
     queryKey: ["ecosystems", slug],
     queryFn: async () => {
       const res = await fetch(
-        `${process.env.NEXT_PUBLIC_THIRDWEB_API_HOST}/v1/ecosystem-wallet/${slug}`,
+        `${THIRDWEB_API_HOST}/v1/ecosystem-wallet/${slug}`,
         { credentials: "include" },
       );
 

--- a/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/create/hooks/use-create-ecosystem.ts
+++ b/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/create/hooks/use-create-ecosystem.ts
@@ -6,6 +6,7 @@ import {
   useQueryClient,
 } from "@tanstack/react-query";
 import { upload } from "thirdweb/storage";
+import { THIRDWEB_API_HOST } from "../../../../../../../constants/urls";
 
 export type CreateEcosystemParams = {
   name: string;
@@ -36,7 +37,7 @@ export function useCreateEcosystem(
       });
 
       const res = await fetch(
-        `${process.env.NEXT_PUBLIC_THIRDWEB_API_HOST}/v1/ecosystem-wallet/add-cloud-hosted`,
+        `${THIRDWEB_API_HOST}/v1/ecosystem-wallet/add-cloud-hosted`,
         {
           method: "POST",
           credentials: "include",

--- a/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/hooks/use-ecosystem-list.ts
+++ b/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/hooks/use-ecosystem-list.ts
@@ -1,5 +1,6 @@
 import { useLoggedInUser } from "@3rdweb-sdk/react/hooks/useLoggedInUser";
 import { useQuery } from "@tanstack/react-query";
+import { THIRDWEB_API_HOST } from "../../../../../../constants/urls";
 import type { Ecosystem } from "../types";
 
 export function useEcosystemList() {
@@ -8,10 +9,9 @@ export function useEcosystemList() {
   const ecosystemQuery = useQuery({
     queryKey: ["ecosystems", user?.address],
     queryFn: async () => {
-      const res = await fetch(
-        `${process.env.NEXT_PUBLIC_THIRDWEB_API_HOST}/v1/ecosystem-wallet/list`,
-        { credentials: "include" },
-      );
+      const res = await fetch(`${THIRDWEB_API_HOST}/v1/ecosystem-wallet/list`, {
+        credentials: "include",
+      });
 
       if (!res.ok) {
         const data = await res.json();

--- a/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/page.tsx
@@ -65,7 +65,7 @@ export default function Page() {
         )}
         <Button variant="outline" asChild>
           <Link
-            href="https://poral.thirdweb.com"
+            href="https://portal.thirdweb.com/connect/ecosystems/overview"
             target="_blank"
             className="flex flex-row gap-2"
           >
@@ -75,7 +75,10 @@ export default function Page() {
         </Button>
       </div>
       <div className="w-full h-0 my-2 border-t" />
-      <Link href="#" className="mb-6 group">
+      <Link
+        href="https://portal.thirdweb.com/connect/ecosystems/overview"
+        className="mb-6 group"
+      >
         <Card className="flex flex-col gap-3 p-6 md:p-8 md:px-10">
           <div className="flex items-center gap-2">
             <BookMarkedIcon className="size-5 text-secondary-foreground" />


### PR DESCRIPTION
### TL;DR

Replaced `process.env.NEXT_PUBLIC_THIRDWEB_API_HOST` with `THIRDWEB_API_HOST` constant for ecosystem wallet-related fetch calls.

### What changed?

1. Updated import statements to bring in the `THIRDWEB_API_HOST` constant.
2. Replaced instances of `${process.env.NEXT_PUBLIC_THIRDWEB_API_HOST}` with `${THIRDWEB_API_HOST}` in ecosystem wallet-related fetch calls.
3. Updated links in the main ecosystem page for better navigation.

### How to test?

1. Ensure all ecosystem wallet functionality (fetching list, creating, etc.) still works without errors.
2. Verify that the navigation links on the main ecosystem page point to the correct URLs.

### Why make this change?

To replace the use of environment variables with constants for better code maintainability and readability.

---

 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates API host references in multiple files to use a constant `THIRDWEB_API_HOST` instead of `process.env.NEXT_PUBLIC_THIRDWEB_API_HOST`.

### Detailed summary
- Updated API host references to use `THIRDWEB_API_HOST` constant
- Refactored URL paths for ecosystem-related endpoints

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->