### PR TITLE
[SDK] Send crypto to Lens handle

### DIFF
--- a/.changeset/rude-spies-worry.md
+++ b/.changeset/rude-spies-worry.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Lens's resolveAddress for sending crypto with lens handles

--- a/packages/thirdweb/src/exports/extensions/lens.ts
+++ b/packages/thirdweb/src/exports/extensions/lens.ts
@@ -119,6 +119,8 @@ export {
 /**
  * Custom extension
  */
+
+// Read
 export {
   getHandleFromProfileId,
   type GetHandleFromProfileIdParams,
@@ -133,6 +135,10 @@ export {
   type GetFullProfileParams,
   type FullProfileResponse,
 } from "../../extensions/lens/read/getFullProfile.js";
+export {
+  resolveAddress,
+  type ResolveLensAddressParams,
+} from "../../extensions/lens/read/resolveAddress.js";
 
 /**
  * Contract addresses

--- a/packages/thirdweb/src/extensions/lens/read/resolveAddress.test.ts
+++ b/packages/thirdweb/src/extensions/lens/read/resolveAddress.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { resolveAddress } from "./resolveAddress.js";
+import { TEST_CLIENT } from "~test/test-clients.js";
+
+describe("resolve lens address", () => {
+
+  // Will remove this test later since this is flaky
+  it("should resolve to correct address", async () => {
+    const address = await resolveAddress({
+      client: TEST_CLIENT,
+      handleOrLocalName: "captain_jack",
+    });
+    expect(address.toLowerCase()).toBe(
+      "0x12345674b599ce99958242b3D3741e7b01841DF3".toLowerCase(),
+    );
+  });
+});

--- a/packages/thirdweb/src/extensions/lens/read/resolveAddress.test.ts
+++ b/packages/thirdweb/src/extensions/lens/read/resolveAddress.test.ts
@@ -1,9 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { resolveAddress } from "./resolveAddress.js";
 import { TEST_CLIENT } from "~test/test-clients.js";
+import { resolveAddress } from "./resolveAddress.js";
 
 describe("resolve lens address", () => {
-
   // Will remove this test later since this is flaky
   it("should resolve to correct address", async () => {
     const address = await resolveAddress({

--- a/packages/thirdweb/src/extensions/lens/read/resolveAddress.ts
+++ b/packages/thirdweb/src/extensions/lens/read/resolveAddress.ts
@@ -1,0 +1,66 @@
+import { polygon } from "../../../chains/chain-definitions/polygon.js";
+import type { Chain } from "../../../chains/types.js";
+import type { ThirdwebClient } from "../../../client/client.js";
+import { getAddress, isAddress } from "../../../utils/address.js";
+import { LENS_HANDLE_ADDRESS } from "../consts.js";
+
+export type ResolveLensAddressParams = {
+  handleOrLocalName: string;
+  client: ThirdwebClient;
+  overrides?: {
+    lensHandleAddress?: string;
+    chain?: Chain;
+  };
+};
+
+/**
+ * Take in a Lens handle _or_ local-name and return the wallet address behind that handle/local-name
+ *
+ * handle = <namespace>/<local-name>
+ * For example, "lens/vitalik" is a handle, with "lens" being the namespace and "vitalik" being the local name
+ */
+export async function resolveAddress(options: ResolveLensAddressParams) {
+  const { handleOrLocalName, overrides, client } = options;
+  if (isAddress(handleOrLocalName)) {
+    return getAddress(handleOrLocalName);
+  }
+  const [{ getContract }, { getTokenId }, { ownerOf }] = await Promise.all([
+    import("../../../contract/contract.js"),
+    import("../__generated__/LensHandle/read/getTokenId.js"),
+    import("../../erc721/__generated__/IERC721A/read/ownerOf.js"),
+  ]);
+  const contract = getContract({
+    address: overrides?.lensHandleAddress || LENS_HANDLE_ADDRESS,
+    chain: overrides?.chain || polygon,
+    client,
+  });
+  /**
+   * For better UX, we accept both handle and local name
+   * The difference: handle = <namespace>/<local-name>
+   * For example, "lens/vitalik" is a handle, with "lens" being the namespace and "vitalik" being the local name
+   * Currently there's only 1 namespace called "lens" but we should make sure the code can scale when there are more
+   *
+   * Since lens does not allow "/" in the name,
+   * if the string contains "/", it is either invalid, or it definitely contains the namespace
+   * In that case we remove the namespace because the `getTokenId` method only accepts localName
+   */
+  const isPossibleHandle = handleOrLocalName.includes("/");
+  const localName = isPossibleHandle
+    ? handleOrLocalName.split("/")[1]
+    : handleOrLocalName;
+  if (!localName) {
+    throw new Error(`missing local name from ${handleOrLocalName}`);
+  }
+  const tokenId = await getTokenId({ contract, localName });
+  if (!tokenId) {
+    throw new Error(`Could not retrieve tokenId from localName: ${localName}`);
+  }
+
+  /**
+   * Another thing to note is that even if you enter an invalid localName,
+   * `getTokenId` still returns you a tokenId - so never rely on the result alone.
+   * Check if the tokenId truly exists using `exists` or in this case, `ownerOf`
+   */
+
+  return await ownerOf({ contract, tokenId });
+}

--- a/packages/thirdweb/src/react/core/hooks/wallets/useSendToken.ts
+++ b/packages/thirdweb/src/react/core/hooks/wallets/useSendToken.ts
@@ -1,11 +1,11 @@
 import { useMutation } from "@tanstack/react-query";
 import type { ThirdwebClient } from "../../../../client/client.js";
 import { getContract } from "../../../../contract/contract.js";
-import { resolveAddress } from "../../../../extensions/ens/resolve-address.js";
+import { resolveAddress as resolveEnsAddress } from "../../../../extensions/ens/resolve-address.js";
+import { resolveAddress as resolveLensAddress } from "../../../../extensions/lens/read/resolveAddress.js";
 import { transfer } from "../../../../extensions/erc20/write/transfer.js";
 import { sendTransaction } from "../../../../transaction/actions/send-transaction.js";
 import { prepareTransaction } from "../../../../transaction/prepare-transaction.js";
-import { isAddress } from "../../../../utils/address.js";
 import { toWei } from "../../../../utils/units.js";
 import { useActiveWallet } from "./useActiveWallet.js";
 
@@ -50,25 +50,24 @@ export function useSendToken(client: ThirdwebClient) {
         throw new Error("No active account");
       }
 
-      // input validation
-      if (
-        !receiverAddress ||
-        (!receiverAddress.endsWith(".eth") && !isAddress(receiverAddress))
-      ) {
-        throw new Error("Invalid address");
-      }
-
       if (!amount || Number.isNaN(Number(amount)) || Number(amount) < 0) {
         throw new Error("Invalid amount");
       }
 
       let to = receiverAddress;
-      // resolve ENS if needed
+      // resolve ENS or Lens handle if needed
+      // There will never be a Lens handle that is the same as an ENS because Lens does not allow "." to be in the name
+      // so we can avoid the scenario where there is a "vitalik.eth" for ENS and there is a "vitalik.eth" for Lens
+      // and each is owned by a different person.
       try {
-        to = await resolveAddress({
-          client,
-          name: receiverAddress,
-        });
+        const [ensAddress, lensAddress] = await Promise.all([
+          resolveEnsAddress({
+            client,
+            name: receiverAddress,
+          }),
+          resolveLensAddress({ client, handleOrLocalName: receiverAddress }),
+        ]);
+        to = ensAddress || lensAddress;
       } catch (e) {
         throw new Error("Failed to resolve address");
       }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to enhance the `useSendToken` function by adding the ability to resolve addresses using Lens handles. 

### Detailed summary
- Added `resolveAddress` function for Lens handles in `useSendToken`
- Updated imports in `useSendToken` to use `resolveLensAddress`
- Implemented `resolveAddress` for Lens handles in a new file

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->