### PR TITLE
[Refactor] Simplify RPC client map key usage in getRpcClient function

### DIFF
--- a/.changeset/polite-pumpkins-dance.md
+++ b/.changeset/polite-pumpkins-dance.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+[performance] - fix rpc client reuse

--- a/packages/thirdweb/src/rpc/rpc.ts
+++ b/packages/thirdweb/src/rpc/rpc.ts
@@ -61,12 +61,10 @@ export function getRpcClient(
   options: RPCOptions,
 ): EIP1193RequestFn<EIP1474Methods> {
   const rpcClientMap = getRpcClientMap(options.client);
-  const chainId = options.chain.id;
+  const rpcUrl = options.chain.rpc;
 
-  if (rpcClientMap.has(options.chain.rpc)) {
-    return rpcClientMap.get(
-      options.chain.rpc,
-    ) as EIP1193RequestFn<EIP1474Methods>;
+  if (rpcClientMap.has(rpcUrl)) {
+    return rpcClientMap.get(rpcUrl) as EIP1193RequestFn<EIP1474Methods>;
   }
 
   const rpcClient: EIP1193RequestFn<EIP1474Methods> = (() => {
@@ -242,6 +240,6 @@ export function getRpcClient(
     };
   })();
 
-  rpcClientMap.set(chainId, rpcClient);
+  rpcClientMap.set(rpcUrl, rpcClient);
   return rpcClient as EIP1193RequestFn<EIP1474Methods>;
 }


### PR DESCRIPTION
### TL;DR
Fixes an issue with RPC client reuse to improve performance.

### What changed?
The change replaces the use of `chainId` with `rpcUrl` as the key in the `rpcClientMap` to ensure the correct RPC client is reused.

### How to test?
Test by running existing unit tests and functional tests for RPC client related functionality. Ensure that performance metrics show improvement in RPC client reuse scenarios.

### Why make this change?
This change is motivated by the need to improve performance by ensuring the RPC client is correctly reused.

---



<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to improve performance by fixing the reuse of RPC clients in the `rpc.ts` file.

### Detailed summary
- Updated variable name from `chainId` to `rpcUrl` for clarity
- Improved RPC client reuse logic by using `rpcUrl` instead of `options.chain.rpc`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->