### PR TITLE
Update page.mdx

### DIFF
--- a/apps/portal/src/app/contracts/build/extensions/page.mdx
+++ b/apps/portal/src/app/contracts/build/extensions/page.mdx
@@ -37,7 +37,7 @@ export const metadata = createMetadata({
 | [ERC1155ClaimConditions](/contracts/build/extensions/erc-1155/ERC1155ClaimConditions) | Allow users to claim NFTs from your drop under specific conditions (one claim phase)       |
 | [ERC1155ClaimCustom](/contracts/build/extensions/erc-1155/ERC1155ClaimCustom)         | Allow users to claim NFTs from your drop under specific conditions                         |
 | [ERC1155ClaimPhases](/contracts/build/extensions/erc-1155/ERC1155ClaimPhases)         | Allow users to claim NFTs from your drop under specific conditions (multiple claim phases) |
-| [ERC1155Drop](/contracts/build/extensions/erc-1155/ERC1155Drop)                       | For distributing ERC21155 tokens to set up multiple claim phases                           |
+| [ERC1155Drop](/contracts/build/extensions/erc-1155/ERC1155Drop)                       | For distributing ERC1155 tokens to set up multiple claim phases                           |
 | [ERC1155DropSinglePhase](/contracts/build/extensions/erc-1155/ERC1155DropSinglePhase) | For distributing ERC1155 tokens to set up a single claim phase                             |
 | [ERC1155Enumerable](/contracts/build/extensions/erc-1155/ERC1155Enumerable)           | Enumerate through NFTs in a contract to get all or get owned NFTs                          |
 | [ERC1155Mintable](/contracts/build/extensions/erc-1155/ERC1155Mintable)               | Mint new NFTs into the contract                                                            |


### PR DESCRIPTION
Fix Typo

## Problem solved

Short description of the bug fixed or feature added



<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to correct a typo in the description of `ERC1155Drop`. 

### Detailed summary
- Fixed a typo in the description of `ERC1155Drop`: changed "ERC21155" to "ERC1155" for accuracy.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->