### PR TITLE
fix(app): update header texts and contract address

### DIFF
--- a/apps/playground-web/src/app/connect/pay/page.tsx
+++ b/apps/playground-web/src/app/connect/pay/page.tsx
@@ -78,7 +78,7 @@ function StyledPayEmbed() {
     <>
       <div className="space-y-2">
         <h2 className="text-2xl sm:text-3xl font-semibold tracking-tight">
-          Fund wallets
+          Top Up
         </h2>
         <p className="max-w-[600px]">
           Inline component that allows users to buy any currency.
@@ -110,7 +110,7 @@ function BuyMerch() {
     <>
       <div className="space-y-2">
         <h2 className="text-2xl sm:text-3xl font-semibold tracking-tight">
-          Direct Payments
+          Commerce
         </h2>
         <p className="max-w-[600px]">
           Take paymets from Fiat or Crypto directly to your seller wallet.
@@ -158,7 +158,7 @@ function BuyOnchainAsset() {
     <>
       <div className="space-y-2">
         <h2 className="text-2xl sm:text-3xl font-semibold tracking-tight">
-          Onchain Payments
+          Transactions
         </h2>
         <p className="max-w-[600px]">
           Let your users pay for onchain transactions with fiat or crypto on any

--- a/apps/playground-web/src/components/pay/transaction-button.tsx
+++ b/apps/playground-web/src/components/pay/transaction-button.tsx
@@ -15,7 +15,7 @@ import { THIRDWEB_CLIENT } from "../../lib/client";
 import { StyledConnectButton } from "../styled-connect-button";
 
 const nftContract = getContract({
-  address: "0x96B30d36f783c7BC68535De23147e2ce65788e93",
+  address: "0x827c1c3889923015C1FC31BF677D00FbE6F01D52",
   chain: polygon,
   client: THIRDWEB_CLIENT,
 });


### PR DESCRIPTION
### TL;DR
Updates various UI headings in the payment-related pages and updates the NFT contract address in the transaction button component.

### What changed?
- Updated headings in `pay/page.tsx`:
  - 'Fund wallets' to 'Top Up'
  - 'Direct Payments' to 'Commerce'
  - 'Onchain Payments' to 'Transactions'
- Changed NFT contract address in `transaction-button.tsx` from `0x96B30d36f783c7BC68535De23147e2ce65788e93` to `0x827c1c3889923015C1FC31BF677D00FbE6F01D52`.

### How to test?
1. Navigate to the payment page and verify that the headings are updated.
2. Ensure that the transactions are working correctly with the new contract address.

### Why make this change?
The updates are intended to enhance user comprehension and ensure the correct NFT contract is being used.

---

## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update text and component names related to payment transactions for clarity and consistency.

### Detailed summary
- Updated NFT contract address
- Renamed "Fund wallets" to "Top Up"
- Renamed "Direct Payments" to "Commerce"
- Renamed "Onchain Payments" to "Transactions"

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->