### PR TITLE
Add option to getApprovalForTransaction for approving infinite amount

### DIFF
--- a/.changeset/itchy-wolves-return.md
+++ b/.changeset/itchy-wolves-return.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Add option to getApprovalForTransaction for approving infinite amount (max uint256) of ERC20

--- a/packages/thirdweb/src/extensions/erc20/write/getApprovalForTransaction.ts
+++ b/packages/thirdweb/src/extensions/erc20/write/getApprovalForTransaction.ts
@@ -1,3 +1,4 @@
+import { maxUint256 } from "viem";
 import { getContract } from "../../../contract/contract.js";
 import type { PreparedTransaction } from "../../../transaction/prepare-transaction.js";
 import { getAddress } from "../../../utils/address.js";
@@ -9,12 +10,22 @@ import { approve } from "../__generated__/IERC20/write/approve.js";
 export type GetApprovalForTransactionParams = {
   transaction: PreparedTransaction;
   account: Account;
+
+  /**
+   * By default, this extension only asks to approve the allowance by an exactly needed amount.
+   *
+   * Which means the next time users will likely have to do it again.
+   *
+   * If `approveInfinite` is set to `true`, this method will return a transaction for approving an infinite amount of ERC20 (aka. max unit256).
+   * This option can potentially make the UX better since users don't have to approve every time.
+   */
+  approveInfinite?: boolean;
 };
 
 export async function getApprovalForTransaction(
   options: GetApprovalForTransactionParams,
 ): Promise<PreparedTransaction | null> {
-  const { transaction, account } = options;
+  const { transaction, account, approveInfinite } = options;
   if (!account) {
     return null;
   }
@@ -49,7 +60,7 @@ export async function getApprovalForTransaction(
 
     return approve({
       contract,
-      value: erc20Value.amountWei,
+      value: approveInfinite ? maxUint256 : erc20Value.amountWei,
       spender: target,
     });
   }


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

## Changes made

- [ ] Public API changes: list the public API changes made if any
- [ ] Internal API changes: explain the internal logic changes

## How to test

- [ ] Automated tests: link to unit test file
- [ ] Manual tests: step by step instructions on how to test

## Contributor NFT

Paste in your wallet address below and we will airdrop you a special NFT when your pull request is merged. 

```Address: ```


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds an option to approve an infinite amount of ERC20 tokens in `getApprovalForTransaction`.

### Detailed summary
- Added `approveInfinite` option to approve an infinite amount of ERC20 tokens
- Updated `getApprovalForTransaction` to handle infinite approval option

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->