### PR TITLE
[Fix] Remove unused loginRequired prop from MismatchButton component

### DIFF
--- a/apps/dashboard/src/components/buttons/MismatchButton.tsx
+++ b/apps/dashboard/src/components/buttons/MismatchButton.tsx
@@ -97,7 +97,6 @@ export const MismatchButton = forwardRef<HTMLButtonElement, ButtonProps>(
       return (
         <CustomConnectWallet
           borderRadius="md"
-          loginRequired={false}
           colorScheme="primary"
           {...props}
         />


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `MismatchButton.tsx` file in the `dashboard` app to remove the `loginRequired` prop from `CustomConnectWallet`.

### Detailed summary
- Removed the `loginRequired` prop from `CustomConnectWallet` component.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->