### PR TITLE
fix(dashboard): update ecosystem wallet copy to include wallet count

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/create/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/create/page.tsx
@@ -18,7 +18,7 @@ export default function Page() {
         <section className="flex items-start">
           <div className="overflow-hidden border shadow rounded-xl bg-card">
             <Image src={headerImage} alt="" sizes="50vw" className="w-full" />
-            <div className="p-4 pb-8 border-t md:p-6 md:pb-12">
+            <div className="p-4 pb-8 border-t md:p-6 md:pb-8 relative">
               <h4 className="text-4xl font-bold text-foreground">
                 $250{" "}
                 <span className="text-lg font-normal text-muted-foreground">
@@ -42,7 +42,14 @@ export default function Page() {
                   <CheckIcon className="w-5 h-5 text-green-500 md:mt-0.5" />{" "}
                   Custom permissions and billing across your ecosystem
                 </li>
+                <li className="flex items-start gap-2">
+                  <CheckIcon className="w-5 h-5 text-green-500 md:mt-0.5" />{" "}
+                  30,000 active wallets included*
+                </li>
               </ul>
+              <p className="mt-4 text-xs italic text-muted-foreground text-right">
+                $0.02 per additional wallet
+              </p>
             </div>
           </div>
         </section>


### PR DESCRIPTION
### TL;DR

Updated UI elements and feature list in the create page of the ecosystem section.

### What changed?

- Adjusted padding and positioning of elements for better alignment and appearance.
- Added a new feature item to the list: '30,000 active wallets included*'.
- Included a note regarding additional wallet costs ('$0.02 per additional wallet').

### How to test?

Navigate to the 'Create Ecosystem' page in the dashboard. Verify that the layout changes are correctly applied and the new feature/item is visible with the note on wallet costs.

### Why make this change?

These updates improve the clarity of information provided to users and enhance the overall user experience on the create page of the ecosystem section.

---

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the styling of the ecosystem creation page in the dashboard.

### Detailed summary
- Updated the styling of a section in the ecosystem creation page
- Added information about active wallets with pricing details
- Adjusted the layout and spacing of elements

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->