### PR TITLE
[Dash] various small updates and fixes

### DIFF
--- a/apps/dashboard/src/@3rdweb-sdk/react/hooks/useDashboardContractMetadata.tsx
+++ b/apps/dashboard/src/@3rdweb-sdk/react/hooks/useDashboardContractMetadata.tsx
@@ -27,6 +27,18 @@ export function useDashboardContractMetadata(contract: ThirdwebContract) {
           getCompilerMetadata(contract).catch(() => undefined),
         ]);
 
+      /**
+       * Handle the case where the contract.thirdweb.com endpoint returns a very long name
+       * example url: https://contract.thirdweb.com/metadata/324/0x66E298335c5992d599132582De8eaAF75348e6e6
+       * In that case, we split the solidity name on ":" and take the second part
+       */
+      if (compilerMetadata?.name.includes(":")) {
+        const _name = compilerMetadata.name.split(":")[1];
+        if (_name) {
+          compilerMetadata.name = compilerMetadata.name.split(":")[1];
+        }
+      }
+
       const contractName =
         contractMetadata?.name || _name || compilerMetadata?.name || "";
       const contractSymbol = contractMetadata?.symbol || _symbol || "";
@@ -35,6 +47,7 @@ export function useDashboardContractMetadata(contract: ThirdwebContract) {
         name: contractName,
         symbol: contractSymbol,
         image: contractMetadata.image || "",
+        contractType: compilerMetadata?.name || "",
       };
     },
   );

--- a/apps/dashboard/src/components/contract-components/tables/cells.tsx
+++ b/apps/dashboard/src/components/contract-components/tables/cells.tsx
@@ -1,3 +1,4 @@
+import { useDashboardContractMetadata } from "@3rdweb-sdk/react/hooks/useDashboardContractMetadata";
 import { Skeleton } from "@chakra-ui/react";
 import type { BasicContract } from "contract-ui/types/types";
 import { useChainSlug } from "hooks/chains/chainSlug";
@@ -5,8 +6,6 @@ import { thirdwebClient } from "lib/thirdweb-client";
 import { useV5DashboardChain } from "lib/v5-adapter";
 import { memo } from "react";
 import { getContract } from "thirdweb";
-import { getContractMetadata } from "thirdweb/extensions/common";
-import { useReadContract } from "thirdweb/react";
 import { ChakraNextLink, Text } from "tw-components";
 import { shortenIfAddress } from "utils/usedapp-external";
 import { usePublishedContractsFromDeploy } from "../hooks";
@@ -14,6 +13,9 @@ import { usePublishedContractsFromDeploy } from "../hooks";
 interface AsyncContractNameCellProps {
   cell: BasicContract;
 }
+
+// The row components for the contract table, in the <Your contracts> page
+// url: /dashboard/contracts/deploy
 
 export const AsyncContractNameCell = memo(
   ({ cell }: AsyncContractNameCellProps) => {
@@ -26,9 +28,7 @@ export const AsyncContractNameCell = memo(
       chain,
     });
 
-    const contractMetadata = useReadContract(getContractMetadata, {
-      contract,
-    });
+    const contractMetadata = useDashboardContractMetadata(contract);
 
     return (
       <Skeleton isLoaded={!contractMetadata.isFetching}>
@@ -60,10 +60,19 @@ export const AsyncContractTypeCell = memo(
       cell.chainId,
     );
 
+    const chain = useV5DashboardChain(cell.chainId);
+
+    const contract = getContract({
+      client: thirdwebClient,
+      address: cell.address,
+      chain,
+    });
+
+    const contractMetadata = useDashboardContractMetadata(contract);
+
     const contractType =
       publishedContractsFromDeployQuery.data?.[0]?.displayName ||
       publishedContractsFromDeployQuery.data?.[0]?.name;
-
     return (
       <Skeleton
         isLoaded={
@@ -77,7 +86,7 @@ export const AsyncContractTypeCell = memo(
           </Text>
         ) : (
           <Text fontStyle="italic" opacity={0.5}>
-            Custom
+            {contractMetadata.data?.contractType || "Custom"}
           </Text>
         )}
       </Skeleton>

--- a/apps/dashboard/src/components/contract-functions/interactive-abi-function.tsx
+++ b/apps/dashboard/src/components/contract-functions/interactive-abi-function.tsx
@@ -32,6 +32,11 @@ import {
 } from "tw-components";
 
 function formatResponseData(data: unknown): string {
+  // Early exit if data is already a string,
+  // otherwise JSON.stringify(data) will wrap it in extra quotes - which will affect the value for [Copy button]
+  if (typeof data === "string") {
+    return data;
+  }
   if (BigNumber.isBigNumber(data)) {
     // biome-ignore lint/style/noParameterAssign: FIXME
     data = data.toString();


### PR DESCRIPTION
- [x] Fix clipboard value for the [copy button] inside /explorer page
- [x] Better handling for some edge cases where the contract's compilation target is a very long string
- [x] Instead of displaying "Custom" for non-thirdweb contracts, display the contract type based on the compilation target

<hr />

Before:
<img width="1241" alt="image" src="https://github.com/user-attachments/assets/397cc15f-5941-4a5c-ae11-cae5a7a7fbde">

After:
<img width="830" alt="image" src="https://github.com/user-attachments/assets/2a353e9c-04c8-4d6d-b15f-c26b7f423213">

<hr />

Before:
<img width="665" alt="image" src="https://github.com/user-attachments/assets/93465f35-d3c4-466c-b9cd-ab905c4fc6f1">

After:
<img width="667" alt="image" src="https://github.com/user-attachments/assets/24c59796-913d-42a4-95a2-2a63e6e726c3">

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to improve contract metadata handling in the dashboard components.

### Detailed summary
- Added a check to handle long contract names from the thirdweb endpoint
- Updated handling of contract type in tables
- Improved handling of contract metadata in components

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->