### PR TITLE
fix(thirdweb): add optional 'from' in readContract method

### DIFF
--- a/.changeset/kind-ducks-run.md
+++ b/.changeset/kind-ducks-run.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Add optional 'from' in readContract()

--- a/apps/playground-web/src/components/blockchain-api/read-contract-raw.tsx
+++ b/apps/playground-web/src/components/blockchain-api/read-contract-raw.tsx
@@ -25,6 +25,7 @@ export function ReadContractRawPreview() {
     contract: onChainCryptoPunks,
     method: "function punkImageSvg(uint16 index) view returns (string svg)",
     params: [1],
+    from: "0x16F5A35647D6F03D5D3da7b35409D65ba03aF3B2",
   });
 
   return (

--- a/apps/playground-web/src/components/blockchain-api/write-contract-extension.tsx
+++ b/apps/playground-web/src/components/blockchain-api/write-contract-extension.tsx
@@ -28,6 +28,8 @@ export function WriteContractExtensionPreview() {
       <Image
         src="/twcoin.svg"
         className="mx-auto rounded-2xl animate-bounce size-32"
+        width={50}
+        height={50}
         alt=""
       />
       <div className="my-3 text-center">Claim free testnet tokens</div>

--- a/apps/playground-web/src/components/blockchain-api/write-contract-raw.tsx
+++ b/apps/playground-web/src/components/blockchain-api/write-contract-raw.tsx
@@ -48,6 +48,8 @@ export function WriteContractRawPreview() {
               <Image
                 src="/twcoin.svg"
                 className="mx-auto rounded-2xl animate-bounce size-5"
+                width={50}
+                height={50}
                 alt=""
               />
               <div>

--- a/packages/thirdweb/src/react/core/hooks/contract/useReadContract.ts
+++ b/packages/thirdweb/src/react/core/hooks/contract/useReadContract.ts
@@ -6,8 +6,8 @@ import {
 } from "@tanstack/react-query";
 import type { Abi, AbiFunction, ExtractAbiFunctionNames } from "abitype";
 import type { ThirdwebContract } from "../../../../contract/contract.js";
-import type { PrepareContractCallOptions } from "../../../../transaction/prepare-contract-call.js";
 import {
+  type ReadContractOptions,
   type ReadContractResult,
   readContract,
 } from "../../../../transaction/read-contract.js";
@@ -44,7 +44,7 @@ export function useReadContract<
     ? AbiFunction | string
     : ExtractAbiFunctionNames<abi>,
 >(
-  options: PrepareContractCallOptions<abi, method> & {
+  options: ReadContractOptions<abi, method> & {
     queryOptions?: PickedQueryOptions;
   },
 ): UseQueryResult<
@@ -88,7 +88,7 @@ export function useReadContract<
 >(
   extensionOrOptions:
     | ((options: BaseTransactionOptions<params, abi>) => Promise<result>)
-    | (PrepareContractCallOptions<abi, method> & {
+    | (ReadContractOptions<abi, method> & {
         queryOptions?: PickedQueryOptions;
       }),
   options?: BaseTransactionOptions<params, abi> & {

--- a/packages/thirdweb/src/transaction/actions/wait-for-tx-receipt.test.ts
+++ b/packages/thirdweb/src/transaction/actions/wait-for-tx-receipt.test.ts
@@ -96,15 +96,16 @@ describe("waitForReceipt", () => {
       chain: TRANSACTION.chain,
       client: TRANSACTION.client,
       transactionHash: MOCK_TX_HASH,
+      maxBlocksWaitTime: 10,
     });
 
-    for (let i = 1; i <= DEFAULT_MAX_BLOCKS_WAIT_TIME + 1; i++) {
+    for (let i = 1; i <= 10 + 1; i++) {
       emitBlockNumber(BigInt(i));
     }
 
     await expect(result).rejects.toThrow(
-      `Transaction not found after ${DEFAULT_MAX_BLOCKS_WAIT_TIME} blocks`,
+      `Transaction not found after ${10} blocks`,
     );
-    expect(mockEthGetTransactionReceipt).toHaveBeenCalledTimes(30);
+    expect(mockEthGetTransactionReceipt).toHaveBeenCalledTimes(10);
   });
 });

--- a/packages/thirdweb/src/transaction/actions/wait-for-tx-receipt.ts
+++ b/packages/thirdweb/src/transaction/actions/wait-for-tx-receipt.ts
@@ -7,7 +7,7 @@ import { watchBlockNumber } from "../../rpc/watchBlockNumber.js";
 import type { Prettify } from "../../utils/type-utils.js";
 import type { SendTransactionResult, TransactionReceipt } from "../types.js";
 
-export const DEFAULT_MAX_BLOCKS_WAIT_TIME = 30;
+export const DEFAULT_MAX_BLOCKS_WAIT_TIME = 100;
 
 const map = new Map<string, Promise<TransactionReceipt>>();
 
@@ -22,7 +22,7 @@ export type WaitForReceiptOptions = Prettify<
 /**
  * Waits for the transaction receipt of a given transaction hash on a specific contract.
  * @param options - The options for waiting for the receipt.
- * By default, it's 30 blocks.
+ * By default, it's 100 blocks.
  * @returns A promise that resolves with the transaction receipt.
  * @transaction
  * @example

--- a/packages/thirdweb/src/transaction/read-contract.test.ts
+++ b/packages/thirdweb/src/transaction/read-contract.test.ts
@@ -13,6 +13,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("transaction: read", () => {
       contract: USDT_CONTRACT,
       method: "function balanceOf(address) returns (uint256)",
       params: [VITALIK_WALLET],
+      from: VITALIK_WALLET,
     });
     expect(result).toMatchInlineSnapshot("1544900798n");
   });

--- a/packages/thirdweb/src/transaction/read-contract.ts
+++ b/packages/thirdweb/src/transaction/read-contract.ts
@@ -63,6 +63,7 @@ export type ReadContractOptions<
     | "nonce"
   > & {
     method: TMethod | TPreparedMethod;
+    from?: string;
   } & ParamsOption<TPreparedMethod[1]> &
     Omit<PrepareTransactionOptions, "to" | "data" | "chain" | "client">,
   TAbi
@@ -169,6 +170,7 @@ export async function readContract<
   const result = await eth_call(rpcRequest, {
     data: encodedData,
     to: contract.address,
+    from: options.from,
   });
   // use the prepared method to decode the result
   const decoded = decodeAbiParameters(resolvedPreparedMethod[2], result);

--- a/packages/thirdweb/src/wallets/eip5792/wait-for-bundle.test.ts
+++ b/packages/thirdweb/src/wallets/eip5792/wait-for-bundle.test.ts
@@ -84,15 +84,16 @@ describe("waitForBundle", () => {
       client: TEST_CLIENT,
       bundleId: MOCK_BUNDLE_ID,
       wallet,
+      maxBlocksWaitTime: 10,
     });
 
-    for (let i = 1; i <= DEFAULT_MAX_BLOCKS_WAIT_TIME + 1; i++) {
+    for (let i = 1; i <= 10 + 1; i++) {
       emitBlockNumber(BigInt(i));
     }
 
     await expect(result).rejects.toThrow(
-      `Bundle not confirmed after ${DEFAULT_MAX_BLOCKS_WAIT_TIME} blocks`,
+      "Bundle not confirmed after 10 blocks",
     );
-    expect(mockGetCallsStatus).toHaveBeenCalledTimes(30);
+    expect(mockGetCallsStatus).toHaveBeenCalledTimes(10);
   });
 });

--- a/packages/thirdweb/src/wallets/eip5792/wait-for-bundle.ts
+++ b/packages/thirdweb/src/wallets/eip5792/wait-for-bundle.ts
@@ -6,7 +6,7 @@ import type { Wallet } from "../interfaces/wallet.js";
 import { getCallsStatus } from "./get-calls-status.js";
 import type { GetCallsStatusResponse, WalletSendCallsId } from "./types.js";
 
-export const DEFAULT_MAX_BLOCKS_WAIT_TIME = 30;
+export const DEFAULT_MAX_BLOCKS_WAIT_TIME = 100;
 
 const map = new Map<string, Promise<GetCallsStatusResponse>>();
 
@@ -24,7 +24,7 @@ export type WaitForBundleOptions = Prettify<{
  * @note This function is dependent on the wallet's support for EIP-5792 and could fail.
  *
  * @param options - The options for waiting for the bundle.
- * By default, the max wait time is 30 blocks.
+ * By default, the max wait time is 100 blocks.
  * @returns A promise that resolves with the final {@link getCallsStatus} result.
  * @throws an error if the wallet does not support EIP-5792.
  * @beta


### PR DESCRIPTION
Fixes #3683

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance the blockchain API functionalities by adding an optional 'from' parameter in `readContract()` and adjusting block wait times.

### Detailed summary
- Added optional 'from' parameter in `readContract()`
- Adjusted block wait times to 10 blocks in multiple files
- Updated default max blocks wait time to 100
- Modified `useReadContract` function parameters for improved functionality

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->