### PR TITLE
[dashboard] Fix Spinner size in Add to wallet button in chain page

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/(chainPage)/components/client/add-chain-to-wallet.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/(chainPage)/components/client/add-chain-to-wallet.tsx
@@ -41,13 +41,13 @@ export const AddChainToWallet: React.FC<AddChainToWalletProps> = (props) => {
         !address || debouncedLoading || activeWalletChainId === props.chain?.id
       }
       className={cn(
-        "w-full md:min-w-40",
+        "w-full md:min-w-40 gap-2",
         props.hasBackground && "invert dark:invert-0",
       )}
       onClick={() => switchChainMutation.mutate()}
     >
-      {debouncedLoading && <Spinner />}
       <span>Add to wallet</span>
+      {debouncedLoading && <Spinner className="size-3" />}
     </Button>
   );
 


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the styling of the "Add to wallet" button in the `add-chain-to-wallet.tsx` file.

### Detailed summary
- Updated the `className` of the button to include `gap-2` for spacing
- Added a `className` for the Spinner component with `size-3` for styling.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->