### PR TITLE
docs: fix fetchProofs jsdocs

### DIFF
--- a/packages/thirdweb/src/utils/extensions/airdrop/fetch-proofs-erc1155.ts
+++ b/packages/thirdweb/src/utils/extensions/airdrop/fetch-proofs-erc1155.ts
@@ -10,7 +10,7 @@ import type {
   ShardedMerkleTreeInfo,
 } from "./types.js";
 
-/*
+/**
  * Retrieves the claim merkle proof for the provided address.
  * @param {Object} options
  * @param {@link ThirdwebContract} contract - The ERC1155 airdrop contract

--- a/packages/thirdweb/src/utils/extensions/airdrop/fetch-proofs-erc20.ts
+++ b/packages/thirdweb/src/utils/extensions/airdrop/fetch-proofs-erc20.ts
@@ -11,7 +11,7 @@ import type {
   ShardedMerkleTreeInfo,
 } from "./types.js";
 
-/*
+/**
  * Retrieves the claim merkle proof for the provided address.
  * @param {Object} options
  * @param {@link ThirdwebContract} contract - The ERC20 airdrop contract

--- a/packages/thirdweb/src/utils/extensions/airdrop/fetch-proofs-erc721.ts
+++ b/packages/thirdweb/src/utils/extensions/airdrop/fetch-proofs-erc721.ts
@@ -10,7 +10,7 @@ import type {
   ShardedMerkleTreeInfo,
 } from "./types.js";
 
-/*
+/**
  * Retrieves the claim merkle proof for the provided address.
  * @param {Object} options
  * @param {@link ThirdwebContract} contract - The ERC721 airdrop contract


### PR DESCRIPTION
### TL;DR

Corrected the comment style to proper JSDoc format in the fetch-proofs methods for consistency.

### What changed?

Changed multi-line comment style to JSDoc for better documentation standards in the following files:
- fetch-proofs-erc1155.ts
- fetch-proofs-erc20.ts
- fetch-proofs-erc721.ts

### How to test?

Review the comments in the files to ensure they follow the JSDoc standard.

### Why make this change?

Adhering to proper documentation standards improves code readability and maintains consistency across the codebase.

---

 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the file headers in airdrop-related utility files for ERC20, ERC721, and ERC1155 contracts.

### Detailed summary
- Updated file headers from `/*` to `/**` for consistency and JSDoc compatibility.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->