### PR TITLE
[dashboard] No sign-in required for /dashboard/connect/playground page

### DIFF
--- a/apps/dashboard/src/@/constants/auth.ts
+++ b/apps/dashboard/src/@/constants/auth.ts
@@ -1,4 +1,4 @@
-export const LOGGED_IN_ONLY_PATHS = [
+const LOGGED_IN_ONLY_PATHS = [
   // anything that _starts_ with /dashboard is logged in only
   "/dashboard",
   // anything that _starts_ with /cli is logged in only
@@ -6,3 +6,12 @@ export const LOGGED_IN_ONLY_PATHS = [
   "/support",
   // TODO: add any other logged in only paths here
 ];
+
+export function isLoginRequired(pathname: string) {
+  // exceptions from LOGGED_IN_ONLY_PATHS
+  if (pathname.startsWith("/dashboard/connect/playground")) {
+    return false;
+  }
+
+  return LOGGED_IN_ONLY_PATHS.some((path) => pathname.startsWith(path));
+}

--- a/apps/dashboard/src/@3rdweb-sdk/react/hooks/useLoggedInUser.ts
+++ b/apps/dashboard/src/@3rdweb-sdk/react/hooks/useLoggedInUser.ts
@@ -1,4 +1,4 @@
-import { LOGGED_IN_ONLY_PATHS } from "@/constants/auth";
+import { isLoginRequired } from "@/constants/auth";
 import { useQuery } from "@tanstack/react-query";
 import type { EnsureLoginResponse } from "app/api/auth/ensure-login/route";
 import { usePathname, useRouter } from "next/navigation";
@@ -35,12 +35,12 @@ export function useLoggedInUser(): {
     // enabled if:
     // - there is a pathname
     // - we are not already currently connecting
-    // - the pathname is one of the LOGGED_IN_ONLY_PATHS
+    // - the pathname requires login
     enabled:
       !!pathname &&
       connectionStatus !== "connecting" &&
       statusWasEverConnecting.current &&
-      LOGGED_IN_ONLY_PATHS.some((path) => pathname.startsWith(path)),
+      isLoginRequired(pathname),
     // the last "persist", part of the queryKey, is to make sure that we do not cache this query in indexDB
     // convention in v4 of the SDK that we are (ab)using here
     queryKey: ["logged_in_user", connectedAddress, { persist: false }],
@@ -113,7 +113,7 @@ export function useLoggedInUser(): {
   }
 
   // if we are not on a logged in path, we can simply return the connected address
-  if (!LOGGED_IN_ONLY_PATHS.some((path) => pathname.startsWith(path))) {
+  if (!isLoginRequired(pathname)) {
     return {
       isLoading: false,
       isLoggedIn: true,

--- a/apps/dashboard/src/middleware.ts
+++ b/apps/dashboard/src/middleware.ts
@@ -1,4 +1,4 @@
-import { LOGGED_IN_ONLY_PATHS } from "@/constants/auth";
+import { isLoginRequired } from "@/constants/auth";
 import { COOKIE_ACTIVE_ACCOUNT, COOKIE_PREFIX_TOKEN } from "@/constants/cookie";
 import { type NextRequest, NextResponse } from "next/server";
 import { getAddress } from "thirdweb";
@@ -28,7 +28,7 @@ export async function middleware(request: NextRequest) {
     : null;
 
   // logged in paths
-  if (LOGGED_IN_ONLY_PATHS.some((path) => pathname.startsWith(path))) {
+  if (isLoginRequired(pathname)) {
     // check if the user is logged in (has a valid auth cookie)
 
     if (!authCookie) {


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the middleware and hooks in the dashboard app to use a centralized function for checking if a path requires login.

### Detailed summary
- Created `isLoginRequired` function in `constants/auth.ts`
- Updated middleware and hooks to use `isLoginRequired` function for checking login requirement

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->