### PR TITLE
test(ts): adds test case for signMessage

### DIFF
--- a/packages/thirdweb/src/utils/signatures/sign-message.test.ts
+++ b/packages/thirdweb/src/utils/signatures/sign-message.test.ts
@@ -21,6 +21,15 @@ test("default", async () => {
   ).toMatchInlineSnapshot(
     '"0xc0cd7599731c37aa4c0815a89dc8dcb4ce479f83df7ee8ffc606a9ef29323e814b54bb8935b56e7c690f1ee4c6290da5c2f6df6fc3443fbe96bb1846a2c4fefc1c"',
   );
+
+  expect(
+    signMessage({
+      message: "0x787037Ba5b7eA8a8737627FfB67d35FdCaAd9A18",
+      privateKey: ANVIL_PKEY_A,
+    }),
+  ).toMatchInlineSnapshot(
+    '"0x151436da0ef734f06ae71f4b907a062fa5683b40af4221e86dfe5f2fc9f09ffa40c90fee4a0e48311506b84dc6f20e513dc4dc434f0f70a03af6ff3e22c7b7591c"',
+  );
 });
 
 test("raw", async () => {


### PR DESCRIPTION
### TL;DR

Added a new test case to `sign-message.test.ts` to verify the signature generated by the `signMessage` function when provided with a specific message and private key.

### What changed?

The test file `sign-message.test.ts` in the `thirdweb` package has been updated to include a new test case that checks the signature generated by the `signMessage` function.

### How to test?

Run the test suite for the `thirdweb` package to ensure all tests, including the new one, pass correctly.

### Why make this change?

To enhance test coverage and ensure that the `signMessage` function generates the expected signature when given specific inputs.

---




<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the test case for signing a message in the `sign-message.test.ts` file.

### Detailed summary
- Updated the test case for signing a message with a specific private key
- Added an additional test case for a raw message signing operation

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->