### PR TITLE
Split extensions

### DIFF
--- a/.changeset/lovely-ears-serve.md
+++ b/.changeset/lovely-ears-serve.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": minor
+---
+
+Add thirdweb Split contract extensions

--- a/packages/thirdweb/scripts/generate/abis/split/Split.json
+++ b/packages/thirdweb/scripts/generate/abis/split/Split.json
@@ -1,0 +1,10 @@
+[
+  "function payee(uint256 index) view returns (address)",
+  "function payeeCount() view returns (uint256)",
+  "function releasable(address account) view returns (uint256)",
+  "function released(address account) view returns (uint256)",
+  "function shares(address account) view returns (uint256)",
+  "function totalReleased() view returns (uint256)",
+  "function distribute()",
+  "function release(address account)"
+]

--- a/packages/thirdweb/src/exports/extensions/split.ts
+++ b/packages/thirdweb/src/exports/extensions/split.ts
@@ -1,0 +1,52 @@
+/**
+ * READ
+ */
+export {
+  payee,
+  type PayeeParams,
+} from "../../extensions/split/__generated__/Split/read/payee.js";
+
+export { payeeCount } from "../../extensions/split/__generated__/Split/read/payeeCount.js";
+
+export {
+  releasable,
+  type ReleasableParams,
+} from "../../extensions/split/__generated__/Split/read/releasable.js";
+
+export {
+  releasableByToken,
+  type ReleasableByTokenParams,
+} from "../../extensions/split/read/releasableByToken.js";
+
+export {
+  released,
+  type ReleasedParams,
+} from "../../extensions/split/__generated__/Split/read/released.js";
+
+export { releasedByToken } from "../../extensions/split/read/releasedByToken.js";
+
+export {
+  shares,
+  type SharesParams,
+} from "../../extensions/split/__generated__/Split/read/shares.js";
+
+export { totalReleased } from "../../extensions/split/__generated__/Split/read/totalReleased.js";
+
+export { totalReleasedByToken } from "../../extensions/split/read/totalReleasedByToken.js";
+
+/**
+ * WRITE
+ */
+export { distribute } from "../../extensions/split/__generated__/Split/write/distribute.js";
+
+export { distributeByToken } from "../../extensions/split/write/distributeByToken.js";
+
+export {
+  release,
+  type ReleaseParams,
+} from "../../extensions/split/__generated__/Split/write/release.js";
+
+export {
+  releaseByToken,
+  type ReleaseByTokenParams,
+} from "../../extensions/split/write/releaseByToken.js";

--- a/packages/thirdweb/src/extensions/split/__generated__/Split/read/payee.ts
+++ b/packages/thirdweb/src/extensions/split/__generated__/Split/read/payee.ts
@@ -1,0 +1,123 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "payee" function.
+ */
+export type PayeeParams = {
+  index: AbiParameterToPrimitiveType<{ type: "uint256"; name: "index" }>;
+};
+
+export const FN_SELECTOR = "0x8b83209b" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "index",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "address",
+  },
+] as const;
+
+/**
+ * Checks if the `payee` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `payee` method is supported.
+ * @extension SPLIT
+ * @example
+ * ```ts
+ * import { isPayeeSupported } from "thirdweb/extensions/split";
+ *
+ * const supported = await isPayeeSupported(contract);
+ * ```
+ */
+export async function isPayeeSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "payee" function.
+ * @param options - The options for the payee function.
+ * @returns The encoded ABI parameters.
+ * @extension SPLIT
+ * @example
+ * ```ts
+ * import { encodePayeeParams } "thirdweb/extensions/split";
+ * const result = encodePayeeParams({
+ *  index: ...,
+ * });
+ * ```
+ */
+export function encodePayeeParams(options: PayeeParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.index]);
+}
+
+/**
+ * Encodes the "payee" function into a Hex string with its parameters.
+ * @param options - The options for the payee function.
+ * @returns The encoded hexadecimal string.
+ * @extension SPLIT
+ * @example
+ * ```ts
+ * import { encodePayee } "thirdweb/extensions/split";
+ * const result = encodePayee({
+ *  index: ...,
+ * });
+ * ```
+ */
+export function encodePayee(options: PayeeParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodePayeeParams(options).slice(2)) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the payee function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension SPLIT
+ * @example
+ * ```ts
+ * import { decodePayeeResult } from "thirdweb/extensions/split";
+ * const result = decodePayeeResult("...");
+ * ```
+ */
+export function decodePayeeResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "payee" function on the contract.
+ * @param options - The options for the payee function.
+ * @returns The parsed result of the function call.
+ * @extension SPLIT
+ * @example
+ * ```ts
+ * import { payee } from "thirdweb/extensions/split";
+ *
+ * const result = await payee({
+ *  contract,
+ *  index: ...,
+ * });
+ *
+ * ```
+ */
+export async function payee(options: BaseTransactionOptions<PayeeParams>) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.index],
+  });
+}

--- a/packages/thirdweb/src/extensions/split/__generated__/Split/read/payeeCount.ts
+++ b/packages/thirdweb/src/extensions/split/__generated__/Split/read/payeeCount.ts
@@ -1,0 +1,72 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0x00dbe109" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Checks if the `payeeCount` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `payeeCount` method is supported.
+ * @extension SPLIT
+ * @example
+ * ```ts
+ * import { isPayeeCountSupported } from "thirdweb/extensions/split";
+ *
+ * const supported = await isPayeeCountSupported(contract);
+ * ```
+ */
+export async function isPayeeCountSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Decodes the result of the payeeCount function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension SPLIT
+ * @example
+ * ```ts
+ * import { decodePayeeCountResult } from "thirdweb/extensions/split";
+ * const result = decodePayeeCountResult("...");
+ * ```
+ */
+export function decodePayeeCountResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "payeeCount" function on the contract.
+ * @param options - The options for the payeeCount function.
+ * @returns The parsed result of the function call.
+ * @extension SPLIT
+ * @example
+ * ```ts
+ * import { payeeCount } from "thirdweb/extensions/split";
+ *
+ * const result = await payeeCount({
+ *  contract,
+ * });
+ *
+ * ```
+ */
+export async function payeeCount(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/split/__generated__/Split/read/releasable.ts
+++ b/packages/thirdweb/src/extensions/split/__generated__/Split/read/releasable.ts
@@ -1,0 +1,127 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "releasable" function.
+ */
+export type ReleasableParams = {
+  account: AbiParameterToPrimitiveType<{ type: "address"; name: "account" }>;
+};
+
+export const FN_SELECTOR = "0xa3f8eace" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "account",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Checks if the `releasable` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `releasable` method is supported.
+ * @extension SPLIT
+ * @example
+ * ```ts
+ * import { isReleasableSupported } from "thirdweb/extensions/split";
+ *
+ * const supported = await isReleasableSupported(contract);
+ * ```
+ */
+export async function isReleasableSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "releasable" function.
+ * @param options - The options for the releasable function.
+ * @returns The encoded ABI parameters.
+ * @extension SPLIT
+ * @example
+ * ```ts
+ * import { encodeReleasableParams } "thirdweb/extensions/split";
+ * const result = encodeReleasableParams({
+ *  account: ...,
+ * });
+ * ```
+ */
+export function encodeReleasableParams(options: ReleasableParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.account]);
+}
+
+/**
+ * Encodes the "releasable" function into a Hex string with its parameters.
+ * @param options - The options for the releasable function.
+ * @returns The encoded hexadecimal string.
+ * @extension SPLIT
+ * @example
+ * ```ts
+ * import { encodeReleasable } "thirdweb/extensions/split";
+ * const result = encodeReleasable({
+ *  account: ...,
+ * });
+ * ```
+ */
+export function encodeReleasable(options: ReleasableParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeReleasableParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the releasable function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension SPLIT
+ * @example
+ * ```ts
+ * import { decodeReleasableResult } from "thirdweb/extensions/split";
+ * const result = decodeReleasableResult("...");
+ * ```
+ */
+export function decodeReleasableResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "releasable" function on the contract.
+ * @param options - The options for the releasable function.
+ * @returns The parsed result of the function call.
+ * @extension SPLIT
+ * @example
+ * ```ts
+ * import { releasable } from "thirdweb/extensions/split";
+ *
+ * const result = await releasable({
+ *  contract,
+ *  account: ...,
+ * });
+ *
+ * ```
+ */
+export async function releasable(
+  options: BaseTransactionOptions<ReleasableParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.account],
+  });
+}

--- a/packages/thirdweb/src/extensions/split/__generated__/Split/read/released.ts
+++ b/packages/thirdweb/src/extensions/split/__generated__/Split/read/released.ts
@@ -1,0 +1,125 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "released" function.
+ */
+export type ReleasedParams = {
+  account: AbiParameterToPrimitiveType<{ type: "address"; name: "account" }>;
+};
+
+export const FN_SELECTOR = "0x9852595c" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "account",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Checks if the `released` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `released` method is supported.
+ * @extension SPLIT
+ * @example
+ * ```ts
+ * import { isReleasedSupported } from "thirdweb/extensions/split";
+ *
+ * const supported = await isReleasedSupported(contract);
+ * ```
+ */
+export async function isReleasedSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "released" function.
+ * @param options - The options for the released function.
+ * @returns The encoded ABI parameters.
+ * @extension SPLIT
+ * @example
+ * ```ts
+ * import { encodeReleasedParams } "thirdweb/extensions/split";
+ * const result = encodeReleasedParams({
+ *  account: ...,
+ * });
+ * ```
+ */
+export function encodeReleasedParams(options: ReleasedParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.account]);
+}
+
+/**
+ * Encodes the "released" function into a Hex string with its parameters.
+ * @param options - The options for the released function.
+ * @returns The encoded hexadecimal string.
+ * @extension SPLIT
+ * @example
+ * ```ts
+ * import { encodeReleased } "thirdweb/extensions/split";
+ * const result = encodeReleased({
+ *  account: ...,
+ * });
+ * ```
+ */
+export function encodeReleased(options: ReleasedParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeReleasedParams(options).slice(2)) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the released function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension SPLIT
+ * @example
+ * ```ts
+ * import { decodeReleasedResult } from "thirdweb/extensions/split";
+ * const result = decodeReleasedResult("...");
+ * ```
+ */
+export function decodeReleasedResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "released" function on the contract.
+ * @param options - The options for the released function.
+ * @returns The parsed result of the function call.
+ * @extension SPLIT
+ * @example
+ * ```ts
+ * import { released } from "thirdweb/extensions/split";
+ *
+ * const result = await released({
+ *  contract,
+ *  account: ...,
+ * });
+ *
+ * ```
+ */
+export async function released(
+  options: BaseTransactionOptions<ReleasedParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.account],
+  });
+}

--- a/packages/thirdweb/src/extensions/split/__generated__/Split/read/shares.ts
+++ b/packages/thirdweb/src/extensions/split/__generated__/Split/read/shares.ts
@@ -1,0 +1,123 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "shares" function.
+ */
+export type SharesParams = {
+  account: AbiParameterToPrimitiveType<{ type: "address"; name: "account" }>;
+};
+
+export const FN_SELECTOR = "0xce7c2ac2" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "account",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Checks if the `shares` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `shares` method is supported.
+ * @extension SPLIT
+ * @example
+ * ```ts
+ * import { isSharesSupported } from "thirdweb/extensions/split";
+ *
+ * const supported = await isSharesSupported(contract);
+ * ```
+ */
+export async function isSharesSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "shares" function.
+ * @param options - The options for the shares function.
+ * @returns The encoded ABI parameters.
+ * @extension SPLIT
+ * @example
+ * ```ts
+ * import { encodeSharesParams } "thirdweb/extensions/split";
+ * const result = encodeSharesParams({
+ *  account: ...,
+ * });
+ * ```
+ */
+export function encodeSharesParams(options: SharesParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.account]);
+}
+
+/**
+ * Encodes the "shares" function into a Hex string with its parameters.
+ * @param options - The options for the shares function.
+ * @returns The encoded hexadecimal string.
+ * @extension SPLIT
+ * @example
+ * ```ts
+ * import { encodeShares } "thirdweb/extensions/split";
+ * const result = encodeShares({
+ *  account: ...,
+ * });
+ * ```
+ */
+export function encodeShares(options: SharesParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeSharesParams(options).slice(2)) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the shares function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension SPLIT
+ * @example
+ * ```ts
+ * import { decodeSharesResult } from "thirdweb/extensions/split";
+ * const result = decodeSharesResult("...");
+ * ```
+ */
+export function decodeSharesResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "shares" function on the contract.
+ * @param options - The options for the shares function.
+ * @returns The parsed result of the function call.
+ * @extension SPLIT
+ * @example
+ * ```ts
+ * import { shares } from "thirdweb/extensions/split";
+ *
+ * const result = await shares({
+ *  contract,
+ *  account: ...,
+ * });
+ *
+ * ```
+ */
+export async function shares(options: BaseTransactionOptions<SharesParams>) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.account],
+  });
+}

--- a/packages/thirdweb/src/extensions/split/__generated__/Split/read/totalReleased.ts
+++ b/packages/thirdweb/src/extensions/split/__generated__/Split/read/totalReleased.ts
@@ -1,0 +1,74 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0xe33b7de3" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Checks if the `totalReleased` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `totalReleased` method is supported.
+ * @extension SPLIT
+ * @example
+ * ```ts
+ * import { isTotalReleasedSupported } from "thirdweb/extensions/split";
+ *
+ * const supported = await isTotalReleasedSupported(contract);
+ * ```
+ */
+export async function isTotalReleasedSupported(
+  contract: ThirdwebContract<any>,
+) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Decodes the result of the totalReleased function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension SPLIT
+ * @example
+ * ```ts
+ * import { decodeTotalReleasedResult } from "thirdweb/extensions/split";
+ * const result = decodeTotalReleasedResult("...");
+ * ```
+ */
+export function decodeTotalReleasedResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "totalReleased" function on the contract.
+ * @param options - The options for the totalReleased function.
+ * @returns The parsed result of the function call.
+ * @extension SPLIT
+ * @example
+ * ```ts
+ * import { totalReleased } from "thirdweb/extensions/split";
+ *
+ * const result = await totalReleased({
+ *  contract,
+ * });
+ *
+ * ```
+ */
+export async function totalReleased(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/split/__generated__/Split/write/distribute.ts
+++ b/packages/thirdweb/src/extensions/split/__generated__/Split/write/distribute.ts
@@ -1,0 +1,51 @@
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0xe4fc6b6d" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `distribute` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `distribute` method is supported.
+ * @extension SPLIT
+ * @example
+ * ```ts
+ * import { isDistributeSupported } from "thirdweb/extensions/split";
+ *
+ * const supported = await isDistributeSupported(contract);
+ * ```
+ */
+export async function isDistributeSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Prepares a transaction to call the "distribute" function on the contract.
+ * @param options - The options for the "distribute" function.
+ * @returns A prepared transaction object.
+ * @extension SPLIT
+ * @example
+ * ```ts
+ * import { distribute } from "thirdweb/extensions/split";
+ *
+ * const transaction = distribute();
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function distribute(options: BaseTransactionOptions) {
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}

--- a/packages/thirdweb/src/extensions/split/__generated__/Split/write/release.ts
+++ b/packages/thirdweb/src/extensions/split/__generated__/Split/write/release.ts
@@ -1,0 +1,136 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "release" function.
+ */
+export type ReleaseParams = WithOverrides<{
+  account: AbiParameterToPrimitiveType<{ type: "address"; name: "account" }>;
+}>;
+
+export const FN_SELECTOR = "0x19165587" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "account",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `release` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `release` method is supported.
+ * @extension SPLIT
+ * @example
+ * ```ts
+ * import { isReleaseSupported } from "thirdweb/extensions/split";
+ *
+ * const supported = await isReleaseSupported(contract);
+ * ```
+ */
+export async function isReleaseSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "release" function.
+ * @param options - The options for the release function.
+ * @returns The encoded ABI parameters.
+ * @extension SPLIT
+ * @example
+ * ```ts
+ * import { encodeReleaseParams } "thirdweb/extensions/split";
+ * const result = encodeReleaseParams({
+ *  account: ...,
+ * });
+ * ```
+ */
+export function encodeReleaseParams(options: ReleaseParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.account]);
+}
+
+/**
+ * Encodes the "release" function into a Hex string with its parameters.
+ * @param options - The options for the release function.
+ * @returns The encoded hexadecimal string.
+ * @extension SPLIT
+ * @example
+ * ```ts
+ * import { encodeRelease } "thirdweb/extensions/split";
+ * const result = encodeRelease({
+ *  account: ...,
+ * });
+ * ```
+ */
+export function encodeRelease(options: ReleaseParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeReleaseParams(options).slice(2)) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "release" function on the contract.
+ * @param options - The options for the "release" function.
+ * @returns A prepared transaction object.
+ * @extension SPLIT
+ * @example
+ * ```ts
+ * import { release } from "thirdweb/extensions/split";
+ *
+ * const transaction = release({
+ *  contract,
+ *  account: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function release(
+  options: BaseTransactionOptions<
+    | ReleaseParams
+    | {
+        asyncParams: () => Promise<ReleaseParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.account] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
+  });
+}

--- a/packages/thirdweb/src/extensions/split/read/releasableByToken.ts
+++ b/packages/thirdweb/src/extensions/split/read/releasableByToken.ts
@@ -1,0 +1,34 @@
+import { readContract } from "../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../transaction/types.js";
+import type { ReleasableParams } from "../__generated__/Split/read/releasable.js";
+
+export type ReleasableByTokenParams = ReleasableParams & {
+  tokenAddress: string;
+};
+
+/**
+ * Calls the "releasable" function on the contract.
+ * @param options - The options for the releasable function.
+ * @returns The parsed result of the function call.
+ * @extension SPLIT
+ * @example
+ * ```ts
+ * import { releasableByToken } from "thirdweb/extensions/split";
+ *
+ * const result = await releasableByToken({
+ *  contract,
+ *  account: ...,
+ * });
+ *
+ * ```
+ */
+export async function releasableByToken(
+  options: BaseTransactionOptions<ReleasableByTokenParams>,
+) {
+  return readContract({
+    method:
+      "function releasable(address token, address account) view returns (uint256)",
+    params: [options.tokenAddress, options.account],
+    ...options,
+  });
+}

--- a/packages/thirdweb/src/extensions/split/read/releasedByToken.ts
+++ b/packages/thirdweb/src/extensions/split/read/releasedByToken.ts
@@ -1,0 +1,33 @@
+import { readContract } from "../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../transaction/types.js";
+import type { ReleasedParams } from "../__generated__/Split/read/released.js";
+
+/**
+ * Calls the "released" function on the contract.
+ * Similar to the `released` extension, however this one requires you to specify a tokenAddress
+ *
+ * @param options - The options for the released function.
+ * @returns The parsed result of the function call.
+ * @extension SPLIT
+ * @example
+ * ```ts
+ * import { releasedByToken } from "thirdweb/extensions/split";
+ *
+ * const result = await releasedByToken({
+ *  contract,
+ *  account: "0x...",
+ *  tokenAddress: "0x...",
+ * });
+ *
+ * ```
+ */
+export async function releasedByToken(
+  options: BaseTransactionOptions<ReleasedParams & { tokenAddress: string }>,
+) {
+  return readContract({
+    contract: options.contract,
+    method:
+      "function released(address token, address account) view returns (uint256)",
+    params: [options.tokenAddress, options.account],
+  });
+}

--- a/packages/thirdweb/src/extensions/split/read/totalReleasedByToken.ts
+++ b/packages/thirdweb/src/extensions/split/read/totalReleasedByToken.ts
@@ -1,0 +1,30 @@
+import { readContract } from "../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../transaction/types.js";
+
+/**
+ * Calls the "totalReleased" function on the contract.
+ * Similar to the `release` extension, however this one requires you to specify a tokenAddress
+ *
+ * @param options - The options for the totalReleased function.
+ * @returns The parsed result of the function call.
+ * @extension SPLIT
+ * @example
+ * ```ts
+ * import { totalReleasedByToken } from "thirdweb/extensions/split";
+ *
+ * const result = await totalReleasedByToken({
+ *  contract,
+ *  tokenAddress: "0x...",
+ * });
+ *
+ * ```
+ */
+export async function totalReleasedByToken(
+  options: BaseTransactionOptions<{ tokenAddress: string }>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: "function totalReleased(address token) view returns (uint256)",
+    params: [options.tokenAddress],
+  });
+}

--- a/packages/thirdweb/src/extensions/split/write/distributeByToken.ts
+++ b/packages/thirdweb/src/extensions/split/write/distributeByToken.ts
@@ -1,0 +1,29 @@
+import { prepareContractCall } from "../../../transaction/prepare-contract-call.js";
+import type { BaseTransactionOptions } from "../../../transaction/types.js";
+
+/**
+ * This extension is similar to the `distribute` extension,
+ * however it require you to specify the token (address) that you want to distribute
+ * @param options.tokenAddress - The contract address of the token you want to distribute
+ * @returns A prepared transaction object.
+ * @extension SPLIT
+ * @example
+ * ```ts
+ * import { distributeByToken } from "thirdweb/extensions/split";
+ *
+ * const transaction = distributeByToken();
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function distributeByToken(
+  options: BaseTransactionOptions<{ tokenAddress: string }>,
+) {
+  return prepareContractCall({
+    method: "function distribute(address token)",
+    params: [options.tokenAddress],
+    ...options,
+  });
+}

--- a/packages/thirdweb/src/extensions/split/write/releaseByToken.ts
+++ b/packages/thirdweb/src/extensions/split/write/releaseByToken.ts
@@ -1,0 +1,39 @@
+import { prepareContractCall } from "../../../transaction/prepare-contract-call.js";
+import type { BaseTransactionOptions } from "../../../transaction/types.js";
+import type { ReleaseParams } from "../__generated__/Split/write/release.js";
+
+export type ReleaseByTokenParams = ReleaseParams & {
+  tokenAddress: string;
+};
+
+/**
+ * Similar to the `release` extension, however this one requires you to specify a tokenAddress to release
+ * @param options
+ * @returns
+ * @example
+ * ```ts
+ * import { releaseByToken } from "thirdweb/extensions/split";
+ *
+ * const transaction = releaseByToken({
+ *  contract,
+ *  account: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ * @extension SPLIT
+ */
+export function releaseByToken(
+  options: BaseTransactionOptions<ReleaseByTokenParams>,
+) {
+  return prepareContractCall({
+    method: "function release(address token, address account)",
+    params: [options.tokenAddress, options.account],
+    ...options,
+  });
+}


### PR DESCRIPTION
This will be a part of the Dashboard migration to v5 (Split page)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds `thirdweb` Split contract extensions for distributing tokens and managing releases.

### Detailed summary
- Added `distributeByToken` extension for distributing tokens
- Added `totalReleasedByToken` extension for total released tokens
- Added `releasableByToken` extension for releasable tokens
- Added `releaseByToken` extension for releasing tokens

> The following files were skipped due to too many changes: `packages/thirdweb/src/extensions/split/__generated__/Split/read/totalReleased.ts`, `packages/thirdweb/src/extensions/split/__generated__/Split/read/payee.ts`, `packages/thirdweb/src/extensions/split/__generated__/Split/read/shares.ts`, `packages/thirdweb/src/extensions/split/__generated__/Split/read/released.ts`, `packages/thirdweb/src/extensions/split/__generated__/Split/read/releasable.ts`, `packages/thirdweb/src/extensions/split/__generated__/Split/write/release.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->