### PR TITLE
[Refactor] Remove unused Bun availability check in CLI bin file

### DIFF
--- a/.changeset/chilled-parents-peel.md
+++ b/.changeset/chilled-parents-peel.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+remove bun options from CLI to increase stability

--- a/packages/thirdweb/src/cli/bin.ts
+++ b/packages/thirdweb/src/cli/bin.ts
@@ -1,6 +1,4 @@
 #!/usr/bin/env node
-
-import { execSync } from "node:child_process";
 import { spawn } from "cross-spawn";
 import {
   generate,
@@ -44,25 +42,9 @@ async function main() {
 
       const isWindows = /^win/.test(process.platform);
 
-      const isBunAvailable = (() => {
-        try {
-          const res = execSync("bun --version", {
-            // stdio: "ignore",
-            encoding: "utf-8",
-          });
-          if (typeof res === "string" && res.indexOf(".") > -1) {
-            return true;
-          }
-        } catch {}
-        return false;
-      })();
-
       let runner = "npx";
 
       switch (true) {
-        case isBunAvailable:
-          runner = "bunx";
-          break;
         case isWindows:
           runner = "npx.cmd";
           break;


### PR DESCRIPTION
FIXES: https://github.com/thirdweb-dev/js/issues/3991
 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes bun options from the CLI in `thirdweb` package to enhance stability.

### Detailed summary
- Removed bun options from CLI in `thirdweb` package
- Replaced `execSync` with `spawn` for better stability
- Updated `main` function in `bin.ts`
- Removed `isBunAvailable` check and related logic

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->