### PR TITLE
[Dashboard] use MediaRenderer for contract's avatar

### DIFF
--- a/apps/dashboard/src/components/custom-contract/contract-header/metadata-header.tsx
+++ b/apps/dashboard/src/components/custom-contract/contract-header/metadata-header.tsx
@@ -1,15 +1,9 @@
 import { thirdwebClient } from "@/constants/client";
-import {
-  Center,
-  Flex,
-  Image,
-  Skeleton,
-  useBreakpointValue,
-} from "@chakra-ui/react";
+import { Center, Flex, Skeleton, useBreakpointValue } from "@chakra-ui/react";
 import { ChainIcon } from "components/icons/ChainIcon";
 import Link from "next/link";
 import type { ChainMetadata } from "thirdweb/chains";
-import { resolveScheme } from "thirdweb/storage";
+import { MediaRenderer } from "thirdweb/react";
 import { Heading, LinkButton, Text } from "tw-components";
 import { AddressCopyButton } from "tw-components/AddressCopyButton";
 
@@ -72,18 +66,18 @@ export const MetadataHeader: React.FC<MetadataHeaderProps> = ({
           position="relative"
         >
           {data?.image ? (
-            <Image
-              position="absolute"
-              top={0}
-              bottom={0}
-              right={0}
-              left={0}
-              objectFit="contain"
-              src={resolveScheme({
-                client: thirdwebClient,
-                uri: data.image,
-              })}
+            <MediaRenderer
+              src={data.image}
+              client={thirdwebClient}
               alt={data?.name?.toString() || ""}
+              style={{
+                position: "absolute",
+                top: 0,
+                bottom: 0,
+                right: 0,
+                left: 0,
+                objectFit: "contain",
+              }}
             />
           ) : null}
         </Skeleton>


### PR DESCRIPTION
- [x] Contract metadata header now uses <MediaRenderer /> instead of <Image/>
This way is works with videos and it gets rid of that weird border-radius bug (see image)

<img width="324" alt="image" src="https://github.com/user-attachments/assets/a57f95c1-eb45-4e6f-8121-0d10358c7c6b">

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to refactor the `MetadataHeader` component in the `custom-contract` folder by replacing `resolveScheme` with `MediaRenderer` for image rendering.

### Detailed summary
- Replaced `resolveScheme` with `MediaRenderer` for image rendering.
- Updated image rendering logic with new props and styles.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->