### PR TITLE
Fix "All Wallets" not shown by default in Pay UI when trying to connect a new wallet

### DIFF
--- a/.changeset/odd-chicken-pretend.md
+++ b/.changeset/odd-chicken-pretend.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix "All Wallets" not shown by default in Pay UI when trying to connect a new wallet

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx
@@ -227,7 +227,11 @@ function BuyScreenContent(props: BuyScreenContentProps) {
           }
         }}
         recommendedWallets={props.connectOptions?.recommendedWallets}
-        showAllWallets={!!props.connectOptions?.showAllWallets}
+        showAllWallets={
+          props.connectOptions?.showAllWallets === undefined
+            ? true
+            : props.connectOptions?.showAllWallets
+        }
         walletConnect={props.connectOptions?.walletConnect}
         wallets={props.connectOptions?.wallets}
       />


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the issue where "All Wallets" were not shown by default in the Pay UI when connecting a new wallet.

### Detailed summary
- Updated `BuyScreen.tsx` to ensure "All Wallets" are shown by default in the Pay UI
- Adjusted logic to display recommended wallets and wallet connection options

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->