### PR TITLE
Fix Network Selector only showing 1 search result

### DIFF
--- a/.changeset/hip-windows-whisper.md
+++ b/.changeset/hip-windows-whisper.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix Network Switcher only showing 1 search result

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/NetworkSelector.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/NetworkSelector.tsx
@@ -330,8 +330,6 @@ export function NetworkSelectorContent(props: NetworkSelectorContentProps) {
             chains: [c],
           });
         }
-
-        return filteredChainSectionsValue;
       }
 
       return filteredChainSectionsValue;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on fixing the issue where the Network Switcher was only showing 1 search result.

### Detailed summary
- Fixed Network Switcher showing only 1 search result in `NetworkSelector.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->