### PR TITLE
Do not show "No Funds" Modal when switch chain is required

### DIFF
--- a/apps/dashboard/src/components/buttons/MismatchButton.tsx
+++ b/apps/dashboard/src/components/buttons/MismatchButton.tsx
@@ -122,6 +122,12 @@ export const MismatchButton = forwardRef<HTMLButtonElement, ButtonProps>(
               loadingText={loadingText}
               onClick={(e) => {
                 e.stopPropagation();
+
+                if (networksMismatch) {
+                  eventRef.current = e;
+                  return;
+                }
+
                 if (notEnoughBalance) {
                   trackEvent({
                     category: "no-funds",
@@ -130,11 +136,6 @@ export const MismatchButton = forwardRef<HTMLButtonElement, ButtonProps>(
                   });
                   setDialog("no-funds");
                   return;
-                }
-
-                if (networksMismatch) {
-                  eventRef.current = e;
-                  return undefined;
                 }
 
                 if (onClick) {


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to refactor the `MismatchButton` component in the dashboard app to handle `networksMismatch` condition more efficiently.

### Detailed summary
- Added condition to handle `networksMismatch` before executing other logic
- Moved event assignment inside the condition block
- Removed redundant code for `networksMismatch` outside the condition block

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->