### PR TITLE
feat(thirdweb): accept ethers and viem accounts in sdk

### DIFF
--- a/packages/thirdweb/src/adapters/viem.ts
+++ b/packages/thirdweb/src/adapters/viem.ts
@@ -60,7 +60,7 @@ export const viemAdapter = {
    * ```ts
    * import { viemAdapter } from "thirdweb/adapters/viem";
    *
-   *  const publicClient = viemAdapter.publicClient.toViem({
+   * const publicClient = viemAdapter.publicClient.toViem({
    *  chain: ethereum,
    *  client,
    * });

--- a/packages/thirdweb/src/transaction/actions/send-transaction.ts
+++ b/packages/thirdweb/src/transaction/actions/send-transaction.ts
@@ -1,4 +1,5 @@
-import type { Account } from "../../wallets/interfaces/wallet.js";
+import type { AnyAccount } from "../../wallets/interfaces/wallet.js";
+import { convertAccount } from "../../wallets/utils/convertAccount.js";
 import type { PreparedTransaction } from "../prepare-transaction.js";
 import { addTransactionToStore } from "../transaction-store.js";
 import type { GaslessOptions } from "./gasless/types.js";
@@ -6,7 +7,7 @@ import { toSerializableTransaction } from "./to-serializable-transaction.js";
 import type { WaitForReceiptOptions } from "./wait-for-tx-receipt.js";
 
 export type SendTransactionOptions = {
-  account: Account;
+  account: AnyAccount;
   // TODO: update this to `Transaction<"prepared">` once the type is available to ensure only prepared transactions are accepted
   // biome-ignore lint/suspicious/noExplicitAny: library function that accepts any prepared transaction type
   transaction: PreparedTransaction<any>;
@@ -103,7 +104,8 @@ export type SendTransactionOptions = {
 export async function sendTransaction(
   options: SendTransactionOptions,
 ): Promise<WaitForReceiptOptions> {
-  const { account, transaction, gasless } = options;
+  const { transaction, gasless } = options;
+  const account = await convertAccount(options.account);
 
   if (account.onTransactionRequested) {
     await account.onTransactionRequested(transaction);

--- a/packages/thirdweb/src/wallets/interfaces/wallet.ts
+++ b/packages/thirdweb/src/wallets/interfaces/wallet.ts
@@ -1,10 +1,12 @@
 import type { Address } from "abitype";
+import type { Signer as EthersSigner } from "ethers6";
 import type {
   Hex,
   SignableMessage,
   TransactionSerializable,
   TypedData,
   TypedDataDefinition,
+  WalletClient as ViemWalletClient,
 } from "viem";
 import type { Chain } from "../../chains/types.js";
 import type { PreparedTransaction } from "../../transaction/prepare-transaction.js";
@@ -261,3 +263,5 @@ export type Account = {
    */
   watchAsset?: (asset: WatchAssetParams) => Promise<boolean>;
 };
+
+export type AnyAccount = Account | ViemWalletClient | EthersSigner;

--- a/packages/thirdweb/src/wallets/smart/types.ts
+++ b/packages/thirdweb/src/wallets/smart/types.ts
@@ -6,7 +6,11 @@ import type { PreparedTransaction } from "../../transaction/prepare-transaction.
 import type { TransactionReceipt } from "../../transaction/types.js";
 import type { Hex } from "../../utils/encoding/hex.js";
 import type { Prettify } from "../../utils/type-utils.js";
-import type { Account, SendTransactionOption } from "../interfaces/wallet.js";
+import type {
+  Account,
+  AnyAccount,
+  SendTransactionOption,
+} from "../interfaces/wallet.js";
 
 export type SmartWalletOptions = Prettify<
   {
@@ -69,7 +73,7 @@ export type BundlerOptions = {
 };
 
 export type SmartWalletConnectionOptions = {
-  personalAccount: Account;
+  personalAccount: AnyAccount;
   client: ThirdwebClient;
   chain?: Chain;
 };

--- a/packages/thirdweb/src/wallets/utils/convertAccount.ts
+++ b/packages/thirdweb/src/wallets/utils/convertAccount.ts
@@ -1,0 +1,23 @@
+import type { Signer } from "ethers6";
+import type { WalletClient } from "viem";
+import { ethers6Adapter } from "../../adapters/ethers6.js";
+import { viemAdapter } from "../../adapters/viem.js";
+import type { Account, AnyAccount } from "../interfaces/wallet.js";
+
+function isViem(anyAccount: AnyAccount): anyAccount is WalletClient {
+  return "account" in anyAccount;
+}
+
+function isEthers6(anyAccount: AnyAccount): anyAccount is Signer {
+  return "provider" in anyAccount;
+}
+
+export async function convertAccount(anyAccount: AnyAccount): Promise<Account> {
+  if (isViem(anyAccount)) {
+    return viemAdapter.walletClient.fromViem({ walletClient: anyAccount });
+  } else if (isEthers6(anyAccount)) {
+    return ethers6Adapter.signer.fromEthers({ signer: anyAccount });
+  } else {
+    return anyAccount as Account;
+  }
+}


### PR DESCRIPTION
### TL;DR

This pull request introduces a utility function `convertAccount` to convert between different account types. It also updates the `Account` type to `AnyAccount` in relevant files and modifies functions to use the new utility.

### What changed?

1. Added `convertAccount` utility function to convert between `Viem`, `Ethers6`, and `Account` types.
2. Updated occurrences of `Account` to `AnyAccount` in various files for versatility:
    - `send-transaction.ts`
    - `wallet.ts`
    - `smart/index.ts`
    - `smart/types.ts`
3. Updated the `connectSmartWallet` and `sendTransaction` functions to use the `convertAccount` utility for account conversion.
4. Minor fix in `viemAdapter` documentation.

### How to test?

1. Verify that all tests run successfully without errors.
2. Specifically test account-related functionalities, ensuring they work with different account types (e.g., `Viem`, `Ethers6`).

### Why make this change?

This change improves the versatility and flexibility of handling different account types, making the codebase more robust and easier to maintain.

---

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing wallet compatibility by introducing `AnyAccount` type and `convertAccount` function for seamless integration with different wallet clients.

### Detailed summary
- Introduced `AnyAccount` type to support multiple wallet clients
- Added `convertAccount` function for converting different wallet clients
- Updated functions to accept `AnyAccount` type for flexible integration

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->