### PR TITLE
Add util function: convertParamValues

### DIFF
--- a/.changeset/khaki-rocks-wave.md
+++ b/.changeset/khaki-rocks-wave.md
@@ -1,0 +1,14 @@
+---
+"thirdweb": patch
+---
+
+Add util function: parseAbiParams
+
+```ts
+import { parseAbiParams } from "thirdweb/utils";
+
+const example1 = parseAbiParams(
+  ["address", "uint256"],
+  ["0x.....", "1200000"]
+); // result: ["0x......", 1200000n]
+```

--- a/packages/thirdweb/src/exports/utils.ts
+++ b/packages/thirdweb/src/exports/utils.ts
@@ -171,3 +171,5 @@ export {
 } from "../utils/extensions/drops/get-claim-params.js";
 
 export type { NFTMetadata, NFTInput } from "../utils/nft/parseNft.js";
+
+export { parseAbiParams } from "../utils/contract/parse-abi-params.js";

--- a/packages/thirdweb/src/utils/contract/parse-abi-params.test.ts
+++ b/packages/thirdweb/src/utils/contract/parse-abi-params.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import { toHex } from "../encoding/hex.js";
+import { parseAbiParams } from "./parse-abi-params.js";
+
+describe("parseAbiParams", () => {
+  describe("parseAbiParams", () => {
+    it("should convert address and uint256 correctly", () => {
+      const types = ["address", "uint256"];
+      const values = ["0x1234567890abcdef1234567890abcdef12345678", "1200000"];
+      const expected = [
+        "0x1234567890abcdef1234567890abcdef12345678",
+        BigInt(1200000),
+      ];
+      expect(parseAbiParams(types, values)).toEqual(expected);
+    });
+
+    it("should convert address and bool correctly", () => {
+      const types = ["address", "bool"];
+      const values = ["0x1234567890abcdef1234567890abcdef12345678", "true"];
+      const expected = ["0x1234567890abcdef1234567890abcdef12345678", true];
+      expect(parseAbiParams(types, values)).toEqual(expected);
+    });
+
+    it("should convert bytes32 correctly", () => {
+      const types = ["bytes32"];
+      const values = [
+        "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+      ];
+      const expected = [
+        "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+      ];
+      expect(parseAbiParams(types, values)).toEqual(expected);
+    });
+
+    it("should throw an error for invalid hex in bytes32", () => {
+      const types = ["bytes32"];
+      const values = ["invalidHex"];
+      expect(() => parseAbiParams(types, values)).toThrowError(
+        "invalidHex is not a valid hex string",
+      );
+    });
+
+    it("should convert uint256 correctly", () => {
+      const types = ["uint256"];
+      const values = ["1200000"];
+      const expected = [BigInt(1200000)];
+      expect(parseAbiParams(types, values)).toEqual(expected);
+    });
+
+    it("should throw an error for invalid address", () => {
+      const types = ["address"];
+      const values = ["invalidAddress"];
+      expect(() => parseAbiParams(types, values)).toThrowError(
+        "invalidAddress is not a valid address",
+      );
+    });
+
+    it("should throw an error for mismatched number of types and values", () => {
+      const types = ["address", "uint256"];
+      const values = ["0x1234567890abcdef1234567890abcdef12345678"];
+      expect(() => parseAbiParams(types, values)).toThrowError(
+        "Passed the wrong number of constructor arguments: 1, expected 2",
+      );
+    });
+
+    it("should convert tuple correctly", () => {
+      const types = ["tuple"];
+      const values = [
+        '["0x1234567890abcdef1234567890abcdef12345678", "1200000"]',
+      ];
+      const expected = [
+        ["0x1234567890abcdef1234567890abcdef12345678", "1200000"],
+      ];
+      expect(parseAbiParams(types, values)).toEqual(expected);
+    });
+
+    it("should convert array of addresses correctly", () => {
+      const types = ["address[]"];
+      const values = [
+        '["0x1234567890abcdef1234567890abcdef12345678", "0xabcdef1234567890abcdef1234567890abcdef12"]',
+      ];
+      const expected = [
+        [
+          "0x1234567890abcdef1234567890abcdef12345678",
+          "0xabcdef1234567890abcdef1234567890abcdef12",
+        ],
+      ];
+      expect(parseAbiParams(types, values)).toEqual(expected);
+    });
+
+    it('should convert boolean correctly for "true"', () => {
+      const types = ["bool"];
+      const values = ["true"];
+      const expected = [true];
+      expect(parseAbiParams(types, values)).toEqual(expected);
+    });
+
+    it('should convert boolean correctly for "false"', () => {
+      const types = ["bool"];
+      const values = ["false"];
+      const expected = [false];
+      expect(parseAbiParams(types, values)).toEqual(expected);
+    });
+
+    it("should convert boolean correctly for boolean true", () => {
+      const types = ["bool"];
+      const values = [true];
+      const expected = [true];
+      expect(parseAbiParams(types, values)).toEqual(expected);
+    });
+
+    it("should convert boolean correctly for boolean false", () => {
+      const types = ["bool"];
+      const values = [false];
+      const expected = [false];
+      expect(parseAbiParams(types, values)).toEqual(expected);
+    });
+
+    it("should throw an error for invalid boolean value", () => {
+      const types = ["bool"];
+      const values = ["notBoolean"];
+      expect(() => parseAbiParams(types, values)).toThrowError(
+        "Invalid boolean value. Expecting either 'true' or 'false'",
+      );
+    });
+
+    it("should just return the value if already json-parsed", () => {
+      const types = ["tuple"];
+      const values = [{ cat: "orange" }];
+      expect(parseAbiParams(types, values)).toEqual(values);
+    });
+
+    it("should throw error if not a hex string", () => {
+      const values = ["orange cat"];
+      expect(() => parseAbiParams(["bytes64"], values)).toThrowError(
+        "orange cat is not a valid hex string",
+      );
+
+      expect(() => parseAbiParams(["bytes32"], values)).toThrowError(
+        "orange cat is not a valid hex string",
+      );
+    });
+
+    it("should throw error if cannot convert to BigInt", () => {
+      expect(() => parseAbiParams(["uint256"], [true])).toThrowError(
+        "Cannot convert type boolean to BigInt",
+      );
+
+      expect(() => parseAbiParams(["uint256"], ["cat"])).toThrowError(
+        "Cannot convert cat to a BigInt",
+      );
+    });
+
+    it("should return value unaltered if already a hex", () => {
+      const value = toHex("cat");
+      const result = parseAbiParams(["bytes64"], [value]);
+      expect(result).toStrictEqual([value]);
+    });
+  });
+});

--- a/packages/thirdweb/src/utils/contract/parse-abi-params.ts
+++ b/packages/thirdweb/src/utils/contract/parse-abi-params.ts
@@ -1,0 +1,90 @@
+import { isAddress } from "../address.js";
+import { isHex, padHex } from "../encoding/hex.js";
+
+/**
+ * Converts an array of parameter values to their respective types based on the provided type array.
+ *
+ * This utility function is particularly useful for ensuring that parameter values are correctly formatted
+ * according to the expected types before they are used in further processing or passed to a Solidity smart contract.
+ *
+ * @param {string[]} constructorParamTypes - An array of type strings indicating the expected types of the values,
+ *                   following Solidity type conventions (e.g., "address", "uint256", "bool").
+ * @param {unknown[]} constructorParamValues - An array of values to be converted according to the types.
+ * @returns - An array of values converted to their respective types.
+ *
+ * @example
+ * ```ts
+ * import { parseAbiParams } from "thirdweb/utils";
+ *
+ * const example1 = parseAbiParams(
+ *   ["address", "uint256"],
+ *   ["0x.....", "1200000"]
+ * ); // result: ["0x......", 1200000n]
+ *
+ * const example2 = parseAbiParams(
+ *   ["address", "bool"],
+ *   ["0x.....", "true"]
+ * ); // result: ["0x......", true]
+ * ```
+ * @utils
+ */
+export function parseAbiParams(
+  constructorParamTypes: string[],
+  constructorParamValues: unknown[],
+): Array<string | bigint | boolean> {
+  // Make sure they have the same length
+  if (constructorParamTypes.length !== constructorParamValues.length) {
+    throw new Error(
+      `Passed the wrong number of constructor arguments: ${constructorParamValues.length}, expected ${constructorParamTypes.length}`,
+    );
+  }
+  return constructorParamTypes.map((type, index) => {
+    const value = constructorParamValues[index];
+    if (type === "tuple" || type.endsWith("[]")) {
+      if (typeof value === "string") {
+        return JSON.parse(value);
+      }
+      return value;
+    }
+    if (type === "bytes32") {
+      if (!isHex(value)) {
+        throw new Error(`${value} is not a valid hex string`);
+      }
+      return padHex(value);
+    }
+    if (type.startsWith("bytes")) {
+      if (!isHex(value)) {
+        throw new Error(`${value} is not a valid hex string`);
+      }
+      return value;
+    }
+    if (type === "address") {
+      if (typeof value !== "string" || !isAddress(value)) {
+        throw new Error(`${value} is not a valid address`);
+      }
+      return value;
+    }
+    if (type.startsWith("uint") || type.startsWith("int")) {
+      if (typeof value !== "string" && typeof value !== "number") {
+        throw new Error(`Cannot convert type ${typeof value} to BigInt`);
+      }
+      try {
+        const val = BigInt(value);
+        return val;
+      } catch (err) {
+        throw new Error((err as Error).message);
+      }
+    }
+    if (type.startsWith("bool")) {
+      if (value === "false" || value === false) {
+        return false;
+      }
+      if (value === "true" || value === true) {
+        return true;
+      }
+      throw new Error(
+        "Invalid boolean value. Expecting either 'true' or 'false'",
+      );
+    }
+  });
+}


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

## Changes made

- [ ] Public API changes: list the public API changes made if any
- [ ] Internal API changes: explain the internal logic changes

## How to test

- [ ] Automated tests: link to unit test file
- [ ] Manual tests: step by step instructions on how to test

## Contributor NFT

Paste in your wallet address below and we will airdrop you a special NFT when your pull request is merged. 

```Address: ```

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add a utility function `parseAbiParams` in the `thirdweb` package for converting parameter values based on type strings. 

### Detailed summary
- Added `parseAbiParams` utility function to convert parameter values
- Added tests for `parseAbiParams` function
- Ensures correct formatting of parameter values based on expected types

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->