### PR TITLE
test(thirdweb): skip deployModularCore tests dependent on TW_SECRET_KEY

### DIFF
--- a/packages/thirdweb/src/extensions/prebuilts/deploy-modular-core.test.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/deploy-modular-core.test.ts
@@ -11,7 +11,7 @@ import { uninstallPublishedExtension } from "../modular/ModularCore/write/uninst
 import { getInstalledExtensions } from "../modular/__generated__/ModularCore/read/getInstalledExtensions.js";
 import { deployPublishedContract } from "./deploy-published.js";
 
-describe.runIf(process.env.TW_SECRET_KEY)(
+describe.skip(
   "deployModularCore",
   {
     timeout: 120000,


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the test for deploying the modular core by skipping the test based on a condition.

### Detailed summary
- Updated the test to skip based on a condition
- Changed `describe.runIf` to `describe.skip`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->