### PR TITLE
[Dashboard]: Migrate major NFT features to v5

### DIFF
--- a/.changeset/calm-llamas-pretend.md
+++ b/.changeset/calm-llamas-pretend.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Add NFT extension: updateTokenURI

--- a/apps/dashboard/src/contract-ui/tabs/listings/components/list-form.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/listings/components/list-form.tsx
@@ -58,7 +58,7 @@ interface ListForm
   quantity: string;
 }
 
-type NFTMintForm = {
+type CreateListingsFormProps = {
   contract: ThirdwebContract;
   formId: string;
   type?: "direct-listings" | "english-auctions";
@@ -80,7 +80,7 @@ const auctionTimes = [
   { label: "1 year", value: 60 * 60 * 24 * 365 },
 ];
 
-export const CreateListingsForm: React.FC<NFTMintForm> = ({
+export const CreateListingsForm: React.FC<CreateListingsFormProps> = ({
   contract,
   formId,
   type,

--- a/apps/dashboard/src/contract-ui/tabs/nfts/components/lazy-mint-button.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/nfts/components/lazy-mint-button.tsx
@@ -1,36 +1,21 @@
 import { MinterOnly } from "@3rdweb-sdk/react/components/roles/minter-only";
 import { Icon, useDisclosure } from "@chakra-ui/react";
-import { type useContract, useLazyMint } from "@thirdweb-dev/react";
-import { thirdwebClient } from "lib/thirdweb-client";
-import { useV5DashboardChain } from "lib/v5-adapter";
 import { FiPlus } from "react-icons/fi";
-import { getContract } from "thirdweb";
+import type { ThirdwebContract } from "thirdweb";
 import { Button, Drawer } from "tw-components";
-import { NFTMintForm } from "./mint-form";
+import { LazyMintNftForm } from "./lazy-mint-form";
 
 interface NFTLazyMintButtonProps {
-  contractQuery: ReturnType<typeof useContract>;
+  contract: ThirdwebContract;
+  isErc721: boolean;
 }
 
 export const NFTLazyMintButton: React.FC<NFTLazyMintButtonProps> = ({
-  contractQuery,
+  contract,
+  isErc721,
   ...restButtonProps
 }) => {
-  const contractV4 = contractQuery.contract;
-  const chain = useV5DashboardChain(contractV4?.chainId);
-  const contract =
-    contractV4 && chain
-      ? getContract({
-          address: contractV4.getAddress(),
-          chain: chain,
-          client: thirdwebClient,
-        })
-      : null;
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const mutation = useLazyMint(contractV4);
-  if (!contract) {
-    return null;
-  }
   return (
     <MinterOnly contract={contract}>
       <Drawer
@@ -40,7 +25,7 @@ export const NFTLazyMintButton: React.FC<NFTLazyMintButtonProps> = ({
         onClose={onClose}
         isOpen={isOpen}
       >
-        <NFTMintForm contract={contractV4} lazyMintMutation={mutation} />
+        <LazyMintNftForm contract={contract} isErc721={isErc721} />
       </Drawer>
       <Button
         colorScheme="primary"

--- a/apps/dashboard/src/contract-ui/tabs/nfts/components/mint-button.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/nfts/components/mint-button.tsx
@@ -1,36 +1,21 @@
 import { MinterOnly } from "@3rdweb-sdk/react/components/roles/minter-only";
 import { Icon, useDisclosure } from "@chakra-ui/react";
-import { type useContract, useMintNFT } from "@thirdweb-dev/react";
-import { thirdwebClient } from "lib/thirdweb-client";
-import { useV5DashboardChain } from "lib/v5-adapter";
 import { FiPlus } from "react-icons/fi";
-import { getContract } from "thirdweb";
+import type { ThirdwebContract } from "thirdweb";
 import { Button, Drawer } from "tw-components";
 import { NFTMintForm } from "./mint-form";
 
 interface NFTMintButtonProps {
-  contractQuery: ReturnType<typeof useContract>;
+  contract: ThirdwebContract;
+  isErc721: boolean;
 }
 
 export const NFTMintButton: React.FC<NFTMintButtonProps> = ({
-  contractQuery,
+  contract,
+  isErc721,
   ...restButtonProps
 }) => {
-  const contractV4 = contractQuery.contract;
-  const chain = useV5DashboardChain(contractV4?.chainId);
-  const contract =
-    contractV4 && chain
-      ? getContract({
-          address: contractV4.getAddress(),
-          chain: chain,
-          client: thirdwebClient,
-        })
-      : null;
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const mutation = useMintNFT(contractV4);
-  if (!contract) {
-    return null;
-  }
   return (
     <MinterOnly contract={contract}>
       <Drawer
@@ -40,7 +25,7 @@ export const NFTMintButton: React.FC<NFTMintButtonProps> = ({
         onClose={onClose}
         isOpen={isOpen}
       >
-        <NFTMintForm contract={contractV4} mintMutation={mutation} />
+        <NFTMintForm contract={contract} isErc721={isErc721} />
       </Drawer>
       <Button
         colorScheme="primary"

--- a/apps/dashboard/src/contract-ui/tabs/nfts/components/shared-metadata-button.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/nfts/components/shared-metadata-button.tsx
@@ -1,35 +1,18 @@
 import { MinterOnly } from "@3rdweb-sdk/react/components/roles/minter-only";
 import { Icon, useDisclosure } from "@chakra-ui/react";
-import { type useContract, useSetSharedMetadata } from "@thirdweb-dev/react";
-import { thirdwebClient } from "lib/thirdweb-client";
-import { useV5DashboardChain } from "lib/v5-adapter";
 import { FiPlus } from "react-icons/fi";
-import { getContract } from "thirdweb";
+import type { ThirdwebContract } from "thirdweb";
 import { Button, Drawer } from "tw-components";
-import { NFTMintForm } from "./mint-form";
+import { SharedMetadataForm } from "./shared-metadata-form";
 
 interface NFTSharedMetadataButtonProps {
-  contractQuery: ReturnType<typeof useContract>;
+  contract: ThirdwebContract;
 }
 
 export const NFTSharedMetadataButton: React.FC<
   NFTSharedMetadataButtonProps
-> = ({ contractQuery, ...restButtonProps }) => {
-  const contractV4 = contractQuery.contract;
-  const chain = useV5DashboardChain(contractV4?.chainId);
-  const contract =
-    contractV4 && chain
-      ? getContract({
-          address: contractV4.getAddress(),
-          chain: chain,
-          client: thirdwebClient,
-        })
-      : null;
+> = ({ contract, ...restButtonProps }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const mutation = useSetSharedMetadata(contractV4);
-  if (!contract) {
-    return null;
-  }
   return (
     <MinterOnly contract={contract}>
       <Drawer
@@ -39,7 +22,7 @@ export const NFTSharedMetadataButton: React.FC<
         onClose={onClose}
         isOpen={isOpen}
       >
-        <NFTMintForm contract={contractV4} sharedMetadataMutation={mutation} />
+        <SharedMetadataForm contract={contract} />
       </Drawer>
       <Button
         colorScheme="primary"

--- a/apps/dashboard/src/contract-ui/tabs/nfts/components/update-metadata-tab.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/nfts/components/update-metadata-tab.tsx
@@ -1,20 +1,25 @@
 import { Flex, useDisclosure } from "@chakra-ui/react";
-import { type SmartContract, useUpdateNFTMetadata } from "@thirdweb-dev/react";
-import type { NFT } from "thirdweb";
+import type { NFT, ThirdwebContract } from "thirdweb";
 import { Button, Drawer, Text } from "tw-components";
-import { NFTMintForm } from "./mint-form";
+import { UpdateNftMetadata } from "./update-metadata-form";
 
 interface UpdateMetadataTabProps {
-  contract: SmartContract | null;
+  contract: ThirdwebContract;
   nft: NFT;
+
+  /**
+   * If isDropContract (NFT Drop, Edition Drop) -> use `updateMetadata`
+   * else (NFT Collection, Edition) -> use `setTokenURI`
+   */
+  isDropContract: boolean;
 }
 
 const UpdateMetadataTab: React.FC<UpdateMetadataTabProps> = ({
   contract,
   nft,
+  isDropContract,
 }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const mutation = useUpdateNFTMetadata(contract);
 
   return (
     <>
@@ -25,10 +30,10 @@ const UpdateMetadataTab: React.FC<UpdateMetadataTabProps> = ({
         onClose={onClose}
         isOpen={isOpen}
       >
-        <NFTMintForm
+        <UpdateNftMetadata
           contract={contract}
-          updateMetadataMutation={mutation}
           nft={nft}
+          isDropContract={isDropContract}
         />
       </Drawer>
       <Flex direction={"column"} gap={6}>

--- a/apps/dashboard/src/contract-ui/tabs/nfts/page.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/nfts/page.tsx
@@ -127,15 +127,15 @@ export const ContractNFTPage: React.FC<NftOverviewPageProps> = ({
             />
           )}
           {detectedMintableState === "enabled" && contractQuery?.contract && (
-            <NFTMintButton contractQuery={contractQuery} />
+            <NFTMintButton contract={contract} isErc721={isErc721} />
           )}
           {detectedSharedMetadataState === "enabled" &&
             contractQuery?.contract && (
-              <NFTSharedMetadataButton contractQuery={contractQuery} />
+              <NFTSharedMetadataButton contract={contract} />
             )}
           {detectedLazyMintableState === "enabled" &&
             contractQuery?.contract && (
-              <NFTLazyMintButton contractQuery={contractQuery} />
+              <NFTLazyMintButton contract={contract} isErc721={isErc721} />
             )}
           {detectedLzyMintState === "enabled" && contractQuery?.contract && (
             <BatchLazyMintButton

--- a/apps/dashboard/src/contract-ui/tabs/permissions/components/contract-permission.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/permissions/components/contract-permission.tsx
@@ -1,11 +1,8 @@
 import { useIsAdmin } from "@3rdweb-sdk/react/hooks/useContractRoles";
 import { Flex, Icon, Select, Spinner, Stack } from "@chakra-ui/react";
-import type { ValidContractInstance } from "@thirdweb-dev/sdk";
-import { thirdwebClient } from "lib/thirdweb-client";
-import { useV5DashboardChain } from "lib/v5-adapter";
 import { useFormContext } from "react-hook-form";
 import { FiInfo } from "react-icons/fi";
-import { ZERO_ADDRESS, getContract } from "thirdweb";
+import { type ThirdwebContract, ZERO_ADDRESS } from "thirdweb";
 import { Card, Heading, Text } from "tw-components";
 import { PermissionEditor } from "./permissions-editor";
 
@@ -14,7 +11,7 @@ interface ContractPermissionProps {
   description: string;
   isLoading: boolean;
   isPrebuilt: boolean;
-  contract: ValidContractInstance;
+  contract: ThirdwebContract;
 }
 
 export const ContractPermission: React.FC<ContractPermissionProps> = ({
@@ -34,13 +31,7 @@ export const ContractPermission: React.FC<ContractPermissionProps> = ({
   const isRestricted =
     !roleMembers.includes(ZERO_ADDRESS) ||
     (role !== "transfer" && role !== "lister" && role !== "asset");
-  const chain = useV5DashboardChain(contract.chainId);
-  const contractV5 = getContract({
-    address: contract.getAddress(),
-    chain,
-    client: thirdwebClient,
-  });
-  const isAdmin = useIsAdmin(contractV5);
+  const isAdmin = useIsAdmin(contract);
 
   return (
     <Card position="relative">
@@ -275,8 +266,7 @@ export const ContractPermission: React.FC<ContractPermissionProps> = ({
             <Spinner />
           ) : (
             isRestricted &&
-            role &&
-            contract && <PermissionEditor role={role} contract={contractV5} />
+            role && <PermissionEditor role={role} contract={contract} />
           )}
         </Stack>
       </Flex>

--- a/apps/dashboard/src/contract-ui/tabs/permissions/components/index.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/permissions/components/index.tsx
@@ -1,3 +1,4 @@
+import { thirdwebClient } from "@/constants/client";
 import { ButtonGroup, Flex } from "@chakra-ui/react";
 import {
   type ContractWithRoles,
@@ -10,8 +11,10 @@ import { TransactionButton } from "components/buttons/TransactionButton";
 import { BuiltinContractMap, ROLE_DESCRIPTION_MAP } from "constants/mappings";
 import { useTrack } from "hooks/analytics/useTrack";
 import { useTxNotifications } from "hooks/useTxNotifications";
+import { useV5DashboardChain } from "lib/v5-adapter";
 import { useMemo } from "react";
 import { FormProvider, useForm } from "react-hook-form";
+import { getContract } from "thirdweb";
 import type { roleMap } from "thirdweb/extensions/permissions";
 import { Button } from "tw-components";
 import { ContractPermission } from "./contract-permission";
@@ -63,6 +66,12 @@ export const Permissions = <TContract extends ContractWithRoles>({
     BuiltinContractMap[contractType as keyof typeof BuiltinContractMap]
       .contractType !== "custom";
 
+  const chain = useV5DashboardChain(contract.chainId);
+  const contractV5 = getContract({
+    address: contract.getAddress(),
+    chain,
+    client: thirdwebClient,
+  });
   return (
     <FormProvider {...form}>
       <Flex
@@ -106,7 +115,7 @@ export const Permissions = <TContract extends ContractWithRoles>({
               role={role}
               description={ROLE_DESCRIPTION_MAP[role] || ""}
               isPrebuilt={isPrebuilt}
-              contract={contract}
+              contract={contractV5}
             />
           );
         })}

--- a/apps/dashboard/src/core-ui/nft-drawer/useNftDrawerTabs.tsx
+++ b/apps/dashboard/src/core-ui/nft-drawer/useNftDrawerTabs.tsx
@@ -2,7 +2,6 @@ import { useIsMinter } from "@3rdweb-sdk/react/hooks/useContractRoles";
 import {
   type DropContract,
   type NFTContract,
-  type SmartContract,
   getErcs,
 } from "@thirdweb-dev/react/evm";
 import { detectFeatures } from "components/contract-components/utils";
@@ -123,6 +122,12 @@ export function useNFTDrawerTabs({
       "ERC721LazyMintable",
     ]);
 
+    const isDropContract = detectFeatures(oldContract, [
+      "ERC721LazyMintable",
+      "ERC1155LazyMintableV1",
+      "ERC1155LazyMintableV2",
+    ]);
+
     const isOwner =
       (isERC1155 && balanceOfQuery?.data) ||
       (isERC721 && nft?.owner === address);
@@ -229,8 +234,9 @@ export function useNFTDrawerTabs({
             "You don't have minter permissions to be able to update metadata",
           children: (
             <UpdateMetadataTab
-              contract={oldContract as SmartContract}
+              contract={contract}
               nft={nft}
+              isDropContract={isDropContract}
             />
           ),
         },
@@ -247,6 +253,7 @@ export function useNFTDrawerTabs({
     address,
     tokenId,
     isMinterRole,
+    contract,
     contractInfo,
   ]);
 }

--- a/packages/thirdweb/src/exports/extensions/erc1155.ts
+++ b/packages/thirdweb/src/exports/extensions/erc1155.ts
@@ -99,6 +99,12 @@ export {
   updateMetadata,
   type UpdateMetadataParams,
 } from "../../extensions/erc1155/drops/write/updateMetadata.js";
+
+export {
+  updateTokenURI,
+  type UpdateTokenURIParams,
+} from "../../extensions/erc1155/write/updateTokenURI.js";
+
 export {
   getClaimConditionById,
   type GetClaimConditionByIdParams,

--- a/packages/thirdweb/src/exports/extensions/erc721.ts
+++ b/packages/thirdweb/src/exports/extensions/erc721.ts
@@ -167,3 +167,7 @@ export {
   updateMetadata,
   type UpdateMetadataParams,
 } from "../../extensions/erc721/drops/write/updateMetadata.js";
+export {
+  updateTokenURI,
+  type UpdateTokenURIParams,
+} from "../../extensions/erc721/write/updateTokenURI.js";

--- a/packages/thirdweb/src/extensions/erc1155/write/updateTokenURI.ts
+++ b/packages/thirdweb/src/extensions/erc1155/write/updateTokenURI.ts
@@ -1,0 +1,97 @@
+import { upload } from "../../../storage/upload.js";
+import type { BaseTransactionOptions } from "../../../transaction/types.js";
+import type { NFTInput } from "../../../utils/nft/parseNft.js";
+import {
+  type SetTokenURIParams,
+  setTokenURI,
+} from "../../erc1155/__generated__/INFTMetadata/write/setTokenURI.js";
+
+/**
+ * @extension ERC1155
+ */
+export type UpdateTokenURIParams = {
+  tokenId: bigint;
+  newMetadata: NFTInput;
+};
+
+/**
+ * This function is an abstracted layer of the [`setTokenURI` extension](https://portal.thirdweb.com/references/typescript/v5/erc1155/setTokenURI),
+ * which means it uses `setTokenURI` under the hood.
+ * While the `setTokenURI` method only takes in a uri string, this extension takes in a user-friendly [`NFTInput`](https://portal.thirdweb.com/references/typescript/v5/NFTInput),
+ * upload that content to IPFS and pass the IPFS URI (of said `NFTInput`) to the underlying `setTokenURI` method.
+ *
+ * This extension does not validate the NFTInput so make sure you are passing the proper content that you want to update.
+ *
+ * @extension ERC1155
+ * @returns the prepared transaction from `setTokenURI`
+ * @example
+ * ```ts
+ * import { updateTokenURI } from "thirdweb/extensions/erc1155";
+ *
+ * const transaction = updateTokenURI({
+ *   tokenId: 0n,
+ *   nft: {
+ *     name: "new name",
+ *     description: "new description",
+ *     image: "https://image-host.com/new-image.png",
+ *   },
+ * });
+ * ```
+ */
+export function updateTokenURI(
+  options: BaseTransactionOptions<UpdateTokenURIParams>,
+) {
+  const { contract } = options;
+  return setTokenURI({
+    contract,
+    asyncParams: async () => getUpdateTokenParams(options),
+  });
+}
+
+export async function getUpdateTokenParams(
+  options: BaseTransactionOptions<UpdateTokenURIParams>,
+): Promise<SetTokenURIParams> {
+  const { tokenId, newMetadata } = options;
+  const batch: Promise<string>[] = [
+    // image URI resolution
+    (async () => {
+      if (!newMetadata.image) {
+        return "";
+      }
+      if (typeof newMetadata.image === "string") {
+        return newMetadata.image;
+      }
+      return await upload({
+        client: options.contract.client,
+        files: [newMetadata.image],
+      });
+    })(),
+    // animation URI resolution
+    (async () => {
+      if (!newMetadata.animation_url) {
+        return "";
+      }
+      if (typeof newMetadata.animation_url === "string") {
+        return newMetadata.animation_url;
+      }
+      return await upload({
+        client: options.contract.client,
+        files: [newMetadata.animation_url],
+      });
+    })(),
+  ];
+
+  const [imageURI, animationURI] = await Promise.all(batch);
+  if (newMetadata.image && imageURI) {
+    newMetadata.image = imageURI;
+  }
+  if (newMetadata.animation_url && animationURI) {
+    newMetadata.animation_url = animationURI;
+  }
+
+  const uri = await upload({
+    client: options.contract.client,
+    files: [newMetadata],
+  });
+  return { tokenId, uri };
+}

--- a/packages/thirdweb/src/extensions/erc721/write/updateTokenURI.ts
+++ b/packages/thirdweb/src/extensions/erc721/write/updateTokenURI.ts
@@ -1,0 +1,97 @@
+import { upload } from "../../../storage/upload.js";
+import type { BaseTransactionOptions } from "../../../transaction/types.js";
+import type { NFTInput } from "../../../utils/nft/parseNft.js";
+import {
+  type SetTokenURIParams,
+  setTokenURI,
+} from "../../erc721/__generated__/INFTMetadata/write/setTokenURI.js";
+
+/**
+ * @extension ERC721
+ */
+export type UpdateTokenURIParams = {
+  tokenId: bigint;
+  newMetadata: NFTInput;
+};
+
+/**
+ * This function is an abstracted layer of the [`setTokenURI` extension](https://portal.thirdweb.com/references/typescript/v5/erc721/setTokenURI),
+ * which means it uses `setTokenURI` under the hood.
+ * While the `setTokenURI` method only takes in a uri string, this extension takes in a user-friendly [`NFTInput`](https://portal.thirdweb.com/references/typescript/v5/NFTInput),
+ * upload that content to IPFS and pass the IPFS URI (of said `NFTInput`) to the underlying `setTokenURI` method.
+ *
+ * This extension does not validate the NFTInput so make sure you are passing the proper content that you want to update.
+ *
+ * @extension ERC721
+ * @returns the prepared transaction from `setTokenURI`
+ * @example
+ * ```ts
+ * import { updateTokenURI } from "thirdweb/extensions/erc721";
+ *
+ * const transaction = updateTokenURI({
+ *   tokenId: 0n,
+ *   nft: {
+ *     name: "new name",
+ *     description: "new description",
+ *     image: "https://image-host.com/new-image.png",
+ *   },
+ * });
+ * ```
+ */
+export function updateTokenURI(
+  options: BaseTransactionOptions<UpdateTokenURIParams>,
+) {
+  const { contract } = options;
+  return setTokenURI({
+    contract,
+    asyncParams: async () => getUpdateTokenParams(options),
+  });
+}
+
+export async function getUpdateTokenParams(
+  options: BaseTransactionOptions<UpdateTokenURIParams>,
+): Promise<SetTokenURIParams> {
+  const { tokenId, newMetadata } = options;
+  const batch: Promise<string>[] = [
+    // image URI resolution
+    (async () => {
+      if (!newMetadata.image) {
+        return "";
+      }
+      if (typeof newMetadata.image === "string") {
+        return newMetadata.image;
+      }
+      return await upload({
+        client: options.contract.client,
+        files: [newMetadata.image],
+      });
+    })(),
+    // animation URI resolution
+    (async () => {
+      if (!newMetadata.animation_url) {
+        return "";
+      }
+      if (typeof newMetadata.animation_url === "string") {
+        return newMetadata.animation_url;
+      }
+      return await upload({
+        client: options.contract.client,
+        files: [newMetadata.animation_url],
+      });
+    })(),
+  ];
+
+  const [imageURI, animationURI] = await Promise.all(batch);
+  if (newMetadata.image && imageURI) {
+    newMetadata.image = imageURI;
+  }
+  if (newMetadata.animation_url && animationURI) {
+    newMetadata.animation_url = animationURI;
+  }
+
+  const uri = await upload({
+    client: options.contract.client,
+    files: [newMetadata],
+  });
+  return { tokenId, uri };
+}


### PR DESCRIPTION
# High level changes
- `mint-form.tsx` is "over-abstracted" (not sure if that's the right word) - it's being used for too many different NFT features, making the code hard-to-migrate.
- solution: breaking it down to different component which makes it much easier to remove v4 code

# to test
- [x] UpdateMetadataForm
  - [x] Drop contracts
  - [x] Collection contracts
- [x] SharedMetadataForm
- [x] NFTMintForm
- [x] LazyMintForm

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add an NFT extension `updateTokenURI` and update related components for ERC721 and ERC1155.

### Detailed summary
- Added NFT extension `updateTokenURI`
- Updated components for ERC721 and ERC1155
- Renamed `NFTMintForm` to `CreateListingsFormProps`
- Updated NFT buttons with contract and ERC721 status
- Added `isDropContract` check in `useNFTDrawerTabs`
- Updated `UpdateMetadataTab` and related components
- Refactored permissions components for `ThirdwebContract`

> The following files were skipped due to too many changes: `apps/dashboard/src/contract-ui/tabs/permissions/components/contract-permission.tsx`, `packages/thirdweb/src/extensions/erc721/write/updateTokenURI.ts`, `packages/thirdweb/src/extensions/erc1155/write/updateTokenURI.ts`, `apps/dashboard/src/contract-ui/tabs/nfts/components/shared-metadata-form.tsx`, `apps/dashboard/src/contract-ui/tabs/nfts/components/lazy-mint-form.tsx`, `apps/dashboard/src/contract-ui/tabs/nfts/components/update-metadata-form.tsx`, `apps/dashboard/src/contract-ui/tabs/nfts/components/mint-form.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->