### PR TITLE
Fix autoconnect of wallets connected from "All wallets" screen

### DIFF
--- a/.changeset/sour-buses-explain.md
+++ b/.changeset/sour-buses-explain.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix autoConnect for wallets that are connected from "All wallets" screen

--- a/packages/thirdweb/src/react/core/hooks/wallets/useAutoConnect.ts
+++ b/packages/thirdweb/src/react/core/hooks/wallets/useAutoConnect.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import type { AsyncStorage } from "../../../../utils/storage/AsyncStorage.js";
+import { createWallet } from "../../../../wallets/create-wallet.js";
 import { getUrlToken } from "../../../../wallets/in-app/web/lib/get-url-token.js";
 import type { Wallet } from "../../../../wallets/interfaces/wallet.js";
 import {
@@ -68,7 +69,8 @@ export function useAutoConnectCore(
     const availableWallets = [...wallets, ...(getInstalledWallets?.() ?? [])];
     const activeWallet =
       lastActiveWalletId &&
-      availableWallets.find((w) => w.id === lastActiveWalletId);
+      (availableWallets.find((w) => w.id === lastActiveWalletId) ||
+        createWallet(lastActiveWalletId));
 
     if (activeWallet) {
       try {


### PR DESCRIPTION
FIXES: DASH-104

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the `useAutoConnect` hook for wallets connected from the "All wallets" screen.

### Detailed summary
- Fixed `createWallet` fallback for lastActiveWalletId
- Updated the logic to handle wallets connected from "All wallets" screen

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->