### PR TITLE
[Fix] Update awaitTransaction and alignedTx nonce handling

### DIFF
--- a/.changeset/four-yaks-approve.md
+++ b/.changeset/four-yaks-approve.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+fix ethers5 adapter populateTransaction for sendTransaction

--- a/packages/thirdweb/src/adapters/ethers5.ts
+++ b/packages/thirdweb/src/adapters/ethers5.ts
@@ -339,7 +339,7 @@ export async function toEthersSigner(
       if (!account.sendTransaction) {
         throw new Error("Account does not support sendTransaction");
       }
-      const awaitedTx = await ethers.utils.resolveProperties(transaction);
+      const awaitedTx = await this.populateTransaction(transaction);
       const alignedTx = await alignTxFromEthers(awaitedTx, ethers);
       const tx = prepareTransaction({
         client: client,
@@ -364,7 +364,7 @@ export async function toEthersSigner(
         chainId: tx.chain.id,
         from: account.address,
         data: alignedTx.data ?? "0x",
-        nonce: alignedTx.nonce ?? -1,
+        nonce: alignedTx.nonce ?? 0,
         value: ethers.BigNumber.from(alignedTx.value ?? 0),
         gasLimit: ethers.BigNumber.from(alignedTx.gas ?? 0),
         // biome-ignore lint/style/noNonNullAssertion: TODO: fix later


### PR DESCRIPTION
FIXES: DASH-58

<!-- start pr-codex -->

---

## PR-Codex overview
This PR fixes an issue in the `ethers5` adapter's `populateTransaction` method for `sendTransaction`.

### Detailed summary
- Updated `populateTransaction` method to correctly handle transaction data
- Changed default nonce value from -1 to 0 for `toEthersSigner` function

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->