### PR TITLE
[Hotfix] Remove async modifier from TrendingContractSection in trending-table.tsx

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/trending/components/trending-table.tsx
+++ b/apps/dashboard/src/app/(dashboard)/trending/components/trending-table.tsx
@@ -17,7 +17,7 @@ import { ChainIcon } from "../../(chain)/components/server/chain-icon";
 import { TablePagination } from "./pagination.client";
 import { SortingHeader } from "./sorting-header.client";
 
-export async function TrendingContractSection(props: {
+export function TrendingContractSection(props: {
   topContracts: TrendingContract[];
   chainId?: number;
   perPage?: number;


### PR DESCRIPTION
FIXES: DASH-128

<!-- start pr-codex -->

---

## PR-Codex overview
This PR changes the `TrendingContractSection` function in `trending-table.tsx` to be a synchronous function instead of an asynchronous one.

### Detailed summary
- Changed `TrendingContractSection` function to be synchronous
- Removed `async` keyword from function signature

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->