### PR TITLE
[Dashboard] Migrate type: ProfileMetadata + ProfileMetadataInput

### DIFF
--- a/apps/dashboard/src/components/contract-components/hooks.ts
+++ b/apps/dashboard/src/components/contract-components/hooks.ts
@@ -14,7 +14,6 @@ import {
   type ExtraPublishMetadata,
   type FeatureName,
   type FeatureWithEnabled,
-  type ProfileMetadata,
   type PublishedContract,
   type ThirdwebSDK,
   detectFeatures,
@@ -34,6 +33,7 @@ import {
   zkDeployContractFromUri,
 } from "@thirdweb-dev/sdk/evm/zksync";
 import type { SnippetApiResponse } from "components/contract-tabs/code/types";
+import type { ProfileMetadataInput } from "constants/schemas";
 import type { providers } from "ethers";
 import { useSupportedChain } from "hooks/chains/configureChains";
 import { isEnsName, resolveEns } from "lib/ens";
@@ -569,7 +569,7 @@ export function useEditProfileMutation() {
   const address = useActiveAccount()?.address;
 
   return useMutationWithInvalidate(
-    async (data: ProfileMetadata) => {
+    async (data: ProfileMetadataInput) => {
       invariant(sdk, "sdk not provided");
       await sdk.getPublisher().updatePublisherProfile(data);
     },

--- a/apps/dashboard/src/components/contract-components/hooks.ts
+++ b/apps/dashboard/src/components/contract-components/hooks.ts
@@ -33,7 +33,7 @@ import {
   zkDeployContractFromUri,
 } from "@thirdweb-dev/sdk/evm/zksync";
 import type { SnippetApiResponse } from "components/contract-tabs/code/types";
-import type { ProfileMetadataInput } from "constants/schemas";
+import type { ProfileMetadata, ProfileMetadataInput } from "constants/schemas";
 import type { providers } from "ethers";
 import { useSupportedChain } from "hooks/chains/configureChains";
 import { isEnsName, resolveEns } from "lib/ens";
@@ -300,7 +300,10 @@ async function fetchPublisherProfile(publisherAddress?: string | null) {
     getDashboardChainRpc(polygon.id, undefined),
   );
   invariant(publisherAddress, "address is not defined");
-  return await sdk.getPublisher().getPublisherProfile(publisherAddress);
+  return (await sdk
+    .getPublisher()
+    // todo: remove type-casting once we have replaced this method
+    .getPublisherProfile(publisherAddress)) as ProfileMetadata;
 }
 
 export function publisherProfileQuery(publisherAddress?: string) {

--- a/apps/dashboard/src/components/contract-components/publisher/PublisherSocials.tsx
+++ b/apps/dashboard/src/components/contract-components/publisher/PublisherSocials.tsx
@@ -7,7 +7,7 @@ import { SiMedium } from "@react-icons/all-files/si/SiMedium";
 import { SiReddit } from "@react-icons/all-files/si/SiReddit";
 import { SiTelegram } from "@react-icons/all-files/si/SiTelegram";
 import { SiTwitter } from "@react-icons/all-files/si/SiTwitter";
-import type { ProfileMetadata } from "@thirdweb-dev/sdk";
+import type { ProfileMetadata } from "constants/schemas";
 import { FiGlobe } from "react-icons/fi";
 import { LinkButton, TrackedIconButton } from "tw-components";
 import { hostnameEndsWith } from "../../../utils/url";

--- a/apps/dashboard/src/components/contract-components/publisher/edit-profile.tsx
+++ b/apps/dashboard/src/components/contract-components/publisher/edit-profile.tsx
@@ -10,8 +10,8 @@ import {
 import { SiDiscord } from "@react-icons/all-files/si/SiDiscord";
 import { SiGithub } from "@react-icons/all-files/si/SiGithub";
 import { SiTwitter } from "@react-icons/all-files/si/SiTwitter";
-import type { ProfileMetadata, ProfileMetadataInput } from "@thirdweb-dev/sdk";
 import { FileInput } from "components/shared/FileInput";
+import type { ProfileMetadata, ProfileMetadataInput } from "constants/schemas";
 import { useTrack } from "hooks/analytics/useTrack";
 import { useImageFileOrUrl } from "hooks/useImageFileOrUrl";
 import { useTxNotifications } from "hooks/useTxNotifications";

--- a/apps/dashboard/src/constants/schemas.ts
+++ b/apps/dashboard/src/constants/schemas.ts
@@ -65,3 +65,27 @@ export const CommonContractSchema = z
     defaultAdmin: AddressOrEnsSchema.optional(),
   })
   .catchall(z.unknown());
+
+// @internal
+const ProfileSchemaInput = z.object({
+  name: z.string().optional(),
+  bio: z.string().optional(),
+  avatar: FileOrStringSchema.optional(),
+  website: z.string().optional(),
+  twitter: z.string().optional(),
+  telegram: z.string().optional(),
+  facebook: z.string().optional(),
+  github: z.string().optional(),
+  medium: z.string().optional(),
+  linkedin: z.string().optional(),
+  reddit: z.string().optional(),
+  discord: z.string().optional(),
+});
+
+// @internal
+const ProfileSchemaOutput = ProfileSchemaInput.extend({
+  avatar: z.string().optional(),
+});
+
+export type ProfileMetadataInput = z.infer<typeof ProfileSchemaInput>;
+export type ProfileMetadata = z.infer<typeof ProfileSchemaOutput>;

--- a/apps/dashboard/src/pages/profile/[profileAddress].tsx
+++ b/apps/dashboard/src/pages/profile/[profileAddress].tsx
@@ -19,6 +19,7 @@ import { EditProfile } from "components/contract-components/publisher/edit-profi
 import { PublisherAvatar } from "components/contract-components/publisher/masked-avatar";
 import { DeployedContracts } from "components/contract-components/tables/deployed-contracts";
 import { PublishedContracts } from "components/contract-components/tables/published-contracts";
+import type { ProfileMetadata } from "constants/schemas";
 import { THIRDWEB_DOMAIN } from "constants/urls";
 import { PublisherSDKContext } from "contexts/custom-sdk-context";
 import { getAddress, isAddress } from "ethers/lib/utils";
@@ -150,14 +151,18 @@ const UserPage: ThirdwebNextPage = (props: UserPageProps) => {
                   <PublisherSocials
                     mt={1}
                     size="md"
-                    publisherProfile={publisherProfile.data}
+                    // todo: remove type-casting once we have replaced `sdk.getPublisher().getPublisherProfile(address)`
+                    publisherProfile={publisherProfile.data as ProfileMetadata}
                   />
                 )}
               </Flex>
             </Flex>
             {ens.data?.address === address && publisherProfile.data && (
               <Box flexShrink={0}>
-                <EditProfile publisherProfile={publisherProfile.data} />
+                <EditProfile
+                  // todo: remove type-casting once we have replaced `sdk.getPublisher().getPublisherProfile(address)`
+                  publisherProfile={publisherProfile.data as ProfileMetadata}
+                />
               </Box>
             )}
           </Flex>

--- a/apps/dashboard/src/pages/profile/[profileAddress].tsx
+++ b/apps/dashboard/src/pages/profile/[profileAddress].tsx
@@ -19,7 +19,6 @@ import { EditProfile } from "components/contract-components/publisher/edit-profi
 import { PublisherAvatar } from "components/contract-components/publisher/masked-avatar";
 import { DeployedContracts } from "components/contract-components/tables/deployed-contracts";
 import { PublishedContracts } from "components/contract-components/tables/published-contracts";
-import type { ProfileMetadata } from "constants/schemas";
 import { THIRDWEB_DOMAIN } from "constants/urls";
 import { PublisherSDKContext } from "contexts/custom-sdk-context";
 import { getAddress, isAddress } from "ethers/lib/utils";
@@ -151,18 +150,14 @@ const UserPage: ThirdwebNextPage = (props: UserPageProps) => {
                   <PublisherSocials
                     mt={1}
                     size="md"
-                    // todo: remove type-casting once we have replaced `sdk.getPublisher().getPublisherProfile(address)`
-                    publisherProfile={publisherProfile.data as ProfileMetadata}
+                    publisherProfile={publisherProfile.data}
                   />
                 )}
               </Flex>
             </Flex>
             {ens.data?.address === address && publisherProfile.data && (
               <Box flexShrink={0}>
-                <EditProfile
-                  // todo: remove type-casting once we have replaced `sdk.getPublisher().getPublisherProfile(address)`
-                  publisherProfile={publisherProfile.data as ProfileMetadata}
-                />
+                <EditProfile publisherProfile={publisherProfile.data} />
               </Box>
             )}
           </Flex>


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added



<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the import paths for `ProfileMetadata` in multiple files and define `ProfileSchemaInput` and `ProfileSchemaOutput` in `schemas.ts`.

### Detailed summary
- Updated import paths for `ProfileMetadata` in multiple files
- Defined `ProfileSchemaInput` and `ProfileSchemaOutput` in `schemas.ts`
- Modified function signatures to use `ProfileMetadataInput` instead of `ProfileMetadata`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->