### PR TITLE
Fix contract card height in dashboard

### DIFF
--- a/apps/dashboard/src/components/explore/contract-card/index.tsx
+++ b/apps/dashboard/src/components/explore/contract-card/index.tsx
@@ -60,7 +60,7 @@ export const ContractCard: React.FC<ContractCardProps> = ({
   return (
     <article
       className={cn(
-        "h-full min-h-[200px] p-4 border border-border relative rounded-lg flex flex-col",
+        "min-h-[200px] p-4 border border-border relative rounded-lg flex flex-col",
         !showSkeleton ? "bg-secondary hover:bg-muted" : "pointer-events-none",
       )}
     >


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR removes the `h-full` class from the `className` prop in the `contract-card` component in the Explore section of the dashboard.

### Detailed summary
- Removed the `h-full` class from the `className` prop in `contract-card` component.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->