### PR TITLE
fix(wallet): ensure disconnect events are emitted

### DIFF
--- a/.changeset/great-students-mate.md
+++ b/.changeset/great-students-mate.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix wallet disconnect events not being emitted

--- a/packages/thirdweb/src/wallets/coinbase/coinbaseWebSDK.ts
+++ b/packages/thirdweb/src/wallets/coinbase/coinbaseWebSDK.ts
@@ -373,7 +373,7 @@ function onConnect(
     await provider.disconnect();
   }
 
-  function onDisconnect() {
+  async function onDisconnect() {
     disconnect();
     emitter.emit("disconnect", undefined);
   }
@@ -401,7 +401,7 @@ function onConnect(
   return [
     account,
     chain,
-    disconnect,
+    onDisconnect,
     (newChain) => switchChainCoinbaseWalletSDK(provider, newChain),
   ];
 }

--- a/packages/thirdweb/src/wallets/injected/index.ts
+++ b/packages/thirdweb/src/wallets/injected/index.ts
@@ -228,7 +228,7 @@ async function onConnect(
     provider.removeListener("disconnect", onDisconnect);
   }
 
-  function onDisconnect() {
+  async function onDisconnect() {
     disconnect();
     emitter.emit("disconnect", undefined);
   }
@@ -258,7 +258,7 @@ async function onConnect(
   return [
     account,
     chain,
-    disconnect,
+    onDisconnect,
     (newChain) => switchChain(provider, newChain),
   ] as const;
 }


### PR DESCRIPTION
Introducing a patch in the `thirdweb` library to address wallet disconnect events. The main changes involve making the `onDisconnect` function asynchronous and ensuring that it correctly emits disconnect events. Affected files include `coinbaseWebSDK.ts` and `index.ts` in the `thirdweb/src/wallets` directory.

---

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing wallet disconnect events not being emitted in `thirdweb` package.

### Detailed summary
- Added `async` keyword to `onDisconnect` function in `injected/index.ts` and `coinbaseWebSDK.ts`
- Replaced `disconnect` with `onDisconnect` in `onConnect` functions in both files

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->