### PR TITLE
fix(sdk): enforce legacy transactions on Vanguard chain

### DIFF
--- a/.changeset/fresh-moons-cheat.md
+++ b/.changeset/fresh-moons-cheat.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Force legacy transactions on Vanguard chain

--- a/packages/thirdweb/src/gas/fee-data.ts
+++ b/packages/thirdweb/src/gas/fee-data.ts
@@ -26,6 +26,11 @@ type FeeDataParams =
       maxPriorityFeePerGas?: never;
     };
 
+// for these chains - always force pre eip1559 transactions
+const FORCE_GAS_PRICE_CHAIN_IDS = [
+  78600, // vanguard
+];
+
 /**
  *
  * @internal
@@ -98,12 +103,15 @@ export async function getDefaultGasOverrides(
   client: ThirdwebClient,
   chain: Chain,
 ) {
-  const feeData = await getDynamicFeeData(client, chain);
-  if (feeData.maxFeePerGas && feeData.maxPriorityFeePerGas) {
-    return {
-      maxFeePerGas: feeData.maxFeePerGas,
-      maxPriorityFeePerGas: feeData.maxPriorityFeePerGas,
-    };
+  // if chain is in the force gas price list, always use gas price
+  if (!FORCE_GAS_PRICE_CHAIN_IDS.includes(chain.id)) {
+    const feeData = await getDynamicFeeData(client, chain);
+    if (feeData.maxFeePerGas && feeData.maxPriorityFeePerGas) {
+      return {
+        maxFeePerGas: feeData.maxFeePerGas,
+        maxPriorityFeePerGas: feeData.maxPriorityFeePerGas,
+      };
+    }
   }
   return {
     gasPrice: await getGasPrice({ client, chain, percentMultiplier: 10 }),


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to force legacy transactions on the Vanguard chain.

### Detailed summary
- Added `FORCE_GAS_PRICE_CHAIN_IDS` array with Vanguard chain ID
- Implemented logic to always use legacy transactions for Vanguard chain

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->