### PR TITLE
[Dashboard to v5] Remove ethers.constants, some ethers.utils, some other things

### DIFF
--- a/apps/dashboard/src/@3rdweb-sdk/react/cache-keys.ts
+++ b/apps/dashboard/src/@3rdweb-sdk/react/cache-keys.ts
@@ -1,5 +1,5 @@
 import type { ContractType } from "@thirdweb-dev/sdk";
-import { constants } from "ethers";
+import { ZERO_ADDRESS } from "thirdweb";
 
 export const networkKeys = {
   all: ["network"] as const,
@@ -97,14 +97,11 @@ export const engineKeys = {
 export const contractKeys = {
   all: ["contract"] as const,
   lists: () => [...contractKeys.all, "list"] as const,
-  list: (address = constants.AddressZero) =>
-    [...contractKeys.lists(), address] as const,
-  listWithFilters: (
-    address = constants.AddressZero,
-    filters?: ContractType[],
-  ) => [...contractKeys.list(address), { filters }] as const,
+  list: (address = ZERO_ADDRESS) => [...contractKeys.lists(), address] as const,
+  listWithFilters: (address = ZERO_ADDRESS, filters?: ContractType[]) =>
+    [...contractKeys.list(address), { filters }] as const,
   details: () => [...contractKeys.all, "detail"] as const,
-  detail: (address: string = constants.AddressZero) =>
+  detail: (address: string = ZERO_ADDRESS) =>
     [...contractKeys.details(), address] as const,
 };
 
@@ -117,42 +114,37 @@ export const walletKeys = {
 export const splitsKeys = {
   all: ["splits"] as const,
   lists: () => [...splitsKeys.all, "list"] as const,
-  list: (address = constants.AddressZero) =>
-    [...splitsKeys.lists(), address] as const,
-  detail: (address = constants.AddressZero) =>
-    [...splitsKeys.all, address] as const,
-  currencies: (address = constants.AddressZero) =>
+  list: (address = ZERO_ADDRESS) => [...splitsKeys.lists(), address] as const,
+  detail: (address = ZERO_ADDRESS) => [...splitsKeys.all, address] as const,
+  currencies: (address = ZERO_ADDRESS) =>
     [...splitsKeys.detail(address), "currencies"] as const,
-  balances: (address = constants.AddressZero) =>
+  balances: (address = ZERO_ADDRESS) =>
     [...splitsKeys.detail(address), "balances"] as const,
 };
 
 export const voteKeys = {
   all: ["vote"] as const,
-  detail: (address = constants.AddressZero) =>
-    [...voteKeys.all, address] as const,
-  proposals: (address = constants.AddressZero) =>
+  detail: (address = ZERO_ADDRESS) => [...voteKeys.all, address] as const,
+  proposals: (address = ZERO_ADDRESS) =>
     [...voteKeys.detail(address), "proposals"] as const,
-  proposal: (proposalId = "-1", address = constants.AddressZero) =>
+  proposal: (proposalId = "-1", address = ZERO_ADDRESS) =>
     [...voteKeys.proposals(address), proposalId] as const,
-  balances: (address = constants.AddressZero, addresses = [] as string[]) =>
+  balances: (address = ZERO_ADDRESS, addresses = [] as string[]) =>
     [...voteKeys.detail(address), "balances", { addresses }] as const,
-  delegations: (address = constants.AddressZero) =>
+  delegations: (address = ZERO_ADDRESS) =>
     [...voteKeys.detail(address), "delegations"] as const,
-  delegation: (
-    address = constants.AddressZero,
-    userAddress = constants.AddressZero,
-  ) => [...voteKeys.delegations(address), userAddress] as const,
+  delegation: (address = ZERO_ADDRESS, userAddress = ZERO_ADDRESS) =>
+    [...voteKeys.delegations(address), userAddress] as const,
   userHasVotedOnProposal: (
     proposalId = "-1",
-    address = constants.AddressZero,
-    userAddress = constants.AddressZero,
+    address = ZERO_ADDRESS,
+    userAddress = ZERO_ADDRESS,
   ) =>
     [
       ...voteKeys.proposal(proposalId, address),
       "hasVotedOnProposal",
       userAddress,
     ] as const,
-  canExecuteProposal: (proposalId = "-1", address = constants.AddressZero) =>
+  canExecuteProposal: (proposalId = "-1", address = ZERO_ADDRESS) =>
     [...voteKeys.proposal(proposalId, address), "canExecute"] as const,
 };

--- a/apps/dashboard/src/@3rdweb-sdk/react/hooks/useContractRoles.ts
+++ b/apps/dashboard/src/@3rdweb-sdk/react/hooks/useContractRoles.ts
@@ -6,7 +6,7 @@ import {
   useRoleMembers,
 } from "@thirdweb-dev/react";
 import type { ValidContractInstance } from "@thirdweb-dev/sdk";
-import { constants } from "ethers";
+import { ZERO_ADDRESS } from "thirdweb";
 import { useActiveAccount } from "thirdweb/react";
 
 function isContractWithRoles(
@@ -30,7 +30,7 @@ function useIsAccountRole<TContract extends ContractWithRoles>(
     return false;
   }
 
-  if (data?.includes(constants.AddressZero)) {
+  if (data?.includes(ZERO_ADDRESS)) {
     return true;
   }
 

--- a/apps/dashboard/src/components/buttons/MismatchButton.tsx
+++ b/apps/dashboard/src/components/buttons/MismatchButton.tsx
@@ -14,7 +14,6 @@ import {
 } from "@chakra-ui/react";
 import { AiOutlineWarning } from "@react-icons/all-files/ai/AiOutlineWarning";
 import { ChainId, useSDK, useSDKChainId } from "@thirdweb-dev/react";
-import { BigNumber } from "ethers";
 import { useTrack } from "hooks/analytics/useTrack";
 import { useSupportedChain } from "hooks/chains/configureChains";
 import { forwardRef, useCallback, useMemo, useRef } from "react";
@@ -69,9 +68,7 @@ export const MismatchButton = forwardRef<HTMLButtonElement, ButtonProps>(
         />
       );
     }
-    const shouldShowEVMFaucet = BigNumber.from(evmBalance.data?.value || 0).eq(
-      0,
-    );
+    const shouldShowEVMFaucet = (evmBalance.data?.value || 0n) === 0n;
     return (
       <Popover
         initialFocusRef={initialFocusRef}

--- a/apps/dashboard/src/components/contract-components/contract-deploy-form/split-fieldset.tsx
+++ b/apps/dashboard/src/components/contract-components/contract-deploy-form/split-fieldset.tsx
@@ -12,8 +12,8 @@ import { IoMdAdd } from "@react-icons/all-files/io/IoMdAdd";
 import { IoMdRemove } from "@react-icons/all-files/io/IoMdRemove";
 import { BasisPointsInput } from "components/inputs/BasisPointsInput";
 import { SolidityInput } from "contract-ui/components/solidity-inputs";
-import { constants } from "ethers";
 import { type UseFormReturn, useFieldArray } from "react-hook-form";
+import { ZERO_ADDRESS } from "thirdweb";
 import { Button, FormErrorMessage, Heading, Text } from "tw-components";
 
 interface SplitFieldsetProps {
@@ -67,7 +67,7 @@ export const SplitFieldset: React.FC<SplitFieldsetProps> = ({ form }) => {
                     solidityType="address"
                     formContext={form}
                     variant="filled"
-                    placeholder={constants.AddressZero}
+                    placeholder={ZERO_ADDRESS}
                     {...form.register(`recipients.${index}.address`)}
                   />
                   <FormErrorMessage>

--- a/apps/dashboard/src/components/contract-tabs/code/ContractCode.tsx
+++ b/apps/dashboard/src/components/contract-tabs/code/ContractCode.tsx
@@ -4,9 +4,9 @@ import { useQuery } from "@tanstack/react-query";
 import { useContract } from "@thirdweb-dev/react";
 import type { Abi } from "@thirdweb-dev/sdk";
 import { CodeOverview } from "contract-ui/tabs/code/components/code-overview";
-import { constants } from "ethers";
 import { useCallback, useMemo, useState } from "react";
 import { IoDocumentOutline } from "react-icons/io5";
+import { ZERO_ADDRESS } from "thirdweb";
 import { useActiveAccount } from "thirdweb/react";
 import { Card, CodeBlock, Heading, LinkButton, Text } from "tw-components";
 import { CodeSegment } from "./CodeSegment";
@@ -60,7 +60,7 @@ const INSTALL_COMMANDS = {
 const CREATE_APP_COMMAND = "npx thirdweb create app";
 
 export const ContractCode: React.FC<ContractCodeProps> = ({
-  contractAddress = constants.AddressZero,
+  contractAddress = ZERO_ADDRESS,
   contractType,
 }) => {
   const { data, isLoading } = useContractCodeSnippetQuery();

--- a/apps/dashboard/src/components/engine/overview/backend-wallets-table.tsx
+++ b/apps/dashboard/src/components/engine/overview/backend-wallets-table.tsx
@@ -29,13 +29,13 @@ import { type ColumnDef, createColumnHelper } from "@tanstack/react-table";
 import { shortenString } from "@thirdweb-dev/react";
 import { ChainIcon } from "components/icons/ChainIcon";
 import { TWTable } from "components/shared/TWTable";
-import { utils } from "ethers";
 import { useTrack } from "hooks/analytics/useTrack";
 import { useTxNotifications } from "hooks/useTxNotifications";
 import QRCode from "qrcode";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { BiExport, BiImport, BiPencil } from "react-icons/bi";
+import { getAddress } from "thirdweb";
 import {
   Badge,
   Button,
@@ -68,7 +68,7 @@ const setColumns = (instanceUrl: string) => [
       const address = cell.getValue();
       return (
         <AddressCopyButton
-          address={utils.getAddress(address)}
+          address={getAddress(address)}
           shortenAddress={false}
           size="xs"
         />

--- a/apps/dashboard/src/components/shared/BigNumberInput.tsx
+++ b/apps/dashboard/src/components/shared/BigNumberInput.tsx
@@ -4,8 +4,9 @@ import {
   type InputProps,
   InputRightElement,
 } from "@chakra-ui/react";
-import { constants, type BigNumber, utils } from "ethers";
+import { type BigNumber, utils } from "ethers";
 import { useEffect, useMemo, useState } from "react";
+import { maxUint256 } from "thirdweb/utils";
 import { Button } from "tw-components";
 
 interface BigNumberInputProps extends Omit<InputProps, "value" | "onChange"> {
@@ -25,7 +26,7 @@ export const BigNumberInput: React.FC<BigNumberInputProps> = ({
   isDisabled,
   decimals = 0,
   maxUIntString = "Unlimited",
-  max = constants.MaxUint256.toString(),
+  max = maxUint256.toString(),
   min,
   ...restInputProps
 }) => {

--- a/apps/dashboard/src/components/shared/CurrencySelector.tsx
+++ b/apps/dashboard/src/components/shared/CurrencySelector.tsx
@@ -1,11 +1,10 @@
 import { Flex, Input, Select, type SelectProps } from "@chakra-ui/react";
 import { useSDKChainId } from "@thirdweb-dev/react";
 import { CURRENCIES, type CurrencyMetadata } from "constants/currencies";
-import { constants, utils } from "ethers";
 import { useSupportedChainsRecord } from "hooks/chains/configureChains";
 import { useMemo, useState } from "react";
+import { NATIVE_TOKEN_ADDRESS, ZERO_ADDRESS, isAddress } from "thirdweb";
 import { Button } from "tw-components";
-import { OtherAddressZero } from "utils/zeroAddress";
 
 interface CurrencySelectorProps extends SelectProps {
   value: string;
@@ -64,7 +63,7 @@ export const CurrencySelector: React.FC<CurrencySelectorProps> = ({
         ? []
         : [
             {
-              address: OtherAddressZero.toLowerCase(),
+              address: NATIVE_TOKEN_ADDRESS.toLowerCase(),
               name: chain?.nativeCurrency.name || "Native Token",
               symbol: chain?.nativeCurrency.symbol || "",
             },
@@ -73,7 +72,7 @@ export const CurrencySelector: React.FC<CurrencySelectorProps> = ({
     ] || [];
 
   const addCustomCurrency = () => {
-    if (!utils.isAddress(editCustomCurrency)) {
+    if (!isAddress(editCustomCurrency)) {
       return;
     }
     if (editCustomCurrency) {
@@ -115,7 +114,7 @@ export const CurrencySelector: React.FC<CurrencySelectorProps> = ({
             borderRadius="0px 4px 4px 0px"
             colorScheme="primary"
             onClick={addCustomCurrency}
-            isDisabled={!utils.isAddress(editCustomCurrency)}
+            isDisabled={!isAddress(editCustomCurrency)}
           >
             Save
           </Button>
@@ -131,8 +130,8 @@ export const CurrencySelector: React.FC<CurrencySelectorProps> = ({
         value={
           isPaymentsSelector
             ? value
-            : value?.toLowerCase() === constants.AddressZero.toLowerCase()
-              ? OtherAddressZero.toLowerCase()
+            : value?.toLowerCase() === ZERO_ADDRESS.toLowerCase()
+              ? NATIVE_TOKEN_ADDRESS.toLowerCase()
               : value?.toLowerCase()
         }
         onChange={(e) => {
@@ -161,7 +160,7 @@ export const CurrencySelector: React.FC<CurrencySelectorProps> = ({
           ))}
         {isCustomCurrency &&
           !isPaymentsSelector &&
-          initialValue !== OtherAddressZero.toLowerCase() && (
+          initialValue !== NATIVE_TOKEN_ADDRESS.toLowerCase() && (
             <option key={initialValue} value={initialValue}>
               {initialValue}
             </option>

--- a/apps/dashboard/src/contract-ui/tabs/claim-conditions/components/claim-conditions-form/index.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/claim-conditions/components/claim-conditions-form/index.tsx
@@ -31,7 +31,6 @@ import { TransactionButton } from "components/buttons/TransactionButton";
 import { TooltipBox } from "components/configure-networks/Form/TooltipBox";
 import { detectFeatures } from "components/contract-components/utils";
 import { SnapshotUpload } from "contract-ui/tabs/claim-conditions/components/snapshot-upload";
-import { constants } from "ethers";
 import { useTrack } from "hooks/analytics/useTrack";
 import { useTxNotifications } from "hooks/useTxNotifications";
 import {
@@ -46,6 +45,7 @@ import {
   useForm,
 } from "react-hook-form";
 import { FiPlus } from "react-icons/fi";
+import { ZERO_ADDRESS } from "thirdweb";
 import { useActiveAccount } from "thirdweb/react";
 import invariant from "tiny-invariant";
 import { Button, Heading, MenuItem, Text } from "tw-components";
@@ -468,14 +468,13 @@ export const ClaimConditionsForm: React.FC<ClaimConditionsFormProps> = ({
                 ? {
                     address: v,
                     maxClaimable: "unlimited",
-                    currencyAddress: constants.AddressZero,
+                    currencyAddress: ZERO_ADDRESS,
                     price: "unlimited",
                   }
                 : {
                     ...v,
                     maxClaimable: v?.maxClaimable?.toString() || "unlimited",
-                    currencyAddress:
-                      v?.currencyAddress || constants.AddressZero,
+                    currencyAddress: v?.currencyAddress || ZERO_ADDRESS,
                     price: v?.price?.toString() || "unlimited",
                   },
             );

--- a/apps/dashboard/src/contract-ui/tabs/claim-conditions/components/snapshot-upload.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/claim-conditions/components/snapshot-upload.tsx
@@ -26,7 +26,6 @@ import {
 } from "@chakra-ui/react";
 import { type ClaimCondition, resolveAddress } from "@thirdweb-dev/sdk";
 import { Logo } from "components/logo";
-import { utils } from "ethers";
 import Papa from "papaparse";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { type DropzoneOptions, useDropzone } from "react-dropzone";
@@ -40,6 +39,7 @@ import {
   MdNavigateNext,
 } from "react-icons/md";
 import { type Column, usePagination, useTable } from "react-table";
+import { isAddress } from "thirdweb";
 import { Button, Drawer, Heading, Text } from "tw-components";
 import { csvMimeTypes } from "utils/batch";
 
@@ -126,7 +126,7 @@ export const SnapshotUpload: React.FC<SnapshotUploadProps> = ({
     [],
   );
 
-  // FIXME: this can be a mutation or query insead!
+  // FIXME: this can be a mutation or query instead!
   // eslint-disable-next-line no-restricted-syntax
   useEffect(() => {
     if (validSnapshot.length === 0) {
@@ -140,7 +140,7 @@ export const SnapshotUpload: React.FC<SnapshotUploadProps> = ({
           let resolvedAddress = address;
 
           try {
-            resolvedAddress = utils.isAddress(address)
+            resolvedAddress = isAddress(address)
               ? address
               : await resolveAddress(address);
             isValid = !!resolvedAddress;

--- a/apps/dashboard/src/contract-ui/tabs/nfts/components/airdrop-upload.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/nfts/components/airdrop-upload.tsx
@@ -25,7 +25,6 @@ import {
 } from "@chakra-ui/react";
 import { resolveAddress } from "@thirdweb-dev/sdk";
 import { Logo } from "components/logo";
-import { utils } from "ethers";
 import Papa from "papaparse";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { type DropzoneOptions, useDropzone } from "react-dropzone";
@@ -38,6 +37,7 @@ import {
   MdNavigateNext,
 } from "react-icons/md";
 import { type Column, usePagination, useTable } from "react-table";
+import { isAddress } from "thirdweb";
 import { Button, Drawer, Heading, Text } from "tw-components";
 import { csvMimeTypes } from "utils/batch";
 
@@ -110,7 +110,7 @@ export const AirdropUpload: React.FC<AirdropUploadProps> = ({
     [],
   );
 
-  // FIXME: this can be a mutation or query insead!
+  // FIXME: this can be a mutation or query instead!
   // eslint-disable-next-line no-restricted-syntax
   useEffect(() => {
     if (validAirdrop.length === 0) {
@@ -124,7 +124,7 @@ export const AirdropUpload: React.FC<AirdropUploadProps> = ({
           let resolvedAddress = address;
 
           try {
-            resolvedAddress = utils.isAddress(address)
+            resolvedAddress = isAddress(address)
               ? address
               : await resolveAddress(address);
             isValid = !!resolvedAddress;

--- a/apps/dashboard/src/contract-ui/tabs/nfts/components/claim-form.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/nfts/components/claim-form.tsx
@@ -9,10 +9,10 @@ import {
 } from "@chakra-ui/react";
 import { type DropContract, useClaimNFT } from "@thirdweb-dev/react";
 import { TransactionButton } from "components/buttons/TransactionButton";
-import { constants } from "ethers";
 import { useTrack } from "hooks/analytics/useTrack";
 import { useTxNotifications } from "hooks/useTxNotifications";
 import { useForm } from "react-hook-form";
+import { ZERO_ADDRESS } from "thirdweb";
 import { useActiveAccount } from "thirdweb/react";
 import {
   FormErrorMessage,
@@ -53,7 +53,7 @@ export const NFTClaimForm: React.FC<NFTClaimFormProps> = ({ contract }) => {
           <Stack spacing={6} w="100%" direction={{ base: "column", md: "row" }}>
             <FormControl isRequired isInvalid={!!errors.to}>
               <FormLabel>To Address</FormLabel>
-              <Input placeholder={constants.AddressZero} {...register("to")} />
+              <Input placeholder={ZERO_ADDRESS} {...register("to")} />
               <FormHelperText>Enter the address to claim to.</FormHelperText>
               <FormErrorMessage>{errors.to?.message}</FormErrorMessage>
             </FormControl>

--- a/apps/dashboard/src/contract-ui/tabs/nfts/components/claim-tab.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/nfts/components/claim-tab.tsx
@@ -1,10 +1,10 @@
 import { Flex, FormControl, Input } from "@chakra-ui/react";
 import { type DropContract, useClaimNFT } from "@thirdweb-dev/react";
 import { TransactionButton } from "components/buttons/TransactionButton";
-import { constants } from "ethers";
 import { useTrack } from "hooks/analytics/useTrack";
 import { useTxNotifications } from "hooks/useTxNotifications";
 import { useForm } from "react-hook-form";
+import { ZERO_ADDRESS } from "thirdweb";
 import { useActiveAccount } from "thirdweb/react";
 import { FormErrorMessage, FormHelperText, FormLabel } from "tw-components";
 
@@ -71,10 +71,7 @@ const ClaimTab: React.FC<ClaimTabProps> = ({ contract, tokenId }) => {
             isInvalid={!!form.getFieldState("to", form.formState).error}
           >
             <FormLabel>To Address</FormLabel>
-            <Input
-              placeholder={constants.AddressZero}
-              {...form.register("to")}
-            />
+            <Input placeholder={ZERO_ADDRESS} {...form.register("to")} />
             <FormHelperText>Enter the address to claim to.</FormHelperText>
             <FormErrorMessage>
               {form.getFieldState("to", form.formState).error?.message}

--- a/apps/dashboard/src/contract-ui/tabs/nfts/components/transfer-tab.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/nfts/components/transfer-tab.tsx
@@ -3,10 +3,10 @@ import { type NFTContract, useTransferNFT } from "@thirdweb-dev/react";
 import { TransactionButton } from "components/buttons/TransactionButton";
 import { detectFeatures } from "components/contract-components/utils";
 import { SolidityInput } from "contract-ui/components/solidity-inputs";
-import { constants } from "ethers";
 import { useTrack } from "hooks/analytics/useTrack";
 import { useTxNotifications } from "hooks/useTxNotifications";
 import { useForm } from "react-hook-form";
+import { ZERO_ADDRESS } from "thirdweb";
 import { FormErrorMessage, FormHelperText, FormLabel } from "tw-components";
 
 interface TransferTabProps {
@@ -75,7 +75,7 @@ const TransferTab: React.FC<TransferTabProps> = ({ contract, tokenId }) => {
               <SolidityInput
                 solidityType="address"
                 formContext={form}
-                placeholder={constants.AddressZero}
+                placeholder={ZERO_ADDRESS}
                 {...form.register("to")}
               />
               <FormHelperText>Enter the address to transfer to.</FormHelperText>

--- a/apps/dashboard/src/contract-ui/tabs/overview/components/PermissionsTable.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/overview/components/PermissionsTable.tsx
@@ -14,10 +14,10 @@ import {
 import { useAllRoleMembers } from "@thirdweb-dev/react";
 import type { SmartContract } from "@thirdweb-dev/sdk";
 import { useTabHref } from "contract-ui/utils";
-import { constants } from "ethers";
 import { AnimatePresence, motion } from "framer-motion";
 import { useMemo } from "react";
 import { FiCopy } from "react-icons/fi";
+import { ZERO_ADDRESS } from "thirdweb";
 import {
   Button,
   Card,
@@ -55,7 +55,7 @@ export const PermissionsTable: React.FC<PermissionsTableProps> = ({
         },
         [] as { member: string; roles: string[] }[],
       ) || []
-    ).filter((m) => m.member !== constants.AddressZero);
+    ).filter((m) => m.member !== ZERO_ADDRESS);
   }, [allRoleMembers.data]);
 
   return (

--- a/apps/dashboard/src/contract-ui/tabs/permissions/components/contract-permission.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/permissions/components/contract-permission.tsx
@@ -1,9 +1,9 @@
 import { useIsAdmin } from "@3rdweb-sdk/react/hooks/useContractRoles";
 import { Flex, Icon, Select, Spinner, Stack } from "@chakra-ui/react";
 import type { ValidContractInstance } from "@thirdweb-dev/sdk";
-import { constants } from "ethers";
 import { useFormContext } from "react-hook-form";
 import { FiInfo } from "react-icons/fi";
+import { ZERO_ADDRESS } from "thirdweb";
 import { Card, Heading, Text } from "tw-components";
 import { PermissionEditor } from "./permissions-editor";
 
@@ -30,7 +30,7 @@ export const ContractPermission: React.FC<ContractPermissionProps> = ({
 
   const roleMembers: string[] = watch()?.[role] || [];
   const isRestricted =
-    !roleMembers.includes(constants.AddressZero) ||
+    !roleMembers.includes(ZERO_ADDRESS) ||
     (role !== "transfer" && role !== "lister" && role !== "asset");
 
   const isAdmin = useIsAdmin(contract as ValidContractInstance);
@@ -64,18 +64,14 @@ export const ContractPermission: React.FC<ContractPermissionProps> = ({
                         setValue(
                           role,
                           roleMembers.filter(
-                            (address) => address !== constants.AddressZero,
+                            (address) => address !== ZERO_ADDRESS,
                           ),
                           { shouldDirty: true },
                         );
                       } else {
-                        setValue(
-                          role,
-                          [constants.AddressZero, ...roleMembers],
-                          {
-                            shouldDirty: true,
-                          },
-                        );
+                        setValue(role, [ZERO_ADDRESS, ...roleMembers], {
+                          shouldDirty: true,
+                        });
                       }
                     }}
                   >
@@ -103,18 +99,14 @@ export const ContractPermission: React.FC<ContractPermissionProps> = ({
                         setValue(
                           role,
                           roleMembers.filter(
-                            (address) => address !== constants.AddressZero,
+                            (address) => address !== ZERO_ADDRESS,
                           ),
                           { shouldDirty: true },
                         );
                       } else {
-                        setValue(
-                          role,
-                          [constants.AddressZero, ...roleMembers],
-                          {
-                            shouldDirty: true,
-                          },
-                        );
+                        setValue(role, [ZERO_ADDRESS, ...roleMembers], {
+                          shouldDirty: true,
+                        });
                       }
                     }}
                   >
@@ -142,18 +134,14 @@ export const ContractPermission: React.FC<ContractPermissionProps> = ({
                         setValue(
                           role,
                           roleMembers.filter(
-                            (address) => address !== constants.AddressZero,
+                            (address) => address !== ZERO_ADDRESS,
                           ),
                           { shouldDirty: true },
                         );
                       } else {
-                        setValue(
-                          role,
-                          [constants.AddressZero, ...roleMembers],
-                          {
-                            shouldDirty: true,
-                          },
-                        );
+                        setValue(role, [ZERO_ADDRESS, ...roleMembers], {
+                          shouldDirty: true,
+                        });
                       }
                     }}
                   >

--- a/apps/dashboard/src/contract-ui/tabs/permissions/components/permissions-editor.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/permissions/components/permissions-editor.tsx
@@ -18,11 +18,11 @@ import {
 } from "@chakra-ui/react";
 import type { ValidContractInstance } from "@thirdweb-dev/sdk";
 import { DelayedDisplay } from "components/delayed-display/delayed-display";
-import { constants, utils } from "ethers";
 import { useState } from "react";
 import { useFieldArray, useFormContext } from "react-hook-form";
 import { BiPaste } from "react-icons/bi";
 import { FiCopy, FiInfo, FiPlus, FiTrash } from "react-icons/fi";
+import { ZERO_ADDRESS, isAddress } from "thirdweb";
 import { Button, FormErrorMessage, Text } from "tw-components";
 
 interface PermissionEditorProps {
@@ -46,7 +46,7 @@ export const PermissionEditor: React.FC<PermissionEditorProps> = ({
   const [address, setAddress] = useState("");
 
   const members = watch(role) || [];
-  const isDisabled = !utils.isAddress(address) || members.includes(address);
+  const isDisabled = !isAddress(address) || members.includes(address);
 
   const addAddress = () => {
     if (isDisabled) {
@@ -125,7 +125,7 @@ export const PermissionEditor: React.FC<PermissionEditorProps> = ({
               fontFamily="mono"
               value={address}
               onChange={(e) => setAddress(e.target.value)}
-              placeholder={constants.AddressZero}
+              placeholder={ZERO_ADDRESS}
               px={2}
             />
             <InputRightAddon p={0} border="none">
@@ -149,7 +149,7 @@ export const PermissionEditor: React.FC<PermissionEditorProps> = ({
           <FormErrorMessage>
             {members.includes(address)
               ? "Address already has this role"
-              : !utils.isAddress(address)
+              : !isAddress(address)
                 ? "Not a valid address"
                 : ""}
           </FormErrorMessage>

--- a/apps/dashboard/src/contract-ui/tabs/split/page.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/split/page.tsx
@@ -15,9 +15,10 @@ import {
   StatNumber,
 } from "@chakra-ui/react";
 import { useContract } from "@thirdweb-dev/react";
-import { constants, BigNumber, ethers } from "ethers";
+import { BigNumber, ethers } from "ethers";
 import { useSupportedChainsRecord } from "hooks/chains/configureChains";
 import { useMemo } from "react";
+import { ZERO_ADDRESS } from "thirdweb";
 import { useActiveAccount } from "thirdweb/react";
 import { Card, Heading, Text } from "tw-components";
 import { shortenIfAddress } from "utils/usedapp-external";
@@ -56,7 +57,7 @@ export const ContractSplitPage: React.FC<SplitPageProps> = ({
     return [
       {
         name: "Native Token",
-        token_address: constants.AddressZero,
+        token_address: ZERO_ADDRESS,
         balance: nativeBalanceQuery?.data?.value?.toString() || "0",
         display_balance: nativeBalanceQuery?.data?.displayValue || "0.0",
         decimals: nativeBalanceQuery?.data?.decimals || 18,
@@ -121,13 +122,13 @@ export const ContractSplitPage: React.FC<SplitPageProps> = ({
                 {nativeBalanceQuery.data?.symbol}
               </StatLabel>
               <StatNumber>{nativeBalanceQuery?.data?.displayValue}</StatNumber>
-              {shareOfBalancesForConnectedWallet[constants.AddressZero] && (
+              {shareOfBalancesForConnectedWallet[ZERO_ADDRESS] && (
                 <StatNumber>
                   <Text size="body.md">
                     <Text as="span" size="label.md">
                       Your Share:
                     </Text>{" "}
-                    {shareOfBalancesForConnectedWallet[constants.AddressZero]}
+                    {shareOfBalancesForConnectedWallet[ZERO_ADDRESS]}
                   </Text>
                 </StatNumber>
               )}

--- a/apps/dashboard/src/contract-ui/tabs/tokens/components/claim-form.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/tokens/components/claim-form.tsx
@@ -13,10 +13,10 @@ import {
   useTokenDecimals,
 } from "@thirdweb-dev/react";
 import { TransactionButton } from "components/buttons/TransactionButton";
-import { constants } from "ethers";
 import { useTrack } from "hooks/analytics/useTrack";
 import { useTxNotifications } from "hooks/useTxNotifications";
 import { useForm } from "react-hook-form";
+import { ZERO_ADDRESS } from "thirdweb";
 import { useActiveAccount } from "thirdweb/react";
 import {
   FormErrorMessage,
@@ -60,7 +60,7 @@ export const TokenClaimForm: React.FC<TokenClaimFormProps> = ({ contract }) => {
             <FormControl isRequired isInvalid={!!errors.to}>
               <FormLabel>To Address</FormLabel>
               <Input
-                placeholder={constants.AddressZero}
+                placeholder={ZERO_ADDRESS}
                 {...register("to", { required: true })}
               />
               <FormHelperText>Enter the address to claim to.</FormHelperText>

--- a/apps/dashboard/src/contract-ui/tabs/tokens/components/transfer-form.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/tokens/components/transfer-form.tsx
@@ -9,11 +9,10 @@ import {
 } from "@chakra-ui/react";
 import { TransactionButton } from "components/buttons/TransactionButton";
 import { SolidityInput } from "contract-ui/components/solidity-inputs";
-import { constants } from "ethers";
 import { useTrack } from "hooks/analytics/useTrack";
 import { useTxNotifications } from "hooks/useTxNotifications";
 import { useForm } from "react-hook-form";
-import type { ThirdwebContract } from "thirdweb";
+import { type ThirdwebContract, ZERO_ADDRESS } from "thirdweb";
 import { decimals, transfer } from "thirdweb/extensions/erc20";
 import { useReadContract, useSendAndConfirmTransaction } from "thirdweb/react";
 import {
@@ -60,7 +59,7 @@ export const TokenTransferForm: React.FC<TokenTransferFormProps> = ({
               <SolidityInput
                 formContext={form}
                 solidityType="address"
-                placeholder={constants.AddressZero}
+                placeholder={ZERO_ADDRESS}
                 {...form.register("to")}
               />
               <FormHelperText>Enter the address to transfer to.</FormHelperText>

--- a/apps/dashboard/src/lib/address-utils.ts
+++ b/apps/dashboard/src/lib/address-utils.ts
@@ -1,4 +1,4 @@
-import { utils } from "ethers";
+import { isAddress } from "thirdweb";
 import { isEnsName } from "./ens";
 
 // if a string is a valid address or ens name
@@ -9,5 +9,5 @@ export function isPossibleEVMAddress(address?: string, ignoreEns?: boolean) {
   if (isEnsName(address) && !ignoreEns) {
     return true;
   }
-  return utils.isAddress(address);
+  return isAddress(address);
 }

--- a/apps/dashboard/src/lib/ens.ts
+++ b/apps/dashboard/src/lib/ens.ts
@@ -1,6 +1,7 @@
 import { Ethereum } from "@thirdweb-dev/chains";
 import { type providers, utils } from "ethers";
 import { getDashboardChainRpc } from "lib/rpc";
+import { isAddress } from "thirdweb";
 import invariant from "tiny-invariant";
 import { getThirdwebSDK } from "./sdk";
 
@@ -29,7 +30,7 @@ export function isEnsName(name: string): boolean {
 async function resolveAddressToEnsName(
   address: string,
 ): Promise<ENSResolveResult> {
-  invariant(utils.isAddress(address), "address must be a valid address");
+  invariant(isAddress(address), "address must be a valid address");
 
   return {
     ensName: await getMainnetProvider().lookupAddress(address),

--- a/apps/dashboard/src/pages/api/moralis/balances.ts
+++ b/apps/dashboard/src/pages/api/moralis/balances.ts
@@ -1,7 +1,7 @@
 import type { SUPPORTED_CHAIN_ID } from "@thirdweb-dev/sdk";
-import { constants, utils } from "ethers";
+import { utils } from "ethers";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { createThirdwebClient } from "thirdweb";
+import { ZERO_ADDRESS, createThirdwebClient, isAddress } from "thirdweb";
 import { getWalletBalance } from "thirdweb/wallets";
 import { DASHBOARD_THIRDWEB_SECRET_KEY } from "../../../constants/rpc";
 import { IPFS_GATEWAY_URL } from "../../../lib/sdk";
@@ -27,7 +27,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   }
 
   const { chainId, address } = req.body;
-  if (!utils.isAddress(address)) {
+  if (!isAddress(address)) {
     return res.status(400).json({ error: "invalid address" });
   }
 
@@ -47,7 +47,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     });
     return [
       {
-        token_address: constants.AddressZero,
+        token_address: ZERO_ADDRESS,
         symbol: balance.symbol,
         name: "Native Token",
         decimals: balance.decimals,

--- a/apps/dashboard/src/utils/zeroAddress.ts
+++ b/apps/dashboard/src/utils/zeroAddress.ts
@@ -1,12 +1,10 @@
-import { constants, utils } from "ethers";
-
-export const OtherAddressZero = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
+import { NATIVE_TOKEN_ADDRESS, ZERO_ADDRESS, isAddress } from "thirdweb";
 
 export function isAddressZero(address: string): boolean {
   const lowerCaseAddress = (address || "").toLowerCase();
   return (
-    utils.isAddress(lowerCaseAddress) &&
-    (lowerCaseAddress === constants.AddressZero ||
-      lowerCaseAddress === OtherAddressZero.toLowerCase())
+    isAddress(lowerCaseAddress) &&
+    (lowerCaseAddress === ZERO_ADDRESS ||
+      lowerCaseAddress === NATIVE_TOKEN_ADDRESS.toLowerCase())
   );
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to refactor address-related functions and constants to use the `thirdweb` library for consistency and efficiency.

### Detailed summary
- Refactored address-related functions to use `thirdweb` library
- Updated constants like `ZERO_ADDRESS` and `NATIVE_TOKEN_ADDRESS`
- Replaced `ethers` imports with `thirdweb` library functions

> The following files were skipped due to too many changes: `apps/dashboard/src/contract-ui/tabs/nfts/components/claim-tab.tsx`, `apps/dashboard/src/contract-ui/tabs/claim-conditions/components/claim-conditions-form/index.tsx`, `apps/dashboard/src/contract-ui/tabs/nfts/components/airdrop-upload.tsx`, `apps/dashboard/src/contract-ui/tabs/claim-conditions/components/snapshot-upload.tsx`, `apps/dashboard/src/contract-ui/tabs/split/page.tsx`, `apps/dashboard/src/contract-ui/tabs/permissions/components/permissions-editor.tsx`, `apps/dashboard/src/components/shared/CurrencySelector.tsx`, `apps/dashboard/src/contract-ui/tabs/permissions/components/contract-permission.tsx`, `apps/dashboard/src/@3rdweb-sdk/react/cache-keys.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->