### PR TITLE
Fix broken Contract metadata image 

### DIFF
--- a/apps/dashboard/src/components/custom-contract/contract-header/metadata-header.tsx
+++ b/apps/dashboard/src/components/custom-contract/contract-header/metadata-header.tsx
@@ -1,3 +1,4 @@
+import { thirdwebClient } from "@/constants/client";
 import {
   Center,
   Flex,
@@ -8,6 +9,7 @@ import {
 import { ChainIcon } from "components/icons/ChainIcon";
 import Link from "next/link";
 import type { ChainMetadata } from "thirdweb/chains";
+import { resolveScheme } from "thirdweb/storage";
 import { Heading, LinkButton, Text } from "tw-components";
 import { AddressCopyButton } from "tw-components/AddressCopyButton";
 
@@ -77,7 +79,10 @@ export const MetadataHeader: React.FC<MetadataHeaderProps> = ({
               right={0}
               left={0}
               objectFit="contain"
-              src={data.image}
+              src={resolveScheme({
+                client: thirdwebClient,
+                uri: data.image,
+              })}
               alt={data?.name?.toString() || ""}
             />
           ) : null}


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the `MetadataHeader` component to resolve the image URI using a new function.

### Detailed summary
- Added import for `resolveScheme` from `thirdweb/storage`
- Updated `src` attribute of the image to use `resolveScheme` function with `thirdwebClient` and `data.image`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->