### PR TITLE
fix(auth): resolve typed data signatures issue in in-app wallet

### DIFF
--- a/.changeset/light-actors-allow.md
+++ b/.changeset/light-actors-allow.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix in-app wallet typed data signatures

--- a/apps/dashboard/src/@3rdweb-sdk/react/hooks/useRegistry.ts
+++ b/apps/dashboard/src/@3rdweb-sdk/react/hooks/useRegistry.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useSDK, useSigner } from "@thirdweb-dev/react";
+import { useSigner } from "@thirdweb-dev/react";
 import {
   addContractToMultiChainRegistry,
   getGaslessPolygonSDK,
@@ -134,23 +134,20 @@ type AddContractParams = {
 };
 
 export function useAddContractMutation() {
-  const sdk = useSDK();
-  const walletAddress = useActiveAccount()?.address;
-  const signer = useSigner();
+  const account = useActiveAccount();
 
   const queryClient = useQueryClient();
 
   return useMutation(
     async (data: AddContractParams) => {
-      invariant(walletAddress, "cannot add a contract without an address");
-      invariant(sdk, "sdk not provided");
+      invariant(account, "cannot add a contract without an address");
 
       return await addContractToMultiChainRegistry(
         {
           address: data.contractAddress,
           chainId: data.chainId,
         },
-        signer,
+        account,
       );
     },
     {

--- a/apps/dashboard/src/components/contract-components/hooks.ts
+++ b/apps/dashboard/src/components/contract-components/hooks.ts
@@ -595,7 +595,8 @@ export function useCustomContractDeployMutation(
 ) {
   const sdk = useSDK();
   const queryClient = useQueryClient();
-  const walletAddress = useActiveAccount()?.address;
+  const account = useActiveAccount();
+  const walletAddress = account?.address;
   const chainId = useActiveWalletChain()?.id;
   const signer = useSigner();
   const deployContext = useDeployContextModal();
@@ -845,7 +846,7 @@ export function useCustomContractDeployMutation(
               address: contractAddress,
               chainId,
             },
-            signer,
+            account,
           );
 
           deployContext.nextStep();

--- a/packages/thirdweb/src/exports/thirdweb.ts
+++ b/packages/thirdweb/src/exports/thirdweb.ts
@@ -277,3 +277,8 @@ export {
 
 // re-exports of types
 export type { AbiParameterToPrimitiveType } from "abitype";
+
+export {
+  type VerifyTypedDataParams,
+  verifyTypedData,
+} from "../auth/verify-typed-data.js";

--- a/packages/thirdweb/src/wallets/in-app/web/lib/in-app-account.ts
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/in-app-account.ts
@@ -307,23 +307,27 @@ export class IFrameWallet {
           parsedTypedData.types.EIP712Domain = undefined;
         }
         const domain = parsedTypedData.domain as TypedDataDefinition["domain"];
-        const chainId = domain?.chainId || 1;
+        const chainId = domain?.chainId;
+        const domainData = {
+          verifyingContract: domain?.verifyingContract,
+          name: domain?.name,
+          version: domain?.version,
+        };
+        // chain id can't be included if it wasn't explicitly specified
+        if (chainId) {
+          (domainData as Record<string, unknown>).chainId = chainId;
+        }
 
         const { signedTypedData } =
           await querier.call<SignedTypedDataReturnType>({
             procedureName: "signTypedDataV4",
             params: {
-              domain: {
-                chainId: chainId,
-                verifyingContract: domain?.verifyingContract,
-                name: domain?.name,
-                version: domain?.version,
-              },
+              domain: domainData,
               types:
                 parsedTypedData.types as SignerProcedureTypes["signTypedDataV4"]["types"],
               message:
                 parsedTypedData.message as SignerProcedureTypes["signTypedDataV4"]["message"],
-              chainId,
+              chainId: chainId || 1,
               partnerId,
               rpcEndpoint: `https://${chainId}.rpc.thirdweb.com`, // TODO (ew) shouldnt be needed
             },


### PR DESCRIPTION
### TL;DR

- Added domain data for typed data signatures.
- Updated hooks and utilities to use `account` instead of `signer`.

### What changed?

- Modified `useRegistry.ts`, `hooks.ts`, and `utils.ts` to replace `signer` with `account` for signing transactions.
- Updated `in-app-account.ts` to correctly handle domain data for typed data signatures.

### How to test?

1. Deploy a contract using the dashboard and ensure that `account` is used correctly instead of `signer`.
2. Validate that typed data signatures are correctly generated in the in-app wallet.

### Why make this change?

To improve the accuracy and reliability of in-app wallet typed data signatures by ensuring the correct handling of domain data and consistent use of `account` across the application.

---

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to fix in-app wallet typed data signatures and improve contract handling in the dashboard.

### Detailed summary
- Fixed in-app wallet typed data signatures
- Improved contract handling in the dashboard
- Refactored use of active account and signer in hooks
- Updated contract registry logic and transaction handling

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->