### PR TITLE
fix: throw when no encryption key

### DIFF
--- a/.changeset/great-plums-lay.md
+++ b/.changeset/great-plums-lay.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Throw error when no encryption key is provided to custom auth

--- a/packages/thirdweb/src/wallets/in-app/web/lib/auth/base-login.ts
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/auth/base-login.ts
@@ -58,6 +58,10 @@ export class BaseLogin extends AbstractLogin<
     encryptionKey,
     jwt,
   }: LoginQuerierTypes["loginWithCustomJwt"]): Promise<AuthAndWalletRpcReturnType> {
+    if (!encryptionKey || encryptionKey.length === 0) {
+      throw new Error("Encryption key is required for custom jwt auth");
+    }
+
     return this.LoginQuerier.call<AuthAndWalletRpcReturnType>({
       procedureName: "loginWithCustomJwt",
       params: { encryptionKey, jwt },
@@ -71,6 +75,10 @@ export class BaseLogin extends AbstractLogin<
     encryptionKey,
     jwt,
   }: LoginQuerierTypes["loginWithCustomJwt"]): Promise<AuthLoginReturnType> {
+    if (!encryptionKey || encryptionKey.length === 0) {
+      throw new Error("Encryption key is required for custom jwt auth");
+    }
+
     await this.preLogin();
     const result = await this.authenticateWithCustomJwt({ encryptionKey, jwt });
     return this.postLogin(result);
@@ -93,6 +101,10 @@ export class BaseLogin extends AbstractLogin<
     encryptionKey,
     payload,
   }: LoginQuerierTypes["loginWithCustomAuthEndpoint"]): Promise<AuthLoginReturnType> {
+    if (!encryptionKey || encryptionKey.length === 0) {
+      throw new Error("Encryption key is required for custom auth");
+    }
+
     await this.preLogin();
     const result = await this.authenticateWithCustomAuthEndpoint({
       encryptionKey,


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing security by throwing an error when no encryption key is provided for custom authentication.

### Detailed summary
- Added error handling for missing encryption key in custom JWT authentication
- Added error handling for missing encryption key in custom authentication endpoint

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->