### PR TITLE
unhide chainsaw in API key settings

### DIFF
--- a/apps/dashboard/src/components/settings/ApiKeys/validations.ts
+++ b/apps/dashboard/src/components/settings/ApiKeys/validations.ts
@@ -149,4 +149,4 @@ export type ApiKeyPayConfigValidationSchema = z.infer<
 >;
 
 // FIXME: Remove
-export const HIDDEN_SERVICES = ["relayer", "chainsaw"];
+export const HIDDEN_SERVICES = ["relayer"];


### PR DESCRIPTION
## Problem solved

Will allow viewing and editing the chainsaw service in api keys management.

How to test? 
Go to `dashboard/settings/api-keys` and see if you can see Chainsaw on your newer api keys and can add them to your older api keys

Should wait until the real external name is decided on before merging



<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes the "chainsaw" service from the `HIDDEN_SERVICES` array in `validations.ts`.

### Detailed summary
- Removed the "chainsaw" service from the `HIDDEN_SERVICES` array

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->