### PR TITLE
fix(dashboard): fix wrong 'version' prop import

### DIFF
--- a/apps/dashboard/src/components/contract-components/hooks.ts
+++ b/apps/dashboard/src/components/contract-components/hooks.ts
@@ -41,7 +41,7 @@ import { getDashboardChainRpc } from "lib/rpc";
 import { StorageSingleton, getThirdwebSDK } from "lib/sdk";
 import type { StaticImageData } from "next/image";
 import { useRouter } from "next/router";
-import { useMemo, version } from "react";
+import { useMemo } from "react";
 import {
   abstractTestnet,
   polygon,
@@ -604,6 +604,7 @@ export function useCustomContractDeployMutation(options: {
 }) {
   const {
     ipfsHash,
+    version,
     hasContractURI,
     hasRoyalty,
     isSplit,


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added



<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes the unused `version` import in `hooks.ts` and adds the `version` parameter to the `useCustomContractDeployMutation` function.

### Detailed summary
- Removed unused `version` import
- Added `version` parameter to `useCustomContractDeployMutation` function

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->