### PR TITLE
fix(tests): conditionally run ClaimButton tests based on TW_SECRET_KEY environment variable

### DIFF
--- a/packages/thirdweb/src/react/web/ui/prebuilt/thirdweb/ClaimButton/ClaimButton.test.tsx
+++ b/packages/thirdweb/src/react/web/ui/prebuilt/thirdweb/ClaimButton/ClaimButton.test.tsx
@@ -25,7 +25,7 @@ const chain = ANVIL_CHAIN;
  * The ClaimButton uses TransactionButton under the hood
  * So all we need to test is whether it gives the correct PreparedTransaction to the TransactionButton
  */
-describe("ClaimButton", () => {
+describe.runIf(process.env.TW_SECRET_KEY)("ClaimButton", () => {
   // ERC721
   it("should throw an error if not an ERC721 contract", async () => {
     const contract = USDT_CONTRACT;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a conditional test for the `ClaimButton` component based on the `TW_SECRET_KEY` environment variable.

### Detailed summary
- Conditionally run tests based on the presence of `TW_SECRET_KEY`
- Updated test suite for `ClaimButton` component

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->