### PR TITLE
Add `type` prop for `TransactionButton`

### DIFF
--- a/.changeset/fluffy-pets-yawn.md
+++ b/.changeset/fluffy-pets-yawn.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Add `type` prop for `TransactionButton`

--- a/packages/thirdweb/src/react/core/hooks/transaction/transaction-button-utils.ts
+++ b/packages/thirdweb/src/react/core/hooks/transaction/transaction-button-utils.ts
@@ -100,6 +100,13 @@ export type TransactionButtonProps = {
    * The theme to use for the button
    */
   theme?: "dark" | "light" | Theme;
+
+  /**
+   * Set the type attribute of the button element.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLButtonElement/type)
+   */
+  type?: HTMLButtonElement["type"];
 };
 
 export const useTransactionButtonMutation = (


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to add a `type` prop for the `TransactionButton` component in the `thirdweb` package.

### Detailed summary
- Added `type` prop for `TransactionButton`
- Updated `TransactionButton` component to accept `type` prop
- Added type definition for `type` prop in `TransactionButton` component
- Updated `useTransactionButtonMutation` hook to handle `type` prop

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->