### PR TITLE
[Fix] Validate and decode `nextPath` to ensure it is a relative path before redirecting

### DIFF
--- a/apps/dashboard/src/app/login/auth-actions.ts
+++ b/apps/dashboard/src/app/login/auth-actions.ts
@@ -131,11 +131,23 @@ export async function doLogin(
   });
 
   // redirect to the nextPath (if set)
-  if (nextPath) {
+  if (nextPath && isValidRedirectPath(nextPath)) {
     return redirect(nextPath);
   }
   // if we do not have a next path, redirect to dashboard home
   return redirect("/dashboard");
+}
+function isValidRedirectPath(encodedPath: string): boolean {
+  try {
+    // Decode the URI component
+    const decodedPath = decodeURIComponent(encodedPath);
+    // ensure the path always starts with a _single_ slash
+    // dobule slash could be interpreted as `//example.com` which is not allowed
+    return decodedPath.startsWith("/") && !decodedPath.startsWith("//");
+  } catch (e) {
+    // If decoding fails, return false
+    return false;
+  }
 }
 
 export async function doLogout() {


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance security by validating redirect paths in the login process.

### Detailed summary
- Added `isValidRedirectPath` function to validate redirect paths
- Ensures decoded path starts with a single slash
- Prevents double slashes in paths
- Improves security by handling decoding errors

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->