### PR TITLE
Fix flash of dark theme when loading dashboard in light mode + replace useColorMode with useTheme

### DIFF
--- a/apps/dashboard/src/components/ClientOnly/ClientOnly.tsx
+++ b/apps/dashboard/src/components/ClientOnly/ClientOnly.tsx
@@ -19,13 +19,7 @@ export const ClientOnly: ComponentWithChildren<ClientOnlyProps> = ({
   ssr,
   style,
 }) => {
-  const [hasMounted, setHasMounted] = useState(false);
-
-  // FIXME: legitimate usecase - however ideally we wouldn't need this entire file
-  // eslint-disable-next-line no-restricted-syntax
-  useEffect(() => {
-    setHasMounted(true);
-  }, []);
+  const hasMounted = useIsClientMounted();
 
   if (!hasMounted) {
     return <> {ssr} </>;
@@ -44,3 +38,14 @@ export const ClientOnly: ComponentWithChildren<ClientOnlyProps> = ({
     </div>
   );
 };
+
+export function useIsClientMounted() {
+  const [hasMounted, setHasMounted] = useState(false);
+
+  // eslint-disable-next-line no-restricted-syntax
+  useEffect(() => {
+    setHasMounted(true);
+  }, []);
+
+  return hasMounted;
+}

--- a/apps/dashboard/src/components/buttons/TransactionButton.tsx
+++ b/apps/dashboard/src/components/buttons/TransactionButton.tsx
@@ -9,9 +9,9 @@ import {
   PopoverContent,
   PopoverTrigger,
   Tooltip,
-  useColorMode,
 } from "@chakra-ui/react";
 import { CHAIN_ID_TO_GNOSIS } from "constants/mappings";
+import { useTheme } from "next-themes";
 import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import { BiTransferAlt } from "react-icons/bi";
 import { FiInfo } from "react-icons/fi";
@@ -60,7 +60,7 @@ export const TransactionButton: React.FC<TransactionButtonProps> = ({
   onChainSelect,
   ...restButtonProps
 }) => {
-  const colorMode = useColorMode();
+  const { theme } = useTheme();
   const activeWallet = useActiveWallet();
   const walletRequiresExternalConfirmation =
     useWalletRequiresExternalConfirmation();
@@ -72,7 +72,7 @@ export const TransactionButton: React.FC<TransactionButtonProps> = ({
     [chain],
   );
 
-  const ColorModeComp = colorMode.colorMode === "dark" ? DarkMode : Fragment;
+  const ColorModeComp = theme === "dark" ? DarkMode : Fragment;
 
   const numberWidth = useMemo(() => {
     // for each digit of transaction count add 8.3px

--- a/apps/dashboard/src/components/color-mode/color-mode-toggle.tsx
+++ b/apps/dashboard/src/components/color-mode/color-mode-toggle.tsx
@@ -1,16 +1,39 @@
-import { Icon, IconButton, useColorMode } from "@chakra-ui/react";
+import { useTheme } from "next-themes";
 import { FiMoon, FiSun } from "react-icons/fi";
+import { Button } from "../../@/components/ui/button";
+import { SkeletonContainer } from "../../@/components/ui/skeleton";
+import { useIsClientMounted } from "../ClientOnly/ClientOnly";
 
 export const ColorModeToggle: React.FC = () => {
-  const { colorMode, toggleColorMode } = useColorMode();
+  const { theme, setTheme } = useTheme();
+  const clientMounted = useIsClientMounted();
 
   return (
-    <IconButton
-      bg="transparent"
-      size="sm"
-      aria-label="toggle-color"
-      icon={<Icon as={colorMode === "light" ? FiMoon : FiSun} />}
-      onClick={() => toggleColorMode()}
+    <SkeletonContainer
+      loadedData={
+        clientMounted
+          ? theme === "light"
+            ? "light"
+            : ("dark" as const)
+          : undefined
+      }
+      skeletonData={"light"}
+      render={(v) => {
+        return (
+          <Button
+            className="p-3 fade-in-0"
+            variant="ghost"
+            aria-label="toggle color"
+            onClick={() => setTheme(theme === "light" ? "dark" : "light")}
+          >
+            {v === "dark" ? (
+              <FiMoon className="size-5" />
+            ) : (
+              <FiSun className="size-5" />
+            )}
+          </Button>
+        );
+      }}
     />
   );
 };

--- a/apps/dashboard/src/components/explore/upsells/publish-submit.tsx
+++ b/apps/dashboard/src/components/explore/upsells/publish-submit.tsx
@@ -1,9 +1,10 @@
-import { ButtonGroup, Flex, useColorMode } from "@chakra-ui/react";
+import { ButtonGroup, Flex } from "@chakra-ui/react";
 import { ChakraNextImage } from "components/Image";
+import { useTheme } from "next-themes";
 import { Heading, LinkButton, Text, TrackedLink } from "tw-components";
 
 export const PublishUpsellCard: React.FC = () => {
-  const { colorMode } = useColorMode();
+  const { theme } = useTheme();
 
   return (
     <Flex
@@ -12,7 +13,7 @@ export const PublishUpsellCard: React.FC = () => {
       p={{ base: 8, md: 10 }}
       gap={12}
       bg="linear-gradient(158.84deg, rgba(255, 255, 255, 0.05) 13.95%, rgba(255, 255, 255, 0) 38.68%)"
-      bgColor={colorMode === "dark" ? "transparent" : "backgroundHighlight"}
+      bgColor={theme === "dark" ? "transparent" : "backgroundHighlight"}
     >
       <Flex flexDir="column" gap={6}>
         <Heading>Accelerate your protocol&apos;s growth.</Heading>
@@ -87,7 +88,7 @@ export const PublishUpsellCard: React.FC = () => {
         </ButtonGroup>
       </Flex>
       <ChakraNextImage
-        display={{ base: "none", md: colorMode === "dark" ? "block" : "none" }}
+        display={{ base: "none", md: theme === "dark" ? "block" : "none" }}
         w="40%"
         src={require("../../../../public/assets/landingpage/explore-featured.png")}
         alt=""

--- a/apps/dashboard/src/components/onboarding/Billing.tsx
+++ b/apps/dashboard/src/components/onboarding/Billing.tsx
@@ -1,11 +1,12 @@
 import { accountKeys } from "@3rdweb-sdk/react/cache-keys";
 import { useUpdateAccount } from "@3rdweb-sdk/react/hooks/useApi";
 import { useLoggedInUser } from "@3rdweb-sdk/react/hooks/useLoggedInUser";
-import { Flex, FocusLock, useColorMode } from "@chakra-ui/react";
+import { Flex, FocusLock } from "@chakra-ui/react";
 import { Elements } from "@stripe/react-stripe-js";
 import { loadStripe } from "@stripe/stripe-js";
 import { useQueryClient } from "@tanstack/react-query";
 import { useTrack } from "hooks/analytics/useTrack";
+import { useTheme } from "next-themes";
 import { OnboardingPaymentForm } from "./PaymentForm";
 import { OnboardingTitle } from "./Title";
 
@@ -23,7 +24,7 @@ export const OnboardingBilling: React.FC<OnboardingBillingProps> = ({
   onSave,
   onCancel,
 }) => {
-  const { colorMode } = useColorMode();
+  const { theme } = useTheme();
   const trackEvent = useTrack();
   const queryClient = useQueryClient();
   const { user } = useLoggedInUser();
@@ -80,7 +81,7 @@ export const OnboardingBilling: React.FC<OnboardingBillingProps> = ({
               paymentMethodConfiguration:
                 process.env.NEXT_PUBLIC_STRIPE_PAYMENT_METHOD_CFG_ID,
               appearance: {
-                theme: colorMode === "dark" ? "night" : "stripe",
+                theme: theme === "dark" ? "night" : "stripe",
                 ...appearance,
               },
             }}

--- a/apps/dashboard/src/components/onboarding/Steps.tsx
+++ b/apps/dashboard/src/components/onboarding/Steps.tsx
@@ -6,16 +6,11 @@ import {
   useApiKeys,
 } from "@3rdweb-sdk/react/hooks/useApi";
 import { useLoggedInUser } from "@3rdweb-sdk/react/hooks/useLoggedInUser";
-import {
-  Flex,
-  HStack,
-  VStack,
-  useBreakpointValue,
-  useColorMode,
-} from "@chakra-ui/react";
+import { Flex, HStack, VStack, useBreakpointValue } from "@chakra-ui/react";
 import { ChakraNextImage } from "components/Image";
 import { useTrack } from "hooks/analytics/useTrack";
 import { useLocalStorage } from "hooks/useLocalStorage";
+import { useTheme } from "next-themes";
 import type { StaticImageData } from "next/image";
 import { useRouter } from "next/router";
 import { useEffect, useMemo } from "react";
@@ -56,7 +51,7 @@ export const OnboardingSteps: React.FC<OnboardingStepsProps> = ({
   const apiKeysQuery = useApiKeys();
   const router = useRouter();
   const trackEvent = useTrack();
-  const { colorMode } = useColorMode();
+  const { theme } = useTheme();
   const { data: credits } = useAccountCredits();
   const opCredit = credits?.find((crd) => crd.name.startsWith("OP -"));
   const [onboardingPaymentMethod, setOnboardingPaymentMethod] = useLocalStorage(
@@ -313,10 +308,10 @@ export const OnboardingSteps: React.FC<OnboardingStepsProps> = ({
           )}
         </HStack>
       </VStack>
-      {rightImageDark && !isMobile && colorMode === "dark" && (
+      {rightImageDark && !isMobile && theme === "dark" && (
         <ChakraNextImage src={rightImageDark} alt={""} w="50%" priority />
       )}
-      {rightImageLight && !isMobile && colorMode === "light" && (
+      {rightImageLight && !isMobile && theme === "light" && (
         <ChakraNextImage src={rightImageLight} alt={""} w="50%" priority />
       )}
     </Card>

--- a/apps/dashboard/src/components/selects/NetworkSelectorButton.tsx
+++ b/apps/dashboard/src/components/selects/NetworkSelectorButton.tsx
@@ -1,5 +1,4 @@
 import { popularChains } from "@3rdweb-sdk/react/components/popularChains";
-import { useColorMode } from "@chakra-ui/react";
 import { ChainIcon } from "components/icons/ChainIcon";
 import type { StoredChain } from "contexts/configured-chains";
 import {
@@ -11,6 +10,7 @@ import {
   useRecentlyUsedChains,
 } from "hooks/chains/recentlyUsedChains";
 import { useSetIsNetworkConfigModalOpen } from "hooks/networkConfigModal";
+import { useTheme } from "next-themes";
 import { useEffect, useMemo, useRef } from "react";
 import { BiChevronDown } from "react-icons/bi";
 import type { Chain } from "thirdweb";
@@ -37,7 +37,7 @@ export const NetworkSelectorButton: React.FC<NetworkSelectorButtonProps> = ({
   const recentlyUsedChains = useRecentlyUsedChains();
   const addRecentlyUsedChains = useAddRecentlyUsedChainId();
   const setIsNetworkConfigModalOpen = useSetIsNetworkConfigModalOpen();
-  const { colorMode } = useColorMode();
+  const { theme } = useTheme();
   const supportedChains = useSupportedChains();
   const supportedChainsRecord = useSupportedChainsRecord();
   const favoriteChainsQuery = useFavoriteChains();
@@ -120,7 +120,7 @@ export const NetworkSelectorButton: React.FC<NetworkSelectorButtonProps> = ({
         }}
         onClick={() => {
           networkSwitcherModal.open({
-            theme: colorMode === "dark" ? "dark" : "light",
+            theme: theme === "dark" ? "dark" : "light",
             sections: [
               {
                 label: "Recently Used",

--- a/apps/dashboard/src/components/wallets/ConnectWalletPlayground/Playground.tsx
+++ b/apps/dashboard/src/components/wallets/ConnectWalletPlayground/Playground.tsx
@@ -1043,7 +1043,7 @@ export const ConnectWalletPlayground: React.FC<{
             theme="dark"
             isSelected={selectedTheme === "dark"}
             onClick={() => {
-              setTheme("light");
+              setTheme("dark");
             }}
           />
 
@@ -1052,7 +1052,7 @@ export const ConnectWalletPlayground: React.FC<{
             theme="light"
             isSelected={selectedTheme === "light"}
             onClick={() => {
-              setTheme("dark");
+              setTheme("light");
             }}
           />
         </Flex>

--- a/apps/dashboard/src/components/wallets/ConnectWalletPlayground/Playground.tsx
+++ b/apps/dashboard/src/components/wallets/ConnectWalletPlayground/Playground.tsx
@@ -14,13 +14,13 @@ import {
   Spacer,
   Switch,
   useBreakpointValue,
-  useColorMode,
 } from "@chakra-ui/react";
 import { useQuery } from "@tanstack/react-query";
 import { ConnectWallet } from "@thirdweb-dev/react";
 import { ClientOnly } from "components/ClientOnly/ClientOnly";
 import { ChakraNextImage } from "components/Image";
 import { useTrack } from "hooks/analytics/useTrack";
+import { useTheme } from "next-themes";
 import parserBabel from "prettier/plugins/babel";
 import estree from "prettier/plugins/estree";
 import { format } from "prettier/standalone";
@@ -111,8 +111,8 @@ export const ConnectWalletPlayground: React.FC<{
     }
   }, [welcomeScreen]);
 
-  const { colorMode, toggleColorMode } = useColorMode();
-  const selectedTheme = colorMode === "light" ? "light" : "dark";
+  const { theme, setTheme } = useTheme();
+  const selectedTheme = theme === "light" ? "light" : "dark";
   const [locale, setLocale] = useState<LocaleId>("en-US");
 
   const { colorOverrides, themeObj, setColorOverrides } =
@@ -1043,9 +1043,7 @@ export const ConnectWalletPlayground: React.FC<{
             theme="dark"
             isSelected={selectedTheme === "dark"}
             onClick={() => {
-              if (selectedTheme !== "dark") {
-                toggleColorMode();
-              }
+              setTheme("light");
             }}
           />
 
@@ -1054,9 +1052,7 @@ export const ConnectWalletPlayground: React.FC<{
             theme="light"
             isSelected={selectedTheme === "light"}
             onClick={() => {
-              if (selectedTheme !== "light") {
-                toggleColorMode();
-              }
+              setTheme("dark");
             }}
           />
         </Flex>

--- a/apps/dashboard/src/pages/_app.tsx
+++ b/apps/dashboard/src/pages/_app.tsx
@@ -269,42 +269,31 @@ const ConsoleApp = memo(function ConsoleApp({
         transitionTimingFunction="ease"
       />
 
-      <ChakraProvider theme={chakraThemeWithFonts}>
-        <AnnouncementBanner />
-        <TailwindTheme>
+      <TailwindTheme>
+        <ChakraProvider theme={chakraThemeWithFonts}>
+          <AnnouncementBanner />
           {isFallback && Component.fallback
             ? Component.fallback
             : getLayout(<Component {...pageProps} />, pageProps)}
           <Toaster />
-        </TailwindTheme>
-      </ChakraProvider>
+          <SyncTheme />
+        </ChakraProvider>
+      </TailwindTheme>
     </PlausibleProvider>
   );
 });
 
 function TailwindTheme(props: { children: React.ReactNode }) {
-  const { colorMode } = useColorMode();
-
-  return (
-    <ThemeProvider
-      attribute="class"
-      // this sets the initial theme
-      forcedTheme={colorMode === "light" ? "light" : "dark"}
-    >
-      {/* this keeps the theme in sync! */}
-      <SyncTheme currentTheme={colorMode === "light" ? "light" : "dark"} />
-      {props.children}
-    </ThemeProvider>
-  );
+  return <ThemeProvider attribute="class">{props.children}</ThemeProvider>;
 }
-const SyncTheme: React.FC<{ currentTheme: "light" | "dark" }> = ({
-  currentTheme,
-}) => {
-  const { setTheme } = useTheme();
+
+const SyncTheme: React.FC = () => {
+  const { theme } = useTheme();
+  const { setColorMode } = useColorMode();
   // eslint-disable-next-line no-restricted-syntax
   useEffect(() => {
-    setTheme(currentTheme);
-  }, [currentTheme, setTheme]);
+    setColorMode(theme === "light" ? "light" : "dark");
+  }, [setColorMode, theme]);
   return null;
 };
 

--- a/apps/dashboard/src/pages/_app.tsx
+++ b/apps/dashboard/src/pages/_app.tsx
@@ -284,7 +284,11 @@ const ConsoleApp = memo(function ConsoleApp({
 });
 
 function TailwindTheme(props: { children: React.ReactNode }) {
-  return <ThemeProvider attribute="class">{props.children}</ThemeProvider>;
+  return (
+    <ThemeProvider attribute="class" disableTransitionOnChange>
+      {props.children}
+    </ThemeProvider>
+  );
 }
 
 const SyncTheme: React.FC = () => {

--- a/apps/dashboard/src/pages/dashboard/connect/analytics.tsx
+++ b/apps/dashboard/src/pages/dashboard/connect/analytics.tsx
@@ -12,7 +12,6 @@ import {
   StatLabel,
   StatNumber,
   useBreakpointValue,
-  useColorMode,
 } from "@chakra-ui/react";
 import {
   AutoBarChart,
@@ -24,6 +23,7 @@ import { AppLayout } from "components/app-layouts/app";
 import { GatedFeature } from "components/settings/Account/Billing/GatedFeature";
 import { ApiKeysMenu } from "components/settings/ApiKeys/Menu";
 import { ConnectSidebar } from "core-ui/sidebar/connect";
+import { useTheme } from "next-themes";
 import { useRouter } from "next/router";
 import { PageId } from "page-id";
 import { useMemo, useState } from "react";
@@ -43,7 +43,7 @@ const RADIAN = Math.PI / 180;
 const DashboardConnectAnalytics: ThirdwebNextPage = () => {
   const router = useRouter();
   const defaultClientId = router.query.clientId?.toString();
-  const { colorMode } = useColorMode();
+  const { theme } = useTheme();
   const isMobile = useBreakpointValue({ base: true, md: false });
   const { isLoading } = useLoggedInUser();
   const keysQuery = useApiKeys();
@@ -72,8 +72,8 @@ const DashboardConnectAnalytics: ThirdwebNextPage = () => {
   const statsQuery = useWalletStats(selectedKey?.key);
 
   const barColors = useMemo(
-    () => (colorMode === "light" ? BAR_COLORS_LIGHT : BAR_COLORS_DARK),
-    [colorMode],
+    () => (theme === "light" ? BAR_COLORS_LIGHT : BAR_COLORS_DARK),
+    [theme],
   );
 
   const pieChartData = useMemo(() => {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces theme management using `next-themes` across multiple components. 

### Detailed summary
- Introduces `useTheme` from `next-themes` to manage themes
- Replaces `useColorMode` with `useTheme` in various components
- Updates color mode logic in components like `ClientOnly`, `ColorModeToggle`, `NetworkSelectorButton`, etc.

> The following files were skipped due to too many changes: `apps/dashboard/src/components/onboarding/Steps.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->