### PR TITLE
[Hotfix] ethers v5 adapter

### DIFF
--- a/.changeset/little-forks-reply.md
+++ b/.changeset/little-forks-reply.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Small fix for ethers5 adapter

--- a/packages/thirdweb/src/adapters/ethers5.ts
+++ b/packages/thirdweb/src/adapters/ethers5.ts
@@ -114,7 +114,7 @@ export const ethers5Adapter = /* @__PURE__ */ (() => {
        * const twContract = await ethers5Adapter.contract.fromEthersContract({
        *  client,
        *  ethersContract,
-       *  chainId,
+       *  chain: defineChain(1), // Replace with your chain
        * });
        * ```
        */
@@ -255,7 +255,9 @@ async function fromEthersContract<abi extends Abi>(
 ): Promise<ThirdwebContract<abi>> {
   return getContract({
     client: options.client,
-    address: await options.ethersContract.getAddress(),
+    address:
+      options.ethersContract.address ||
+      (await options.ethersContract.getAddress()),
     chain: options.chain,
   });
 }


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `ethers5.ts` adapter in the `thirdweb` package to replace the `chainId` parameter with `chain: defineChain(1)`.

### Detailed summary
- Replaced `chainId` parameter with `chain: defineChain(1)`
- Updated the `fromEthersContract` function to handle `options.ethersContract.address` being undefined

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->