### PR TITLE
Ensure account address is checksum encoded

### DIFF
--- a/.changeset/gorgeous-students-tap.md
+++ b/.changeset/gorgeous-students-tap.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Ensure all wallet's account address is checksum encoded

--- a/packages/thirdweb/src/wallets/coinbase/coinbaseWebSDK.ts
+++ b/packages/thirdweb/src/wallets/coinbase/coinbaseWebSDK.ts
@@ -277,7 +277,8 @@ export async function coinbaseSDKWalletGetCallsStatus(args: {
   }) as Promise<GetCallsStatusResponse>;
 }
 
-function createAccount(provider: ProviderInterface, address: string) {
+function createAccount(provider: ProviderInterface, _address: string) {
+  const address = getAddress(_address);
   const account: Account = {
     address,
     async sendTransaction(tx: SendTransactionOption) {

--- a/packages/thirdweb/src/wallets/in-app/web/lib/in-app-account.ts
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/in-app-account.ts
@@ -4,6 +4,7 @@ import { getCachedChain } from "../../../../chains/utils.js";
 import type { ThirdwebClient } from "../../../../client/client.js";
 import { eth_sendRawTransaction } from "../../../../rpc/actions/eth_sendRawTransaction.js";
 import { getRpcClient } from "../../../../rpc/rpc.js";
+import { getAddress } from "../../../../utils/address.js";
 import { type Hex, hexToString } from "../../../../utils/encoding/hex.js";
 import { parseTypedData } from "../../../../utils/signatures/helpers/parseTypedData.js";
 import type { Prettify } from "../../../../utils/type-utils.js";
@@ -247,7 +248,7 @@ export class IFrameWallet {
       return signedTransaction as Hex;
     };
     return {
-      address,
+      address: getAddress(address),
       async signTransaction(tx) {
         if (!tx.chainId) {
           throw new Error("chainId required in tx to sign");

--- a/packages/thirdweb/src/wallets/injected/index.ts
+++ b/packages/thirdweb/src/wallets/injected/index.ts
@@ -124,9 +124,9 @@ export async function autoConnectInjectedWallet(
   return onConnect(provider, address, connectedChain, emitter);
 }
 
-function createAccount(provider: Ethereum, address: string) {
+function createAccount(provider: Ethereum, _address: string) {
   const account: Account = {
-    address,
+    address: getAddress(_address),
     async sendTransaction(tx: SendTransactionOption) {
       const transactionHash = (await provider.request({
         method: "eth_sendTransaction",

--- a/packages/thirdweb/src/wallets/smart/index.ts
+++ b/packages/thirdweb/src/wallets/smart/index.ts
@@ -14,6 +14,7 @@ import {
   signEip712Transaction,
 } from "../../transaction/actions/zksync/send-eip712-transaction.js";
 import type { PreparedTransaction } from "../../transaction/prepare-transaction.js";
+import { getAddress } from "../../utils/address.js";
 import { parseTypedData } from "../../utils/signatures/helpers/parseTypedData.js";
 import type {
   Account,
@@ -166,7 +167,7 @@ async function createSmartAccount(
 ): Promise<Account> {
   const { accountContract } = options;
   const account: Account = {
-    address: accountContract.address,
+    address: getAddress(accountContract.address),
     async sendTransaction(transaction: SendTransactionOption) {
       const executeTx = prepareExecute({
         accountContract,

--- a/packages/thirdweb/src/wallets/wallet-connect/controller.ts
+++ b/packages/thirdweb/src/wallets/wallet-connect/controller.ts
@@ -297,9 +297,10 @@ async function initProvider(
   return provider;
 }
 
-function createAccount(provider: WCProvider, address: string) {
+function createAccount(provider: WCProvider, _address: string) {
+  const address = getAddress(_address);
   const account: Account = {
-    address,
+    address: address,
     async sendTransaction(tx: SendTransactionOption) {
       const transactionHash = (await provider.request({
         method: "eth_sendTransaction",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on ensuring all wallet account addresses are checksum encoded. 

### Detailed summary
- Modified `createAccount` functions to encode addresses
- Added `getAddress` import in various files for address encoding

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->