### PR TITLE
[dashboard] Use dark default Theme for first time users

### DIFF
--- a/apps/dashboard/src/pages/_app.tsx
+++ b/apps/dashboard/src/pages/_app.tsx
@@ -289,6 +289,7 @@ function TailwindTheme(props: { children: React.ReactNode }) {
       attribute="class"
       disableTransitionOnChange
       enableSystem={false}
+      defaultTheme="dark"
     >
       {props.children}
     </ThemeProvider>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new `defaultTheme` prop with the value "dark" to the `ThemeProvider` component in the `_app.tsx` file.

### Detailed summary
- Added `defaultTheme="dark"` prop to the `ThemeProvider` component in `_app.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->