### PR TITLE
fix(gas): handle gas free chains where baseFeePerGas is 0

### DIFF
--- a/.changeset/rare-starfishes-impress.md
+++ b/.changeset/rare-starfishes-impress.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Handle gas free chains where baseFeePerGas is 0

--- a/apps/dashboard/src/components/buttons/MismatchButton.tsx
+++ b/apps/dashboard/src/components/buttons/MismatchButton.tsx
@@ -16,6 +16,7 @@ import { AiOutlineWarning } from "@react-icons/all-files/ai/AiOutlineWarning";
 import { useSDK, useSDKChainId } from "@thirdweb-dev/react";
 import { useTrack } from "hooks/analytics/useTrack";
 import { useSupportedChain } from "hooks/chains/configureChains";
+import { useRouter } from "next/navigation";
 import { forwardRef, useCallback, useMemo, useRef } from "react";
 import { VscDebugDisconnect } from "react-icons/vsc";
 import { localhost } from "thirdweb/chains";
@@ -29,6 +30,11 @@ import {
 } from "thirdweb/react";
 import { Button, type ButtonProps, Card, Heading, Text } from "tw-components";
 import { defineDashboardChain } from "../../lib/v5-adapter";
+
+const GAS_FREE_CHAINS = [
+  75513, // Geek verse testnet
+  75512, // Geek verse mainnet
+];
 
 function useNetworkMismatchAdapter() {
   const walletChainId = useActiveWalletChain()?.id;
@@ -56,7 +62,7 @@ export const MismatchButton = forwardRef<HTMLButtonElement, ButtonProps>(
     const { isOpen, onOpen, onClose } = useDisclosure();
     const trackEvent = useTrack();
 
-    const chainId = useActiveWalletChain()?.id;
+    const chainId = activeWalletChain?.id;
     const chainInfo = useSupportedChain(chainId || -1);
 
     const eventRef = useRef<React.MouseEvent<HTMLButtonElement, MouseEvent>>();
@@ -69,7 +75,10 @@ export const MismatchButton = forwardRef<HTMLButtonElement, ButtonProps>(
         />
       );
     }
-    const shouldShowEVMFaucet = (evmBalance.data?.value || 0n) === 0n;
+    const shouldShowEVMFaucet =
+      chainId &&
+      (evmBalance.data?.value || 0n) === 0n &&
+      !GAS_FREE_CHAINS.includes(chainId);
     return (
       <Popover
         initialFocusRef={initialFocusRef}
@@ -239,11 +248,10 @@ const NoFundsNotice: React.FC<NoFundsNoticeProps> = ({ symbol }) => {
   const sdk = useSDK();
   const chainId = useActiveWalletChain()?.id;
   const chainInfo = useSupportedChain(chainId || -1);
+  const router = useRouter();
 
   const hasFaucet =
-    chainInfo &&
-    (chainInfo.chainId === localhost.id ||
-      (chainInfo.faucets && chainInfo.faucets.length > 0));
+    chainInfo && (chainInfo.chainId === localhost.id || chainInfo.testnet);
 
   const requestFunds = async () => {
     if (sdk && hasFaucet) {
@@ -254,9 +262,8 @@ const NoFundsNotice: React.FC<NoFundsNoticeProps> = ({ symbol }) => {
       });
       if (chainInfo.chainId === localhost.id) {
         await sdk.wallet.requestFunds(10);
-      } else if (chainInfo?.faucets && chainInfo.faucets.length > 0) {
-        const faucet = chainInfo.faucets[0];
-        window.open(faucet, "_blank");
+      } else if (chainInfo?.testnet) {
+        router.push(`/${chainInfo.chainId}/faucet`);
       }
     }
   };

--- a/legacy_packages/sdk/src/evm/core/classes/internal/contract-wrapper.ts
+++ b/legacy_packages/sdk/src/evm/core/classes/internal/contract-wrapper.ts
@@ -48,6 +48,11 @@ import { RPCConnectionHandler } from "./rpc-connection-handler";
 import { isBrowser } from "../../../common/utils";
 import { detectFeatures } from "../../../common/feature-detection/detectFeatures";
 
+const GAS_FREE_CHAINS = [
+  75513, // Geek verse testnet
+  75512, // Geek verse mainnet
+];
+
 /**
  * @internal
  */
@@ -155,6 +160,14 @@ export class ContractWrapper<
    * @internal
    */
   public async getCallOverrides(): Promise<CallOverrides> {
+    const chainId = await this.getChainID();
+    // avoid ethers5 defaulting to 1.5gwei -> https://github.com/oasysgames/verse-layer-opstack?tab=readme-ov-file#why-doesnt-metamask-automatically-set-gas-to-zero
+    if(GAS_FREE_CHAINS.includes(chainId)) {
+      return {
+        maxFeePerGas: 0,
+        maxPriorityFeePerGas: 0,
+      };
+    }
     // If we're running in the browser, let users configure gas price in their wallet UI
     if (isBrowser()) {
       return {};

--- a/packages/thirdweb/src/gas/fee-data.ts
+++ b/packages/thirdweb/src/gas/fee-data.ts
@@ -143,7 +143,7 @@ async function getDynamicFeeData(
     eth_maxPriorityFeePerGas(rpcRequest).catch(() => null),
   ]);
 
-  const baseBlockFee = block?.baseFeePerGas ? block.baseFeePerGas : 100n;
+  const baseBlockFee = block?.baseFeePerGas ?? 0n;
 
   const chainId = chain.id;
   // flag chain testnet & flag chain


### PR DESCRIPTION
## Problem solved

Handle chains that are 100% gas free. Fixes gas estimation + bypasses dashboard 0 balance check

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to handle gas-free chains where `baseFeePerGas` is 0.

### Detailed summary
- Updated `fee-data.ts` to handle gas-free chains with `baseBlockFee`
- Modified `ContractWrapper` to return 0 gas fees for gas-free chains
- Added `GAS_FREE_CHAINS` in `MismatchButton` and `NoFundsNotice` components

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->