### PR TITLE
docs: add callouts for generating client ID across multiple guides

### DIFF
--- a/apps/portal/src/app/connect/page.mdx
+++ b/apps/portal/src/app/connect/page.mdx
@@ -7,8 +7,11 @@ import {
 	OpenSourceCard,
 	Stack,
 	ConnectCard,
+	Callout
 } from "@doc";
 import { cn } from "@/lib/utils";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
 
 export const metadata = createMetadata({
 	title: "thirdweb Connect",
@@ -58,6 +61,22 @@ Connect is the complete toolkit for connecting every user to your application. I
 - **Perform wallet actions** like connecting and disconnecting wallets, viewing balance, displaying ENS names, and execute transactions with our [perfomant, reliable and type safe API](https://portal.thirdweb.com/connect/blockchain-api)
 - **Easily integrate with thirdweb's contracts** to enable users to interact with your application.
 - **Facilitate payments** by lettung user top up their wallets or do onchain purchases with a credit card with [Pay](https://portal.thirdweb.com/connect/pay/overview).
+
+<Callout variant="info" title="Have you generated a client ID?">
+	<div className="flex flex-col gap-4 items-start">
+	<p>
+		You'll need a client ID to access Connect's free blockchain APIs, storage, and more.
+	</p>
+	<Link
+			href="https://thirdweb.com/create-api-key"
+			target="_blank"
+		>
+		<Button> 
+			Generate
+		</Button>
+		</Link>
+	</div>
+</Callout>
 
 ### Supported Chains
 

--- a/apps/portal/src/app/react-native/v5/page.mdx
+++ b/apps/portal/src/app/react-native/v5/page.mdx
@@ -12,6 +12,8 @@ import {
 } from "lucide-react";
 import { TypeScriptIcon, ReactIcon } from "@/icons";
 import { Callout } from "@doc";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
 
 # React Native SDK
 
@@ -36,6 +38,22 @@ Many of the components and hooks in the React Native SDK use a [`client`](/types
 	href="/react-native/v5/differences"
 	description="Get to know the differences between React and React Native usage"
 />
+
+<Callout variant="info" title="Have you generated a client ID?">
+	<div className="flex flex-col gap-4 items-start">
+	<p>
+		You'll need a client ID to access the SDK's free blockchain APIs, storage, and more.
+	</p>
+	<Link
+			href="https://thirdweb.com/dashboard/settings/api-keys"
+			target="_blank"
+		>
+		<Button> 
+			Generate
+		</Button>
+		</Link>
+	</div>
+</Callout>
 
 ## Starter kit
 

--- a/apps/portal/src/app/react/v5/page.mdx
+++ b/apps/portal/src/app/react/v5/page.mdx
@@ -1,4 +1,4 @@
-import { Details, ArticleIconCard, Stack, GithubTemplateCard } from "@doc";
+import { Details, ArticleIconCard, Stack, GithubTemplateCard, Callout } from "@doc";
 import {
 	ZapIcon,
 	ScrollTextIcon,
@@ -12,6 +12,8 @@ import {
 	CableIcon,
 } from "lucide-react";
 import { TypeScriptIcon } from "@/icons";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
 
 # React SDK
 
@@ -28,6 +30,22 @@ Follow this [guide](/react/v5/getting-started) to get started with the React SDK
 	description="Get started with the React SDK"
 />
 </Stack>
+
+<Callout variant="info" title="Have you generated a client ID?">
+	<div className="flex flex-col gap-4 items-start">
+	<p>
+		You'll need a client ID to access the SDK's free blockchain APIs, storage, and more.
+	</p>
+	<Link
+			href="https://thirdweb.com/create-api-key"
+			target="_blank"
+		>
+		<Button> 
+			Generate
+		</Button>
+		</Link>
+	</div>
+</Callout>
 
 ## Starter kits
 

--- a/apps/portal/src/app/typescript/v5/client/page.mdx
+++ b/apps/portal/src/app/typescript/v5/client/page.mdx
@@ -4,11 +4,11 @@ import { Callout } from "@doc";
 
 A client is the entry point to the thirdweb SDK. It is required for all other actions.
 
-<Callout title="Api Key" variant="info">
+<Callout title="Client ID" variant="info">
 
     You must provide a `clientId` or `secretKey` in order to initialize a client.
 
-    You can create an Api key for free at
+    You can create an client ID for free at
     [thirdweb.com/create-api-key](https://thirdweb.com/create-api-key).
 
 </Callout>

--- a/apps/portal/src/app/typescript/v5/page.mdx
+++ b/apps/portal/src/app/typescript/v5/page.mdx
@@ -18,6 +18,9 @@ import {
 	BoxIcon,
 	KeyRoundIcon,
 } from "lucide-react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
 import { ReactIcon } from "@/icons";
 
 export const metadata = createMetadata({
@@ -47,6 +50,22 @@ Performant & lightweight SDK to interact with any EVM chain from Node, React and
 	pnpm="pnpm i thirdweb"
 	bun="bun i thirdweb"
 />
+
+<Callout variant="info" title="Have you generated a client ID?">
+	<div className="flex flex-col gap-4 items-start">
+	<p>
+		You'll need a client ID to access the SDK's free blockchain APIs, storage, and more.
+	</p>
+	<Link
+			href="https://thirdweb.com/create-api-key"
+			target="_blank"
+		>
+		<Button> 
+			Generate
+		</Button>
+		</Link>
+	</div>
+</Callout>
 
 ## Quickstart
 


### PR DESCRIPTION
### TL;DR

Added information callouts across various SDK documentation pages, prompting users to generate a client ID to access blockchain APIs, storage, and more.

### What changed?

1. Integrated `Link` and `Button` components from `next/link` and `@/components/ui/button` respectively.
2. Added `<Callout>` components with instructional text and links for generating client IDs.
3. Changed existing callout in TypeScript client page from 'Api Key' to 'Client ID'.

### How to test?

Check the following pages for the new callout additions:
- `/connect`
- `/react-native/v5`
- `/react/v5`
- `/typescript/v5`
- `/typescript/v5/client`

### Why make this change?

To guide users in generating a client ID, which is necessary to access various features offered by the SDK.

---

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update references from "Api Key" to "Client ID" across multiple files and add client ID generation callouts with buttons and links.

### Detailed summary
- Updated references from "Api Key" to "Client ID" for clarity.
- Added callouts prompting users to generate client IDs with buttons and links in multiple files.
- Imported `Link` and `Button` components for client ID generation functionality.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->