### PR TITLE
[Dashboard] Hide ERC721 Claim button if viewing ERC1155 Drop

### DIFF
--- a/apps/dashboard/src/contract-ui/tabs/nfts/components/claim-button.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/nfts/components/claim-button.tsx
@@ -8,6 +8,10 @@ interface NFTClaimButtonProps {
   chainId: number;
 }
 
+/**
+ * This button is used for claiming NFT Drop contract (erc721) only!
+ * For Edition Drop we have a dedicated ClaimTabERC1155 inside each Edition's page
+ */
 export const NFTClaimButton: React.FC<NFTClaimButtonProps> = ({
   contractAddress,
   chainId,

--- a/apps/dashboard/src/contract-ui/tabs/nfts/page.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/nfts/page.tsx
@@ -120,7 +120,11 @@ export const ContractNFTPage: React.FC<NftOverviewPageProps> = ({
           {detectedRevealableState === "enabled" && contractQuery?.contract && (
             <NFTRevealButton contractQuery={contractQuery} />
           )}
-          {detectedClaimState && contractQuery?.contract && (
+          {detectedClaimState && contractQuery?.contract && isErc721 && (
+            /**
+             * This button is used for claiming NFT Drop contract (erc721) only!
+             * For Edition Drop we have a dedicated ClaimTabERC1155 inside each Edition's page
+             */
             <NFTClaimButton
               contractAddress={contractQuery.contract.getAddress()}
               chainId={contractQuery.contract.chainId}


### PR DESCRIPTION
For Edition Drop we have a dedicated ClaimTabERC1155 inside each Edition's page

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a clarification comment and condition for claiming NFT Drop contracts in `claim-button.tsx`.

### Detailed summary
- Added comment specifying this button is for erc721 contracts only
- Added condition `isErc721` to show the claim button for erc721 contracts only

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->