### PR TITLE
Dashboard v5: Remove v4 code

### DIFF
--- a/apps/dashboard/src/@3rdweb-sdk/react/components/roles/admin-only.tsx
+++ b/apps/dashboard/src/@3rdweb-sdk/react/components/roles/admin-only.tsx
@@ -2,11 +2,11 @@ import {
   useIsAdmin,
   useIsAdminOrSelf,
 } from "@3rdweb-sdk/react/hooks/useContractRoles";
-import type { ValidContractInstance } from "@thirdweb-dev/sdk";
+import type { ThirdwebContract } from "thirdweb";
 import type { ComponentWithChildren } from "types/component-with-children";
 
 interface AdminOnlyProps {
-  contract?: ValidContractInstance;
+  contract: ThirdwebContract;
   fallback?: JSX.Element;
 }
 
@@ -22,7 +22,9 @@ export const AdminOnly: ComponentWithChildren<AdminOnlyProps> = ({
   return <>{children}</>;
 };
 
-interface AdminOrSelfOnlyProps extends AdminOnlyProps {
+interface AdminOrSelfOnlyProps {
+  contract: ThirdwebContract;
+  fallback?: JSX.Element;
   /**
    * The address of the account to check against
    */

--- a/apps/dashboard/src/@3rdweb-sdk/react/hooks/useContractRoles.ts
+++ b/apps/dashboard/src/@3rdweb-sdk/react/hooks/useContractRoles.ts
@@ -1,74 +1,29 @@
-import {
-  type ContractWithRoles,
-  type RolesForContract,
-  useContractType,
-  useRoleMembers,
-} from "@thirdweb-dev/react";
-import type { ValidContractInstance } from "@thirdweb-dev/sdk";
 import { type ThirdwebContract, ZERO_ADDRESS } from "thirdweb";
 import { hasRole } from "thirdweb/extensions/permissions";
 import { useActiveAccount, useReadContract } from "thirdweb/react";
 import type { RequiredParam } from "utils/types";
 
-function isContractWithRoles(
-  contract: RequiredParam<ValidContractInstance>,
-): contract is ContractWithRoles {
-  if (contract && "roles" in contract) {
-    return true;
-  }
-  return false;
-}
-
-function useIsAccountRole<TContract extends ContractWithRoles>(
-  role: RolesForContract<TContract>[number],
-  contract: RequiredParam<TContract>,
-  account: RequiredParam<string>,
-): boolean {
-  const contractHasRoles = isContractWithRoles(contract);
-  const { data } = useRoleMembers(contract, role);
-
-  if (contractHasRoles === false) {
-    return false;
-  }
-
-  if (data?.includes(ZERO_ADDRESS)) {
-    return true;
-  }
-
-  return !!(account && data?.includes(account));
-}
-
-export function useIsAdmin<TContract extends ValidContractInstance>(
-  contract: RequiredParam<TContract>,
-) {
+export function useIsAdmin(contract: ThirdwebContract) {
   const address = useActiveAccount()?.address;
-  const { data: contractType } = useContractType(contract?.getAddress());
+  const { data: userIsAdmin, isError } = useReadContract(hasRole, {
+    contract,
+    targetAccountAddress: address ?? "",
+    role: "admin",
+    queryOptions: { enabled: !!address },
+  });
 
-  const contractHasRoles = isContractWithRoles(contract);
-  const isAccountRole = useIsAccountRole(
-    "admin",
-    contractHasRoles ? contract : undefined,
-    address,
-  );
-
-  if (contractType === "custom") {
-    return true;
-  }
-  return isAccountRole;
+  // If the request results in an error, it's likely that the contract is a non-thirdweb contract
+  // in that case we return `true` anyway
+  return userIsAdmin || isError;
 }
 
-export function useIsAdminOrSelf<TContract extends ValidContractInstance>(
-  contract: RequiredParam<TContract>,
+export function useIsAdminOrSelf(
+  contract: ThirdwebContract,
   self: RequiredParam<string>,
 ) {
   const address = useActiveAccount()?.address;
-  const { data: contractType } = useContractType(contract?.getAddress());
   const isAdmin = useIsAdmin(contract);
-
   if (address === self) {
-    return true;
-  }
-  if (contractType === "custom") {
     return true;
   }
   return isAdmin;

--- a/apps/dashboard/src/contract-ui/tabs/claim-conditions/components/claim-conditions-form/index.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/claim-conditions/components/claim-conditions-form/index.tsx
@@ -24,7 +24,6 @@ import {
   type ClaimConditionInput,
   ClaimConditionInputSchema,
   type SnapshotEntry,
-  type ValidContractInstance,
 } from "@thirdweb-dev/sdk";
 import { TransactionButton } from "components/buttons/TransactionButton";
 import { TooltipBox } from "components/configure-networks/Form/TooltipBox";
@@ -44,7 +43,11 @@ import {
   useForm,
 } from "react-hook-form";
 import { FiPlus } from "react-icons/fi";
-import { NATIVE_TOKEN_ADDRESS, ZERO_ADDRESS } from "thirdweb";
+import {
+  NATIVE_TOKEN_ADDRESS,
+  type ThirdwebContract,
+  ZERO_ADDRESS,
+} from "thirdweb";
 import { useActiveAccount } from "thirdweb/react";
 import invariant from "tiny-invariant";
 import { Button, Heading, MenuItem, Text } from "tw-components";
@@ -184,12 +187,14 @@ interface ClaimConditionsFormProps {
   contract: DropContract;
   tokenId?: string;
   isColumn?: true;
+  contractV5: ThirdwebContract;
 }
 
 export const ClaimConditionsForm: React.FC<ClaimConditionsFormProps> = ({
   contract,
   tokenId,
   isColumn,
+  contractV5,
 }) => {
   const { isMultiPhase, isClaimPhaseV1, isErc20 } = useMemo(() => {
     return {
@@ -202,7 +207,7 @@ export const ClaimConditionsForm: React.FC<ClaimConditionsFormProps> = ({
   const walletAddress = useActiveAccount()?.address;
   const trackEvent = useTrack();
   const [resetFlag, setResetFlag] = useState(false);
-  const isAdmin = useIsAdmin(contract);
+  const isAdmin = useIsAdmin(contractV5);
   const [openSnapshotIndex, setOpenSnapshotIndex] = useState(-1);
   const setClaimConditionsQuery = useSetClaimConditions(contract, tokenId);
 
@@ -549,74 +554,79 @@ export const ClaimConditionsForm: React.FC<ClaimConditionsFormProps> = ({
             gap={2}
           >
             <Flex gap={2}>
-              <AdminOnly contract={contract as ValidContractInstance}>
-                {!isClaimPhaseV1 ? (
-                  <>
-                    <Menu>
-                      <MenuButton
-                        as={Button}
-                        size="sm"
-                        colorScheme="primary"
-                        variant={phases?.length > 0 ? "outline" : "solid"}
-                        borderRadius="md"
-                        leftIcon={<Icon as={FiPlus} />}
-                        isDisabled={
-                          setClaimConditionsQuery.isLoading ||
-                          (!isMultiPhase && phases?.length > 0)
-                        }
-                      >
-                        Add {isMultiPhase ? "Phase" : "Claim Conditions"}
-                      </MenuButton>
-                      <MenuList
-                        borderRadius="lg"
-                        overflow="hidden"
-                        zIndex="overlay"
-                      >
-                        {Object.keys(ClaimConditionTypeData).map((key) => {
-                          const type = key as ClaimConditionType;
-
-                          if (type === "custom") {
-                            return null;
+              {contractV5 && (
+                <AdminOnly contract={contractV5}>
+                  {!isClaimPhaseV1 ? (
+                    <>
+                      <Menu>
+                        <MenuButton
+                          as={Button}
+                          size="sm"
+                          colorScheme="primary"
+                          variant={phases?.length > 0 ? "outline" : "solid"}
+                          borderRadius="md"
+                          leftIcon={<Icon as={FiPlus} />}
+                          isDisabled={
+                            setClaimConditionsQuery.isLoading ||
+                            (!isMultiPhase && phases?.length > 0)
                           }
+                        >
+                          Add {isMultiPhase ? "Phase" : "Claim Conditions"}
+                        </MenuButton>
+                        <MenuList
+                          borderRadius="lg"
+                          overflow="hidden"
+                          zIndex="overlay"
+                        >
+                          {Object.keys(ClaimConditionTypeData).map((key) => {
+                            const type = key as ClaimConditionType;
 
-                          return (
-                            <MenuItem
-                              key={type}
-                              onClick={() => {
-                                addPhase(type);
-                                // TODO: Automatically start editing the new phase after adding it
-                              }}
-                            >
-                              <Flex>
-                                {ClaimConditionTypeData[type].name}
-                                <TooltipBox
-                                  content={
-                                    <Text size="body.md">
-                                      {ClaimConditionTypeData[type].description}
-                                    </Text>
-                                  }
-                                />
-                              </Flex>
-                            </MenuItem>
-                          );
-                        })}
-                      </MenuList>
-                    </Menu>
-                  </>
-                ) : (
-                  <Button
-                    size="sm"
-                    colorScheme="primary"
-                    variant="solid"
-                    borderRadius="md"
-                    leftIcon={<Icon as={FiPlus} />}
-                    onClick={() => addPhase("custom")}
-                    isDisabled={setClaimConditionsQuery.isLoading}
-                  >
-                    Add {isMultiPhase ? "Phase" : "Claim Conditions"}
-                  </Button>
-                )}
-              </AdminOnly>
+                            if (type === "custom") {
+                              return null;
+                            }
+
+                            return (
+                              <MenuItem
+                                key={type}
+                                onClick={() => {
+                                  addPhase(type);
+                                  // TODO: Automatically start editing the new phase after adding it
+                                }}
+                              >
+                                <Flex>
+                                  {ClaimConditionTypeData[type].name}
+                                  <TooltipBox
+                                    content={
+                                      <Text size="body.md">
+                                        {
+                                          ClaimConditionTypeData[type]
+                                            .description
+                                        }
+                                      </Text>
+                                    }
+                                  />
+                                </Flex>
+                              </MenuItem>
+                            );
+                          })}
+                        </MenuList>
+                      </Menu>
+                    </>
+                  ) : (
+                    <Button
+                      size="sm"
+                      colorScheme="primary"
+                      variant="solid"
+                      borderRadius="md"
+                      leftIcon={<Icon as={FiPlus} />}
+                      onClick={() => addPhase("custom")}
+                      isDisabled={setClaimConditionsQuery.isLoading}
+                    >
+                      Add {isMultiPhase ? "Phase" : "Claim Conditions"}
+                    </Button>
+                  )}
+                </AdminOnly>
+              )}
               {controlledFields.some((field) => field.fromSdk) && (
                 <ResetClaimEligibility
                   isErc20={isErc20}
@@ -628,33 +638,32 @@ export const ClaimConditionsForm: React.FC<ClaimConditionsFormProps> = ({
             </Flex>
 
             <Flex>
-              <AdminOnly
-                contract={contract as ValidContractInstance}
-                fallback={<Box pb={5} />}
-              >
-                <Flex justifyContent="center" alignItems="center" gap={3}>
-                  {(hasRemovedPhases || hasAddedPhases) && (
-                    <Text color="red.500" fontWeight="bold">
-                      You have unsaved changes
-                    </Text>
-                  )}
-                  {controlledFields.length > 0 ||
-                  hasRemovedPhases ||
-                  !isMultiPhase ? (
-                    <TransactionButton
-                      colorScheme="primary"
-                      transactionCount={1}
-                      isDisabled={claimConditionsQuery.isLoading}
-                      type="submit"
-                      isLoading={setClaimConditionsQuery.isLoading}
-                      loadingText="Saving..."
-                      size="md"
-                    >
-                      Save Phases
-                    </TransactionButton>
-                  ) : null}
-                </Flex>
-              </AdminOnly>
+              {contractV5 && (
+                <AdminOnly contract={contractV5} fallback={<Box pb={5} />}>
+                  <Flex justifyContent="center" alignItems="center" gap={3}>
+                    {(hasRemovedPhases || hasAddedPhases) && (
+                      <Text color="red.500" fontWeight="bold">
+                        You have unsaved changes
+                      </Text>
+                    )}
+                    {controlledFields.length > 0 ||
+                    hasRemovedPhases ||
+                    !isMultiPhase ? (
+                      <TransactionButton
+                        colorScheme="primary"
+                        transactionCount={1}
+                        isDisabled={claimConditionsQuery.isLoading}
+                        type="submit"
+                        isLoading={setClaimConditionsQuery.isLoading}
+                        loadingText="Saving..."
+                        size="md"
+                      >
+                        Save Phases
+                      </TransactionButton>
+                    ) : null}
+                  </Flex>
+                </AdminOnly>
+              )}
             </Flex>
           </Flex>
         </Flex>

--- a/apps/dashboard/src/contract-ui/tabs/claim-conditions/components/claim-conditions-form/phase.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/claim-conditions/components/claim-conditions-form/phase.tsx
@@ -1,9 +1,11 @@
+import { thirdwebClient } from "@/constants/client";
 import { AdminOnly } from "@3rdweb-sdk/react/components/roles/admin-only";
 import { Box, Flex, Icon, SimpleGrid } from "@chakra-ui/react";
 import type { DropContract } from "@thirdweb-dev/react";
-import type { ValidContractInstance } from "@thirdweb-dev/sdk";
+import { useV5DashboardChain } from "lib/v5-adapter";
 import { FiX } from "react-icons/fi";
 import { RxCaretDown, RxCaretUp } from "react-icons/rx";
+import { getContract } from "thirdweb";
 import { Badge, Button, Card, Heading, Text } from "tw-components";
 import { ClaimConditionTypeData, useClaimConditionsFormContext } from ".";
 import { PricePreview } from "../price-preview";
@@ -44,6 +46,17 @@ export const ClaimConditionsPhase: React.FC<ClaimConditionsPhaseProps> = ({
     form.setValue(`phases.${phaseIndex}.isEditing`, !field.isEditing);
   };
 
+  const chain = useV5DashboardChain(contract?.chainId);
+
+  const contractV5 =
+    contract && chain
+      ? getContract({
+          address: contract.getAddress(),
+          chain,
+          client: thirdwebClient,
+        })
+      : null;
+
   return (
     <Card position="relative" p={8}>
       <Flex direction="column" gap={8}>
@@ -68,18 +81,20 @@ export const ClaimConditionsPhase: React.FC<ClaimConditionsPhaseProps> = ({
           >
             {field.isEditing ? "Collapse" : isAdmin ? "Edit" : "See Phase"}
           </Button>
-          <AdminOnly contract={contract as ValidContractInstance}>
-            <Button
-              variant="ghost"
-              onClick={onRemove}
-              isDisabled={isLoading}
-              colorScheme="red"
-              size="sm"
-              rightIcon={<Icon as={FiX} />}
-            >
-              Remove
-            </Button>
-          </AdminOnly>
+          {contractV5 && (
+            <AdminOnly contract={contractV5}>
+              <Button
+                variant="ghost"
+                onClick={onRemove}
+                isDisabled={isLoading}
+                colorScheme="red"
+                size="sm"
+                rightIcon={<Icon as={FiX} />}
+              >
+                Remove
+              </Button>
+            </AdminOnly>
+          )}
         </Flex>
 
         <Flex flexDir="column" gap={2} mt={{ base: 4, md: 0 }}>

--- a/apps/dashboard/src/contract-ui/tabs/claim-conditions/components/claim-conditions.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/claim-conditions/components/claim-conditions.tsx
@@ -1,9 +1,12 @@
+import { thirdwebClient } from "@/constants/client";
 import { Flex, Stack } from "@chakra-ui/react";
 import type { DropContract, TokenContract } from "@thirdweb-dev/react";
 import { detectFeatures } from "components/contract-components/utils";
 import { UpdateNotice } from "core-ui/update-notice/update-notice";
 import { hasNewClaimConditions } from "lib/claimcondition-utils";
+import { useV5DashboardChain } from "lib/v5-adapter";
 import { useMemo } from "react";
+import { getContract } from "thirdweb";
 import { Heading, Text } from "tw-components";
 import { ClaimConditionsForm } from "./claim-conditions-form/index";
 
@@ -23,6 +26,8 @@ export const ClaimConditions: React.FC<ClaimConditionsProps> = ({
       isErc20: detectFeatures<TokenContract>(contract, ["ERC20"]),
     };
   }, [contract]);
+
+  const chain = useV5DashboardChain(contract?.chainId);
 
   return (
     <Stack spacing={8}>
@@ -58,11 +63,16 @@ export const ClaimConditions: React.FC<ClaimConditionsProps> = ({
           </Flex>
 
           {/* Set Claim Conditions */}
-          {contract && (
+          {contract && chain && (
             <ClaimConditionsForm
               contract={contract}
               tokenId={tokenId}
               isColumn={isColumn}
+              contractV5={getContract({
+                address: contract.getAddress(),
+                chain,
+                client: thirdwebClient,
+              })}
             />
           )}
         </Flex>

--- a/apps/dashboard/src/contract-ui/tabs/claim-conditions/components/reset-claim-eligibility.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/claim-conditions/components/reset-claim-eligibility.tsx
@@ -1,14 +1,16 @@
+import { thirdwebClient } from "@/constants/client";
 import { AdminOnly } from "@3rdweb-sdk/react/components/roles/admin-only";
 import { Box } from "@chakra-ui/react";
 import {
   type DropContract,
   useResetClaimConditions,
 } from "@thirdweb-dev/react";
-import type { ValidContractInstance } from "@thirdweb-dev/sdk";
 import { TransactionButton } from "components/buttons/TransactionButton";
 import { TooltipBox } from "components/configure-networks/Form/TooltipBox";
 import { useTrack } from "hooks/analytics/useTrack";
 import { useTxNotifications } from "hooks/useTxNotifications";
+import { useV5DashboardChain } from "lib/v5-adapter";
+import { getContract } from "thirdweb";
 import { Text } from "tw-components";
 
 interface ResetClaimEligibilityProps {
@@ -60,11 +62,20 @@ export const ResetClaimEligibility: React.FC<ResetClaimEligibilityProps> = ({
     });
   };
 
+  const chain = useV5DashboardChain(contract?.chainId);
+
+  if (!contract || !chain) {
+    return null;
+  }
+
+  const contractV5 = getContract({
+    address: contract.getAddress(),
+    chain,
+    client: thirdwebClient,
+  });
+
   return (
-    <AdminOnly
-      contract={contract as ValidContractInstance}
-      fallback={<Box pb={5} />}
-    >
+    <AdminOnly contract={contractV5} fallback={<Box pb={5} />}>
       <TransactionButton
         colorScheme="secondary"
         bg="bgBlack"

--- a/apps/dashboard/src/contract-ui/tabs/overview/components/ContractChecklist.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/overview/components/ContractChecklist.tsx
@@ -61,7 +61,7 @@ export const ContractChecklist: React.FC<ContractChecklistProps> = ({
     },
   ];
 
-  const isAdmin = useIsAdmin(contract);
+  const isAdmin = useIsAdmin(contractv5);
   const isMinter = useIsMinter(contractv5);
 
   if (!isAdmin) {

--- a/apps/dashboard/src/contract-ui/tabs/permissions/components/contract-permission.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/permissions/components/contract-permission.tsx
@@ -1,9 +1,11 @@
 import { useIsAdmin } from "@3rdweb-sdk/react/hooks/useContractRoles";
 import { Flex, Icon, Select, Spinner, Stack } from "@chakra-ui/react";
 import type { ValidContractInstance } from "@thirdweb-dev/sdk";
+import { thirdwebClient } from "lib/thirdweb-client";
+import { useV5DashboardChain } from "lib/v5-adapter";
 import { useFormContext } from "react-hook-form";
 import { FiInfo } from "react-icons/fi";
-import { ZERO_ADDRESS } from "thirdweb";
+import { ZERO_ADDRESS, getContract } from "thirdweb";
 import { Card, Heading, Text } from "tw-components";
 import { PermissionEditor } from "./permissions-editor";
 
@@ -32,8 +34,13 @@ export const ContractPermission: React.FC<ContractPermissionProps> = ({
   const isRestricted =
     !roleMembers.includes(ZERO_ADDRESS) ||
     (role !== "transfer" && role !== "lister" && role !== "asset");
-
-  const isAdmin = useIsAdmin(contract as ValidContractInstance);
+  const chain = useV5DashboardChain(contract.chainId);
+  const contractV5 = getContract({
+    address: contract.getAddress(),
+    chain,
+    client: thirdwebClient,
+  });
+  const isAdmin = useIsAdmin(contractV5);
 
   return (
     <Card position="relative">
@@ -269,7 +276,7 @@ export const ContractPermission: React.FC<ContractPermissionProps> = ({
           ) : (
             isRestricted &&
             role &&
-            contract && <PermissionEditor role={role} contract={contract} />
+            contract && <PermissionEditor role={role} contract={contractV5} />
           )}
         </Stack>
       </Flex>

--- a/apps/dashboard/src/contract-ui/tabs/permissions/components/permissions-editor.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/permissions/components/permissions-editor.tsx
@@ -16,18 +16,17 @@ import {
   useClipboard,
   useToast,
 } from "@chakra-ui/react";
-import type { ValidContractInstance } from "@thirdweb-dev/sdk";
 import { DelayedDisplay } from "components/delayed-display/delayed-display";
 import { useState } from "react";
 import { useFieldArray, useFormContext } from "react-hook-form";
 import { BiPaste } from "react-icons/bi";
 import { FiCopy, FiInfo, FiPlus, FiTrash } from "react-icons/fi";
-import { ZERO_ADDRESS, isAddress } from "thirdweb";
+import { type ThirdwebContract, ZERO_ADDRESS, isAddress } from "thirdweb";
 import { Button, FormErrorMessage, Text } from "tw-components";
 
 interface PermissionEditorProps {
   role: string;
-  contract: ValidContractInstance;
+  contract: ThirdwebContract;
 }
 
 export const PermissionEditor: React.FC<PermissionEditorProps> = ({
@@ -90,7 +89,7 @@ export const PermissionEditor: React.FC<PermissionEditorProps> = ({
           contract={contract}
         />
       ))}
-      <AdminOnly contract={contract as ValidContractInstance}>
+      <AdminOnly contract={contract}>
         <FormControl
           isDisabled={isSubmitting}
           isInvalid={address && isDisabled}
@@ -164,7 +163,7 @@ interface PermissionAddressProps {
   member: string;
   removeAddress: () => void;
   isSubmitting: boolean;
-  contract: ValidContractInstance;
+  contract: ThirdwebContract;
 }
 
 const PermissionAddress: React.FC<PermissionAddressProps> = ({
@@ -212,10 +211,7 @@ const PermissionAddress: React.FC<PermissionAddressProps> = ({
           defaultValue={member}
           px={2}
         />
-        <AdminOrSelfOnly
-          contract={contract as ValidContractInstance}
-          self={member}
-        >
+        <AdminOrSelfOnly contract={contract} self={member}>
           <InputRightAddon p={0} border="none">
             <Button
               leftIcon={<Icon as={FiTrash} boxSize={3} />}

--- a/apps/dashboard/src/contract-ui/tabs/settings/components/metadata.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/settings/components/metadata.tsx
@@ -153,7 +153,7 @@ export const SettingsMetadata = <
             },
             {},
           );
-          if (!contract || !chain) {
+          if (!contract || !contractV5) {
             return;
           }
 
@@ -163,11 +163,6 @@ export const SettingsMetadata = <
             label: "attempt",
           });
 
-          const contractV5 = getContract({
-            address: contract.getAddress(),
-            chain: chain,
-            client: thirdwebClient,
-          });
           const tx = setContractMetadata({
             contract: contractV5,
             ...data,
@@ -328,22 +323,24 @@ export const SettingsMetadata = <
           </Flex>
         </Flex>
 
-        <AdminOnly contract={contract as ValidContractInstance}>
-          <TransactionButton
-            colorScheme="primary"
-            transactionCount={1}
-            isDisabled={metadata.isLoading || !formState.isDirty}
-            type="submit"
-            isLoading={sendTransaction.isPending}
-            loadingText="Saving..."
-            size="md"
-            borderRadius="xl"
-            borderTopLeftRadius="0"
-            borderTopRightRadius="0"
-          >
-            Update Metadata
-          </TransactionButton>
-        </AdminOnly>
+        {contractV5 && (
+          <AdminOnly contract={contractV5}>
+            <TransactionButton
+              colorScheme="primary"
+              transactionCount={1}
+              isDisabled={metadata.isLoading || !formState.isDirty}
+              type="submit"
+              isLoading={sendTransaction.isPending}
+              loadingText="Saving..."
+              size="md"
+              borderRadius="xl"
+              borderTopLeftRadius="0"
+              borderTopRightRadius="0"
+            >
+              Update Metadata
+            </TransactionButton>
+          </AdminOnly>
+        )}
       </Flex>
     </Card>
   );

--- a/apps/dashboard/src/contract-ui/tabs/settings/components/platform-fees.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/settings/components/platform-fees.tsx
@@ -158,22 +158,24 @@ export const SettingsPlatformFees = <
             </FormControl>
           </Flex>
         </Flex>
-        <AdminOnly contract={contract as ValidContractInstance}>
-          <TransactionButton
-            colorScheme="primary"
-            transactionCount={1}
-            isDisabled={query.isLoading || !form.formState.isDirty}
-            type="submit"
-            isLoading={mutation.isLoading}
-            loadingText="Saving..."
-            size="md"
-            borderRadius="xl"
-            borderTopLeftRadius="0"
-            borderTopRightRadius="0"
-          >
-            Update Platform Fee Settings
-          </TransactionButton>
-        </AdminOnly>
+        {contractV5 && (
+          <AdminOnly contract={contractV5}>
+            <TransactionButton
+              colorScheme="primary"
+              transactionCount={1}
+              isDisabled={query.isLoading || !form.formState.isDirty}
+              type="submit"
+              isLoading={mutation.isLoading}
+              loadingText="Saving..."
+              size="md"
+              borderRadius="xl"
+              borderTopLeftRadius="0"
+              borderTopRightRadius="0"
+            >
+              Update Platform Fee Settings
+            </TransactionButton>
+          </AdminOnly>
+        )}
       </Flex>
     </Card>
   );

--- a/apps/dashboard/src/contract-ui/tabs/settings/components/primary-sale.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/settings/components/primary-sale.tsx
@@ -135,22 +135,24 @@ export const SettingsPrimarySale = <
             </FormControl>
           </Flex>
         </Flex>
-        <AdminOnly contract={contract as ValidContractInstance}>
-          <TransactionButton
-            colorScheme="primary"
-            transactionCount={1}
-            isDisabled={query.isLoading || !form.formState.isDirty}
-            type="submit"
-            isLoading={mutation.isLoading}
-            loadingText="Saving..."
-            size="md"
-            borderRadius="xl"
-            borderTopLeftRadius="0"
-            borderTopRightRadius="0"
-          >
-            Update Primary Sale Settings
-          </TransactionButton>
-        </AdminOnly>
+        {contractV5 && (
+          <AdminOnly contract={contractV5}>
+            <TransactionButton
+              colorScheme="primary"
+              transactionCount={1}
+              isDisabled={query.isLoading || !form.formState.isDirty}
+              type="submit"
+              isLoading={mutation.isLoading}
+              loadingText="Saving..."
+              size="md"
+              borderRadius="xl"
+              borderTopLeftRadius="0"
+              borderTopRightRadius="0"
+            >
+              Update Primary Sale Settings
+            </TransactionButton>
+          </AdminOnly>
+        )}
       </Flex>
     </Card>
   );

--- a/apps/dashboard/src/contract-ui/tabs/settings/components/royalties.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/settings/components/royalties.tsx
@@ -157,22 +157,24 @@ export const SettingsRoyalties = <
             </FormControl>
           </Flex>
         </Flex>
-        <AdminOnly contract={contract as ValidContractInstance}>
-          <TransactionButton
-            colorScheme="primary"
-            transactionCount={1}
-            isDisabled={query.isLoading || !form.formState.isDirty}
-            type="submit"
-            isLoading={mutation.isLoading}
-            loadingText="Saving..."
-            size="md"
-            borderRadius="xl"
-            borderTopLeftRadius="0"
-            borderTopRightRadius="0"
-          >
-            Update Royalty Settings
-          </TransactionButton>
-        </AdminOnly>
+        {contractV5 && (
+          <AdminOnly contract={contractV5}>
+            <TransactionButton
+              colorScheme="primary"
+              transactionCount={1}
+              isDisabled={query.isLoading || !form.formState.isDirty}
+              type="submit"
+              isLoading={mutation.isLoading}
+              loadingText="Saving..."
+              size="md"
+              borderRadius="xl"
+              borderTopLeftRadius="0"
+              borderTopRightRadius="0"
+            >
+              Update Royalty Settings
+            </TransactionButton>
+          </AdminOnly>
+        )}
       </Flex>
     </Card>
   );

--- a/apps/dashboard/src/contract-ui/tabs/tokens/components/claim-button.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/tokens/components/claim-button.tsx
@@ -1,33 +1,28 @@
+import { thirdwebClient } from "@/constants/client";
 import { Icon, useDisclosure } from "@chakra-ui/react";
-import type { TokenContract, useContract } from "@thirdweb-dev/react";
-import { detectFeatures } from "components/contract-components/utils";
+import { useV5DashboardChain } from "lib/v5-adapter";
 import { GiDiamondHard } from "react-icons/gi";
+import { getContract } from "thirdweb";
 import { Button, Drawer } from "tw-components";
 import { TokenClaimForm } from "./claim-form";
 
 interface TokenClaimButtonProps {
-  contractQuery: ReturnType<typeof useContract>;
+  contractAddress: string;
+  chainId: number;
 }
 
 export const TokenClaimButton: React.FC<TokenClaimButtonProps> = ({
-  contractQuery,
+  contractAddress,
+  chainId,
   ...restButtonProps
 }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
-
-  const isERC20Claimable = detectFeatures<TokenContract>(
-    contractQuery.contract,
-    [
-      "ERC20ClaimConditionsV1",
-      "ERC20ClaimConditionsV2",
-      "ERC20ClaimPhasesV1",
-      "ERC20ClaimPhasesV2",
-    ],
-  );
-
-  if (!isERC20Claimable || !contractQuery.contract) {
-    return null;
-  }
+  const chain = useV5DashboardChain(chainId);
+  const contract = getContract({
+    address: contractAddress,
+    chain,
+    client: thirdwebClient,
+  });
 
   return (
     <>
@@ -38,7 +33,7 @@ export const TokenClaimButton: React.FC<TokenClaimButtonProps> = ({
         onClose={onClose}
         isOpen={isOpen}
       >
-        <TokenClaimForm contract={contractQuery.contract} />
+        <TokenClaimForm contract={contract} />
       </Drawer>
       <Button
         colorScheme="primary"

--- a/apps/dashboard/src/contract-ui/tabs/tokens/components/claim-form.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/tokens/components/claim-form.tsx
@@ -7,19 +7,17 @@ import {
   Stack,
   useModalContext,
 } from "@chakra-ui/react";
-import {
-  type TokenContract,
-  useClaimToken,
-  useTokenDecimals,
-} from "@thirdweb-dev/react";
 import { TransactionButton } from "components/buttons/TransactionButton";
 import { useTrack } from "hooks/analytics/useTrack";
 import { useTxNotifications } from "hooks/useTxNotifications";
-import { thirdwebClient } from "lib/thirdweb-client";
-import { useV5DashboardChain } from "lib/v5-adapter";
 import { useForm } from "react-hook-form";
-import { ZERO_ADDRESS, getContract } from "thirdweb";
-import { useActiveAccount } from "thirdweb/react";
+import { type ThirdwebContract, ZERO_ADDRESS } from "thirdweb";
+import { claimTo, decimals } from "thirdweb/extensions/erc20";
+import {
+  useActiveAccount,
+  useReadContract,
+  useSendAndConfirmTransaction,
+} from "thirdweb/react";
 import {
   FormErrorMessage,
   FormHelperText,
@@ -29,36 +27,29 @@ import {
 
 const CLAIM_FORM_ID = "token-claim-form";
 interface TokenClaimFormProps {
-  contract: TokenContract;
+  contract: ThirdwebContract;
 }
 
 export const TokenClaimForm: React.FC<TokenClaimFormProps> = ({ contract }) => {
   const trackEvent = useTrack();
   const address = useActiveAccount()?.address;
-  const claim = useClaimToken(contract);
   const {
     register,
     handleSubmit,
     formState: { errors, isDirty },
   } = useForm({ defaultValues: { amount: "0", to: address } });
   const modalContext = useModalContext();
-  const chain = useV5DashboardChain(contract?.chainId);
-  const contractV5 =
-    contract && chain
-      ? getContract({
-          address: contract.getAddress(),
-          chain: chain,
-          client: thirdwebClient,
-        })
-      : null;
 
   const { onSuccess, onError } = useTxNotifications(
     "Tokens claimed successfully",
     "Failed to claim tokens",
-    contractV5,
+    contract,
   );
 
-  const decimals = useTokenDecimals(contract);
+  const { data: _decimals, isLoading } = useReadContract(decimals, {
+    contract,
+  });
+  const { mutate, isPending } = useSendAndConfirmTransaction();
 
   return (
     <>
@@ -81,7 +72,7 @@ export const TokenClaimForm: React.FC<TokenClaimFormProps> = ({ contract }) => {
               <FormLabel>Amount</FormLabel>
               <Input
                 type="text"
-                pattern={`^\\d+(\\.\\d{1,${decimals?.data || 18}})?$`}
+                pattern={`^\\d+(\\.\\d{1,${_decimals || 18}})?$`}
                 {...register("amount", { required: true })}
               />
               <FormHelperText>How many would you like to claim?</FormHelperText>
@@ -94,10 +85,10 @@ export const TokenClaimForm: React.FC<TokenClaimFormProps> = ({ contract }) => {
         <TransactionButton
           transactionCount={1}
           form={CLAIM_FORM_ID}
-          isLoading={claim.isLoading}
+          isLoading={isPending}
           type="submit"
           colorScheme="primary"
-          isDisabled={!isDirty}
+          isDisabled={!isDirty || isLoading}
           onClick={handleSubmit((d) => {
             if (d.to) {
               trackEvent({
@@ -105,29 +96,31 @@ export const TokenClaimForm: React.FC<TokenClaimFormProps> = ({ contract }) => {
                 action: "claim",
                 label: "attempt",
               });
-              claim.mutate(
-                { amount: d.amount, to: d.to },
-                {
-                  onSuccess: () => {
-                    trackEvent({
-                      category: "token",
-                      action: "claim",
-                      label: "success",
-                    });
-                    onSuccess();
-                    modalContext.onClose();
-                  },
-                  onError: (error) => {
-                    trackEvent({
-                      category: "token",
-                      action: "claim",
-                      label: "error",
-                      error,
-                    });
-                    onError(error);
-                  },
+              const transaction = claimTo({
+                contract,
+                to: d.to,
+                quantity: d.amount,
+              });
+              mutate(transaction, {
+                onSuccess: () => {
+                  trackEvent({
+                    category: "token",
+                    action: "claim",
+                    label: "success",
+                  });
+                  onSuccess();
+                  modalContext.onClose();
                 },
-              );
+                onError: (error) => {
+                  trackEvent({
+                    category: "token",
+                    action: "claim",
+                    label: "error",
+                    error,
+                  });
+                  onError(error);
+                },
+              });
             }
           })}
         >

--- a/apps/dashboard/src/contract-ui/tabs/tokens/components/mint-button.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/tokens/components/mint-button.tsx
@@ -1,6 +1,5 @@
 import { MinterOnly } from "@3rdweb-sdk/react/components/roles/minter-only";
 import { Icon, useDisclosure } from "@chakra-ui/react";
-import type { useContract } from "@thirdweb-dev/react";
 import { thirdwebClient } from "lib/thirdweb-client";
 import { useV5DashboardChain } from "lib/v5-adapter";
 import { FiPlus } from "react-icons/fi";
@@ -9,27 +8,22 @@ import { Button, Drawer } from "tw-components";
 import { TokenERC20MintForm } from "./mint-form-erc20";
 
 interface TokenMintButtonProps {
-  contractQuery: ReturnType<typeof useContract>;
+  contractAddress: string;
+  chainId: number;
 }
 
 export const TokenMintButton: React.FC<TokenMintButtonProps> = ({
-  contractQuery,
+  contractAddress,
+  chainId,
   ...restButtonProps
 }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const contractV4 = contractQuery.contract;
-  const chain = useV5DashboardChain(contractV4?.chainId);
-  const contract =
-    contractV4 && chain
-      ? getContract({
-          address: contractV4.getAddress(),
-          chain: chain,
-          client: thirdwebClient,
-        })
-      : null;
-  if (!contract || !contractV4) {
-    return null;
-  }
+  const chain = useV5DashboardChain(chainId);
+  const contract = getContract({
+    address: contractAddress,
+    chain,
+    client: thirdwebClient,
+  });
   return (
     <MinterOnly contract={contract}>
       <Drawer

--- a/apps/dashboard/src/contract-ui/tabs/tokens/page.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/tokens/page.tsx
@@ -1,5 +1,5 @@
 import { Box, ButtonGroup, Flex } from "@chakra-ui/react";
-import { type TokenContract, useContract } from "@thirdweb-dev/react";
+import { useContract } from "@thirdweb-dev/react";
 import { detectFeatures } from "components/contract-components/utils";
 import { Card, Heading, LinkButton, Text } from "tw-components";
 import { TokenAirdropButton } from "./components/airdrop-button";
@@ -29,14 +29,18 @@ export const ContractTokensPage: React.FC<ContractTokenPageProps> = ({
     return <div>Loading...</div>;
   }
 
-  const isERC20 = detectFeatures<TokenContract>(contractQuery.contract, [
-    "ERC20",
+  const isERC20 = detectFeatures(contractQuery.contract, ["ERC20"]);
+
+  const isERC20Mintable = detectFeatures(contractQuery.contract, [
+    "ERC20Mintable",
   ]);
 
-  const isERC20Mintable = detectFeatures<TokenContract>(
-    contractQuery.contract,
-    ["ERC20Mintable"],
-  );
+  const isERC20Claimable = detectFeatures(contractQuery.contract, [
+    "ERC20ClaimConditionsV1",
+    "ERC20ClaimConditionsV2",
+    "ERC20ClaimPhasesV1",
+    "ERC20ClaimPhasesV2",
+  ]);
 
   if (!isERC20) {
     return (
@@ -69,8 +73,12 @@ export const ContractTokensPage: React.FC<ContractTokenPageProps> = ({
           gap={2}
           w="inherit"
         >
-          {/* TODO: update (claimable detection) */}
-          <TokenClaimButton contractQuery={contractQuery} />
+          {isERC20Claimable && contractQuery.contract && (
+            <TokenClaimButton
+              contractAddress={contractQuery.contract.getAddress()}
+              chainId={contractQuery.contract.chainId}
+            />
+          )}
           <TokenBurnButton
             contractAddress={contractAddress}
             chainId={chainId}
@@ -86,7 +94,10 @@ export const ContractTokensPage: React.FC<ContractTokenPageProps> = ({
             chainId={chainId}
           />
           {isERC20Mintable && contractQuery.contract && (
-            <TokenMintButton contractQuery={contractQuery} />
+            <TokenMintButton
+              contractAddress={contractQuery.contract.getAddress()}
+              chainId={contractQuery.contract.chainId}
+            />
           )}
         </ButtonGroup>
       </Flex>

--- a/apps/dashboard/src/core-ui/batch-upload/progress-box.tsx
+++ b/apps/dashboard/src/core-ui/batch-upload/progress-box.tsx
@@ -1,8 +1,11 @@
 import { Flex, Progress } from "@chakra-ui/react";
-import type { UploadProgressEvent } from "@thirdweb-dev/storage";
 import { useEffect, useState } from "react";
 import { Text } from "tw-components";
 
+type UploadProgressEvent = {
+  progress: number;
+  total: number;
+};
 interface ProgressBoxProps {
   progress: UploadProgressEvent;
 }


### PR DESCRIPTION
High-level changes:
- [x] useAdmin migrated to v5
- [x] useAdminOrSelf migrated to v5
- [x] ERC20 mint form to v5

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates contract-related components to use `contractV5` instead of `contract` for improved functionality and consistency.

### Detailed summary
- Updated components to use `contractV5` instead of `contract` for better functionality and consistency.
- Added `contractV5` object in various components for improved contract handling.
- Replaced `contractQuery` with `contractAddress` and `chainId` in `TokenMintButton` and `TokenClaimButton` components for clarity and consistency.

> The following files were skipped due to too many changes: `apps/dashboard/src/contract-ui/tabs/tokens/components/claim-button.tsx`, `apps/dashboard/src/contract-ui/tabs/permissions/components/permissions-editor.tsx`, `apps/dashboard/src/contract-ui/tabs/tokens/page.tsx`, `apps/dashboard/src/contract-ui/tabs/claim-conditions/components/claim-conditions-form/phase.tsx`, `apps/dashboard/src/@3rdweb-sdk/react/hooks/useContractRoles.ts`, `apps/dashboard/src/contract-ui/tabs/tokens/components/claim-form.tsx`, `apps/dashboard/src/contract-ui/tabs/claim-conditions/components/claim-conditions-form/index.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->