### PR TITLE
Fix custom chain RPC not used if passed via chains prop

### DIFF
--- a/.changeset/spicy-bananas-compare.md
+++ b/.changeset/spicy-bananas-compare.md
@@ -1,0 +1,7 @@
+---
+"thirdweb": patch
+---
+
+Fix chain with custom RPC not used if the chain object is passed in the `chains` prop to `ConnectButton`, `ConnectEmbed` or `PayEmbed` components.
+
+This also fixes dashboard not using custom chain's RPC since it passes the chain object via `chains` prop

--- a/packages/thirdweb/src/chains/utils.ts
+++ b/packages/thirdweb/src/chains/utils.ts
@@ -63,6 +63,15 @@ export function defineChain(
 /**
  * @internal
  */
+export function cacheChains(chains: Chain[]) {
+  for (const chain of chains) {
+    CUSTOM_CHAIN_MAP.set(chain.id, chain);
+  }
+}
+
+/**
+ * @internal
+ */
 export function getCachedChain(id: number) {
   if (CUSTOM_CHAIN_MAP.has(id)) {
     return CUSTOM_CHAIN_MAP.get(id) as Chain;

--- a/packages/thirdweb/src/react/native/ui/connect/ConnectButton.tsx
+++ b/packages/thirdweb/src/react/native/ui/connect/ConnectButton.tsx
@@ -9,6 +9,7 @@ import {
   StyleSheet,
   View,
 } from "react-native";
+import { cacheChains } from "../../../../chains/utils.js";
 import { parseTheme } from "../../../core/design-system/CustomThemeProvider.js";
 import { useSiweAuth } from "../../../core/hooks/auth/useSiweAuth.js";
 import type { ConnectButtonProps } from "../../../core/hooks/connection/ConnectButtonProps.js";
@@ -66,6 +67,15 @@ export function ConnectButton(props: ConnectButtonProps) {
       }),
     ]).start();
   }, []);
+
+  // to update cached chains ASAP, we skip using useEffect - this does not trigger a re-render so it's fine
+  if (props.chains) {
+    cacheChains(props.chains);
+  }
+
+  if (props.chain) {
+    cacheChains([props.chain]);
+  }
 
   const closeModal = useCallback(() => {
     Animated.parallel([

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/ConnectButton.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/ConnectButton.tsx
@@ -2,6 +2,7 @@
 
 import styled from "@emotion/styled";
 import { useEffect, useMemo, useState } from "react";
+import { cacheChains } from "../../../../chains/utils.js";
 import { iconSize } from "../../../core/design-system/index.js";
 import { useSiweAuth } from "../../../core/hooks/auth/useSiweAuth.js";
 import type { ConnectButtonProps } from "../../../core/hooks/connection/ConnectButtonProps.js";
@@ -62,6 +63,15 @@ export function ConnectButton(props: ConnectButtonProps) {
     wallets,
     client: props.client,
   });
+
+  // to update cached chains ASAP, we skip using useEffect - this does not trigger a re-render so it's fine
+  if (props.chains) {
+    cacheChains(props.chains);
+  }
+
+  if (props.chain) {
+    cacheChains([props.chain]);
+  }
 
   const size = useMemo(() => {
     return !canFitWideModal() || wallets.length === 1

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/ConnectEmbed.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/ConnectEmbed.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useMemo } from "react";
 import type { Chain } from "../../../../../chains/types.js";
+import { cacheChains } from "../../../../../chains/utils.js";
 import type { ThirdwebClient } from "../../../../../client/client.js";
 import type { Wallet } from "../../../../../wallets/interfaces/wallet.js";
 import type { SmartWalletOptions } from "../../../../../wallets/smart/types.js";
@@ -61,6 +62,15 @@ export function ConnectEmbed(props: ConnectEmbedProps) {
   const siweAuth = useSiweAuth(activeWallet, props.auth);
   const show =
     !activeAccount || (siweAuth.requiresAuth && !siweAuth.isLoggedIn);
+
+  // to update cached chains ASAP, we skip using useEffect - this does not trigger a re-render so it's fine
+  if (props.chains) {
+    cacheChains(props.chains);
+  }
+
+  if (props.chain) {
+    cacheChains([props.chain]);
+  }
 
   const wallets = useMemo(
     () =>

--- a/packages/thirdweb/src/react/web/ui/PayEmbed.tsx
+++ b/packages/thirdweb/src/react/web/ui/PayEmbed.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import type { Chain } from "../../../chains/types.js";
+import { cacheChains } from "../../../chains/utils.js";
 import type { ThirdwebClient } from "../../../client/client.js";
 import type { Wallet } from "../../../wallets/interfaces/wallet.js";
 import type { SmartWalletOptions } from "../../../wallets/smart/types.js";
@@ -160,6 +161,15 @@ export function PayEmbed(props: PayEmbedProps) {
   const localeQuery = useConnectLocale(props.locale || "en_US");
   const [screen, setScreen] = useState<"buy" | "tx-history">("buy");
   const theme = props.theme || "dark";
+
+  // to update cached chains ASAP, we skip using useEffect - this does not trigger a re-render so it's fine
+  if (props.connectOptions?.chains) {
+    cacheChains(props.connectOptions?.chains);
+  }
+
+  if (props.connectOptions?.chain) {
+    cacheChains([props.connectOptions?.chain]);
+  }
 
   let content = null;
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on fixing the issue where custom RPC chains were not used when passed in props to certain components. 

### Detailed summary
- Added `cacheChains` function to update cached chains
- Utilized `cacheChains` in `ConnectButton`, `ConnectEmbed`, and `PayEmbed` components to handle custom RPC chains passed in props

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->