### PR TITLE
Fix XDC network sendTransaction issue

### DIFF
--- a/.changeset/dirty-flies-shake.md
+++ b/.changeset/dirty-flies-shake.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+handle `null` value of `effectiveGasPrice` in `sendTransaction`  method of `toEthersSigner` adapter that throws error when trying to convert to BigNumber. This is causing issue in XDC Network (chain Id 50) and XDC Apothem testnet (chain id 51)

--- a/packages/thirdweb/src/adapters/ethers5.ts
+++ b/packages/thirdweb/src/adapters/ethers5.ts
@@ -398,7 +398,7 @@ export async function toEthersSigner(
             cumulativeGasUsed: ethers.BigNumber.from(receipt.cumulativeGasUsed),
             // How to handle effectiveGasPrice being null? - setting 0 for now
             effectiveGasPrice: ethers.BigNumber.from(
-              receipt.effectiveGasPrice || 0,
+              receipt.effectiveGasPrice || 0n,
             ),
             byzantium: true,
           };

--- a/packages/thirdweb/src/adapters/ethers5.ts
+++ b/packages/thirdweb/src/adapters/ethers5.ts
@@ -396,10 +396,10 @@ export async function toEthersSigner(
               blockNumber: Number(log.blockNumber),
             })),
             cumulativeGasUsed: ethers.BigNumber.from(receipt.cumulativeGasUsed),
-            // How to handle effectiveGasPrice being null? - setting 0 for now
-            effectiveGasPrice: ethers.BigNumber.from(
-              receipt.effectiveGasPrice || 0n,
-            ),
+            effectiveGasPrice:
+              receipt.effectiveGasPrice !== null
+                ? ethers.BigNumber.from(receipt.effectiveGasPrice)
+                : receipt.effectiveGasPrice,
             byzantium: true,
           };
         },

--- a/packages/thirdweb/src/adapters/ethers5.ts
+++ b/packages/thirdweb/src/adapters/ethers5.ts
@@ -396,7 +396,10 @@ export async function toEthersSigner(
               blockNumber: Number(log.blockNumber),
             })),
             cumulativeGasUsed: ethers.BigNumber.from(receipt.cumulativeGasUsed),
-            effectiveGasPrice: ethers.BigNumber.from(receipt.effectiveGasPrice),
+            // How to handle effectiveGasPrice being null? - setting 0 for now
+            effectiveGasPrice: ethers.BigNumber.from(
+              receipt.effectiveGasPrice || 0,
+            ),
             byzantium: true,
           };
         },


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on handling `null` values for `effectiveGasPrice` in the `sendTransaction` method of the `toEthersSigner` adapter to prevent errors in XDC Network and XDC Apothem testnet.

### Detailed summary
- Handle `null` value for `effectiveGasPrice` in `sendTransaction` method
- Update `effectiveGasPrice` assignment based on `receipt.effectiveGasPrice` value
- Prevent error when converting `effectiveGasPrice` to BigNumber

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->