### PR TITLE
(crusade) Dashboard v5

### DIFF
--- a/apps/dashboard/src/components/engine/relayer/add-relayer-button.tsx
+++ b/apps/dashboard/src/components/engine/relayer/add-relayer-button.tsx
@@ -20,7 +20,6 @@ import {
   type UseDisclosureReturn,
   useDisclosure,
 } from "@chakra-ui/react";
-import { shortenString } from "@thirdweb-dev/react";
 import { NetworkDropdown } from "components/contract-components/contract-publish-form/NetworkDropdown";
 import { isAddress } from "ethers/lib/utils";
 import { useTrack } from "hooks/analytics/useTrack";
@@ -28,6 +27,7 @@ import { useAllChainsData } from "hooks/chains/allChains";
 import { useTxNotifications } from "hooks/useTxNotifications";
 import { useForm } from "react-hook-form";
 import { AiOutlinePlusCircle } from "react-icons/ai";
+import { shortenAddress } from "thirdweb/utils";
 import { Button, FormHelperText, FormLabel } from "tw-components";
 
 interface AddRelayerButtonProps {
@@ -148,7 +148,7 @@ const AddModal = ({
                 </option>
                 {backendWallets?.map((wallet) => (
                   <option key={wallet.address} value={wallet.address}>
-                    {shortenString(wallet.address, false)}
+                    {shortenAddress(wallet.address)}
                     {wallet.label && ` (${wallet.label})`}
                   </option>
                 ))}

--- a/apps/dashboard/src/components/ipfs-upload/dropzone.tsx
+++ b/apps/dashboard/src/components/ipfs-upload/dropzone.tsx
@@ -1,3 +1,4 @@
+import { thirdwebClient } from "@/constants/client";
 import {
   AspectRatio,
   Box,
@@ -15,7 +16,7 @@ import {
   useToast,
 } from "@chakra-ui/react";
 import { useQueryClient } from "@tanstack/react-query";
-import { MediaRenderer, useStorageUpload } from "@thirdweb-dev/react";
+import { useStorageUpload } from "@thirdweb-dev/react";
 import type { UploadProgressEvent } from "@thirdweb-dev/storage";
 import { PINNED_FILES_QUERY_KEY_ROOT } from "components/storage/your-files";
 import { useErrorHandler } from "contexts/error-handler";
@@ -25,6 +26,7 @@ import { type Dispatch, type SetStateAction, useMemo, useState } from "react";
 import { useDropzone } from "react-dropzone";
 import { BsFillCloudUploadFill } from "react-icons/bs";
 import { FiExternalLink, FiTrash2, FiUploadCloud } from "react-icons/fi";
+import { MediaRenderer } from "thirdweb/react";
 import { useActiveAccount } from "thirdweb/react";
 import {
   Button,
@@ -241,6 +243,7 @@ const FileUpload: React.FC<FileUploadProps> = ({ files, updateFiles }) => {
                         src={URL.createObjectURL(file)}
                         mimeType={file.type}
                         requireInteraction
+                        client={thirdwebClient}
                       />
                     </Box>
                   </AspectRatio>

--- a/apps/dashboard/src/constants/currencies.ts
+++ b/apps/dashboard/src/constants/currencies.ts
@@ -1,5 +1,19 @@
-import { ChainId, NATIVE_TOKENS } from "@thirdweb-dev/sdk";
-import { arbitrumSepolia } from "thirdweb/chains";
+import {
+  arbitrum,
+  arbitrumSepolia,
+  avalanche,
+  avalancheFuji,
+  bsc,
+  bscTestnet,
+  ethereum,
+  fantom,
+  fantomTestnet,
+  hardhat,
+  localhost,
+  optimism,
+  polygon,
+  sepolia,
+} from "thirdweb/chains";
 
 export interface CurrencyMetadata {
   address: string;
@@ -7,9 +21,160 @@ export interface CurrencyMetadata {
   symbol: string;
 }
 
+const NATIVE_TOKENS: Record<
+  number,
+  {
+    name: string;
+    symbol: string;
+    decimals: number;
+    wrapped: CurrencyMetadata;
+  }
+> = /* @__PURE__ */ {
+  [ethereum.id]: {
+    name: "Ether",
+    symbol: "ETH",
+    decimals: 18,
+    wrapped: {
+      address: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+      name: "Wrapped Ether",
+      symbol: "WETH",
+    },
+  },
+  [sepolia.id]: {
+    name: "Sepolia Ether",
+    symbol: "SEP",
+    decimals: 18,
+    wrapped: {
+      address: "0x7b79995e5f793A07Bc00c21412e50Ecae098E7f9",
+      name: "Wrapped Ether",
+      symbol: "WETH",
+    },
+  },
+  [polygon.id]: {
+    name: "Matic",
+    symbol: "MATIC",
+    decimals: 18,
+    wrapped: {
+      address: "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270",
+      name: "Wrapped Matic",
+      symbol: "WMATIC",
+    },
+  },
+  [avalanche.id]: {
+    name: "Avalanche",
+    symbol: "AVAX",
+    decimals: 18,
+    wrapped: {
+      address: "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7",
+      name: "Wrapped AVAX",
+      symbol: "WAVAX",
+    },
+  },
+  [avalancheFuji.id]: {
+    name: "Avalanche",
+    symbol: "AVAX",
+    decimals: 18,
+    wrapped: {
+      address: "0xd00ae08403B9bbb9124bB305C09058E32C39A48c",
+      name: "Wrapped AVAX",
+      symbol: "WAVAX",
+    },
+  },
+  [fantom.id]: {
+    name: "Fantom",
+    symbol: "FTM",
+    decimals: 18,
+    wrapped: {
+      address: "0x21be370D5312f44cB42ce377BC9b8a0cEF1A4C83",
+      name: "Wrapped Fantom",
+      symbol: "WFTM",
+    },
+  },
+  [fantomTestnet.id]: {
+    name: "Fantom",
+    symbol: "FTM",
+    decimals: 18,
+    wrapped: {
+      address: "0xf1277d1Ed8AD466beddF92ef448A132661956621",
+      name: "Wrapped Fantom",
+      symbol: "WFTM",
+    },
+  },
+  [arbitrum.id]: {
+    name: "Ether",
+    symbol: "ETH",
+    decimals: 18,
+    wrapped: {
+      address: "0x82af49447d8a07e3bd95bd0d56f35241523fbab1",
+      name: "Wrapped Ether",
+      symbol: "WETH",
+    },
+  },
+  [optimism.id]: {
+    name: "Ether",
+    symbol: "ETH",
+    decimals: 18,
+    wrapped: {
+      address: "0x4200000000000000000000000000000000000006",
+      name: "Wrapped Ether",
+      symbol: "WETH",
+    },
+  },
+  [bsc.id]: {
+    name: "Binance Chain Native Token",
+    symbol: "BNB",
+    decimals: 18,
+    wrapped: {
+      address: "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c",
+      name: "Wrapped Binance Chain Token",
+      symbol: "WBNB",
+    },
+  },
+  [bscTestnet.id]: {
+    name: "Binance Chain Native Token",
+    symbol: "TBNB",
+    decimals: 18,
+    wrapped: {
+      address: "0xae13d989daC2f0dEbFf460aC112a837C89BAa7cd",
+      name: "Wrapped Binance Chain Testnet Token",
+      symbol: "WBNB",
+    },
+  },
+  [hardhat.id]: {
+    name: "Ether",
+    symbol: "ETH",
+    decimals: 18,
+    wrapped: {
+      address: "0x5FbDB2315678afecb367f032d93F642f64180aa3",
+      name: "Wrapped Ether",
+      symbol: "WETH",
+    },
+  },
+  [localhost.id]: {
+    name: "Ether",
+    symbol: "ETH",
+    decimals: 18,
+    wrapped: {
+      address: "0x5FbDB2315678afecb367f032d93F642f64180aa3",
+      name: "Wrapped Ether",
+      symbol: "WETH",
+    },
+  },
+  [280]: {
+    name: "zkSync Era Testnet",
+    symbol: "ETH",
+    decimals: 18,
+    wrapped: {
+      address: "0x5AEa5775959fBC2557Cc8789bC1bf90A239D9a91",
+      name: "Wrapped Ether",
+      symbol: "WETH",
+    },
+  },
+};
+
 const Ethereum: CurrencyMetadata[] = [
   {
-    ...NATIVE_TOKENS[ChainId.Mainnet].wrapped,
+    ...NATIVE_TOKENS[ethereum.id].wrapped,
   },
   {
     address: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
@@ -35,7 +200,7 @@ const Ethereum: CurrencyMetadata[] = [
 
 const Polygon: CurrencyMetadata[] = [
   {
-    ...NATIVE_TOKENS[ChainId.Polygon].wrapped,
+    ...NATIVE_TOKENS[polygon.id].wrapped,
   },
   {
     address: "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619",
@@ -66,45 +231,9 @@ const Polygon: CurrencyMetadata[] = [
   },
 ];
 
-const Mumbai: CurrencyMetadata[] = [
-  {
-    ...NATIVE_TOKENS[ChainId.Mumbai].wrapped,
-  },
-  {
-    name: "Wrapped Ether",
-    address: "0xa6fa4fb5f76172d178d61b04b0ecd319c5d1c0aa",
-    symbol: "WETH",
-  },
-  {
-    address: "0x0FA8781a83E46826621b3BC094Ea2A0212e71B23",
-    name: "USD Coin",
-    symbol: "USDC",
-  },
-  {
-    address: "0x0FA8781a83E46826621b3BC094Ea2A0212e71B23",
-    name: "USD Coin (Bridged)",
-    symbol: "USDC.e",
-  },
-  {
-    name: "Tether USD",
-    address: "0x3813e82e6f7098b9583FC0F33a962D02018B6803",
-    symbol: "USDT",
-  },
-  {
-    name: "DERC20",
-    address: "0xfe4F5145f6e09952a5ba9e956ED0C25e3Fa4c7F1",
-    symbol: "DERC20",
-  },
-  {
-    name: "CDOL",
-    address: "0x4E0068513994fD4526AEc7f558Ee572234AeeFB8",
-    symbol: "CDOL",
-  },
-];
-
 const Fantom: CurrencyMetadata[] = [
   {
-    ...NATIVE_TOKENS[ChainId.Fantom].wrapped,
+    ...NATIVE_TOKENS[fantom.id].wrapped,
   },
   {
     name: "Wrapped Ether",
@@ -125,13 +254,13 @@ const Fantom: CurrencyMetadata[] = [
 
 const FantomTestnet: CurrencyMetadata[] = [
   {
-    ...NATIVE_TOKENS[ChainId.FantomTestnet].wrapped,
+    ...NATIVE_TOKENS[fantomTestnet.id].wrapped,
   },
 ];
 
 const Avalanche: CurrencyMetadata[] = [
   {
-    ...NATIVE_TOKENS[ChainId.Avalanche].wrapped,
+    ...NATIVE_TOKENS[avalanche.id].wrapped,
   },
   {
     address: "0x49D5c2BdFfac6CE2BFdB6640F4F80f226bc10bAB",
@@ -162,7 +291,7 @@ const Avalanche: CurrencyMetadata[] = [
 
 const AvalancheFujiTestnet: CurrencyMetadata[] = [
   {
-    ...NATIVE_TOKENS[ChainId.AvalancheFujiTestnet].wrapped,
+    ...NATIVE_TOKENS[avalancheFuji.id].wrapped,
   },
   // Source: https://developers.circle.com/stablecoins/docs/usdc-on-testing-networks#usdc-on-avalanche-testnet
   {
@@ -174,7 +303,7 @@ const AvalancheFujiTestnet: CurrencyMetadata[] = [
 
 const Optimism: CurrencyMetadata[] = [
   {
-    ...NATIVE_TOKENS[ChainId.Optimism].wrapped,
+    ...NATIVE_TOKENS[optimism.id].wrapped,
   },
   // Source: https://www.circle.com/blog/now-available-usdc-on-op-mainnet
   {
@@ -192,7 +321,7 @@ const Optimism: CurrencyMetadata[] = [
 
 const Arbitrum: CurrencyMetadata[] = [
   {
-    ...NATIVE_TOKENS[ChainId.Arbitrum].wrapped,
+    ...NATIVE_TOKENS[arbitrum.id].wrapped,
   },
   // Source: https://www.circle.com/blog/arbitrum-usdc-now-available
   {
@@ -210,7 +339,7 @@ const Arbitrum: CurrencyMetadata[] = [
 
 const BinanceMainnet: CurrencyMetadata[] = [
   {
-    ...NATIVE_TOKENS[ChainId.BinanceSmartChainMainnet].wrapped,
+    ...NATIVE_TOKENS[bsc.id].wrapped,
   },
   {
     address: "0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56",
@@ -231,7 +360,7 @@ const BinanceMainnet: CurrencyMetadata[] = [
 
 const BinanceTestnet: CurrencyMetadata[] = [
   {
-    ...NATIVE_TOKENS[ChainId.BinanceSmartChainTestnet].wrapped,
+    ...NATIVE_TOKENS[bscTestnet.id].wrapped,
   },
   {
     address: "0xed24fc36d5ee211ea25a80239fb8c4cfd80f12ee",
@@ -254,16 +383,15 @@ const ArbitrumSepolia: CurrencyMetadata[] = [
 ];
 
 export const CURRENCIES: Record<number, CurrencyMetadata[] | undefined> = {
-  [ChainId.Mainnet]: Ethereum,
-  [ChainId.Polygon]: Polygon,
-  [ChainId.Mumbai]: Mumbai,
-  [ChainId.Fantom]: Fantom,
-  [ChainId.FantomTestnet]: FantomTestnet,
-  [ChainId.Avalanche]: Avalanche,
-  [ChainId.AvalancheFujiTestnet]: AvalancheFujiTestnet,
-  [ChainId.Optimism]: Optimism,
-  [ChainId.Arbitrum]: Arbitrum,
-  [ChainId.BinanceSmartChainMainnet]: BinanceMainnet,
-  [ChainId.BinanceSmartChainTestnet]: BinanceTestnet,
+  [ethereum.id]: Ethereum,
+  [polygon.id]: Polygon,
+  [fantom.id]: Fantom,
+  [fantomTestnet.id]: FantomTestnet,
+  [avalanche.id]: Avalanche,
+  [avalancheFuji.id]: AvalancheFujiTestnet,
+  [optimism.id]: Optimism,
+  [arbitrum.id]: Arbitrum,
+  [bsc.id]: BinanceMainnet,
+  [bscTestnet.id]: BinanceTestnet,
   [arbitrumSepolia.id]: ArbitrumSepolia,
 } as const;

--- a/apps/dashboard/src/constants/mappings.ts
+++ b/apps/dashboard/src/constants/mappings.ts
@@ -1,9 +1,6 @@
-import {
-  CONTRACTS_MAP,
-  type FullPublishMetadata,
-  type Role,
-} from "@thirdweb-dev/sdk";
+import { CONTRACTS_MAP, type FullPublishMetadata } from "@thirdweb-dev/sdk";
 import type { StaticImageData } from "next/image";
+import type { roleMap } from "thirdweb/extensions/permissions";
 import type { ContractType } from "./contracts";
 
 const FeatureIconMap: Record<ContractType, StaticImageData> = {
@@ -32,7 +29,7 @@ export interface BuiltinContractDetails {
   comingSoon?: boolean;
   contractType: ContractType;
   erc?: "ERC721" | "ERC20" | "ERC1155" | "ERC721A";
-  roles?: readonly Role[];
+  roles?: readonly (keyof typeof roleMap)[];
   metadata: Omit<FullPublishMetadata, "logo"> & { logo: StaticImageData };
 }
 
@@ -135,7 +132,10 @@ export const BuiltinContractMap: Record<ContractType, BuiltinContractDetails> =
     }),
   };
 
-export const ROLE_DESCRIPTION_MAP: Record<Role | string, string> = {
+export const ROLE_DESCRIPTION_MAP: Record<
+  keyof typeof roleMap | string,
+  string
+> = {
   admin:
     "Determine who can grant or revoke roles and modify settings on this contract.",
   minter: "Determine who can mint / create new tokens on this contract.",

--- a/apps/dashboard/src/contract-ui/tabs/claim-conditions/components/claim-conditions-form/index.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/claim-conditions/components/claim-conditions-form/index.tsx
@@ -23,7 +23,6 @@ import {
 import {
   type ClaimConditionInput,
   ClaimConditionInputSchema,
-  NATIVE_TOKEN_ADDRESS,
   type SnapshotEntry,
   type ValidContractInstance,
 } from "@thirdweb-dev/sdk";
@@ -45,7 +44,7 @@ import {
   useForm,
 } from "react-hook-form";
 import { FiPlus } from "react-icons/fi";
-import { ZERO_ADDRESS } from "thirdweb";
+import { NATIVE_TOKEN_ADDRESS, ZERO_ADDRESS } from "thirdweb";
 import { useActiveAccount } from "thirdweb/react";
 import invariant from "tiny-invariant";
 import { Button, Heading, MenuItem, Text } from "tw-components";

--- a/apps/dashboard/src/contract-ui/tabs/claim-conditions/components/snapshot-upload.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/claim-conditions/components/snapshot-upload.tsx
@@ -1,3 +1,4 @@
+import { thirdwebClient } from "@/constants/client";
 import {
   AspectRatio,
   Box,
@@ -24,7 +25,6 @@ import {
   UnorderedList,
   VStack,
 } from "@chakra-ui/react";
-import { type ClaimCondition, resolveAddress } from "@thirdweb-dev/sdk";
 import { Logo } from "components/logo";
 import Papa from "papaparse";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -40,6 +40,7 @@ import {
 } from "react-icons/md";
 import { type Column, usePagination, useTable } from "react-table";
 import { isAddress } from "thirdweb";
+import { resolveAddress } from "thirdweb/extensions/ens";
 import { Button, Drawer, Heading, Text } from "tw-components";
 import { csvMimeTypes } from "utils/batch";
 
@@ -54,7 +55,14 @@ interface SnapshotUploadProps {
   setSnapshot: (snapshot: SnapshotAddressInput[]) => void;
   isOpen: boolean;
   onClose: () => void;
-  value?: ClaimCondition["snapshot"];
+  value?:
+    | {
+        address: string;
+        maxClaimable: string;
+        price?: string | undefined;
+        currencyAddress?: string | undefined;
+      }[]
+    | null;
   dropType: "specific" | "any" | "overrides";
   isV1ClaimCondition: boolean;
   isDisabled: boolean;
@@ -142,7 +150,7 @@ export const SnapshotUpload: React.FC<SnapshotUploadProps> = ({
           try {
             resolvedAddress = isAddress(address)
               ? address
-              : await resolveAddress(address);
+              : await resolveAddress({ client: thirdwebClient, name: address });
             isValid = !!resolvedAddress;
           } catch {
             isValid = false;

--- a/apps/dashboard/src/contract-ui/tabs/direct-listings/components/cancel.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/direct-listings/components/cancel.tsx
@@ -1,17 +1,21 @@
-import { useCancelDirectListing } from "@thirdweb-dev/react";
-import type { MarketplaceV3 } from "@thirdweb-dev/sdk";
 import { CancelTab } from "contract-ui/tabs/shared-components/cancel-tab";
 
 interface CancelDirectListingProps {
-  contract: MarketplaceV3;
+  contractAddress: string;
+  chainId: number;
   listingId: string;
 }
 
 export const CancelDirectListing: React.FC<CancelDirectListingProps> = ({
-  contract,
+  contractAddress,
   listingId,
+  chainId,
 }) => {
-  const cancelDirectListing = useCancelDirectListing(contract);
-
-  return <CancelTab cancelQuery={cancelDirectListing} id={listingId} />;
+  return (
+    <CancelTab
+      contractAddress={contractAddress}
+      chainId={chainId}
+      id={listingId}
+    />
+  );
 };

--- a/apps/dashboard/src/contract-ui/tabs/direct-listings/components/table.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/direct-listings/components/table.tsx
@@ -1,4 +1,3 @@
-import type { MarketplaceV3 } from "@thirdweb-dev/sdk";
 import { MarketplaceTable } from "contract-ui/tabs/shared-components/marketplace-table";
 import { useState } from "react";
 import { getContract } from "thirdweb";
@@ -12,18 +11,20 @@ import { thirdwebClient } from "../../../../lib/thirdweb-client";
 import { defineDashboardChain } from "../../../../lib/v5-adapter";
 
 interface DirectListingsTableProps {
-  contract: MarketplaceV3;
+  contractAddress: string;
+  chainId: number;
 }
 
 const DEFAULT_QUERY_STATE = { count: 50, start: 0 };
 
 export const DirectListingsTable: React.FC<DirectListingsTableProps> = ({
-  contract: v4Contract,
+  contractAddress,
+  chainId,
 }) => {
   const contract = getContract({
     client: thirdwebClient,
-    address: v4Contract.getAddress(),
-    chain: defineDashboardChain(v4Contract.chainId),
+    address: contractAddress,
+    chain: defineDashboardChain(chainId),
   });
   const [queryParams, setQueryParams] = useState(DEFAULT_QUERY_STATE);
   const getAllQueryResult = useReadContract(getAllListings, {
@@ -40,7 +41,8 @@ export const DirectListingsTable: React.FC<DirectListingsTableProps> = ({
 
   return (
     <MarketplaceTable
-      contract={v4Contract}
+      contractAddress={contractAddress}
+      chainId={chainId}
       getAllQueryResult={getAllQueryResult}
       getValidQueryResult={getValidQueryResult}
       totalCountQuery={totalCountQuery}

--- a/apps/dashboard/src/contract-ui/tabs/direct-listings/page.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/direct-listings/page.tsx
@@ -36,7 +36,10 @@ export const ContractDirectListingsPage: React.FC<
         </Flex>
       </Flex>
 
-      <DirectListingsTable contract={contractQuery.contract} />
+      <DirectListingsTable
+        contractAddress={contractQuery.contract.getAddress()}
+        chainId={contractQuery.contract.chainId}
+      />
     </Flex>
   );
 };

--- a/apps/dashboard/src/contract-ui/tabs/english-auctions/components/cancel.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/english-auctions/components/cancel.tsx
@@ -1,17 +1,21 @@
-import { useCancelEnglishAuction } from "@thirdweb-dev/react";
-import type { MarketplaceV3 } from "@thirdweb-dev/sdk";
 import { CancelTab } from "contract-ui/tabs/shared-components/cancel-tab";
 
 interface CancelEnglishAuctionProps {
-  contract: MarketplaceV3;
+  contractAddress: string;
+  chainId: number;
   auctionId: string;
 }
 
 export const CancelEnglishAuction: React.FC<CancelEnglishAuctionProps> = ({
-  contract,
+  contractAddress,
+  chainId,
   auctionId,
 }) => {
-  const cancelEnglishAuction = useCancelEnglishAuction(contract);
-
-  return <CancelTab cancelQuery={cancelEnglishAuction} id={auctionId} />;
+  return (
+    <CancelTab
+      contractAddress={contractAddress}
+      chainId={chainId}
+      id={auctionId}
+    />
+  );
 };

--- a/apps/dashboard/src/contract-ui/tabs/english-auctions/components/table.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/english-auctions/components/table.tsx
@@ -1,4 +1,3 @@
-import type { MarketplaceV3 } from "@thirdweb-dev/sdk";
 import { MarketplaceTable } from "contract-ui/tabs/shared-components/marketplace-table";
 import { useState } from "react";
 import { getContract } from "thirdweb";
@@ -12,19 +11,21 @@ import { thirdwebClient } from "../../../../lib/thirdweb-client";
 import { defineDashboardChain } from "../../../../lib/v5-adapter";
 
 interface EnglishAuctionsTableProps {
-  contract: MarketplaceV3;
+  contractAddress: string;
+  chainId: number;
 }
 
 const DEFAULT_QUERY_STATE = { count: 50, start: 0 };
 
 export const EnglishAuctionsTable: React.FC<EnglishAuctionsTableProps> = ({
-  contract: v4Contract,
+  contractAddress,
+  chainId,
 }) => {
   const [queryParams, setQueryParams] = useState(DEFAULT_QUERY_STATE);
   const contract = getContract({
     client: thirdwebClient,
-    address: v4Contract.getAddress(),
-    chain: defineDashboardChain(v4Contract.chainId),
+    address: contractAddress,
+    chain: defineDashboardChain(chainId),
   });
   const getAllQueryResult = useReadContract(getAllAuctions, {
     contract,
@@ -40,7 +41,8 @@ export const EnglishAuctionsTable: React.FC<EnglishAuctionsTableProps> = ({
 
   return (
     <MarketplaceTable
-      contract={v4Contract}
+      contractAddress={contractAddress}
+      chainId={chainId}
       getAllQueryResult={getAllQueryResult}
       getValidQueryResult={getValidQueryResult}
       totalCountQuery={totalCountQuery}

--- a/apps/dashboard/src/contract-ui/tabs/english-auctions/page.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/english-auctions/page.tsx
@@ -35,7 +35,10 @@ export const ContractEnglishAuctionsPage: React.FC<
         </Flex>
       </Flex>
 
-      <EnglishAuctionsTable contract={contractQuery.contract} />
+      <EnglishAuctionsTable
+        contractAddress={contractQuery.contract.getAddress()}
+        chainId={contractQuery.contract.chainId}
+      />
     </Flex>
   );
 };

--- a/apps/dashboard/src/contract-ui/tabs/shared-components/listing-drawer.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/shared-components/listing-drawer.tsx
@@ -9,8 +9,6 @@ import {
   Tabs,
   usePrevious,
 } from "@chakra-ui/react";
-import type { MarketplaceV3 } from "@thirdweb-dev/sdk";
-import { BigNumber } from "ethers";
 import { useMemo } from "react";
 import type {
   DirectListing,
@@ -25,7 +23,8 @@ import { CancelEnglishAuction } from "../english-auctions/components/cancel";
 import { LISTING_STATUS } from "./types";
 
 interface NFTDrawerProps {
-  contract: MarketplaceV3;
+  contractAddress: string;
+  chainId: number;
   isOpen: boolean;
   onClose: () => void;
   data: DirectListing | EnglishAuction | null;
@@ -33,7 +32,8 @@ interface NFTDrawerProps {
 }
 
 export const ListingDrawer: React.FC<NFTDrawerProps> = ({
-  contract,
+  contractAddress,
+  chainId,
   isOpen,
   onClose,
   data,
@@ -123,7 +123,7 @@ export const ListingDrawer: React.FC<NFTDrawerProps> = ({
                 </GridItem>
                 <GridItem colSpan={9}>
                   <Text fontFamily="mono" size="body.md">
-                    {BigNumber.from(renderData.quantity || "0").toString()}{" "}
+                    {(renderData.quantity || 0n).toString()}{" "}
                     {/* For listings that are completed, the `quantity` would be `0`
                     So we show this text to make it clear */}
                     {LISTING_STATUS[renderData.status] === "Completed"
@@ -175,12 +175,14 @@ export const ListingDrawer: React.FC<NFTDrawerProps> = ({
         children: () =>
           type === "direct-listings" ? (
             <CancelDirectListing
-              contract={contract}
+              contractAddress={contractAddress}
+              chainId={chainId}
               listingId={renderData.id.toString()}
             />
           ) : (
             <CancelEnglishAuction
-              contract={contract}
+              contractAddress={contractAddress}
+              chainId={chainId}
               auctionId={renderData.id.toString()}
             />
           ),
@@ -194,7 +196,8 @@ export const ListingDrawer: React.FC<NFTDrawerProps> = ({
     tokenId,
     data?.asset.metadata.properties,
     type,
-    contract,
+    contractAddress,
+    chainId,
   ]);
 
   if (!renderData) {

--- a/apps/dashboard/src/contract-ui/tabs/shared-components/marketplace-table.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/shared-components/marketplace-table.tsx
@@ -16,7 +16,6 @@ import {
   Tr,
   usePrevious,
 } from "@chakra-ui/react";
-import type { MarketplaceV3 } from "@thirdweb-dev/sdk";
 import { MediaCell } from "components/contract-pages/table/table-columns/cells/media-cell";
 import { ListingDrawer } from "contract-ui/tabs/shared-components/listing-drawer";
 import { BigNumber } from "ethers";
@@ -88,7 +87,8 @@ const tableColumns: Column<DirectListing | EnglishAuction>[] = [
 ];
 
 interface MarketplaceTableProps {
-  contract: MarketplaceV3;
+  contractAddress: string;
+  chainId: number;
   getAllQueryResult: UseQueryResult<DirectListing[] | EnglishAuction[]>;
   getValidQueryResult: UseQueryResult<DirectListing[] | EnglishAuction[]>;
   totalCountQuery: UseQueryResult<bigint>;
@@ -108,7 +108,8 @@ interface MarketplaceTableProps {
 const DEFAULT_QUERY_STATE = { count: 50, start: 0 };
 
 export const MarketplaceTable: React.FC<MarketplaceTableProps> = ({
-  contract,
+  contractAddress,
+  chainId,
   getAllQueryResult,
   getValidQueryResult,
   totalCountQuery,
@@ -212,7 +213,8 @@ export const MarketplaceTable: React.FC<MarketplaceTableProps> = ({
           />
         )}
         <ListingDrawer
-          contract={contract}
+          contractAddress={contractAddress}
+          chainId={chainId}
           data={tokenRow}
           isOpen={!!tokenRow}
           onClose={() => setTokenRow(null)}

--- a/apps/dashboard/src/pages/api/frame/base/get-tx-frame.ts
+++ b/apps/dashboard/src/pages/api/frame/base/get-tx-frame.ts
@@ -1,9 +1,9 @@
 import type { FrameRequest } from "@coinbase/onchainkit";
 import { CoinbaseKit } from "classes/CoinbaseKit";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { base } from "thirdweb/chains";
 import { errorResponse } from "utils/api";
 import {
-  getContractForErc721OpenEdition,
   getErc721PreparedEncodedData,
   getFarcasterAccountAddress,
 } from "utils/tx-frame";
@@ -34,11 +34,12 @@ export default async function handler(
   // Get the first verified account address or custody address
   const accountAddress = getFarcasterAccountAddress(message.interactor);
 
-  // Get the contract instnace
-  const contract = await getContractForErc721OpenEdition(contractAddress);
-
   // Get encoded data
-  const data = await getErc721PreparedEncodedData(accountAddress, contract);
+  const data = await getErc721PreparedEncodedData(
+    accountAddress,
+    contractAddress,
+    base.id,
+  );
 
   // Return transaction details response to farcaster
   return res.status(200).json({

--- a/apps/dashboard/src/utils/tx-frame.ts
+++ b/apps/dashboard/src/utils/tx-frame.ts
@@ -1,40 +1,23 @@
 import type { FrameValidationData } from "@coinbase/onchainkit";
-import type { SmartContract } from "@thirdweb-dev/sdk";
-import { type BaseContract, Wallet } from "ethers";
-import { getDashboardChainRpc } from "lib/rpc";
-import { getThirdwebSDK } from "lib/sdk";
-import { base } from "thirdweb/chains";
-
-export const getContractForErc721OpenEdition = async (
-  contractAddress: string,
-) => {
-  // Create a random signer. This is required to encode erc721 tx data
-  const signer = Wallet.createRandom();
-
-  // Initialize sdk
-  const sdk = getThirdwebSDK(
-    base.id,
-    getDashboardChainRpc(base.id),
-    undefined,
-    signer,
-  );
-
-  // Get contract instance
-  const contract = await sdk.getContract(contractAddress);
-
-  // Return contract instance
-  return contract;
-};
+import { thirdwebClient } from "lib/thirdweb-client";
+import { defineChain, encode, getContract } from "thirdweb";
+import { claimTo } from "thirdweb/extensions/erc721";
 
 export const getErc721PreparedEncodedData = async (
   walletAddress: string,
-  contract: SmartContract<BaseContract>,
+  contractAddress: string,
+  chainId: number,
 ) => {
+  const contract = getContract({
+    address: contractAddress,
+    chain: defineChain(chainId),
+    client: thirdwebClient,
+  });
   // Prepare erc721 transaction data. Takes in destination address and quantity as parameters
-  const transaction = await contract.erc721.claimTo.prepare(walletAddress, 1);
+  const transaction = claimTo({ contract, to: walletAddress, quantity: 1n });
 
   // Encode transaction data
-  const encodedTransactionData = await transaction.encode();
+  const encodedTransactionData = await encode(transaction);
 
   // Return encoded transaction data
   return encodedTransactionData;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to refactor components in the contract UI tabs to use `contractAddress` and `chainId` instead of passing the entire `contract` object.

### Detailed summary
- Refactored `DirectListingsTable` and `EnglishAuctionsTable` components to accept `contractAddress` and `chainId`.
- Updated `CancelDirectListing` and `CancelEnglishAuction` components to use `contractAddress` and `chainId`.
- Modified transaction handling in `get-tx-frame.ts`.
- Updated `AddRelayerButton` component to use `shortenAddress`.
- Refactored `MarketplaceTable` and related components to accept `contractAddress` and `chainId`.
- Adjusted `Dropzone` and `MediaRenderer` imports.
- Updated `mappings.ts` to include `roleMap` and adjust `ROLE_DESCRIPTION_MAP`.
- Refactored components in the claim conditions tab.
- Added `resolveAddress` import in `snapshot-upload.tsx`.

> The following files were skipped due to too many changes: `apps/dashboard/src/contract-ui/tabs/claim-conditions/components/snapshot-upload.tsx`, `apps/dashboard/src/utils/tx-frame.ts`, `apps/dashboard/src/contract-ui/tabs/shared-components/listing-drawer.tsx`, `apps/dashboard/src/contract-ui/tabs/shared-components/cancel-tab.tsx`, `apps/dashboard/src/constants/currencies.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->