### PR TITLE
test(thirdweb): add condition to serialize-transaction eip1559 test based on TW_SECRET_KEY

### DIFF
--- a/packages/thirdweb/src/transaction/serialize-transaction.test.ts
+++ b/packages/thirdweb/src/transaction/serialize-transaction.test.ts
@@ -26,7 +26,7 @@ const BASE_TRANSACTION = {
   value: toWei("1"),
 } as const satisfies TransactionSerializableBase;
 
-describe("eip1559", () => {
+describe.runIf(process.env.TW_SECRET_KEY)("eip1559", () => {
   const baseEip1559 = {
     ...BASE_TRANSACTION,
     chainId: 1,


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a conditional test suite execution based on a secret key in the `serialize-transaction.test.ts` file.

### Detailed summary
- Added a conditional test suite execution based on a secret key in `serialize-transaction.test.ts`
- Updated the test suite description from "eip1559" to "eip1559" when `TW_SECRET_KEY` environment variable is present

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->