### PR TITLE
fix(transaction): handle undefined predefinedGas value in estimate-gas and add test for 0 gas value

### DIFF
--- a/packages/thirdweb/src/transaction/actions/estimate-gas.ts
+++ b/packages/thirdweb/src/transaction/actions/estimate-gas.ts
@@ -69,7 +69,7 @@ export async function estimateGas(
   const promise = (async () => {
     const predefinedGas = await resolvePromisedValue(options.transaction.gas);
     // if we have a predefined gas value in the TX -> always use that
-    if (predefinedGas) {
+    if (predefinedGas !== undefined) {
       return predefinedGas;
     }
 

--- a/packages/thirdweb/src/transaction/actions/to-serializable-transaction.test.ts
+++ b/packages/thirdweb/src/transaction/actions/to-serializable-transaction.test.ts
@@ -254,6 +254,22 @@ describe("toSerializableTransaction", () => {
         }),
       ).not.toThrow();
     });
+
+    test("should respect a 0 gas value", async () => {
+      const serializableTransaction = await toSerializableTransaction({
+        transaction: {
+          ...transaction,
+          gas: async () => Promise.resolve(0n),
+        },
+      });
+
+      expect(() =>
+        serializeTransaction({
+          transaction: serializableTransaction,
+        }),
+      ).not.toThrow();
+      expect(serializableTransaction.gas).toBe(0n);
+    });
   });
 
   describe("extraGas override", () => {


### PR DESCRIPTION
### TL;DR

This pull request addresses a bug in the `estimateGas` function where a gas value of `0` is now respected instead of being overridden.

### What changed?

- Updated `estimateGas` function to properly handle and respect a gas value of `0`.
- Added a test case to ensure that a gas value of `0` does not throw an error and is correctly serialized.

### How to test?

- Run unit tests to ensure the new test case passes.

### Why make this change?

This change ensures that transactions explicitly set with a gas value of `0` are respected and not overridden, providing more accurate and expected behavior.

---

 

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to handle gas values in transactions more accurately. 

### Detailed summary
- Updated logic to always use predefined gas value if not `undefined`
- Added a test to ensure proper handling of a gas value of 0 in a transaction

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->