### PR TITLE
fix(thirdweb): update TransactionError constructor to correctly set message property

### DIFF
--- a/.changeset/twenty-donuts-battle.md
+++ b/.changeset/twenty-donuts-battle.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix error message not showing on reverts

--- a/packages/thirdweb/src/transaction/extract-error.ts
+++ b/packages/thirdweb/src/transaction/extract-error.ts
@@ -48,20 +48,20 @@ class TransactionError<abi extends Abi> extends Error {
   public chainId: number | undefined;
 
   constructor(reason: string, contract?: ThirdwebContract<abi>) {
-    super();
+    let message = reason;
+    if (__DEV__ && contract) {
+      // show more infor in dev
+      message = [
+        reason,
+        "",
+        `contract: ${contract.address}`,
+        `chainId: ${contract.chain?.id}`,
+      ].join("\n");
+    }
+    super(message);
     this.name = "TransactionError";
     this.contractAddress = contract?.address;
     this.chainId = contract?.chain?.id;
-    if (__DEV__ && contract) {
-      // show more infor in dev
-      this.message = [
-        reason,
-        "",
-        `contract: ${this.contractAddress}`,
-        `chainId: ${this.chainId}`,
-      ].join("\n");
-    } else {
-      this.message = reason;
-    }
+    this.message = message;
   }
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on fixing an issue where error messages were not displaying correctly during reverts in the `extract-error.ts` file.

### Detailed summary
- Refactored constructor in `extract-error.ts` to correctly display error messages on reverts
- Updated logic to show more information in development mode

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->