### PR TITLE
[Dashboard/SDK] Add more Split extensions and remove Split v4 code from Dashboard

### DIFF
--- a/.changeset/bright-kiwis-smell.md
+++ b/.changeset/bright-kiwis-smell.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Add more Split contract extensions

--- a/apps/dashboard/src/contract-ui/tabs/account/components/account-balance.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/account/components/account-balance.tsx
@@ -1,21 +1,33 @@
 import { thirdwebClient } from "@/constants/client";
 import { useSplitBalances } from "@3rdweb-sdk/react/hooks/useSplit";
 import { SimpleGrid, Stat, StatLabel, StatNumber } from "@chakra-ui/react";
+import { useV5DashboardChain } from "lib/v5-adapter";
+import { getContract } from "thirdweb";
 import { useActiveWalletChain, useWalletBalance } from "thirdweb/react";
 import { Card } from "tw-components";
 
 interface AccountBalanceProps {
   address: string;
+  chainId: number;
 }
 
-export const AccountBalance: React.FC<AccountBalanceProps> = ({ address }) => {
+export const AccountBalance: React.FC<AccountBalanceProps> = ({
+  address,
+  chainId,
+}) => {
+  const v5Chain = useV5DashboardChain(chainId);
   const activeChain = useActiveWalletChain();
   const { data: balance } = useWalletBalance({
     address,
     chain: activeChain,
     client: thirdwebClient,
   });
-  const balanceQuery = useSplitBalances(address);
+  const contract = getContract({
+    address,
+    chain: v5Chain,
+    client: thirdwebClient,
+  });
+  const balanceQuery = useSplitBalances(contract);
 
   return (
     <SimpleGrid spacing={{ base: 3, md: 6 }} columns={{ base: 2, md: 4 }}>

--- a/apps/dashboard/src/contract-ui/tabs/account/page.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/account/page.tsx
@@ -50,12 +50,19 @@ export const AccountPage: React.FC<AccountPageProps> = ({
     );
   }
 
+  const contract = contractQuery.contract;
+
   return (
     <Flex direction="column" gap={6}>
       <Flex direction="row" justify="space-between" align="center">
         <Heading size="title.sm">Balances</Heading>
       </Flex>
-      <AccountBalance address={contractAddress || ""} />
+      {contract && (
+        <AccountBalance
+          address={contract.getAddress()}
+          chainId={contract.chainId}
+        />
+      )}
       <Flex direction="row" justify="space-between" align="center">
         <Heading size="title.sm">Deposit {symbol}</Heading>
       </Flex>

--- a/packages/thirdweb/scripts/generate/abis/prebuilts/Split.json
+++ b/packages/thirdweb/scripts/generate/abis/prebuilts/Split.json
@@ -1,0 +1,3 @@
+[
+  "function initialize(address _defaultAdmin, string memory _contractURI, address[] memory _trustedForwarders, address[] memory _payees, uint256[] memory _shares)"
+]

--- a/packages/thirdweb/scripts/generate/abis/split/Split.json
+++ b/packages/thirdweb/scripts/generate/abis/split/Split.json
@@ -6,5 +6,6 @@
   "function shares(address account) view returns (uint256)",
   "function totalReleased() view returns (uint256)",
   "function distribute()",
-  "function release(address account)"
+  "function release(address account)",
+  "function totalShares() view returns (uint256)"
 ]

--- a/packages/thirdweb/src/exports/deploys.ts
+++ b/packages/thirdweb/src/exports/deploys.ts
@@ -33,3 +33,8 @@ export {
   type PrepareDirectDeployTransactionOptions,
 } from "../contract/deployment/deploy-with-abi.js";
 export { computePublishedContractAddress } from "../utils/any-evm/compute-published-contract-address.js";
+export {
+  deploySplitContract,
+  type SplitContractParams,
+  type DeploySplitContractOptions,
+} from "../extensions/prebuilts/deploy-split.js";

--- a/packages/thirdweb/src/exports/extensions/split.ts
+++ b/packages/thirdweb/src/exports/extensions/split.ts
@@ -34,6 +34,14 @@ export { totalReleased } from "../../extensions/split/__generated__/Split/read/t
 
 export { totalReleasedByToken } from "../../extensions/split/read/totalReleasedByToken.js";
 
+export { getAllRecipientsAddresses } from "../../extensions/split/read/getAllRecipientsAddresses.js";
+
+export { getAllRecipientsPercentages } from "../../extensions/split/read/getAllRecipientsPercentages.js";
+
+export {
+  getRecipientSplitPercentage,
+  type SplitRecipient,
+} from "../../extensions/split/read/getRecipientSplitPercentage.js";
 /**
  * WRITE
  */

--- a/packages/thirdweb/src/extensions/prebuilts/__generated__/Split/write/initialize.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/__generated__/Split/write/initialize.ts
@@ -1,0 +1,191 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "initialize" function.
+ */
+export type InitializeParams = WithOverrides<{
+  defaultAdmin: AbiParameterToPrimitiveType<{
+    type: "address";
+    name: "_defaultAdmin";
+  }>;
+  contractURI: AbiParameterToPrimitiveType<{
+    type: "string";
+    name: "_contractURI";
+  }>;
+  trustedForwarders: AbiParameterToPrimitiveType<{
+    type: "address[]";
+    name: "_trustedForwarders";
+  }>;
+  payees: AbiParameterToPrimitiveType<{ type: "address[]"; name: "_payees" }>;
+  shares: AbiParameterToPrimitiveType<{ type: "uint256[]"; name: "_shares" }>;
+}>;
+
+export const FN_SELECTOR = "0xb1a14437" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "_defaultAdmin",
+  },
+  {
+    type: "string",
+    name: "_contractURI",
+  },
+  {
+    type: "address[]",
+    name: "_trustedForwarders",
+  },
+  {
+    type: "address[]",
+    name: "_payees",
+  },
+  {
+    type: "uint256[]",
+    name: "_shares",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `initialize` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `initialize` method is supported.
+ * @extension PREBUILTS
+ * @example
+ * ```ts
+ * import { isInitializeSupported } from "thirdweb/extensions/prebuilts";
+ *
+ * const supported = await isInitializeSupported(contract);
+ * ```
+ */
+export async function isInitializeSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "initialize" function.
+ * @param options - The options for the initialize function.
+ * @returns The encoded ABI parameters.
+ * @extension PREBUILTS
+ * @example
+ * ```ts
+ * import { encodeInitializeParams } "thirdweb/extensions/prebuilts";
+ * const result = encodeInitializeParams({
+ *  defaultAdmin: ...,
+ *  contractURI: ...,
+ *  trustedForwarders: ...,
+ *  payees: ...,
+ *  shares: ...,
+ * });
+ * ```
+ */
+export function encodeInitializeParams(options: InitializeParams) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.defaultAdmin,
+    options.contractURI,
+    options.trustedForwarders,
+    options.payees,
+    options.shares,
+  ]);
+}
+
+/**
+ * Encodes the "initialize" function into a Hex string with its parameters.
+ * @param options - The options for the initialize function.
+ * @returns The encoded hexadecimal string.
+ * @extension PREBUILTS
+ * @example
+ * ```ts
+ * import { encodeInitialize } "thirdweb/extensions/prebuilts";
+ * const result = encodeInitialize({
+ *  defaultAdmin: ...,
+ *  contractURI: ...,
+ *  trustedForwarders: ...,
+ *  payees: ...,
+ *  shares: ...,
+ * });
+ * ```
+ */
+export function encodeInitialize(options: InitializeParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeInitializeParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "initialize" function on the contract.
+ * @param options - The options for the "initialize" function.
+ * @returns A prepared transaction object.
+ * @extension PREBUILTS
+ * @example
+ * ```ts
+ * import { initialize } from "thirdweb/extensions/prebuilts";
+ *
+ * const transaction = initialize({
+ *  contract,
+ *  defaultAdmin: ...,
+ *  contractURI: ...,
+ *  trustedForwarders: ...,
+ *  payees: ...,
+ *  shares: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * ...
+ *
+ * ```
+ */
+export function initialize(
+  options: BaseTransactionOptions<
+    | InitializeParams
+    | {
+        asyncParams: () => Promise<InitializeParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [
+        resolvedOptions.defaultAdmin,
+        resolvedOptions.contractURI,
+        resolvedOptions.trustedForwarders,
+        resolvedOptions.payees,
+        resolvedOptions.shares,
+      ] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
+  });
+}

--- a/packages/thirdweb/src/extensions/prebuilts/deploy-split.test.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/deploy-split.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { ANVIL_CHAIN } from "~test/chains.js";
+import { TEST_CLIENT } from "~test/test-clients.js";
+import { TEST_ACCOUNT_A } from "~test/test-wallets.js";
+import { isAddress } from "../../utils/address.js";
+import { deploySplitContract } from "./deploy-split.js";
+
+describe("deploy-split contract", () => {
+  it("should deploy Split contract", async () => {
+    const address = await deploySplitContract({
+      account: TEST_ACCOUNT_A,
+      client: TEST_CLIENT,
+      chain: ANVIL_CHAIN,
+      params: {
+        name: "split-contract",
+        payees: [
+          "0x12345674b599ce99958242b3D3741e7b01841DF3",
+          "0xA6f11e47dE28B3dB934e945daeb6F538E9019694",
+        ],
+        shares: [
+          5100n, // 51%
+          4900n, // 49%
+        ],
+      },
+    });
+    expect(address).toBeDefined();
+    expect(isAddress(address)).toBe(true);
+    // Further tests to verify the functionality of this contract
+    // are done in other Split tests
+  });
+});

--- a/packages/thirdweb/src/extensions/prebuilts/deploy-split.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/deploy-split.ts
@@ -1,0 +1,144 @@
+import type { ThirdwebClient } from "../../client/client.js";
+import type { ThirdwebContract } from "../../contract/contract.js";
+import { deployViaAutoFactory } from "../../contract/deployment/deploy-via-autofactory.js";
+import { getOrDeployInfraForPublishedContract } from "../../contract/deployment/utils/bootstrap.js";
+import { upload } from "../../storage/upload.js";
+import type { FileOrBufferOrString } from "../../storage/upload/types.js";
+import type { Prettify } from "../../utils/type-utils.js";
+import type { ClientAndChainAndAccount } from "../../utils/types.js";
+import { initialize } from "./__generated__/Split/write/initialize.js";
+
+/**
+ * @extension PREBUILT
+ */
+export type SplitContractParams = {
+  name: string;
+
+  /**
+   * An array of strings containing wallet addresses of the recipients
+   * For example:
+   * ```ts
+   * ["0x...123", "0x...456"]
+   * ```
+   */
+  payees: string[];
+  /**
+   * An array of bigints containing the shared percentages of each respective payees.
+   * Must have the same length as `payees`
+   * @example
+   * ```ts
+   * [
+   *   5100n, // 51%
+   *   4900n, // 49%
+   * ]
+   * ```
+   */
+  shares: bigint[];
+  description?: string;
+  image?: FileOrBufferOrString;
+  external_link?: string;
+  social_urls?: Record<string, string>;
+  symbol?: string;
+  contractURI?: string;
+  defaultAdmin?: string;
+  trustedForwarders?: string[];
+};
+
+/**
+ * @extension DEPLOY
+ */
+export type DeploySplitContractOptions = Prettify<
+  ClientAndChainAndAccount & {
+    params: SplitContractParams;
+  }
+>;
+
+/**
+ * Deploys a thirdweb [`Split contract`](https://thirdweb.com/thirdweb.eth/Split)
+ * On chains where the thirdweb infrastructure contracts are not deployed, this function will deploy them as well.
+ * @param options - The deployment options.
+ * @returns The deployed contract address.
+ * @extension DEPLOY
+ *
+ * @example
+ * ```ts
+ * import { deploySplitContract } from "thirdweb/deploys";
+ * const contractAddress = await deploySplitContract({
+ *  chain,
+ *  client,
+ *  account,
+ *  params: {
+ *    name: "Split contract",
+ *    payees: ["0x...123", "0x...456"],
+ *    shares: [5100, 4900], // See type `SplitContractParams` for more context
+ * });
+ * ```
+ */
+export async function deploySplitContract(options: DeploySplitContractOptions) {
+  const { chain, client, account, params } = options;
+  const { cloneFactoryContract, implementationContract } =
+    await getOrDeployInfraForPublishedContract({
+      chain,
+      client,
+      account,
+      contractId: "Split",
+      constructorParams: [],
+    });
+  const initializeTransaction = await getInitializeTransaction({
+    client,
+    implementationContract,
+    params,
+    accountAddress: account.address,
+  });
+
+  return deployViaAutoFactory({
+    client,
+    chain,
+    account,
+    cloneFactoryContract,
+    initializeTransaction,
+  });
+}
+
+async function getInitializeTransaction(options: {
+  client: ThirdwebClient;
+  implementationContract: ThirdwebContract;
+  params: SplitContractParams;
+  accountAddress: string;
+}) {
+  const { client, implementationContract, params, accountAddress } = options;
+  const {
+    name,
+    description,
+    symbol,
+    image,
+    external_link,
+    social_urls,
+    payees,
+    shares,
+  } = params;
+  const contractURI =
+    params.contractURI ||
+    (await upload({
+      client,
+      files: [
+        {
+          name,
+          description,
+          symbol,
+          image,
+          external_link,
+          social_urls,
+        },
+      ],
+    })) ||
+    "";
+  return initialize({
+    contract: implementationContract,
+    defaultAdmin: params.defaultAdmin || accountAddress,
+    contractURI,
+    trustedForwarders: params.trustedForwarders || [],
+    payees,
+    shares,
+  });
+}

--- a/packages/thirdweb/src/extensions/split/__generated__/Split/read/totalShares.ts
+++ b/packages/thirdweb/src/extensions/split/__generated__/Split/read/totalShares.ts
@@ -1,0 +1,72 @@
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0x3a98ef39" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Checks if the `totalShares` method is supported by the given contract.
+ * @param contract The ThirdwebContract.
+ * @returns A promise that resolves to a boolean indicating if the `totalShares` method is supported.
+ * @extension SPLIT
+ * @example
+ * ```ts
+ * import { isTotalSharesSupported } from "thirdweb/extensions/split";
+ *
+ * const supported = await isTotalSharesSupported(contract);
+ * ```
+ */
+export async function isTotalSharesSupported(contract: ThirdwebContract<any>) {
+  return detectMethod({
+    contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Decodes the result of the totalShares function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension SPLIT
+ * @example
+ * ```ts
+ * import { decodeTotalSharesResult } from "thirdweb/extensions/split";
+ * const result = decodeTotalSharesResult("...");
+ * ```
+ */
+export function decodeTotalSharesResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "totalShares" function on the contract.
+ * @param options - The options for the totalShares function.
+ * @returns The parsed result of the function call.
+ * @extension SPLIT
+ * @example
+ * ```ts
+ * import { totalShares } from "thirdweb/extensions/split";
+ *
+ * const result = await totalShares({
+ *  contract,
+ * });
+ *
+ * ```
+ */
+export async function totalShares(options: BaseTransactionOptions) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [],
+  });
+}

--- a/packages/thirdweb/src/extensions/split/read/getAllRecipientsAddresses.test.ts
+++ b/packages/thirdweb/src/extensions/split/read/getAllRecipientsAddresses.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { ANVIL_CHAIN } from "~test/chains.js";
+import { TEST_CLIENT } from "~test/test-clients.js";
+import { TEST_ACCOUNT_A } from "~test/test-wallets.js";
+import { getContract } from "../../../contract/contract.js";
+import { deploySplitContract } from "../../../extensions/prebuilts/deploy-split.js";
+import { getAllRecipientsAddresses } from "./getAllRecipientsAddresses.js";
+
+const chain = ANVIL_CHAIN;
+const client = TEST_CLIENT;
+
+describe("getAllRecipientsAddresses", () => {
+  it("should work", async () => {
+    const payees = [
+      "0x12345674b599ce99958242b3D3741e7b01841DF3",
+      "0xA6f11e47dE28B3dB934e945daeb6F538E9019694",
+    ];
+    const address = await deploySplitContract({
+      account: TEST_ACCOUNT_A,
+      client: TEST_CLIENT,
+      chain: ANVIL_CHAIN,
+      params: {
+        name: "split-contract",
+        payees,
+        shares: [
+          5100n, // 51%
+          4900n, // 49%
+        ],
+      },
+    });
+    const contract = getContract({
+      address,
+      chain,
+      client,
+    });
+    const result = await getAllRecipientsAddresses({ contract });
+    expect(result).toStrictEqual(payees);
+  });
+});

--- a/packages/thirdweb/src/extensions/split/read/getAllRecipientsAddresses.ts
+++ b/packages/thirdweb/src/extensions/split/read/getAllRecipientsAddresses.ts
@@ -1,0 +1,26 @@
+import type { BaseTransactionOptions } from "../../../transaction/types.js";
+import { payee } from "../__generated__/Split/read/payee.js";
+import { payeeCount } from "../__generated__/Split/read/payeeCount.js";
+
+/**
+ * Get the addresses of all recipients of a [`thirdweb Split contract`](https://thirdweb.com/thirdweb.eth/Split)
+ * @extension SPLIT
+ * @returns an array of wallet addresses
+ *
+ * @example
+ * ```ts
+ * import { getAllRecipientsAddresses } from "thirdweb/extensions/split";
+ *
+ * const addresses = await getAllRecipientsAddresses({ contract });
+ */
+export async function getAllRecipientsAddresses(
+  options: BaseTransactionOptions,
+): Promise<string[]> {
+  const { contract } = options;
+  const _totalRecipients = await payeeCount(options);
+  const indexes = Array.from({ length: Number(_totalRecipients) }, (_, i) => i);
+  const recipientAddresses = await Promise.all(
+    indexes.map((index) => payee({ contract, index: BigInt(index) })),
+  );
+  return recipientAddresses;
+}

--- a/packages/thirdweb/src/extensions/split/read/getAllRecipientsPercentages.test.ts
+++ b/packages/thirdweb/src/extensions/split/read/getAllRecipientsPercentages.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { ANVIL_CHAIN } from "~test/chains.js";
+import { TEST_CLIENT } from "~test/test-clients.js";
+import { TEST_ACCOUNT_A } from "~test/test-wallets.js";
+import { getContract } from "../../../contract/contract.js";
+import { deploySplitContract } from "../../../extensions/prebuilts/deploy-split.js";
+import { getAllRecipientsPercentages } from "./getAllRecipientsPercentages.js";
+
+const chain = ANVIL_CHAIN;
+const client = TEST_CLIENT;
+
+describe("getAllRecipientsPercentages", () => {
+  it("should work", async () => {
+    const payees = [
+      "0x12345674b599ce99958242b3D3741e7b01841DF3",
+      "0xA6f11e47dE28B3dB934e945daeb6F538E9019694",
+    ];
+    const address = await deploySplitContract({
+      account: TEST_ACCOUNT_A,
+      client: TEST_CLIENT,
+      chain: ANVIL_CHAIN,
+      params: {
+        name: "split-contract",
+        payees,
+        shares: [
+          5100n, // 51%
+          4900n, // 49%
+        ],
+      },
+    });
+    const contract = getContract({
+      address,
+      chain,
+      client,
+    });
+    const result = await getAllRecipientsPercentages({ contract });
+    expect(result).toStrictEqual([
+      {
+        address: "0x12345674b599ce99958242b3D3741e7b01841DF3",
+        splitPercentage: 51,
+      },
+      {
+        address: "0xA6f11e47dE28B3dB934e945daeb6F538E9019694",
+        splitPercentage: 49,
+      },
+    ]);
+  });
+});

--- a/packages/thirdweb/src/extensions/split/read/getAllRecipientsPercentages.ts
+++ b/packages/thirdweb/src/extensions/split/read/getAllRecipientsPercentages.ts
@@ -1,0 +1,41 @@
+import type { BaseTransactionOptions } from "../../../transaction/types.js";
+import { getAllRecipientsAddresses } from "./getAllRecipientsAddresses.js";
+import {
+  type SplitRecipient,
+  getRecipientSplitPercentage,
+} from "./getRecipientSplitPercentage.js";
+
+/**
+ * Get all the recipients of a Split contracts
+ * @extension SPLIT
+ * @returns an array of recipients' addresses and split percentage of each
+ *
+ * @example
+ * ```ts
+ * import { getAllRecipientsPercentages } from "thirdweb/extensions/split";
+ *
+ * const allRecipients = await getAllRecipientsPercentages({ contract });
+ * // Example result:
+ * [
+ *   {
+ *     address: "0x1...",
+ *     splitPercentage: 25, // 25%
+ *   },
+ *   {
+ *     address: "0x2...",
+ *     splitPercentage: 75, // 75%
+ *   },
+ * ];
+ * ```
+ */
+export async function getAllRecipientsPercentages(
+  options: BaseTransactionOptions,
+): Promise<SplitRecipient[]> {
+  const { contract } = options;
+  const recipientAddresses = await getAllRecipientsAddresses({ contract });
+  return await Promise.all(
+    recipientAddresses.map((recipientAddress) =>
+      getRecipientSplitPercentage({ contract, recipientAddress }),
+    ),
+  );
+}

--- a/packages/thirdweb/src/extensions/split/read/getRecipientSplitPercentage.test.ts
+++ b/packages/thirdweb/src/extensions/split/read/getRecipientSplitPercentage.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { ANVIL_CHAIN } from "~test/chains.js";
+import { TEST_CLIENT } from "~test/test-clients.js";
+import { TEST_ACCOUNT_A } from "~test/test-wallets.js";
+import { getContract } from "../../../contract/contract.js";
+import { deploySplitContract } from "../../../extensions/prebuilts/deploy-split.js";
+import { getRecipientSplitPercentage } from "./getRecipientSplitPercentage.js";
+const chain = ANVIL_CHAIN;
+const client = TEST_CLIENT;
+
+describe("getRecipientSplitPercentage", () => {
+  it("should work", async () => {
+    const payees = [
+      "0x12345674b599ce99958242b3D3741e7b01841DF3",
+      "0xA6f11e47dE28B3dB934e945daeb6F538E9019694",
+    ];
+    const address = await deploySplitContract({
+      account: TEST_ACCOUNT_A,
+      client: TEST_CLIENT,
+      chain: ANVIL_CHAIN,
+      params: {
+        name: "split-contract",
+        payees,
+        shares: [
+          5100n, // 51%
+          4900n, // 49%
+        ],
+      },
+    });
+    const contract = getContract({
+      address,
+      chain,
+      client,
+    });
+    const result = await getRecipientSplitPercentage({
+      contract,
+      recipientAddress: "0x12345674b599ce99958242b3D3741e7b01841DF3",
+    });
+
+    expect(result).toStrictEqual({
+      address: "0x12345674b599ce99958242b3D3741e7b01841DF3",
+      splitPercentage: 51,
+    });
+  });
+});

--- a/packages/thirdweb/src/extensions/split/read/getRecipientSplitPercentage.ts
+++ b/packages/thirdweb/src/extensions/split/read/getRecipientSplitPercentage.ts
@@ -1,0 +1,40 @@
+import type { BaseTransactionOptions } from "../../../transaction/types.js";
+import { shares } from "../__generated__/Split/read/shares.js";
+import { totalShares } from "../__generated__/Split/read/totalShares.js";
+
+/**
+ * @extension SPLIT
+ */
+export interface SplitRecipient {
+  /**
+   * The address of the recipient
+   */
+  address: string;
+
+  /**
+   * The split of the recipient as a percentage of the total amount
+   *
+   * I.e. If a recipient has a split of 50%, and the asset sells for 100 ETH,
+   * the recipient will receive 50 ETH.
+   */
+  splitPercentage: number;
+}
+
+export async function getRecipientSplitPercentage(
+  options: BaseTransactionOptions<{ recipientAddress: string }>,
+): Promise<SplitRecipient> {
+  const { contract, recipientAddress } = options;
+  const [_totalShares, walletsShares] = await Promise.all([
+    totalShares({ contract }),
+    shares({ contract, account: recipientAddress }),
+  ]);
+  // We convert to basis points to avoid floating point loss of precision
+  // 7544n -> 75.44 (75.44 %)
+  // also we don't have to worry about number overflow in this particular context
+  const splitPercentage =
+    (Number(walletsShares) * 1e7) / Number(_totalShares) / 1e5;
+  return {
+    address: recipientAddress,
+    splitPercentage,
+  };
+}

--- a/packages/thirdweb/test/src/test-contracts.ts
+++ b/packages/thirdweb/test/src/test-contracts.ts
@@ -1,24 +1,24 @@
-import { TEST_CLIENT } from "./test-clients.js";
+import { getContract } from "../../src/contract/contract.js";
 import { USDT_ABI } from "./abis/usdt.js";
 import { FORKED_ETHEREUM_CHAIN } from "./chains.js";
-import { getContract } from "../../src/contract/contract.js";
+import { TEST_CLIENT } from "./test-clients.js";
 
 // ERC20
 
 export const USDT_CONTRACT_ADDRESS =
-	"0xdAC17F958D2ee523a2206206994597C13D831ec7";
+  "0xdAC17F958D2ee523a2206206994597C13D831ec7";
 
 export const USDT_CONTRACT = getContract({
-	client: TEST_CLIENT,
-	address: USDT_CONTRACT_ADDRESS,
-	chain: FORKED_ETHEREUM_CHAIN,
+  client: TEST_CLIENT,
+  address: USDT_CONTRACT_ADDRESS,
+  chain: FORKED_ETHEREUM_CHAIN,
 });
 
 export const USDT_CONTRACT_WITH_ABI = getContract({
-	client: TEST_CLIENT,
-	address: USDT_CONTRACT_ADDRESS,
-	chain: FORKED_ETHEREUM_CHAIN,
-	abi: USDT_ABI,
+  client: TEST_CLIENT,
+  address: USDT_CONTRACT_ADDRESS,
+  chain: FORKED_ETHEREUM_CHAIN,
+  abi: USDT_ABI,
 });
 
 // ERC721
@@ -26,18 +26,19 @@ export const USDT_CONTRACT_WITH_ABI = getContract({
 const DOODLES_ADDRESS = "0x8a90cab2b38dba80c64b7734e58ee1db38b8992e";
 
 export const DOODLES_CONTRACT = getContract({
-	client: TEST_CLIENT,
-	address: DOODLES_ADDRESS,
-	chain: FORKED_ETHEREUM_CHAIN,
+  client: TEST_CLIENT,
+  address: DOODLES_ADDRESS,
+  chain: FORKED_ETHEREUM_CHAIN,
 });
 
 const NFT_DROP_ADDRESS = "0xE333cD2f6e26A949Ce1F3FB15d7BfAc2871cc9e4";
-export const NFT_DROP_IMPLEMENTATION = "0x6f6010fb5da6f757d5b1822aadf1d3b806d6546d"; // https://etherscan.io/address/0x6f6010fb5da6f757d5b1822aadf1d3b806d6546d#code
+export const NFT_DROP_IMPLEMENTATION =
+  "0x6f6010fb5da6f757d5b1822aadf1d3b806d6546d"; // https://etherscan.io/address/0x6f6010fb5da6f757d5b1822aadf1d3b806d6546d#code
 
 export const NFT_DROP_CONTRACT = getContract({
-	client: TEST_CLIENT,
-	address: NFT_DROP_ADDRESS,
-	chain: FORKED_ETHEREUM_CHAIN,
+  client: TEST_CLIENT,
+  address: NFT_DROP_ADDRESS,
+  chain: FORKED_ETHEREUM_CHAIN,
 });
 
 // ERC1155
@@ -45,9 +46,9 @@ export const NFT_DROP_CONTRACT = getContract({
 const AURA_ADDRESS = "0x42d3641255C946CC451474295d29D3505173F22A";
 
 export const DROP1155_CONTRACT = getContract({
-	client: TEST_CLIENT,
-	address: AURA_ADDRESS,
-	chain: FORKED_ETHEREUM_CHAIN,
+  client: TEST_CLIENT,
+  address: AURA_ADDRESS,
+  chain: FORKED_ETHEREUM_CHAIN,
 });
 
 // Uniswap
@@ -55,14 +56,14 @@ export const DROP1155_CONTRACT = getContract({
 const UNISWAPV3_FACTORY_ADDRESS = "0x1F98431c8aD98523631AE4a59f267346ea31F984";
 
 export const OHM_CONTRACT_ADDRESS =
-	"0x64aa3364F17a4D01c6f1751Fd97C2BD3D7e7f1D5";
+  "0x64aa3364F17a4D01c6f1751Fd97C2BD3D7e7f1D5";
 export const WETH_CONTRACT_ADDRESS =
-	"0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
+  "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
 export const MOG_CONTRACT_ADDRESS =
-	"0xaaeE1A9723aaDB7afA2810263653A34bA2C21C7a";
+  "0xaaeE1A9723aaDB7afA2810263653A34bA2C21C7a";
 
 export const UNISWAPV3_FACTORY_CONTRACT = getContract({
-	client: TEST_CLIENT,
-	address: UNISWAPV3_FACTORY_ADDRESS,
-	chain: FORKED_ETHEREUM_CHAIN,
+  client: TEST_CLIENT,
+  address: UNISWAPV3_FACTORY_ADDRESS,
+  chain: FORKED_ETHEREUM_CHAIN,
 });


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding more functionality to the Split contract extensions, including deploying Split contracts, retrieving recipient addresses and percentages, and updating UI components.

### Detailed summary
- Added more Split contract extensions for deploying and reading data
- Updated UI components to display Split contract information
- Added tests for deploying Split contracts and retrieving recipient data

> The following files were skipped due to too many changes: `packages/thirdweb/src/extensions/split/__generated__/Split/read/totalShares.ts`, `apps/dashboard/src/contract-ui/tabs/split/components/distribute-button.tsx`, `packages/thirdweb/test/src/test-contracts.ts`, `apps/dashboard/src/@3rdweb-sdk/react/hooks/useSplit.ts`, `packages/thirdweb/src/extensions/prebuilts/deploy-split.ts`, `packages/thirdweb/src/extensions/prebuilts/__generated__/Split/write/initialize.ts`, `apps/dashboard/src/contract-ui/tabs/split/page.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->