### PR TITLE
Added Fraxtal and Mode Testnets to the chain-definitions

### DIFF
--- a/.changeset/strange-jars-search.md
+++ b/.changeset/strange-jars-search.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Added Fraxtal and Mode Testnets to the chain-definitions

--- a/packages/thirdweb/src/chains/chain-definitions/fraxtal-testnet.ts
+++ b/packages/thirdweb/src/chains/chain-definitions/fraxtal-testnet.ts
@@ -1,0 +1,17 @@
+import { defineChain } from "../utils.js";
+
+/**
+ * @chain
+ */
+export const fraxtalTestnet = /* @__PURE__ */ defineChain({
+  id: 2522,
+  name: "Fraxtal Testnet",
+  nativeCurrency: { name: "Frax Ether", symbol: "frxETH", decimals: 18 },
+  blockExplorers: [
+    {
+      name: "Fraxscan",
+      url: "https://holesky.fraxscan.com/",
+    },
+  ],
+  testnet: true,
+});

--- a/packages/thirdweb/src/chains/chain-definitions/mode-testnet.ts
+++ b/packages/thirdweb/src/chains/chain-definitions/mode-testnet.ts
@@ -1,0 +1,17 @@
+import { defineChain } from "../utils.js";
+
+/**
+ * @chain
+ */
+export const modeTestnet = /* @__PURE__ */ defineChain({
+  id: 919,
+  name: "Mode Testnet",
+  nativeCurrency: { name: "Sepolia Ether", symbol: "ETH", decimals: 18 },
+  blockExplorers: [
+    {
+      name: "Modescout",
+      url: "https://sepolia.explorer.mode.network/",
+    },
+  ],
+  testnet: true,
+});


### PR DESCRIPTION
Same as #3941. Here are the details of both networks:

1. [Fraxtal Testnet](https://thirdweb.com/fraxtal-testnet)
2. [Mode Testnet](https://thirdweb.com/mode-testnet)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds Fraxtal and Mode Testnets to the chain definitions.

### Detailed summary
- Added Fraxtal Testnet with ID 2522, native currency Frax Ether, and Fraxscan explorer
- Added Mode Testnet with ID 919, native currency Sepolia Ether, and Modescout explorer

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->