### PR TITLE
[Refactor] Remove unused TimeRangeSwitcher component

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/trending/components/trending-table.tsx
+++ b/apps/dashboard/src/app/(dashboard)/trending/components/trending-table.tsx
@@ -17,7 +17,6 @@ import type {
 } from "../../../../lib/search";
 import { TablePagination } from "./pagination.client";
 import { SortingHeader } from "./sorting-header.client";
-import { TimeRangeSwitcher } from "./time-range-switcher.client";
 
 export async function TrendingContractSection(props: {
   topContracts: TrendingContract[];
@@ -32,9 +31,6 @@ export async function TrendingContractSection(props: {
   return (
     props.topContracts.length > 0 && (
       <div className="flex flex-col gap-4 w-full">
-        <div className="w-full flex flex-row gap-4 justify-center md:justify-end py-4">
-          <TimeRangeSwitcher />
-        </div>
         <Table
           className={`border-white ${isLandingPage && "border-b-[1px] font-mono text-xs md:text-sm mb-4"}`}
         >

--- a/apps/dashboard/src/app/(dashboard)/trending/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/trending/page.tsx
@@ -20,6 +20,7 @@ export default async function DashboardContractTrendingPage(props: {
 }) {
   const topContracts = await fetchTopContracts({
     ...props.searchParams,
+    timeRange: "month",
   });
   return (
     <div>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to remove the `TimeRangeSwitcher` component from the `TrendingContractSection` in the dashboard trending page.

### Detailed summary
- Removed `TimeRangeSwitcher` component from `TrendingContractSection`
- Updated `fetchTopContracts` to include a `timeRange` parameter with a value of "month"

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->