### PR TITLE
Fix isLoggedin auth action

### DIFF
--- a/apps/dashboard/src/app/login/auth-actions.ts
+++ b/apps/dashboard/src/app/login/auth-actions.ts
@@ -197,7 +197,7 @@ export async function isLoggedIn(address: string) {
     return false;
   }
   // if the address matches what we expect, we're logged in
-  if (getAddress(json.address) === getAddress(address)) {
+  if (getAddress(json.data.creatorWalletAddress) === getAddress(address)) {
     // set the active account cookie again
     cookieStore.set(COOKIE_ACTIVE_ACCOUNT, getAddress(address), {
       httpOnly: false,


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the authentication logic in `auth-actions.ts` to compare the creator wallet address instead of the general address for logging in.

### Detailed summary
- Updated the comparison to use `creatorWalletAddress` instead of `address` for authentication.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->