### PR TITLE
feat(pay): add recipient address support to PayEmbed

### DIFF
--- a/.changeset/friendly-jars-warn.md
+++ b/.changeset/friendly-jars-warn.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Add recipient address to PayEmbed

--- a/packages/thirdweb/src/pay/buyWithFiat/getPostOnRampQuote.ts
+++ b/packages/thirdweb/src/pay/buyWithFiat/getPostOnRampQuote.ts
@@ -67,11 +67,8 @@ export async function getPostOnRampQuote({
   return getBuyWithCryptoQuote({
     client,
     intentId: buyWithFiatStatus.intentId,
-    // setting the fromAddress and toAddress same - because post onramp swap can only be done if payer wallet is same as the receiver wallet
-    // TODO: in future - if fromAddress and toAddress are different, we will onramp to payer wallet and then swap to receiver wallet
-    // fiat endpoint should assume this flow and return the quote/status/history accordingly
-    // but for now - we will just not allow doing a fiat flow in Pay UI if payer and receiver wallets are different + requires a swap
-    fromAddress: buyWithFiatStatus.toAddress,
+    // onramp always happens to fromAddress, and then swap is done from - fromAddress to toAddress
+    fromAddress: buyWithFiatStatus.fromAddress,
     toAddress: buyWithFiatStatus.toAddress,
     fromChainId: buyWithFiatStatus.quote.onRampToken.chainId,
     fromTokenAddress: buyWithFiatStatus.quote.onRampToken.tokenAddress,

--- a/packages/thirdweb/src/pay/buyWithFiat/getStatus.ts
+++ b/packages/thirdweb/src/pay/buyWithFiat/getStatus.ts
@@ -70,9 +70,16 @@ export type BuyWithFiatStatus =
         | "CRYPTO_SWAP_IN_PROGRESS"
         | "CRYPTO_SWAP_FAILED";
       /**
-       * The wallet address to which the tokens are sent to
+       * The wallet address to which the desired tokens are sent to
        */
       toAddress: string;
+      /**
+       * The wallet address that started the transaction.
+       *
+       * If onramp provider supports buying the destination token directly, the tokens are sent to "toAddress" directly.
+       * Otherwise, the tokens are sent to "fromAddress" and a swap is performed by the payer wallet and the tokens are converted to the desired token and sent to "toAddress".
+       */
+      fromAddress: string;
       /**
        * The quote object for the transaction
        */

--- a/packages/thirdweb/src/react/core/hooks/connection/ConnectButtonProps.ts
+++ b/packages/thirdweb/src/react/core/hooks/connection/ConnectButtonProps.ts
@@ -84,6 +84,13 @@ export type PayUIOptions = {
    * This details will be stored with the purchase and can be retrieved later via the status API or Webhook
    */
   purchaseData?: object;
+
+  /**
+   * The address of the recipient of the purchase.
+   *
+   * This address will be used to send the purchased tokens to.
+   */
+  recipientAddress?: string;
 };
 
 /**

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx
@@ -831,7 +831,7 @@ function SwapScreenContent(props: {
   } = props;
 
   const [receiverAddress, setReceiverAddress] = useState(
-    props.activeAccount.address,
+    props.payOptions.recipientAddress || props.activeAccount.address,
   );
   const { drawerRef, drawerOverlayRef, isOpen, setIsOpen } = useDrawer();
   const [drawerScreen, setDrawerScreen] = useState<
@@ -923,6 +923,8 @@ function SwapScreenContent(props: {
     payOptions.buyWithCrypto !== false
       ? payOptions.buyWithCrypto?.prefillSource
       : undefined;
+
+  const disableReceiverSelection = !!props.payOptions.recipientAddress;
 
   return (
     <Container flex="column" gap="md" animate="fadein">
@@ -1025,6 +1027,8 @@ function SwapScreenContent(props: {
         <Spacer y="xs" />
         <WalletSelectorButton
           client={props.client}
+          disabled={disableReceiverSelection}
+          disableChevron={disableReceiverSelection}
           onClick={() => {
             setIsOpen(true);
             setDrawerScreen("receiver");
@@ -1100,12 +1104,6 @@ function FiatScreenContent(props: {
   setTokenAmount: (amount: string) => void;
   setHasEditedAmount: (hasEdited: boolean) => void;
 }) {
-  const [receiverAddress, setReceiverAddress] = useState(
-    props.payer.account.address,
-  );
-  const { drawerRef, drawerOverlayRef, isOpen, setIsOpen } = useDrawer();
-  const [drawerScreen, setDrawerScreen] = useState<"fees" | "receiver">("fees");
-
   const {
     toToken,
     tokenAmount,
@@ -1116,6 +1114,11 @@ function FiatScreenContent(props: {
     showCurrencySelector,
     selectedCurrency,
   } = props;
+  const [receiverAddress, setReceiverAddress] = useState(
+    props.payOptions.recipientAddress || props.payer.account.address,
+  );
+  const { drawerRef, drawerOverlayRef, isOpen, setIsOpen } = useDrawer();
+  const [drawerScreen, setDrawerScreen] = useState<"fees" | "receiver">("fees");
 
   const buyWithFiatOptions = props.payOptions.buyWithFiat;
 
@@ -1219,13 +1222,7 @@ function FiatScreenContent(props: {
 
   const disableSubmit = !fiatQuoteQuery.data;
 
-  // TODO: API should just not return a quote if fromAddress !== toAddress and a swap is required after onramp and return an error message with a specific error id
-
-  // TODO: if the receiver wallet is frozen by the developer, we need to stop the user from clicking continue here
-
-  // Selecting Reciever wallet only allowed if no swap required after onramp
-  const enableReceiverSelection =
-    fiatQuoteQuery.data && !isSwapRequiredPostOnramp(fiatQuoteQuery.data);
+  const disableReceiverSelection = !!props.payOptions.recipientAddress;
 
   const errorMsg =
     !fiatQuoteQuery.isLoading && fiatQuoteQuery.error
@@ -1234,11 +1231,11 @@ function FiatScreenContent(props: {
 
   return (
     <Container flex="column" gap="md" animate="fadein">
-      {isOpen && fiatQuoteQuery.data && (
+      {isOpen && (
         <>
           <DrawerOverlay ref={drawerOverlayRef} />
           <Drawer ref={drawerRef} close={() => setIsOpen(false)}>
-            {drawerScreen === "fees" && (
+            {drawerScreen === "fees" && fiatQuoteQuery.data && (
               <div>
                 <Text size="lg" color="primaryText">
                   Fees
@@ -1285,7 +1282,8 @@ function FiatScreenContent(props: {
             setIsOpen(true);
           }}
           address={receiverAddress}
-          disabled={!enableReceiverSelection}
+          disabled={disableReceiverSelection}
+          disableChevron={disableReceiverSelection}
           walletId={undefined}
         />
       </div>

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/fiat/FiatStatusScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/fiat/FiatStatusScreen.tsx
@@ -177,8 +177,6 @@ function OnrampStatusScreenUI(props: {
             }
           : undefined
       }
-      fromAddress={props.quote.fromAddress.toLowerCase()}
-      toAddress={props.quote.toAddress.toLowerCase()}
     />
   );
 

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/fiat/FiatTxDetailsTable.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/fiat/FiatTxDetailsTable.tsx
@@ -1,7 +1,6 @@
 import { ExternalLinkIcon } from "@radix-ui/react-icons";
 import { getCachedChain } from "../../../../../../../chains/utils.js";
 import type { ThirdwebClient } from "../../../../../../../client/client.js";
-import { shortenAddress } from "../../../../../../../utils/address.js";
 import { formatNumber } from "../../../../../../../utils/formatNumber.js";
 import {
   fontSize,
@@ -38,8 +37,6 @@ export function OnRampTxDetailsTable(props: {
     text: FiatStatusMeta["status"];
     txHash?: string;
   };
-  fromAddress?: string;
-  toAddress?: string;
 }) {
   const onRampExplorers = useChainExplorers(
     getCachedChain(props.token.chainId),
@@ -114,26 +111,6 @@ export function OnRampTxDetailsTable(props: {
           </Container>
         </>
       )}
-
-      {props.fromAddress &&
-        props.toAddress &&
-        props.fromAddress !== props.toAddress && (
-          <>
-            {lineSpacer}
-            <Container
-              flex="row"
-              center="y"
-              style={{
-                justifyContent: "space-between",
-              }}
-            >
-              <Text>Send to</Text>
-              <Container flex="row" gap="xs" center="y">
-                <Text>{shortenAddress(props.toAddress)}</Text>
-              </Container>
-            </Container>
-          </>
-        )}
 
       {lineSpacer}
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to enhance the PayEmbed feature by adding a recipient address field for sending purchased tokens.

### Detailed summary
- Added `recipientAddress` field to `ConnectButtonProps` for specifying recipient of purchase
- Updated `getStatus.ts` to clarify token transfer process with `fromAddress` and `toAddress`
- Modified `FiatTxDetailsTable.tsx` to use `recipientAddress` for token transfer details
- Updated `BuyScreen.tsx` and `FiatScreenContent` to handle recipient address for transactions

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->