### PR TITLE
Fix Various "couldn't be rendered statically" errors in Sentry

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/(chainPage)/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/(chainPage)/page.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@/components/ui/button";
-import { type SortBy, fetchTopContracts } from "lib/search";
+import { fetchTopContracts } from "lib/search";
 import { ArrowRightIcon, CircleAlertIcon } from "lucide-react";
 import Link from "next/link";
 import { TrendingContractSection } from "../../../trending/components/trending-table";
@@ -14,7 +14,6 @@ import { ExplorersSection } from "./components/server/explorer-section";
 
 export default async function Page(props: {
   params: { chain_id: string };
-  searchParams: { page?: number; sortBy?: SortBy };
 }) {
   const chain = await getChain(props.params.chain_id);
   const chainMetadata = await getChainMetadata(chain.chainId);
@@ -22,8 +21,6 @@ export default async function Page(props: {
 
   const topContracts = await fetchTopContracts({
     chainId: chain.chainId,
-    page: props.searchParams.page,
-    sortBy: props.searchParams.sortBy,
     perPage: 3,
     timeRange: "month",
   });
@@ -83,8 +80,8 @@ export default async function Page(props: {
           <TrendingContractSection
             topContracts={topContracts}
             chainId={chain.chainId}
-            searchParams={props.searchParams}
             showPagination={false}
+            searchParams={undefined}
           />
         </section>
       )}

--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/(chainPage)/popular/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/(chainPage)/popular/page.tsx
@@ -4,6 +4,9 @@ import React from "react";
 import { TrendingContractSection } from "../../../../trending/components/trending-table";
 import { getChain } from "../../../utils";
 
+// we're using searchParams here - use dynamic rendering
+export const dynamic = "force-dynamic";
+
 export default async function Page(props: {
   params: { chain_id: string };
   searchParams: { page?: number; sortBy?: SortBy };

--- a/apps/dashboard/src/app/(dashboard)/trending/components/sorting-header.client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/trending/components/sorting-header.client.tsx
@@ -1,23 +1,30 @@
 "use client";
 import { Button } from "@/components/ui/button";
 import { ChevronDown } from "lucide-react";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
+import type { SortBy, TimeRange } from "../../../../lib/search";
 
 export type SortingHeaderProps = {
   sortBy: string;
   title: string;
+  searchParams:
+    | { timeRange?: TimeRange; page?: number; sortBy?: SortBy }
+    | undefined;
 };
 
 export function SortingHeader(props: SortingHeaderProps) {
   const router = useRouter();
   const path = usePathname();
-  const searchParams = useSearchParams();
-  const range = searchParams?.get("timeRange");
-  const page = searchParams?.get("page");
-  const currentSort = searchParams?.get("sortBy") || "transactionCount";
+  const enableSorting = !!props.searchParams;
+  const { timeRange, page, sortBy } = props.searchParams || {};
+  const currentSort = sortBy || "transactionCount";
   const isCurrentSort = currentSort === props.sortBy;
   const justify =
     props.sortBy === "transactionCountChange" ? "justify-start" : "justify-end";
+
+  if (!enableSorting) {
+    return <div className={`flex flex-row ${justify}`}>{props.title}</div>;
+  }
 
   return (
     <div className={`flex flex-row ${justify}`}>
@@ -26,7 +33,7 @@ export function SortingHeader(props: SortingHeaderProps) {
         variant={"link"}
         onClick={() => {
           router.replace(
-            `${path}?sortBy=${props.sortBy}${range?.length ? `&timeRange=${range}` : ""}${page?.length ? `&page=${page}` : ""}`,
+            `${path}?sortBy=${props.sortBy}${timeRange?.length ? `&timeRange=${timeRange}` : ""}${page ? `&page=${page}` : ""}`,
             {
               scroll: false,
             },

--- a/apps/dashboard/src/app/(dashboard)/trending/components/trending-table.tsx
+++ b/apps/dashboard/src/app/(dashboard)/trending/components/trending-table.tsx
@@ -21,10 +21,12 @@ export function TrendingContractSection(props: {
   topContracts: TrendingContract[];
   chainId?: number;
   perPage?: number;
-  searchParams: { timeRange?: TimeRange; page?: number; sortBy?: SortBy };
+  searchParams:
+    | { timeRange?: TimeRange; page?: number; sortBy?: SortBy }
+    | undefined;
   showPagination: boolean;
 }) {
-  const { page } = props.searchParams;
+  const { page } = props.searchParams || {};
   const firstIndex = Math.max(0, ((page || 1) - 1) * (props.perPage || 10));
   const showChainColumn = !props.chainId;
 
@@ -44,16 +46,29 @@ export function TrendingContractSection(props: {
                   <SortingHeader
                     title="Transactions"
                     sortBy="transactionCount"
+                    searchParams={props.searchParams}
                   />
                 </TableHead>
                 <TableHead>
-                  <SortingHeader title="Wallets" sortBy="walletCount" />
+                  <SortingHeader
+                    title="Wallets"
+                    sortBy="walletCount"
+                    searchParams={props.searchParams}
+                  />
                 </TableHead>
                 <TableHead>
-                  <SortingHeader title="Gas Usage" sortBy="gasUsage" />
+                  <SortingHeader
+                    title="Gas Usage"
+                    sortBy="gasUsage"
+                    searchParams={props.searchParams}
+                  />
                 </TableHead>
                 <TableHead>
-                  <SortingHeader title="Value Moved" sortBy="totalValueMoved" />
+                  <SortingHeader
+                    title="Value Moved"
+                    sortBy="totalValueMoved"
+                    searchParams={props.searchParams}
+                  />
                 </TableHead>
               </TableRow>
             </TableHeader>

--- a/apps/dashboard/src/app/(dashboard)/trending/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/trending/page.tsx
@@ -11,6 +11,9 @@ export const metadata: Metadata = {
   },
 };
 
+// we're using searchParams here - use dynamic rendering
+export const dynamic = "force-dynamic";
+
 export default async function DashboardContractTrendingPage(props: {
   searchParams: { timeRange?: TimeRange; page?: number; sortBy?: SortBy };
 }) {


### PR DESCRIPTION
TLDR; is - In the Chain landing page, we don't really care about filtering the popular contracts - so I removed so we can statically render the chain page, 

Added force-dynamic for /popular and /trending pages where we allow filtering by search params

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to implement dynamic rendering using searchParams and update sorting functionality in the trending dashboard pages.

### Detailed summary
- Implemented dynamic rendering using `searchParams`
- Updated sorting functionality in trending dashboard components
- Removed unnecessary imports and unused code

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->