### PR TITLE
Fix TransactionButton callbacks not called when sending tx from pay modal

### DIFF
--- a/.changeset/slimy-hotels-sniff.md
+++ b/.changeset/slimy-hotels-sniff.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix Transaction Button callbacks not called when tx is executed in Pay Modal

--- a/packages/thirdweb/src/react/core/hooks/transaction/useSendTransaction.ts
+++ b/packages/thirdweb/src/react/core/hooks/transaction/useSendTransaction.ts
@@ -70,9 +70,10 @@ export type SendTransactionConfig = {
 type ShowModalData = {
   tx: PreparedTransaction;
   sendTx: () => void;
-  rejectTx: () => void;
+  rejectTx: (reason: Error) => void;
   totalCostWei: bigint;
   walletBalance: GetWalletBalanceResult;
+  resolveTx: (data: WaitForReceiptOptions) => void;
 };
 
 /**
@@ -171,9 +172,8 @@ export function useSendTransactionCore(args: {
             showPayModal({
               tx,
               sendTx,
-              rejectTx: () => {
-                reject(new Error("Not enough balance"));
-              },
+              rejectTx: reject,
+              resolveTx: resolve,
               totalCostWei,
               walletBalance,
             });

--- a/packages/thirdweb/src/react/web/hooks/transaction/useSendTransaction.tsx
+++ b/packages/thirdweb/src/react/web/hooks/transaction/useSendTransaction.tsx
@@ -1,6 +1,7 @@
 import { CheckCircledIcon } from "@radix-ui/react-icons";
 import { useCallback, useContext, useEffect, useRef, useState } from "react";
 import type { ThirdwebClient } from "../../../../client/client.js";
+import type { WaitForReceiptOptions } from "../../../../transaction/actions/wait-for-tx-receipt.js";
 import type { PreparedTransaction } from "../../../../transaction/prepare-transaction.js";
 import type { Wallet } from "../../../../wallets/interfaces/wallet.js";
 import { CustomThemeProvider } from "../../../core/design-system/CustomThemeProvider.js";
@@ -80,8 +81,11 @@ export function useSendTransaction(config: SendTransactionConfig = {}) {
                 onComplete={data.sendTx}
                 onClose={() => {
                   setRootEl(null);
-                  data.rejectTx();
+                  data.rejectTx(
+                    new Error("User rejected transaction by closing modal"),
+                  );
                 }}
+                onTxSent={data.resolveTx}
                 client={data.tx.client}
                 localeId={payModal?.locale || "en_US"}
                 supportedTokens={payModal?.supportedTokens}
@@ -115,6 +119,7 @@ type ModalProps = {
   nativeTokenSymbol: string;
   tx: PreparedTransaction;
   payOptions: PayUIOptions;
+  onTxSent: (data: WaitForReceiptOptions) => void;
 };
 
 function TxModal(props: ModalProps) {
@@ -146,7 +151,13 @@ function ModalContent(props: ModalProps) {
   }
 
   if (screen === "execute-tx") {
-    return <ExecutingTxScreen tx={props.tx} closeModal={props.onClose} />;
+    return (
+      <ExecutingTxScreen
+        tx={props.tx}
+        closeModal={props.onClose}
+        onTxSent={props.onTxSent}
+      />
+    );
   }
 
   if (screen === "tx-history") {
@@ -194,6 +205,7 @@ function ModalContent(props: ModalProps) {
 function ExecutingTxScreen(props: {
   tx: PreparedTransaction;
   closeModal: () => void;
+  onTxSent: (data: WaitForReceiptOptions) => void;
 }) {
   const sendTxCore = useSendTransaction({
     payModal: false,
@@ -205,13 +217,16 @@ function ExecutingTxScreen(props: {
   const sendTx = useCallback(async () => {
     setStatus("loading");
     try {
-      await sendTxCore.mutateAsync(props.tx);
+      const txData = await sendTxCore.mutateAsync(props.tx);
+      props.onTxSent(txData);
       setStatus("sent");
     } catch (e) {
+      // Do not reject the transaction here, because the user may want to try again
+      // we only reject on modal close
       console.error(e);
       setStatus("failed");
     }
-  }, [sendTxCore, props.tx]);
+  }, [sendTxCore, props.tx, props.onTxSent]);
 
   const done = useRef(false);
   useEffect(() => {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to fix Transaction Button callbacks not being called when a transaction is executed in the Pay Modal.

### Detailed summary
- Added `rejectTx` callback with a reason parameter
- Added `resolveTx` callback with data parameter
- Updated `useSendTransactionCore` to pass `reject` and `resolve` to the Pay Modal
- Updated `useSendTransaction` to handle modal onClose and onTxSent events
- Added `onTxSent` callback to `TxModal` component
- Updated `ExecutingTxScreen` to handle onTxSent callback and error handling

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->