### PR TITLE
[Fix] Remove 'create' command from key-requiring CLI commands

### DIFF
--- a/.changeset/rude-fireants-compete.md
+++ b/.changeset/rude-fireants-compete.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+fix "create" command requiring login

--- a/packages/thirdweb/src/cli/bin.ts
+++ b/packages/thirdweb/src/cli/bin.ts
@@ -33,7 +33,7 @@ async function main() {
 
     default: {
       // check several commands for missing -k flag
-      const commands = ["create", "deploy", "publish", "generate", "upload"];
+      const commands = ["deploy", "publish", "generate", "upload"];
       if (commands.includes(command) && !rest.includes("-k")) {
         console.info(
           "Please include the -k flag with your secret key, learn more: https://support.thirdweb.com/troubleshooting-errors/7Y1BqKNvtLdBv5fZkRZZB3/issue-linking-device-on-the-authorization-page-via-thirdweb-cli/cn9LRA3ax7XCP6uxwRYdvx",


### PR DESCRIPTION
This pull request addresses a bug in the thirdweb CLI where the 'create' command incorrectly required users to login. The 'create' command has now been removed from the list of commands that check for the '-k' flag. This fix ensures a smoother user experience by allowing the 'create' command to be executed without unnecessary login prompts. The changes can be tested by running the 'create' command and verifying that it no longer requires login.

---

## Problem solved

Short description of the bug fixed or feature added



<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the "create" command in the `thirdweb` package by requiring login. 

### Detailed summary
- Removed "create" command from the list of commands that require the "-k" flag in `bin.ts` of `thirdweb` package.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->