### PR TITLE
Map generic inputs to prebuilt components for Modular Contract install params fiedsets

### DIFF
--- a/apps/dashboard/src/components/contract-components/contract-deploy-form/modular-contract-default-extensions-fieldset.tsx
+++ b/apps/dashboard/src/components/contract-components/contract-deploy-form/modular-contract-default-extensions-fieldset.tsx
@@ -5,6 +5,8 @@ import { getExtensionInstalledParams } from "contract-ui/tabs/manage/components/
 import invariant from "tiny-invariant";
 import { FormErrorMessage, FormLabel } from "tw-components";
 import type { CustomContractDeploymentForm } from "./custom-contract";
+import { PrimarySaleFieldset } from "./primary-sale-fieldset";
+import { RoyaltyFieldset } from "./royalty-fieldset";
 
 type ExtensionMeta = {
   extensionName: string;
@@ -38,16 +40,19 @@ export type UseModularContractsDefaultExtensionsInstallParams = ReturnType<
   typeof useModularContractsDefaultExtensionsInstallParams
 >;
 
-export function ModularContractDefaultExtensionsFieldset(props: {
-  installParams: NonNullable<
-    UseModularContractsDefaultExtensionsInstallParams["data"]
-  >;
-  form: CustomContractDeploymentForm;
-}) {
-  const { form } = props;
+type Extensions = NonNullable<
+  UseModularContractsDefaultExtensionsInstallParams["data"]
+>;
 
+type ExtensionWithIndex = Extensions[number] & { extensionIndex: number };
+
+export function ModularContractDefaultExtensionsFieldset(props: {
+  extensions: Extensions;
+  form: CustomContractDeploymentForm;
+  isTWPublisher: boolean;
+}) {
   // save the index of the extension before filtering out
-  const installParams = props.installParams
+  const extensionsWithIndex: ExtensionWithIndex[] = props.extensions
     .map((v, i) => ({
       ...v,
       extensionIndex: i,
@@ -56,45 +61,163 @@ export function ModularContractDefaultExtensionsFieldset(props: {
 
   return (
     <div className="py-4">
-      <div className="flex flex-col gap-6">
-        {installParams.map((ext) => {
+      <div className="flex flex-col gap-4">
+        {extensionsWithIndex.map((ext) => {
           return (
-            <div key={ext.extensionName}>
-              <h3 className="text-lg mb-4">{ext.extensionName}</h3>
-              <div className="flex flex-col gap-3">
-                {ext.params.map((param) => {
-                  const formFieldKey =
-                    `modularContractDefaultExtensionsInstallParams.${ext.extensionIndex}.${param.name}` as const;
-
-                  return (
-                    <FormControl
-                      key={formFieldKey}
-                      isRequired
-                      isInvalid={
-                        !!form.getFieldState(formFieldKey, form.formState).error
-                      }
-                    >
-                      <FormLabel> {param.name}</FormLabel>
-                      <SolidityInput
-                        solidityType={param.type}
-                        solidityComponents={param.components}
-                        variant="filled"
-                        {...form.register(formFieldKey)}
-                      />
-                      <FormErrorMessage>
-                        {
-                          form.getFieldState(formFieldKey, form.formState).error
-                            ?.message
-                        }
-                      </FormErrorMessage>
-                    </FormControl>
-                  );
-                })}
-              </div>
-            </div>
+            <RenderExtension
+              key={ext.extensionName}
+              extension={ext}
+              isTWPublisher={props.isTWPublisher}
+              form={props.form}
+            />
           );
         })}
       </div>
     </div>
   );
+}
+
+function RenderExtension(props: {
+  extension: ExtensionWithIndex;
+  form: CustomContractDeploymentForm;
+  isTWPublisher: boolean;
+}) {
+  const { extension, form } = props;
+
+  // only consider mapping if published by thirdweb, else show the generic form
+  if (props.isTWPublisher) {
+    const paramNames = extension.params.map((param) => param.name);
+
+    if (showRoyaltyFieldset(paramNames)) {
+      return (
+        <RenderRoyaltyFieldset
+          extension={extension}
+          form={form}
+          isTWPublisher
+        />
+      );
+    }
+
+    if (showPrimarySaleFiedset(paramNames)) {
+      return (
+        <RenderPrimarySaleFieldset
+          extension={extension}
+          form={form}
+          isTWPublisher
+        />
+      );
+    }
+  }
+
+  return (
+    <div>
+      <h3 className="text-lg mb-2 text-secondary-foreground font-medium">
+        {extension.extensionName}
+      </h3>
+      <div className="flex flex-col gap-3">
+        {extension.params.map((param) => {
+          const formFieldKey =
+            `modularContractDefaultExtensionsInstallParams.${extension.extensionIndex}.${param.name}` as const;
+
+          return (
+            <FormControl
+              key={formFieldKey}
+              isRequired
+              isInvalid={
+                !!form.getFieldState(formFieldKey, form.formState).error
+              }
+            >
+              <FormLabel> {param.name}</FormLabel>
+              <SolidityInput
+                solidityType={param.type}
+                solidityComponents={param.components}
+                variant="filled"
+                {...form.register(formFieldKey)}
+              />
+              <FormErrorMessage>
+                {
+                  form.getFieldState(formFieldKey, form.formState).error
+                    ?.message
+                }
+              </FormErrorMessage>
+            </FormControl>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function RenderPrimarySaleFieldset(prosp: {
+  extension: ExtensionWithIndex;
+  form: CustomContractDeploymentForm;
+  isTWPublisher: boolean;
+}) {
+  const { extension, form } = prosp;
+
+  const primarySaleRecipientPath =
+    `modularContractDefaultExtensionsInstallParams.${extension.extensionIndex}.primarySaleRecipient` as const;
+
+  return (
+    <PrimarySaleFieldset
+      isInvalid={
+        !!form.getFieldState(primarySaleRecipientPath, form.formState).error
+      }
+      register={form.register(primarySaleRecipientPath)}
+      errorMessage={
+        form.getFieldState(primarySaleRecipientPath, form.formState).error
+          ?.message
+      }
+    />
+  );
+}
+
+function RenderRoyaltyFieldset(props: {
+  extension: ExtensionWithIndex;
+  form: CustomContractDeploymentForm;
+  isTWPublisher: boolean;
+}) {
+  const { extension: ext, form } = props;
+
+  const royaltyRecipientPath =
+    `modularContractDefaultExtensionsInstallParams.${ext.extensionIndex}.royaltyRecipient` as const;
+
+  const royaltyBpsPath =
+    `modularContractDefaultExtensionsInstallParams.${ext.extensionIndex}.royaltyBps` as const;
+
+  return (
+    <RoyaltyFieldset
+      royaltyRecipient={{
+        isInvalid: !!form.getFieldState(royaltyRecipientPath, form.formState)
+          .error,
+        register: form.register(royaltyRecipientPath, {
+          required: "Required",
+        }),
+        errorMessage: form.getFieldState(royaltyRecipientPath, form.formState)
+          .error?.message,
+      }}
+      royaltyBps={{
+        isInvalid: !!form.getFieldState(royaltyBpsPath, form.formState).error,
+        value: form.watch(royaltyBpsPath) || "0",
+        setValue: (value) =>
+          form.setValue(royaltyBpsPath, value, {
+            shouldTouch: true,
+          }),
+        errorMessage: form.getFieldState(royaltyBpsPath, form.formState).error
+          ?.message,
+      }}
+    />
+  );
+}
+
+export function showRoyaltyFieldset(paramNames: string[]) {
+  return (
+    paramNames.length === 2 &&
+    paramNames.includes("royaltyRecipient") &&
+    paramNames.includes("royaltyBps")
+  );
+}
+
+export function showPrimarySaleFiedset(paramNames: string[]) {
+  return paramNames.length === 1 && paramNames.includes("primarySaleRecipient");
 }

--- a/apps/dashboard/src/components/contract-components/contract-deploy-form/primary-sale-fieldset.tsx
+++ b/apps/dashboard/src/components/contract-components/contract-deploy-form/primary-sale-fieldset.tsx
@@ -1,15 +1,17 @@
 import { Flex, FormControl } from "@chakra-ui/react";
 import { SolidityInput } from "contract-ui/components/solidity-inputs";
+import type { UseFormRegisterReturn } from "react-hook-form";
 import { FormErrorMessage, FormLabel, Heading, Text } from "tw-components";
-import type { CustomContractDeploymentForm } from "./custom-contract";
 
 interface PrimarySaleFieldsetProps {
-  form: CustomContractDeploymentForm;
+  isInvalid: boolean;
+  register: UseFormRegisterReturn;
+  errorMessage: string | undefined;
 }
 
-export const PrimarySaleFieldset: React.FC<PrimarySaleFieldsetProps> = ({
-  form,
-}) => {
+export const PrimarySaleFieldset: React.FC<PrimarySaleFieldsetProps> = (
+  props,
+) => {
   return (
     <Flex pb={4} direction="column" gap={2}>
       <Heading size="label.lg">Primary Sales</Heading>
@@ -18,25 +20,14 @@ export const PrimarySaleFieldset: React.FC<PrimarySaleFieldsetProps> = ({
         of the assets.
       </Text>
       <Flex gap={4} direction={{ base: "column", md: "row" }}>
-        <FormControl
-          isRequired
-          isInvalid={
-            !!form.getFieldState("deployParams._saleRecipient", form.formState)
-              .error
-          }
-        >
+        <FormControl isRequired isInvalid={props.isInvalid}>
           <FormLabel>Recipient Address</FormLabel>
           <SolidityInput
             solidityType="address"
             variant="filled"
-            {...form.register("deployParams._saleRecipient")}
+            {...props.register}
           />
-          <FormErrorMessage>
-            {
-              form.getFieldState("deployParams._saleRecipient", form.formState)
-                .error?.message
-            }
-          </FormErrorMessage>
+          <FormErrorMessage>{props.errorMessage}</FormErrorMessage>
         </FormControl>
       </Flex>
     </Flex>

--- a/apps/dashboard/src/components/contract-components/contract-deploy-form/royalty-fieldset.tsx
+++ b/apps/dashboard/src/components/contract-components/contract-deploy-form/royalty-fieldset.tsx
@@ -1,14 +1,23 @@
 import { Flex, FormControl } from "@chakra-ui/react";
 import { BasisPointsInput } from "components/inputs/BasisPointsInput";
 import { SolidityInput } from "contract-ui/components/solidity-inputs";
+import type { UseFormRegisterReturn } from "react-hook-form";
 import { FormErrorMessage, FormLabel, Heading, Text } from "tw-components";
-import type { CustomContractDeploymentForm } from "./custom-contract";
 
-interface RoyaltyFieldsetProps {
-  form: CustomContractDeploymentForm;
-}
-
-export const RoyaltyFieldset: React.FC<RoyaltyFieldsetProps> = ({ form }) => {
+export function RoyaltyFieldset(props: {
+  royaltyRecipient: {
+    isInvalid: boolean;
+    register: UseFormRegisterReturn;
+    errorMessage: string | undefined;
+  };
+  royaltyBps: {
+    isInvalid: boolean;
+    errorMessage: string | undefined;
+    value: string;
+    setValue: (value: string) => void;
+  };
+}) {
+  const bpsNumValue = Number.parseInt(props.royaltyBps.value);
   return (
     <Flex pb={4} direction="column" gap={2}>
       <Heading size="label.lg">Royalties</Heading>
@@ -17,57 +26,32 @@ export const RoyaltyFieldset: React.FC<RoyaltyFieldsetProps> = ({ form }) => {
         earned from secondary sales of the assets.
       </Text>
       <Flex gap={4} direction={{ base: "column", md: "row" }}>
-        <FormControl
-          isRequired
-          isInvalid={
-            !!form.getFieldState(
-              "deployParams._royaltyRecipient",
-              form.formState,
-            ).error
-          }
-        >
+        <FormControl isRequired isInvalid={props.royaltyRecipient.isInvalid}>
           <FormLabel>Recipient Address</FormLabel>
           <SolidityInput
             solidityType="address"
             variant="filled"
-            {...form.register("deployParams._royaltyRecipient")}
+            {...props.royaltyRecipient.register}
           />
           <FormErrorMessage>
-            {
-              form.getFieldState(
-                "deployParams._royaltyRecipient",
-                form.formState,
-              ).error?.message
-            }
+            {props.royaltyRecipient.errorMessage}
           </FormErrorMessage>
         </FormControl>
         <FormControl
           isRequired
           maxW={{ base: "100%", md: "150px" }}
-          isInvalid={
-            !!form.getFieldState("deployParams._royaltyBps", form.formState)
-              .error
-          }
+          isInvalid={props.royaltyBps.isInvalid}
           defaultValue="0"
         >
           <FormLabel>Percentage</FormLabel>
           <BasisPointsInput
             variant="filled"
-            value={Number.parseInt(form.watch("deployParams._royaltyBps"))}
-            onChange={(value) =>
-              form.setValue("deployParams._royaltyBps", value.toString(), {
-                shouldTouch: true,
-              })
-            }
+            value={Number.isNaN(bpsNumValue) ? 0 : bpsNumValue}
+            onChange={(value) => props.royaltyBps.setValue(value.toString())}
           />
-          <FormErrorMessage>
-            {
-              form.getFieldState("deployParams._royaltyBps", form.formState)
-                .error?.message
-            }
-          </FormErrorMessage>
+          <FormErrorMessage>{props.royaltyBps.errorMessage}</FormErrorMessage>
         </FormControl>
       </Flex>
     </Flex>
   );
-};
+}

--- a/apps/dashboard/src/components/contract-components/shared/published-by.tsx
+++ b/apps/dashboard/src/components/contract-components/shared/published-by.tsx
@@ -53,11 +53,16 @@ export const PublishedBy: React.FC<PublishedByProps> = ({
     return null;
   }
 
+  console.log("publishedContractToShow", publishedContractToShow);
+
   return (
     <ContractCard
       contractId={publishedContractToShow.name}
       publisher={publisherAddress}
       version={publishedContractToShow.version}
+      isBeta={(publishedContractToShow.displayName || "")
+        .toLowerCase()
+        .includes("beta")}
     />
   );
 };

--- a/apps/dashboard/src/components/explore/contract-card/index.tsx
+++ b/apps/dashboard/src/components/explore/contract-card/index.tsx
@@ -25,7 +25,7 @@ interface ContractCardProps {
     source: string;
     itemIndex: `${number}`;
   };
-  isBeta?: boolean;
+  isBeta: boolean | undefined;
 }
 
 export const ContractCard: React.FC<ContractCardProps> = ({

--- a/apps/dashboard/src/pages/explore/[category]/index.tsx
+++ b/apps/dashboard/src/pages/explore/[category]/index.tsx
@@ -103,6 +103,7 @@ const ExploreCategoryPage: ThirdwebNextPage = (
                   source: props.category.id,
                   itemIndex: `${idx}`,
                 }}
+                isBeta={props.category.isBeta}
               />
             );
           })}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to add and update form fields related to royalties and primary sales in the contract deployment form.

### Detailed summary
- Added `isBeta` prop to `ContractCard` component
- Modified `isBeta` prop to accept `boolean` or `undefined`
- Updated form fields for royalties and primary sales in the contract deployment form
- Added `UseFormRegisterReturn` import in multiple files
- Refactored `PrimarySaleFieldset` and `RoyaltyFieldset` components to accept props instead of `form` object

> The following files were skipped due to too many changes: `apps/dashboard/src/components/contract-components/contract-deploy-form/modular-contract-default-extensions-fieldset.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->