### PR TITLE
feat(dashboard): add apple-app-site-association for iOS app link verification

### DIFF
--- a/apps/dashboard/public/.well-known/apple-app-site-association
+++ b/apps/dashboard/public/.well-known/apple-app-site-association
@@ -1,0 +1,7 @@
+{
+  "applinks": {},
+  "webcredentials": {
+    "apps": ["XYHGSFAMHX.com.thirdweb.demo"]
+  },
+  "appclips": {}
+}

--- a/apps/dashboard/public/.well-known/assetlinks.json
+++ b/apps/dashboard/public/.well-known/assetlinks.json
@@ -5,7 +5,7 @@
       "namespace": "android_app",
       "package_name": "com.thirdweb.demo",
       "sha256_cert_fingerprints": [
-        "fac61745dc0903786fb9ede62a962b399f7348f0bb6f899b8332667591033b9c"
+        "40:EB:0D:96:57:F3:D8:1F:BA:87:B8:E4:26:E0:3A:DB:C8:35:96:A8:A2:B2:55:F0:B1:64:F1:39:F8:6F:7E:EB"
       ]
     }
   }


### PR DESCRIPTION
## Problem solved

for passkeys on ios

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `apple-app-site-association` and `assetlinks.json` files in the dashboard public directory to include specific app credentials.

### Detailed summary
- Added `webcredentials` for specific app ID in `apple-app-site-association`
- Updated `sha256_cert_fingerprints` in `assetlinks.json` for package `com.thirdweb.demo`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->