### PR TITLE
[Fix] Handle account switching inside connected wallet for SIWE auth

### DIFF
--- a/.changeset/ninety-balloons-accept.md
+++ b/.changeset/ninety-balloons-accept.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+handle switching accounts inside a connected wallet in SIWE auth states

--- a/apps/playground-web/next.config.mjs
+++ b/apps/playground-web/next.config.mjs
@@ -49,9 +49,6 @@ const nextConfig = {
     config.externals.push("pino-pretty", "lokijs", "encoding");
     return config;
   },
-  experimental: {
-    serverExternalPackages: ["@shikijs/twoslash", "prettier", "shiki"],
-  },
 };
 
 export default nextConfig;

--- a/apps/playground-web/package.json
+++ b/apps/playground-web/package.json
@@ -16,7 +16,6 @@
     "@radix-ui/react-dropdown-menu": "^2.1.1",
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-tabs": "^1.1.0",
-    "@shikijs/twoslash": "^1.10.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "lucide-react": "^0.399.0",

--- a/apps/playground-web/src/app/connect/auth/server/actions/auth.ts
+++ b/apps/playground-web/src/app/connect/auth/server/actions/auth.ts
@@ -1,6 +1,7 @@
 "use server";
 import { THIRDWEB_CLIENT } from "@/lib/client";
 import { cookies } from "next/headers";
+import { getAddress } from "thirdweb";
 import { type VerifyLoginPayloadParams, createAuth } from "thirdweb/auth";
 import { generateAccount, privateKeyToAccount } from "thirdweb/wallets";
 
@@ -25,17 +26,28 @@ export async function login(payload: VerifyLoginPayloadParams) {
   }
 }
 
-export async function isLoggedIn() {
+export async function isLoggedIn(address: string) {
+  // if no address is passed then return false
+  if (!address) {
+    return false;
+  }
   const jwt = cookies().get("jwt");
+  // if no jwt is found then return false
   if (!jwt?.value) {
     return false;
   }
 
   const authResult = await thirdwebAuth.verifyJWT({ jwt: jwt.value });
+  // if the JWT is not valid then return false
   if (!authResult.valid) {
     return false;
   }
-  return authResult;
+  // if the address in the JWT does not match the address we are checking for then return false
+  if (getAddress(authResult.parsedJWT.sub) !== getAddress(address)) {
+    return false;
+  }
+  // we are logged in
+  return true;
 }
 
 export async function getAuthResult(jwtValue: string) {

--- a/apps/playground-web/src/components/auth/auth-button.tsx
+++ b/apps/playground-web/src/components/auth/auth-button.tsx
@@ -14,19 +14,10 @@ export function AuthButton() {
     <ConnectButton
       client={THIRDWEB_CLIENT}
       auth={{
-        isLoggedIn: async () => {
-          const authResult = await isLoggedIn();
-          if (!authResult) return false;
-          return true;
-        },
-        doLogin: async (params) => {
-          console.log("logging in!");
-          await login(params);
-        },
-        getLoginPayload: async ({ address }) => generatePayload({ address }),
-        doLogout: async () => {
-          await logout();
-        },
+        isLoggedIn: (address) => isLoggedIn(address),
+        doLogin: (params) => login(params),
+        getLoginPayload: ({ address }) => generatePayload({ address }),
+        doLogout: () => logout(),
       }}
     />
   );

--- a/apps/playground-web/src/components/auth/gated-content.tsx
+++ b/apps/playground-web/src/components/auth/gated-content.tsx
@@ -1,5 +1,6 @@
-import { isLoggedIn } from "@/app/connect/auth/server/actions/auth";
+import { getAuthResult } from "@/app/connect/auth/server/actions/auth";
 import { THIRDWEB_CLIENT } from "@/lib/client";
+import { cookies } from "next/headers";
 import Link from "next/link";
 import { getContract } from "thirdweb";
 import { sepolia } from "thirdweb/chains";
@@ -7,7 +8,8 @@ import { balanceOf } from "thirdweb/extensions/erc20";
 import { AuthButton } from "./auth-button";
 
 export async function GatedContentPreview() {
-  const authResult = await isLoggedIn();
+  const jwt = cookies().get("jwt");
+  const authResult = await getAuthResult(jwt?.value || "");
   if (!authResult) {
     return (
       <div className="flex flex-col gap-5">

--- a/packages/thirdweb/src/react/core/hooks/auth/useSiweAuth.ts
+++ b/packages/thirdweb/src/react/core/hooks/auth/useSiweAuth.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { LoginPayload } from "../../../../auth/core/types.js";
 import type { VerifyLoginPayloadParams } from "../../../../auth/core/verify-login-payload.js";
-import type { Wallet } from "../../../../wallets/interfaces/wallet.js";
+import type { Account, Wallet } from "../../../../wallets/interfaces/wallet.js";
 
 /**
  * Options for Setting up SIWE (Sign in with Ethereum) Authentication
@@ -48,10 +48,9 @@ export type SiweAuthOptions = {
  */
 export function useSiweAuth(
   activeWallet?: Wallet,
+  activeAccount?: Account,
   authOptions?: SiweAuthOptions,
 ) {
-  const activeAccount = activeWallet?.getAccount();
-
   const requiresAuth = !!authOptions;
 
   const queryClient = useQueryClient();

--- a/packages/thirdweb/src/react/native/ui/connect/ConnectButton.tsx
+++ b/packages/thirdweb/src/react/native/ui/connect/ConnectButton.tsx
@@ -45,7 +45,7 @@ export function ConnectButton(props: ConnectButtonProps) {
   const wallet = useActiveWallet();
   const account = useActiveAccount();
   const status = useActiveWalletConnectionStatus();
-  const siweAuth = useSiweAuth(wallet, props.auth);
+  const siweAuth = useSiweAuth(wallet, account, props.auth);
   useAutoConnect(props);
 
   const fadeAnim = useRef(new Animated.Value(0)); // For background opacity

--- a/packages/thirdweb/src/react/native/ui/connect/ConnectModal.tsx
+++ b/packages/thirdweb/src/react/native/ui/connect/ConnectModal.tsx
@@ -9,6 +9,7 @@ import type { Theme } from "../../../core/design-system/index.js";
 import { useSiweAuth } from "../../../core/hooks/auth/useSiweAuth.js";
 import type { ConnectButtonProps } from "../../../core/hooks/connection/ConnectButtonProps.js";
 import type { ConnectEmbedProps } from "../../../core/hooks/connection/ConnectEmbedProps.js";
+import { useActiveAccount } from "../../../core/hooks/wallets/useActiveAccount.js";
 import { useActiveWallet } from "../../../core/hooks/wallets/useActiveWallet.js";
 import { useDisconnect } from "../../../core/hooks/wallets/useDisconnect.js";
 import { useConnectionManager } from "../../../core/providers/connection-manager.js";
@@ -60,7 +61,8 @@ export type ModalState =
 export function ConnectEmbed(props: ConnectEmbedProps) {
   const theme = parseTheme(props.theme);
   const wallet = useActiveWallet();
-  const siweAuth = useSiweAuth(wallet, props.auth);
+  const account = useActiveAccount();
+  const siweAuth = useSiweAuth(wallet, account, props.auth);
   const needsAuth = siweAuth.requiresAuth && !siweAuth.isLoggedIn;
   const isConnected = wallet && !needsAuth;
   const adaptedProps = {

--- a/packages/thirdweb/src/react/native/ui/connect/ConnectedModal.tsx
+++ b/packages/thirdweb/src/react/native/ui/connect/ConnectedModal.tsx
@@ -310,9 +310,9 @@ const ViewFunds = (props: ConnectedModalPropsInner) => {
 };
 
 const DisconnectWallet = (props: ConnectedModalProps) => {
-  const { wallet, theme, onClose } = props;
+  const { wallet, account, theme, onClose } = props;
   const { disconnect } = useDisconnect();
-  const siweAuth = useSiweAuth(wallet, props.auth);
+  const siweAuth = useSiweAuth(wallet, account, props.auth);
   return (
     <TouchableOpacity
       style={styles.walletMenuRow}

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/ConnectButton.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/ConnectButton.tsx
@@ -363,7 +363,7 @@ function ConnectButtonInner(
 ) {
   const activeWallet = useActiveWallet();
   const activeAccount = useActiveAccount();
-  const siweAuth = useSiweAuth(activeWallet, props.auth);
+  const siweAuth = useSiweAuth(activeWallet, activeAccount, props.auth);
   const [showSignatureModal, setShowSignatureModal] = useState(false);
 
   // if wallet gets disconnected suddently, close the signature modal if it's open

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/ConnectEmbed.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/ConnectEmbed.tsx
@@ -181,7 +181,7 @@ import { useSetupScreen } from "./screen.js";
 export function ConnectEmbed(props: ConnectEmbedProps) {
   const activeWallet = useActiveWallet();
   const activeAccount = useActiveAccount();
-  const siweAuth = useSiweAuth(activeWallet, props.auth);
+  const siweAuth = useSiweAuth(activeWallet, activeAccount, props.auth);
   const show =
     !activeAccount || (siweAuth.requiresAuth && !siweAuth.isLoggedIn);
 
@@ -334,8 +334,8 @@ const ConnectEmbedContent = (props: {
   });
   const { setScreen, initialScreen, screen } = screenSetup;
   const activeWallet = useActiveWallet();
-  const siweAuth = useSiweAuth(activeWallet, props.auth);
   const activeAccount = useActiveAccount();
+  const siweAuth = useSiweAuth(activeWallet, activeAccount, props.auth);
 
   const isAutoConnecting = useIsAutoConnecting();
 

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/ConnectModalContent.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/ConnectModalContent.tsx
@@ -9,6 +9,7 @@ import {
   type SiweAuthOptions,
   useSiweAuth,
 } from "../../../../core/hooks/auth/useSiweAuth.js";
+import { useActiveAccount } from "../../../../core/hooks/wallets/useActiveAccount.js";
 import { useActiveWallet } from "../../../../core/hooks/wallets/useActiveWallet.js";
 import { useSetActiveWallet } from "../../../../core/hooks/wallets/useSetActiveWallet.js";
 import { useConnectionManager } from "../../../../core/providers/connection-manager.js";
@@ -76,9 +77,9 @@ export const ConnectModalContent = (props: {
   const { screen, setScreen, initialScreen } = props.screenSetup;
   const setActiveWallet = useSetActiveWallet();
   const setSelectionData = useSetSelectionData();
-
   const activeWallet = useActiveWallet();
-  const siweAuth = useSiweAuth(activeWallet, props.auth);
+  const activeAccount = useActiveAccount();
+  const siweAuth = useSiweAuth(activeWallet, activeAccount, props.auth);
   const showSignatureScreen = siweAuth.requiresAuth && !siweAuth.isLoggedIn;
   const connectionManager = useConnectionManager();
 

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/SignatureScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/SignatureScreen.tsx
@@ -11,6 +11,7 @@ import {
 } from "../../../../core/design-system/index.js";
 import { useSiweAuth } from "../../../../core/hooks/auth/useSiweAuth.js";
 import type { ConnectButtonProps } from "../../../../core/hooks/connection/ConnectButtonProps.js";
+import { useActiveAccount } from "../../../../core/hooks/wallets/useActiveAccount.js";
 import { useActiveWallet } from "../../../../core/hooks/wallets/useActiveWallet.js";
 import { useDisconnect } from "../../../../core/hooks/wallets/useDisconnect.js";
 import { wait } from "../../../../core/utils/wait.js";
@@ -46,7 +47,8 @@ export const SignatureScreen: React.FC<{
   } = props;
 
   const activeWallet = useActiveWallet();
-  const siweAuth = useSiweAuth(activeWallet, props.auth);
+  const activeAccount = useActiveAccount();
+  const siweAuth = useSiweAuth(activeWallet, activeAccount, props.auth);
   const [status, setStatus] = useState<Status>("idle");
   const { disconnect } = useDisconnect();
   const wallet = useActiveWallet();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -540,9 +540,6 @@ importers:
       '@radix-ui/react-tabs':
         specifier: ^1.1.0
         version: 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@shikijs/twoslash':
-        specifier: ^1.10.0
-        version: 1.10.0(typescript@5.5.4)
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.0
@@ -7782,9 +7779,6 @@ packages:
   '@shikijs/core@1.10.0':
     resolution: {integrity: sha512-BZcr6FCmPfP6TXaekvujZcnkFmJHZ/Yglu97r/9VjzVndQA56/F4WjUKtJRQUnK59Wi7p/UTAOekMfCJv7jnYg==}
 
-  '@shikijs/twoslash@1.10.0':
-    resolution: {integrity: sha512-LMvsYyFs73Saf0VsxrScXQZkV2UszxnYa4gGJbK0Ct8NH6YpQDg+FROsNsbqKk+SsKsbbydZP0W8ojKuvq69pA==}
-
   '@shuding/opentype.js@1.4.0-beta.0':
     resolution: {integrity: sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==}
     engines: {node: '>= 8.0.0'}
@@ -8978,9 +8972,6 @@ packages:
   '@typescript-eslint/visitor-keys@7.2.0':
     resolution: {integrity: sha512-c6EIQRHhcpl6+tO8EMR+kjkkV+ugUNXOmeASA1rlzkd8EPIriavpWoiEz1HR/VLhbVIdhqnV6E7JZm00cBDx2A==}
     engines: {node: ^16.0.0 || >=18.0.0}
-
-  '@typescript/vfs@1.5.0':
-    resolution: {integrity: sha512-AJS307bPgbsZZ9ggCT3wwpg3VbTKMFNHfaY/uF0ahSkYYrPF2dSSKDNIDIQAHm9qJqbLvCsSJH7yN4Vs/CsMMg==}
 
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
@@ -17679,14 +17670,6 @@ packages:
 
   tweetnacl@1.0.3:
     resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
-
-  twoslash-protocol@0.2.9:
-    resolution: {integrity: sha512-uKQl8UboT6JU4VAtYaSI3DbNtgaNhFaTpCSMy/n3tRl5lMlMhrjiuNKdqx15xjcviconuGJ9oObkz1h9zJFrJg==}
-
-  twoslash@0.2.9:
-    resolution: {integrity: sha512-oj7XY6h8E9nTZBmfRE1gpsSSUqAQo5kcIpFkXyQPp8UCsyCQsUlP2bJ2s32o02c1n5+xl4h9rcCsQ1F97Z6LZg==}
-    peerDependencies:
-      typescript: '*'
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -28333,14 +28316,6 @@ snapshots:
 
   '@shikijs/core@1.10.0': {}
 
-  '@shikijs/twoslash@1.10.0(typescript@5.5.4)':
-    dependencies:
-      '@shikijs/core': 1.10.0
-      twoslash: 0.2.9(typescript@5.5.4)
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
   '@shuding/opentype.js@1.4.0-beta.0':
     dependencies:
       fflate: 0.7.3
@@ -30007,12 +29982,6 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 7.2.0
       eslint-visitor-keys: 3.4.3
-
-  '@typescript/vfs@1.5.0':
-    dependencies:
-      debug: 4.3.5(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
 
   '@ungap/structured-clone@1.2.0': {}
 
@@ -41881,16 +41850,6 @@ snapshots:
   tweetnacl-util@0.15.1: {}
 
   tweetnacl@1.0.3: {}
-
-  twoslash-protocol@0.2.9: {}
-
-  twoslash@0.2.9(typescript@5.5.4):
-    dependencies:
-      '@typescript/vfs': 1.5.0
-      twoslash-protocol: 0.2.9
-      typescript: 5.5.4
-    transitivePeerDependencies:
-      - supports-color
 
   type-check@0.4.0:
     dependencies:


### PR DESCRIPTION
FIXES: #3912

### TL;DR
This PR fixes the handling of account switching within a connected wallet in Sign-In with Ethereum (SIWE) authentication states.

### What changed?
- Updated the `isLoggedIn` function to accept an `address` argument and added more checks to validate the JWT and the associated address.
- Pass `account` as a new parameter to `useSiweAuth` to ensure the correct account is handled.
- Removed experimental server external packages from `next.config.mjs`.
- Removed `@shikijs/twoslash` dependency from `package.json`.

### How to test?
1. Switch accounts within a connected wallet and ensure the SIWE authentication state updates correctly.
2. Verify that the application runs without errors related to the removed experimental packages and dependencies.

### Why make this change?
To ensure better account management and state consistency within the SIWE authentication framework, and to remove unused or experimental configurations for better stability and performance.

---

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances SIWE auth handling in connected wallets. 

### Detailed summary
- Updated `useSiweAuth` to include `activeAccount`
- Modified auth functions to use address parameter for verification
- Improved logic for checking authentication status

> The following files were skipped due to too many changes: `pnpm-lock.yaml`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->