### PR TITLE
Disable system option in next-theme provider

### DIFF
--- a/apps/dashboard/src/pages/_app.tsx
+++ b/apps/dashboard/src/pages/_app.tsx
@@ -285,7 +285,11 @@ const ConsoleApp = memo(function ConsoleApp({
 
 function TailwindTheme(props: { children: React.ReactNode }) {
   return (
-    <ThemeProvider attribute="class" disableTransitionOnChange>
+    <ThemeProvider
+      attribute="class"
+      disableTransitionOnChange
+      enableSystem={false}
+    >
       {props.children}
     </ThemeProvider>
   );

--- a/apps/dashboard/src/pages/_app.tsx
+++ b/apps/dashboard/src/pages/_app.tsx
@@ -296,12 +296,22 @@ function TailwindTheme(props: { children: React.ReactNode }) {
 }
 
 const SyncTheme: React.FC = () => {
-  const { theme } = useTheme();
+  const { theme, setTheme } = useTheme();
   const { setColorMode } = useColorMode();
   // eslint-disable-next-line no-restricted-syntax
   useEffect(() => {
     setColorMode(theme === "light" ? "light" : "dark");
   }, [setColorMode, theme]);
+
+  // handle dashboard with now old "system" set
+  // eslint-disable-next-line no-restricted-syntax
+  useEffect(() => {
+    if (theme === "system") {
+      setTheme("dark");
+      setColorMode("dark");
+    }
+  }, [theme, setTheme, setColorMode]);
+
   return null;
 };
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the theme handling in `_app.tsx` to include a new prop and additional logic for handling the "system" theme setting.

### Detailed summary
- Added `enableSystem={false}` prop to `TailwindTheme`
- Added `setTheme` and additional logic in `SyncTheme` to handle "system" theme setting

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->