### PR TITLE
fix(dashboard): domain validation for ecosystem partner domains

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/[slug]/(active)/components/client/add-partner-form.client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/[slug]/(active)/components/client/add-partner-form.client.tsx
@@ -26,7 +26,7 @@ import type { Ecosystem } from "../../../../types";
 import { useAddPartner } from "../../hooks/use-add-partner";
 
 const isDomainRegex =
-  /^(?:\*|localhost(?::\d{1,5})?|(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9])$/;
+  /^(?:\*|(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)*(?:\*(?:\.[a-z0-9][a-z0-9-]{0,61}[a-z0-9](?:\.[a-z0-9][a-z0-9-]{0,61}[a-z0-9])*)?)|(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]|localhost(?::\d{1,5})?)$/;
 const formSchema = z.object({
   name: z
     .string()


### PR DESCRIPTION
### TL;DR
Updated the domain validation regex in the AddPartnerForm component to handle new wildcard subdomain cases and made minor formatting fixes.

### What changed?
- Updated the domain validation regex to handle new wildcard subdomain cases.
- Fixed minor formatting issues with array and string declarations.

### How to test?
1. Navigate to the Add Partner form in the dashboard.
2. Test the domain input field with the following cases to ensure proper validation:
   - general domains (e.g., example.com)
   - wildcard subdomains (e.g., *.example.com)
   - nested wildcard subdomains (e.g., *.*.example.com)

### Why make this change?
The changes were necessary to improve the domain validation mechanism by accommodating new wildcard subdomain cases, and to maintain code quality through consistent formatting.

---

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the regular expression for domain validation in the `add-partner-form.client.tsx` file.

### Detailed summary
- Updated the regular expression for domain validation to allow for subdomains and wildcards.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->