### PR TITLE
feat(smart): ERC20 paymaster support

### DIFF
--- a/.changeset/loud-lies-suffer.md
+++ b/.changeset/loud-lies-suffer.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Add support for ERC20 paymaster for smart accounts

--- a/packages/thirdweb/src/react/core/utils/defaultTokens.ts
+++ b/packages/thirdweb/src/react/core/utils/defaultTokens.ts
@@ -91,6 +91,14 @@ export const defaultTokens: SupportedTokens = {
       icon: maticIcon,
     },
   ],
+  "11155111": [
+    {
+      address: "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",
+      name: "USD Coin",
+      symbol: "USDC",
+      icon: usdcIcon,
+    },
+  ],
   "10": [
     {
       address: "0x4200000000000000000000000000000000000006",

--- a/packages/thirdweb/src/wallets/smart/index.ts
+++ b/packages/thirdweb/src/wallets/smart/index.ts
@@ -4,10 +4,14 @@ import {
   type TypedDataDefinition,
   type TypedDataDomain,
   hashTypedData,
+  maxUint96,
 } from "viem";
 import type { Chain } from "../../chains/types.js";
 import { getCachedChain } from "../../chains/utils.js";
 import { type ThirdwebContract, getContract } from "../../contract/contract.js";
+import { allowance } from "../../extensions/erc20/__generated__/IERC20/read/allowance.js";
+import { approve } from "../../extensions/erc20/write/approve.js";
+import { toSerializableTransaction } from "../../transaction/actions/to-serializable-transaction.js";
 import type { WaitForReceiptOptions } from "../../transaction/actions/wait-for-tx-receipt.js";
 import {
   populateEip712Transaction,
@@ -15,6 +19,8 @@ import {
 } from "../../transaction/actions/zksync/send-eip712-transaction.js";
 import type { PreparedTransaction } from "../../transaction/prepare-transaction.js";
 import { getAddress } from "../../utils/address.js";
+import { concatHex } from "../../utils/encoding/helpers/concat-hex.js";
+import type { Hex } from "../../utils/encoding/hex.js";
 import { parseTypedData } from "../../utils/signatures/helpers/parseTypedData.js";
 import type {
   Account,
@@ -44,9 +50,11 @@ import {
 } from "./lib/userop.js";
 import { isNativeAAChain } from "./lib/utils.js";
 import type {
+  PaymasterResult,
   SmartAccountOptions,
   SmartWalletConnectionOptions,
   SmartWalletOptions,
+  UserOperation,
 } from "./types.js";
 
 /**
@@ -170,6 +178,27 @@ async function createSmartAccount(
   const account: Account = {
     address: getAddress(accountContract.address),
     async sendTransaction(transaction: SendTransactionOption) {
+      // if erc20 paymaster - check allowance and approve if needed
+      const erc20Paymaster = options.overrides?.erc20Paymaster;
+      let paymasterOverride:
+        | undefined
+        | ((userOp: UserOperation) => Promise<PaymasterResult>) = undefined;
+      if (erc20Paymaster) {
+        await approveERC20({
+          accountContract,
+          erc20Paymaster,
+          options,
+        });
+        const paymasterCallback = async (): Promise<PaymasterResult> => {
+          return {
+            paymasterAndData: concatHex([
+              erc20Paymaster.address as Hex,
+              erc20Paymaster?.token as Hex,
+            ]),
+          };
+        };
+        paymasterOverride = options.overrides?.paymaster || paymasterCallback;
+      }
       const executeTx = prepareExecute({
         accountContract,
         transaction,
@@ -177,7 +206,13 @@ async function createSmartAccount(
       });
       return _sendUserOp({
         executeTx,
-        options,
+        options: {
+          ...options,
+          overrides: {
+            ...options.overrides,
+            paymaster: paymasterOverride,
+          },
+        },
       });
     },
     async sendBatchTransaction(transactions: SendTransactionOption[]) {
@@ -360,6 +395,57 @@ async function createSmartAccount(
     },
   };
   return account;
+}
+
+async function approveERC20(args: {
+  accountContract: ThirdwebContract;
+  options: SmartAccountOptions;
+  erc20Paymaster: {
+    address: string;
+    token: string;
+  };
+}) {
+  const { accountContract, erc20Paymaster, options } = args;
+  const tokenAddress = erc20Paymaster.token;
+  const tokenContract = getContract({
+    address: tokenAddress,
+    chain: accountContract.chain,
+    client: accountContract.client,
+  });
+  const accountAllowance = await allowance({
+    contract: tokenContract,
+    owner: accountContract.address,
+    spender: erc20Paymaster.address,
+  });
+
+  if (accountAllowance > 0n) {
+    return;
+  }
+
+  const approveTx = approve({
+    contract: tokenContract,
+    spender: erc20Paymaster.address,
+    amountWei: maxUint96 - 1n,
+  });
+  const transaction = await toSerializableTransaction({
+    transaction: approveTx,
+    from: accountContract.address,
+  });
+  const executeTx = prepareExecute({
+    accountContract,
+    transaction,
+    executeOverride: options.overrides?.execute,
+  });
+  await _sendUserOp({
+    executeTx,
+    options: {
+      ...options,
+      overrides: {
+        ...options.overrides,
+        erc20Paymaster: undefined,
+      },
+    },
+  });
 }
 
 function createZkSyncAccount(args: {

--- a/packages/thirdweb/src/wallets/smart/types.ts
+++ b/packages/thirdweb/src/wallets/smart/types.ts
@@ -17,6 +17,10 @@ export type SmartWalletOptions = Prettify<
       accountAddress?: string;
       accountSalt?: string;
       entrypointAddress?: string;
+      erc20Paymaster?: {
+        address: string;
+        token: string;
+      };
       paymaster?: (userOp: UserOperation) => Promise<PaymasterResult>;
       predictAddress?: (factoryContract: ThirdwebContract) => Promise<string>;
       createAccount?: (


### PR DESCRIPTION
### TL;DR

Adds support for using an ERC20 paymaster in smart accounts. This includes functionality to check and approve ERC20 allowances as needed.

### What changed?

- Introduced support for ERC20 paymasters in smart accounts.
- Added logic to check and approve ERC20 allowances.
- Updated the `defaultTokens` list to include a new token for testing purposes.

### How to test?

1. Ensure that the smart account can interact with ERC20 paymasters.
2. Verify that the account approval for ERC20 paymasters works as expected.
3. Check that the default tokens list reflects the new token and can be utilized appropriately.

### Why make this change?

To enable smart accounts to use ERC20 tokens for paymaster functionalities, enhancing versatility and use-case scenarios for smart accounts.

---

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for ERC20 paymaster for smart accounts.

### Detailed summary
- Added ERC20 paymaster support for smart accounts
- Implemented functions for approving ERC20 tokens
- Updated transaction handling for ERC20 paymaster integration

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->