### PR TITLE
[Fix] Ensure -k flag is included for key-requiring thirdweb CLI commands

### DIFF
--- a/.changeset/old-chicken-invite.md
+++ b/.changeset/old-chicken-invite.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+temporarily disable CLI login

--- a/packages/thirdweb/src/cli/bin.ts
+++ b/packages/thirdweb/src/cli/bin.ts
@@ -19,11 +19,29 @@ async function main() {
       } else {
         await generate(chainIdPlusContract);
       }
+      break;
+    }
 
+    case "login": {
+      // Not implemented yet
+      console.info(
+        "Please instead pass a secret key to the command directly, learn more: https://support.thirdweb.com/troubleshooting-errors/7Y1BqKNvtLdBv5fZkRZZB3/issue-linking-device-on-the-authorization-page-via-thirdweb-cli/cn9LRA3ax7XCP6uxwRYdvx",
+      );
+      process.exit(1);
       break;
     }
 
     default: {
+      // check several commands for missing -k flag
+      const commands = ["create", "deploy", "publish", "generate", "upload"];
+      if (commands.includes(command) && !rest.includes("-k")) {
+        console.info(
+          "Please include the -k flag with your secret key, learn more: https://support.thirdweb.com/troubleshooting-errors/7Y1BqKNvtLdBv5fZkRZZB3/issue-linking-device-on-the-authorization-page-via-thirdweb-cli/cn9LRA3ax7XCP6uxwRYdvx",
+        );
+        process.exit(1);
+        return;
+      }
+
       const isWindows = /^win/.test(process.platform);
 
       const isBunAvailable = (() => {


### PR DESCRIPTION
FIXES: DASH-50

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to temporarily disable CLI login and provide instructions for passing a secret key directly. 

### Detailed summary
- Temporarily disable CLI login functionality
- Add instructions for passing a secret key directly
- Check and prompt for missing secret key flag in certain commands

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->