### PR TITLE
MediaRenderer: only render video poster if it's an image

### DIFF
--- a/.changeset/angry-fireants-boil.md
+++ b/.changeset/angry-fireants-boil.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+MediaRenderer: only render video poster if it's an image

--- a/packages/thirdweb/src/react/web/ui/MediaRenderer/MediaRenderer.tsx
+++ b/packages/thirdweb/src/react/web/ui/MediaRenderer/MediaRenderer.tsx
@@ -139,7 +139,11 @@ export const MediaRenderer = /* @__PURE__ */ (() =>
               style={mergedStyle}
               src={mediaInfo.url}
               ref={ref as unknown as React.ForwardedRef<HTMLVideoElement>}
-              poster={possiblePosterSrc.url}
+              poster={
+                possiblePosterSrc.mimeType?.startsWith("image/")
+                  ? possiblePosterSrc.url
+                  : undefined
+              }
               requireInteraction={requireInteraction}
               className={className}
               controls={controls}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to only render the video poster in the `MediaRenderer` component if it's an image.

### Detailed summary
- Updated `MediaRenderer.tsx` to conditionally render video poster based on MIME type
- Changed poster prop logic to check if MIME type starts with "image/" before rendering

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->