### PR TITLE
fix(dashboard): replace Wrench icon with Pencil icon in partners table

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/[slug]/(active)/components/server/partners-table.tsx
+++ b/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/[slug]/(active)/components/server/partners-table.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ToolTipLabel } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
-import { Trash2, Wrench } from "lucide-react";
+import { Pencil, Trash2 } from "lucide-react";
 import Link from "next/link";
 import { toast } from "sonner";
 import type { Ecosystem, Partner } from "../../../../types";
@@ -130,7 +130,7 @@ function TableRow(props: {
               className="text-accent-foreground/50 hover:text-accent-foreground hover:bg-accent"
               disabled={isDeleting}
             >
-              <Wrench className="size-4" />
+              <Pencil className="size-4" />
               <span className="sr-only">Edit</span>
             </Button>
           </UpdatePartnerModal>


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

## Changes made

- [ ] Public API changes: list the public API changes made if any
- [ ] Internal API changes: explain the internal logic changes

## How to test

- [ ] Automated tests: link to unit test file
- [ ] Manual tests: step by step instructions on how to test

## Contributor NFT

Paste in your wallet address below and we will airdrop you a special NFT when your pull request is merged. 

```Address: ```

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the icon used for editing partners in the partners table component.

### Detailed summary
- Updated icon from `Wrench` to `Pencil` for editing partners in the partners table component.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->