### PR TITLE
embed-setup.tsx to v5

### DIFF
--- a/apps/dashboard/src/contract-ui/tabs/embed/components/embed-setup.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/embed/components/embed-setup.tsx
@@ -11,13 +11,13 @@ import {
   useClipboard,
 } from "@chakra-ui/react";
 import { IoMdCheckmark } from "@react-icons/all-files/io/IoMdCheckmark";
-import type { DropContract } from "@thirdweb-dev/react";
 import { useTrack } from "hooks/analytics/useTrack";
 import { useSupportedChainsRecord } from "hooks/chains/configureChains";
 import { useTxNotifications } from "hooks/useTxNotifications";
 import { useMemo } from "react";
 import { useForm } from "react-hook-form";
 import { FiCopy } from "react-icons/fi";
+import type { ThirdwebContract } from "thirdweb";
 import type { ChainMetadata } from "thirdweb/chains";
 import {
   Button,
@@ -31,7 +31,7 @@ import {
 import type { StoredChain } from "../../../../contexts/configured-chains";
 
 interface EmbedSetupProps {
-  contract: DropContract;
+  contract: ThirdwebContract;
   ercOrMarketplace: string;
 }
 
@@ -81,7 +81,7 @@ const isValidUrl = (url: string | undefined) => {
 };
 
 const buildIframeSrc = (
-  contract?: DropContract,
+  contract: ThirdwebContract,
   ercOrMarketplace?: string,
   options?: IframeSrcOptions,
 ): string => {
@@ -114,7 +114,7 @@ const buildIframeSrc = (
     `https://embed.ipfscdn.io/ipfs/${contractEmbedHash}/${contractPath}`,
   );
 
-  url.searchParams.append("contract", contract.getAddress());
+  url.searchParams.append("contract", contract.address);
   url.searchParams.append("chain", chain);
   url.searchParams.append("clientId", clientId);
 
@@ -565,7 +565,7 @@ export const EmbedSetup: React.FC<EmbedSetupProps> = ({
                 category: "embed",
                 action: "click",
                 label: "copy-code",
-                address: contract?.getAddress(),
+                address: contract.address,
                 chainId,
               });
             }}

--- a/apps/dashboard/src/contract-ui/tabs/embed/page.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/embed/page.tsx
@@ -1,6 +1,9 @@
 import { Flex } from "@chakra-ui/react";
 import { getErcs, useContract, useContractType } from "@thirdweb-dev/react";
 import { detectFeatures } from "components/contract-components/utils";
+import { thirdwebClient } from "lib/thirdweb-client";
+import { useV5DashboardChain } from "lib/v5-adapter";
+import { getContract } from "thirdweb";
 import { EmbedSetup } from "./components/embed-setup";
 
 interface ContractEmbedPageProps {
@@ -33,18 +36,27 @@ export const ContractEmbedPage: React.FC<ContractEmbedPageProps> = ({
               ? "erc721"
               : null;
 
+  const chain = useV5DashboardChain(contractQuery.contract?.chainId);
+
   if (contractQuery.isLoading) {
     // TODO build a skeleton for this
     return <div>Loading...</div>;
   }
 
+  if (!contractQuery.contract || !chain) {
+    return null;
+  }
+
+  const contract = getContract({
+    address: contractQuery.contract.getAddress(),
+    chain,
+    client: thirdwebClient,
+  });
+
   return (
     <Flex direction="column" gap={6}>
       {contractQuery?.contract && ercOrMarketplace && (
-        <EmbedSetup
-          contract={contractQuery.contract}
-          ercOrMarketplace={ercOrMarketplace}
-        />
+        <EmbedSetup contract={contract} ercOrMarketplace={ercOrMarketplace} />
       )}
     </Flex>
   );


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to integrate `thirdweb-client` and `v5-adapter` in the contract UI tabs and update `DropContract` to `ThirdwebContract`.

### Detailed summary
- Added `thirdwebClient` and `useV5DashboardChain`
- Replaced `DropContract` with `ThirdwebContract`
- Updated `buildIframeSrc` to use `ThirdwebContract` properties
- Adjusted `url.searchParams` to access `contract.address`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->