### PR TITLE
[Feature] Add /support path to the list of logged in only paths

### DIFF
--- a/apps/dashboard/src/@/constants/auth.ts
+++ b/apps/dashboard/src/@/constants/auth.ts
@@ -3,5 +3,6 @@ export const LOGGED_IN_ONLY_PATHS = [
   "/dashboard",
   // anything that _starts_ with /cli is logged in only
   "/cli",
+  "/support",
   // TODO: add any other logged in only paths here
 ];


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds the `/support` path to the list of logged-in only paths in the `auth.ts` file.

### Detailed summary
- Added `/support` to the list of logged-in only paths in `auth.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->