### PR TITLE
Remove @thirdweb-dev/sdk from dashboard (partially)

### DIFF
--- a/.changeset/curly-bags-relax.md
+++ b/.changeset/curly-bags-relax.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Expose roleMap and getRoleHash

--- a/apps/dashboard/src/contract-ui/tabs/claim-conditions/components/claim-conditions-form/Inputs/ClaimPriceInput.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/claim-conditions/components/claim-conditions-form/Inputs/ClaimPriceInput.tsx
@@ -1,6 +1,6 @@
 import { Box, Flex } from "@chakra-ui/react";
-import { NATIVE_TOKEN_ADDRESS } from "@thirdweb-dev/sdk";
 import { CurrencySelector } from "components/shared/CurrencySelector";
+import { NATIVE_TOKEN_ADDRESS } from "thirdweb";
 import { useClaimConditionsFormContext } from "..";
 import { PriceInput } from "../../price-input";
 import { CustomFormControl } from "../common";

--- a/apps/dashboard/src/contract-ui/tabs/listings/components/list-form.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/listings/components/list-form.tsx
@@ -21,12 +21,11 @@ import {
   type useCreateDirectListing,
   useOwnedNFTs,
 } from "@thirdweb-dev/react";
-import {
-  type Marketplace,
-  type MarketplaceV3,
-  NATIVE_TOKEN_ADDRESS,
-  type NewAuctionListing,
-  type NewDirectListing,
+import type {
+  Marketplace,
+  MarketplaceV3,
+  NewAuctionListing,
+  NewDirectListing,
 } from "@thirdweb-dev/sdk";
 import { CurrencySelector } from "components/shared/CurrencySelector";
 import { SolidityInput } from "contract-ui/components/solidity-inputs";
@@ -40,6 +39,7 @@ import type { WalletNFT } from "lib/wallet/nfts/types";
 import { useMemo } from "react";
 import { useForm } from "react-hook-form";
 import { FiInfo } from "react-icons/fi";
+import { NATIVE_TOKEN_ADDRESS } from "thirdweb";
 import { useActiveAccount } from "thirdweb/react";
 import {
   FormErrorMessage,

--- a/apps/dashboard/src/contract-ui/tabs/nfts/components/airdrop-upload.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/nfts/components/airdrop-upload.tsx
@@ -23,8 +23,8 @@ import {
   UnorderedList,
   VStack,
 } from "@chakra-ui/react";
-import { resolveAddress } from "@thirdweb-dev/sdk";
 import { Logo } from "components/logo";
+import { thirdwebClient } from "lib/thirdweb-client";
 import Papa from "papaparse";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { type DropzoneOptions, useDropzone } from "react-dropzone";
@@ -37,7 +37,8 @@ import {
   MdNavigateNext,
 } from "react-icons/md";
 import { type Column, usePagination, useTable } from "react-table";
-import { isAddress } from "thirdweb";
+import { resolveAddress } from "thirdweb/extensions/ens";
+import { isAddress } from "thirdweb/utils";
 import { Button, Drawer, Heading, Text } from "tw-components";
 import { csvMimeTypes } from "utils/batch";
 
@@ -126,7 +127,7 @@ export const AirdropUpload: React.FC<AirdropUploadProps> = ({
           try {
             resolvedAddress = isAddress(address)
               ? address
-              : await resolveAddress(address);
+              : await resolveAddress({ name: address, client: thirdwebClient });
             isValid = !!resolvedAddress;
           } catch {
             isValid = false;

--- a/apps/dashboard/src/contract-ui/tabs/permissions/components/index.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/permissions/components/index.tsx
@@ -6,13 +6,13 @@ import {
   useContractType,
   useSetAllRoleMembers,
 } from "@thirdweb-dev/react";
-import type { Role } from "@thirdweb-dev/sdk";
 import { TransactionButton } from "components/buttons/TransactionButton";
 import { BuiltinContractMap, ROLE_DESCRIPTION_MAP } from "constants/mappings";
 import { useTrack } from "hooks/analytics/useTrack";
 import { useTxNotifications } from "hooks/useTxNotifications";
 import { useMemo } from "react";
 import { FormProvider, useForm } from "react-hook-form";
+import type { roleMap } from "thirdweb/extensions/permissions";
 import { Button } from "tw-components";
 import { ContractPermission } from "./contract-permission";
 
@@ -54,7 +54,7 @@ export const Permissions = <TContract extends ContractWithRoles>({
     return Object.keys(allRoleMembers.data || ROLE_DESCRIPTION_MAP).filter(
       (role) =>
         contractData && contractData.contractType !== "custom"
-          ? contractData.roles?.includes(role as Role)
+          ? contractData.roles?.includes(role as keyof typeof roleMap)
           : true,
     );
   }, [allRoleMembers.data, contractData]);

--- a/packages/thirdweb/src/exports/extensions/permissions.ts
+++ b/packages/thirdweb/src/exports/extensions/permissions.ts
@@ -57,3 +57,8 @@ export {
   getAllRoleMembers,
   type GetAllRoleMembersParams,
 } from "../../extensions/permissions/read/getAllMembers.js";
+
+// --------------------------------------------------------
+// Utils
+// --------------------------------------------------------
+export { roleMap, getRoleHash } from "../../extensions/permissions/utils.js";

--- a/packages/thirdweb/src/extensions/permissions/utils.ts
+++ b/packages/thirdweb/src/extensions/permissions/utils.ts
@@ -2,7 +2,10 @@ import { keccakId } from "../../utils/any-evm/keccak-id.js";
 import { LruMap } from "../../utils/caching/lru.js";
 import { type Hex, isHex, padHex } from "../../utils/encoding/hex.js";
 
-const roleMap = {
+/**
+ * A map of all current thirdweb's smart contract roles
+ */
+export const roleMap = {
   admin: "",
   transfer: "TRANSFER_ROLE",
   minter: "MINTER_ROLE",
@@ -32,6 +35,17 @@ export type RoleInput = ThirdwebContractRole | Hex | (string & {});
 
 const roleCache = new LruMap<Hex>(128);
 
+/**
+ * Get a hex value of a smart contract role
+ * You need the hex value to interact with the smart contracts.
+ * @param role string
+ * @returns hex value of the contract role
+ *
+ * @example
+ * ```ts
+ * const adminRoleHash = getRoleHash("admin"); // 0x0000000...000000
+ * ```
+ */
 export function getRoleHash(role: RoleInput) {
   if (roleCache.has(role)) {
     // biome-ignore lint/style/noNonNullAssertion: we know it's in the cache


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to expose `roleMap` and `getRoleHash` in the `permissions` module. 

### Detailed summary
- Exposed `roleMap` and `getRoleHash` in `permissions/utils.ts`
- Updated imports to use `thirdweb` instead of `@thirdweb-dev/sdk`
- Refactored role handling in various components
- Improved address resolution and handling in `nfts/components/airdrop-upload.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->