### PR TITLE
feat(dashboard): add assetlinks.json for Android app link verification

### DIFF
--- a/apps/dashboard/public/.well-known/assetlinks.json
+++ b/apps/dashboard/public/.well-known/assetlinks.json
@@ -1,0 +1,12 @@
+[
+  {
+    "relation": ["delegate_permission/common.get_login_creds"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "com.thirdweb.demo",
+      "sha256_cert_fingerprints": [
+        "fac61745dc0903786fb9ede62a962b399f7348f0bb6f899b8332667591033b9c"
+      ]
+    }
+  }
+]


### PR DESCRIPTION
## Problem solved

Need this publicly accessible for testing native passkeys



<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add a digital asset link for Android app authentication.

### Detailed summary
- Added assetlinks.json file for Android app authentication
- Included delegate_permission/common.get_login_creds relation
- Specified package name and SHA-256 certificate fingerprint

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->