### PR TITLE
Move faucet inside chain page layout + UI tweaks

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/(chainPage)/faucet/components/SpinWheel.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/(chainPage)/faucet/components/SpinWheel.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { CopyTextButton } from "@/components/ui/CopyTextButton";
-import { Spinner } from "@/components/ui/Spinner/Spinner";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -13,6 +12,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import { Skeleton } from "@/components/ui/skeleton";
 import { THIRDWEB_ENGINE_FAUCET_WALLET } from "@/constants/env";
 import { CustomConnectWallet } from "@3rdweb-sdk/react/components/connect-wallet";
 import { useMutation } from "@tanstack/react-query";
@@ -157,38 +157,49 @@ export function TestnetSpinWheel({
 
   return (
     <>
-      {isLoading ?? <Spinner />}
-      {faucetMessage}
-      <Dialog>
-        <DialogTrigger asChild>
-          {!isFaucetEmpty && (
-            <Button className="min-w-48" disabled={ttlSeconds > 0}>
-              {claimButtonCta}
-            </Button>
-          )}
-        </DialogTrigger>
-        <DialogContent className="w-auto h-fit max-w-none">
-          {claimMutation.isSuccess && <Confetti className="w-full h-full" />}
-          <DialogHeader>
-            <DialogTitle>
-              Spin to claim {chain.nativeCurrency.symbol} on {chain.name}
-            </DialogTitle>
-            <DialogDescription>
-              <p className="py-2">Click the wheel to get your claim amount.</p>
-              <div className="p-4">
-                <SpinWheel {...spinWheelProps} />
-              </div>
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter className="flex justify-between">
-            <DialogClose asChild>
-              <Button variant="outline">
-                <span className="text-muted-foreground">{closeButtonCta}</span>
-              </Button>
-            </DialogClose>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      {isLoading ? (
+        <Skeleton className="h-20" />
+      ) : (
+        <>
+          <div className="mb-3">{faucetMessage}</div>
+          <Dialog>
+            <DialogTrigger asChild>
+              {!isFaucetEmpty && (
+                <Button className="min-w-48" disabled={ttlSeconds > 0}>
+                  {claimButtonCta}
+                </Button>
+              )}
+            </DialogTrigger>
+            <DialogContent className="w-auto h-fit max-w-none">
+              {claimMutation.isSuccess && (
+                <Confetti className="w-full h-full" />
+              )}
+              <DialogHeader>
+                <DialogTitle>
+                  Spin to claim {chain.nativeCurrency.symbol} on {chain.name}
+                </DialogTitle>
+                <DialogDescription>
+                  <p className="py-2">
+                    Click the wheel to get your claim amount.
+                  </p>
+                  <div className="p-4">
+                    <SpinWheel {...spinWheelProps} />
+                  </div>
+                </DialogDescription>
+              </DialogHeader>
+              <DialogFooter className="flex justify-between">
+                <DialogClose asChild>
+                  <Button variant="outline">
+                    <span className="text-muted-foreground">
+                      {closeButtonCta}
+                    </span>
+                  </Button>
+                </DialogClose>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+        </>
+      )}
     </>
   );
 }

--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/(chainPage)/faucet/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/(chainPage)/faucet/page.tsx
@@ -5,8 +5,8 @@ import { getIpAddress } from "lib/ip";
 import { cacheTtl } from "lib/redis";
 import { redirect } from "next/navigation";
 import type { Metadata } from "next/types";
-import { InfoCard } from "../(chainPage)/components/server/info-card";
-import { getChain } from "../../utils";
+import { getChain } from "../../../utils";
+import { InfoCard } from "../components/server/info-card";
 import { TestnetSpinWheel } from "./components/SpinWheel";
 
 export async function generateMetadata({
@@ -36,16 +36,15 @@ export default async function Page(props: { params: { chain_id: string } }) {
   return (
     <>
       <div className="items-center">
-        <InfoCard title="Faucet">
-          <ClientOnly ssr={null}>
-            <TestnetSpinWheel chain={chain} ttlSeconds={ttlSeconds} />
-          </ClientOnly>
-        </InfoCard>
+        <h3 className="mb-3 text-lg font-semibold"> Faucet </h3>
+        <ClientOnly ssr={null}>
+          <TestnetSpinWheel chain={chain} ttlSeconds={ttlSeconds} />
+        </ClientOnly>
 
         <div className="h-10" />
 
         <InfoCard title="Resources">
-          <h3>What is a faucet?</h3>
+          <h3 className="mb-2 text-lg font-semibold">What is a faucet?</h3>
           <p>
             An testnet faucet is an online service that provides free testnet
             currency to web3 app and blockchain developers. This allows them to
@@ -57,7 +56,9 @@ export default async function Page(props: { params: { chain_id: string } }) {
           <h2>How often can I claim from the faucet?</h2>
           <p>You may claim funds once per testnet chain every 24 hours.</p>
 
-          <h3>How can I refill the faucet?</h3>
+          <h3 className="mb-2 text-lg font-semibold">
+            How can I refill the faucet?
+          </h3>
           <p>Please send funds the following address:</p>
           <div>
             <CopyTextButton
@@ -69,7 +70,9 @@ export default async function Page(props: { params: { chain_id: string } }) {
             />
           </div>
 
-          <h3>How does the faucet work?</h3>
+          <h3 className="mb-2 text-lg font-semibold">
+            How does the faucet work?
+          </h3>
           <p>
             When you request testnet funds, a multi-chain backend wallet
             transfers a small amount of {chain.nativeCurrency.symbol} on{" "}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to refactor the `faucet` page in the dashboard for a specific chain. 

### Detailed summary
- Moved `getChain` import to a different path
- Reorganized the structure of the `InfoCard` and added new styling
- Updated the content and styling of various headings
- Removed `Spinner` import and replaced with `Skeleton`
- Improved conditional rendering logic for loading state in `TestnetSpinWheel`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->