### PR TITLE
Dashboard v5: Remove useStorageUpload

### DIFF
--- a/apps/dashboard/src/@3rdweb-sdk/react/hooks/useDashboardStorageUpload.tsx
+++ b/apps/dashboard/src/@3rdweb-sdk/react/hooks/useDashboardStorageUpload.tsx
@@ -1,0 +1,26 @@
+import { thirdwebClient } from "@/constants/client";
+import { useMutation } from "@tanstack/react-query";
+import { upload } from "thirdweb/storage";
+
+type DashboardUploadOptions = {
+  uploadWithoutDirectory?: boolean;
+  metadata?: Record<string, string>;
+};
+
+export function useDashboardStorageUpload(options?: DashboardUploadOptions) {
+  return useMutation({
+    mutationFn: async (files: Array<File | string>): Promise<string[]> => {
+      const uris = await upload({
+        client: thirdwebClient,
+        files,
+        ...options,
+      });
+      // the upload method in SDK v5 has this logic
+      // that will make it return only a string if you upload only 1 file
+      if (typeof uris === "string") {
+        return [uris];
+      }
+      return uris;
+    },
+  });
+}

--- a/apps/dashboard/src/components/configure-networks/Form/IconUpload.tsx
+++ b/apps/dashboard/src/components/configure-networks/Form/IconUpload.tsx
@@ -1,6 +1,6 @@
+import { useDashboardStorageUpload } from "@3rdweb-sdk/react/hooks/useDashboardStorageUpload";
 import { Icon } from "@chakra-ui/react";
 import { useQueryClient } from "@tanstack/react-query";
-import { useStorageUpload } from "@thirdweb-dev/react";
 import { FileInput } from "components/shared/FileInput";
 import { PINNED_FILES_QUERY_KEY_ROOT } from "components/storage/your-files";
 import { useErrorHandler } from "contexts/error-handler";
@@ -11,7 +11,7 @@ export const IconUpload: React.FC<{ onUpload: (url: string) => void }> = ({
   onUpload,
 }) => {
   const errorHandler = useErrorHandler();
-  const storageUpload = useStorageUpload();
+  const storageUpload = useDashboardStorageUpload();
   const queryClient = useQueryClient();
 
   const handleIconUpload = (file: File) => {
@@ -21,19 +21,16 @@ export const IconUpload: React.FC<{ onUpload: (url: string) => void }> = ({
       return;
     }
 
-    storageUpload.mutate(
-      { data: [file] },
-      {
-        onSuccess([uri]) {
-          onUpload(uri);
-          // also refetch the files list
-          queryClient.invalidateQueries([PINNED_FILES_QUERY_KEY_ROOT]);
-        },
-        onError(error) {
-          errorHandler.onError(error, "Failed to upload file");
-        },
+    storageUpload.mutate([file], {
+      onSuccess([uri]) {
+        onUpload(uri);
+        // also refetch the files list
+        queryClient.invalidateQueries([PINNED_FILES_QUERY_KEY_ROOT]);
       },
-    );
+      onError(error) {
+        errorHandler.onError(error, "Failed to upload file");
+      },
+    });
   };
 
   return (

--- a/apps/dashboard/src/components/ipfs-upload/button.tsx
+++ b/apps/dashboard/src/components/ipfs-upload/button.tsx
@@ -20,13 +20,10 @@ export const IpfsUploadButton: ComponentWithChildren<IpfsUploadButtonProps> = ({
 }) => {
   const { onError } = useErrorHandler();
   const handleUpload = (file: File) => {
-    storageUpload.mutate(
-      { data: [file] },
-      {
-        onSuccess: ([uri]) => onUpload(uri),
-        onError: (error) => onError(error, "Failed to upload file"),
-      },
-    );
+    storageUpload.mutate([file], {
+      onSuccess: ([uri]) => onUpload(uri),
+      onError: (error) => onError(error, "Failed to upload file"),
+    });
   };
 
   return (

--- a/apps/dashboard/src/components/ipfs-upload/dropzone.tsx
+++ b/apps/dashboard/src/components/ipfs-upload/dropzone.tsx
@@ -1,4 +1,5 @@
 import { thirdwebClient } from "@/constants/client";
+import { useDashboardStorageUpload } from "@3rdweb-sdk/react/hooks/useDashboardStorageUpload";
 import {
   AspectRatio,
   Box,
@@ -16,8 +17,6 @@ import {
   useToast,
 } from "@chakra-ui/react";
 import { useQueryClient } from "@tanstack/react-query";
-import { useStorageUpload } from "@thirdweb-dev/react";
-import type { UploadProgressEvent } from "@thirdweb-dev/storage";
 import { PINNED_FILES_QUERY_KEY_ROOT } from "components/storage/your-files";
 import { useErrorHandler } from "contexts/error-handler";
 import { useTrack } from "hooks/analytics/useTrack";
@@ -159,19 +158,19 @@ const filesPerPage = 20;
 const FileUpload: React.FC<FileUploadProps> = ({ files, updateFiles }) => {
   const trackEvent = useTrack();
   const address = useActiveAccount()?.address;
-  const [progress, setProgress] = useState<UploadProgressEvent>({
-    progress: 0,
-    total: 100,
-  });
+  // const [progress, setProgress] = useState<UploadProgressEvent>({
+  //   progress: 0,
+  //   total: 100,
+  // });
   const [uploadWithoutDirectory, setUploadWithoutDirectory] = useState(
     files.length === 1,
   );
   const uploadToAFolder = !uploadWithoutDirectory;
-  const storageUpload = useStorageUpload({
+  const storageUpload = useDashboardStorageUpload({
     uploadWithoutDirectory,
-    onProgress: setProgress,
+    // onProgress: setProgress,
     metadata: {
-      address,
+      address: address ?? "",
       uploadedAt: new Date().toISOString(),
       uploadedFrom: "thirdweb-dashboard",
     },
@@ -182,7 +181,7 @@ const FileUpload: React.FC<FileUploadProps> = ({ files, updateFiles }) => {
 
   const [page, setPage] = useState(0);
 
-  const progressPercent = (progress.progress / progress.total) * 100;
+  // const progressPercent = (progress.progress / progress.total) * 100;
 
   const mainIpfsUri = useMemo(() => {
     if (ipfsHashes.length === 0) {
@@ -430,11 +429,11 @@ const FileUpload: React.FC<FileUploadProps> = ({ files, updateFiles }) => {
             >
               <Progress
                 colorScheme="green"
-                value={progress.progress ? progressPercent : undefined}
+                // value={progress.progress ? progressPercent : undefined}
                 size={{ base: "xs", md: "lg" }}
                 w="100%"
                 borderRadius="full"
-                isIndeterminate={progress.progress === progress.total}
+                isIndeterminate={storageUpload.isLoading}
                 position="relative"
               />
               <Center
@@ -445,7 +444,7 @@ const FileUpload: React.FC<FileUploadProps> = ({ files, updateFiles }) => {
                 top={0}
                 bottom={0}
               >
-                <Text
+                {/* <Text
                   mt={0.5}
                   size="label.xs"
                   fontSize={11}
@@ -470,7 +469,7 @@ const FileUpload: React.FC<FileUploadProps> = ({ files, updateFiles }) => {
                   transition="color 0.2s"
                 >
                   {Math.round(progressPercent)}%
-                </Text>
+                </Text> */}
               </Center>
             </Flex>
           )}
@@ -516,49 +515,34 @@ const FileUpload: React.FC<FileUploadProps> = ({ files, updateFiles }) => {
                     action: "upload",
                     label: "start",
                   });
-                  storageUpload.mutate(
-                    {
-                      data: files,
+                  storageUpload.mutate(files, {
+                    onError: (error) => {
+                      trackEvent({
+                        category: TRACKING_CATEGORY,
+                        action: "upload",
+                        label: "error",
+                        error,
+                      });
+                      onError(error, "Failed to upload file");
                     },
-                    {
-                      onError: (error) => {
-                        trackEvent({
-                          category: TRACKING_CATEGORY,
-                          action: "upload",
-                          label: "error",
-                          error,
-                        });
-                        onError(error, "Failed to upload file");
-                        setProgress({
-                          progress: 0,
-                          total: 100,
-                        });
-                      },
-                      onSuccess: (uris) => {
-                        trackEvent({
-                          category: TRACKING_CATEGORY,
-                          action: "upload",
-                          label: "success",
-                          address,
-                          uri:
-                            uris.length === 1
-                              ? uris[0]
-                              : uris[0].split("/").slice(0, -1).join("/"),
-                        });
-                        setIpfsHashes(uris);
-                        // also refetch the files list
-                        queryClient.invalidateQueries([
-                          PINNED_FILES_QUERY_KEY_ROOT,
-                        ]);
-                      },
-                      onSettled: () => {
-                        setProgress({
-                          progress: 0,
-                          total: 100,
-                        });
-                      },
+                    onSuccess: (uris) => {
+                      trackEvent({
+                        category: TRACKING_CATEGORY,
+                        action: "upload",
+                        label: "success",
+                        address,
+                        uri:
+                          uris.length === 1
+                            ? uris[0]
+                            : uris[0].split("/").slice(0, -1).join("/"),
+                      });
+                      setIpfsHashes(uris);
+                      // also refetch the files list
+                      queryClient.invalidateQueries([
+                        PINNED_FILES_QUERY_KEY_ROOT,
+                      ]);
                     },
-                  );
+                  });
                 }}
               >
                 Start Upload

--- a/apps/dashboard/src/contract-ui/components/solidity-inputs/string-input.tsx
+++ b/apps/dashboard/src/contract-ui/components/solidity-inputs/string-input.tsx
@@ -1,6 +1,6 @@
+import { useDashboardStorageUpload } from "@3rdweb-sdk/react/hooks/useDashboardStorageUpload";
 import { Box, Input, InputGroup, InputRightElement } from "@chakra-ui/react";
 import { useQueryClient } from "@tanstack/react-query";
-import { useStorageUpload } from "@thirdweb-dev/react";
 import { IpfsUploadButton } from "components/ipfs-upload/button";
 import { PINNED_FILES_QUERY_KEY_ROOT } from "components/storage/your-files";
 import type { SolidityInputWithTypeProps } from ".";
@@ -11,7 +11,7 @@ export const SolidityStringInput: React.FC<SolidityInputWithTypeProps> = ({
   functionName,
   ...inputProps
 }) => {
-  const storageUpload = useStorageUpload();
+  const storageUpload = useDashboardStorageUpload();
   const queryClient = useQueryClient();
   const { name, ...restOfInputProps } = inputProps;
   const inputName = name as string;


### PR DESCRIPTION
- Add new React hook that uses v5's `upload` under the hood
- Sacrifice has been made - we remove the progress % from the loading bar

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to refactor file upload functionality in the dashboard components to use a new SDK method for improved storage handling.

### Detailed summary
- Refactored file upload functions in `IconUpload`, `SolidityStringInput`, `FileUpload`, and related components to use `useDashboardStorageUpload`
- Updated `useDashboardStorageUpload` to handle file uploads with options and metadata

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->