### PR TITLE
feat(react): add `enabled` param to `useWalletBalance` hook

### DIFF
--- a/.changeset/yellow-numbers-yell.md
+++ b/.changeset/yellow-numbers-yell.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Added `enabled` param to `useWalletBalance` hook

--- a/packages/thirdweb/src/react/core/hooks/others/useWalletBalance.ts
+++ b/packages/thirdweb/src/react/core/hooks/others/useWalletBalance.ts
@@ -19,7 +19,7 @@ export type UseWalletBalanceOptions = Prettify<
 >;
 export type UseWalletBalanceQueryOptions = Omit<
   UseQueryOptions<GetWalletBalanceResult>,
-  "queryFn" | "queryKey" | "enabled"
+  "queryFn" | "queryKey"
 >;
 
 /**
@@ -85,6 +85,10 @@ export function useWalletBalance(
         tokenAddress,
       });
     },
-    enabled: !!chain && !!client && !!address,
+    enabled:
+      (queryOptions?.enabled === undefined || queryOptions.enabled) &&
+      !!chain &&
+      !!client &&
+      !!address,
   });
 }


### PR DESCRIPTION
Adds an `enabled` param to the `queryOptions` in the `useWalletBalance` hook so consumers of this hook can control the overall enabling/disabling of the fetch request without having to do a hacky workaround like passing `address: undefined`.

An example use case for this is fetching the balance of a token that may exist on some chains but not others:
```
const result = useWalletBalance({
  client,
  chain,
  address,
  tokenAddress,
}, {
  enabled: !!tokenAddress,
});
```

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add an `enabled` parameter to the `useWalletBalance` hook in `useWalletBalance.ts`.

### Detailed summary
- Added `enabled` parameter to `useWalletBalance` hook
- Updated the `UseWalletBalanceQueryOptions` type to include the `enabled` parameter
- Modified the `useWalletBalance` function to utilize the new `enabled` parameter for conditional activation

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->