### PR TITLE
Force legacy 248, 9372, 841, 842

### DIFF
--- a/packages/thirdweb/src/gas/fee-data.ts
+++ b/packages/thirdweb/src/gas/fee-data.ts
@@ -30,6 +30,10 @@ type FeeDataParams =
 const FORCE_GAS_PRICE_CHAIN_IDS = [
   78600, // Vanar testnet
   2040, // Vanar mainnet
+  248, // Oasys Mainnet
+  9372, // Oasys Testnet
+  841, // Taraxa Mainnet
+  842, // Taraxa Testnet
 ];
 
 /**


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds fee data for Oasys and Taraxa networks in the gas/fee-data.ts file.

### Detailed summary
- Added fee data for Oasys Mainnet and Testnet
- Added fee data for Taraxa Mainnet and Testnet

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->