### PR TITLE
fix(thirdweb): make client and chain mandatory in useWalletBalance

### DIFF
--- a/.changeset/lucky-bees-wave.md
+++ b/.changeset/lucky-bees-wave.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Make client and chain mandatory in useWalletBalance

--- a/packages/thirdweb/src/react/core/hooks/others/useWalletBalance.ts
+++ b/packages/thirdweb/src/react/core/hooks/others/useWalletBalance.ts
@@ -3,12 +3,20 @@ import {
   type UseQueryResult,
   useQuery,
 } from "@tanstack/react-query";
+import type { Chain } from "../../../../chains/types.js";
+import type { Prettify } from "../../../../utils/type-utils.js";
 import {
   type GetWalletBalanceOptions,
   type GetWalletBalanceResult,
   getWalletBalance,
 } from "../../../../wallets/utils/getWalletBalance.js";
 
+export type UseWalletBalanceOptions = Prettify<
+  Omit<GetWalletBalanceOptions, "address" | "chain"> & {
+    address: string | undefined;
+    chain: Chain | undefined;
+  }
+>;
 export type UseWalletBalanceQueryOptions = Omit<
   UseQueryOptions<GetWalletBalanceResult>,
   "queryFn" | "queryKey" | "enabled"
@@ -33,7 +41,7 @@ export type UseWalletBalanceQueryOptions = Omit<
  * @wallet
  */
 export function useWalletBalance(
-  options: Partial<GetWalletBalanceOptions>,
+  options: UseWalletBalanceOptions,
   queryOptions?: UseWalletBalanceQueryOptions,
 ): UseQueryResult<GetWalletBalanceResult> {
   const { chain, address, tokenAddress, client } = options;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to make the `client` and `chain` parameters mandatory in the `useWalletBalance` function.

### Detailed summary
- Added `Chain` import
- Added `Prettify` import
- Defined `UseWalletBalanceOptions` type
- Updated `useWalletBalance` function to require `chain` and `client` parameters

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->