### PR TITLE
added cache removal when faucet transfer fails

### DIFF
--- a/apps/dashboard/src/lib/redis.ts
+++ b/apps/dashboard/src/lib/redis.ts
@@ -16,3 +16,5 @@ export const cacheGet = async (key: string) => await _redis.get(key);
 export const cacheExists = async (key: string) => await _redis.exists(key);
 
 export const cacheTtl = async (key: string) => await _redis.ttl(key);
+
+export const cacheDeleteKey = async (key: string) => await _redis.del(key);


### PR DESCRIPTION
## Problem solved

Users rate limited when faucet fails to transfer funds e.g. faucet empty

## Changes made

- [ ] Added the mechanism to remove users from the cache when the funding transfer fails (e.g. when the faucet is empty)

## How to test

- [ ] empty the faucet or make the transfer request fail

## Contributor NFT

Paste in your wallet address below and we will airdrop you a special NFT when your pull request is merged. 

```Address: ```

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add a new function `cacheDeleteKey` to delete cache keys and update the testnet faucet configuration check.

### Detailed summary
- Added `cacheDeleteKey` function to delete cache keys in `redis.ts`
- Updated testnet faucet configuration check in `route.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->