### PR TITLE
[Dashboard] Replace useSDKChainId with useDashboardEVMChainId

### DIFF
--- a/apps/dashboard/src/components/buttons/MismatchButton.tsx
+++ b/apps/dashboard/src/components/buttons/MismatchButton.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/dialog";
 import { thirdwebClient } from "@/constants/client";
 import { cn } from "@/lib/utils";
+import { useDashboardEVMChainId } from "@3rdweb-sdk/react";
 import { CustomConnectWallet } from "@3rdweb-sdk/react/components/connect-wallet";
 import {
   Box,
@@ -25,7 +26,6 @@ import {
 } from "@chakra-ui/react";
 import { AiOutlineWarning } from "@react-icons/all-files/ai/AiOutlineWarning";
 import { useQuery } from "@tanstack/react-query";
-import { useSDKChainId } from "@thirdweb-dev/react";
 import { FaucetButton } from "app/(dashboard)/(chain)/[chain_id]/(chainPage)/components/client/FaucetButton";
 import { GiftIcon } from "app/(dashboard)/(chain)/[chain_id]/(chainPage)/components/icons/GiftIcon";
 import type {
@@ -65,7 +65,7 @@ const GAS_FREE_CHAINS = [
 
 function useNetworkMismatchAdapter() {
   const walletChainId = useActiveWalletChain()?.id;
-  const v4SDKChainId = useSDKChainId();
+  const v4SDKChainId = useDashboardEVMChainId();
   if (!walletChainId || !v4SDKChainId) {
     // simply not ready yet, assume false
     return false;
@@ -400,7 +400,7 @@ const MismatchNotice: React.FC<{
   onClose: (hasSwitched: boolean) => void;
 }> = ({ initialFocusRef, onClose }) => {
   const connectedChainId = useActiveWalletChain()?.id;
-  const desiredChainId = useSDKChainId();
+  const desiredChainId = useDashboardEVMChainId();
   const switchNetwork = useSwitchActiveWalletChain();
   const connectionStatus = useActiveWalletConnectionStatus();
   const activeWallet = useActiveWallet();

--- a/apps/dashboard/src/components/shared/CurrencySelector.tsx
+++ b/apps/dashboard/src/components/shared/CurrencySelector.tsx
@@ -1,5 +1,5 @@
+import { useDashboardEVMChainId } from "@3rdweb-sdk/react";
 import { Flex, Input, Select, type SelectProps } from "@chakra-ui/react";
-import { useSDKChainId } from "@thirdweb-dev/react";
 import { CURRENCIES, type CurrencyMetadata } from "constants/currencies";
 import { useSupportedChainsRecord } from "hooks/chains/configureChains";
 import { useMemo, useState } from "react";
@@ -25,7 +25,7 @@ export const CurrencySelector: React.FC<CurrencySelectorProps> = ({
   defaultCurrencies = [],
   ...props
 }) => {
-  const chainId = useSDKChainId();
+  const chainId = useDashboardEVMChainId();
   const configuredChainsRecord = useSupportedChainsRecord();
   const chain = chainId ? configuredChainsRecord[chainId] : undefined;
 

--- a/apps/dashboard/src/contract-ui/tabs/account-permissions/components/account-signer.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/account-permissions/components/account-signer.tsx
@@ -1,5 +1,5 @@
+import { useDashboardEVMChainId } from "@3rdweb-sdk/react";
 import { Flex, SimpleGrid, useBreakpointValue } from "@chakra-ui/react";
-import { useSDKChainId } from "@thirdweb-dev/react";
 import { formatDistance } from "date-fns/formatDistance";
 import { useSupportedChainsRecord } from "hooks/chains/configureChains";
 import { useActiveAccount } from "thirdweb/react";
@@ -19,7 +19,7 @@ interface AccountSignerProps {
 
 export const AccountSigner: React.FC<AccountSignerProps> = ({ item }) => {
   const address = useActiveAccount()?.address;
-  const chainId = useSDKChainId();
+  const chainId = useDashboardEVMChainId();
   const configuredChainsRecord = useSupportedChainsRecord();
   const chain = chainId ? configuredChainsRecord[chainId] : undefined;
   const isMobile = useBreakpointValue({ base: true, md: false });

--- a/apps/dashboard/src/contract-ui/tabs/claim-conditions/components/price-preview.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/claim-conditions/components/price-preview.tsx
@@ -1,5 +1,5 @@
+import { useDashboardEVMChainId } from "@3rdweb-sdk/react";
 import { Flex } from "@chakra-ui/react";
-import { useSDKChainId } from "@thirdweb-dev/react";
 import { CURRENCIES } from "constants/currencies";
 import { useSupportedChainsRecord } from "hooks/chains/configureChains";
 import { Text } from "tw-components";
@@ -15,7 +15,7 @@ export const PricePreview: React.FC<PricePreviewProps> = ({
   price,
   currencyAddress,
 }) => {
-  const chainId = useSDKChainId();
+  const chainId = useDashboardEVMChainId();
   const configuredChainsRecord = useSupportedChainsRecord();
   const chain = chainId ? configuredChainsRecord[chainId] : undefined;
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the usage of `useSDKChainId` to `useDashboardEVMChainId` across multiple components for consistency and compatibility.

### Detailed summary
- Replaced `useSDKChainId` with `useDashboardEVMChainId` in several components
- Updated imports and references accordingly

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->