### PR TITLE
fix(thirdweb): resolve autoconnect issue for phone number sign-in on React Native

### DIFF
--- a/.changeset/clean-doors-tell.md
+++ b/.changeset/clean-doors-tell.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix autoconnect for phone number sign in on RN

--- a/packages/thirdweb/src/wallets/in-app/native/helpers/auth/middleware.ts
+++ b/packages/thirdweb/src/wallets/in-app/native/helpers/auth/middleware.ts
@@ -42,7 +42,9 @@ export async function postAuth({
     email:
       "email" in storedToken.authDetails
         ? storedToken.authDetails.email
-        : undefined, // TODO (rn) store phone number too?
+        : "phoneNumber" in storedToken.authDetails
+          ? storedToken.authDetails.phoneNumber
+          : undefined,
   });
 
   if (storedToken.isNewUser) {
@@ -100,7 +102,9 @@ export async function postAuthUserManaged(
     email:
       "email" in storedToken.authDetails
         ? storedToken.authDetails.email
-        : undefined, // TODO (rn) store phone number too?
+        : "phoneNumber" in storedToken.authDetails
+          ? storedToken.authDetails.phoneNumber
+          : undefined,
   });
 
   if (storedToken.isNewUser) {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on fixing autoconnect for phone number sign-in on React Native.

### Detailed summary
- Added logic to handle phone number sign-in in `middleware.ts`
- Updated the `postAuthUserManaged` function to include phone number handling

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->