### PR TITLE
fix(deploy): add missing version argument in computeDeploymentInfoFromContractId function

### DIFF
--- a/.changeset/large-cycles-joke.md
+++ b/.changeset/large-cycles-joke.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix deterministic deploys with specified versions

--- a/packages/thirdweb/src/utils/any-evm/compute-published-contract-deploy-info.ts
+++ b/packages/thirdweb/src/utils/any-evm/compute-published-contract-deploy-info.ts
@@ -24,6 +24,7 @@ export async function computeDeploymentInfoFromContractId(args: {
     client,
     contractId,
     publisher: args.publisher,
+    version: args.version,
   });
   return computeDeploymentInfoFromMetadata({
     client,


### PR DESCRIPTION
Fix deterministic deploys with specified versions by adding the 'version' argument to the 'computeDeploymentInfoFromContractId' function.

---

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing deterministic deploys in `thirdweb` by allowing specified versions. 

### Detailed summary
- Added `version` parameter in `compute-published-contract-deploy-info.ts` for specified versions in deploys.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->