### PR TITLE
feature(ts): adds verifyTypedData and verifyHash

### DIFF
--- a/.changeset/eight-hounds-relate.md
+++ b/.changeset/eight-hounds-relate.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": minor
+---
+
+Adds verifyTypedData and verifyHash functions with full wallet interoperability

--- a/packages/thirdweb/src/auth/verify-hash.test.ts
+++ b/packages/thirdweb/src/auth/verify-hash.test.ts
@@ -1,0 +1,66 @@
+import { parseSignature } from "viem";
+import { describe, expect, test } from "vitest";
+import { FORKED_ETHEREUM_CHAIN } from "../../test/src/chains.js";
+import { TEST_CLIENT } from "../../test/src/test-clients.js";
+import { ANVIL_PKEY_A, TEST_ACCOUNT_A } from "../../test/src/test-wallets.js";
+import { toBytes } from "../utils/encoding/to-bytes.js";
+import { hashMessage } from "../utils/hashing/hashMessage.js";
+import { signMessage } from "../utils/signatures/sign-message.js";
+import { verifyHash } from "./verify-hash.js";
+
+describe("verifyHash", async () => {
+  describe("EOA", async () => {
+    test("hex", async () => {
+      const signature = signMessage({
+        message: "hello world",
+        privateKey: ANVIL_PKEY_A,
+      });
+
+      expect(
+        verifyHash({
+          address: TEST_ACCOUNT_A.address,
+          hash: hashMessage("hello world"),
+          signature,
+          client: TEST_CLIENT,
+          chain: FORKED_ETHEREUM_CHAIN,
+        }),
+      ).resolves.toBe(true);
+    });
+
+    test("bytes", async () => {
+      const signature = signMessage({
+        message: "hello world",
+        privateKey: ANVIL_PKEY_A,
+      });
+
+      expect(
+        verifyHash({
+          address: TEST_ACCOUNT_A.address,
+          hash: hashMessage("hello world"),
+          signature: toBytes(signature),
+          client: TEST_CLIENT,
+          chain: FORKED_ETHEREUM_CHAIN,
+        }),
+      ).resolves.toBe(true);
+    });
+
+    test("object", async () => {
+      const signature = signMessage({
+        message: "hello world",
+        privateKey: ANVIL_PKEY_A,
+      });
+
+      expect(
+        verifyHash({
+          address: TEST_ACCOUNT_A.address,
+          hash: hashMessage("hello world"),
+          signature: parseSignature(signature),
+          client: TEST_CLIENT,
+          chain: FORKED_ETHEREUM_CHAIN,
+        }),
+      ).resolves.toBe(true);
+    });
+  });
+});
+
+// TODO: Create utilities to mock smart accounts on anvil so we can test them here

--- a/packages/thirdweb/src/auth/verify-typed-data.test.ts
+++ b/packages/thirdweb/src/auth/verify-typed-data.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "vitest";
+import { TEST_CLIENT } from "../../test/src/test-clients.js";
+import { ANVIL_PKEY_A, TEST_ACCOUNT_A } from "../../test/src/test-wallets.js";
+import { typedData } from "../../test/src/typed-data.js";
+import { mainnet } from "../chains/chain-definitions/ethereum.js";
+import { signTypedData } from "../utils/signatures/sign-typed-data.js";
+import { verifyTypedData } from "./verify-typed-data.js";
+
+describe("verifyTypedData", async () => {
+  test("valid EOA signature", async () => {
+    const signature = signTypedData({
+      ...typedData.basic,
+      primaryType: "Mail",
+      privateKey: ANVIL_PKEY_A,
+    });
+
+    expect(
+      await verifyTypedData({
+        ...typedData.basic,
+        primaryType: "Mail",
+        address: TEST_ACCOUNT_A.address,
+        signature,
+        chain: mainnet,
+        client: TEST_CLIENT,
+      }),
+    ).toBe(true);
+  });
+
+  test("invalid EOA signature", async () => {
+    expect(
+      await verifyTypedData({
+        ...typedData.basic,
+        primaryType: "Mail",
+        address: TEST_ACCOUNT_A.address,
+        signature: "0xdead",
+        chain: mainnet,
+        client: TEST_CLIENT,
+      }),
+    ).toBe(false);
+  });
+
+  test("valid smart account signature", async () => {
+    expect(
+      await verifyTypedData({
+        ...typedData.basic,
+        primaryType: "Mail",
+        address: "0x3FCf42e10CC70Fe75A62EB3aDD6D305Aa840d145",
+        signature:
+          "0x79d756d805073dc97b7bc885b0d56ddf319a2599530fe1e178c2a7de5be88980068d24f20a79b318ea0a84d33ae06f93db77e4235e5d9eeb8b1d7a63922ada3e1c",
+        chain: mainnet,
+        client: TEST_CLIENT,
+      }),
+    ).toBe(true);
+  });
+
+  test("invalid smart account signature", async () => {
+    expect(
+      await verifyTypedData({
+        ...typedData.basic,
+        primaryType: "Mail",
+        address: "0x3FCf42e10CC70Fe75A62EB3aDD6D305Aa840d145",
+        signature: "0xdead",
+        chain: mainnet,
+        client: TEST_CLIENT,
+      }),
+    ).toBe(false);
+  });
+
+  test("non-existent account", async () => {
+    expect(
+      await verifyTypedData({
+        ...typedData.basic,
+        primaryType: "Mail",
+        address: "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+        signature:
+          "0x79d756d805073dc97b7bc885b0d56ddf319a2599530fe1e178c2a7de5be88980068d24f20a79b318ea0a84d33ae06f93db77e4235e5d9eeb8b1d7a63922ada3e1c",
+        chain: mainnet,
+        client: TEST_CLIENT,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/thirdweb/src/auth/verify-typed-data.ts
+++ b/packages/thirdweb/src/auth/verify-typed-data.ts
@@ -1,0 +1,110 @@
+import type { Signature, TypedData, TypedDataDefinition } from "viem";
+import { hashTypedData } from "viem";
+import type { Chain } from "../chains/types.js";
+import type { ThirdwebClient } from "../client/client.js";
+import type { Hex } from "../utils/encoding/hex.js";
+import type { HashTypedDataParams } from "../utils/hashing/hashTypedData.js";
+import { type VerifyHashParams, verifyHash } from "./verify-hash.js";
+
+export type VerifyTypedDataParams<
+  typedData extends TypedData | Record<string, unknown> = TypedData,
+  primaryType extends keyof typedData | "EIP712Domain" = keyof typedData,
+> = Omit<VerifyHashParams, "hash"> &
+  TypedDataDefinition<typedData, primaryType> & {
+    address: string;
+    signature: string | Uint8Array | Signature;
+    client: ThirdwebClient;
+    chain: Chain;
+    accountFactory?: {
+      address: string;
+      verificationCalldata: Hex;
+    };
+  };
+
+/**
+ * @description Verify am [EIP-712](https://eips.ethereum.org/EIPS/eip-712) typed data signature. This function is interoperable with all wallet types (smart accounts or EOAs).
+ *
+ * @param {string} options.address The address that signed the typed data
+ * @param {string | Uint8Array | Signature} options.signature The signature that was signed
+ * @param {ThirdwebClient} options.client The Thirdweb client
+ * @param {Chain} options.chain The chain that the address is on. For an EOA, this can be any chain.
+ * @param {string} [options.accountFactory.address] The address of the account factory that created the account if using a smart account with a custom account factory
+ * @param {Hex} [options.accountFactory.verificationCalldata] The calldata that was used to create the account if using a smart account with a custom account factory
+ * @param {typeof VerifyTypedDataParams.message} options.message The EIP-712 message that was signed.
+ * @param {typeof VerifyTypedDataParams.domain} options.domain The EIP-712 domain that was signed.
+ * @param {typeof VerifyTypedDataParams.primaryType} options.primaryType The EIP-712 primary type that was signed.
+ * @param {typeof VerifyTypedDataParams.types} options.types The EIP-712 types that were signed.
+ *
+ * @returns {Promise<boolean>} A promise that resolves to `true` if the signature is valid, or `false` otherwise.
+ * 
+ * @example
+ * ```ts
+ * import { verifyTypedData } from "thirdweb/utils";
+ * const isValid = await verifyTypedData({
+ *   address: "0x...",
+ *   signature: "0x...",
+ *   client,
+ *   chain,
+ *   domain: {
+      name: "Ether Mail",
+      version: "1",
+      chainId: 1,
+      verifyingContract: "0x0000000000000000000000000000000000000000",
+    },
+ *   primaryType: "Mail",
+ *   types: {
+      Person: [
+        { name: "name", type: "string" },
+        { name: "wallet", type: "address" },
+      ],
+      Mail: [
+        { name: "from", type: "Person" },
+        { name: "to", type: "Person" },
+        { name: "contents", type: "string" },
+      ],
+    },
+    message: {
+      from: {
+        name: "Cow",
+        wallet: "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826",
+      },
+      to: {
+        name: "Bob",
+        wallet: "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+      },
+      contents: "Hello, Bob!",
+    },
+ * });
+ * ```
+ *
+ * @auth
+ */
+export async function verifyTypedData<
+  typedData extends TypedData | Record<string, unknown>,
+  primaryType extends keyof typedData | "EIP712Domain",
+>({
+  address,
+  signature,
+  client,
+  chain,
+  accountFactory,
+  message,
+  domain,
+  primaryType,
+  types,
+}: VerifyTypedDataParams<typedData, primaryType>): Promise<boolean> {
+  const messageHash = hashTypedData({
+    message,
+    domain,
+    primaryType,
+    types,
+  } as HashTypedDataParams);
+  return verifyHash({
+    hash: messageHash,
+    signature,
+    address,
+    chain,
+    client,
+    accountFactory,
+  });
+}

--- a/packages/thirdweb/src/extensions/erc1271/checkContractWalletSignature.ts
+++ b/packages/thirdweb/src/extensions/erc1271/checkContractWalletSignature.ts
@@ -12,6 +12,7 @@ const MAGIC_VALUE = "0x1626ba7e";
 
 /**
  * Checks if a contract wallet signature is valid.
+ * @deprecated Use `verifySignature` instead
  * @param options - The options for the checkContractWalletSignature function.
  * @param options.contract - The contract to check the signature against.
  * @param options.message - The message to check the signature against.

--- a/packages/thirdweb/src/extensions/erc1271/checkContractWalletSignedTypedData.ts
+++ b/packages/thirdweb/src/extensions/erc1271/checkContractWalletSignedTypedData.ts
@@ -15,6 +15,7 @@ const MAGIC_VALUE = "0x1626ba7e";
 
 /**
  * Checks if a contract wallet signature is valid.
+ * @deprecated Use `verifyTypedData` instead
  * @param options - The options for the checkContractWalletSignature function.
  * @param options.contract - The contract to check the signature against.
  * @param options.message - The message to check the signature against.

--- a/packages/thirdweb/src/utils/hashing/hashTypedData.test.ts
+++ b/packages/thirdweb/src/utils/hashing/hashTypedData.test.ts
@@ -1,0 +1,207 @@
+import { expect, test } from "vitest";
+
+import { pad } from "viem";
+import { typedData } from "../../../test/src/typed-data.js";
+import { toHex } from "../encoding/hex.js";
+import { hashTypedData } from "./hashTypedData.js";
+
+test("default", () => {
+  expect(
+    hashTypedData({
+      ...typedData.basic,
+      primaryType: "Mail",
+    }),
+  ).toMatchInlineSnapshot(
+    '"0x448f54762ef8ecccdc4d19bb7d467161383cd4b271617a8cee05c790eb745d74"',
+  );
+});
+
+test("complex", () => {
+  expect(
+    hashTypedData({
+      ...typedData.complex,
+      primaryType: "Mail",
+    }),
+  ).toMatchInlineSnapshot(
+    '"0x9a74cb859ad30835ffb2da406423233c212cf6dd78e6c2c98b0c9289568954ae"',
+  );
+});
+
+test("no domain", () => {
+  expect(
+    hashTypedData({
+      ...typedData.complex,
+      domain: undefined,
+      primaryType: "Mail",
+    }),
+  ).toMatchInlineSnapshot(
+    '"0x14ed1dbbfecbe5de3919f7ea47daafdf3a29dfbb60dd88d85509f79773d503a5"',
+  );
+  expect(
+    hashTypedData({
+      ...typedData.complex,
+      domain: {},
+      primaryType: "Mail",
+    }),
+  ).toMatchInlineSnapshot(
+    '"0x14ed1dbbfecbe5de3919f7ea47daafdf3a29dfbb60dd88d85509f79773d503a5"',
+  );
+});
+
+test("domain: empty name", () => {
+  expect(
+    hashTypedData({
+      ...typedData.complex,
+      domain: { name: "" },
+      primaryType: "Mail",
+    }),
+  ).toMatchInlineSnapshot(
+    '"0xc3f4f9ebd774352940f60aebbc83fcee20d0b17eb42bd1b20c91a748001ecb53"',
+  );
+});
+
+test("minimal valid typed message", () => {
+  const hash = hashTypedData({
+    types: {
+      EIP712Domain: [],
+    },
+    primaryType: "EIP712Domain",
+    domain: {},
+  });
+
+  expect(hash).toMatchInlineSnapshot(
+    '"0x8d4a3f4082945b7879e2b55f181c31a77c8c0a464b70669458abbaaf99de4c38"',
+  );
+});
+
+test("typed message with a domain separator that uses all fields.", () => {
+  const hash = hashTypedData({
+    types: {
+      EIP712Domain: [
+        {
+          name: "name",
+          type: "string",
+        },
+        {
+          name: "version",
+          type: "string",
+        },
+        {
+          name: "chainId",
+          type: "uint256",
+        },
+        {
+          name: "verifyingContract",
+          type: "address",
+        },
+        {
+          name: "salt",
+          type: "bytes32",
+        },
+      ],
+    },
+    primaryType: "EIP712Domain",
+    domain: {
+      name: "example.metamask.io",
+      version: "1",
+      chainId: 1n,
+      verifyingContract: "0x0000000000000000000000000000000000000000",
+      salt: pad(toHex(new Uint8Array([1, 2, 3])), { dir: "right" }),
+    },
+  });
+
+  expect(hash).toMatchInlineSnapshot(
+    '"0x54ffed5209a17ac210ef3823740b3852ee9cd518b84ee39f0a3fa7f2f9b4205b"',
+  );
+});
+
+test("typed message with only custom domain separator fields", () => {
+  const hash = hashTypedData({
+    types: {
+      EIP712Domain: [
+        {
+          name: "customName",
+          type: "string",
+        },
+        {
+          name: "customVersion",
+          type: "string",
+        },
+        {
+          name: "customChainId",
+          type: "uint256",
+        },
+        {
+          name: "customVerifyingContract",
+          type: "address",
+        },
+        {
+          name: "customSalt",
+          type: "bytes32",
+        },
+        {
+          name: "extraField",
+          type: "string",
+        },
+      ],
+    },
+    primaryType: "EIP712Domain",
+    domain: {
+      customName: "example.metamask.io",
+      customVersion: "1",
+      customChainId: 1n,
+      customVerifyingContract: "0x0000000000000000000000000000000000000000",
+      customSalt: pad(toHex(new Uint8Array([1, 2, 3])), { dir: "right" }),
+      extraField: "stuff",
+    },
+  });
+
+  expect(hash).toMatchInlineSnapshot(
+    '"0x3efa3ef0305f56ba5bba62000500e29fe82c5314bca2f958c64e31b2498560f8"',
+  );
+});
+
+test("typed message with data", () => {
+  const hash = hashTypedData({
+    types: {
+      EIP712Domain: [
+        {
+          name: "name",
+          type: "string",
+        },
+        {
+          name: "version",
+          type: "string",
+        },
+        {
+          name: "chainId",
+          type: "uint256",
+        },
+        {
+          name: "verifyingContract",
+          type: "address",
+        },
+        {
+          name: "salt",
+          type: "bytes32",
+        },
+      ],
+      Message: [{ name: "data", type: "string" }],
+    },
+    primaryType: "Message",
+    domain: {
+      name: "example.metamask.io",
+      version: "1",
+      chainId: 1n,
+      verifyingContract: "0x0000000000000000000000000000000000000000",
+      salt: pad(toHex(new Uint8Array([1, 2, 3])), { dir: "right" }),
+    },
+    message: {
+      data: "Hello!",
+    },
+  });
+
+  expect(hash).toMatchInlineSnapshot(
+    '"0xd2669f23b7849020ad41bcbff5b51372793f91320e0f901641945568ed7322be"',
+  );
+});

--- a/packages/thirdweb/src/utils/hashing/hashTypedData.ts
+++ b/packages/thirdweb/src/utils/hashing/hashTypedData.ts
@@ -1,0 +1,210 @@
+import {
+  type AbiParameter,
+  type TypedData,
+  type TypedDataDefinition,
+  concat,
+  getTypesForEIP712Domain,
+  hashDomain,
+  validateTypedData,
+} from "viem";
+import { encodeAbiParameters } from "../abi/encodeAbiParameters.js";
+import { type Hex, toHex } from "../encoding/hex.js";
+import { keccak256 } from "./keccak256.js";
+
+type MessageTypeProperty = {
+  name: string;
+  type: string;
+};
+
+export type HashTypedDataParams<
+  typedData extends TypedData | Record<string, unknown> = TypedData,
+  primaryType extends keyof typedData | "EIP712Domain" = keyof typedData,
+> = TypedDataDefinition<typedData, primaryType>;
+
+/**
+ * @internal
+ */
+export function hashTypedData<
+  const typedData extends TypedData | Record<string, unknown>,
+  primaryType extends keyof typedData | "EIP712Domain",
+>(parameters: HashTypedDataParams<typedData, primaryType>): Hex {
+  const {
+    domain = {},
+    message,
+    primaryType,
+  } = parameters as HashTypedDataParams;
+  const types = {
+    EIP712Domain: getTypesForEIP712Domain({ domain }),
+    ...parameters.types,
+  };
+
+  // Need to do a runtime validation check on addresses, byte ranges, integer ranges, etc
+  // as we can't statically check this with TypeScript.
+  validateTypedData({
+    domain,
+    message,
+    primaryType,
+    types,
+  });
+
+  const parts: Hex[] = ["0x1901"];
+  if (domain)
+    parts.push(
+      hashDomain({
+        domain,
+        types: types as Record<string, MessageTypeProperty[]>,
+      }),
+    );
+
+  if (primaryType !== "EIP712Domain") {
+    const hashedStruct = (() => {
+      const encoded = encodeData({
+        data: message,
+        primaryType,
+        types: types as Record<string, MessageTypeProperty[]>,
+      });
+      return keccak256(encoded);
+    })();
+
+    parts.push(hashedStruct);
+  }
+
+  return keccak256(concat(parts));
+}
+
+function encodeData({
+  data,
+  primaryType,
+  types,
+}: {
+  data: Record<string, unknown>;
+  primaryType: string;
+  types: Record<string, MessageTypeProperty[]>;
+}) {
+  const encodedTypes: AbiParameter[] = [{ type: "bytes32" }];
+  const encodedValues: unknown[] = [hashType({ primaryType, types })];
+
+  if (!types[primaryType]) throw new Error("Invalid types");
+  for (const field of types[primaryType]) {
+    const [type, value] = encodeField({
+      types,
+      name: field.name,
+      type: field.type,
+      value: data[field.name],
+    });
+    encodedTypes.push(type);
+    encodedValues.push(value);
+  }
+
+  return encodeAbiParameters(encodedTypes, encodedValues);
+}
+
+function hashType({
+  primaryType,
+  types,
+}: {
+  primaryType: string;
+  types: Record<string, MessageTypeProperty[]>;
+}) {
+  const encodedHashType = toHex(encodeType({ primaryType, types }));
+  return keccak256(encodedHashType);
+}
+
+export function encodeType({
+  primaryType,
+  types,
+}: {
+  primaryType: string;
+  types: Record<string, MessageTypeProperty[]>;
+}) {
+  let result = "";
+  const unsortedDeps = findTypeDependencies({ primaryType, types });
+  unsortedDeps.delete(primaryType);
+
+  const deps = [primaryType, ...Array.from(unsortedDeps).sort()];
+  for (const type of deps) {
+    if (!types[type]) throw new Error("Invalid types");
+    result += `${type}(${types[type]
+      .map(({ name, type: t }) => `${t} ${name}`)
+      .join(",")})`;
+  }
+
+  return result;
+}
+
+function findTypeDependencies(
+  {
+    primaryType: primaryType_,
+    types,
+  }: {
+    primaryType: string;
+    types: Record<string, MessageTypeProperty[]>;
+  },
+  results: Set<string> = new Set(),
+): Set<string> {
+  const match = primaryType_.match(/^\w*/u);
+  const primaryType = match?.[0] as string;
+  if (results.has(primaryType) || types[primaryType] === undefined) {
+    return results;
+  }
+
+  results.add(primaryType);
+
+  for (const field of types[primaryType]) {
+    findTypeDependencies({ primaryType: field.type, types }, results);
+  }
+  return results;
+}
+
+function encodeField({
+  types,
+  name,
+  type,
+  value,
+}: {
+  types: Record<string, MessageTypeProperty[]>;
+  name: string;
+  type: string;
+  // biome-ignore lint/suspicious/noExplicitAny: Can't anticipate types of nested values
+  value: any;
+  // biome-ignore lint/suspicious/noExplicitAny: Can't anticipate types of nested values
+}): [type: AbiParameter, value: any] {
+  if (types[type] !== undefined) {
+    return [
+      { type: "bytes32" },
+      keccak256(encodeData({ data: value, primaryType: type, types })),
+    ];
+  }
+
+  if (type === "bytes") {
+    const prepend = value.length % 2 ? "0" : "";
+    value = `0x${prepend + value.slice(2)}`;
+    return [{ type: "bytes32" }, keccak256(value)];
+  }
+
+  if (type === "string") return [{ type: "bytes32" }, keccak256(toHex(value))];
+
+  if (type.lastIndexOf("]") === type.length - 1) {
+    const parsedType = type.slice(0, type.lastIndexOf("["));
+    // biome-ignore lint/suspicious/noExplicitAny: Can't anticipate types of nested values
+    const typeValuePairs = (value as [AbiParameter, any][]).map((item) =>
+      encodeField({
+        name,
+        type: parsedType,
+        types,
+        value: item,
+      }),
+    );
+    return [
+      { type: "bytes32" },
+      keccak256(
+        encodeAbiParameters(
+          typeValuePairs.map(([t]) => t),
+          typeValuePairs.map(([, v]) => v),
+        ),
+      ),
+    ];
+  }
+
+  return [{ type }, value];
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces new functions `verifyTypedData` and `verifyHash` for verifying signatures with full wallet interoperability. 

### Detailed summary
- Added `verifyTypedData` and `verifyHash` functions
- Deprecated `checkContractWalletSignature` in favor of `verifySignature`
- Updated tests for `verifyHash` and `verifyTypedData`
- Refactored `verifySignature` to use `verifyHash`

> The following files were skipped due to too many changes: `packages/thirdweb/src/auth/verify-typed-data.ts`, `packages/thirdweb/src/utils/hashing/hashTypedData.test.ts`, `packages/thirdweb/src/auth/verify-hash.ts`, `packages/thirdweb/src/utils/hashing/hashTypedData.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->