### PR TITLE
fix(thirdweb): resolve occasional iframe error during OAuth login

### DIFF
--- a/.changeset/unlucky-news-tease.md
+++ b/.changeset/unlucky-news-tease.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix occasional iframe error when logging in with oauth

--- a/packages/thirdweb/src/wallets/in-app/web/lib/auth/oauth.ts
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/auth/oauth.ts
@@ -111,7 +111,7 @@ export const loginWithOauth = async (options: {
             break;
           }
           default: {
-            reject(new Error(`Invalid event type: ${event.data.eventType}`));
+            // no-op, DO NOT THROW HERE
           }
         }
       };


### PR DESCRIPTION
### TL;DR
Fix occasional iframe error when logging in with oauth

### What changed?
Removed error throwing for invalid event type in OAuth login flow.

### How to test?
Attempt OAuth login and ensure no errors occur related to iframes.

### Why make this change?
To prevent unnecessary exceptions which impede the OAuth login user experience.

---

 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing an occasional iframe error when logging in with OAuth in the `thirdweb` package.

### Detailed summary
- Fixed occasional iframe error in OAuth login process
- Updated error handling in `oauth.ts` to prevent throwing errors

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->