### PR TITLE
[Dashboard] (partial) useContract removal

### DIFF
--- a/apps/dashboard/src/contract-ui/tabs/account-permissions/page.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/account-permissions/page.tsx
@@ -1,39 +1,19 @@
 import { Box, Flex } from "@chakra-ui/react";
-import { useContract } from "@thirdweb-dev/react";
-import { extensionDetectedState } from "components/buttons/ExtensionDetectButton";
-import { thirdwebClient } from "lib/thirdweb-client";
-import { useV5DashboardChain } from "lib/v5-adapter";
-import { getContract } from "thirdweb";
+import type { ExtensionDetectedState } from "components/buttons/ExtensionDetectButton";
+import type { ThirdwebContract } from "thirdweb";
 import { Card, Heading, LinkButton, Text } from "tw-components";
 import { AccountSigners } from "./components/account-signers";
 
 interface AccountPermissionsPageProps {
-  contractAddress?: string;
+  contract: ThirdwebContract;
+  detectedPermissionFeature: ExtensionDetectedState;
 }
 
 export const AccountPermissionsPage: React.FC<AccountPermissionsPageProps> = ({
-  contractAddress,
+  contract,
+  detectedPermissionFeature,
 }) => {
-  const contractQuery = useContract(contractAddress);
-
-  const detectedFeature = extensionDetectedState({
-    contractQuery,
-    feature: ["AccountPermissions", "AccountPermissionsV1"],
-  });
-
-  const chain = useV5DashboardChain(contractQuery.contract?.chainId);
-
-  if (contractQuery.isLoading || !contractQuery.contract || !chain) {
-    return null;
-  }
-
-  const contract = getContract({
-    address: contractQuery.contract.getAddress(),
-    chain,
-    client: thirdwebClient,
-  });
-
-  if (!detectedFeature) {
+  if (!detectedPermissionFeature) {
     return (
       <Card as={Flex} flexDir="column" gap={3}>
         {/* TODO  extract this out into it's own component and make it better */}

--- a/apps/dashboard/src/contract-ui/tabs/account/components/account-balance.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/account/components/account-balance.tsx
@@ -1,30 +1,19 @@
 import { thirdwebClient } from "@/constants/client";
 import { useSplitBalances } from "@3rdweb-sdk/react/hooks/useSplit";
 import { SimpleGrid, Stat, StatLabel, StatNumber } from "@chakra-ui/react";
-import { useV5DashboardChain } from "lib/v5-adapter";
-import { getContract } from "thirdweb";
+import type { ThirdwebContract } from "thirdweb";
 import { useActiveWalletChain, useWalletBalance } from "thirdweb/react";
 import { Card } from "tw-components";
 
 interface AccountBalanceProps {
-  address: string;
-  chainId: number;
+  contract: ThirdwebContract;
 }
 
-export const AccountBalance: React.FC<AccountBalanceProps> = ({
-  address,
-  chainId,
-}) => {
-  const v5Chain = useV5DashboardChain(chainId);
+export const AccountBalance: React.FC<AccountBalanceProps> = ({ contract }) => {
   const activeChain = useActiveWalletChain();
   const { data: balance } = useWalletBalance({
-    address,
+    address: contract.address,
     chain: activeChain,
-    client: thirdwebClient,
-  });
-  const contract = getContract({
-    address,
-    chain: v5Chain,
     client: thirdwebClient,
   });
   const balanceQuery = useSplitBalances(contract);

--- a/apps/dashboard/src/contract-ui/tabs/account/page.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/account/page.tsx
@@ -1,37 +1,28 @@
 import { useDashboardEVMChainId } from "@3rdweb-sdk/react";
 import { Box, Flex } from "@chakra-ui/react";
-import { useContract } from "@thirdweb-dev/react";
-import { extensionDetectedState } from "components/buttons/ExtensionDetectButton";
+import type { ExtensionDetectedState } from "components/buttons/ExtensionDetectButton";
 import { useSupportedChainsRecord } from "hooks/chains/configureChains";
+import type { ThirdwebContract } from "thirdweb";
 import { Card, Heading, LinkButton, Text } from "tw-components";
 import { AccountBalance } from "./components/account-balance";
 import { DepositNative } from "./components/deposit-native";
 import { NftsOwned } from "./components/nfts-owned";
 
 interface AccountPageProps {
-  contractAddress?: string;
+  contract: ThirdwebContract;
+  detectedAccountFeature: ExtensionDetectedState;
 }
 
 export const AccountPage: React.FC<AccountPageProps> = ({
-  contractAddress,
+  contract,
+  detectedAccountFeature,
 }) => {
-  const contractQuery = useContract(contractAddress);
   const configuredChainsRecord = useSupportedChainsRecord();
   const chainId = useDashboardEVMChainId();
   const chain = chainId ? configuredChainsRecord[chainId] : undefined;
-
   const symbol = chain?.nativeCurrency.symbol || "Native Token";
 
-  const detectedFeature = extensionDetectedState({
-    contractQuery,
-    feature: ["Account"],
-  });
-
-  if (contractQuery.isLoading) {
-    return null;
-  }
-
-  if (!detectedFeature) {
+  if (!detectedAccountFeature) {
     return (
       <Card as={Flex} flexDir="column" gap={3}>
         {/* TODO  extract this out into it's own component and make it better */}
@@ -49,27 +40,19 @@ export const AccountPage: React.FC<AccountPageProps> = ({
       </Card>
     );
   }
-
-  const contract = contractQuery.contract;
-
   return (
     <Flex direction="column" gap={6}>
       <Flex direction="row" justify="space-between" align="center">
         <Heading size="title.sm">Balances</Heading>
       </Flex>
-      {contract && (
-        <AccountBalance
-          address={contract.getAddress()}
-          chainId={contract.chainId}
-        />
-      )}
+      <AccountBalance contract={contract} />
       <Flex direction="row" justify="space-between" align="center">
         <Heading size="title.sm">Deposit {symbol}</Heading>
       </Flex>
 
-      {chain && contractAddress && (
+      {chain && (
         <DepositNative
-          address={contractAddress}
+          address={contract.address}
           symbol={symbol}
           chain={chain}
         />
@@ -78,7 +61,7 @@ export const AccountPage: React.FC<AccountPageProps> = ({
       <Flex direction="row" justify="space-between" align="center">
         <Heading size="title.sm">NFTs owned</Heading>
       </Flex>
-      <NftsOwned address={contractAddress || ""} />
+      <NftsOwned address={contract.address} />
     </Flex>
   );
 };

--- a/apps/dashboard/src/contract-ui/tabs/direct-listings/components/cancel.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/direct-listings/components/cancel.tsx
@@ -1,21 +1,14 @@
 import { CancelTab } from "contract-ui/tabs/shared-components/cancel-tab";
+import type { ThirdwebContract } from "thirdweb";
 
 interface CancelDirectListingProps {
-  contractAddress: string;
-  chainId: number;
+  contract: ThirdwebContract;
   listingId: string;
 }
 
 export const CancelDirectListing: React.FC<CancelDirectListingProps> = ({
-  contractAddress,
+  contract,
   listingId,
-  chainId,
 }) => {
-  return (
-    <CancelTab
-      contractAddress={contractAddress}
-      chainId={chainId}
-      id={listingId}
-    />
-  );
+  return <CancelTab contract={contract} id={listingId} />;
 };

--- a/apps/dashboard/src/contract-ui/tabs/direct-listings/components/table.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/direct-listings/components/table.tsx
@@ -1,32 +1,22 @@
 import { MarketplaceTable } from "contract-ui/tabs/shared-components/marketplace-table";
-import { useV5DashboardChain } from "lib/v5-adapter";
 import { useState } from "react";
-import { getContract } from "thirdweb";
+import type { ThirdwebContract } from "thirdweb";
 import {
   getAllListings,
   getAllValidListings,
   totalListings,
 } from "thirdweb/extensions/marketplace";
 import { useReadContract } from "thirdweb/react";
-import { thirdwebClient } from "../../../../lib/thirdweb-client";
 
 interface DirectListingsTableProps {
-  contractAddress: string;
-  chainId: number;
+  contract: ThirdwebContract;
 }
 
 const DEFAULT_QUERY_STATE = { count: 50, start: 0 };
 
 export const DirectListingsTable: React.FC<DirectListingsTableProps> = ({
-  contractAddress,
-  chainId,
+  contract,
 }) => {
-  const chain = useV5DashboardChain(chainId);
-  const contract = getContract({
-    client: thirdwebClient,
-    address: contractAddress,
-    chain: chain,
-  });
   const [queryParams, setQueryParams] = useState(DEFAULT_QUERY_STATE);
   const getAllQueryResult = useReadContract(getAllListings, {
     contract,
@@ -42,8 +32,7 @@ export const DirectListingsTable: React.FC<DirectListingsTableProps> = ({
 
   return (
     <MarketplaceTable
-      contractAddress={contractAddress}
-      chainId={chainId}
+      contract={contract}
       getAllQueryResult={getAllQueryResult}
       getValidQueryResult={getValidQueryResult}
       totalCountQuery={totalCountQuery}

--- a/apps/dashboard/src/contract-ui/tabs/direct-listings/page.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/direct-listings/page.tsx
@@ -1,46 +1,31 @@
 import { Flex } from "@chakra-ui/react";
-import { useContract } from "@thirdweb-dev/react";
+import type { ThirdwebContract } from "thirdweb";
 import { Heading } from "tw-components";
 /* import { CreateListingButton } from "./components/list-button"; */
 import { CreateListingButton } from "../shared-components/list-button";
 import { DirectListingsTable } from "./components/table";
 
 interface ContractDirectListingsPageProps {
-  contractAddress?: string;
+  contract: ThirdwebContract;
 }
 
 export const ContractDirectListingsPage: React.FC<
   ContractDirectListingsPageProps
-> = ({ contractAddress }) => {
-  const contractQuery = useContract(contractAddress, "marketplace-v3");
-
-  if (contractQuery.isLoading) {
-    // TODO build a skeleton for this
-    return <div>Loading...</div>;
-  }
-
-  if (!contractQuery?.contract) {
-    return null;
-  }
-
+> = ({ contract }) => {
   return (
     <Flex direction="column" gap={6}>
       <Flex direction="row" justify="space-between" align="center">
         <Heading size="title.sm">Contract Listings</Heading>
         <Flex gap={4}>
           <CreateListingButton
-            contractAddress={contractQuery.contract.getAddress()}
-            chainId={contractQuery.contract.chainId}
+            contract={contract}
             type="direct-listings"
             createText="Create Direct Listing"
           />
         </Flex>
       </Flex>
 
-      <DirectListingsTable
-        contractAddress={contractQuery.contract.getAddress()}
-        chainId={contractQuery.contract.chainId}
-      />
+      <DirectListingsTable contract={contract} />
     </Flex>
   );
 };

--- a/apps/dashboard/src/contract-ui/tabs/embed/page.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/embed/page.tsx
@@ -1,61 +1,25 @@
 import { Flex } from "@chakra-ui/react";
-import { getErcs, useContract, useContractType } from "@thirdweb-dev/react";
-import { detectFeatures } from "components/contract-components/utils";
-import { thirdwebClient } from "lib/thirdweb-client";
-import { useV5DashboardChain } from "lib/v5-adapter";
-import { getContract } from "thirdweb";
+import type { ThirdwebContract } from "thirdweb";
 import { EmbedSetup } from "./components/embed-setup";
 
 interface ContractEmbedPageProps {
-  contractAddress?: string;
+  contract: ThirdwebContract;
+  ercOrMarketplace:
+    | "marketplace"
+    | "marketplace-v3"
+    | "erc20"
+    | "erc1155"
+    | "erc721"
+    | null;
 }
 
 export const ContractEmbedPage: React.FC<ContractEmbedPageProps> = ({
-  contractAddress,
+  contract,
+  ercOrMarketplace,
 }) => {
-  const contractQuery = useContract(contractAddress);
-  const { data: contractType } = useContractType(contractAddress);
-
-  const { erc20, erc1155, erc721 } = getErcs(contractQuery?.contract);
-
-  const isMarketplaceV3 = detectFeatures(contractQuery?.contract, [
-    "DirectListings",
-    "EnglishAuctions",
-  ]);
-
-  const ercOrMarketplace =
-    contractType === "marketplace"
-      ? "marketplace"
-      : isMarketplaceV3
-        ? "marketplace-v3"
-        : erc20
-          ? "erc20"
-          : erc1155
-            ? "erc1155"
-            : erc721
-              ? "erc721"
-              : null;
-
-  const chain = useV5DashboardChain(contractQuery.contract?.chainId);
-
-  if (contractQuery.isLoading) {
-    // TODO build a skeleton for this
-    return <div>Loading...</div>;
-  }
-
-  if (!contractQuery.contract || !chain) {
-    return null;
-  }
-
-  const contract = getContract({
-    address: contractQuery.contract.getAddress(),
-    chain,
-    client: thirdwebClient,
-  });
-
   return (
     <Flex direction="column" gap={6}>
-      {contractQuery?.contract && ercOrMarketplace && (
+      {ercOrMarketplace && (
         <EmbedSetup contract={contract} ercOrMarketplace={ercOrMarketplace} />
       )}
     </Flex>

--- a/apps/dashboard/src/contract-ui/tabs/english-auctions/components/cancel.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/english-auctions/components/cancel.tsx
@@ -1,21 +1,14 @@
 import { CancelTab } from "contract-ui/tabs/shared-components/cancel-tab";
+import type { ThirdwebContract } from "thirdweb";
 
 interface CancelEnglishAuctionProps {
-  contractAddress: string;
-  chainId: number;
+  contract: ThirdwebContract;
   auctionId: string;
 }
 
 export const CancelEnglishAuction: React.FC<CancelEnglishAuctionProps> = ({
-  contractAddress,
-  chainId,
+  contract,
   auctionId,
 }) => {
-  return (
-    <CancelTab
-      contractAddress={contractAddress}
-      chainId={chainId}
-      id={auctionId}
-    />
-  );
+  return <CancelTab contract={contract} id={auctionId} />;
 };

--- a/apps/dashboard/src/contract-ui/tabs/english-auctions/components/table.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/english-auctions/components/table.tsx
@@ -1,8 +1,6 @@
 import { MarketplaceTable } from "contract-ui/tabs/shared-components/marketplace-table";
-import { thirdwebClient } from "lib/thirdweb-client";
-import { useV5DashboardChain } from "lib/v5-adapter";
 import { useState } from "react";
-import { getContract } from "thirdweb";
+import type { ThirdwebContract } from "thirdweb";
 import {
   getAllAuctions,
   getAllValidAuctions,
@@ -11,23 +9,15 @@ import {
 import { useReadContract } from "thirdweb/react";
 
 interface EnglishAuctionsTableProps {
-  contractAddress: string;
-  chainId: number;
+  contract: ThirdwebContract;
 }
 
 const DEFAULT_QUERY_STATE = { count: 50, start: 0 };
 
 export const EnglishAuctionsTable: React.FC<EnglishAuctionsTableProps> = ({
-  contractAddress,
-  chainId,
+  contract,
 }) => {
-  const chain = useV5DashboardChain(chainId);
   const [queryParams, setQueryParams] = useState(DEFAULT_QUERY_STATE);
-  const contract = getContract({
-    client: thirdwebClient,
-    address: contractAddress,
-    chain: chain,
-  });
   const getAllQueryResult = useReadContract(getAllAuctions, {
     contract,
     count: BigInt(queryParams.count),
@@ -42,8 +32,7 @@ export const EnglishAuctionsTable: React.FC<EnglishAuctionsTableProps> = ({
 
   return (
     <MarketplaceTable
-      contractAddress={contractAddress}
-      chainId={chainId}
+      contract={contract}
       getAllQueryResult={getAllQueryResult}
       getValidQueryResult={getValidQueryResult}
       totalCountQuery={totalCountQuery}

--- a/apps/dashboard/src/contract-ui/tabs/english-auctions/page.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/english-auctions/page.tsx
@@ -1,45 +1,30 @@
 import { Flex } from "@chakra-ui/react";
-import { useContract } from "@thirdweb-dev/react";
+import type { ThirdwebContract } from "thirdweb";
 import { Heading } from "tw-components";
 import { CreateListingButton } from "../shared-components/list-button";
 import { EnglishAuctionsTable } from "./components/table";
 
 interface ContractEnglishAuctionsProps {
-  contractAddress?: string;
+  contract: ThirdwebContract;
 }
 
 export const ContractEnglishAuctionsPage: React.FC<
   ContractEnglishAuctionsProps
-> = ({ contractAddress }) => {
-  const contractQuery = useContract(contractAddress, "marketplace-v3");
-
-  if (contractQuery.isLoading) {
-    // TODO build a skeleton for this
-    return <div>Loading...</div>;
-  }
-
-  if (!contractQuery?.contract) {
-    return null;
-  }
-
+> = ({ contract }) => {
   return (
     <Flex direction="column" gap={6}>
       <Flex direction="row" justify="space-between" align="center">
         <Heading size="title.sm">Contract Auctions</Heading>
         <Flex gap={4}>
           <CreateListingButton
-            contractAddress={contractQuery.contract.getAddress()}
-            chainId={contractQuery.contract.chainId}
+            contract={contract}
             type="english-auctions"
             createText="Create English Auction"
           />
         </Flex>
       </Flex>
 
-      <EnglishAuctionsTable
-        contractAddress={contractQuery.contract.getAddress()}
-        chainId={contractQuery.contract.chainId}
-      />
+      <EnglishAuctionsTable contract={contract} />
     </Flex>
   );
 };

--- a/apps/dashboard/src/contract-ui/tabs/nfts/page.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/nfts/page.tsx
@@ -16,7 +16,6 @@ import { NFTGetAllTable } from "./components/table";
 import { TokenIdPage } from "./components/token-id";
 
 interface NftOverviewPageProps {
-  contractAddress: string;
   contract: ThirdwebContract;
 }
 
@@ -25,10 +24,9 @@ function isOnlyNumbers(str: string) {
 }
 
 export const ContractNFTPage: React.FC<NftOverviewPageProps> = ({
-  contractAddress,
   contract,
 }) => {
-  const contractQuery = useContract(contractAddress);
+  const contractQuery = useContract(contract.address);
   const router = useRouter();
   const tokenId = router.query?.paths?.[2];
   const isErc721 = detectFeatures(contractQuery?.contract, ["ERC721"]);

--- a/apps/dashboard/src/contract-ui/tabs/overview/components/TokenDetails.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/overview/components/TokenDetails.tsx
@@ -1,22 +1,19 @@
 import { Flex } from "@chakra-ui/react";
 import { TokenSupply } from "contract-ui/tabs/tokens/components/supply";
+import type { ThirdwebContract } from "thirdweb";
 import { Heading } from "tw-components";
 
 interface TokenDetailsProps {
-  contractAddress: string;
-  chainId: number;
+  contract: ThirdwebContract;
 }
 
-export const TokenDetails: React.FC<TokenDetailsProps> = ({
-  contractAddress,
-  chainId,
-}) => {
+export const TokenDetails: React.FC<TokenDetailsProps> = ({ contract }) => {
   return (
     <Flex direction="column" gap={6}>
       <Flex align="center" justify="space-between" w="full">
         <Heading size="title.sm">Token Details</Heading>
       </Flex>
-      <TokenSupply contractAddress={contractAddress} chainId={chainId} />
+      <TokenSupply contract={contract} />
     </Flex>
   );
 };

--- a/apps/dashboard/src/contract-ui/tabs/overview/page.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/overview/page.tsx
@@ -49,13 +49,13 @@ export const ContractOverviewPage: React.FC<ContractOverviewPageProps> = ({
   }
 
   const contractV5 =
-    chain && contract
+    contract && chain
       ? getContract({
           address: contract.getAddress(),
           chain,
           client: thirdwebClient,
         })
-      : null;
+      : undefined;
 
   return (
     <SimpleGrid columns={{ base: 1, xl: 10 }} gap={20}>
@@ -91,12 +91,9 @@ export const ContractOverviewPage: React.FC<ContractOverviewPageProps> = ({
               features={detectedFeatureNames}
             />
           )}
-        {contract &&
+        {contractV5 &&
           ["ERC20"].some((type) => detectedFeatureNames.includes(type)) && (
-            <TokenDetails
-              contractAddress={contractAddress}
-              chainId={contract.chainId}
-            />
+            <TokenDetails contract={contractV5} />
           )}
         <LatestEvents
           address={contractAddress}

--- a/apps/dashboard/src/contract-ui/tabs/settings/page.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/settings/page.tsx
@@ -1,56 +1,26 @@
 import { Flex, GridItem, SimpleGrid } from "@chakra-ui/react";
-import { useContract } from "@thirdweb-dev/react";
-import { extensionDetectedState } from "components/buttons/ExtensionDetectButton";
-import { thirdwebClient } from "lib/thirdweb-client";
-import { useV5DashboardChain } from "lib/v5-adapter";
-import { getContract } from "thirdweb";
+import type { ExtensionDetectedState } from "components/buttons/ExtensionDetectButton";
+import type { ThirdwebContract } from "thirdweb";
 import { SettingsMetadata } from "./components/metadata";
 import { SettingsPlatformFees } from "./components/platform-fees";
 import { SettingsPrimarySale } from "./components/primary-sale";
 import { SettingsRoyalties } from "./components/royalties";
 
 interface ContractSettingsPageProps {
-  contractAddress?: string;
+  contract: ThirdwebContract;
+  detectedMetadata: ExtensionDetectedState;
+  detectedPrimarySale: ExtensionDetectedState;
+  detectedRoyalties: ExtensionDetectedState;
+  detectedPlatformFees: ExtensionDetectedState;
 }
 
 export const ContractSettingsPage: React.FC<ContractSettingsPageProps> = ({
-  contractAddress,
+  contract,
+  detectedMetadata,
+  detectedPlatformFees,
+  detectedPrimarySale,
+  detectedRoyalties,
 }) => {
-  const contractQuery = useContract(contractAddress);
-
-  const detectedMetadata = extensionDetectedState({
-    contractQuery,
-    feature: "ContractMetadata",
-  });
-  const detectedPrimarySale = extensionDetectedState({
-    contractQuery,
-    feature: "PrimarySale",
-  });
-  const detectedRoyalties = extensionDetectedState({
-    contractQuery,
-    feature: "Royalty",
-  });
-  const detectedPlatformFees = extensionDetectedState({
-    contractQuery,
-    feature: "PlatformFee",
-  });
-
-  const chain = useV5DashboardChain(contractQuery.contract?.chainId);
-
-  if (contractQuery.isLoading) {
-    // TODO build a skeleton for this
-    return <div>Loading...</div>;
-  }
-
-  const contract =
-    contractQuery.contract && chain
-      ? getContract({
-          address: contractQuery.contract.getAddress(),
-          chain,
-          client: thirdwebClient,
-        })
-      : null;
-
   return (
     <Flex direction="column" gap={4}>
       <Flex gap={8} w="100%">

--- a/apps/dashboard/src/contract-ui/tabs/shared-components/cancel-tab.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/shared-components/cancel-tab.tsx
@@ -1,35 +1,25 @@
-import { thirdwebClient } from "@/constants/client";
 import { useEVMContractInfo } from "@3rdweb-sdk/react";
 import { Stack } from "@chakra-ui/react";
 import { TransactionButton } from "components/buttons/TransactionButton";
 import { useTrack } from "hooks/analytics/useTrack";
 import { useTxNotifications } from "hooks/useTxNotifications";
-import { useV5DashboardChain } from "lib/v5-adapter";
-import { getContract } from "thirdweb";
+import type { ThirdwebContract } from "thirdweb";
 import { cancelAuction, cancelListing } from "thirdweb/extensions/marketplace";
 import { useSendAndConfirmTransaction } from "thirdweb/react";
 
 interface CancelTabProps {
   id: string;
-  contractAddress: string;
-  chainId: number;
+  contract: ThirdwebContract;
   isAuction?: boolean;
 }
 
 export const CancelTab: React.FC<CancelTabProps> = ({
   id,
-  contractAddress,
-  chainId,
+  contract,
   isAuction,
 }) => {
   const trackEvent = useTrack();
   const network = useEVMContractInfo()?.chain;
-  const chain = useV5DashboardChain(chainId);
-  const contract = getContract({
-    address: contractAddress,
-    chain: chain,
-    client: thirdwebClient,
-  });
   const transaction = isAuction
     ? cancelAuction({ contract, auctionId: BigInt(id) })
     : cancelListing({ contract, listingId: BigInt(id) });

--- a/apps/dashboard/src/contract-ui/tabs/shared-components/list-button.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/shared-components/list-button.tsx
@@ -1,10 +1,8 @@
 import { ListerOnly } from "@3rdweb-sdk/react/components/roles/lister-only";
 import { Icon, useDisclosure } from "@chakra-ui/react";
 import { TransactionButton } from "components/buttons/TransactionButton";
-import { thirdwebClient } from "lib/thirdweb-client";
-import { useV5DashboardChain } from "lib/v5-adapter";
 import { FiPlus } from "react-icons/fi";
-import { getContract } from "thirdweb";
+import type { ThirdwebContract } from "thirdweb";
 import { useActiveAccount, useSendAndConfirmTransaction } from "thirdweb/react";
 import { Button, Drawer } from "tw-components";
 import { CreateListingsForm } from "../listings/components/list-form";
@@ -12,8 +10,7 @@ import { CreateListingsForm } from "../listings/components/list-form";
 const LIST_FORM_ID = "marketplace-list-form";
 
 interface CreateListingButtonProps {
-  contractAddress: string;
-  chainId: number;
+  contract: ThirdwebContract;
   createText?: string;
   type?: "direct-listings" | "english-auctions";
 }
@@ -21,19 +18,13 @@ interface CreateListingButtonProps {
 export const CreateListingButton: React.FC<CreateListingButtonProps> = ({
   createText = "Create",
   type,
-  contractAddress,
-  chainId,
+  contract,
   ...restButtonProps
 }) => {
   const address = useActiveAccount()?.address;
   const { isOpen, onOpen, onClose } = useDisclosure();
   const { mutate, isPending } = useSendAndConfirmTransaction();
-  const chain = useV5DashboardChain(chainId);
-  const contract = getContract({
-    address: contractAddress,
-    chain: chain,
-    client: thirdwebClient,
-  });
+
   return (
     <ListerOnly contract={contract}>
       <Drawer

--- a/apps/dashboard/src/contract-ui/tabs/shared-components/listing-drawer.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/shared-components/listing-drawer.tsx
@@ -10,6 +10,7 @@ import {
   usePrevious,
 } from "@chakra-ui/react";
 import { useMemo } from "react";
+import type { ThirdwebContract } from "thirdweb";
 import type {
   DirectListing,
   EnglishAuction,
@@ -23,8 +24,7 @@ import { CancelEnglishAuction } from "../english-auctions/components/cancel";
 import { LISTING_STATUS } from "./types";
 
 interface NFTDrawerProps {
-  contractAddress: string;
-  chainId: number;
+  contract: ThirdwebContract;
   isOpen: boolean;
   onClose: () => void;
   data: DirectListing | EnglishAuction | null;
@@ -32,8 +32,7 @@ interface NFTDrawerProps {
 }
 
 export const ListingDrawer: React.FC<NFTDrawerProps> = ({
-  contractAddress,
-  chainId,
+  contract,
   isOpen,
   onClose,
   data,
@@ -176,14 +175,12 @@ export const ListingDrawer: React.FC<NFTDrawerProps> = ({
         children: () =>
           type === "direct-listings" ? (
             <CancelDirectListing
-              contractAddress={contractAddress}
-              chainId={chainId}
+              contract={contract}
               listingId={renderData.id.toString()}
             />
           ) : (
             <CancelEnglishAuction
-              contractAddress={contractAddress}
-              chainId={chainId}
+              contract={contract}
               auctionId={renderData.id.toString()}
             />
           ),
@@ -197,8 +194,7 @@ export const ListingDrawer: React.FC<NFTDrawerProps> = ({
     tokenId,
     data?.asset.metadata.properties,
     type,
-    contractAddress,
-    chainId,
+    contract,
   ]);
 
   if (!renderData) {

--- a/apps/dashboard/src/contract-ui/tabs/shared-components/marketplace-table.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/shared-components/marketplace-table.tsx
@@ -34,6 +34,7 @@ import {
 } from "react-icons/md";
 import type { UseQueryResult } from "react-query-v5";
 import { type Cell, type Column, usePagination, useTable } from "react-table";
+import type { ThirdwebContract } from "thirdweb";
 import type {
   DirectListing,
   EnglishAuction,
@@ -87,8 +88,7 @@ const tableColumns: Column<DirectListing | EnglishAuction>[] = [
 ];
 
 interface MarketplaceTableProps {
-  contractAddress: string;
-  chainId: number;
+  contract: ThirdwebContract;
   getAllQueryResult: UseQueryResult<DirectListing[] | EnglishAuction[]>;
   getValidQueryResult: UseQueryResult<DirectListing[] | EnglishAuction[]>;
   totalCountQuery: UseQueryResult<bigint>;
@@ -108,8 +108,7 @@ interface MarketplaceTableProps {
 const DEFAULT_QUERY_STATE = { count: 50, start: 0 };
 
 export const MarketplaceTable: React.FC<MarketplaceTableProps> = ({
-  contractAddress,
-  chainId,
+  contract,
   getAllQueryResult,
   getValidQueryResult,
   totalCountQuery,
@@ -215,8 +214,7 @@ export const MarketplaceTable: React.FC<MarketplaceTableProps> = ({
           />
         )}
         <ListingDrawer
-          contractAddress={contractAddress}
-          chainId={chainId}
+          contract={contract}
           data={tokenRow}
           isOpen={!!tokenRow}
           onClose={() => setTokenRow(null)}

--- a/apps/dashboard/src/contract-ui/tabs/split/page.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/split/page.tsx
@@ -10,13 +10,11 @@ import {
   StatLabel,
   StatNumber,
 } from "@chakra-ui/react";
-import { useContract } from "@thirdweb-dev/react";
 import { useSupportedChainsRecord } from "hooks/chains/configureChains";
 import { useMemo } from "react";
 import {
   type ThirdwebContract,
   ZERO_ADDRESS,
-  getContract,
   toEther,
   toTokens,
 } from "thirdweb";
@@ -28,7 +26,6 @@ import {
 } from "thirdweb/react";
 import { Card, Heading, Text } from "tw-components";
 import { shortenIfAddress } from "utils/usedapp-external";
-import { useV5DashboardChain } from "../../../lib/v5-adapter";
 import { DistributeButton } from "./components/distribute-button";
 
 export type Balance = {
@@ -40,28 +37,10 @@ export type Balance = {
 };
 
 interface SplitPageProps {
-  contractAddress?: string;
+  contract: ThirdwebContract;
 }
 
-export const ContractSplitPage: React.FC<SplitPageProps> = ({
-  contractAddress,
-}) => {
-  const contractQuery = useContract(contractAddress, "split");
-  const v5Chain = useV5DashboardChain(contractQuery.contract?.chainId);
-
-  if (contractQuery.isLoading) {
-    // TODO build a skeleton for this
-    return <div>Loading...</div>;
-  }
-
-  if (!contractQuery?.contract || !v5Chain) {
-    return null;
-  }
-  const contract = getContract({
-    address: contractQuery.contract.getAddress(),
-    client: thirdwebClient,
-    chain: v5Chain,
-  });
+export const ContractSplitPage: React.FC<SplitPageProps> = ({ contract }) => {
   return <ContractSplitContent contract={contract} />;
 };
 

--- a/apps/dashboard/src/contract-ui/tabs/tokens/components/airdrop-button.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/tokens/components/airdrop-button.tsx
@@ -1,38 +1,21 @@
-import { thirdwebClient } from "@/constants/client";
 import { Icon, useDisclosure } from "@chakra-ui/react";
-import { useV5DashboardChain } from "lib/v5-adapter";
-import { useMemo } from "react";
 import { FiDroplet } from "react-icons/fi";
-import { getContract } from "thirdweb";
+import type { ThirdwebContract } from "thirdweb";
 import { balanceOf } from "thirdweb/extensions/erc20";
 import { useActiveAccount, useReadContract } from "thirdweb/react";
 import { Button, Drawer } from "tw-components";
 import { TokenAirdropForm } from "./airdrop-form";
 
 interface TokenAirdropButtonProps {
-  contractAddress: string;
-  chainId: number;
+  contract: ThirdwebContract;
 }
 
 export const TokenAirdropButton: React.FC<TokenAirdropButtonProps> = ({
-  contractAddress,
-  chainId,
+  contract,
   ...restButtonProps
 }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const address = useActiveAccount()?.address;
-
-  const chain = useV5DashboardChain(chainId);
-
-  const contract = useMemo(
-    () =>
-      getContract({
-        address: contractAddress,
-        chain,
-        client: thirdwebClient,
-      }),
-    [chain, contractAddress],
-  );
 
   const tokenBalanceQuery = useReadContract(balanceOf, {
     contract,

--- a/apps/dashboard/src/contract-ui/tabs/tokens/components/burn-button.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/tokens/components/burn-button.tsx
@@ -1,38 +1,21 @@
-import { thirdwebClient } from "@/constants/client";
 import { Icon, useDisclosure } from "@chakra-ui/react";
-import { useV5DashboardChain } from "lib/v5-adapter";
-import { useMemo } from "react";
 import { FaBurn } from "react-icons/fa";
-import { getContract } from "thirdweb";
+import type { ThirdwebContract } from "thirdweb";
 import { balanceOf } from "thirdweb/extensions/erc20";
 import { useActiveAccount, useReadContract } from "thirdweb/react";
 import { Button, Drawer } from "tw-components";
 import { TokenBurnForm } from "./burn-form";
 
 interface TokenBurnButtonProps {
-  contractAddress: string;
-  chainId: number;
+  contract: ThirdwebContract;
 }
 
 export const TokenBurnButton: React.FC<TokenBurnButtonProps> = ({
-  contractAddress,
-  chainId,
+  contract,
   ...restButtonProps
 }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const address = useActiveAccount()?.address;
-
-  const chain = useV5DashboardChain(chainId);
-
-  const contract = useMemo(
-    () =>
-      getContract({
-        address: contractAddress,
-        chain,
-        client: thirdwebClient,
-      }),
-    [chain, contractAddress],
-  );
 
   const tokenBalanceQuery = useReadContract(balanceOf, {
     contract,

--- a/apps/dashboard/src/contract-ui/tabs/tokens/components/claim-button.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/tokens/components/claim-button.tsx
@@ -1,29 +1,18 @@
-import { thirdwebClient } from "@/constants/client";
 import { Icon, useDisclosure } from "@chakra-ui/react";
-import { useV5DashboardChain } from "lib/v5-adapter";
 import { GiDiamondHard } from "react-icons/gi";
-import { getContract } from "thirdweb";
+import type { ThirdwebContract } from "thirdweb";
 import { Button, Drawer } from "tw-components";
 import { TokenClaimForm } from "./claim-form";
 
 interface TokenClaimButtonProps {
-  contractAddress: string;
-  chainId: number;
+  contract: ThirdwebContract;
 }
 
 export const TokenClaimButton: React.FC<TokenClaimButtonProps> = ({
-  contractAddress,
-  chainId,
+  contract,
   ...restButtonProps
 }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const chain = useV5DashboardChain(chainId);
-  const contract = getContract({
-    address: contractAddress,
-    chain,
-    client: thirdwebClient,
-  });
-
   return (
     <>
       <Drawer

--- a/apps/dashboard/src/contract-ui/tabs/tokens/components/mint-button.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/tokens/components/mint-button.tsx
@@ -1,29 +1,19 @@
 import { MinterOnly } from "@3rdweb-sdk/react/components/roles/minter-only";
 import { Icon, useDisclosure } from "@chakra-ui/react";
-import { thirdwebClient } from "lib/thirdweb-client";
-import { useV5DashboardChain } from "lib/v5-adapter";
 import { FiPlus } from "react-icons/fi";
-import { getContract } from "thirdweb";
+import type { ThirdwebContract } from "thirdweb";
 import { Button, Drawer } from "tw-components";
 import { TokenERC20MintForm } from "./mint-form-erc20";
 
 interface TokenMintButtonProps {
-  contractAddress: string;
-  chainId: number;
+  contract: ThirdwebContract;
 }
 
 export const TokenMintButton: React.FC<TokenMintButtonProps> = ({
-  contractAddress,
-  chainId,
+  contract,
   ...restButtonProps
 }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const chain = useV5DashboardChain(chainId);
-  const contract = getContract({
-    address: contractAddress,
-    chain,
-    client: thirdwebClient,
-  });
   return (
     <MinterOnly contract={contract}>
       <Drawer

--- a/apps/dashboard/src/contract-ui/tabs/tokens/components/supply.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/tokens/components/supply.tsx
@@ -1,7 +1,5 @@
-import { thirdwebClient } from "@/constants/client";
-import { useV5DashboardChain } from "lib/v5-adapter";
 import { useMemo } from "react";
-import { getContract, toTokens } from "thirdweb";
+import { type ThirdwebContract, toTokens } from "thirdweb";
 import {
   getBalance,
   getCurrencyMetadata,
@@ -11,27 +9,11 @@ import { useActiveAccount, useReadContract } from "thirdweb/react";
 import { TokenSupplyLayout } from "./supply-layout";
 
 interface TokenBalancesProps {
-  contractAddress: string;
-  chainId: number;
+  contract: ThirdwebContract;
 }
 
-export const TokenSupply: React.FC<TokenBalancesProps> = ({
-  contractAddress,
-  chainId,
-}) => {
+export const TokenSupply: React.FC<TokenBalancesProps> = ({ contract }) => {
   const address = useActiveAccount()?.address;
-
-  const chain = useV5DashboardChain(chainId);
-
-  const contract = useMemo(
-    () =>
-      getContract({
-        address: contractAddress,
-        chain,
-        client: thirdwebClient,
-      }),
-    [chain, contractAddress],
-  );
 
   const tokenBalanceQuery = useReadContract(getBalance, {
     contract,

--- a/apps/dashboard/src/contract-ui/tabs/tokens/components/transfer-button.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/tokens/components/transfer-button.tsx
@@ -1,39 +1,21 @@
-import { thirdwebClient } from "@/constants/client";
 import { Icon, useDisclosure } from "@chakra-ui/react";
-import { useV5DashboardChain } from "lib/v5-adapter";
-import { useMemo } from "react";
 import { FiSend } from "react-icons/fi";
-import { getContract } from "thirdweb";
+import type { ThirdwebContract } from "thirdweb";
 import { balanceOf } from "thirdweb/extensions/erc20";
 import { useActiveAccount, useReadContract } from "thirdweb/react";
 import { Button, Drawer } from "tw-components";
 import { TokenTransferForm } from "./transfer-form";
 
 interface TokenTransferButtonProps {
-  contractAddress: string;
-  chainId: number;
+  contract: ThirdwebContract;
 }
 
 export const TokenTransferButton: React.FC<TokenTransferButtonProps> = ({
-  contractAddress,
-  chainId,
+  contract,
   ...restButtonProps
 }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const address = useActiveAccount()?.address;
-
-  const chain = useV5DashboardChain(chainId);
-
-  const contract = useMemo(
-    () =>
-      getContract({
-        address: contractAddress,
-        chain,
-        client: thirdwebClient,
-      }),
-    [chain, contractAddress],
-  );
-
   const tokenBalanceQuery = useReadContract(balanceOf, {
     contract,
     address: address || "",

--- a/apps/dashboard/src/contract-ui/tabs/tokens/page.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/tokens/page.tsx
@@ -1,6 +1,5 @@
 import { Box, ButtonGroup, Flex } from "@chakra-ui/react";
-import { useContract } from "@thirdweb-dev/react";
-import { detectFeatures } from "components/contract-components/utils";
+import type { ThirdwebContract } from "thirdweb";
 import { Card, Heading, LinkButton, Text } from "tw-components";
 import { TokenAirdropButton } from "./components/airdrop-button";
 import { TokenBurnButton } from "./components/burn-button";
@@ -10,38 +9,18 @@ import { TokenSupply } from "./components/supply";
 import { TokenTransferButton } from "./components/transfer-button";
 
 interface ContractTokenPageProps {
-  contractAddress?: string;
+  contract: ThirdwebContract;
+  isERC20: boolean;
+  isERC20Mintable: boolean;
+  isERC20Claimable: boolean;
 }
 
 export const ContractTokensPage: React.FC<ContractTokenPageProps> = ({
-  contractAddress,
+  contract,
+  isERC20,
+  isERC20Claimable,
+  isERC20Mintable,
 }) => {
-  const contractQuery = useContract(contractAddress);
-  const chainId = contractQuery.contract?.chainId;
-
-  if (
-    contractQuery.isLoading ||
-    !contractQuery?.contract ||
-    !contractAddress ||
-    !chainId
-  ) {
-    // TODO build a skeleton for this
-    return <div>Loading...</div>;
-  }
-
-  const isERC20 = detectFeatures(contractQuery.contract, ["ERC20"]);
-
-  const isERC20Mintable = detectFeatures(contractQuery.contract, [
-    "ERC20Mintable",
-  ]);
-
-  const isERC20Claimable = detectFeatures(contractQuery.contract, [
-    "ERC20ClaimConditionsV1",
-    "ERC20ClaimConditionsV2",
-    "ERC20ClaimPhasesV1",
-    "ERC20ClaimPhasesV2",
-  ]);
-
   if (!isERC20) {
     return (
       <Card as={Flex} flexDir="column" gap={3}>
@@ -73,36 +52,17 @@ export const ContractTokensPage: React.FC<ContractTokenPageProps> = ({
           gap={2}
           w="inherit"
         >
-          {isERC20Claimable && contractQuery.contract && (
-            <TokenClaimButton
-              contractAddress={contractQuery.contract.getAddress()}
-              chainId={contractQuery.contract.chainId}
-            />
-          )}
-          <TokenBurnButton
-            contractAddress={contractAddress}
-            chainId={chainId}
-          />
+          {isERC20Claimable && <TokenClaimButton contract={contract} />}
+          <TokenBurnButton contract={contract} />
 
-          <TokenAirdropButton
-            contractAddress={contractAddress}
-            chainId={chainId}
-          />
+          <TokenAirdropButton contract={contract} />
 
-          <TokenTransferButton
-            contractAddress={contractAddress}
-            chainId={chainId}
-          />
-          {isERC20Mintable && contractQuery.contract && (
-            <TokenMintButton
-              contractAddress={contractQuery.contract.getAddress()}
-              chainId={contractQuery.contract.chainId}
-            />
-          )}
+          <TokenTransferButton contract={contract} />
+          {isERC20Mintable && <TokenMintButton contract={contract} />}
         </ButtonGroup>
       </Flex>
 
-      <TokenSupply contractAddress={contractAddress} chainId={chainId} />
+      <TokenSupply contract={contract} />
     </Flex>
   );
 };

--- a/apps/dashboard/src/pages/[chain_id]/[...paths].tsx
+++ b/apps/dashboard/src/pages/[chain_id]/[...paths].tsx
@@ -163,7 +163,7 @@ const ContractPage: ThirdwebNextPage = () => {
   const v5Chain = useV5DashboardChain(chain?.chainId);
   const contract = useMemo(() => {
     if (!contractAddress || !v5Chain) {
-      return null;
+      return undefined;
     }
     return getContract({
       address: contractAddress,
@@ -172,7 +172,7 @@ const ContractPage: ThirdwebNextPage = () => {
     });
   }, [contractAddress, v5Chain]);
 
-  const routes = useContractRouteConfig(contractAddress);
+  const routes = useContractRouteConfig(contractAddress, contract);
 
   const activeRoute = useMemo(
     () => routes.find((route) => route.path === activeTab),


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added



<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update contract-related components to use `ThirdwebContract` type instead of `contractAddress` and `chainId`.

### Detailed summary
- Updated components to use `ThirdwebContract` type instead of `contractAddress` and `chainId`
- Replaced `null` with `undefined` in `contract` initialization
- Refactored components to accept `contract` object directly

> The following files were skipped due to too many changes: `apps/dashboard/src/contract-ui/tabs/shared-components/marketplace-table.tsx`, `apps/dashboard/src/contract-ui/tabs/shared-components/cancel-tab.tsx`, `apps/dashboard/src/contract-ui/tabs/shared-components/listing-drawer.tsx`, `apps/dashboard/src/contract-ui/tabs/english-auctions/components/table.tsx`, `apps/dashboard/src/contract-ui/tabs/direct-listings/components/table.tsx`, `apps/dashboard/src/contract-ui/tabs/english-auctions/page.tsx`, `apps/dashboard/src/contract-ui/tabs/direct-listings/page.tsx`, `apps/dashboard/src/contract-ui/tabs/split/page.tsx`, `apps/dashboard/src/contract-ui/tabs/shared-components/list-button.tsx`, `apps/dashboard/src/contract-ui/tabs/account-permissions/page.tsx`, `apps/dashboard/src/contract-ui/tabs/embed/page.tsx`, `apps/dashboard/src/contract-ui/tabs/settings/page.tsx`, `apps/dashboard/src/contract-ui/tabs/account/page.tsx`, `apps/dashboard/src/contract-ui/tabs/tokens/page.tsx`, `apps/dashboard/src/contract-ui/hooks/useRouteConfig.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->