### PR TITLE
feat(chain): add Blast chain definition and export

### DIFF
--- a/.changeset/few-mangos-warn.md
+++ b/.changeset/few-mangos-warn.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": minor
+---
+
+Adds blast preset

--- a/packages/thirdweb/src/chains/chain-definitions/blast.ts
+++ b/packages/thirdweb/src/chains/chain-definitions/blast.ts
@@ -1,0 +1,14 @@
+import { defineChain } from "../utils.js";
+
+export const blast = /* @__PURE__ */ defineChain({
+  id: 81457,
+  name: "Blast",
+  nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
+  blockExplorers: [
+    {
+      name: "Blastscan",
+      url: "https://blastscan.io",
+      apiUrl: "https://api.blastscan.io/api",
+    },
+  ],
+});

--- a/packages/thirdweb/src/exports/chains.ts
+++ b/packages/thirdweb/src/exports/chains.ts
@@ -21,6 +21,7 @@ export { baseSepolia } from "../chains/chain-definitions/base-sepolia.js";
 export { base } from "../chains/chain-definitions/base.js";
 // mainnet = alias for ethereum
 export { ethereum, mainnet } from "../chains/chain-definitions/ethereum.js";
+export { blast } from "../chains/chain-definitions/blast.js";
 export { optimismSepolia } from "../chains/chain-definitions/optimism-sepolia.js";
 export { optimism } from "../chains/chain-definitions/optimism.js";
 export { lineaSepolia } from "../chains/chain-definitions/linea-sepolia.js";


### PR DESCRIPTION
### TL;DR

Added a new chain definition for the 'Blast' chain.

### What changed?

- Added a new file `blast.ts` in `chain-definitions`
- Defined the Blast chain with ID 81457, name 'Blast', and native currency 'Ether'.
- Added Blastscan as the block explorer with corresponding URL and API URL.
- Updated `chains.ts` to export the `blast` chain.

### How to test?

1. Verify that the `blast.ts` file exists in the `chain-definitions` directory.
2. Check that the chain ID, name, and native currency are correctly defined.
3. Ensure the block explorer details are accurate.
4. Confirm that `chains.ts` exports the `blast` chain.

### Why make this change?

This change adds support for the Blast chain, which may be required for upcoming features or integrations. Including it ensures that the system can recognize and interact with the Blast blockchain.

---

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add the `Blast` chain definition and preset.

### Detailed summary
- Added `blast` chain definition with native currency and block explorers
- Exported `blast` in `chains.ts` for easy access

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->