### PR TITLE
[Dashboard] Migrate useContractSources to v5

### DIFF
--- a/apps/dashboard/src/contract-ui/hooks/useContractSources.ts
+++ b/apps/dashboard/src/contract-ui/hooks/useContractSources.ts
@@ -30,7 +30,9 @@ export function useContractSources(contract?: ThirdwebContract) {
             const source = await download({
               uri: `ipfs://${ipfsHash}`,
               client: thirdwebClient,
-            }).then((r) => r.text());
+            })
+              .then((r) => r.text())
+              .catch(() => "Failed to fetch source from IPFS");
             return {
               filename: path,
               source,

--- a/apps/dashboard/src/contract-ui/hooks/useContractSources.ts
+++ b/apps/dashboard/src/contract-ui/hooks/useContractSources.ts
@@ -6,7 +6,7 @@ import invariant from "tiny-invariant";
 export function useContractSources(contract?: ThirdwebContract) {
   return useQuery(
     [
-      "dashboard-contract-sources",
+      "contract-sources",
       contract?.chain.id || "",
       contract?.address || "",
     ],

--- a/apps/dashboard/src/contract-ui/hooks/useContractSources.ts
+++ b/apps/dashboard/src/contract-ui/hooks/useContractSources.ts
@@ -5,6 +5,8 @@ import { getCompilerMetadata } from "thirdweb/contract";
 import { download } from "thirdweb/storage";
 import invariant from "tiny-invariant";
 
+// An example for a contract that has IPFS URIs in its metadata: abstract-testnet/0x8A24a7Df38fA5fCCcFD1259e90Fb6996fDdfcADa
+
 export function useContractSources(contract?: ThirdwebContract) {
   return useQuery({
     queryKey: [

--- a/apps/dashboard/src/contract-ui/hooks/useContractSources.ts
+++ b/apps/dashboard/src/contract-ui/hooks/useContractSources.ts
@@ -3,13 +3,6 @@ import type { ThirdwebContract } from "thirdweb";
 import { getCompilerMetadata } from "thirdweb/contract";
 import invariant from "tiny-invariant";
 
-/**
- * Fetch all the .sol files (and their content) for a contract
- * We cannot reuse `getCompilerMetadata` from the SDK here because the `sources` field is omitted
- * because we are using `formatCompilerMetadata` in that method
- *
- * Which raises the question where we should do that in the first place
- */
 export function useContractSources(contract?: ThirdwebContract) {
   return useQuery(
     [

--- a/apps/dashboard/src/contract-ui/hooks/useContractSources.ts
+++ b/apps/dashboard/src/contract-ui/hooks/useContractSources.ts
@@ -4,9 +4,13 @@ import { getCompilerMetadata } from "thirdweb/contract";
 import invariant from "tiny-invariant";
 
 export function useContractSources(contract?: ThirdwebContract) {
-  return useQuery(
-    ["contract-sources", contract?.chain.id || "", contract?.address || ""],
-    async (): Promise<Array<{ filename: string; source: string }>> => {
+  return useQuery({
+    queryKey: [
+      "contract-sources",
+      contract?.chain.id || "",
+      contract?.address || "",
+    ],
+    queryFn: async (): Promise<Array<{ filename: string; source: string }>> => {
       invariant(contract, "contract is required");
       const data = await getCompilerMetadata(contract);
       const sources = data.metadata.sources || {};
@@ -16,6 +20,6 @@ export function useContractSources(contract?: ThirdwebContract) {
       }));
       return arr;
     },
-    { enabled: !!contract },
-  );
+    enabled: !!contract,
+  });
 }

--- a/apps/dashboard/src/contract-ui/hooks/useContractSources.ts
+++ b/apps/dashboard/src/contract-ui/hooks/useContractSources.ts
@@ -5,11 +5,7 @@ import invariant from "tiny-invariant";
 
 export function useContractSources(contract?: ThirdwebContract) {
   return useQuery(
-    [
-      "contract-sources",
-      contract?.chain.id || "",
-      contract?.address || "",
-    ],
+    ["contract-sources", contract?.chain.id || "", contract?.address || ""],
     async (): Promise<Array<{ filename: string; source: string }>> => {
       invariant(contract, "contract is required");
       const data = await getCompilerMetadata(contract);

--- a/apps/dashboard/src/contract-ui/tabs/sources/page.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/sources/page.tsx
@@ -18,9 +18,12 @@ import { useContract } from "@thirdweb-dev/react";
 import type { Abi } from "@thirdweb-dev/sdk";
 import { SourcesPanel } from "components/contract-components/shared/sources-panel";
 import { useContractSources } from "contract-ui/hooks/useContractSources";
+import { thirdwebClient } from "lib/thirdweb-client";
+import { useV5DashboardChain } from "lib/v5-adapter";
 import { useMemo, useState } from "react";
 import { FiCheckCircle, FiXCircle } from "react-icons/fi";
 import { toast } from "sonner";
+import { getContract } from "thirdweb";
 import { Badge, Button, Card, Heading } from "tw-components";
 import { useDashboardRouter } from "../../../@/lib/DashboardRouter";
 
@@ -188,10 +191,17 @@ export const ContractSourcesPage: React.FC<ContractSourcesPageProps> = ({
     setResetSignal((prev: number) => prev + 1);
   };
 
-  const contractSourcesQuery = useContractSources(contractAddress);
-
   const { contract } = useContract(contractAddress);
-
+  const chain = useV5DashboardChain(contract?.chainId);
+  const contractV5 =
+    contract && chain
+      ? getContract({
+          address: contract.getAddress(),
+          chain,
+          client: thirdwebClient,
+        })
+      : undefined;
+  const contractSourcesQuery = useContractSources(contractV5);
   const abi = useMemo(() => contract?.abi as Abi, [contract]);
 
   // clean up the source filenames and filter out libraries

--- a/packages/thirdweb/src/contract/actions/compiler-metadata.ts
+++ b/packages/thirdweb/src/contract/actions/compiler-metadata.ts
@@ -7,7 +7,9 @@ export type PublishedMetadata = {
   name: string;
   abi: Abi;
   // biome-ignore lint/suspicious/noExplicitAny: TODO: fix later
-  metadata: Record<string, any>;
+  metadata: Record<string, any> & {
+    sources: Record<string, { content: string } | { urls: string[] }>;
+  };
   info: {
     title?: string;
     author?: string;

--- a/packages/thirdweb/src/contract/actions/compiler-metadata.ts
+++ b/packages/thirdweb/src/contract/actions/compiler-metadata.ts
@@ -6,7 +6,7 @@ import type { Abi } from "abitype";
 export type PublishedMetadata = {
   name: string;
   abi: Abi;
-  // biome-ignore lint/suspicious/noExplicitAny: TODO: fix later
+  // biome-ignore lint/suspicious/noExplicitAny: TODO: fix later by updating this type to match the specs here: https://docs.soliditylang.org/en/latest/metadata.html
   metadata: Record<string, any> & {
     sources: Record<string, { content: string } | { urls: string[] }>;
   };


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update the `compiler-metadata` type and enhance the `ContractSourcesPage` with new functionality.

### Detailed summary
- Updated `metadata` type in `compiler-metadata.ts`
- Added `thirdwebClient` import and `getContract` usage in `page.tsx`
- Refactored `useContractSources` function in `useContractSources.ts` to handle IPFS URIs

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->