### PR TITLE
Export getClaimParams for thirdweb Drop contracts

### DIFF
--- a/.changeset/smart-mails-learn.md
+++ b/.changeset/smart-mails-learn.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Export utils method: getClaimParams for thirdweb Drop contracts

--- a/packages/thirdweb/src/exports/utils.ts
+++ b/packages/thirdweb/src/exports/utils.ts
@@ -157,3 +157,11 @@ export { decodeJWT } from "../utils/jwt/decode-jwt.js";
 export { encodeJWT, type JWTPayloadInput } from "../utils/jwt/encode-jwt.js";
 export { refreshJWT, type RefreshJWTParams } from "../utils/jwt/refresh-jwt.js";
 export type { JWTPayload } from "../utils/jwt/types.js";
+
+// ------------------------------------------------
+// thirdweb Drop contracts
+// ------------------------------------------------
+export {
+  getClaimParams,
+  type GetClaimParamsOptions,
+} from "../utils/extensions/drops/get-claim-params.js";


### PR DESCRIPTION
Initially this is for interacting with other frameworks like frog.fm
Might be useful elsewhere idk

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on exporting a new utils method `getClaimParams` for thirdweb Drop contracts.

### Detailed summary
- Exported `getClaimParams` method for thirdweb Drop contracts
- Added type `GetClaimParamsOptions` for `getClaimParams`
- Updated exports in `utils.ts` to include `getClaimParams` and related types

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->