### PR TITLE
CI: Fix benchmarks

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -142,6 +142,31 @@ jobs:
             echo "Bundling failed"
             exit 1
           fi
+      
+
+  benchmark:
+    # cannot run benchmarks on merge group
+    if: github.event_name != 'merge_group'
+    timeout-minutes: 15
+    name: "Benchmarks"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v4
+
+      - name: Setup & Install
+        uses: ./.github/composite-actions/install
+
+      - name: Set up foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          cache: false
+
+      - name: Run benchmarks
+        uses: CodSpeedHQ/action@v3
+        with:
+          token: ${{ secrets.CODSPEED_TOKEN }}
+          run: "pnpm bench"
 
   size:
     # only run on pull requests

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@biomejs/biome": "1.8.3",
     "@changesets/changelog-github": "0.5.0",
     "@changesets/cli": "2.27.6",
-    "@codspeed/vitest-plugin": "3.1.0",
+    "@codspeed/vitest-plugin": "3.1.1",
     "@manypkg/cli": "0.21.4",
     "@manypkg/get-packages": "2.2.2",
     "@playwright/test": "1.44.1",

--- a/packages/thirdweb/src/utils/any-evm/keccak-id.bench.ts
+++ b/packages/thirdweb/src/utils/any-evm/keccak-id.bench.ts
@@ -1,8 +1,6 @@
 import { bench } from "vitest";
 import { keccakId } from "./keccak-id.js";
 
-const input = "Hello, World!";
-
-bench("keccakId", () => {
-  keccakId(input);
+bench("keccakId - Hello, World!", () => {
+  keccakId("Hello, World!");
 });

--- a/packages/thirdweb/src/utils/toUnits.bench.ts
+++ b/packages/thirdweb/src/utils/toUnits.bench.ts
@@ -1,0 +1,10 @@
+import { bench } from "vitest";
+import { toUnits } from "./units.js";
+
+bench(`units:toUnits("40", 18)`, () => {
+  toUnits("40", 18);
+});
+
+bench(`units:toUnits("40.0", 18)`, () => {
+  toUnits("40.0", 18);
+});

--- a/packages/thirdweb/src/utils/units.bench.ts
+++ b/packages/thirdweb/src/utils/units.bench.ts
@@ -1,5 +1,5 @@
 import { bench } from "vitest";
-import { toTokens, toUnits } from "./units.js";
+import { toTokens } from "./units.js";
 
 bench("units:toTokens(12345678901234567890n, 18)", () => {
   toTokens(12345678901234567890n, 18);
@@ -7,12 +7,4 @@ bench("units:toTokens(12345678901234567890n, 18)", () => {
 
 bench("units:toTokens(40000000000000000000n, 18)", () => {
   toTokens(40000000000000000000n, 18);
-});
-
-bench(`units:toUnits("40", 18)`, () => {
-  toUnits("40", 18);
-});
-
-bench(`units:toUnits("40.0", 18)`, () => {
-  toUnits("40.0", 18);
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,8 +54,8 @@ importers:
         specifier: 2.27.6
         version: 2.27.6
       '@codspeed/vitest-plugin':
-        specifier: 3.1.0
-        version: 3.1.0(vite@5.3.1(@types/node@20.14.9)(terser@5.31.0))(vitest@1.6.0(@types/node@20.14.9)(@vitest/ui@1.6.0)(happy-dom@14.12.3)(terser@5.31.0))
+        specifier: 3.1.1
+        version: 3.1.1(vite@5.3.1(@types/node@20.14.9)(terser@5.31.0))(vitest@1.6.0(@types/node@20.14.9)(@vitest/ui@1.6.0)(happy-dom@14.12.3)(terser@5.31.0))
       '@manypkg/cli':
         specifier: 0.21.4
         version: 0.21.4
@@ -4721,11 +4721,11 @@ packages:
   '@cloudflare/workers-types@4.20240405.0':
     resolution: {integrity: sha512-sEVOhyOgXUwfLkgHqbLZa/sfkSYrh7/zLmI6EZNibPaVPvAnAcItbNNl3SAlLyLKuwf8m4wAIAgu9meKWCvXjg==}
 
-  '@codspeed/core@3.1.0':
-    resolution: {integrity: sha512-oYd7X46QhnRkgRbZkqAoX9i3Fwm17FpunK4Ee5RdrvRYR0Xr93ewH8/O5g6uyTPDOOqDEv1v2KRYtWhVgN+2VQ==}
+  '@codspeed/core@3.1.1':
+    resolution: {integrity: sha512-ONhERVDAtkm0nc+FYPivDozoMOlNUP2BWRBFDJYATGA18Iap5Kd2mZ1/Lwz54RB5+g+3YDOpsvotHa4hd3Q+7Q==}
 
-  '@codspeed/vitest-plugin@3.1.0':
-    resolution: {integrity: sha512-ms11tUytiQTgB+idxZRUuCUQfgz4LaKTDJCLYm5VTSpOCUU7D5+QWvJnA8X8B9glPfR5siIK8RxrnZP4yuysKQ==}
+  '@codspeed/vitest-plugin@3.1.1':
+    resolution: {integrity: sha512-/PJUgxIfuRqpBSbaD8bgWXtbXxCqgnW89dzr3220fMkx/LA6z6oUb4tJGjeVsOWAzAgu0VBdSA+8hC+7D9BIuQ==}
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0
       vitest: '>=1.2.2'
@@ -23726,7 +23726,7 @@ snapshots:
 
   '@cloudflare/workers-types@4.20240405.0': {}
 
-  '@codspeed/core@3.1.0':
+  '@codspeed/core@3.1.1':
     dependencies:
       axios: 1.6.8
       find-up: 6.3.0
@@ -23735,9 +23735,9 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@codspeed/vitest-plugin@3.1.0(vite@5.3.1(@types/node@20.14.9)(terser@5.31.0))(vitest@1.6.0(@types/node@20.14.9)(@vitest/ui@1.6.0)(happy-dom@14.12.3)(terser@5.31.0))':
+  '@codspeed/vitest-plugin@3.1.1(vite@5.3.1(@types/node@20.14.9)(terser@5.31.0))(vitest@1.6.0(@types/node@20.14.9)(@vitest/ui@1.6.0)(happy-dom@14.12.3)(terser@5.31.0))':
     dependencies:
-      '@codspeed/core': 3.1.0
+      '@codspeed/core': 3.1.1
       vite: 5.3.1(@types/node@20.14.9)(terser@5.31.0)
       vitest: 1.6.0(@types/node@20.14.9)(@vitest/ui@1.6.0)(happy-dom@14.12.3)(terser@5.31.0)
     transitivePeerDependencies:


### PR DESCRIPTION
This pull request introduces a new benchmark job to the CI workflow and updates existing benchmark test cases. The changes include:

1. **CI Workflow**
   - Added a `benchmark` job in the GitHub Actions workflow (`.github/workflows/CI.yml`).
   - The `benchmark` job checks out the code, sets up the environment, and runs benchmarks using `CodSpeedHQ/action@v3`.
   - Added conditional to prevent running benchmarks on merge groups.
2. **Benchmark Tests**
   - Modified `keccak-id.bench.ts` to create a more descriptive benchmark test name.
   - Added a new benchmark test, `toUnits.bench.ts`, for `toUnits` function.
   - Removed `toUnits` benchmarks from `units.bench.ts` to avoid duplication.

### TL;DR

Adds and updates benchmark jobs and tests in CI workflow.

### What changed?

- Added a new `benchmark` job within the CI workflow file.
- Updated existing benchmark test names to be more descriptive.
- Added a new benchmark test file for `toUnits` function.
- Prevent duplicate benchmarks by refactoring existing tests.

### How to test?

Run the CI pipeline and check the benchmark job for successful execution. Verify benchmark results and ensure no duplications.

### Why make this change?

To enhance the continuous integration process with benchmark tests, ensuring code performance metrics are tracked and maintained.

---

## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates dependencies, refactors benchmark tests, and adds a CI workflow for running benchmarks on pull requests.

### Detailed summary
- Updated `@codspeed/vitest-plugin` to version `3.1.1`
- Refactored benchmark tests for `keccakId` and `toUnits`
- Added CI workflow to run benchmarks on pull requests

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->