### PR TITLE
fix(dashboard): update partner ID description in ecosystem partners section

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/[slug]/(active)/components/server/ecosystem-partners-section.tsx
+++ b/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/[slug]/(active)/components/server/ecosystem-partners-section.tsx
@@ -13,7 +13,8 @@ export function EcosystemPartnersSection({
         </h4>
         <p className="text-sm text-muted-foreground">
           Configure apps that can use your wallet. Creating a partner will
-          generate a unique partner ID that can access your ecosystem.
+          generate a unique partner ID that can access your ecosystem. You will
+          need to generate at least one partner ID for use in your own app.
         </p>
       </div>
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update the text in the `EcosystemPartnersSection` component to provide clearer instructions on generating partner IDs.

### Detailed summary
- Added a sentence instructing the user to generate at least one partner ID for use in their own app.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->