### PR TITLE
Allow to add extra call data to prepareContractCall

### DIFF
--- a/.changeset/strange-yaks-move.md
+++ b/.changeset/strange-yaks-move.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Allow to add extra call data to `prepareContractCall`

--- a/packages/thirdweb/src/transaction/actions/encode.test.ts
+++ b/packages/thirdweb/src/transaction/actions/encode.test.ts
@@ -1,13 +1,25 @@
 import { describe, expect, it } from "vitest";
-import { TEST_WALLET_A } from "~test/addresses.js";
+import { TEST_WALLET_A, TEST_WALLET_B } from "~test/addresses.js";
+import { FORKED_ETHEREUM_CHAIN } from "~test/chains.js";
+import { TEST_CLIENT } from "~test/test-clients.js";
 import { USDT_CONTRACT, USDT_CONTRACT_WITH_ABI } from "~test/test-contracts.js";
-import { encode } from "./encode.js";
-
+import { concatHex } from "../../utils/encoding/helpers/concat-hex.js";
+import { toHex } from "../../utils/encoding/hex.js";
+import { toWei } from "../../utils/units.js";
 import { prepareContractCall } from "../prepare-contract-call.js";
+import { prepareTransaction } from "../prepare-transaction.js";
 import { resolveMethod } from "../resolve-method.js";
+import { encode, getDataFromTx, getExtraCallDataFromTx } from "./encode.js";
 
 const USDC_TRANSFER_ENCODE_RESULT =
   "0xa9059cbb00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000064";
+
+const extraCallDataMsg = "Hello, World";
+const extraCallData = toHex(extraCallDataMsg);
+const expectedFinalData = concatHex([
+  USDC_TRANSFER_ENCODE_RESULT,
+  extraCallData,
+]);
 
 describe("transaction: encode", () => {
   it("should encode correctly (human-readable)", async () => {
@@ -57,5 +69,142 @@ describe("transaction: encode", () => {
     });
     const encoded = await encode(tx);
     expect(encoded).toEqual(USDC_TRANSFER_ENCODE_RESULT);
+  });
+
+  // Repeat the same test cases above but now with extraCallData
+
+  it("extraCallData | should encode correctly (human-readable)", async () => {
+    const tx = prepareContractCall({
+      contract: USDT_CONTRACT,
+      method: "function transfer(address, uint256) returns (bool)",
+      params: [TEST_WALLET_A, 100n],
+      extraCallData,
+    });
+    const encoded = await encode(tx);
+    expect(encoded).toEqual(expectedFinalData);
+  });
+
+  it("extraCallData | should encode correctly (transaction abi)", async () => {
+    const tx = prepareContractCall({
+      contract: USDT_CONTRACT,
+      method: {
+        inputs: [
+          { internalType: "address", name: "to", type: "address" },
+          { internalType: "uint256", name: "value", type: "uint256" },
+        ],
+        name: "transfer",
+        outputs: [{ internalType: "bool", name: "", type: "bool" }],
+        stateMutability: "nonpayable",
+        type: "function",
+      },
+      params: [TEST_WALLET_A, 100n],
+      extraCallData,
+    });
+    const encoded = await encode(tx);
+    expect(encoded).toEqual(expectedFinalData);
+  });
+
+  it("extraCallData | should encode correctly (contract abi)", async () => {
+    const tx = prepareContractCall({
+      contract: USDT_CONTRACT_WITH_ABI,
+      method: "transfer",
+      params: [TEST_WALLET_A, 100n],
+      extraCallData,
+    });
+    const encoded = await encode(tx);
+    expect(encoded).toEqual(expectedFinalData);
+  });
+  it("extraCallData | should encode correctly (auto-abi)", async () => {
+    const tx = prepareContractCall({
+      contract: USDT_CONTRACT,
+      method: resolveMethod("transfer"),
+      params: [TEST_WALLET_A, 100n],
+      extraCallData,
+    });
+    const encoded = await encode(tx);
+    expect(encoded).toEqual(expectedFinalData);
+  });
+
+  it("extraCallData - should work with prepareTransaction", async () => {
+    const tx = prepareTransaction({
+      chain: FORKED_ETHEREUM_CHAIN,
+      client: TEST_CLIENT,
+      to: TEST_WALLET_B,
+      value: toWei("0.1"),
+    });
+    const encoded = await encode(tx);
+
+    const txWithExtraData = prepareTransaction({
+      chain: FORKED_ETHEREUM_CHAIN,
+      client: TEST_CLIENT,
+      to: TEST_WALLET_B,
+      value: toWei("0.1"),
+      extraCallData,
+    });
+
+    const encoded2 = await encode(txWithExtraData);
+    expect(encoded2).toBe(concatHex([encoded, extraCallData]));
+  });
+
+  it("internal func: getDataFromTx | should return `0x` if no data is attached", async () => {
+    const tx = prepareTransaction({
+      chain: FORKED_ETHEREUM_CHAIN,
+      client: TEST_CLIENT,
+      to: TEST_WALLET_B,
+      value: toWei("0.1"),
+    });
+    const _hex = await getDataFromTx(tx);
+    expect(_hex).toBe("0x");
+  });
+
+  it("internal func: getDataFromTx | should return correctly encoded data", async () => {
+    const tx = prepareTransaction({
+      chain: FORKED_ETHEREUM_CHAIN,
+      client: TEST_CLIENT,
+      to: TEST_WALLET_B,
+      value: toWei("0.1"),
+      data: extraCallData,
+    });
+    const _hex = await getDataFromTx(tx);
+    expect(_hex).toBe(extraCallData);
+  });
+
+  it("internal func: getExtraCallDataFromTx | should return `undefined` if no data is attached", async () => {
+    const tx = prepareTransaction({
+      chain: FORKED_ETHEREUM_CHAIN,
+      client: TEST_CLIENT,
+      to: TEST_WALLET_B,
+      value: toWei("0.1"),
+    });
+    const result = await getExtraCallDataFromTx(tx);
+    expect(result).toBe(undefined);
+  });
+
+  it("internal func: getExtraCallDataFromTx | should return correct extraCallData", async () => {
+    const tx = prepareTransaction({
+      chain: FORKED_ETHEREUM_CHAIN,
+      client: TEST_CLIENT,
+      to: TEST_WALLET_B,
+      value: toWei("0.1"),
+      data: toHex("getExtraCallDataFromTx-should-not-return-this"),
+      extraCallData,
+    });
+    const result = await getExtraCallDataFromTx(tx);
+    expect(result).toBe(extraCallData);
+  });
+
+  it("internal func: getExtraCallDataFromTx | should throw error if extraCallData is not hex-encoded", async () => {
+    const tx = prepareTransaction({
+      chain: FORKED_ETHEREUM_CHAIN,
+      client: TEST_CLIENT,
+      to: TEST_WALLET_B,
+      value: toWei("0.1"),
+      data: toHex("getExtraCallDataFromTx-should-not-return-this"),
+      // @ts-ignore Intentionally for the test purpose
+      extraCallData: "I'm a cat",
+    });
+    await expect(() => getExtraCallDataFromTx(tx)).rejects.toThrowError(
+      "Invalid extra calldata - must be a hex string",
+    );
   });
 });

--- a/packages/thirdweb/src/transaction/prepare-contract-call.test.ts
+++ b/packages/thirdweb/src/transaction/prepare-contract-call.test.ts
@@ -1,13 +1,11 @@
-import { describe, expect, test } from "vitest";
-
+import { describe, expect, it } from "vitest";
 import { TEST_WALLET_B } from "../../test/src/addresses.js";
-
 import { USDT_CONTRACT_WITH_ABI } from "../../test/src/test-contracts.js";
 import { toWei } from "../utils/units.js";
 import { prepareContractCall } from "./prepare-contract-call.js";
 
-describe("prepareContractCall", () => {
-  test("should prepare a contract call with ABI", () => {
+describe.runIf(process.env.TW_SECRET_KEY)("prepareContractCall", () => {
+  it("should prepare a contract call with ABI", () => {
     const preparedTx = prepareContractCall({
       contract: USDT_CONTRACT_WITH_ABI,
       method: "transfer",

--- a/packages/thirdweb/src/transaction/prepare-contract-call.ts
+++ b/packages/thirdweb/src/transaction/prepare-contract-call.ts
@@ -121,6 +121,23 @@ export type PrepareContractCallOptions<
  *  params: [to, value],
  * });
  * ```
+ *
+ * @example
+ * Passing extra call data to the transaction
+ * ```ts
+ * import { getContract, prepareContractCall } from "thirdweb";
+ * const contract = getContract({
+ *   ..., // chain, address, client
+ * });
+ *
+ * const transaction = prepareContractCall({
+ *   contract,
+ *   method: "function transfer(address to, uint256 value)",
+ *   params: [...],
+ *   // The extra call data MUST be encoded to hex before passing
+ *   extraCallData: "0x......."
+ * });
+ * ```
  */
 export function prepareContractCall<
   const TAbi extends Abi,

--- a/packages/thirdweb/src/transaction/prepare-transaction.ts
+++ b/packages/thirdweb/src/transaction/prepare-transaction.ts
@@ -24,6 +24,7 @@ export type StaticPrepareTransactionOptions = {
   chain: Chain;
   client: ThirdwebClient;
   // extras
+  extraCallData?: Hex;
   erc20Value?: {
     amountWei: bigint;
     tokenAddress: Address;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR enhances the `prepareContractCall` function in the `thirdweb` package to support adding extra call data to transactions.

### Detailed summary
- Added support for `extraCallData` in `prepareContractCall`
- Implemented `getDataFromTx` to extract transaction data
- Implemented `getExtraCallDataFromTx` to extract extra call data

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->