### PR TITLE
fix(react): switch chains for SIWE

### DIFF
--- a/.changeset/forty-tools-hear.md
+++ b/.changeset/forty-tools-hear.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Switch to the proper chain prior to signing SIWE payloads

--- a/apps/playground-web/src/app/connect/auth/server/actions/auth.ts
+++ b/apps/playground-web/src/app/connect/auth/server/actions/auth.ts
@@ -9,6 +9,7 @@ const privateKey = process.env.THIRDWEB_ADMIN_PRIVATE_KEY;
 
 const thirdwebAuth = createAuth({
   domain: process.env.NEXT_PUBLIC_THIRDWEB_AUTH_DOMAIN || "",
+  client: THIRDWEB_CLIENT,
   adminAccount: privateKey
     ? privateKeyToAccount({ client: THIRDWEB_CLIENT, privateKey })
     : await generateAccount({ client: THIRDWEB_CLIENT }),

--- a/apps/playground-web/src/components/auth/auth-button.tsx
+++ b/apps/playground-web/src/components/auth/auth-button.tsx
@@ -16,7 +16,8 @@ export function AuthButton() {
       auth={{
         isLoggedIn: (address) => isLoggedIn(address),
         doLogin: (params) => login(params),
-        getLoginPayload: ({ address }) => generatePayload({ address }),
+        getLoginPayload: ({ address }) =>
+          generatePayload({ address, chainId: 84532 }),
         doLogout: () => logout(),
       }}
     />

--- a/packages/thirdweb/src/react/core/hooks/auth/useSiweAuth.ts
+++ b/packages/thirdweb/src/react/core/hooks/auth/useSiweAuth.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { LoginPayload } from "../../../../auth/core/types.js";
 import type { VerifyLoginPayloadParams } from "../../../../auth/core/verify-login-payload.js";
+import { getCachedChain } from "../../../../chains/utils.js";
 import type { Account, Wallet } from "../../../../wallets/interfaces/wallet.js";
 
 /**
@@ -94,6 +95,12 @@ export function useSiweAuth(
         // we lazy-load this because it's only needed when logging in
         import("../../../../auth/core/sign-login-payload.js"),
       ]);
+
+      if (payload.chain_id) {
+        await activeWallet.switchChain(
+          getCachedChain(Number(payload.chain_id)),
+        );
+      }
 
       const signedPayload = await signLoginPayload({
         payload,


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing authentication by switching to the proper chain before signing SIWE payloads.

### Detailed summary
- Added `chainId` parameter to `getLoginPayload` function
- Added logic to switch to the correct chain based on payload in `useSiweAuth`
- Updated initialization of `thirdwebAuth` with proper client and account

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->