### PR TITLE
Remove sign-in requirement for TransactionButton

### DIFF
--- a/apps/dashboard/src/components/buttons/MismatchButton.tsx
+++ b/apps/dashboard/src/components/buttons/MismatchButton.tsx
@@ -97,6 +97,7 @@ export const MismatchButton = forwardRef<HTMLButtonElement, ButtonProps>(
       return (
         <CustomConnectWallet
           borderRadius="md"
+          loginRequired={false}
           colorScheme="primary"
           {...props}
         />


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `MismatchButton.tsx` component in the dashboard app to add a `loginRequired` prop set to `false`.

### Detailed summary
- Added `loginRequired={false}` prop to `CustomConnectWallet` component.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->