### PR TITLE
Add chainlist link to the contract page

### DIFF
--- a/apps/dashboard/src/components/custom-contract/contract-header/metadata-header.tsx
+++ b/apps/dashboard/src/components/custom-contract/contract-header/metadata-header.tsx
@@ -7,6 +7,7 @@ import {
 } from "@chakra-ui/react";
 import type { Chain } from "@thirdweb-dev/chains";
 import { ChainIcon } from "components/icons/ChainIcon";
+import Link from "next/link";
 import { Heading, LinkButton, Text } from "tw-components";
 import { AddressCopyButton } from "tw-components/AddressCopyButton";
 
@@ -111,6 +112,9 @@ export const MetadataHeader: React.FC<MetadataHeaderProps> = ({
                 py={{ base: 1.5, md: 1 }}
                 px={{ base: 1.5, md: 2 }}
                 gap={3}
+                as={Link}
+                href={`/${chain.chainId}`}
+                cursor="pointer"
               >
                 {chain.icon?.url && (
                   <Center


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to add a link to the chain ID in the MetadataHeader component.

### Detailed summary
- Added `Link` import from "next/link".
- Set the `as` prop to `Link`.
- Added `href` prop with `/${chain.chainId}` value.
- Set `cursor` to "pointer" for the link.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->