### PR TITLE
test: fix split tests

### DIFF
--- a/packages/thirdweb/src/extensions/split/read/getAllRecipientsAddresses.test.ts
+++ b/packages/thirdweb/src/extensions/split/read/getAllRecipientsAddresses.test.ts
@@ -9,7 +9,7 @@ import { getAllRecipientsAddresses } from "./getAllRecipientsAddresses.js";
 const chain = ANVIL_CHAIN;
 const client = TEST_CLIENT;
 
-describe("getAllRecipientsAddresses", () => {
+describe.runIf(process.env.TW_SECRET_KEY)("getAllRecipientsAddresses", () => {
   it("should work", async () => {
     const payees = [
       "0x12345674b599ce99958242b3D3741e7b01841DF3",

--- a/packages/thirdweb/src/extensions/split/read/getAllRecipientsPercentages.test.ts
+++ b/packages/thirdweb/src/extensions/split/read/getAllRecipientsPercentages.test.ts
@@ -9,7 +9,7 @@ import { getAllRecipientsPercentages } from "./getAllRecipientsPercentages.js";
 const chain = ANVIL_CHAIN;
 const client = TEST_CLIENT;
 
-describe("getAllRecipientsPercentages", () => {
+describe.runIf(process.env.TW_SECRET_KEY)("getAllRecipientsPercentages", () => {
   it("should work", async () => {
     const payees = [
       "0x12345674b599ce99958242b3D3741e7b01841DF3",

--- a/packages/thirdweb/src/extensions/split/read/getRecipientSplitPercentage.test.ts
+++ b/packages/thirdweb/src/extensions/split/read/getRecipientSplitPercentage.test.ts
@@ -8,7 +8,7 @@ import { getRecipientSplitPercentage } from "./getRecipientSplitPercentage.js";
 const chain = ANVIL_CHAIN;
 const client = TEST_CLIENT;
 
-describe("getRecipientSplitPercentage", () => {
+describe.runIf(process.env.TW_SECRET_KEY)("getRecipientSplitPercentage", () => {
   it("should work", async () => {
     const payees = [
       "0x12345674b599ce99958242b3D3741e7b01841DF3",


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates test descriptions in `getAllRecipientsAddresses`, `getAllRecipientsPercentages`, and `getRecipientSplitPercentage` to run only if `TW_SECRET_KEY` is set.

### Detailed summary
- Updated test descriptions to run conditionally based on `TW_SECRET_KEY` environment variable.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->