### PR TITLE
Dashboard v5: Remove more v4 code

### DIFF
--- a/apps/dashboard/src/@3rdweb-sdk/react/components/roles/minter-only.tsx
+++ b/apps/dashboard/src/@3rdweb-sdk/react/components/roles/minter-only.tsx
@@ -1,9 +1,9 @@
 import { useIsMinter } from "@3rdweb-sdk/react/hooks/useContractRoles";
-import type { ValidContractInstance } from "@thirdweb-dev/sdk";
+import type { ThirdwebContract } from "thirdweb";
 import type { ComponentWithChildren } from "types/component-with-children";
 
 interface IMinterOnlyProps {
-  contract?: ValidContractInstance;
+  contract: ThirdwebContract;
 }
 
 export const MinterOnly: ComponentWithChildren<IMinterOnlyProps> = ({

--- a/apps/dashboard/src/contract-ui/tabs/nfts/components/lazy-mint-button.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/nfts/components/lazy-mint-button.tsx
@@ -1,8 +1,10 @@
 import { MinterOnly } from "@3rdweb-sdk/react/components/roles/minter-only";
 import { Icon, useDisclosure } from "@chakra-ui/react";
 import { type useContract, useLazyMint } from "@thirdweb-dev/react";
-import { extensionDetectedState } from "components/buttons/ExtensionDetectButton";
+import { thirdwebClient } from "lib/thirdweb-client";
+import { defineDashboardChain } from "lib/v5-adapter";
 import { FiPlus } from "react-icons/fi";
+import { getContract } from "thirdweb";
 import { Button, Drawer } from "tw-components";
 import { NFTMintForm } from "./mint-form";
 
@@ -14,24 +16,21 @@ export const NFTLazyMintButton: React.FC<NFTLazyMintButtonProps> = ({
   contractQuery,
   ...restButtonProps
 }) => {
+  const contractV4 = contractQuery.contract;
+  const contract = contractV4
+    ? getContract({
+        address: contractV4.getAddress(),
+        chain: defineDashboardChain(contractV4.chainId),
+        client: thirdwebClient,
+      })
+    : null;
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const mutation = useLazyMint(contractQuery.contract);
-
-  const detectedState = extensionDetectedState({
-    contractQuery,
-    feature: [
-      "ERC721LazyMintable",
-      "ERC1155LazyMintableV1",
-      "ERC1155LazyMintableV2",
-    ],
-  });
-
-  if (detectedState !== "enabled" || !contractQuery.contract) {
+  const mutation = useLazyMint(contractV4);
+  if (!contract) {
     return null;
   }
-
   return (
-    <MinterOnly contract={contractQuery.contract}>
+    <MinterOnly contract={contract}>
       <Drawer
         allowPinchZoom
         preserveScrollBarGap
@@ -39,10 +38,7 @@ export const NFTLazyMintButton: React.FC<NFTLazyMintButtonProps> = ({
         onClose={onClose}
         isOpen={isOpen}
       >
-        <NFTMintForm
-          contract={contractQuery.contract}
-          lazyMintMutation={mutation}
-        />
+        <NFTMintForm contract={contractV4} lazyMintMutation={mutation} />
       </Drawer>
       <Button
         colorScheme="primary"

--- a/apps/dashboard/src/contract-ui/tabs/nfts/components/mint-button.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/nfts/components/mint-button.tsx
@@ -1,8 +1,10 @@
 import { MinterOnly } from "@3rdweb-sdk/react/components/roles/minter-only";
 import { Icon, useDisclosure } from "@chakra-ui/react";
 import { type useContract, useMintNFT } from "@thirdweb-dev/react";
-import { extensionDetectedState } from "components/buttons/ExtensionDetectButton";
+import { thirdwebClient } from "lib/thirdweb-client";
+import { defineDashboardChain } from "lib/v5-adapter";
 import { FiPlus } from "react-icons/fi";
+import { getContract } from "thirdweb";
 import { Button, Drawer } from "tw-components";
 import { NFTMintForm } from "./mint-form";
 
@@ -14,20 +16,21 @@ export const NFTMintButton: React.FC<NFTMintButtonProps> = ({
   contractQuery,
   ...restButtonProps
 }) => {
+  const contractV4 = contractQuery.contract;
+  const contract = contractV4
+    ? getContract({
+        address: contractV4.getAddress(),
+        chain: defineDashboardChain(contractV4.chainId),
+        client: thirdwebClient,
+      })
+    : null;
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const mutation = useMintNFT(contractQuery.contract);
-
-  const detectedState = extensionDetectedState({
-    contractQuery,
-    feature: ["ERC721Mintable", "ERC1155Mintable"],
-  });
-
-  if (detectedState !== "enabled" || !contractQuery.contract) {
+  const mutation = useMintNFT(contractV4);
+  if (!contract) {
     return null;
   }
-
   return (
-    <MinterOnly contract={contractQuery.contract}>
+    <MinterOnly contract={contract}>
       <Drawer
         allowPinchZoom
         preserveScrollBarGap
@@ -35,10 +38,7 @@ export const NFTMintButton: React.FC<NFTMintButtonProps> = ({
         onClose={onClose}
         isOpen={isOpen}
       >
-        <NFTMintForm
-          contract={contractQuery.contract}
-          mintMutation={mutation}
-        />
+        <NFTMintForm contract={contractV4} mintMutation={mutation} />
       </Drawer>
       <Button
         colorScheme="primary"

--- a/apps/dashboard/src/contract-ui/tabs/nfts/components/reveal-button.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/nfts/components/reveal-button.tsx
@@ -1,8 +1,10 @@
 import { MinterOnly } from "@3rdweb-sdk/react/components/roles/minter-only";
 import { Icon, useDisclosure } from "@chakra-ui/react";
 import { useBatchesToReveal, type useContract } from "@thirdweb-dev/react";
-import { extensionDetectedState } from "components/buttons/ExtensionDetectButton";
+import { thirdwebClient } from "lib/thirdweb-client";
+import { defineDashboardChain } from "lib/v5-adapter";
 import { FiEye } from "react-icons/fi";
+import { getContract } from "thirdweb";
 import { Button, Drawer } from "tw-components";
 import { NFTRevealForm } from "./reveal-form";
 
@@ -15,20 +17,20 @@ export const NFTRevealButton: React.FC<NFTRevealButtonProps> = ({
   ...restButtonProps
 }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
-
-  const detectedState = extensionDetectedState({
-    contractQuery,
-    feature: ["ERC721Revealable", "ERC1155Revealable"],
-  });
-
-  const { data: batchesToReveal } = useBatchesToReveal(contractQuery.contract);
-
-  if (detectedState !== "enabled" || !contractQuery.contract) {
+  const contractV4 = contractQuery.contract;
+  const contract = contractV4
+    ? getContract({
+        address: contractV4.getAddress(),
+        chain: defineDashboardChain(contractV4.chainId),
+        client: thirdwebClient,
+      })
+    : null;
+  const { data: batchesToReveal } = useBatchesToReveal(contractV4);
+  if (!contract || !contractV4) {
     return null;
   }
-
   return batchesToReveal?.length ? (
-    <MinterOnly contract={contractQuery.contract}>
+    <MinterOnly contract={contract}>
       <Drawer
         allowPinchZoom
         preserveScrollBarGap
@@ -36,7 +38,7 @@ export const NFTRevealButton: React.FC<NFTRevealButtonProps> = ({
         onClose={onClose}
         isOpen={isOpen}
       >
-        <NFTRevealForm contract={contractQuery.contract} />
+        <NFTRevealForm contract={contractV4} />
       </Drawer>
       <Button
         colorScheme="primary"

--- a/apps/dashboard/src/contract-ui/tabs/nfts/components/shared-metadata-button.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/nfts/components/shared-metadata-button.tsx
@@ -1,8 +1,10 @@
 import { MinterOnly } from "@3rdweb-sdk/react/components/roles/minter-only";
 import { Icon, useDisclosure } from "@chakra-ui/react";
 import { type useContract, useSetSharedMetadata } from "@thirdweb-dev/react";
-import { extensionDetectedState } from "components/buttons/ExtensionDetectButton";
+import { thirdwebClient } from "lib/thirdweb-client";
+import { defineDashboardChain } from "lib/v5-adapter";
 import { FiPlus } from "react-icons/fi";
+import { getContract } from "thirdweb";
 import { Button, Drawer } from "tw-components";
 import { NFTMintForm } from "./mint-form";
 
@@ -13,19 +15,21 @@ interface NFTSharedMetadataButtonProps {
 export const NFTSharedMetadataButton: React.FC<
   NFTSharedMetadataButtonProps
 > = ({ contractQuery, ...restButtonProps }) => {
+  const contractV4 = contractQuery.contract;
+  const contract = contractV4
+    ? getContract({
+        address: contractV4.getAddress(),
+        chain: defineDashboardChain(contractV4.chainId),
+        client: thirdwebClient,
+      })
+    : null;
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const mutation = useSetSharedMetadata(contractQuery.contract);
-
-  const detectedState = extensionDetectedState({
-    contractQuery,
-    feature: ["ERC721SharedMetadata"],
-  });
-  if (detectedState !== "enabled" || !contractQuery.contract) {
+  const mutation = useSetSharedMetadata(contractV4);
+  if (!contract) {
     return null;
   }
-
   return (
-    <MinterOnly contract={contractQuery.contract}>
+    <MinterOnly contract={contract}>
       <Drawer
         allowPinchZoom
         preserveScrollBarGap
@@ -33,10 +37,7 @@ export const NFTSharedMetadataButton: React.FC<
         onClose={onClose}
         isOpen={isOpen}
       >
-        <NFTMintForm
-          contract={contractQuery.contract}
-          sharedMetadataMutation={mutation}
-        />
+        <NFTMintForm contract={contractV4} sharedMetadataMutation={mutation} />
       </Drawer>
       <Button
         colorScheme="primary"

--- a/apps/dashboard/src/contract-ui/tabs/nfts/page.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/nfts/page.tsx
@@ -29,37 +29,9 @@ export const ContractNFTPage: React.FC<NftOverviewPageProps> = ({
   contract,
 }) => {
   const contractQuery = useContract(contractAddress);
-
   const router = useRouter();
   const tokenId = router.query?.paths?.[2];
-
-  const detectedState = detectFeatures(contractQuery?.contract, [
-    "ERC721Enumerable",
-    "ERC1155Enumerable",
-    "ERC721Supply",
-  ]);
-
   const isErc721 = detectFeatures(contractQuery?.contract, ["ERC721"]);
-
-  const isErc721Claimable = detectFeatures(contractQuery?.contract, [
-    "ERC721ClaimPhasesV1",
-    "ERC721ClaimPhasesV2",
-    "ERC721ClaimConditionsV1",
-    "ERC721ClaimConditionsV2",
-    "ERC721ClaimCustom",
-  ]);
-
-  const detectedClaimState = extensionDetectedState({
-    contractQuery,
-    feature: [
-      // erc 721
-      "ERC721ClaimPhasesV1",
-      "ERC721ClaimPhasesV2",
-      "ERC721ClaimConditionsV1",
-      "ERC721ClaimConditionsV2",
-      "ERC721ClaimCustom",
-    ],
-  });
 
   if (tokenId && isOnlyNumbers(tokenId)) {
     return (
@@ -77,22 +49,100 @@ export const ContractNFTPage: React.FC<NftOverviewPageProps> = ({
     return <div>Loading...</div>;
   }
 
+  const detectedClaimState = extensionDetectedState({
+    contractQuery,
+    feature: [
+      "ERC721ClaimPhasesV1",
+      "ERC721ClaimPhasesV2",
+      "ERC721ClaimConditionsV1",
+      "ERC721ClaimConditionsV2",
+      "ERC721ClaimCustom",
+    ],
+  });
+
+  const isErc721Claimable = detectFeatures(contractQuery?.contract, [
+    "ERC721ClaimPhasesV1",
+    "ERC721ClaimPhasesV2",
+    "ERC721ClaimConditionsV1",
+    "ERC721ClaimConditionsV2",
+    "ERC721ClaimCustom",
+  ]);
+
+  const detectedState = detectFeatures(contractQuery?.contract, [
+    "ERC721Enumerable",
+    "ERC1155Enumerable",
+    "ERC721Supply",
+  ]);
+
+  const detectedLzyMintState = extensionDetectedState({
+    contractQuery,
+    feature: [
+      "ERC721LazyMintable",
+      "ERC1155LazyMintableV1",
+      "ERC1155LazyMintableV2",
+    ],
+  });
+
+  const isRevealable = detectFeatures(contractQuery.contract, [
+    "ERC721Revealable",
+    "ERC1155Revealable",
+  ]);
+
+  const detectedRevealableState = extensionDetectedState({
+    contractQuery,
+    feature: ["ERC721Revealable", "ERC1155Revealable"],
+  });
+
+  const detectedMintableState = extensionDetectedState({
+    contractQuery,
+    feature: ["ERC721Mintable", "ERC1155Mintable"],
+  });
+
+  const detectedLazyMintableState = extensionDetectedState({
+    contractQuery,
+    feature: [
+      "ERC721LazyMintable",
+      "ERC1155LazyMintableV1",
+      "ERC1155LazyMintableV2",
+    ],
+  });
+
+  const detectedSharedMetadataState = extensionDetectedState({
+    contractQuery,
+    feature: ["ERC721SharedMetadata"],
+  });
+
   return (
     <Flex direction="column" gap={6}>
       <Flex direction="row" justify="space-between" align="center">
         <Heading size="title.sm">Contract NFTs</Heading>
         <Flex gap={2} flexDir={{ base: "column", md: "row" }}>
-          <NFTRevealButton contractQuery={contractQuery} />
+          {detectedRevealableState === "enabled" && contractQuery?.contract && (
+            <NFTRevealButton contractQuery={contractQuery} />
+          )}
           {detectedClaimState && contractQuery?.contract && (
             <NFTClaimButton
               contractAddress={contractQuery.contract.getAddress()}
               chainId={contractQuery.contract.chainId}
             />
           )}
-          <NFTMintButton contractQuery={contractQuery} />
-          <NFTSharedMetadataButton contractQuery={contractQuery} />
-          <NFTLazyMintButton contractQuery={contractQuery} />
-          <BatchLazyMintButton contractQuery={contractQuery} />
+          {detectedMintableState === "enabled" && contractQuery?.contract && (
+            <NFTMintButton contractQuery={contractQuery} />
+          )}
+          {detectedSharedMetadataState === "enabled" &&
+            contractQuery?.contract && (
+              <NFTSharedMetadataButton contractQuery={contractQuery} />
+            )}
+          {detectedLazyMintableState === "enabled" &&
+            contractQuery?.contract && (
+              <NFTLazyMintButton contractQuery={contractQuery} />
+            )}
+          {detectedLzyMintState === "enabled" && contractQuery?.contract && (
+            <BatchLazyMintButton
+              contractQuery={contractQuery}
+              isRevealable={isRevealable}
+            />
+          )}
         </Flex>
       </Flex>
       {!detectedState ? (

--- a/apps/dashboard/src/contract-ui/tabs/overview/components/ContractChecklist.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/overview/components/ContractChecklist.tsx
@@ -1,3 +1,4 @@
+import { thirdwebClient } from "@/constants/client";
 import {
   useIsAdmin,
   useIsMinter,
@@ -16,6 +17,8 @@ import { detectFeatures } from "components/contract-components/utils";
 import { StepsCard } from "components/dashboard/StepsCard";
 import { useTabHref } from "contract-ui/utils";
 import { BigNumber } from "ethers";
+import { defineDashboardChain } from "lib/v5-adapter";
+import { getContract } from "thirdweb";
 import { Link, Text } from "tw-components";
 
 interface ContractChecklistProps {
@@ -31,6 +34,11 @@ type Step = {
 export const ContractChecklist: React.FC<ContractChecklistProps> = ({
   contract,
 }) => {
+  const contractv5 = getContract({
+    address: contract.getAddress(),
+    chain: defineDashboardChain(contract.chainId),
+    client: thirdwebClient,
+  });
   const nftHref = useTabHref("nfts");
   const tokenHref = useTabHref("tokens");
   const accountsHref = useTabHref("accounts");
@@ -53,7 +61,7 @@ export const ContractChecklist: React.FC<ContractChecklistProps> = ({
   ];
 
   const isAdmin = useIsAdmin(contract);
-  const isMinter = useIsMinter(contract);
+  const isMinter = useIsMinter(contractv5);
 
   if (!isAdmin) {
     return null;

--- a/apps/dashboard/src/contract-ui/tabs/tokens/components/mint-button.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/tokens/components/mint-button.tsx
@@ -1,8 +1,10 @@
 import { MinterOnly } from "@3rdweb-sdk/react/components/roles/minter-only";
 import { Icon, useDisclosure } from "@chakra-ui/react";
-import type { TokenContract, useContract } from "@thirdweb-dev/react";
-import { detectFeatures } from "components/contract-components/utils";
+import type { useContract } from "@thirdweb-dev/react";
+import { thirdwebClient } from "lib/thirdweb-client";
+import { defineDashboardChain } from "lib/v5-adapter";
 import { FiPlus } from "react-icons/fi";
+import { getContract } from "thirdweb";
 import { Button, Drawer } from "tw-components";
 import { TokenMintForm } from "./mint-form";
 
@@ -15,17 +17,19 @@ export const TokenMintButton: React.FC<TokenMintButtonProps> = ({
   ...restButtonProps
 }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const isERC20Mintable = detectFeatures<TokenContract>(
-    contractQuery.contract,
-    ["ERC20Mintable"],
-  );
-
-  if (!isERC20Mintable || !contractQuery.contract) {
+  const contractV4 = contractQuery.contract;
+  const contract = contractV4
+    ? getContract({
+        address: contractV4.getAddress(),
+        chain: defineDashboardChain(contractV4.chainId),
+        client: thirdwebClient,
+      })
+    : null;
+  if (!contract || !contractV4) {
     return null;
   }
-
   return (
-    <MinterOnly contract={contractQuery.contract}>
+    <MinterOnly contract={contract}>
       <Drawer
         allowPinchZoom
         preserveScrollBarGap
@@ -33,7 +37,7 @@ export const TokenMintButton: React.FC<TokenMintButtonProps> = ({
         onClose={onClose}
         isOpen={isOpen}
       >
-        <TokenMintForm contract={contractQuery.contract} />
+        <TokenMintForm contract={contractV4} />
       </Drawer>
       <Button
         colorScheme="primary"

--- a/apps/dashboard/src/contract-ui/tabs/tokens/page.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/tokens/page.tsx
@@ -33,6 +33,11 @@ export const ContractTokensPage: React.FC<ContractTokenPageProps> = ({
     "ERC20",
   ]);
 
+  const isERC20Mintable = detectFeatures<TokenContract>(
+    contractQuery.contract,
+    ["ERC20Mintable"],
+  );
+
   if (!isERC20) {
     return (
       <Card as={Flex} flexDir="column" gap={3}>
@@ -80,8 +85,9 @@ export const ContractTokensPage: React.FC<ContractTokenPageProps> = ({
             contractAddress={contractAddress}
             chainId={chainId}
           />
-          {/* TODO: update (mintable detection) */}
-          <TokenMintButton contractQuery={contractQuery} />
+          {isERC20Mintable && contractQuery.contract && (
+            <TokenMintButton contractQuery={contractQuery} />
+          )}
         </ButtonGroup>
       </Flex>
 

--- a/apps/dashboard/src/core-ui/nft-drawer/useNftDrawerTabs.tsx
+++ b/apps/dashboard/src/core-ui/nft-drawer/useNftDrawerTabs.tsx
@@ -72,7 +72,7 @@ export function useNFTDrawerTabs({
     },
   );
 
-  const isMinterRole = useIsMinter(oldContract);
+  const isMinterRole = useIsMinter(contract);
 
   return useMemo(() => {
     const isMintable = detectFeatures(oldContract, ["ERC1155Mintable"]);


### PR DESCRIPTION
This PR is the first step to eventually remove all the v4 code inside `src/contract-ui/tabs/nfts/page.tsx`

2 main components that is now v4-free:
- [x] useIsMinter
- [x] MinterOnly

In fear of putting up a huge PR, I submit this PR as the first in this series

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates contract handling in various components, switching to `ThirdwebContract` and improving mintable feature detection.

### Detailed summary
- Replaced `ValidContractInstance` with `ThirdwebContract` in multiple files
- Improved mintable feature detection in `TokenMintButton` and `NFTMintButton`
- Updated contract handling in `useIsMinter` function

> The following files were skipped due to too many changes: `apps/dashboard/src/contract-ui/tabs/nfts/components/shared-metadata-button.tsx`, `apps/dashboard/src/contract-ui/tabs/nfts/components/batch-lazy-mint-button.tsx`, `apps/dashboard/src/contract-ui/tabs/nfts/page.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->