### PR TITLE
Improved error messages when connection management hooks used outside ThirdwebProvider

### DIFF
--- a/.changeset/slow-parents-relate.md
+++ b/.changeset/slow-parents-relate.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Improved error messages when connection management hooks used outside ThirdwebProvider

--- a/packages/thirdweb/src/react/core/hooks/wallets/useActiveAccount.ts
+++ b/packages/thirdweb/src/react/core/hooks/wallets/useActiveAccount.ts
@@ -1,5 +1,5 @@
 import { useSyncExternalStore } from "react";
-import { useConnectionManager } from "../../providers/connection-manager.js";
+import { useConnectionManagerCtx } from "../../providers/connection-manager.js";
 
 /**
  * A hook that returns the active account
@@ -13,7 +13,7 @@ import { useConnectionManager } from "../../providers/connection-manager.js";
  * @walletConnection
  */
 export function useActiveAccount() {
-  const manager = useConnectionManager();
+  const manager = useConnectionManagerCtx("useActiveAccount");
   const store = manager.activeAccountStore;
   return useSyncExternalStore(store.subscribe, store.getValue, store.getValue);
 }

--- a/packages/thirdweb/src/react/core/hooks/wallets/useActiveWallet.ts
+++ b/packages/thirdweb/src/react/core/hooks/wallets/useActiveWallet.ts
@@ -1,5 +1,5 @@
 import { useSyncExternalStore } from "react";
-import { useConnectionManager } from "../../providers/connection-manager.js";
+import { useConnectionManagerCtx } from "../../providers/connection-manager.js";
 
 /**
  * A hook that returns the active wallet
@@ -13,7 +13,7 @@ import { useConnectionManager } from "../../providers/connection-manager.js";
  * @walletConnection
  */
 export function useActiveWallet() {
-  const manager = useConnectionManager();
+  const manager = useConnectionManagerCtx("useActiveWallet");
   const store = manager.activeWalletStore;
   return useSyncExternalStore(store.subscribe, store.getValue, store.getValue);
 }

--- a/packages/thirdweb/src/react/core/hooks/wallets/useActiveWalletChain.ts
+++ b/packages/thirdweb/src/react/core/hooks/wallets/useActiveWalletChain.ts
@@ -1,5 +1,5 @@
 import { useSyncExternalStore } from "react";
-import { useConnectionManager } from "../../providers/connection-manager.js";
+import { useConnectionManagerCtx } from "../../providers/connection-manager.js";
 
 /**
  * A hook that returns the chain the active wallet is connected to
@@ -13,7 +13,7 @@ import { useConnectionManager } from "../../providers/connection-manager.js";
  * @walletConnection
  */
 export function useActiveWalletChain() {
-  const manager = useConnectionManager();
+  const manager = useConnectionManagerCtx("useActiveWalletChain");
   const store = manager.activeWalletChainStore;
   return useSyncExternalStore(store.subscribe, store.getValue, store.getValue);
 }

--- a/packages/thirdweb/src/react/core/hooks/wallets/useActiveWalletConnectionStatus.ts
+++ b/packages/thirdweb/src/react/core/hooks/wallets/useActiveWalletConnectionStatus.ts
@@ -1,5 +1,5 @@
 import { useSyncExternalStore } from "react";
-import { useConnectionManager } from "../../providers/connection-manager.js";
+import { useConnectionManagerCtx } from "../../providers/connection-manager.js";
 
 /**
  * A hook that returns the active account's connection status.
@@ -17,7 +17,7 @@ import { useConnectionManager } from "../../providers/connection-manager.js";
  * @walletConnection
  */
 export function useActiveWalletConnectionStatus() {
-  const manager = useConnectionManager();
+  const manager = useConnectionManagerCtx("useActiveWalletConnectionStatus");
   const store = manager.activeWalletConnectionStatusStore;
   return useSyncExternalStore(store.subscribe, store.getValue, store.getValue);
 }

--- a/packages/thirdweb/src/react/core/hooks/wallets/useAutoConnect.ts
+++ b/packages/thirdweb/src/react/core/hooks/wallets/useAutoConnect.ts
@@ -8,7 +8,7 @@ import {
   getStoredActiveWalletId,
   getStoredConnectedWalletIds,
 } from "../../../../wallets/manager/index.js";
-import { useConnectionManager } from "../../providers/connection-manager.js";
+import { useConnectionManagerCtx } from "../../providers/connection-manager.js";
 import { setLastAuthProvider } from "../../utils/storage.js";
 import { timeoutPromise } from "../../utils/timeoutPromise.js";
 import type { AutoConnectProps } from "../connection/types.js";
@@ -20,7 +20,7 @@ export function useAutoConnectCore(
   props: AutoConnectProps & { wallets: Wallet[] },
   getInstalledWallets?: () => Wallet[],
 ) {
-  const manager = useConnectionManager();
+  const manager = useConnectionManagerCtx("useAutoConnect");
   const setConnectionStatus = useSetActiveWalletConnectionStatus();
   const { connect } = useConnect({
     client: props.client,

--- a/packages/thirdweb/src/react/core/hooks/wallets/useConnect.ts
+++ b/packages/thirdweb/src/react/core/hooks/wallets/useConnect.ts
@@ -1,7 +1,7 @@
 import { useCallback, useState } from "react";
 import type { Wallet } from "../../../../wallets/interfaces/wallet.js";
 import type { ConnectManagerOptions } from "../../../../wallets/manager/index.js";
-import { useConnectionManager } from "../../providers/connection-manager.js";
+import { useConnectionManagerCtx } from "../../providers/connection-manager.js";
 
 /**
  * A hook to set a wallet as active wallet
@@ -34,7 +34,7 @@ import { useConnectionManager } from "../../providers/connection-manager.js";
  * @walletConnection
  */
 export function useConnect(options?: ConnectManagerOptions) {
-  const manager = useConnectionManager();
+  const manager = useConnectionManagerCtx("useConnect");
   const { connect } = manager;
   const [isConnecting, setIsConnecting] = useState(false);
   const [error, setError] = useState<Error | null>(null);

--- a/packages/thirdweb/src/react/core/hooks/wallets/useConnectedWallets.ts
+++ b/packages/thirdweb/src/react/core/hooks/wallets/useConnectedWallets.ts
@@ -1,5 +1,5 @@
 import { useSyncExternalStore } from "react";
-import { useConnectionManager } from "../../providers/connection-manager.js";
+import { useConnectionManagerCtx } from "../../providers/connection-manager.js";
 
 /**
  * A hook that returns all connected wallets
@@ -13,7 +13,7 @@ import { useConnectionManager } from "../../providers/connection-manager.js";
  * @walletConnection
  */
 export function useConnectedWallets() {
-  const manager = useConnectionManager();
+  const manager = useConnectionManagerCtx("useConnectedWallets");
   const store = manager.connectedWallets;
   return useSyncExternalStore(store.subscribe, store.getValue, store.getValue);
 }

--- a/packages/thirdweb/src/react/core/hooks/wallets/useDisconnect.ts
+++ b/packages/thirdweb/src/react/core/hooks/wallets/useDisconnect.ts
@@ -1,4 +1,4 @@
-import { useConnectionManager } from "../../providers/connection-manager.js";
+import { useConnectionManagerCtx } from "../../providers/connection-manager.js";
 
 /**
  * Disconnect from given account
@@ -21,7 +21,7 @@ import { useConnectionManager } from "../../providers/connection-manager.js";
  * @returns An object with a function to disconnect an account
  */
 export function useDisconnect() {
-  const manager = useConnectionManager();
+  const manager = useConnectionManagerCtx("useDisconnect");
   const disconnect = manager.disconnectWallet;
   return { disconnect };
 }

--- a/packages/thirdweb/src/react/core/hooks/wallets/useIsAutoConnecting.ts
+++ b/packages/thirdweb/src/react/core/hooks/wallets/useIsAutoConnecting.ts
@@ -1,5 +1,5 @@
 import { useSyncExternalStore } from "react";
-import { useConnectionManager } from "../../providers/connection-manager.js";
+import { useConnectionManagerCtx } from "../../providers/connection-manager.js";
 
 /**
  * A hook to check if the auto connect is in progress.
@@ -15,7 +15,7 @@ import { useConnectionManager } from "../../providers/connection-manager.js";
  * @walletConnection
  */
 export function useIsAutoConnecting() {
-  const manager = useConnectionManager();
+  const manager = useConnectionManagerCtx("useIsAutoConnecting");
   const store = manager.isAutoConnecting;
   return useSyncExternalStore(store.subscribe, store.getValue, store.getValue);
 }

--- a/packages/thirdweb/src/react/core/hooks/wallets/useSetActiveWallet.ts
+++ b/packages/thirdweb/src/react/core/hooks/wallets/useSetActiveWallet.ts
@@ -1,4 +1,4 @@
-import { useConnectionManager } from "../../providers/connection-manager.js";
+import { useConnectionManagerCtx } from "../../providers/connection-manager.js";
 
 /**
  * A hook that lets you set the active wallet.
@@ -15,6 +15,6 @@ import { useConnectionManager } from "../../providers/connection-manager.js";
  * @walletConnection
  */
 export function useSetActiveWallet() {
-  const manager = useConnectionManager();
+  const manager = useConnectionManagerCtx("useSetActiveWallet");
   return manager.setActiveWallet;
 }

--- a/packages/thirdweb/src/react/core/hooks/wallets/useSetActiveWalletConnectionStatus.ts
+++ b/packages/thirdweb/src/react/core/hooks/wallets/useSetActiveWalletConnectionStatus.ts
@@ -1,4 +1,4 @@
-import { useConnectionManager } from "../../providers/connection-manager.js";
+import { useConnectionManagerCtx } from "../../providers/connection-manager.js";
 
 /**
  * A hook that returns the active wallet's connection status.
@@ -15,6 +15,6 @@ import { useConnectionManager } from "../../providers/connection-manager.js";
  * @internal
  */
 export function useSetActiveWalletConnectionStatus() {
-  const manager = useConnectionManager();
+  const manager = useConnectionManagerCtx("useSetActiveWalletConnectionStatus");
   return manager.activeWalletConnectionStatusStore.setValue;
 }

--- a/packages/thirdweb/src/react/core/hooks/wallets/useSwitchActiveWalletChain.ts
+++ b/packages/thirdweb/src/react/core/hooks/wallets/useSwitchActiveWalletChain.ts
@@ -1,4 +1,4 @@
-import { useConnectionManager } from "../../providers/connection-manager.js";
+import { useConnectionManagerCtx } from "../../providers/connection-manager.js";
 
 /**
  * Switch to blockchain with given chain id in the active wallet.
@@ -16,6 +16,6 @@ import { useConnectionManager } from "../../providers/connection-manager.js";
  * @walletConnection
  */
 export function useSwitchActiveWalletChain() {
-  const manager = useConnectionManager();
+  const manager = useConnectionManagerCtx("useSwitchActiveWalletChain");
   return manager.switchActiveWalletChain;
 }

--- a/packages/thirdweb/src/react/core/providers/connection-manager.tsx
+++ b/packages/thirdweb/src/react/core/providers/connection-manager.tsx
@@ -6,11 +6,24 @@ export const ConnectionManagerCtx = createContext<
 >(undefined);
 
 export function useConnectionManager() {
-  const connectionManager = useContext(ConnectionManagerCtx);
+  const connectionManager = useConnectionManagerCtx("useConnectionManager");
   if (!connectionManager) {
     throw new Error(
-      "useConnectionManager must be used within a ConnectionManager Provider",
+      "useConnectionManager must be used within a <ThirdwebProvider> Provider",
     );
   }
   return connectionManager;
+}
+
+/**
+ * Use this instead of `useConnectionManager` to throw a more specific error message when used outside of a provider.
+ * @internal
+ */
+export function useConnectionManagerCtx(hookname: string) {
+  const manager = useContext(ConnectionManagerCtx);
+  if (!manager) {
+    throw new Error(`${hookname} must be used within <ThirdwebProvider>`);
+  }
+
+  return manager;
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR improves error messages for connection management hooks when used outside `ThirdwebProvider`.

### Detailed summary
- Added `useConnectionManagerCtx` to provide specific error messages for hook usage outside `ThirdwebProvider`
- Updated hooks to use `useConnectionManagerCtx` instead of `useConnectionManager` for error handling

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->