### PR TITLE
fix(portal): update prefix URL in EditPage component

### DIFF
--- a/apps/portal/src/components/Document/EditPage.tsx
+++ b/apps/portal/src/components/Document/EditPage.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { BsGithub } from "react-icons/bs";
 
-const prefix = `https://github.com/thirdweb-dev/docs-v2/edit/main/src/app`;
+const prefix = `https://github.com/thirdweb-dev/js/edit/main/apps/portal/src/app`;
 
 export function EditPage(props: { path: string }) {
 	return (


### PR DESCRIPTION
Updated the GitHub edit URL prefix in the EditPage component from 'https://github.com/thirdweb-dev/docs-v2/edit/main/src/app' to 'https://github.com/thirdweb-dev/js/edit/main/apps/portal/src/app'.

---

## Problem solved

Short description of the bug fixed or feature added



<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the GitHub prefix URL in the `EditPage` component of the portal app.

### Detailed summary
- Updated the GitHub prefix URL in the `EditPage` component from `docs-v2` to `js` in the portal app.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->