### PR TITLE
Sync Chain object changes to Connection manager and wallets from UI components

### DIFF
--- a/.changeset/silver-adults-sort.md
+++ b/.changeset/silver-adults-sort.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Update the chain object in connection manager and wallets when chain objects passed to UI components are updated.

--- a/packages/thirdweb/src/adapters/wallet-adapter.ts
+++ b/packages/thirdweb/src/adapters/wallet-adapter.ts
@@ -1,4 +1,5 @@
 import type { Chain } from "../chains/types.js";
+import { getCachedChainIfExists } from "../chains/utils.js";
 import type { ThirdwebClient } from "../client/client.js";
 import type { Account, Wallet } from "../wallets/interfaces/wallet.js";
 import { createWalletEmitter } from "../wallets/wallet-emitter.js";
@@ -69,6 +70,8 @@ export function createWalletAdapter(
       return options.adaptedAccount;
     },
     getChain() {
+      const cachedChain = getCachedChainIfExists(_chain.id);
+      _chain = cachedChain || _chain;
       return _chain;
     },
     getConfig() {

--- a/packages/thirdweb/src/chains/utils.ts
+++ b/packages/thirdweb/src/chains/utils.ts
@@ -85,6 +85,13 @@ export function getCachedChain(id: number) {
   return chain;
 }
 
+/**
+ * @internal
+ */
+export function getCachedChainIfExists(id: number) {
+  return CUSTOM_CHAIN_MAP.get(id);
+}
+
 function isLegacyChain(
   chain: ChainOptions | ViemChain | LegacyChain,
 ): chain is LegacyChain {

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/ConnectButton.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/ConnectButton.tsx
@@ -2,13 +2,13 @@
 
 import styled from "@emotion/styled";
 import { useEffect, useMemo, useState } from "react";
-import { cacheChains } from "../../../../chains/utils.js";
 import { iconSize } from "../../../core/design-system/index.js";
 import { useSiweAuth } from "../../../core/hooks/auth/useSiweAuth.js";
 import type { ConnectButtonProps } from "../../../core/hooks/connection/ConnectButtonProps.js";
 import { useActiveAccount } from "../../../core/hooks/wallets/useActiveAccount.js";
 import { useActiveWallet } from "../../../core/hooks/wallets/useActiveWallet.js";
 import { useActiveWalletConnectionStatus } from "../../../core/hooks/wallets/useActiveWalletConnectionStatus.js";
+import { useConnectionManager } from "../../../core/providers/connection-manager.js";
 import { defaultTokens } from "../../../core/utils/defaultTokens.js";
 import {
   WalletUIStatesProvider,
@@ -267,20 +267,25 @@ export function ConnectButton(props: ConnectButtonProps) {
     [props.wallets, props.appMetadata, props.chains],
   );
   const localeQuery = useConnectLocale(props.locale || "en_US");
+  const connectionManager = useConnectionManager();
 
   usePreloadWalletProviders({
     wallets,
     client: props.client,
   });
 
-  // to update cached chains ASAP, we skip using useEffect - this does not trigger a re-render so it's fine
-  if (props.chains) {
-    cacheChains(props.chains);
-  }
+  // Add props.chain and props.chains to defined chains store
+  useEffect(() => {
+    if (props.chain) {
+      connectionManager.defineChains([props.chain]);
+    }
+  }, [props.chain, connectionManager]);
 
-  if (props.chain) {
-    cacheChains([props.chain]);
-  }
+  useEffect(() => {
+    if (props.chains) {
+      connectionManager.defineChains(props.chains);
+    }
+  }, [props.chains, connectionManager]);
 
   const size = useMemo(() => {
     return !canFitWideModal() || wallets.length === 1

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/ConnectEmbed.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/ConnectEmbed.tsx
@@ -1,7 +1,6 @@
 "use client";
 import { useEffect, useMemo } from "react";
 import type { Chain } from "../../../../../chains/types.js";
-import { cacheChains } from "../../../../../chains/utils.js";
 import type { ThirdwebClient } from "../../../../../client/client.js";
 import type { Wallet } from "../../../../../wallets/interfaces/wallet.js";
 import type { SmartWalletOptions } from "../../../../../wallets/smart/types.js";
@@ -18,6 +17,7 @@ import type { ConnectEmbedProps } from "../../../../core/hooks/connection/Connec
 import { useActiveAccount } from "../../../../core/hooks/wallets/useActiveAccount.js";
 import { useActiveWallet } from "../../../../core/hooks/wallets/useActiveWallet.js";
 import { useIsAutoConnecting } from "../../../../core/hooks/wallets/useIsAutoConnecting.js";
+import { useConnectionManager } from "../../../../core/providers/connection-manager.js";
 import { WalletUIStatesProvider } from "../../../providers/wallet-ui-states-provider.js";
 import { canFitWideModal } from "../../../utils/canFitWideModal.js";
 import { usePreloadWalletProviders } from "../../../utils/usePreloadWalletProviders.js";
@@ -184,15 +184,20 @@ export function ConnectEmbed(props: ConnectEmbedProps) {
   const siweAuth = useSiweAuth(activeWallet, activeAccount, props.auth);
   const show =
     !activeAccount || (siweAuth.requiresAuth && !siweAuth.isLoggedIn);
+  const connectionManager = useConnectionManager();
 
-  // to update cached chains ASAP, we skip using useEffect - this does not trigger a re-render so it's fine
-  if (props.chains) {
-    cacheChains(props.chains);
-  }
+  // Add props.chain and props.chains to defined chains store
+  useEffect(() => {
+    if (props.chain) {
+      connectionManager.defineChains([props.chain]);
+    }
+  }, [props.chain, connectionManager]);
 
-  if (props.chain) {
-    cacheChains([props.chain]);
-  }
+  useEffect(() => {
+    if (props.chains) {
+      connectionManager.defineChains(props.chains);
+    }
+  }, [props.chains, connectionManager]);
 
   const wallets = useMemo(
     () =>

--- a/packages/thirdweb/src/react/web/ui/PayEmbed.tsx
+++ b/packages/thirdweb/src/react/web/ui/PayEmbed.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type { Chain } from "../../../chains/types.js";
-import { cacheChains } from "../../../chains/utils.js";
 import type { ThirdwebClient } from "../../../client/client.js";
 import type { Wallet } from "../../../wallets/interfaces/wallet.js";
 import type { SmartWalletOptions } from "../../../wallets/smart/types.js";
@@ -14,6 +13,7 @@ import type {
   ConnectButton_connectModalOptions,
   PayUIOptions,
 } from "../../core/hooks/connection/ConnectButtonProps.js";
+import { useConnectionManager } from "../../core/providers/connection-manager.js";
 import type { SupportedTokens } from "../../core/utils/defaultTokens.js";
 import { EmbedContainer } from "./ConnectWallet/Modal/ConnectEmbed.js";
 import { useConnectLocale } from "./ConnectWallet/locale/getConnectLocale.js";
@@ -156,15 +156,20 @@ export function PayEmbed(props: PayEmbedProps) {
   const localeQuery = useConnectLocale(props.locale || "en_US");
   const [screen, setScreen] = useState<"buy" | "execute-tx">("buy");
   const theme = props.theme || "dark";
+  const connectionManager = useConnectionManager();
 
-  // to update cached chains ASAP, we skip using useEffect - this does not trigger a re-render so it's fine
-  if (props.connectOptions?.chains) {
-    cacheChains(props.connectOptions?.chains);
-  }
+  // Add props.chain and props.chains to defined chains store
+  useEffect(() => {
+    if (props.connectOptions?.chain) {
+      connectionManager.defineChains([props.connectOptions?.chain]);
+    }
+  }, [props.connectOptions?.chain, connectionManager]);
 
-  if (props.connectOptions?.chain) {
-    cacheChains([props.connectOptions?.chain]);
-  }
+  useEffect(() => {
+    if (props.connectOptions?.chains) {
+      connectionManager.defineChains(props.connectOptions?.chains);
+    }
+  }, [props.connectOptions?.chains, connectionManager]);
 
   let content = null;
   const metadata =

--- a/packages/thirdweb/src/reactive/store.ts
+++ b/packages/thirdweb/src/reactive/store.ts
@@ -31,6 +31,9 @@ export function createStore<T>(initialValue: T): Store<T> {
       return value;
     },
     setValue(newValue: T) {
+      if (newValue === value) {
+        return;
+      }
       value = newValue;
       notify();
     },

--- a/packages/thirdweb/src/wallets/coinbase/coinbase-wallet.ts
+++ b/packages/thirdweb/src/wallets/coinbase/coinbase-wallet.ts
@@ -5,6 +5,7 @@
 import type { ProviderInterface } from "@coinbase/wallet-sdk";
 import { trackConnect } from "../../analytics/track.js";
 import type { Chain } from "../../chains/types.js";
+import { getCachedChainIfExists } from "../../chains/utils.js";
 import { COINBASE } from "../constants.js";
 import type { Account, Wallet } from "../interfaces/wallet.js";
 import { createWalletEmitter } from "../wallet-emitter.js";
@@ -54,7 +55,14 @@ export function coinbaseWalletSDK(args: {
   return {
     id: COINBASE,
     subscribe: emitter.subscribe,
-    getChain: () => chain,
+    getChain() {
+      if (!chain) {
+        return undefined;
+      }
+
+      chain = getCachedChainIfExists(chain.id) || chain;
+      return chain;
+    },
     getConfig: () => createOptions,
     getAccount: () => account,
     autoConnect: async (options) => {

--- a/packages/thirdweb/src/wallets/create-wallet.ts
+++ b/packages/thirdweb/src/wallets/create-wallet.ts
@@ -13,6 +13,7 @@ import type {
 } from "./wallet-types.js";
 
 import { trackConnect } from "../analytics/track.js";
+import { getCachedChainIfExists } from "../chains/utils.js";
 import { webLocalStorage } from "../utils/storage/webStorage.js";
 import { isMobile } from "../utils/web/isMobile.js";
 import { openWindow } from "../utils/web/openWindow.js";
@@ -206,7 +207,14 @@ export function createWallet<const ID extends WalletId>(
         id,
         subscribe: emitter.subscribe,
         getConfig: () => args[1],
-        getChain: () => chain,
+        getChain() {
+          if (!chain) {
+            return undefined;
+          }
+
+          chain = getCachedChainIfExists(chain.id) || chain;
+          return chain;
+        },
         getAccount: () => account,
         autoConnect: async (
           options: WalletAutoConnectionOption<

--- a/packages/thirdweb/src/wallets/in-app/core/wallet/ecosystem-core.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/wallet/ecosystem-core.ts
@@ -1,5 +1,6 @@
 import { trackConnect } from "../../../../analytics/track.js";
 import type { Chain } from "../../../../chains/types.js";
+import { getCachedChainIfExists } from "../../../../chains/utils.js";
 import type { ThirdwebClient } from "../../../../client/client.js";
 import type { Account, Wallet } from "../../../interfaces/wallet.js";
 import { createWalletEmitter } from "../../../wallet-emitter.js";
@@ -28,8 +29,16 @@ export function createEcosystemWallet(args: {
   return {
     id,
     subscribe: emitter.subscribe,
-    getChain: () => chain,
+    getChain() {
+      if (!chain) {
+        return undefined;
+      }
+
+      chain = getCachedChainIfExists(chain.id) || chain;
+      return chain;
+    },
     getConfig: () => createOptions,
+
     getAccount: () => account,
     autoConnect: async (options) => {
       const { autoConnectInAppWallet } = await import("./index.js");

--- a/packages/thirdweb/src/wallets/in-app/core/wallet/in-app-core.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/wallet/in-app-core.ts
@@ -1,5 +1,6 @@
 import { trackConnect } from "../../../../analytics/track.js";
 import type { Chain } from "../../../../chains/types.js";
+import { getCachedChainIfExists } from "../../../../chains/utils.js";
 import type { ThirdwebClient } from "../../../../client/client.js";
 import type { Account, Wallet } from "../../../interfaces/wallet.js";
 import { createWalletEmitter } from "../../../wallet-emitter.js";
@@ -45,7 +46,14 @@ export function createInAppWallet(args: {
   return {
     id: "inApp",
     subscribe: emitter.subscribe,
-    getChain: () => chain,
+    getChain() {
+      if (!chain) {
+        return undefined;
+      }
+
+      chain = getCachedChainIfExists(chain.id) || chain;
+      return chain;
+    },
     getConfig: () => createOptions,
     getAccount: () => account,
     autoConnect: async (options) => {

--- a/packages/thirdweb/src/wallets/manager/index.ts
+++ b/packages/thirdweb/src/wallets/manager/index.ts
@@ -1,4 +1,5 @@
 import type { Chain } from "../../chains/types.js";
+import { cacheChains } from "../../chains/utils.js";
 import type { ThirdwebClient } from "../../client/client.js";
 import { hasSmartAccount } from "../../react/core/utils/isSmartWallet.js";
 import { computedStore } from "../../reactive/computedStore.js";
@@ -44,6 +45,30 @@ export function createConnectionManager(storage: AsyncStorage) {
   const activeWalletChainStore = createStore<Chain | undefined>(undefined);
   const activeWalletConnectionStatusStore =
     createStore<ConnectionStatus>("disconnected");
+
+  const definedChainsStore = createStore<Map<number, Chain>>(new Map());
+
+  // update global cachedChains when defined Chains store updates
+  effect(() => {
+    cacheChains([...definedChainsStore.getValue().values()]);
+  }, [definedChainsStore]);
+
+  // change the active chain object to use the defined chain object
+  effect(() => {
+    const chainVal = activeWalletChainStore.getValue();
+    if (!chainVal) {
+      return;
+    }
+
+    const definedChain = definedChainsStore.getValue().get(chainVal.id);
+
+    if (!definedChain || definedChain === chainVal) {
+      return;
+    }
+
+    // update active chain store
+    activeWalletChainStore.setValue(definedChain);
+  }, [definedChainsStore, activeWalletChainStore]);
 
   // other connected accounts
   const walletIdToConnectedWalletMap =
@@ -241,21 +266,42 @@ export function createConnectionManager(storage: AsyncStorage) {
     activeWalletChainStore.setValue(wallet.getChain());
   };
 
+  function defineChains(chains: Chain[]) {
+    const currentMapVal = definedChainsStore.getValue();
+
+    // if all chains to be defined are already defined, no need to update the definedChains map
+    const allChainsSame = chains.every((c) => {
+      const definedChain = currentMapVal.get(c.id);
+      // basically a deep equal check
+      return JSON.stringify(definedChain) === JSON.stringify(c);
+    });
+
+    if (allChainsSame) {
+      return;
+    }
+
+    const newMapVal = new Map(currentMapVal);
+    for (const c of chains) {
+      newMapVal.set(c.id, c);
+    }
+    definedChainsStore.setValue(newMapVal);
+  }
+
   return {
-    // account
-    activeWalletStore: activeWalletStore,
-    activeAccountStore: activeAccountStore,
+    activeWalletStore,
+    activeAccountStore,
     connectedWallets,
     addConnectedWallet,
     disconnectWallet,
     setActiveWallet,
     connect,
     handleConnection,
-    activeWalletChainStore: activeWalletChainStore,
+    activeWalletChainStore,
     switchActiveWalletChain,
-    activeWalletConnectionStatusStore: activeWalletConnectionStatusStore,
+    activeWalletConnectionStatusStore,
     isAutoConnecting,
     removeConnectedWallet,
+    defineChains,
   };
 }
 

--- a/packages/thirdweb/src/wallets/native/create-wallet.ts
+++ b/packages/thirdweb/src/wallets/native/create-wallet.ts
@@ -3,6 +3,7 @@
 import { Linking } from "react-native";
 import { trackConnect } from "../../analytics/track.js";
 import type { Chain } from "../../chains/types.js";
+import { getCachedChainIfExists } from "../../chains/utils.js";
 import { nativeLocalStorage } from "../../utils/storage/nativeStorage.js";
 import type { WCSupportedWalletIds } from "../__generated__/wallet-ids.js";
 import { coinbaseWalletSDK } from "../coinbase/coinbase-wallet.js";
@@ -121,7 +122,14 @@ export function createWallet<const ID extends WalletId>(
         id,
         subscribe: emitter.subscribe,
         getConfig: () => args[1],
-        getChain: () => chain,
+        getChain() {
+          if (!chain) {
+            return undefined;
+          }
+
+          chain = getCachedChainIfExists(chain.id) || chain;
+          return chain;
+        },
         getAccount: () => account,
         autoConnect: async (
           options: WalletAutoConnectionOption<WCSupportedWalletIds>,

--- a/packages/thirdweb/src/wallets/smart/smart-wallet.ts
+++ b/packages/thirdweb/src/wallets/smart/smart-wallet.ts
@@ -1,5 +1,6 @@
 import { trackConnect } from "../../analytics/track.js";
 import type { Chain } from "../../chains/types.js";
+import { getCachedChainIfExists } from "../../chains/utils.js";
 import { getContract } from "../../contract/contract.js";
 import { isContractDeployed } from "../../utils/bytecode/is-contract-deployed.js";
 import type { Account, Wallet } from "../interfaces/wallet.js";
@@ -107,7 +108,14 @@ export function smartWallet(
   const _smartWallet: Wallet<"smart"> = {
     id: "smart",
     subscribe: emitter.subscribe,
-    getChain: () => chain,
+    getChain() {
+      if (!chain) {
+        return undefined;
+      }
+
+      chain = getCachedChainIfExists(chain.id) || chain;
+      return chain;
+    },
     getConfig: () => createOptions,
     getAccount: () => account,
     autoConnect: async (options) => {


### PR DESCRIPTION
* When `chain` or `chains` prop passed to UI components like `ConnectButton` , `ConnectEmbed` etc are updated - make sure that those chain makes their way to connection manager ( useActiveWalletChain ) and to all the wallets ( getChain ) 

This is mainly for dashboard - where users can modify the chains and we need to update the chain objects when that's done

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates multiple files in `thirdweb` package to optimize chain object handling in UI components.

### Detailed summary
- Added `getCachedChainIfExists` function to retrieve cached chain objects
- Updated `getChain` method in various wallet adapters to handle cached chains
- Utilized `useConnectionManager` to define chains in UI components

> The following files were skipped due to too many changes: `packages/thirdweb/src/react/native/ui/connect/ConnectButton.tsx`, `packages/thirdweb/src/wallets/manager/index.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->