### PR TITLE
[dash] Fix wrong balance shown in Split contract

### DIFF
--- a/apps/dashboard/src/contract-ui/tabs/split/page.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/split/page.tsx
@@ -51,7 +51,7 @@ export const ContractSplitPage: React.FC<SplitPageProps> = ({
     ? defineDashboardChain(chainId, chain)
     : undefined;
   const nativeBalanceQuery = useWalletBalance({
-    address,
+    address: contractAddress,
     client: thirdwebClient,
     chain: convertedChain,
   });


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `nativeBalanceQuery` in `page.tsx` to use the `contractAddress` instead of `address`.

### Detailed summary
- Updated `nativeBalanceQuery` to use `contractAddress` instead of `address`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->