### PR TITLE
[Feature] Update title in PRICING_SECTIONS for Monthly Active In-App Wallets

### DIFF
--- a/apps/dashboard/src/utils/pricing.tsx
+++ b/apps/dashboard/src/utils/pricing.tsx
@@ -88,7 +88,7 @@ export const PRICING_SECTIONS: PricingSection[] = [
     title: "Usage based pricing:",
     items: [
       {
-        title: "Monthly Active Wallets",
+        title: "Monthly Active In-App Wallets",
         starter: ["1,000", "then $0.02/wallet"],
         growth: ["10,000", "then $0.02/wallet"],
         pro: "Custom",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the title of a pricing item in `pricing.tsx` from "Monthly Active Wallets" to "Monthly Active In-App Wallets".

### Detailed summary
- Updated the title of a pricing item from "Monthly Active Wallets" to "Monthly Active In-App Wallets"

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->