### PR TITLE
fix: update import statement for smartWallet in smart-wallet.ts

### DIFF
--- a/packages/thirdweb/src/wallets/smart/smart-wallet.ts
+++ b/packages/thirdweb/src/wallets/smart/smart-wallet.ts
@@ -38,7 +38,7 @@ import { DEFAULT_ACCOUNT_FACTORY } from "./lib/constants.js";
  * The `sponsorGas` option is used to enable sponsored gas for transactions automatically.
  *
  * ```ts
- * import { smartWalletm inAppWallet } from "thirdweb/wallets";
+ * import { smartWallet, inAppWallet } from "thirdweb/wallets";
  * import { sepolia } from "thirdweb/chains";
  * import { sendTransaction } from "thirdweb";
  *


### PR DESCRIPTION
Got an error while experimenting with the first code snippet provided on [this](https://portal.thirdweb.com/typescript/v5/smartWallet) page. Found out it's just a simple typo, that is fixed now.

![Screenshot (115)](https://github.com/user-attachments/assets/3d9ec54c-3358-4440-bd35-cd314dd3ab13)

Moreover, I noticed the link that says `Edit this page` doesn't point to the right file in this repository. Probably you guys are aware of it, just letting you know!

![image_2024-08-06_175923961](https://github.com/user-attachments/assets/f1ac4534-dd2f-41a5-8df8-ff2e60a44131)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the import statement in `smart-wallet.ts` to correct the spelling of `smartWallet`.

### Detailed summary
- Fixed import statement for `smartWallet` in `smart-wallet.ts`
- No other significant changes made

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->