### PR TITLE
[Dashboard] Remove useClaimNFT; use erc1155/claimTo

### DIFF
--- a/apps/dashboard/src/core-ui/nft-drawer/useNftDrawerTabs.tsx
+++ b/apps/dashboard/src/core-ui/nft-drawer/useNftDrawerTabs.tsx
@@ -39,7 +39,7 @@ const ClaimConditionTab = dynamic(() =>
     ({ ClaimConditions }) => ClaimConditions,
   ),
 );
-const ClaimTab = dynamic(
+const ClaimTabERC1155 = dynamic(
   () => import("contract-ui/tabs/nfts/components/claim-tab"),
 );
 const UpdateMetadataTab = dynamic(
@@ -216,12 +216,18 @@ export function useNFTDrawerTabs({
         },
       ]);
     }
-    if (isClaimable && isERC1155) {
+    if (isClaimable && isERC1155 && oldContract) {
       tabs = tabs.concat([
         {
           title: "Claim",
           isDisabled: false,
-          children: <ClaimTab contract={oldContract} tokenId={tokenId} />,
+          children: (
+            <ClaimTabERC1155
+              contractAddress={oldContract.getAddress()}
+              chainId={oldContract.chainId}
+              tokenId={tokenId}
+            />
+          ),
         },
       ]);
     }


### PR DESCRIPTION
The component in this PR is meant for Edition Drop only

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the `ClaimTab` component to handle ERC1155 contracts and improve transaction handling.

### Detailed summary
- Renamed `ClaimTab` component to `ClaimTabERC1155` for ERC1155 contracts.
- Updated `ClaimTabERC1155` to work with ERC1155 contracts.
- Improved transaction handling in `ClaimTabERC1155`.
- Added `useSendAndConfirmTransaction` hook.
- Refactored contract handling in `ClaimTabERC1155`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->