### PR TITLE
fix(thirdweb): update utils file and export fetchContractMetadata function

### DIFF
--- a/.changeset/grumpy-teachers-tease.md
+++ b/.changeset/grumpy-teachers-tease.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": minor
+---
+
+Adds fetchContractMetadata

--- a/packages/thirdweb/src/exports/utils.ts
+++ b/packages/thirdweb/src/exports/utils.ts
@@ -163,11 +163,11 @@ export { refreshJWT, type RefreshJWTParams } from "../utils/jwt/refresh-jwt.js";
 export type { JWTPayload } from "../utils/jwt/types.js";
 
 // ------------------------------------------------
-// thirdweb Drop contracts
+// thirdweb contracts
 // ------------------------------------------------
 export {
   getClaimParams,
   type GetClaimParamsOptions,
 } from "../utils/extensions/drops/get-claim-params.js";
-
 export type { NFTMetadata, NFTInput } from "../utils/nft/parseNft.js";
+export { fetchContractMetadata } from "../utils/contract/fetchContractMetadata.js";

--- a/packages/thirdweb/src/utils/contract/fetchContractMetadata.ts
+++ b/packages/thirdweb/src/utils/contract/fetchContractMetadata.ts
@@ -14,7 +14,16 @@ export type FetchContractMetadata = {
  *
  * @param options - The options for fetching the token metadata.
  * @returns The token metadata.
- * @internal
+ * 
+ * @example
+ * ```ts
+ * import { fetchContractMetadata } from "thirdweb/utils";
+ * 
+ * const metadata = await fetchContractMetadata({
+ *   client, 
+ *   uri: "..."
+ * });
+ * ```
  */
 export async function fetchContractMetadata(
   options: FetchContractMetadata,


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

## Changes made

- [ ] Public API changes: list the public API changes made if any
- [ ] Internal API changes: explain the internal logic changes

## How to test

- [ ] Automated tests: link to unit test file
- [ ] Manual tests: step by step instructions on how to test

## Contributor NFT

Paste in your wallet address below and we will airdrop you a special NFT when your pull request is merged. 

```Address: ```

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new function `fetchContractMetadata` to `thirdweb/utils` for fetching token metadata.

### Detailed summary
- Added `fetchContractMetadata` function to fetch token metadata
- Updated example usage in `fetchContractMetadata`
- Renamed `thirdweb Drop contracts` to `thirdweb contracts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->