### PR TITLE
feat(smart): allow overriding nonce for smart accounts

### DIFF
--- a/.changeset/nervous-fans-clap.md
+++ b/.changeset/nervous-fans-clap.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Allow overriding nonce for smart accounts

--- a/packages/thirdweb/src/wallets/smart/lib/utils.ts
+++ b/packages/thirdweb/src/wallets/smart/lib/utils.ts
@@ -3,7 +3,7 @@ import type { Chain } from "../../../chains/types.js";
 import { isHex, numberToHex, toHex } from "../../../utils/encoding/hex.js";
 import type { UserOperation, UserOperationHexed } from "../types.js";
 
-const generateRandomUint192 = (): bigint => {
+export const generateRandomUint192 = (): bigint => {
   const rand1 = BigInt(Math.floor(Math.random() * 0x100000000));
   const rand2 = BigInt(Math.floor(Math.random() * 0x100000000));
   const rand3 = BigInt(Math.floor(Math.random() * 0x100000000));

--- a/packages/thirdweb/src/wallets/smart/types.ts
+++ b/packages/thirdweb/src/wallets/smart/types.ts
@@ -34,6 +34,7 @@ export type SmartWalletOptions = Prettify<
         accountContract: ThirdwebContract,
         transactions: SendTransactionOption[],
       ) => PreparedTransaction;
+      getAccountNonce?: (accountContract: ThirdwebContract) => Promise<bigint>;
     };
   } & (
     | {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to allow overriding the nonce for smart accounts in the Thirdweb package.

### Detailed summary
- Added the ability to override the nonce for smart accounts
- Exported `generateRandomUint192` function
- Updated imports and added `getAccountNonce` function in `lib/userop.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->