### PR TITLE
Fix "add custom network" button not closing details modal

### DIFF
--- a/.changeset/serious-avocados-juggle.md
+++ b/.changeset/serious-avocados-juggle.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix "add custom network" button not closing details modal

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/NetworkSelector.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/NetworkSelector.tsx
@@ -464,6 +464,7 @@ export function NetworkSelectorContent(props: NetworkSelectorContentProps) {
               variant="link"
               onClick={() => {
                 onCustomClick();
+                props.closeModal();
               }}
               style={{
                 display: "flex",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR fixes the issue where the "add custom network" button did not close the details modal in `NetworkSelector.tsx`.

### Detailed summary
- Fixed issue with "add custom network" button not closing details modal
- Added `props.closeModal()` to the onClick event handler

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->