### PR TITLE
Dashboard: Fix [Open IPFS folder] link

### DIFF
--- a/apps/dashboard/src/components/ipfs-upload/dropzone.tsx
+++ b/apps/dashboard/src/components/ipfs-upload/dropzone.tsx
@@ -192,8 +192,9 @@ const FileUpload: React.FC<FileUploadProps> = ({ files, updateFiles }) => {
       return replaceIpfsUrl(ipfsHashes[0]);
     }
     // get the folder
-    // return replaceIpfsUrl(ipfsHashes[0].split("/").slice(0, -1).join("/"));
-    return `https://ipfs.io/ipfs/${ipfsHashes[0].split("ipfs://")[1]}`;
+    const uri = ipfsHashes[0].split("ipfs://")[1];
+    const folderPath = uri.split("/")[0]; // "Qma.../image.png" -> "Qma..."
+    return `https://ipfs.io/ipfs/${folderPath}`;
   }, [ipfsHashes]);
 
   const filesToShow = useMemo(() => {


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to refactor the IPFS URL handling in the `dropzone.tsx` component.

### Detailed summary
- Extracted folder path from IPFS URL for better readability
- Updated the return statement to use the extracted folder path for IPFS URL generation

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->