### PR TITLE
Replace useSDKChainId with useDashboardEVMChainId

### DIFF
--- a/apps/dashboard/src/components/buttons/MismatchButton.tsx
+++ b/apps/dashboard/src/components/buttons/MismatchButton.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/dialog";
 import { thirdwebClient } from "@/constants/client";
 import { cn } from "@/lib/utils";
+import { useDashboardEVMChainId } from "@3rdweb-sdk/react";
 import { CustomConnectWallet } from "@3rdweb-sdk/react/components/connect-wallet";
 import {
   Box,
@@ -25,7 +26,7 @@ import {
 } from "@chakra-ui/react";
 import { AiOutlineWarning } from "@react-icons/all-files/ai/AiOutlineWarning";
 import { useQuery } from "@tanstack/react-query";
-import { useSDK, useSDKChainId } from "@thirdweb-dev/react";
+import { useSDK } from "@thirdweb-dev/react";
 import { FaucetButton } from "app/(dashboard)/(chain)/[chain_id]/(chainPage)/components/client/FaucetButton";
 import { GiftIcon } from "app/(dashboard)/(chain)/[chain_id]/(chainPage)/components/icons/GiftIcon";
 import type {
@@ -62,7 +63,7 @@ const GAS_FREE_CHAINS = [
 
 function useNetworkMismatchAdapter() {
   const walletChainId = useActiveWalletChain()?.id;
-  const v4SDKChainId = useSDKChainId();
+  const v4SDKChainId = useDashboardEVMChainId();
   if (!walletChainId || !v4SDKChainId) {
     // simply not ready yet, assume false
     return false;
@@ -397,7 +398,7 @@ const MismatchNotice: React.FC<{
   onClose: (hasSwitched: boolean) => void;
 }> = ({ initialFocusRef, onClose }) => {
   const connectedChainId = useActiveWalletChain()?.id;
-  const desiredChainId = useSDKChainId();
+  const desiredChainId = useDashboardEVMChainId();
   const switchNetwork = useSwitchActiveWalletChain();
   const connectionStatus = useActiveWalletConnectionStatus();
   const activeWallet = useActiveWallet();

--- a/apps/dashboard/src/components/contract-components/hooks.ts
+++ b/apps/dashboard/src/components/contract-components/hooks.ts
@@ -1,4 +1,8 @@
-import { contractKeys, networkKeys } from "@3rdweb-sdk/react";
+import {
+  contractKeys,
+  networkKeys,
+  useDashboardEVMChainId,
+} from "@3rdweb-sdk/react";
 import { useMutationWithInvalidate } from "@3rdweb-sdk/react/hooks/query/useQueryWithNetwork";
 import {
   type QueryClient,
@@ -6,7 +10,7 @@ import {
   useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
-import { useSDK, useSDKChainId, useSigner } from "@thirdweb-dev/react";
+import { useSDK, useSigner } from "@thirdweb-dev/react";
 import {
   type Abi,
   type ContractInfoSchema,
@@ -214,7 +218,7 @@ export function useDefaultForwarders() {
   const provider = sdk?.getProvider();
   invariant(provider, "Require provider");
 
-  const chainId = useSDKChainId();
+  const chainId = useDashboardEVMChainId();
 
   return useQuery(["default-forwarders", chainId], async () => {
     const forwarders = await getTrustedForwarders(provider, StorageSingleton);
@@ -388,7 +392,7 @@ export function usePublishedContractsFromDeploy(
   contractAddress?: string,
   chainId?: number,
 ) {
-  const activeChainId = useSDKChainId();
+  const activeChainId = useDashboardEVMChainId();
   const cId = chainId || activeChainId;
   const chainInfo = useSupportedChain(cId || -1);
 

--- a/apps/dashboard/src/components/shared/CurrencySelector.tsx
+++ b/apps/dashboard/src/components/shared/CurrencySelector.tsx
@@ -1,5 +1,5 @@
+import { useDashboardEVMChainId } from "@3rdweb-sdk/react";
 import { Flex, Input, Select, type SelectProps } from "@chakra-ui/react";
-import { useSDKChainId } from "@thirdweb-dev/react";
 import { CURRENCIES, type CurrencyMetadata } from "constants/currencies";
 import { useSupportedChainsRecord } from "hooks/chains/configureChains";
 import { useMemo, useState } from "react";
@@ -25,7 +25,7 @@ export const CurrencySelector: React.FC<CurrencySelectorProps> = ({
   defaultCurrencies = [],
   ...props
 }) => {
-  const chainId = useSDKChainId();
+  const chainId = useDashboardEVMChainId();
   const configuredChainsRecord = useSupportedChainsRecord();
   const chain = chainId ? configuredChainsRecord[chainId] : undefined;
 

--- a/apps/dashboard/src/contract-ui/tabs/account-permissions/components/account-signer.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/account-permissions/components/account-signer.tsx
@@ -1,5 +1,5 @@
+import { useDashboardEVMChainId } from "@3rdweb-sdk/react";
 import { Flex, SimpleGrid, useBreakpointValue } from "@chakra-ui/react";
-import { useSDKChainId } from "@thirdweb-dev/react";
 import { formatDistance } from "date-fns/formatDistance";
 import { useSupportedChainsRecord } from "hooks/chains/configureChains";
 import { useActiveAccount } from "thirdweb/react";
@@ -19,7 +19,7 @@ interface AccountSignerProps {
 
 export const AccountSigner: React.FC<AccountSignerProps> = ({ item }) => {
   const address = useActiveAccount()?.address;
-  const chainId = useSDKChainId();
+  const chainId = useDashboardEVMChainId();
   const configuredChainsRecord = useSupportedChainsRecord();
   const chain = chainId ? configuredChainsRecord[chainId] : undefined;
   const isMobile = useBreakpointValue({ base: true, md: false });

--- a/apps/dashboard/src/contract-ui/tabs/claim-conditions/components/price-preview.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/claim-conditions/components/price-preview.tsx
@@ -1,5 +1,5 @@
+import { useDashboardEVMChainId } from "@3rdweb-sdk/react";
 import { Flex } from "@chakra-ui/react";
-import { useSDKChainId } from "@thirdweb-dev/react";
 import { CURRENCIES } from "constants/currencies";
 import { useSupportedChainsRecord } from "hooks/chains/configureChains";
 import { Text } from "tw-components";
@@ -15,7 +15,7 @@ export const PricePreview: React.FC<PricePreviewProps> = ({
   price,
   currencyAddress,
 }) => {
-  const chainId = useSDKChainId();
+  const chainId = useDashboardEVMChainId();
   const configuredChainsRecord = useSupportedChainsRecord();
   const chain = chainId ? configuredChainsRecord[chainId] : undefined;
 


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added



<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the usage of `useSDKChainId` to `useDashboardEVMChainId` across multiple components and hooks.

### Detailed summary
- Replaced `useSDKChainId` with `useDashboardEVMChainId` in multiple files
- Updated import statements for the new `useDashboardEVMChainId` function

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->