### PR TITLE
Increased Transaction cost buffer for Pay Modal

### DIFF
--- a/.changeset/blue-steaks-join.md
+++ b/.changeset/blue-steaks-join.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Update buffer calculation of transaction if gas estimation fails for Pay Modal

--- a/packages/thirdweb/src/react/core/hooks/transaction/useSendTransaction.ts
+++ b/packages/thirdweb/src/react/core/hooks/transaction/useSendTransaction.ts
@@ -1,5 +1,6 @@
 import { type UseMutationResult, useMutation } from "@tanstack/react-query";
 import type { Chain } from "../../../../chains/types.js";
+import { getGasPrice } from "../../../../gas/get-gas-price.js";
 import { estimateGasCost } from "../../../../transaction/actions/estimate-gas-cost.js";
 import type { GaslessOptions } from "../../../../transaction/actions/gasless/types.js";
 import { sendTransaction } from "../../../../transaction/actions/send-transaction.js";
@@ -213,11 +214,19 @@ export async function getTotalTxCostForBuy(
       // try again without passing from
       return await getTotalTxCostForBuy(tx);
     }
-    // fallback if both fail, use the tx value + 1% buffer
+    // fallback if both fail, use the tx value + 2M * gas price
     const value = await resolvePromisedValue(tx.value);
+
+    const gasPrice = await getGasPrice({
+      client: tx.client,
+      chain: tx.chain,
+    });
+
+    const buffer = 2_000_000n * gasPrice;
+
     if (!value) {
-      return 0n;
+      return 0n + buffer;
     }
-    return value + value / 100n;
+    return value + buffer;
   }
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update the buffer calculation of transactions when gas estimation fails for the Pay Modal.

### Detailed summary
- Update buffer calculation to use the transaction value + 2M * gas price
- Introduce gasPrice calculation using getGasPrice function
- Adjust the fallback logic to include the new buffer calculation

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->