### PR TITLE
fix(wallet): resolve issues with native AutoConnect and URL token retrieval

### DIFF
--- a/.changeset/clean-mugs-study.md
+++ b/.changeset/clean-mugs-study.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix native AutoConnect

--- a/packages/thirdweb/src/wallets/in-app/web/lib/get-url-token.ts
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/get-url-token.ts
@@ -10,8 +10,9 @@ export function getUrlToken(): {
   authResult?: AuthStoredTokenWithCookieReturnType;
   authProvider?: AuthOption;
 } {
-  if (!window) {
-    throw new Error("Attempted to fetch a URL token on the server");
+  if (!window?.location) {
+    // Not in web
+    return {};
   }
 
   const queryString = window.location.search;


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to fix the native AutoConnect feature in `thirdweb`. 

### Detailed summary
- Updated `get-url-token.ts` to check for `window?.location` before fetching URL token
- Added a comment to clarify the code logic

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->