### PR TITLE
fix(dashboard): ecosystem images

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/[slug]/(active)/components/client/ecosystem-header.client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/[slug]/(active)/components/client/ecosystem-header.client.tsx
@@ -39,8 +39,10 @@ export function EcosystemHeader({ ecosystemSlug }: { ecosystemSlug: string }) {
                     uri: ecosystem.imageUrl,
                     client: thirdwebClient,
                   })}
+                  sizes="100px"
                   alt={ecosystem.name}
                   fill
+                  unoptimized
                   className="object-cover object-center"
                 />
               </div>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to add the `sizes`, `fill`, and `unoptimized` attributes to the image in `ecosystem-header.client.tsx`.

### Detailed summary
- Added `sizes="100px"` attribute to the image
- Added `fill` attribute
- Added `unoptimized` attribute

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->