### PR TITLE
feat(airdrop): add fetchProofsERC methods for ERC20, ERC721, and ERC1155

### DIFF
--- a/.changeset/lucky-cougars-add.md
+++ b/.changeset/lucky-cougars-add.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": minor
+---
+
+Adds fetchProofsERCXX methods

--- a/packages/thirdweb/src/exports/extensions/airdrop.ts
+++ b/packages/thirdweb/src/exports/extensions/airdrop.ts
@@ -13,6 +13,9 @@ export {
   tokenMerkleRoot,
   type TokenMerkleRootParams,
 } from "../../extensions/airdrop/__generated__/Airdrop/read/tokenMerkleRoot.js";
+export { fetchProofsERC721 } from "../../utils/extensions/airdrop/fetch-proofs-erc721.js";
+export { fetchProofsERC20 } from "../../utils/extensions/airdrop/fetch-proofs-erc20.js";
+export { fetchProofsERC1155 } from "../../utils/extensions/airdrop/fetch-proofs-erc1155.js";
 
 /**
  * Write

--- a/packages/thirdweb/src/extensions/airdrop/write/claimERC20.ts
+++ b/packages/thirdweb/src/extensions/airdrop/write/claimERC20.ts
@@ -4,7 +4,7 @@ import {
 } from "../../../constants/addresses.js";
 import type { BaseTransactionOptions } from "../../../transaction/types.js";
 import type { Address } from "../../../utils/address.js";
-import { fetchProofsrERC20 } from "../../../utils/extensions/airdrop/fetch-proofs-erc20.js";
+import { fetchProofsERC20 } from "../../../utils/extensions/airdrop/fetch-proofs-erc20.js";
 import { tokenMerkleRoot } from "../__generated__/Airdrop/read/tokenMerkleRoot.js";
 import { claimERC20 as generatedClaimERC20 } from "../__generated__/Airdrop/write/claimERC20.js";
 
@@ -67,7 +67,7 @@ export function claimERC20(options: BaseTransactionOptions<ClaimERC20Params>) {
         return await getDecimals({ contract: tokenContract });
       })();
 
-      const merkleProof = await fetchProofsrERC20({
+      const merkleProof = await fetchProofsERC20({
         contract: options.contract,
         recipient: options.recipient,
         merkleRoot,

--- a/packages/thirdweb/src/utils/extensions/airdrop/fetch-proofs-erc1155.ts
+++ b/packages/thirdweb/src/utils/extensions/airdrop/fetch-proofs-erc1155.ts
@@ -10,6 +10,40 @@ import type {
   ShardedMerkleTreeInfo,
 } from "./types.js";
 
+/*
+ * Retrieves the claim merkle proof for the provided address.
+ * @param {Object} options
+ * @param {@link ThirdwebContract} contract - The ERC1155 airdrop contract
+ * @param {string} recipient - The address of the drop recipient
+ * @param {string} merkleRoot - The merkle root, found on the active claim condition
+ *
+ * @returns {Promise<ClaimProofERC20 | null>} A promise that resolves to the proof or null if the recipient is not in the allowlist
+ *
+ * @example
+ * ```ts
+ * import { fetchProofsERCC1155 } from "thirdweb/extensions/airdrop";
+ * import { getContract, defineChain } from "thirdweb";
+ *
+ * const TOKEN = getContracct({
+ *  client,
+ *  chain: defineChain(1),
+ *  address: "0x..."
+ * });
+ *
+ * const merkleRoot = await tokenMerkleRoot({
+ *  contract: TOKEN,
+ *  tokenAddress: TOKEN.address
+ * });
+ *
+ * const proof = await fetchProofsERC1155({
+ *  contract: TOKEN,
+ *  recipient: "0x...",
+ *  merkleRoot
+ * });
+ * ```
+ *
+ * @extension AIRDROP
+ */
 export async function fetchProofsERC1155(options: {
   contract: ThirdwebContract;
   recipient: string;

--- a/packages/thirdweb/src/utils/extensions/airdrop/fetch-proofs-erc20.ts
+++ b/packages/thirdweb/src/utils/extensions/airdrop/fetch-proofs-erc20.ts
@@ -11,7 +11,41 @@ import type {
   ShardedMerkleTreeInfo,
 } from "./types.js";
 
-export async function fetchProofsrERC20(options: {
+/*
+ * Retrieves the claim merkle proof for the provided address.
+ * @param {Object} options
+ * @param {@link ThirdwebContract} contract - The ERC20 airdrop contract
+ * @param {string} recipient - The address of the drop recipient
+ * @param {string} merkleRoot - The merkle root, found on the active claim condition
+ *
+ * @returns {Promise<ClaimProofERC20 | null>} A promise that resolves to the proof or null if the recipient is not in the allowlist
+ *
+ * @example
+ * ```ts
+ * import { fetchProofsERCC20 } from "thirdweb/extensions/airdrop";
+ * import { getContract, defineChain } from "thirdweb";
+ *
+ * const TOKEN = getContracct({
+ *  client,
+ *  chain: defineChain(1),
+ *  address: "0x..."
+ * });
+ *
+ * const merkleRoot = await tokenMerkleRoot({
+ *  contract: TOKEN,
+ *  tokenAddress: TOKEN.address
+ * });
+ *
+ * const proof = await fetchProofsERC20({
+ *  contract: TOKEN,
+ *  recipient: "0x...",
+ *  merkleRoot
+ * });
+ * ```
+ *
+ * @extension AIRDROP
+ */
+export async function fetchProofsERC20(options: {
   contract: ThirdwebContract;
   recipient: string;
   merkleRoot: string;

--- a/packages/thirdweb/src/utils/extensions/airdrop/fetch-proofs-erc721.ts
+++ b/packages/thirdweb/src/utils/extensions/airdrop/fetch-proofs-erc721.ts
@@ -10,6 +10,40 @@ import type {
   ShardedMerkleTreeInfo,
 } from "./types.js";
 
+/*
+ * Retrieves the claim merkle proof for the provided address.
+ * @param {Object} options
+ * @param {@link ThirdwebContract} contract - The ERC721 airdrop contract
+ * @param {string} recipient - The address of the drop recipient
+ * @param {string} merkleRoot - The merkle root, found on the active claim condition
+ *
+ * @returns {Promise<ClaimProofERC721 | null>} A promise that resolves to the proof or null if the recipient is not in the allowlist
+ *
+ * @example
+ * ```ts
+ * import { fetchProofsERC721 } from "thirdweb/extensions/airdrop";
+ * import { getContract, defineChain } from "thirdweb";
+ *
+ * const NFT = getContracct({
+ *  client,
+ *  chain: defineChain(1),
+ *  address: "0x..."
+ * });
+ *
+ * const merkleRoot = await tokenMerkleRoot({
+ *  contract: NFT,
+ *  tokenAddress: NFT.address
+ * });
+ *
+ * const proof = await fetchProofsERC721({
+ *  contract: NFT,
+ *  recipient: "0x...",
+ *  merkleRoot
+ * });
+ * ```
+ *
+ * @extension AIRDROP
+ */
 export async function fetchProofsERC721(options: {
   contract: ThirdwebContract;
   recipient: string;


### PR DESCRIPTION
This update introduces new methods for fetching proofs for ERCXX tokens (specifically ERC20, ERC721, and ERC1155). The methods `fetchProofsERC20`, `fetchProofsERC721`, and `fetchProofsERC1155` have been added to the airdrop extension. These methods allow users to retrieve claim Merkle proofs for the specified address and tokens, ensuring that users in the allowlist can claim their airdrop. Additionally, example usage and detailed docstrings have been included to guide developers on how to implement these methods in their projects.

---

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add `fetchProofsERCXX` methods for ERC721, ERC20, and ERC1155 airdrop contracts.

### Detailed summary
- Added `fetchProofsERC721`, `fetchProofsERC20`, and `fetchProofsERC1155` methods
- Updated imports in `claimERC20.ts`
- Added detailed documentation for each method

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->