### PR TITLE
update middleware to handle chainId: 404

### DIFF
--- a/apps/dashboard/src/middleware.ts
+++ b/apps/dashboard/src/middleware.ts
@@ -51,7 +51,7 @@ export async function middleware(request: NextRequest) {
 
   // if the first section of the path is a number, check if it's a valid chain_id and re-write it to the slug
   const possibleChainId = Number.parseInt(paths[0]);
-  if (!Number.isNaN(possibleChainId)) {
+  if (!Number.isNaN(possibleChainId) && possibleChainId !== 404) {
     const possibleChain = defineChain(possibleChainId);
     try {
       const chainMetadata = await getChainMetadata(possibleChain);


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR ensures that the `possibleChainId` is not equal to 404 before proceeding with chain operations.

### Detailed summary
- Added a condition to check if `possibleChainId` is not equal to 404 before further processing.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->