### PR TITLE
refactor(ts): use viem serialization in signTransaction

### DIFF
--- a/packages/thirdweb/src/transaction/actions/sign-transaction.ts
+++ b/packages/thirdweb/src/transaction/actions/sign-transaction.ts
@@ -1,8 +1,7 @@
-import type { TransactionSerializable } from "viem";
+import { type TransactionSerializable, serializeTransaction } from "viem";
 import type { Hex } from "../../utils/encoding/hex.js";
 import { keccak256 } from "../../utils/hashing/keccak256.js";
 import { sign } from "../../utils/signatures/sign.js";
-import { serializeTransaction } from "../serialize-transaction.js";
 
 export type SignTransactionOptions = {
   transaction: TransactionSerializable;
@@ -36,13 +35,11 @@ export function signTransaction({
     transaction = { ...transaction, sidecars: false };
   }
 
-  const serializedTransaction = serializeTransaction({ transaction });
+  const serializedTransaction = serializeTransaction(transaction);
 
   const signature = sign({
     hash: keccak256(serializedTransaction),
     privateKey: privateKey,
   });
-  return serializeTransaction({
-    transaction: { ...transaction, ...signature },
-  });
+  return serializeTransaction(transaction, signature);
 }


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added



<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the `signTransaction` function to use the `serializeTransaction` function from the `viem` package and make necessary adjustments.

### Detailed summary
- Updated import of `serializeTransaction` from `viem` package
- Refactored function to use the new `serializeTransaction` signature
- Adjusted function to incorporate signature in a more concise way

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->