### PR TITLE
[Dashboard] migration to SDK v5 - some small changes

### DIFF
--- a/apps/dashboard/src/components/contract-components/contract-publish-form/landing-fieldset.tsx
+++ b/apps/dashboard/src/components/contract-components/contract-publish-form/landing-fieldset.tsx
@@ -11,7 +11,6 @@ import {
   Tabs,
   Textarea,
 } from "@chakra-ui/react";
-import type { ExtraPublishMetadata } from "@thirdweb-dev/sdk";
 import { compare, validate } from "compare-versions";
 import { FileInput } from "components/shared/FileInput";
 import { SolidityInput } from "contract-ui/components/solidity-inputs";
@@ -30,6 +29,24 @@ import {
 } from "tw-components";
 import { MarkdownRenderer } from "../published-contract/markdown-renderer";
 import { ExternalLinksFieldset } from "./external-links-fieldset";
+
+type ExtraPublishMetadata = {
+  version: string;
+  displayName?: string | undefined;
+  description?: string | undefined;
+  externalLinks?:
+    | {
+        name: string;
+        url: string;
+      }[]
+    | undefined;
+  readme?: string | undefined;
+  license?: string | undefined;
+  logo?: string | File;
+  changelog?: string;
+  audit?: string | null;
+  deployType?: "standard" | "autoFactory" | "customFactory";
+};
 
 interface LandingFieldsetProps {
   latestVersion: string | undefined;

--- a/apps/dashboard/src/components/gas-estimator/GasEstimatorBox.tsx
+++ b/apps/dashboard/src/components/gas-estimator/GasEstimatorBox.tsx
@@ -1,9 +1,9 @@
 import type { GasEstimate } from "@3rdweb-sdk/react/hooks/useGas";
 import { Box, type BoxProps, Flex, Icon, Tooltip } from "@chakra-ui/react";
 import { AiOutlineInfoCircle } from "@react-icons/all-files/ai/AiOutlineInfoCircle";
-import { utils } from "ethers";
 import { useTrack } from "hooks/analytics/useTrack";
 import { FiExternalLink } from "react-icons/fi";
+import { toTokens } from "thirdweb";
 import { Heading, Link, Text } from "tw-components";
 import { contractSlugMapping } from "./contractSlugMapping";
 import { functionNameMapping } from "./functionNameMapping";
@@ -31,18 +31,15 @@ export const GasEstimatorBox: React.FC<GasEstimatorBoxProps> = ({
   const formatPrice = (price: number | undefined) => {
     if (price && ethOrUsd === "eth") {
       return `~${Number(
-        utils.formatUnits(
-          `${((gasEstimate?.gasPrice as number) || 30) * price}`,
-          "gwei",
-        ),
+        toTokens(BigInt(((gasEstimate?.gasPrice as number) || 30) * price), 9),
       ).toFixed(4)} ETH`;
     }
     if (price && ethOrUsd === "usd") {
       return `~$${(
         Number(
-          utils.formatUnits(
-            `${((gasEstimate?.gasPrice as number) || 30) * price}`,
-            "gwei",
+          toTokens(
+            BigInt(((gasEstimate?.gasPrice as number) || 30) * price),
+            9,
           ),
         ) * (gasEstimate?.ethPrice || 3400)
       ).toFixed(2)}`;

--- a/apps/dashboard/src/contract-ui/tabs/claim-conditions/components/claim-conditions-form/index.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/claim-conditions/components/claim-conditions-form/index.tsx
@@ -23,7 +23,6 @@ import {
 import {
   type ClaimConditionInput,
   ClaimConditionInputSchema,
-  type SnapshotEntry,
 } from "@thirdweb-dev/sdk";
 import { TransactionButton } from "components/buttons/TransactionButton";
 import { TooltipBox } from "components/configure-networks/Form/TooltipBox";
@@ -51,6 +50,13 @@ import * as z from "zod";
 import { ZodError } from "zod";
 import { ResetClaimEligibility } from "../reset-claim-eligibility";
 import { ClaimConditionsPhase } from "./phase";
+
+type SnapshotEntry = {
+  address: string;
+  maxClaimable: string;
+  price?: string | undefined;
+  currencyAddress?: string | undefined;
+};
 
 type ClaimConditionDashboardInput = ClaimConditionInput & {
   isEditing: boolean;

--- a/apps/dashboard/src/contract-ui/tabs/overview/components/MarketplaceDetails.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/overview/components/MarketplaceDetails.tsx
@@ -9,7 +9,6 @@ import {
 } from "@chakra-ui/react";
 import { ListingStatsV3 } from "contract-ui/tabs/listings/components/listing-stats";
 import { useTabHref } from "contract-ui/utils";
-import { BigNumber } from "ethers";
 import { useMemo } from "react";
 import type { ThirdwebContract } from "thirdweb";
 import {
@@ -82,7 +81,7 @@ const DirectListingCards: React.FC<ListingCardsSectionProps> = ({
   const listingsQuery = useReadContract(getAllListings, {
     contract,
     count: 3n,
-    start: Math.max(BigNumber.from(countQuery?.data || 3)?.toNumber() - 3, 0),
+    start: Math.max(Number(countQuery?.data || 3n) - 3, 0),
   });
   const listings = useMemo(
     () =>
@@ -97,7 +96,7 @@ const DirectListingCards: React.FC<ListingCardsSectionProps> = ({
     [listingsQuery?.data],
   );
 
-  if (!countQuery.isLoading && BigNumber.from(countQuery.data || 0).eq(0)) {
+  if (!countQuery.isLoading && (countQuery.data || 0n) === 0n) {
     return null;
   }
   if (!listingsQuery.isLoading && listings.length === 0) {
@@ -139,7 +138,7 @@ const EnglishAuctionCards: React.FC<ListingCardsSectionProps> = ({
   const auctionsQuery = useReadContract(getAllAuctions, {
     contract,
     count: 3n,
-    start: Math.max(BigNumber.from(countQuery?.data || 3)?.toNumber() - 3, 0),
+    start: Math.max(Number(countQuery?.data || 3n) - 3, 0),
   });
   const auctions = useMemo(
     () =>
@@ -154,7 +153,7 @@ const EnglishAuctionCards: React.FC<ListingCardsSectionProps> = ({
     [auctionsQuery?.data],
   );
 
-  if (!countQuery.isLoading && BigNumber.from(countQuery.data || 0).eq(0)) {
+  if (!countQuery.isLoading && (countQuery.data || 0n) === 0n) {
     return null;
   }
   if (!auctionsQuery.isLoading && auctions.length === 0) {

--- a/apps/dashboard/src/contract-ui/tabs/overview/page.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/overview/page.tsx
@@ -1,9 +1,12 @@
+import { thirdwebClient } from "@/constants/client";
 import { Divider, Flex, GridItem, SimpleGrid } from "@chakra-ui/react";
 import { contractType, useContract } from "@thirdweb-dev/react";
 import { type Abi, getAllDetectedFeatureNames } from "@thirdweb-dev/sdk";
 import { PublishedBy } from "components/contract-components/shared/published-by";
 import { RelevantDataSection } from "components/dashboard/RelevantDataSection";
+import { useV5DashboardChain } from "lib/v5-adapter";
 import { useMemo } from "react";
+import { getContract } from "thirdweb";
 import { AnalyticsOverview } from "./components/Analytics";
 import { BuildYourApp } from "./components/BuildYourApp";
 import { ContractChecklist } from "./components/ContractChecklist";
@@ -39,9 +42,20 @@ export const ContractOverviewPage: React.FC<ContractOverviewPageProps> = ({
     [detectedFeatureNames, contractTypeData],
   );
 
+  const chain = useV5DashboardChain(contract?.chainId);
+
   if (!contractAddress) {
     return <div>No contract address provided</div>;
   }
+
+  const contractV5 =
+    chain && contract
+      ? getContract({
+          address: contract.getAddress(),
+          chain,
+          client: thirdwebClient,
+        })
+      : null;
 
   return (
     <SimpleGrid columns={{ base: 1, xl: 10 }} gap={20}>
@@ -58,11 +72,11 @@ export const ContractOverviewPage: React.FC<ContractOverviewPageProps> = ({
           (contractTypeData === "marketplace" ||
             ["DirectListings", "EnglishAuctions"].some((type) =>
               detectedFeatureNames.includes(type),
-            )) && (
+            )) &&
+          contractV5 && (
             <MarketplaceDetails
-              contractAddress={contractAddress}
+              contract={contractV5}
               trackingCategory={TRACKING_CATEGORY}
-              contractType={contractTypeData as "marketplace"}
               features={detectedFeatureNames}
             />
           )}

--- a/apps/dashboard/src/contract-ui/tabs/shared-components/marketplace-table.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/shared-components/marketplace-table.tsx
@@ -18,7 +18,6 @@ import {
 } from "@chakra-ui/react";
 import { MediaCell } from "components/contract-pages/table/table-columns/cells/media-cell";
 import { ListingDrawer } from "contract-ui/tabs/shared-components/listing-drawer";
-import { BigNumber } from "ethers";
 import {
   type Dispatch,
   type SetStateAction,
@@ -162,10 +161,7 @@ export const MarketplaceTable: React.FC<MarketplaceTableProps> = ({
       },
       manualPagination: true,
       pageCount: Math.max(
-        Math.ceil(
-          BigNumber.from(totalCountQuery.data || 0).toNumber() /
-            queryParams.count,
-        ),
+        Math.ceil(Number(totalCountQuery.data || 0n) / queryParams.count),
         1,
       ),
     },


### PR DESCRIPTION
Aug 12

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates various components in the codebase to use the `thirdweb` library instead of `@thirdweb-dev/sdk` for improved functionality and consistency.

### Detailed summary
- Updated components to use `thirdweb` library instead of `@thirdweb-dev/sdk`
- Refactored functions to utilize `thirdweb` features like `toTokens`
- Replaced specific types and imports with `ThirdwebContract` and `useReadContract` for better integration

> The following files were skipped due to too many changes: `apps/dashboard/src/contract-ui/tabs/overview/components/MarketplaceDetails.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->