### PR TITLE
fix(dashboard): Fix zksync deployments with inapp wallet

### DIFF
--- a/legacy_packages/sdk/src/evm/zksync/zkDeployContractDeterministic.ts
+++ b/legacy_packages/sdk/src/evm/zksync/zkDeployContractDeterministic.ts
@@ -121,16 +121,16 @@ export async function zkDeployContractDeterministic(
         );
       } catch (error) {}
 
-      try {
-        zkVerify(
-          transaction.predictedAddress,
-          chainId,
-          blockExplorerApiMap[chainId],
-          "",
-          storage,
-          metadataUri,
-        );
-      } catch (error) {}
+      zkVerify(
+        transaction.predictedAddress,
+        chainId,
+        blockExplorerApiMap[chainId],
+        "",
+        storage,
+        metadataUri,
+      ).catch((error) => {
+        console.warn("Error verifying contract", error);
+      });
     }
   }
 }

--- a/legacy_packages/sdk/src/evm/zksync/zksync-deploy-utils.ts
+++ b/legacy_packages/sdk/src/evm/zksync/zksync-deploy-utils.ts
@@ -304,18 +304,16 @@ export async function zkDeployContractFromUri(
   }
 
   // fire-and-forget verification, don't await
-  try {
-    zkVerify(
-      deployedAddress,
-      chainId,
-      blockExplorerApiMap[chainId],
-      "",
-      storage,
-      compilerMetadata.fetchedMetadataUri,
-    );
-  } catch (error) {
-    // ignore error
-  }
+  zkVerify(
+    deployedAddress,
+    chainId,
+    blockExplorerApiMap[chainId],
+    "",
+    storage,
+    compilerMetadata.fetchedMetadataUri,
+  ).catch((error) => {
+    console.warn("Error verifying contract", error);
+  });
 
   return deployedAddress;
 }


### PR DESCRIPTION
This PR removes the usage of a fake zkSigner when deploying contracts with zkSync on the dashboard. The code now uses the regular signer directly without creating a fake external provider. Additionally, error handling for the zkVerify function has been improved by converting try-catch blocks to promise catch handlers to log warnings instead of silently ignoring errors.

---

 

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to refactor contract verification code in `zkDeployContractDeterministic.ts` and `zksync-deploy-utils.ts`, and remove unnecessary dependencies in `hooks.ts`.

### Detailed summary
- Refactored contract verification to use `catch` for error handling
- Removed unnecessary `ethers` import in `hooks.ts`
- Removed `Web3Provider` import and related code in `hooks.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->