### PR TITLE
fix(thirdweb): mobile auth

### DIFF
--- a/packages/thirdweb/src/wallets/in-app/core/authentication/getLoginPath.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/authentication/getLoginPath.ts
@@ -8,11 +8,13 @@ export const getSocialAuthLoginPath = ({
   client,
   ecosystem,
   mode = "popup",
+  redirectUrl,
 }: {
   authOption: SocialAuthOption;
   client: ThirdwebClient;
   ecosystem?: Ecosystem;
-  mode?: "popup" | "redirect";
+  mode?: "popup" | "redirect" | "mobile";
+  redirectUrl?: string;
 }) => {
   let baseUrl = `${getThirdwebBaseUrl("inAppWallet")}/api/2024-05-05/login/${authOption}?clientId=${client.clientId}`;
   if (ecosystem?.partnerId) {
@@ -22,10 +24,17 @@ export const getSocialAuthLoginPath = ({
   }
 
   if (mode === "redirect") {
-    const redirectUrl = new URL(window.location.href);
-    redirectUrl.searchParams.set("walletId", ecosystem?.id || "inApp");
-    redirectUrl.searchParams.set("authProvider", authOption);
-    baseUrl = `${baseUrl}&redirectUrl=${encodeURIComponent(redirectUrl.toString())}`;
+    const formattedRedirectUrl = new URL(redirectUrl || window.location.href);
+    formattedRedirectUrl.searchParams.set("walletId", ecosystem?.id || "inApp");
+    formattedRedirectUrl.searchParams.set("authProvider", authOption);
+    baseUrl = `${baseUrl}&redirectUrl=${encodeURIComponent(formattedRedirectUrl.toString())}`;
+  }
+
+  if (mode === "mobile") {
+    if (!redirectUrl) {
+      throw new Error("Redirect URL is required for mobile authentication");
+    }
+    baseUrl = `${baseUrl}&redirectUrl=${encodeURIComponent(redirectUrl)}`;
   }
 
   return baseUrl;

--- a/packages/thirdweb/src/wallets/in-app/native/auth/native-auth.ts
+++ b/packages/thirdweb/src/wallets/in-app/native/auth/native-auth.ts
@@ -211,7 +211,8 @@ export async function socialLogin(
   const loginUrl = getSocialAuthLoginPath({
     authOption: auth.strategy,
     client,
-    mode: "popup",
+    mode: "mobile",
+    redirectUrl: auth.redirectUrl,
   });
 
   const result = await WebBrowser.openAuthSessionAsync(

--- a/packages/thirdweb/src/wallets/in-app/native/helpers/auth/middleware.ts
+++ b/packages/thirdweb/src/wallets/in-app/native/helpers/auth/middleware.ts
@@ -11,7 +11,10 @@ import {
   setWallerUserDetails,
 } from "../storage/local.js";
 import { setUpNewUserWallet } from "../wallet/creation.js";
-import { getCognitoRecoveryPasswordV2 } from "../wallet/recoveryCode.js";
+import {
+  getCognitoRecoveryPasswordV1,
+  getCognitoRecoveryPasswordV2,
+} from "../wallet/recoveryCode.js";
 import { setUpShareForNewDevice } from "../wallet/retrieval.js";
 
 export async function preAuth(args: {
@@ -153,7 +156,9 @@ async function getRecoveryCode(
       try {
         return await getCognitoRecoveryPasswordV2(client);
       } catch (e) {
-        throw new Error("Something went wrong getting cognito recovery code");
+        return await getCognitoRecoveryPasswordV1(client).catch(() => {
+          throw new Error("Something went wrong getting cognito recovery code");
+        });
       }
     }
   } else if (

--- a/packages/thirdweb/src/wallets/in-app/native/native-connector.ts
+++ b/packages/thirdweb/src/wallets/in-app/native/native-connector.ts
@@ -113,7 +113,7 @@ export class InAppNativeConnector implements InAppConnector {
       case "apple": {
         const ExpoLinking = require("expo-linking");
         const redirectUrl =
-          params.redirectUrl || (ExpoLinking.createURL("") as string);
+          params.redirectUrl || (ExpoLinking.createURL("") as string); // Will default to the app scheme
         return this.socialLogin({
           strategy,
           redirectUrl,
@@ -167,7 +167,7 @@ export class InAppNativeConnector implements InAppConnector {
         },
       };
     } catch (error) {
-      console.error(`Error while validating otp: ${error}`);
+      console.error(`Error while validating OTP: ${error}`);
       if (error instanceof Error) {
         throw new Error(`Error while validating otp: ${error.message}`);
       }


### PR DESCRIPTION
### TL;DR

Improved social authentication flexibility by adding support for an optional `redirectUrl` parameter and a new `mobile` mode.

### What changed?

- `getLoginPath.ts`: Added handling for `redirectUrl` and a new mode `mobile`.
- `native-auth.ts`: Updated social login to use `mobile` mode and include `redirectUrl`.
- `auth/middleware.ts`: Enhanced error handling for recovery codes by attempting fallback recovery code method.
- `native-connector.ts`: Fixed typo in console error message and ensured `redirectUrl` defaults correctly for native social logins.

### How to test?

1. Initiate a social login with the added `mobile` mode and verify if the `redirectUrl` functions correctly.
2. Trigger an error scenario in recovery code fetching and check that the fallback method is attempted and appropriate error is thrown if both fail.
3. Check the console for corrected error messages.

### Why make this change?

To increase the robustness and flexibility of social authentication by supporting mobile specific workflows and enhanced error resilience.

---

## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance mobile authentication in the thirdweb application by updating redirect URL handling and recovery code logic.

### Detailed summary
- Updated authentication mode to "mobile" in `native-auth.ts`
- Improved redirect URL handling in `native-connector.ts`
- Added support for multiple recovery code versions in `middleware.ts`
- Enhanced authentication options in `getLoginPath.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->