### PR TITLE
feat(pay): add metadata title support for pay screens

### DIFF
--- a/packages/thirdweb/src/react/core/hooks/transaction/useSendTransaction.ts
+++ b/packages/thirdweb/src/react/core/hooks/transaction/useSendTransaction.ts
@@ -38,6 +38,9 @@ import type { SupportedTokens } from "../../utils/defaultTokens.js";
  */
 export type SendTransactionPayModalConfig =
   | {
+      metadata?: {
+        title?: string;
+      };
       locale?: LocaleId;
       supportedTokens?: SupportedTokens;
       theme?: Theme | "light" | "dark";

--- a/packages/thirdweb/src/react/web/hooks/transaction/useSendTransaction.tsx
+++ b/packages/thirdweb/src/react/web/hooks/transaction/useSendTransaction.tsx
@@ -77,6 +77,7 @@ export function useSendTransaction(config: SendTransactionConfig = {}) {
         : (data) => {
             setRootEl(
               <TxModal
+                title={payModal?.metadata?.title || "Buy"}
                 tx={data.tx}
                 onComplete={data.sendTx}
                 onClose={() => {
@@ -108,6 +109,7 @@ export function useSendTransaction(config: SendTransactionConfig = {}) {
 }
 
 type ModalProps = {
+  title: string;
   onComplete: () => void;
   onClose: () => void;
   client: ThirdwebClient;
@@ -178,6 +180,7 @@ function ModalContent(props: ModalProps) {
 
   return (
     <LazyBuyScreen
+      title={props.title}
       isEmbed={false}
       client={props.client}
       onViewPendingTx={() => {

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/Details.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/Details.tsx
@@ -810,6 +810,7 @@ function DetailsModal(props: {
   else if (screen === "buy") {
     content = (
       <LazyBuyScreen
+        title="Buy"
         isEmbed={false}
         client={client}
         onBack={() => setScreen("main")}

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx
@@ -77,6 +77,7 @@ import type { PayerInfo } from "./types.js";
 import { usePayerSetup } from "./usePayerSetup.js";
 
 export type BuyScreenProps = {
+  title: string;
   onBack: (() => void) | undefined;
   supportedTokens: SupportedTokens | undefined;
   onViewPendingTx: () => void;
@@ -111,6 +112,7 @@ export default function BuyScreen(props: BuyScreenProps) {
 }
 
 type BuyScreenContentProps = {
+  title: string;
   client: ThirdwebClient;
   onBack?: () => void;
   supportedTokens?: SupportedTokens;
@@ -228,6 +230,7 @@ function BuyScreenContent(props: BuyScreenContentProps) {
   if (screen.id === "swap-flow" && payer) {
     return (
       <SwapFlow
+        title={props.title}
         isBuyForTx={!!props.buyForTx}
         isEmbed={props.isEmbed}
         client={client}
@@ -253,6 +256,7 @@ function BuyScreenContent(props: BuyScreenContentProps) {
   if (screen.id === "fiat-flow" && payer) {
     return (
       <FiatFlow
+        title={props.title}
         isBuyForTx={!!props.buyForTx}
         quote={screen.quote}
         onBack={() => {
@@ -329,7 +333,7 @@ function BuyScreenContent(props: BuyScreenContentProps) {
         }
         connectLocale={connectLocale}
         client={client}
-        modalTitle="Buy"
+        modalTitle={props.title}
       />
     );
   }
@@ -391,6 +395,7 @@ function BuyScreenContent(props: BuyScreenContentProps) {
       <div>
         {screen.id === "main" && (
           <MainScreen
+            title={props.title}
             payerAccount={payer?.account}
             buyForTx={buyForTx}
             client={client}
@@ -418,6 +423,7 @@ function BuyScreenContent(props: BuyScreenContentProps) {
           screen.id === "buy-with-fiat") &&
           payer && (
             <TokenSelectedLayout
+              title={props.title}
               selectedChain={toChain}
               selectedToken={toToken}
               tokenAmount={tokenAmount}
@@ -547,6 +553,7 @@ function SelectedTokenInfo(props: {
 }
 
 function MainScreen(props: {
+  title: string;
   buyForTx: BuyForTx | undefined;
   client: ThirdwebClient;
   setTokenAmount: (amount: string) => void;
@@ -598,7 +605,9 @@ function MainScreen(props: {
     <Container p="lg">
       <ModalHeader
         title={
-          props.buyForTx ? `Not enough ${props.buyForTx.tokenSymbol}` : "Buy"
+          props.buyForTx
+            ? `Not enough ${props.buyForTx.tokenSymbol}`
+            : props.title
         }
         onBack={props.onBack}
       />
@@ -697,6 +706,7 @@ function MainScreen(props: {
 }
 
 function TokenSelectedLayout(props: {
+  title: string;
   children: React.ReactNode;
   tokenAmount: string;
   selectedToken: ERC20OrNativeToken;
@@ -707,7 +717,7 @@ function TokenSelectedLayout(props: {
   return (
     <Container>
       <Container p="lg">
-        <ModalHeader title={"Buy"} onBack={props.onBack} />
+        <ModalHeader title={props.title} onBack={props.onBack} />
       </Container>
 
       <Container

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/fiat/FiatFlow.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/fiat/FiatFlow.tsx
@@ -37,6 +37,7 @@ type Screen =
     };
 
 export function FiatFlow(props: {
+  title: string;
   quote: BuyWithFiatQuote;
   onBack: () => void;
   client: ThirdwebClient;
@@ -67,6 +68,7 @@ export function FiatFlow(props: {
   if (screen.id === "step-1") {
     return (
       <FiatSteps
+        title={props.title}
         client={props.client}
         onBack={props.onBack}
         partialQuote={fiatQuoteToPartialQuote(props.quote)}
@@ -87,6 +89,7 @@ export function FiatFlow(props: {
   if (screen.id === "onramp-status") {
     return (
       <OnrampStatusScreen
+        title={props.title}
         client={props.client}
         intentId={props.quote.intentId}
         onBack={props.onBack}
@@ -107,6 +110,7 @@ export function FiatFlow(props: {
   if (screen.id === "postonramp-swap") {
     return (
       <PostOnRampSwapFlow
+        title={props.title}
         status={screen.data}
         quote={fiatQuoteToPartialQuote(props.quote)}
         client={props.client}

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/fiat/FiatStatusScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/fiat/FiatStatusScreen.tsx
@@ -30,6 +30,7 @@ type UIStatus = "loading" | "failed" | "completed" | "partialSuccess";
  * - call `onShowSwapFlow` if on-ramp is completed and swap is required
  */
 export function OnrampStatusScreen(props: {
+  title: string;
   client: ThirdwebClient;
   onBack: () => void;
   intentId: string;
@@ -97,7 +98,7 @@ export function OnrampStatusScreen(props: {
 
   return (
     <Container p="lg">
-      <ModalHeader title="Buy" onBack={props.onBack} />
+      <ModalHeader title={props.title} onBack={props.onBack} />
 
       {props.hasTwoSteps && (
         <>

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/fiat/FiatSteps.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/fiat/FiatSteps.tsx
@@ -83,6 +83,7 @@ export function fiatQuoteToPartialQuote(
 }
 
 export function FiatSteps(props: {
+  title: string;
   partialQuote: BuyWithFiatPartialQuote;
   status?: BuyWithFiatStatus;
   onBack: () => void;
@@ -308,7 +309,7 @@ export function FiatSteps(props: {
 
   return (
     <Container p="lg">
-      <ModalHeader title="Buy" onBack={props.onBack} />
+      <ModalHeader title={props.title} onBack={props.onBack} />
       <Spacer y="lg" />
 
       {/* Step 1 */}

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/fiat/PostOnRampSwap.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/fiat/PostOnRampSwap.tsx
@@ -15,6 +15,7 @@ import { SwapFlow } from "../swap/SwapFlow.js";
 import type { PayerInfo } from "../types.js";
 
 export function PostOnRampSwap(props: {
+  title: string;
   client: ThirdwebClient;
   buyWithFiatStatus: BuyWithFiatStatus;
   onBack?: () => void;
@@ -59,7 +60,7 @@ export function PostOnRampSwap(props: {
     return (
       <Container fullHeight>
         <Container p="lg">
-          <ModalHeader title="Buy" onBack={props.onBack} />
+          <ModalHeader title={props.title} onBack={props.onBack} />
         </Container>
 
         <Container
@@ -95,7 +96,7 @@ export function PostOnRampSwap(props: {
     return (
       <Container fullHeight>
         <Container p="lg">
-          <ModalHeader title="Buy" onBack={props.onBack} />
+          <ModalHeader title={props.title} onBack={props.onBack} />
         </Container>
 
         <Container
@@ -117,6 +118,7 @@ export function PostOnRampSwap(props: {
 
   return (
     <SwapFlow
+      title={props.title}
       payer={props.payer}
       buyWithCryptoQuote={lockedOnRampQuote}
       client={props.client}

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/fiat/PostOnRampSwapFlow.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/fiat/PostOnRampSwapFlow.tsx
@@ -12,6 +12,7 @@ import { PostOnRampSwap } from "./PostOnRampSwap.js";
  * - Show swap flow
  */
 export function PostOnRampSwapFlow(props: {
+  title: string;
   status: BuyWithFiatStatus;
   quote: BuyWithFiatPartialQuote;
   client: ThirdwebClient;
@@ -31,6 +32,7 @@ export function PostOnRampSwapFlow(props: {
   if (statusForSwap) {
     return (
       <PostOnRampSwap
+        title={props.title}
         buyWithFiatStatus={statusForSwap}
         client={props.client}
         onViewPendingTx={props.onViewPendingTx}
@@ -45,6 +47,7 @@ export function PostOnRampSwapFlow(props: {
   // show step 1 and step 2 details
   return (
     <FiatSteps
+      title={props.title}
       client={props.client}
       onBack={props.onBack}
       partialQuote={props.quote}

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/ConfirmationScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/ConfirmationScreen.tsx
@@ -34,6 +34,7 @@ import { addPendingTx } from "./pendingSwapTx.js";
  * @internal
  */
 export function SwapConfirmationScreen(props: {
+  title: string;
   onBack?: () => void;
   client: ThirdwebClient;
   quote: BuyWithCryptoQuote;
@@ -63,7 +64,7 @@ export function SwapConfirmationScreen(props: {
 
   return (
     <Container p="lg">
-      <ModalHeader title="Buy" onBack={props.onBack} />
+      <ModalHeader title={props.title} onBack={props.onBack} />
 
       {props.isFiatFlow ? (
         <>

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/SwapFlow.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/SwapFlow.tsx
@@ -10,6 +10,7 @@ import { SwapConfirmationScreen } from "./ConfirmationScreen.js";
 import { SwapStatusScreen } from "./SwapStatusScreen.js";
 
 type SwapFlowProps = {
+  title: string;
   onBack?: () => void;
   buyWithCryptoQuote: BuyWithCryptoQuote;
   payer: PayerInfo;
@@ -75,6 +76,7 @@ export function SwapFlow(props: SwapFlowProps) {
   if (swapTxHash) {
     return (
       <SwapStatusScreen
+        title={props.title}
         onBack={props.onBack}
         onTryAgain={props.onTryAgain}
         onViewPendingTx={props.onViewPendingTx}
@@ -90,6 +92,7 @@ export function SwapFlow(props: SwapFlowProps) {
 
   return (
     <SwapConfirmationScreen
+      title={props.title}
       setSwapTxHash={setSwapTxHash}
       toChain={toChain}
       toAmount={toAmount}

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/SwapStatusScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/SwapStatusScreen.tsx
@@ -17,6 +17,7 @@ import { SwapTxDetailsTable } from "../tx-history/SwapDetailsScreen.js";
 type UIStatus = "pending" | "success" | "failed" | "partialSuccess";
 
 export function SwapStatusScreen(props: {
+  title: string;
   onBack?: () => void;
   onViewPendingTx: () => void;
   swapTxHash: string;
@@ -77,7 +78,7 @@ export function SwapStatusScreen(props: {
   return (
     <Container animate="fadein">
       <Container p="lg">
-        <ModalHeader title="Buy" onBack={props.onBack} />
+        <ModalHeader title={props.title} onBack={props.onBack} />
         <Spacer y="sm" />
 
         {uiStatus === "success" && (

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/tx-history/FiatDetailsScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/tx-history/FiatDetailsScreen.tsx
@@ -43,6 +43,7 @@ export function FiatDetailsScreen(props: {
     const fiatQuote = status.quote;
     return (
       <PostOnRampSwapFlow
+        title="Buy"
         client={props.client}
         status={status}
         onBack={props.onBack}

--- a/packages/thirdweb/src/react/web/ui/PayEmbed.tsx
+++ b/packages/thirdweb/src/react/web/ui/PayEmbed.tsx
@@ -124,6 +124,13 @@ export type PayEmbedProps = {
    */
   connectOptions?: PayEmbedConnectOptions;
 
+  /**
+   * Customize the display of the PayEmbed UI.
+   */
+  metadata?: {
+    title?: string;
+  };
+
   style?: React.CSSProperties;
 };
 
@@ -175,6 +182,7 @@ export function PayEmbed(props: PayEmbedProps) {
       <>
         <div style={{ display: screen === "tx-history" ? "none" : "inherit" }}>
           <BuyScreen
+            title={props.metadata?.title || "Buy"}
             isEmbed={true}
             supportedTokens={props.supportedTokens}
             theme={theme}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to add a dynamic `title` feature to various UI screens and components related to buying and swapping in the `ConnectWallet` module.

### Detailed summary
- Added dynamic `title` feature to multiple UI screens and components for customization.
- Updated `title` handling in `BuyScreen`, `SwapConfirmationScreen`, `FiatSteps`, and more.
- Improved user experience by allowing custom titles in different stages of the buying and swapping process.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->