### PR TITLE
feat(pay): add async ERC20 value property to transaction options

### DIFF
--- a/.changeset/moody-hairs-laugh.md
+++ b/.changeset/moody-hairs-laugh.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Handle ERC20 transaction value in Pay components

--- a/apps/playground-web/src/components/pay/transaction-button.tsx
+++ b/apps/playground-web/src/components/pay/transaction-button.tsx
@@ -2,15 +2,22 @@
 
 import { useTheme } from "next-themes";
 import { getContract } from "thirdweb";
-import { polygon } from "thirdweb/chains";
+import { base, polygon } from "thirdweb/chains";
+import { transfer } from "thirdweb/extensions/erc20";
 import { claimTo } from "thirdweb/extensions/erc1155";
 import { TransactionButton, useActiveAccount } from "thirdweb/react";
 import { THIRDWEB_CLIENT } from "../../lib/client";
 import { StyledConnectButton } from "../styled-connect-button";
 
-const contract = getContract({
+const nftContract = getContract({
   address: "0x96B30d36f783c7BC68535De23147e2ce65788e93",
   chain: polygon,
+  client: THIRDWEB_CLIENT,
+});
+
+const usdcContract = getContract({
+  address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+  chain: base,
   client: THIRDWEB_CLIENT,
 });
 
@@ -18,24 +25,43 @@ export function PayTransactionButtonPreview() {
   const account = useActiveAccount();
   const { theme } = useTheme();
 
-  return account ? (
-    <TransactionButton
-      transaction={() => {
-        if (!account) throw new Error("No active account");
-        return claimTo({
-          contract,
-          quantity: 1n,
-          tokenId: 0n,
-          to: account?.address,
-        });
-      }}
-      payModal={{
-        theme: theme === "light" ? "light" : "dark",
-      }}
-    >
-      Buy for 10 MATIC
-    </TransactionButton>
-  ) : (
-    <StyledConnectButton />
+  return (
+    <>
+      <StyledConnectButton />
+      <div className="h-10" />
+      <TransactionButton
+        transaction={() => {
+          if (!account) throw new Error("No active account");
+          return transfer({
+            contract: usdcContract,
+            amount: "15",
+            to: account?.address,
+          });
+        }}
+        payModal={{
+          theme: theme === "light" ? "light" : "dark",
+        }}
+      >
+        Pay 15 USDC
+      </TransactionButton>
+      <div className="h-10" />
+
+      <TransactionButton
+        transaction={() => {
+          if (!account) throw new Error("No active account");
+          return claimTo({
+            contract: nftContract,
+            quantity: 1n,
+            tokenId: 0n,
+            to: account?.address,
+          });
+        }}
+        payModal={{
+          theme: theme === "light" ? "light" : "dark",
+        }}
+      >
+        Buy NFT for 10 MATIC
+      </TransactionButton>
+    </>
   );
 }

--- a/packages/thirdweb/scripts/generate/generate.ts
+++ b/packages/thirdweb/scripts/generate/generate.ts
@@ -279,6 +279,7 @@ export function ${f.name}(
       maxPriorityFeePerGas: async () => (await asyncOptions()).overrides?.maxPriorityFeePerGas,
       nonce: async () => (await asyncOptions()).overrides?.nonce,
       extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+      erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
       `
         : ""
     }

--- a/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/airdropERC1155.ts
+++ b/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/airdropERC1155.ts
@@ -178,5 +178,6 @@ export function airdropERC1155(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/airdropERC1155WithSignature.ts
+++ b/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/airdropERC1155WithSignature.ts
@@ -211,5 +211,6 @@ export function airdropERC1155WithSignature(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/airdropERC20.ts
+++ b/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/airdropERC20.ts
@@ -170,5 +170,6 @@ export function airdropERC20(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/airdropERC20WithSignature.ts
+++ b/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/airdropERC20WithSignature.ts
@@ -205,5 +205,6 @@ export function airdropERC20WithSignature(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/airdropERC721.ts
+++ b/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/airdropERC721.ts
@@ -172,5 +172,6 @@ export function airdropERC721(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/airdropERC721WithSignature.ts
+++ b/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/airdropERC721WithSignature.ts
@@ -205,5 +205,6 @@ export function airdropERC721WithSignature(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/airdropNativeToken.ts
+++ b/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/airdropNativeToken.ts
@@ -158,5 +158,6 @@ export function airdropNativeToken(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/claimERC1155.ts
+++ b/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/claimERC1155.ts
@@ -202,5 +202,6 @@ export function claimERC1155(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/claimERC20.ts
+++ b/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/claimERC20.ts
@@ -187,5 +187,6 @@ export function claimERC20(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/claimERC721.ts
+++ b/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/claimERC721.ts
@@ -187,5 +187,6 @@ export function claimERC721(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/initialize.ts
+++ b/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/initialize.ts
@@ -138,5 +138,6 @@ export function initialize(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/setMerkleRoot.ts
+++ b/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/setMerkleRoot.ts
@@ -174,5 +174,6 @@ export function setMerkleRoot(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/setOwner.ts
+++ b/packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/setOwner.ts
@@ -136,5 +136,6 @@ export function setOwner(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/common/__generated__/IClaimConditionsSinglePhase/write/setClaimConditions.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IClaimConditionsSinglePhase/write/setClaimConditions.ts
@@ -201,5 +201,6 @@ export function setClaimConditions(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/common/__generated__/IContractMetadata/write/setContractURI.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IContractMetadata/write/setContractURI.ts
@@ -135,5 +135,6 @@ export function setContractURI(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/common/__generated__/IMulticall/write/multicall.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IMulticall/write/multicall.ts
@@ -138,5 +138,6 @@ export function multicall(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/common/__generated__/IOwnable/write/setOwner.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IOwnable/write/setOwner.ts
@@ -131,5 +131,6 @@ export function setOwner(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/common/__generated__/IPlatformFee/write/setPlatformFeeInfo.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IPlatformFee/write/setPlatformFeeInfo.ts
@@ -157,5 +157,6 @@ export function setPlatformFeeInfo(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/common/__generated__/IPrimarySale/write/setPrimarySaleRecipient.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IPrimarySale/write/setPrimarySaleRecipient.ts
@@ -142,5 +142,6 @@ export function setPrimarySaleRecipient(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/common/__generated__/IRoyalty/write/setDefaultRoyaltyInfo.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IRoyalty/write/setDefaultRoyaltyInfo.ts
@@ -159,5 +159,6 @@ export function setDefaultRoyaltyInfo(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/common/__generated__/IRoyalty/write/setRoyaltyInfoForToken.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IRoyalty/write/setRoyaltyInfoForToken.ts
@@ -166,5 +166,6 @@ export function setRoyaltyInfoForToken(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/common/__generated__/IRoyaltyPayments/write/getRoyalty.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IRoyaltyPayments/write/getRoyalty.ts
@@ -169,5 +169,6 @@ export function getRoyalty(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/common/__generated__/IRoyaltyPayments/write/setRoyaltyEngine.ts
+++ b/packages/thirdweb/src/extensions/common/__generated__/IRoyaltyPayments/write/setRoyaltyEngine.ts
@@ -138,5 +138,6 @@ export function setRoyaltyEngine(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/DropERC1155/write/freezeBatchBaseURI.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/DropERC1155/write/freezeBatchBaseURI.ts
@@ -137,5 +137,6 @@ export function freezeBatchBaseURI(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/DropERC1155/write/setMaxTotalSupply.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/DropERC1155/write/setMaxTotalSupply.ts
@@ -151,5 +151,6 @@ export function setMaxTotalSupply(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/DropERC1155/write/setSaleRecipientForToken.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/DropERC1155/write/setSaleRecipientForToken.ts
@@ -153,5 +153,6 @@ export function setSaleRecipientForToken(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/DropERC1155/write/updateBatchBaseURI.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/DropERC1155/write/updateBatchBaseURI.ts
@@ -145,5 +145,6 @@ export function updateBatchBaseURI(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IAirdropERC1155/write/airdropERC1155.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IAirdropERC1155/write/airdropERC1155.ts
@@ -187,5 +187,6 @@ export function airdropERC1155(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IAirdropERC1155Claimable/write/claim.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IAirdropERC1155Claimable/write/claim.ts
@@ -178,5 +178,6 @@ export function claim(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IBurnableERC1155/write/burn.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IBurnableERC1155/write/burn.ts
@@ -155,5 +155,6 @@ export function burn(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IBurnableERC1155/write/burnBatch.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IBurnableERC1155/write/burnBatch.ts
@@ -157,5 +157,6 @@ export function burnBatch(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IClaimableERC1155/write/claim.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IClaimableERC1155/write/claim.ts
@@ -155,5 +155,6 @@ export function claim(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IDrop1155/write/claim.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IDrop1155/write/claim.ts
@@ -225,5 +225,6 @@ export function claim(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IDrop1155/write/setClaimConditions.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IDrop1155/write/setClaimConditions.ts
@@ -211,5 +211,6 @@ export function setClaimConditions(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/write/safeBatchTransferFrom.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/write/safeBatchTransferFrom.ts
@@ -186,5 +186,6 @@ export function safeBatchTransferFrom(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/write/safeTransferFrom.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/write/safeTransferFrom.ts
@@ -179,5 +179,6 @@ export function safeTransferFrom(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/write/setApprovalForAll.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/write/setApprovalForAll.ts
@@ -145,5 +145,6 @@ export function setApprovalForAll(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155Receiver/write/onERC1155BatchReceived.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155Receiver/write/onERC1155BatchReceived.ts
@@ -187,5 +187,6 @@ export function onERC1155BatchReceived(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155Receiver/write/onERC1155Received.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155Receiver/write/onERC1155Received.ts
@@ -185,5 +185,6 @@ export function onERC1155Received(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IEditionStake/write/depositRewardTokens.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IEditionStake/write/depositRewardTokens.ts
@@ -137,5 +137,6 @@ export function depositRewardTokens(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IEditionStake/write/withdrawRewardTokens.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IEditionStake/write/withdrawRewardTokens.ts
@@ -139,5 +139,6 @@ export function withdrawRewardTokens(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/ILazyMint/write/lazyMint.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/ILazyMint/write/lazyMint.ts
@@ -163,5 +163,6 @@ export function lazyMint(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IMintableERC1155/write/mintTo.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IMintableERC1155/write/mintTo.ts
@@ -165,5 +165,6 @@ export function mintTo(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/INFTMetadata/write/setTokenURI.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/INFTMetadata/write/setTokenURI.ts
@@ -141,5 +141,6 @@ export function setTokenURI(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IPack/write/createPack.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IPack/write/createPack.ts
@@ -235,5 +235,6 @@ export function createPack(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IPack/write/openPack.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IPack/write/openPack.ts
@@ -164,5 +164,6 @@ export function openPack(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IPackVRFDirect/write/openPackAndClaimRewards.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IPackVRFDirect/write/openPackAndClaimRewards.ts
@@ -173,5 +173,6 @@ export function openPackAndClaimRewards(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/ISignatureMintERC1155/write/mintWithSignature.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/ISignatureMintERC1155/write/mintWithSignature.ts
@@ -212,5 +212,6 @@ export function mintWithSignature(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IStaking1155/write/claimRewards.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IStaking1155/write/claimRewards.ts
@@ -133,5 +133,6 @@ export function claimRewards(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IStaking1155/write/stake.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IStaking1155/write/stake.ts
@@ -139,5 +139,6 @@ export function stake(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IStaking1155/write/withdraw.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IStaking1155/write/withdraw.ts
@@ -139,5 +139,6 @@ export function withdraw(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IAirdropERC20/write/airdropERC20.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IAirdropERC20/write/airdropERC20.ts
@@ -180,5 +180,6 @@ export function airdropERC20(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IAirdropERC20Claimable/write/claim.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IAirdropERC20Claimable/write/claim.ts
@@ -168,5 +168,6 @@ export function claim(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IBurnableERC20/write/burn.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IBurnableERC20/write/burn.ts
@@ -131,5 +131,6 @@ export function burn(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IBurnableERC20/write/burnFrom.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IBurnableERC20/write/burnFrom.ts
@@ -139,5 +139,6 @@ export function burnFrom(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IDropERC20/write/claim.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IDropERC20/write/claim.ts
@@ -215,5 +215,6 @@ export function claim(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IDropERC20/write/setClaimConditions.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IDropERC20/write/setClaimConditions.ts
@@ -201,5 +201,6 @@ export function setClaimConditions(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IERC20/write/approve.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IERC20/write/approve.ts
@@ -143,5 +143,6 @@ export function approve(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IERC20/write/transfer.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IERC20/write/transfer.ts
@@ -143,5 +143,6 @@ export function transfer(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IERC20/write/transferFrom.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IERC20/write/transferFrom.ts
@@ -161,5 +161,6 @@ export function transferFrom(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IERC20Permit/write/permit.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IERC20Permit/write/permit.ts
@@ -195,5 +195,6 @@ export function permit(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IMintableERC20/write/mintTo.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IMintableERC20/write/mintTo.ts
@@ -139,5 +139,6 @@ export function mintTo(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/ISignatureMintERC20/write/mintWithSignature.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/ISignatureMintERC20/write/mintWithSignature.ts
@@ -192,5 +192,6 @@ export function mintWithSignature(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IStaking20/write/stake.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IStaking20/write/stake.ts
@@ -131,5 +131,6 @@ export function stake(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IStaking20/write/withdraw.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IStaking20/write/withdraw.ts
@@ -131,5 +131,6 @@ export function withdraw(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/ITokenStake/write/depositRewardTokens.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/ITokenStake/write/depositRewardTokens.ts
@@ -137,5 +137,6 @@ export function depositRewardTokens(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/ITokenStake/write/withdrawRewardTokens.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/ITokenStake/write/withdrawRewardTokens.ts
@@ -139,5 +139,6 @@ export function withdrawRewardTokens(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IVotes/write/delegate.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IVotes/write/delegate.ts
@@ -134,5 +134,6 @@ export function delegate(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IVotes/write/delegateBySig.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IVotes/write/delegateBySig.ts
@@ -192,5 +192,6 @@ export function delegateBySig(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IWETH/write/transfer.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IWETH/write/transfer.ts
@@ -143,5 +143,6 @@ export function transfer(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/__generated__/IWETH/write/withdraw.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/IWETH/write/withdraw.ts
@@ -131,5 +131,6 @@ export function withdraw(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/write/approve.ts
+++ b/packages/thirdweb/src/extensions/erc20/write/approve.ts
@@ -55,6 +55,12 @@ export function approve(options: BaseTransactionOptions<ApproveParams>) {
       return {
         spender: options.spender,
         value: amount,
+        overrides: {
+          erc20Value: {
+            amountWei: amount,
+            tokenAddress: options.contract.address,
+          },
+        },
       } as const;
     },
   });

--- a/packages/thirdweb/src/extensions/erc20/write/deposit.ts
+++ b/packages/thirdweb/src/extensions/erc20/write/deposit.ts
@@ -25,9 +25,15 @@ export type DepositParams =
  * ```
  */
 export function deposit(options: BaseTransactionOptions<DepositParams>) {
+  const value =
+    "amountWei" in options ? options.amountWei : toWei(options.amount);
   return prepareContractCall({
     contract: options.contract,
     method: [FN_SELECTOR, [], []] as const,
-    value: "amountWei" in options ? options.amountWei : toWei(options.amount),
+    value,
+    erc20Value: {
+      amountWei: value,
+      tokenAddress: options.contract.address,
+    },
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/write/getApprovalForTransaction.ts
+++ b/packages/thirdweb/src/extensions/erc20/write/getApprovalForTransaction.ts
@@ -1,0 +1,58 @@
+import { getContract } from "../../../contract/contract.js";
+import type { PreparedTransaction } from "../../../transaction/prepare-transaction.js";
+import { getAddress } from "../../../utils/address.js";
+import { resolvePromisedValue } from "../../../utils/promise/resolve-promised-value.js";
+import type { Account } from "../../../wallets/interfaces/wallet.js";
+import { allowance } from "../__generated__/IERC20/read/allowance.js";
+import { approve } from "../__generated__/IERC20/write/approve.js";
+
+export type GetApprovalForTransactionParams = {
+  transaction: PreparedTransaction;
+  account: Account;
+};
+
+export async function getApprovalForTransaction(
+  options: GetApprovalForTransactionParams,
+): Promise<PreparedTransaction | null> {
+  const { transaction, account } = options;
+  if (!account) {
+    return null;
+  }
+
+  const erc20Value = await resolvePromisedValue(transaction.erc20Value);
+  if (erc20Value) {
+    const target = await resolvePromisedValue(transaction.to);
+
+    if (
+      !target ||
+      !erc20Value.tokenAddress ||
+      getAddress(target) === getAddress(erc20Value.tokenAddress)
+    ) {
+      return null;
+    }
+
+    const contract = getContract({
+      address: erc20Value.tokenAddress,
+      chain: transaction.chain,
+      client: transaction.client,
+    });
+
+    const approvedValue = await allowance({
+      contract,
+      owner: account.address,
+      spender: target,
+    });
+
+    if (approvedValue > erc20Value.amountWei) {
+      return null;
+    }
+
+    return approve({
+      contract,
+      value: erc20Value.amountWei,
+      spender: target,
+    });
+  }
+
+  return null;
+}

--- a/packages/thirdweb/src/extensions/erc20/write/sigMint.ts
+++ b/packages/thirdweb/src/extensions/erc20/write/sigMint.ts
@@ -42,10 +42,19 @@ export function mintWithSignature(
   const value = isNativeTokenAddress(options.payload.currency)
     ? options.payload.price
     : 0n;
+  const erc20Value =
+    !isNativeTokenAddress(options.payload.currency) &&
+    options.payload.price > 0n
+      ? {
+          amountWei: options.payload.price,
+          tokenAddress: options.payload.currency,
+        }
+      : undefined;
   return generatedMintWithSignature({
     ...options,
     overrides: {
       value,
+      erc20Value,
     },
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/write/transfer.ts
+++ b/packages/thirdweb/src/extensions/erc20/write/transfer.ts
@@ -53,6 +53,12 @@ export function transfer(options: BaseTransactionOptions<TransferParams>) {
       return {
         to: options.to,
         value: amount,
+        overrides: {
+          erc20Value: {
+            amountWei: amount,
+            tokenAddress: options.contract.address,
+          },
+        },
       } as const;
     },
   });

--- a/packages/thirdweb/src/extensions/erc20/write/transferBatch.ts
+++ b/packages/thirdweb/src/extensions/erc20/write/transferBatch.ts
@@ -69,6 +69,12 @@ export function transferBatch(
             return encodeTransfer({
               to: transfer.to,
               value: amount,
+              overrides: {
+                erc20Value: {
+                  amountWei: amount,
+                  tokenAddress: options.contract.address,
+                },
+              },
             });
           }),
         ),

--- a/packages/thirdweb/src/extensions/erc20/write/transferFrom.ts
+++ b/packages/thirdweb/src/extensions/erc20/write/transferFrom.ts
@@ -59,6 +59,12 @@ export function transferFrom(
         from: options.from,
         to: options.to,
         value: amount,
+        overrides: {
+          erc20Value: {
+            amountWei: amount,
+            tokenAddress: options.contract.address,
+          },
+        },
       } as const;
     },
   });

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IAccount/write/validateUserOp.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IAccount/write/validateUserOp.ts
@@ -232,5 +232,6 @@ export function validateUserOp(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/write/createAccount.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/write/createAccount.ts
@@ -148,5 +148,6 @@ export function createAccount(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/write/onSignerAdded.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/write/onSignerAdded.ts
@@ -162,5 +162,6 @@ export function onSignerAdded(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/write/onSignerRemoved.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/write/onSignerRemoved.ts
@@ -162,5 +162,6 @@ export function onSignerRemoved(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountPermissions/write/setPermissionsForSigner.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IAccountPermissions/write/setPermissionsForSigner.ts
@@ -199,5 +199,6 @@ export function setPermissionsForSigner(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/addStake.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/addStake.ts
@@ -134,5 +134,6 @@ export function addStake(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/depositTo.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/depositTo.ts
@@ -133,5 +133,6 @@ export function depositTo(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/getSenderAddress.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/getSenderAddress.ts
@@ -135,5 +135,6 @@ export function getSenderAddress(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/handleAggregatedOps.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/handleAggregatedOps.ts
@@ -238,5 +238,6 @@ export function handleAggregatedOps(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/handleOps.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/handleOps.ts
@@ -206,5 +206,6 @@ export function handleOps(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/incrementNonce.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/incrementNonce.ts
@@ -135,5 +135,6 @@ export function incrementNonce(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/simulateHandleOp.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/simulateHandleOp.ts
@@ -224,5 +224,6 @@ export function simulateHandleOp(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/simulateValidation.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/simulateValidation.ts
@@ -199,5 +199,6 @@ export function simulateValidation(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/withdrawStake.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/withdrawStake.ts
@@ -138,5 +138,6 @@ export function withdrawStake(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/withdrawTo.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/withdrawTo.ts
@@ -153,5 +153,6 @@ export function withdrawTo(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IPaymaster/write/postOp.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IPaymaster/write/postOp.ts
@@ -158,5 +158,6 @@ export function postOp(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc4337/__generated__/IPaymaster/write/validatePaymasterUserOp.ts
+++ b/packages/thirdweb/src/extensions/erc4337/__generated__/IPaymaster/write/validatePaymasterUserOp.ts
@@ -237,5 +237,6 @@ export function validatePaymasterUserOp(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/write/deposit.ts
+++ b/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/write/deposit.ts
@@ -155,5 +155,6 @@ export function deposit(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/write/mint.ts
+++ b/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/write/mint.ts
@@ -155,5 +155,6 @@ export function mint(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/write/redeem.ts
+++ b/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/write/redeem.ts
@@ -176,5 +176,6 @@ export function redeem(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/write/withdraw.ts
+++ b/packages/thirdweb/src/extensions/erc4626/__generated__/IERC4626/write/withdraw.ts
@@ -176,5 +176,6 @@ export function withdraw(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/DropERC721/write/freezeBatchBaseURI.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/DropERC721/write/freezeBatchBaseURI.ts
@@ -137,5 +137,6 @@ export function freezeBatchBaseURI(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/DropERC721/write/setMaxTotalSupply.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/DropERC721/write/setMaxTotalSupply.ts
@@ -140,5 +140,6 @@ export function setMaxTotalSupply(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/DropERC721/write/updateBatchBaseURI.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/DropERC721/write/updateBatchBaseURI.ts
@@ -145,5 +145,6 @@ export function updateBatchBaseURI(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IAirdropERC721/write/airdropERC721.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IAirdropERC721/write/airdropERC721.ts
@@ -182,5 +182,6 @@ export function airdropERC721(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IAirdropERC721Claimable/write/claim.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IAirdropERC721Claimable/write/claim.ts
@@ -168,5 +168,6 @@ export function claim(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IBurnableERC721/write/burn.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IBurnableERC721/write/burn.ts
@@ -131,5 +131,6 @@ export function burn(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IClaimableERC721/write/claim.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IClaimableERC721/write/claim.ts
@@ -139,5 +139,6 @@ export function claim(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IDelayedReveal/write/reveal.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IDelayedReveal/write/reveal.ts
@@ -147,5 +147,6 @@ export function reveal(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IDrop/write/claim.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IDrop/write/claim.ts
@@ -215,5 +215,6 @@ export function claim(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IDrop/write/setClaimConditions.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IDrop/write/setClaimConditions.ts
@@ -201,5 +201,6 @@ export function setClaimConditions(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/write/approve.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/write/approve.ts
@@ -139,5 +139,6 @@ export function approve(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/write/safeTransferFrom.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/write/safeTransferFrom.ts
@@ -159,5 +159,6 @@ export function safeTransferFrom(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/write/setApprovalForAll.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/write/setApprovalForAll.ts
@@ -145,5 +145,6 @@ export function setApprovalForAll(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/write/transferFrom.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/write/transferFrom.ts
@@ -157,5 +157,6 @@ export function transferFrom(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IERC721Receiver/write/onERC721Received.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IERC721Receiver/write/onERC721Received.ts
@@ -173,5 +173,6 @@ export function onERC721Received(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ILazyMint/write/lazyMint.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ILazyMint/write/lazyMint.ts
@@ -163,5 +163,6 @@ export function lazyMint(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IMintableERC721/write/mintTo.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IMintableERC721/write/mintTo.ts
@@ -143,5 +143,6 @@ export function mintTo(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/INFTMetadata/write/setTokenURI.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/INFTMetadata/write/setTokenURI.ts
@@ -141,5 +141,6 @@ export function setTokenURI(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/INFTStake/write/depositRewardTokens.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/INFTStake/write/depositRewardTokens.ts
@@ -137,5 +137,6 @@ export function depositRewardTokens(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/INFTStake/write/withdrawRewardTokens.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/INFTStake/write/withdrawRewardTokens.ts
@@ -139,5 +139,6 @@ export function withdrawRewardTokens(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ISharedMetadata/write/setSharedMetadata.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ISharedMetadata/write/setSharedMetadata.ts
@@ -164,5 +164,6 @@ export function setSharedMetadata(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ISharedMetadataBatch/write/deleteSharedMetadata.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ISharedMetadataBatch/write/deleteSharedMetadata.ts
@@ -139,5 +139,6 @@ export function deleteSharedMetadata(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ISharedMetadataBatch/write/setSharedMetadata.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ISharedMetadataBatch/write/setSharedMetadata.ts
@@ -172,5 +172,6 @@ export function setSharedMetadata(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/ISignatureMintERC721/write/mintWithSignature.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/ISignatureMintERC721/write/mintWithSignature.ts
@@ -207,5 +207,6 @@ export function mintWithSignature(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IStaking721/write/stake.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IStaking721/write/stake.ts
@@ -134,5 +134,6 @@ export function stake(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/erc721/__generated__/IStaking721/write/withdraw.ts
+++ b/packages/thirdweb/src/extensions/erc721/__generated__/IStaking721/write/withdraw.ts
@@ -134,5 +134,6 @@ export function withdraw(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IBundler/write/register.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IBundler/write/register.ts
@@ -227,5 +227,6 @@ export function register(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IIdGateway/write/register.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IIdGateway/write/register.ts
@@ -154,5 +154,6 @@ export function register(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IIdGateway/write/registerFor.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IIdGateway/write/registerFor.ts
@@ -189,5 +189,6 @@ export function registerFor(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/changeRecoveryAddress.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/changeRecoveryAddress.ts
@@ -139,5 +139,6 @@ export function changeRecoveryAddress(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/changeRecoveryAddressFor.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/changeRecoveryAddressFor.ts
@@ -173,5 +173,6 @@ export function changeRecoveryAddressFor(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/recover.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/recover.ts
@@ -165,5 +165,6 @@ export function recover(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/recoverFor.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/recoverFor.ts
@@ -196,5 +196,6 @@ export function recoverFor(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/transfer.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/transfer.ts
@@ -155,5 +155,6 @@ export function transfer(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/transferAndChangeRecovery.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/transferAndChangeRecovery.ts
@@ -173,5 +173,6 @@ export function transferAndChangeRecovery(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/transferAndChangeRecoveryFor.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/transferAndChangeRecoveryFor.ts
@@ -209,5 +209,6 @@ export function transferAndChangeRecoveryFor(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/transferFor.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/transferFor.ts
@@ -193,5 +193,6 @@ export function transferFor(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyGateway/write/add.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyGateway/write/add.ts
@@ -168,5 +168,6 @@ export function add(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyGateway/write/addFor.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyGateway/write/addFor.ts
@@ -198,5 +198,6 @@ export function addFor(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyRegistry/write/remove.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyRegistry/write/remove.ts
@@ -131,5 +131,6 @@ export function remove(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyRegistry/write/removeFor.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IKeyRegistry/write/removeFor.ts
@@ -167,5 +167,6 @@ export function removeFor(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IStorageRegistry/write/batchRent.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IStorageRegistry/write/batchRent.ts
@@ -141,5 +141,6 @@ export function batchRent(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/farcaster/__generated__/IStorageRegistry/write/rent.ts
+++ b/packages/thirdweb/src/extensions/farcaster/__generated__/IStorageRegistry/write/rent.ts
@@ -144,5 +144,6 @@ export function rent(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/approveBuyerForListing.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/approveBuyerForListing.ts
@@ -166,5 +166,6 @@ export function approveBuyerForListing(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/approveCurrencyForListing.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/approveCurrencyForListing.ts
@@ -169,5 +169,6 @@ export function approveCurrencyForListing(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/buyFromListing.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/buyFromListing.ts
@@ -185,5 +185,6 @@ export function buyFromListing(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/cancelListing.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/cancelListing.ts
@@ -138,5 +138,6 @@ export function cancelListing(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/createListing.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/createListing.ts
@@ -187,5 +187,6 @@ export function createListing(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/updateListing.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/updateListing.ts
@@ -193,5 +193,6 @@ export function updateListing(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/bidInAuction.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/bidInAuction.ts
@@ -147,5 +147,6 @@ export function bidInAuction(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/cancelAuction.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/cancelAuction.ts
@@ -138,5 +138,6 @@ export function cancelAuction(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/collectAuctionPayout.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/collectAuctionPayout.ts
@@ -142,5 +142,6 @@ export function collectAuctionPayout(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/collectAuctionTokens.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/collectAuctionTokens.ts
@@ -142,5 +142,6 @@ export function collectAuctionTokens(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/createAuction.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/createAuction.ts
@@ -197,5 +197,6 @@ export function createAuction(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/acceptOffer.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/acceptOffer.ts
@@ -173,5 +173,6 @@ export function acceptOffer(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/buy.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/buy.ts
@@ -181,5 +181,6 @@ export function buy(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/cancelDirectListing.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/cancelDirectListing.ts
@@ -140,5 +140,6 @@ export function cancelDirectListing(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/closeAuction.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/closeAuction.ts
@@ -144,5 +144,6 @@ export function closeAuction(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/createListing.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/createListing.ts
@@ -187,5 +187,6 @@ export function createListing(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/offer.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/offer.ts
@@ -187,5 +187,6 @@ export function offer(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/setContractURI.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/setContractURI.ts
@@ -135,5 +135,6 @@ export function setContractURI(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/setPlatformFeeInfo.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/setPlatformFeeInfo.ts
@@ -157,5 +157,6 @@ export function setPlatformFeeInfo(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/updateListing.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/updateListing.ts
@@ -220,5 +220,6 @@ export function updateListing(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IOffers/write/acceptOffer.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IOffers/write/acceptOffer.ts
@@ -133,5 +133,6 @@ export function acceptOffer(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IOffers/write/cancelOffer.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IOffers/write/cancelOffer.ts
@@ -133,5 +133,6 @@ export function cancelOffer(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/marketplace/__generated__/IOffers/write/makeOffer.ts
+++ b/packages/thirdweb/src/extensions/marketplace/__generated__/IOffers/write/makeOffer.ts
@@ -175,5 +175,6 @@ export function makeOffer(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/modular/__generated__/IModularCore/write/installExtension.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/IModularCore/write/installExtension.ts
@@ -156,5 +156,6 @@ export function installExtension(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/modular/__generated__/IModularCore/write/uninstallExtension.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/IModularCore/write/uninstallExtension.ts
@@ -158,5 +158,6 @@ export function uninstallExtension(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/modular/__generated__/ModularCore/write/completeOwnershipHandover.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ModularCore/write/completeOwnershipHandover.ts
@@ -144,5 +144,6 @@ export function completeOwnershipHandover(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/modular/__generated__/ModularCore/write/grantRoles.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ModularCore/write/grantRoles.ts
@@ -151,5 +151,6 @@ export function grantRoles(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/modular/__generated__/ModularCore/write/installExtension.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ModularCore/write/installExtension.ts
@@ -153,5 +153,6 @@ export function installExtension(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/modular/__generated__/ModularCore/write/renounceRoles.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ModularCore/write/renounceRoles.ts
@@ -140,5 +140,6 @@ export function renounceRoles(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/modular/__generated__/ModularCore/write/revokeRoles.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ModularCore/write/revokeRoles.ts
@@ -151,5 +151,6 @@ export function revokeRoles(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/modular/__generated__/ModularCore/write/transferOwnership.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ModularCore/write/transferOwnership.ts
@@ -142,5 +142,6 @@ export function transferOwnership(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/modular/__generated__/ModularCore/write/uninstallExtension.ts
+++ b/packages/thirdweb/src/extensions/modular/__generated__/ModularCore/write/uninstallExtension.ts
@@ -155,5 +155,6 @@ export function uninstallExtension(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/aggregate.ts
+++ b/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/aggregate.ts
@@ -165,5 +165,6 @@ export function aggregate(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/aggregate3.ts
+++ b/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/aggregate3.ts
@@ -178,5 +178,6 @@ export function aggregate3(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/aggregate3Value.ts
+++ b/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/aggregate3Value.ts
@@ -186,5 +186,6 @@ export function aggregate3Value(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/blockAndAggregate.ts
+++ b/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/blockAndAggregate.ts
@@ -186,5 +186,6 @@ export function blockAndAggregate(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/tryAggregate.ts
+++ b/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/tryAggregate.ts
@@ -188,5 +188,6 @@ export function tryAggregate(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/tryBlockAndAggregate.ts
+++ b/packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/tryBlockAndAggregate.ts
@@ -204,5 +204,6 @@ export function tryBlockAndAggregate(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/permissions/__generated__/IPermissions/write/grantRole.ts
+++ b/packages/thirdweb/src/extensions/permissions/__generated__/IPermissions/write/grantRole.ts
@@ -141,5 +141,6 @@ export function grantRole(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/permissions/__generated__/IPermissions/write/renounceRole.ts
+++ b/packages/thirdweb/src/extensions/permissions/__generated__/IPermissions/write/renounceRole.ts
@@ -141,5 +141,6 @@ export function renounceRole(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/permissions/__generated__/IPermissions/write/revokeRole.ts
+++ b/packages/thirdweb/src/extensions/permissions/__generated__/IPermissions/write/revokeRole.ts
@@ -141,5 +141,6 @@ export function revokeRole(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/permissions/__generated__/IPermissionsEnumerable/write/grantRole.ts
+++ b/packages/thirdweb/src/extensions/permissions/__generated__/IPermissionsEnumerable/write/grantRole.ts
@@ -141,5 +141,6 @@ export function grantRole(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/permissions/__generated__/IPermissionsEnumerable/write/renounceRole.ts
+++ b/packages/thirdweb/src/extensions/permissions/__generated__/IPermissionsEnumerable/write/renounceRole.ts
@@ -141,5 +141,6 @@ export function renounceRole(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/permissions/__generated__/IPermissionsEnumerable/write/revokeRole.ts
+++ b/packages/thirdweb/src/extensions/permissions/__generated__/IPermissionsEnumerable/write/revokeRole.ts
@@ -141,5 +141,6 @@ export function revokeRole(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/prebuilts/__generated__/DropERC1155/write/initialize.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/__generated__/DropERC1155/write/initialize.ts
@@ -251,5 +251,6 @@ export function initialize(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/prebuilts/__generated__/DropERC20/write/initialize.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/__generated__/DropERC20/write/initialize.ts
@@ -225,5 +225,6 @@ export function initialize(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/prebuilts/__generated__/DropERC721/write/initialize.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/__generated__/DropERC721/write/initialize.ts
@@ -251,5 +251,6 @@ export function initialize(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/prebuilts/__generated__/Marketplace/write/initialize.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/__generated__/Marketplace/write/initialize.ts
@@ -192,5 +192,6 @@ export function initialize(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/prebuilts/__generated__/OpenEditionERC721/write/initialize.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/__generated__/OpenEditionERC721/write/initialize.ts
@@ -225,5 +225,6 @@ export function initialize(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/prebuilts/__generated__/TokenERC1155/write/initialize.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/__generated__/TokenERC1155/write/initialize.ts
@@ -251,5 +251,6 @@ export function initialize(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/prebuilts/__generated__/TokenERC20/write/initialize.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/__generated__/TokenERC20/write/initialize.ts
@@ -225,5 +225,6 @@ export function initialize(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/prebuilts/__generated__/TokenERC721/write/initialize.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/__generated__/TokenERC721/write/initialize.ts
@@ -251,5 +251,6 @@ export function initialize(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/IAppURI/write/setAppURI.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/IAppURI/write/setAppURI.ts
@@ -133,5 +133,6 @@ export function setAppURI(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/IContractFactory/write/deployProxyByImplementation.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/IContractFactory/write/deployProxyByImplementation.ts
@@ -170,5 +170,6 @@ export function deployProxyByImplementation(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/write/publishContract.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/write/publishContract.ts
@@ -207,5 +207,6 @@ export function publishContract(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/write/setPublisherProfileUri.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/write/setPublisherProfileUri.ts
@@ -150,5 +150,6 @@ export function setPublisherProfileUri(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/write/unpublishContract.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/write/unpublishContract.ts
@@ -154,5 +154,6 @@ export function unpublishContract(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/write/createRuleMultiplicative.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/write/createRuleMultiplicative.ts
@@ -171,5 +171,6 @@ export function createRuleMultiplicative(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/write/createRuleThreshold.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/write/createRuleThreshold.ts
@@ -174,5 +174,6 @@ export function createRuleThreshold(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/write/deleteRule.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/write/deleteRule.ts
@@ -133,5 +133,6 @@ export function deleteRule(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/write/setRulesEngineOverride.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/write/setRulesEngineOverride.ts
@@ -142,5 +142,6 @@ export function setRulesEngineOverride(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/ITWMultichainRegistry/write/add.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/ITWMultichainRegistry/write/add.ts
@@ -171,5 +171,6 @@ export function add(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/ITWMultichainRegistry/write/remove.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/ITWMultichainRegistry/write/remove.ts
@@ -158,5 +158,6 @@ export function remove(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/thirdweb/__generated__/IThirdwebContract/write/setContractURI.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/__generated__/IThirdwebContract/write/setContractURI.ts
@@ -135,5 +135,6 @@ export function setContractURI(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/uniswap/__generated__/IQuoter/write/quoteExactInput.ts
+++ b/packages/thirdweb/src/extensions/uniswap/__generated__/IQuoter/write/quoteExactInput.ts
@@ -148,5 +148,6 @@ export function quoteExactInput(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/uniswap/__generated__/IQuoter/write/quoteExactInputSingle.ts
+++ b/packages/thirdweb/src/extensions/uniswap/__generated__/IQuoter/write/quoteExactInputSingle.ts
@@ -191,5 +191,6 @@ export function quoteExactInputSingle(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/uniswap/__generated__/IQuoter/write/quoteExactOutput.ts
+++ b/packages/thirdweb/src/extensions/uniswap/__generated__/IQuoter/write/quoteExactOutput.ts
@@ -151,5 +151,6 @@ export function quoteExactOutput(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/uniswap/__generated__/IQuoter/write/quoteExactOutputSingle.ts
+++ b/packages/thirdweb/src/extensions/uniswap/__generated__/IQuoter/write/quoteExactOutputSingle.ts
@@ -194,5 +194,6 @@ export function quoteExactOutputSingle(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/uniswap/__generated__/ISwapRouter/write/exactInput.ts
+++ b/packages/thirdweb/src/extensions/uniswap/__generated__/ISwapRouter/write/exactInput.ts
@@ -170,5 +170,6 @@ export function exactInput(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/uniswap/__generated__/ISwapRouter/write/exactInputSingle.ts
+++ b/packages/thirdweb/src/extensions/uniswap/__generated__/ISwapRouter/write/exactInputSingle.ts
@@ -187,5 +187,6 @@ export function exactInputSingle(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/uniswap/__generated__/ISwapRouter/write/exactOutput.ts
+++ b/packages/thirdweb/src/extensions/uniswap/__generated__/ISwapRouter/write/exactOutput.ts
@@ -170,5 +170,6 @@ export function exactOutput(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/uniswap/__generated__/ISwapRouter/write/exactOutputSingle.ts
+++ b/packages/thirdweb/src/extensions/uniswap/__generated__/ISwapRouter/write/exactOutputSingle.ts
@@ -189,5 +189,6 @@ export function exactOutputSingle(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/uniswap/__generated__/IUniswapV3Factory/write/createPool.ts
+++ b/packages/thirdweb/src/extensions/uniswap/__generated__/IUniswapV3Factory/write/createPool.ts
@@ -162,5 +162,6 @@ export function createPool(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/uniswap/__generated__/IUniswapV3Factory/write/enableFeeAmount.ts
+++ b/packages/thirdweb/src/extensions/uniswap/__generated__/IUniswapV3Factory/write/enableFeeAmount.ts
@@ -146,5 +146,6 @@ export function enableFeeAmount(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/extensions/uniswap/__generated__/IUniswapV3Factory/write/setOwner.ts
+++ b/packages/thirdweb/src/extensions/uniswap/__generated__/IUniswapV3Factory/write/setOwner.ts
@@ -131,5 +131,6 @@ export function setOwner(
       (await asyncOptions()).overrides?.maxPriorityFeePerGas,
     nonce: async () => (await asyncOptions()).overrides?.nonce,
     extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
   });
 }

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/Details.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/Details.tsx
@@ -629,6 +629,7 @@ function DetailsModal(props: {
   if (screen === "transactions") {
     content = (
       <TransactionsScreen
+        title="Buy"
         onBack={() => setScreen("main")}
         closeModal={closeModal}
         locale={locale}

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/TransactionsScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/TransactionsScreen.tsx
@@ -26,6 +26,7 @@ import type { WalletDetailsModalScreen } from "./screens/types.js";
  * @internal
  */
 export function TransactionsScreen(props: {
+  title: string;
   onBack: () => void;
   setScreen: (screen: WalletDetailsModalScreen) => void;
   closeModal: () => void;
@@ -53,6 +54,7 @@ export function TransactionsScreen(props: {
   if (selectedTx) {
     return (
       <TxDetailsScreen
+        title={props.title}
         client={props.client}
         statusInfo={selectedTx}
         onBack={() => setSelectedTx(null)}

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx
@@ -6,7 +6,7 @@ import { NATIVE_TOKEN_ADDRESS } from "../../../../../../constants/addresses.js";
 import type { GetBuyWithCryptoQuoteParams } from "../../../../../../pay/buyWithCrypto/getQuote.js";
 import { isSwapRequiredPostOnramp } from "../../../../../../pay/buyWithFiat/isSwapRequiredPostOnramp.js";
 import { formatNumber } from "../../../../../../utils/formatNumber.js";
-import { toEther } from "../../../../../../utils/units.js";
+import { toEther, toTokens } from "../../../../../../utils/units.js";
 import type { Account } from "../../../../../../wallets/interfaces/wallet.js";
 import {
   type Theme,
@@ -618,7 +618,10 @@ function MainScreen(props: {
           <Spacer y="lg" />
           <BuyForTxUI
             amountNeeded={String(
-              formatNumber(Number(toEther(amountNeeded)), 6),
+              formatNumber(
+                Number(toTokens(amountNeeded, props.buyForTx.tokenDecimals)),
+                6,
+              ),
             )}
             buyForTx={props.buyForTx}
             client={client}

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/PayTokenIcon.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/PayTokenIcon.tsx
@@ -1,5 +1,6 @@
 import type { Chain } from "../../../../../../chains/types.js";
 import type { ThirdwebClient } from "../../../../../../client/client.js";
+import { getAddress } from "../../../../../../utils/address.js";
 import type { iconSize } from "../../../../../core/design-system/index.js";
 import { TokenIcon } from "../../../components/TokenIcon.js";
 import { type NativeToken, isNativeToken } from "../nativeToken.js";
@@ -24,7 +25,9 @@ export function PayTokenIcon(props: {
   const tokenIcon = !isNativeToken(token)
     ? supportedDestinationsQuery.data
         ?.find((c) => c.chain.id === props.chain.id)
-        ?.tokens.find((t) => t.address === token.address)?.icon
+        ?.tokens.find(
+          (t) => getAddress(t.address) === getAddress(token.address),
+        )?.icon
     : undefined;
 
   return (

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/main/types.ts
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/main/types.ts
@@ -7,6 +7,7 @@ export type BuyForTx = {
   balance: bigint;
   tx: PreparedTransaction;
   tokenSymbol: string;
+  tokenDecimals: number;
 };
 
 export type SelectedScreen =

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/main/useBuyTxStates.ts
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/main/useBuyTxStates.ts
@@ -28,6 +28,11 @@ export function useBuyTxStates(options: {
 
     let mounted = true;
 
+    if (buyForTx.tx.erc20Value) {
+      // if erc20 value is set, we don't need to poll
+      return;
+    }
+
     async function pollTxCost() {
       if (!buyForTx || !mounted) {
         return;
@@ -50,7 +55,7 @@ export function useBuyTxStates(options: {
             setTokenAmount(toEther(totalCost - buyForTx.balance));
           }
         }
-      } catch {
+      } catch (error) {
         // no op
       }
 

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/pay-transactions/BuyTxHistory.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/pay-transactions/BuyTxHistory.tsx
@@ -36,6 +36,7 @@ import {
  * @internal
  */
 export function PayTxHistoryScreen(props: {
+  title: string;
   onBack?: () => void;
   client: ThirdwebClient;
   onDone: () => void;
@@ -60,6 +61,7 @@ export function PayTxHistoryScreen(props: {
   if (selectedTx) {
     return (
       <TxDetailsScreen
+        title={props.title}
         client={props.client}
         statusInfo={selectedTx}
         onBack={() => setSelectedTx(null)}

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/pay-transactions/FiatDetailsScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/pay-transactions/FiatDetailsScreen.tsx
@@ -12,6 +12,7 @@ import type { PayerInfo } from "../types.js";
 import { getBuyWithFiatStatusMeta } from "./statusMeta.js";
 
 export function FiatDetailsScreen(props: {
+  title: string;
   status: ValidBuyWithFiatStatus;
   onBack: () => void;
   client: ThirdwebClient;
@@ -43,7 +44,7 @@ export function FiatDetailsScreen(props: {
     const fiatQuote = status.quote;
     return (
       <PostOnRampSwapFlow
-        title="Buy"
+        title={props.title}
         client={props.client}
         status={status}
         onBack={props.onBack}

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/pay-transactions/TxDetailsScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/pay-transactions/TxDetailsScreen.tsx
@@ -5,6 +5,7 @@ import { SwapDetailsScreen } from "./SwapDetailsScreen.js";
 import type { TxStatusInfo } from "./useBuyTransactionsToShow.js";
 
 export function TxDetailsScreen(props: {
+  title: string;
   client: ThirdwebClient;
   statusInfo: TxStatusInfo;
   onBack: () => void;
@@ -28,6 +29,7 @@ export function TxDetailsScreen(props: {
   if (statusInfo.type === "fiat") {
     return (
       <FiatDetailsScreen
+        title={props.title}
         client={props.client}
         status={statusInfo.status}
         onBack={props.onBack}

--- a/packages/thirdweb/src/react/web/ui/PayEmbed.tsx
+++ b/packages/thirdweb/src/react/web/ui/PayEmbed.tsx
@@ -213,6 +213,7 @@ export function PayEmbed(props: PayEmbedProps) {
         {/* this does not need to persist so we can just show-hide it with JS */}
         {screen === "tx-history" && (
           <PayTxHistoryScreen
+            title={props.metadata?.title || "Buy"}
             client={props.client}
             onBack={() => {
               setScreen("buy");

--- a/packages/thirdweb/src/transaction/prepare-transaction.ts
+++ b/packages/thirdweb/src/transaction/prepare-transaction.ts
@@ -23,6 +23,11 @@ export type StaticPrepareTransactionOptions = {
   // tw specific
   chain: Chain;
   client: ThirdwebClient;
+  // extras
+  erc20Value?: {
+    amountWei: bigint;
+    tokenAddress: Address;
+  };
 };
 
 export type EIP712TransactionOptions = {

--- a/packages/thirdweb/src/utils/extensions/drops/get-claim-params.ts
+++ b/packages/thirdweb/src/utils/extensions/drops/get-claim-params.ts
@@ -127,6 +127,17 @@ export async function getClaimParams(options: GetClaimParamsOptions) {
       ? allowlistProof.pricePerToken
       : cc.pricePerToken;
 
+  const totalPrice =
+    (pricePerToken * options.quantity) / BigInt(10 ** tokenDecimals);
+  const value = isNativeTokenAddress(currency) ? totalPrice : 0n;
+  const erc20Value =
+    !isNativeTokenAddress(currency) && pricePerToken > 0n
+      ? {
+          amountWei: totalPrice,
+          tokenAddress: currency,
+        }
+      : undefined;
+
   return {
     receiver: options.to,
     tokenId: options.type === "erc1155" ? options.tokenId : undefined,
@@ -136,9 +147,8 @@ export async function getClaimParams(options: GetClaimParamsOptions) {
     allowlistProof,
     data: "0x" as Hex,
     overrides: {
-      value: isNativeTokenAddress(currency)
-        ? (pricePerToken * options.quantity) / BigInt(10 ** tokenDecimals)
-        : 0n,
+      value,
+      erc20Value,
     },
   };
 }


### PR DESCRIPTION
### TL;DR

This PR introduces support for ERC20 tokens in the transaction flow, allowing users to seamlessly interact with contracts that require ERC20 token payments.

### What changed?

1. Added ERC20 token handling in the `useSendTransaction` hook to check balance and prompt users to buy ERC20 if needed.
2. Integrated ERC20 token fields, such as `erc20Value`, into the transaction preparation and cost estimation processes.
3. Updated various contract-writing scripts to include `erc20Value` overrides where necessary.
4. Enhanced the UI in `TxModal` and `BuyScreen` to display and process ERC20 token transactions.
5. Added tests for ERC20 token transactions in the `drop721.test.ts` file.
6. Extended documentation and examples to include ERC20 token use cases in transaction flows.

### How to test?

1. Run the unit tests in the `drop721.test.ts` file to ensure ERC20 transactions are correctly processed.
2. Use the `useSendTransaction` hook in a sample component and attempt transactions with both native and ERC20 tokens.
3. Verify that the ERC20 token purchase prompt appears when balance is insufficient.

### Why make this change?

Adding ERC20 support enhances the flexibility and functionality of the transaction flow, making it easier for users to interact with a wider range of smart contracts that require different types of token payments.

---

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on handling ERC20 transaction values in Pay components.

### Detailed summary
- Added `tokenDecimals` to `types.ts`
- Updated titles in `Details.tsx` and `PayEmbed.tsx`
- Added `overrides` object in ERC20 transaction functions
- Added `erc20Value` field in various transaction options
- Updated multiple generated files with `erc20Value` async functions

> The following files were skipped due to too many changes: `packages/thirdweb/src/extensions/common/__generated__/IMulticall/write/multicall.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IMintableERC20/write/mintTo.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IBurnableERC721/write/burn.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IStaking721/write/withdraw.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IBundler/write/register.ts`, `packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/airdropERC20.ts`, `packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/claimERC1155.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/addStake.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IDelayedReveal/write/reveal.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/write/transferFrom.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IKeyGateway/write/addFor.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/buy.ts`, `packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/airdropERC721.ts`, `packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/setMerkleRoot.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IBurnableERC1155/write/burn.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IStaking1155/write/withdraw.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IBurnableERC20/write/burnFrom.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/depositTo.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/handleOps.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IClaimableERC721/write/claim.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IMintableERC721/write/mintTo.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IIdGateway/write/register.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/recover.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IKeyRegistry/write/remove.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IOffers/write/makeOffer.ts`, `packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/airdropERC1155.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/withdrawTo.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/transfer.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/offer.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ModularCore/write/grantRoles.ts`, `packages/thirdweb/src/extensions/prebuilts/__generated__/DropERC20/write/initialize.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/ISwapRouter/write/exactInput.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IClaimableERC1155/write/claim.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IMintableERC1155/write/mintTo.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccount/write/validateUserOp.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IDrop/write/setClaimConditions.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/INFTMetadata/write/setTokenURI.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IStorageRegistry/write/rent.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IOffers/write/acceptOffer.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IOffers/write/cancelOffer.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ModularCore/write/revokeRoles.ts`, `packages/thirdweb/src/extensions/prebuilts/__generated__/DropERC721/write/initialize.ts`, `packages/thirdweb/src/extensions/prebuilts/__generated__/TokenERC20/write/initialize.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/IQuoter/write/quoteExactInput.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/ISwapRouter/write/exactOutput.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/INFTMetadata/write/setTokenURI.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IAirdropERC20/write/airdropERC20.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/write/safeTransferFrom.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IIdGateway/write/registerFor.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/recoverFor.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IKeyRegistry/write/removeFor.ts`, `packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/aggregate.ts`, `packages/thirdweb/src/extensions/prebuilts/__generated__/DropERC1155/write/initialize.ts`, `packages/thirdweb/src/extensions/prebuilts/__generated__/Marketplace/write/initialize.ts`, `packages/thirdweb/src/extensions/prebuilts/__generated__/TokenERC721/write/initialize.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/write/deleteRule.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/IQuoter/write/quoteExactOutput.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/write/safeTransferFrom.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IStaking1155/write/claimRewards.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/withdrawStake.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721A/write/setApprovalForAll.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/transferFor.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ModularCore/write/renounceRoles.ts`, `packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/aggregate3.ts`, `packages/thirdweb/src/extensions/prebuilts/__generated__/TokenERC1155/write/initialize.ts`, `packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/airdropNativeToken.ts`, `packages/thirdweb/src/extensions/common/__generated__/IRoyaltyPayments/write/getRoyalty.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IBurnableERC1155/write/burnBatch.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/write/setApprovalForAll.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IAirdropERC20Claimable/write/claim.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/incrementNonce.ts`, `packages/thirdweb/src/extensions/permissions/__generated__/IPermissions/write/grantRole.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/ITWMultichainRegistry/write/add.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/IUniswapV3Factory/write/setOwner.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/IDropERC20/write/setClaimConditions.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/DropERC721/write/setMaxTotalSupply.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IAirdropERC721/write/airdropERC721.ts`, `packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/tryAggregate.ts`, `packages/thirdweb/src/extensions/permissions/__generated__/IPermissions/write/revokeRole.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IDrop1155/write/setClaimConditions.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/getSenderAddress.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/simulateHandleOp.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/DropERC721/write/freezeBatchBaseURI.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/DropERC721/write/updateBatchBaseURI.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IAirdropERC721Claimable/write/claim.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/INFTStake/write/depositRewardTokens.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IStorageRegistry/write/batchRent.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/acceptOffer.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ModularCore/write/installExtension.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/ISwapRouter/write/exactInputSingle.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/IUniswapV3Factory/write/createPool.ts`, `packages/thirdweb/src/extensions/common/__generated__/IRoyalty/write/setDefaultRoyaltyInfo.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/DropERC1155/write/setMaxTotalSupply.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/ITokenStake/write/depositRewardTokens.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/write/createAccount.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/write/onSignerAdded.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/INFTStake/write/withdrawRewardTokens.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/closeAuction.ts`, `packages/thirdweb/src/extensions/modular/__generated__/IModularCore/write/installExtension.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ModularCore/write/transferOwnership.ts`, `packages/thirdweb/src/extensions/permissions/__generated__/IPermissions/write/renounceRole.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/ITWMultichainRegistry/write/remove.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/IQuoter/write/quoteExactInputSingle.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/ISwapRouter/write/exactOutputSingle.ts`, `packages/thirdweb/src/extensions/common/__generated__/IPlatformFee/write/setPlatformFeeInfo.ts`, `packages/thirdweb/src/extensions/common/__generated__/IRoyalty/write/setRoyaltyInfoForToken.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/DropERC1155/write/freezeBatchBaseURI.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/DropERC1155/write/updateBatchBaseURI.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IAirdropERC1155/write/airdropERC1155.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IAirdropERC1155Claimable/write/claim.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155/write/safeBatchTransferFrom.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/ITokenStake/write/withdrawRewardTokens.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/simulateValidation.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/createListing.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/updateListing.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ModularCore/write/uninstallExtension.ts`, `packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/aggregate3Value.ts`, `packages/thirdweb/src/extensions/prebuilts/__generated__/OpenEditionERC721/write/initialize.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/IQuoter/write/quoteExactOutputSingle.ts`, `packages/thirdweb/src/extensions/common/__generated__/IContractMetadata/write/setContractURI.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccountFactory/write/onSignerRemoved.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IEntryPoint/write/handleAggregatedOps.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/IERC721Receiver/write/onERC721Received.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/setContractURI.ts`, `packages/thirdweb/src/extensions/modular/__generated__/IModularCore/write/uninstallExtension.ts`, `packages/thirdweb/src/extensions/common/__generated__/IRoyaltyPayments/write/setRoyaltyEngine.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ISharedMetadata/write/setSharedMetadata.ts`, `packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/blockAndAggregate.ts`, `packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/airdropERC20WithSignature.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IEditionStake/write/depositRewardTokens.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/cancelListing.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/createListing.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/updateListing.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/bidInAuction.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/write/createRuleThreshold.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IThirdwebContract/write/setContractURI.ts`, `packages/thirdweb/src/extensions/uniswap/__generated__/IUniswapV3Factory/write/enableFeeAmount.ts`, `packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/airdropERC721WithSignature.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155Receiver/write/onERC1155Received.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IEditionStake/write/withdrawRewardTokens.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IPaymaster/write/validatePaymasterUserOp.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/buyFromListing.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/cancelAuction.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/createAuction.ts`, `packages/thirdweb/src/extensions/airdrop/__generated__/Airdrop/write/airdropERC1155WithSignature.ts`, `packages/thirdweb/src/extensions/common/__generated__/IPrimarySale/write/setPrimarySaleRecipient.ts`, `packages/thirdweb/src/extensions/erc20/__generated__/ISignatureMintERC20/write/mintWithSignature.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/changeRecoveryAddress.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/setPlatformFeeInfo.ts`, `packages/thirdweb/src/extensions/multicall3/__generated__/IMulticall3/write/tryBlockAndAggregate.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/write/publishContract.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/DropERC1155/write/setSaleRecipientForToken.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IMarketplace/write/cancelDirectListing.ts`, `packages/thirdweb/src/extensions/permissions/__generated__/IPermissionsEnumerable/write/grantRole.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/write/setRulesEngineOverride.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ISharedMetadataBatch/write/setSharedMetadata.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ISignatureMintERC721/write/mintWithSignature.ts`, `packages/thirdweb/src/extensions/modular/__generated__/ModularCore/write/completeOwnershipHandover.ts`, `packages/thirdweb/src/extensions/permissions/__generated__/IPermissionsEnumerable/write/revokeRole.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/write/unpublishContract.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IPackVRFDirect/write/openPackAndClaimRewards.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/changeRecoveryAddressFor.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IRulesEngine/write/createRuleMultiplicative.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/IERC1155Receiver/write/onERC1155BatchReceived.ts`, `packages/thirdweb/src/extensions/erc1155/__generated__/ISignatureMintERC1155/write/mintWithSignature.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/transferAndChangeRecovery.ts`, `packages/thirdweb/src/extensions/permissions/__generated__/IPermissionsEnumerable/write/renounceRole.ts`, `packages/thirdweb/src/extensions/erc721/__generated__/ISharedMetadataBatch/write/deleteSharedMetadata.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/collectAuctionPayout.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IEnglishAuctions/write/collectAuctionTokens.ts`, `packages/thirdweb/src/extensions/farcaster/__generated__/IIdRegistry/write/transferAndChangeRecoveryFor.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/approveBuyerForListing.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IContractPublisher/write/setPublisherProfileUri.ts`, `packages/thirdweb/src/extensions/erc4337/__generated__/IAccountPermissions/write/setPermissionsForSigner.ts`, `packages/thirdweb/src/extensions/common/__generated__/IClaimConditionsSinglePhase/write/setClaimConditions.ts`, `packages/thirdweb/src/extensions/marketplace/__generated__/IDirectListings/write/approveCurrencyForListing.ts`, `packages/thirdweb/src/extensions/thirdweb/__generated__/IContractFactory/write/deployProxyByImplementation.ts`, `packages/thirdweb/src/extensions/erc20/write/sigMint.ts`, `packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/main/useBuyTxStates.ts`, `packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/pay-transactions/BuyTxHistory.tsx`, `packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/pay-transactions/TxDetailsScreen.tsx`, `packages/thirdweb/src/react/web/ui/ConnectWallet/TransactionsScreen.tsx`, `packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/pay-transactions/FiatDetailsScreen.tsx`, `packages/thirdweb/src/extensions/erc20/write/deposit.ts`, `packages/thirdweb/src/utils/extensions/drops/get-claim-params.ts`, `packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/PayTokenIcon.tsx`, `packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx`, `packages/thirdweb/src/extensions/erc20/write/getApprovalForTransaction.ts`, `apps/playground-web/src/components/pay/transaction-button.tsx`, `packages/thirdweb/src/extensions/erc721/drop721.test.ts`, `packages/thirdweb/src/react/core/hooks/transaction/useSendTransaction.ts`, `packages/thirdweb/src/react/web/hooks/transaction/useSendTransaction.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->