### PR TITLE
Add validation for NFT claim amount to be integer

### DIFF
--- a/apps/dashboard/src/contract-ui/tabs/nfts/components/claim-form.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/nfts/components/claim-form.tsx
@@ -70,7 +70,17 @@ export const NFTClaimForm: React.FC<NFTClaimFormProps> = ({
             </FormControl>
             <FormControl isRequired isInvalid={!!errors.amount}>
               <FormLabel>Amount</FormLabel>
-              <Input type="text" {...register("amount")} />
+              <Input
+                type="text"
+                {...register("amount", {
+                  validate: (value) => {
+                    const valueNum = Number(value);
+                    if (!Number.isInteger(valueNum)) {
+                      return "Amount must be an integer";
+                    }
+                  },
+                })}
+              />
               <FormHelperText>How many would you like to claim?</FormHelperText>
               <FormErrorMessage>{errors.amount?.message}</FormErrorMessage>
             </FormControl>

--- a/apps/dashboard/src/contract-ui/tabs/nfts/components/claim-tab.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/nfts/components/claim-tab.tsx
@@ -94,7 +94,18 @@ const ClaimTab: React.FC<ClaimTabProps> = ({ contract, tokenId }) => {
             isInvalid={!!form.getFieldState("amount", form.formState).error}
           >
             <FormLabel>Amount</FormLabel>
-            <Input type="text" {...form.register("amount")} />
+            <Input
+              type="text"
+              {...form.register("amount", {
+                validate: (value) => {
+                  // must be an integer
+                  const valueNum = Number(value);
+                  if (!Number.isInteger(valueNum)) {
+                    return "Amount must be an integer";
+                  }
+                },
+              })}
+            />
             <FormHelperText>How many would you like to claim?</FormHelperText>
             <FormErrorMessage>
               {form.getFieldState("amount", form.formState).error?.message}


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added



<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add integer validation for the "Amount" input field in the claim form for NFTs.

### Detailed summary
- Added integer validation for the "Amount" input field in claim-tab.tsx and claim-form.tsx.
- Display error message if the entered value is not an integer.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->