### PR TITLE
Add Deploy button link on the Contract Card

### DIFF
--- a/apps/dashboard/src/components/explore/contract-card/index.tsx
+++ b/apps/dashboard/src/components/explore/contract-card/index.tsx
@@ -1,4 +1,5 @@
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Skeleton, SkeletonContainer } from "@/components/ui/skeleton";
 import { TrackedLinkTW } from "@/components/ui/tracked-link";
 import { cn } from "@/lib/utils";
@@ -10,7 +11,7 @@ import {
 import { ensQuery } from "components/contract-components/hooks";
 import { getDashboardChainRpc } from "lib/rpc";
 import { getThirdwebSDK, replaceIpfsUrl } from "lib/sdk";
-import { ShieldCheckIcon } from "lucide-react";
+import { RocketIcon, ShieldCheckIcon } from "lucide-react";
 import Link from "next/link";
 import { useMemo } from "react";
 import { polygon } from "thirdweb/chains";
@@ -60,7 +61,7 @@ export const ContractCard: React.FC<ContractCardProps> = ({
   return (
     <article
       className={cn(
-        "min-h-[200px] p-4 border border-border relative rounded-lg flex flex-col",
+        "min-h-[220px] p-4 border border-border relative rounded-lg flex flex-col",
         !showSkeleton ? "bg-secondary hover:bg-muted" : "pointer-events-none",
       )}
     >
@@ -151,11 +152,25 @@ export const ContractCard: React.FC<ContractCardProps> = ({
         </div>
       )}
 
-      <div className="mt-auto pt-3 relative z-1 flex">
+      <div className="mt-auto pt-3 relative z-1 flex gap-2 justify-between">
         <ContractPublisher
           addressOrEns={publishedContractResult.data?.publisher}
           showSkeleton={showSkeleton}
         />
+
+        <div className="flex justify-between items-center">
+          <Button
+            variant="primary"
+            size="sm"
+            className="gap-1.5 py-1.5 px-2.5 text-xs h-auto relative z-10"
+            asChild
+          >
+            <Link href={`${href}/deploy`}>
+              <RocketIcon className="size-3" />
+              Deploy
+            </Link>
+          </Button>
+        </div>
       </div>
     </article>
   );


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance the ContractCard component in the Explore section by adding a deploy button with a RocketIcon.

### Detailed summary
- Added RocketIcon from lucide-react for deploy button
- Adjusted styling for better layout and spacing
- Linked deploy button to deployment page with Next.js Link

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->