### PR TITLE
[Dashboard] Fix missing contract metadata

### DIFF
--- a/.changeset/nasty-masks-carry.md
+++ b/.changeset/nasty-masks-carry.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Add contract util method: `getCompilerMetadata()`

--- a/apps/dashboard/src/@3rdweb-sdk/react/hooks/useDashboardContractMetadata.tsx
+++ b/apps/dashboard/src/@3rdweb-sdk/react/hooks/useDashboardContractMetadata.tsx
@@ -1,0 +1,38 @@
+import { useQuery } from "@tanstack/react-query";
+import type { ThirdwebContract } from "thirdweb";
+import { getCompilerMetadata } from "thirdweb/contract";
+import { getContractMetadata, name, symbol } from "thirdweb/extensions/common";
+
+/**
+ * Fetch the contract metadata for Dashboard
+ *
+ * If the contract itself doesn't implement the metadata extension,
+ * we try to fall back to:
+ * 1. name(), symbol()
+ * 2. our API endpoint
+ */
+export function useDashboardContractMetadata(contract: ThirdwebContract) {
+  return useQuery([], async () => {
+    const [contractMetadata, _name, _symbol, compilerMetadata] =
+      await Promise.all([
+        getContractMetadata({ contract }).catch(() => ({
+          image: "",
+          name: "",
+          symbol: "",
+        })),
+        name({ contract }).catch(() => ""),
+        symbol({ contract }).catch(() => ""),
+        getCompilerMetadata(contract).catch(() => undefined),
+      ]);
+
+    const contractName =
+      contractMetadata?.name || _name || compilerMetadata?.name || "";
+    const contractSymbol = contractMetadata?.symbol || _symbol || "";
+
+    return {
+      name: contractName,
+      symbol: contractSymbol,
+      image: contractMetadata.image || "",
+    };
+  });
+}

--- a/apps/dashboard/src/components/custom-contract/contract-header/contract-metadata.tsx
+++ b/apps/dashboard/src/components/custom-contract/contract-header/contract-metadata.tsx
@@ -1,9 +1,8 @@
+import { useDashboardContractMetadata } from "@3rdweb-sdk/react/hooks/useDashboardContractMetadata";
 import { usePublishedContractsFromDeploy } from "components/contract-components/hooks";
 import { useEffect, useState } from "react";
 import type { ThirdwebContract } from "thirdweb";
 import type { ChainMetadata } from "thirdweb/chains";
-import { getContractMetadata } from "thirdweb/extensions/common";
-import { useReadContract } from "thirdweb/react";
 import { MetadataHeader } from "./metadata-header";
 
 interface ContractMetadataProps {
@@ -16,10 +15,7 @@ export const ContractMetadata: React.FC<ContractMetadataProps> = ({
   chain,
 }) => {
   const [wasError, setWasError] = useState(false);
-  const contractMetadataQuery = useReadContract(getContractMetadata, {
-    contract,
-  });
-
+  const contractMetadataQuery = useDashboardContractMetadata(contract);
   const publishedContractsFromDeploy = usePublishedContractsFromDeploy(
     contract.address,
     contract.chain.id,

--- a/packages/thirdweb/src/contract/actions/get-compiler-metadata.ts
+++ b/packages/thirdweb/src/contract/actions/get-compiler-metadata.ts
@@ -1,0 +1,40 @@
+import type { ThirdwebContract } from "../contract.js";
+import { formatCompilerMetadata } from "./compiler-metadata.js";
+
+/**
+ * Down the compiled metadata from thirdweb contract api and format it
+ * @param metadata The (json) data returned from https://contract.thirdweb.com/metadata/<chainId>/<contractAddress>
+ *
+ * @example
+ * ```ts
+ * import { getCompilerMetadata, getContract } from "thirdweb/contracts";
+ *
+ * const contract = getContract({
+ *   address: "0x...",
+ *   chain: ethereum,
+ *   client: "",
+ * });
+ * const metadata = await getCompilerMetadata(contract);
+ * ```
+ * @returns
+ */
+export async function getCompilerMetadata(contract: ThirdwebContract) {
+  const { address, chain } = contract;
+  const response = await fetch(
+    `https://contract.thirdweb.com/metadata/${chain.id}/${address}`,
+    {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    },
+  );
+  if (!response.ok) {
+    const errorMsg = await response.json();
+    throw new Error(
+      errorMsg.message || errorMsg.error || "Failed to get compiler metadata",
+    );
+  }
+  const data = await response.json();
+  return formatCompilerMetadata(data);
+}

--- a/packages/thirdweb/src/exports/contract.ts
+++ b/packages/thirdweb/src/exports/contract.ts
@@ -34,3 +34,5 @@ export {
   type PrepareDirectDeployTransactionOptions,
 } from "../contract/deployment/deploy-with-abi.js";
 export { prepareAutoFactoryDeployTransaction } from "../contract/deployment/deploy-via-autofactory.js";
+
+export { getCompilerMetadata } from "../contract/actions/get-compiler-metadata.js";

--- a/packages/thirdweb/src/utils/any-evm/deploy-metadata.ts
+++ b/packages/thirdweb/src/utils/any-evm/deploy-metadata.ts
@@ -1,5 +1,6 @@
 import type { Abi } from "abitype";
 import type { ThirdwebClient } from "../../client/client.js";
+import { formatCompilerMetadata } from "../../contract/actions/compiler-metadata.js";
 import { download } from "../../storage/download.js";
 import type { Hex } from "../encoding/hex.js";
 import type { Prettify } from "../type-utils.js";
@@ -87,34 +88,6 @@ async function fetchAndParseCompilerMetadata(
     );
   }
   return formatCompilerMetadata(metadata);
-}
-
-// biome-ignore lint/suspicious/noExplicitAny: TODO: fix later
-function formatCompilerMetadata(metadata: any): ParsedCompilerMetadata {
-  const abi = metadata.output.abi;
-  const compilationTarget = metadata.settings.compilationTarget;
-  const targets = Object.keys(compilationTarget);
-  const name = compilationTarget[targets[0] as keyof typeof compilationTarget];
-  const info = {
-    title: metadata.output.devdoc.title,
-    author: metadata.output.devdoc.author,
-    details: metadata.output.devdoc.detail,
-    notice: metadata.output.userdoc.notice,
-  };
-  const licenses: string[] = [
-    ...new Set(
-      // biome-ignore lint/suspicious/noExplicitAny: TODO: fix later
-      Object.entries(metadata.sources).map(([, src]) => (src as any).license),
-    ),
-  ];
-  return {
-    name,
-    abi,
-    metadata,
-    info,
-    licenses,
-    isPartialAbi: metadata.isPartialAbi,
-  };
 }
 
 // types


### PR DESCRIPTION
- [x] Remove duplicated formatCompilerMetadata method
- [x] Add getCompilerMetadata method to the SDK
- [x] Add a custom hook for Dashboard for fetching basic contract metadata (useDashboardContractMetadata)

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add a contract utility method `getCompilerMetadata()` and enhance contract metadata handling in the Dashboard.

### Detailed summary
- Added `getCompilerMetadata()` utility method to fetch compiler metadata
- Improved contract metadata retrieval in Dashboard
- Updated contract metadata handling in the Dashboard components

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->