### PR TITLE
[Fix] Exclude auth token from pay URLs when setting request headers

### DIFF
--- a/packages/thirdweb/src/utils/fetch.ts
+++ b/packages/thirdweb/src/utils/fetch.ts
@@ -43,7 +43,8 @@ export function getClientFetch(client: ThirdwebClient, ecosystem?: Ecosystem) {
       }
       const authToken = getTWAuthToken();
       // if we have an auth token set, use that (thirdweb.com/dashboard sets this for the user)
-      if (authToken) {
+      // pay urls should never send the auth token, because we always want the "developer" to be the one making the request, not the "end user"
+      if (authToken && !isPayUrl(url)) {
         headers.set("authorization", `Bearer ${authToken}`);
       } else if (client.secretKey) {
         headers.set("x-secret-key", client.secretKey);
@@ -123,6 +124,16 @@ export function isThirdwebUrl(url: string): boolean {
     return is;
   } catch {
     IS_THIRDWEB_URL_CACHE.set(url, false);
+    return false;
+  }
+}
+
+function isPayUrl(url: string): boolean {
+  try {
+    const { hostname } = new URL(url);
+    // pay service hostname always starts with "pay."
+    return hostname.startsWith("pay.");
+  } catch {
     return false;
   }
 }


### PR DESCRIPTION
This PR updates the fetch utility in the Thirdweb package to exclude the authorization token from being sent when the endpoint is related to the pay service. This ensures that requests to 'pay.' prefixed URLs are always made on behalf of the 'developer' rather than the 'end user.' It introduces a new function, isPayUrl, to determine if the URL belongs to the pay service.

---



<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to prevent sending the auth token in pay URLs in the `fetch.ts` file.

### Detailed summary
- Added a new function `isPayUrl` to check if a URL is a pay service URL.
- Updated the logic in `fetch.ts` to exclude sending the auth token in pay URLs.
- Improved security by ensuring only the developer, not the end user, makes requests to pay URLs.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->