### PR TITLE
use workspace version for service-utils

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -56,7 +56,7 @@
     "@thirdweb-dev/react": "workspace:*",
     "@thirdweb-dev/react-core": "workspace:*",
     "@thirdweb-dev/sdk": "workspace:*",
-    "@thirdweb-dev/service-utils": "^0.4.36",
+    "@thirdweb-dev/service-utils": "workspace:*",
     "@thirdweb-dev/storage": "workspace:*",
     "@thirdweb-dev/wallets": "workspace:*",
     "@vercel/og": "^0.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -249,8 +249,8 @@ importers:
         specifier: workspace:*
         version: link:../../legacy_packages/sdk
       '@thirdweb-dev/service-utils':
-        specifier: ^0.4.36
-        version: 0.4.36
+        specifier: workspace:*
+        version: link:../../packages/service-utils
       '@thirdweb-dev/storage':
         specifier: workspace:*
         version: link:../../legacy_packages/storage
@@ -8225,9 +8225,6 @@ packages:
   '@thirdweb-dev/dynamic-contracts@1.2.5':
     resolution: {integrity: sha512-YVsz+jUWbwj+6aF2eTZGMfyw47a1HRmgNl4LQ3gW9gwYL5y5+OX/yOzv6aV5ibvoqCk/k10aIVK2eFrcpMubQA==}
     engines: {node: '>=18.0.0'}
-
-  '@thirdweb-dev/service-utils@0.4.36':
-    resolution: {integrity: sha512-LBK+fBpc7KK9JuTM1NlVTSYYxrnKwmEkv3xe5tMi5ZFYoGn+f5UOaagJqqznzaz5mKxtRsVLtmaZPv5xHLMCug==}
 
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
@@ -28529,11 +28526,6 @@ snapshots:
       solady: 0.0.180
 
   '@thirdweb-dev/dynamic-contracts@1.2.5': {}
-
-  '@thirdweb-dev/service-utils@0.4.36':
-    dependencies:
-      aws4fetch: 1.0.18
-      zod: 3.23.8
 
   '@tokenizer/token@0.3.0': {}
 


### PR DESCRIPTION
## Problem solved

Reverts back to workspace version for `service-utils` package

## Changes made

- [ ] Public API changes: list the public API changes made if any
- [ ] Internal API changes: explain the internal logic changes

## How to test

- [ ] Automated tests: link to unit test file
- [ ] Manual tests: step by step instructions on how to test

## Contributor NFT

Paste in your wallet address below and we will airdrop you a special NFT when your pull request is merged. 

```Address: ```

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `@thirdweb-dev/service-utils` package to use a workspace link instead of a specific version.

### Detailed summary
- Updated `@thirdweb-dev/service-utils` to use a workspace link
- Removed specific version dependency for `@thirdweb-dev/service-utils`
- Updated package resolutions and dependencies for consistency

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->