### PR TITLE
[Feature] Add CustomPayEmbed component to pay page for chain integration

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/pay/components/pay-embed.client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/pay/components/pay-embed.client.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { thirdwebClient } from "@/constants/client";
+import { useTheme } from "next-themes";
+import { useMemo } from "react";
+import { defineChain } from "thirdweb";
+import { PayEmbed } from "thirdweb/react";
+
+export function CustomPayEmbed(props: { chainId: number }) {
+  const { resolvedTheme } = useTheme();
+  const theme = resolvedTheme === "dark" ? "dark" : "light";
+  const chain = useMemo(() => defineChain(props.chainId), [props.chainId]);
+  return (
+    <PayEmbed
+      client={thirdwebClient}
+      connectOptions={{ chain }}
+      theme={theme}
+      payOptions={{
+        prefillBuy: {
+          chain,
+          allowEdits: { chain: false, amount: true, token: true },
+        },
+      }}
+    />
+  );
+}

--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/pay/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/pay/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import { getChain } from "../../utils";
 import { InfoCard } from "../components/server/info-card";
+import { CustomPayEmbed } from "./components/pay-embed.client";
 
 export default async function Page(props: { params: { chain_id: string } }) {
   const chain = await getChain(props.params.chain_id);
@@ -11,7 +12,8 @@ export default async function Page(props: { params: { chain_id: string } }) {
   }
 
   return (
-    <div className="pb-20">
+    <div className="pb-20 flex flex-col xl:flex-row gap-8">
+      <CustomPayEmbed chainId={chain.chainId} />
       <InfoCard
         title="thirdweb Pay"
         links={[


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to add a custom payment embed feature for a specific chain in the dashboard.

### Detailed summary
- Added `CustomPayEmbed` component in `pay-embed.client.tsx`
- Utilized `thirdwebClient` and `defineChain` for payment integration
- Implemented theme selection based on user preference
- Configured payment options for the specified chain

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->