### PR TITLE
[dashboard] Fix faucet filter in chainlist page

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/(chain)/chainlist/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/chainlist/page.tsx
@@ -92,11 +92,18 @@ async function getChainsToRender(params: SearchParams) {
       const urlServiceArray = Array.isArray(params.service)
         ? params.service
         : [params.service];
+
       // if the chain does not have all of the services in the filter, return false to filter it out
       if (
-        !urlServiceArray.every((service) =>
-          chain.services.find((s) => s.enabled && s.service === service),
-        )
+        !urlServiceArray.every((service) => {
+          // TODO improve this
+          // We don't have "faucet" added in services array, so for now we just check if it's testnet or not
+          if (service === "faucet") {
+            return chain.testnet;
+          }
+
+          return chain.services.find((s) => s.enabled && s.service === service);
+        })
       ) {
         // skip to the next chain
         continue;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR improves the filtering logic in the `chainlist` page by handling the "faucet" service differently based on whether the chain is a testnet or not.

### Detailed summary
- Updated filtering logic in `chainlist` page
- Added handling for "faucet" service based on testnet status

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->