### PR TITLE
[Dashboard] Migration Royalties to v5

### DIFF
--- a/apps/dashboard/src/contract-ui/tabs/settings/components/royalties.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/settings/components/royalties.tsx
@@ -1,25 +1,25 @@
-import { thirdwebClient } from "@/constants/client";
 import { AdminOnly } from "@3rdweb-sdk/react/components/roles/admin-only";
 import { Flex, FormControl } from "@chakra-ui/react";
 import { zodResolver } from "@hookform/resolvers/zod";
-import {
-  useRoyaltySettings,
-  useUpdateRoyaltySettings,
-} from "@thirdweb-dev/react";
-import {
-  CommonRoyaltySchema,
-  type ValidContractInstance,
-} from "@thirdweb-dev/sdk";
 import type { ExtensionDetectedState } from "components/buttons/ExtensionDetectButton";
 import { TransactionButton } from "components/buttons/TransactionButton";
 import { BasisPointsInput } from "components/inputs/BasisPointsInput";
+import { AddressOrEnsSchema, BasisPointsSchema } from "constants/schemas";
 import { SolidityInput } from "contract-ui/components/solidity-inputs";
 import { useTrack } from "hooks/analytics/useTrack";
 import { useTxNotifications } from "hooks/useTxNotifications";
-import { useV5DashboardChain } from "lib/v5-adapter";
 import { useForm } from "react-hook-form";
-import { getContract } from "thirdweb";
-import { useActiveAccount } from "thirdweb/react";
+import { toast } from "sonner";
+import { type ThirdwebContract, ZERO_ADDRESS } from "thirdweb";
+import {
+  getDefaultRoyaltyInfo,
+  setDefaultRoyaltyInfo,
+} from "thirdweb/extensions/common";
+import {
+  useActiveAccount,
+  useReadContract,
+  useSendAndConfirmTransaction,
+} from "thirdweb/react";
 import {
   Card,
   FormErrorMessage,
@@ -27,43 +27,62 @@ import {
   Heading,
   Text,
 } from "tw-components";
-import type { z } from "zod";
+import { z } from "zod";
 import { SettingDetectedState } from "./detected-state";
 
-export const SettingsRoyalties = <
-  TContract extends ValidContractInstance | undefined,
->({
+/**
+ * @internal
+ */
+const CommonRoyaltySchema = z.object({
+  /**
+   * The amount of royalty collected on all royalties represented as basis points.
+   * The default is 0 (no royalties).
+   *
+   * 1 basis point = 0.01%
+   *
+   * For example: if this value is 100, then the royalty is 1% of the total sales.
+   *
+   * @internal
+   * @remarks used by OpenSea "seller_fee_basis_points"
+   */
+  seller_fee_basis_points: BasisPointsSchema.default(0),
+
+  /**
+   * The address of the royalty recipient. All royalties will be sent
+   * to this address.
+   * @internal
+   * @remarks used by OpenSea "fee_recipient"
+   */
+  fee_recipient: AddressOrEnsSchema.default(ZERO_ADDRESS),
+});
+
+export const SettingsRoyalties = ({
   contract,
   detectedState,
 }: {
-  contract: TContract;
+  contract: ThirdwebContract;
   detectedState: ExtensionDetectedState;
 }) => {
   const trackEvent = useTrack();
-  const query = useRoyaltySettings(contract);
-  const mutation = useUpdateRoyaltySettings(contract);
-
+  const query = useReadContract(getDefaultRoyaltyInfo, {
+    contract,
+  });
+  const royaltyInfo = query.data
+    ? { seller_fee_basis_points: query.data[1], fee_recipient: query.data[0] }
+    : undefined;
+  const mutation = useSendAndConfirmTransaction();
   const form = useForm<z.input<typeof CommonRoyaltySchema>>({
     resolver: zodResolver(CommonRoyaltySchema),
-    defaultValues: query.data,
-    values: query.data,
+    defaultValues: royaltyInfo,
+    values: royaltyInfo,
   });
-  const address = useActiveAccount()?.address;
-  const chain = useV5DashboardChain(contract?.chainId);
 
-  const contractV5 =
-    contract && chain
-      ? getContract({
-          address: contract.getAddress(),
-          chain: chain,
-          client: thirdwebClient,
-        })
-      : null;
+  const address = useActiveAccount()?.address;
 
   const { onSuccess, onError } = useTxNotifications(
     "Royalty settings updated",
     "Error updating royalty settings",
-    contractV5,
+    contract,
   );
 
   return (
@@ -77,15 +96,27 @@ export const SettingsRoyalties = <
             action: "set-royalty",
             label: "attempt",
           });
-          // if we switch back to mutateAsync then *need* to catch errors
-          mutation.mutate(d, {
-            onSuccess: (_data, variables) => {
+          // In the v4 hook we defaulted recipient to address_zero and bps to `0`
+          // but let's actually throw an error here for better transparency
+          if (!d.seller_fee_basis_points) {
+            return toast.error("Please enter valid basis points.");
+          }
+          if (!d.fee_recipient) {
+            return toast.error("Please enter a valid royalty fee recipient.");
+          }
+          const transaction = setDefaultRoyaltyInfo({
+            contract,
+            royaltyRecipient: d.fee_recipient,
+            royaltyBps: BigInt(d.seller_fee_basis_points),
+          });
+          mutation.mutate(transaction, {
+            onSuccess: () => {
               trackEvent({
                 category: "settings",
                 action: "set-royalty",
                 label: "success",
               });
-              form.reset(variables);
+              form.reset(d);
               onSuccess();
             },
             onError: (error) => {
@@ -157,24 +188,22 @@ export const SettingsRoyalties = <
             </FormControl>
           </Flex>
         </Flex>
-        {contractV5 && (
-          <AdminOnly contract={contractV5}>
-            <TransactionButton
-              colorScheme="primary"
-              transactionCount={1}
-              isDisabled={query.isLoading || !form.formState.isDirty}
-              type="submit"
-              isLoading={mutation.isLoading}
-              loadingText="Saving..."
-              size="md"
-              borderRadius="xl"
-              borderTopLeftRadius="0"
-              borderTopRightRadius="0"
-            >
-              Update Royalty Settings
-            </TransactionButton>
-          </AdminOnly>
-        )}
+        <AdminOnly contract={contract}>
+          <TransactionButton
+            colorScheme="primary"
+            transactionCount={1}
+            isDisabled={query.isLoading || !form.formState.isDirty}
+            type="submit"
+            isLoading={mutation.isPending}
+            loadingText="Saving..."
+            size="md"
+            borderRadius="xl"
+            borderTopLeftRadius="0"
+            borderTopRightRadius="0"
+          >
+            Update Royalty Settings
+          </TransactionButton>
+        </AdminOnly>
       </Flex>
     </Card>
   );

--- a/apps/dashboard/src/contract-ui/tabs/settings/page.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/settings/page.tsx
@@ -68,12 +68,14 @@ export const ContractSettingsPage: React.FC<ContractSettingsPageProps> = ({
             />
           </GridItem>
 
-          <GridItem order={detectedRoyalties === "enabled" ? 3 : 102}>
-            <SettingsRoyalties
-              contract={contractQuery.contract}
-              detectedState={detectedRoyalties}
-            />
-          </GridItem>
+          {contract && (
+            <GridItem order={detectedRoyalties === "enabled" ? 3 : 102}>
+              <SettingsRoyalties
+                contract={contract}
+                detectedState={detectedRoyalties}
+              />
+            </GridItem>
+          )}
 
           {contract && (
             <GridItem order={detectedPlatformFees === "enabled" ? 4 : 103}>


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the royalty settings in the contract UI. 

### Detailed summary
- Refactored `SettingsRoyalties` component to use `ThirdwebContract`
- Updated schema imports and added new schemas
- Replaced certain hooks with `useReadContract` and `useSendAndConfirmTransaction`
- Improved error handling and transaction logic
- Updated UI components and button functionality

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->