### PR TITLE
new fields for usage event schema

### DIFF
--- a/.changeset/tasty-wolves-approve.md
+++ b/.changeset/tasty-wolves-approve.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+schema changes for usage tracker event

--- a/packages/service-utils/src/cf-worker/usage.ts
+++ b/packages/service-utils/src/cf-worker/usage.ts
@@ -26,6 +26,7 @@ const usageEventSchema = z.object({
     "checkout",
     "engine",
     "pay",
+    "rpcV2",
   ]),
   action: z.string(),
 
@@ -98,6 +99,8 @@ const usageEventSchema = z.object({
   toAmountUSDCents: z.number().optional(),
   secondaryProvider: z.string().optional(),
   onRampId: z.string().optional(),
+  evmRequestParams: z.string().optional(),
+  providerIp: z.string().optional(),
 });
 export type UsageEvent = z.infer<typeof usageEventSchema>;
 


### PR DESCRIPTION
## Problem solved

Adds 2 new optional fields to usage event schema:
* evmRequestParams
* providerIp

Allows a new possible source for the event - `rpcV2`

## Changes made

- [x] service-utils: Update usage tracker schema

## How to test

## Contributor NFT

Paste in your wallet address below and we will airdrop you a special NFT when your pull request is merged. 

```Address: ```

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the schema for the usage tracker event in `usage.ts` and adds new fields like `evmRequestParams` and `providerIp`.

### Detailed summary
- Updated schema for usage tracker event in `usage.ts`
- Added `evmRequestParams` field
- Added `providerIp` field

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->