### PR TITLE
[SDK] resolveAddress for Lens handles

### DIFF
--- a/.changeset/rude-spies-worry.md
+++ b/.changeset/rude-spies-worry.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Lens's resolveAddress for sending crypto with lens handles

--- a/packages/thirdweb/src/exports/extensions/lens.ts
+++ b/packages/thirdweb/src/exports/extensions/lens.ts
@@ -119,6 +119,8 @@ export {
 /**
  * Custom extension
  */
+
+// Read
 export {
   getHandleFromProfileId,
   type GetHandleFromProfileIdParams,
@@ -133,6 +135,10 @@ export {
   type GetFullProfileParams,
   type FullProfileResponse,
 } from "../../extensions/lens/read/getFullProfile.js";
+export {
+  resolveAddress,
+  type ResolveLensAddressParams,
+} from "../../extensions/lens/read/resolveAddress.js";
 
 /**
  * Contract addresses

--- a/packages/thirdweb/src/extensions/lens/read/getFullProfile.ts
+++ b/packages/thirdweb/src/extensions/lens/read/getFullProfile.ts
@@ -2,7 +2,6 @@ import { polygon } from "../../../chains/chain-definitions/polygon.js";
 import type { Chain } from "../../../chains/types.js";
 import type { ThirdwebClient } from "../../../client/client.js";
 import { getContract } from "../../../contract/contract.js";
-import type { Hex } from "../../../utils/encoding/hex.js";
 import { getProfile } from "../__generated__/LensHub/read/getProfile.js";
 import { getDefaultHandle } from "../__generated__/TokenHandleRegistry/read/getDefaultHandle.js";
 import {
@@ -19,10 +18,23 @@ export type GetFullProfileParams = {
   profileId: bigint;
   client: ThirdwebClient;
   includeJoinDate?: boolean;
+  /**
+   * Override variables for Lens smart contracts
+   * Make sure all of them have to be on the same network
+   */
   overrides?: {
-    lensHubAddress?: Hex;
-    lensHandleAddress?: Hex;
-    tokenHandleRegistryAddress?: Hex;
+    /**
+     * Contract address for the LensHub contract
+     */
+    lensHubAddress?: string;
+    /**
+     * Contract address for the LensHandle contract
+     */
+    lensHandleAddress?: string;
+    /**
+     * Contract address for the TokenHandleRegistry contract
+     */
+    tokenHandleRegistryAddress?: string;
     chain?: Chain;
   };
 };

--- a/packages/thirdweb/src/extensions/lens/read/getHandleFromProfileId.ts
+++ b/packages/thirdweb/src/extensions/lens/read/getHandleFromProfileId.ts
@@ -2,7 +2,6 @@ import { polygon } from "../../../chains/chain-definitions/polygon.js";
 import type { Chain } from "../../../chains/types.js";
 import type { ThirdwebClient } from "../../../client/client.js";
 import { getContract } from "../../../contract/contract.js";
-import type { Hex } from "../../../utils/encoding/hex.js";
 import { getHandle } from "../__generated__/LensHandle/read/getHandle.js";
 import { getDefaultHandle } from "../__generated__/TokenHandleRegistry/read/getDefaultHandle.js";
 import {
@@ -16,9 +15,19 @@ import {
 export type GetHandleFromProfileIdParams = {
   profileId: bigint;
   client: ThirdwebClient;
+  /**
+   * Override variables for LensHandle contract and TokenHandleRegistry contract
+   * Make sure both of them have to be on the same network
+   */
   overrides?: {
-    lensHandleAddress?: Hex;
-    tokenHandleRegistryAddress?: Hex;
+    /**
+     * Contract address for the LensHandle contract
+     */
+    lensHandleAddress?: string;
+    /**
+     * Contract address for the TokenHandleRegistry contract
+     */
+    tokenHandleRegistryAddress?: string;
     chain?: Chain;
   };
 };

--- a/packages/thirdweb/src/extensions/lens/read/getProfileMetadata.ts
+++ b/packages/thirdweb/src/extensions/lens/read/getProfileMetadata.ts
@@ -2,7 +2,6 @@ import { polygon } from "../../../chains/chain-definitions/polygon.js";
 import type { Chain } from "../../../chains/types.js";
 import type { ThirdwebClient } from "../../../client/client.js";
 import { getContract } from "../../../contract/contract.js";
-import type { Hex } from "../../../utils/encoding/hex.js";
 import { getProfile } from "../__generated__/LensHub/read/getProfile.js";
 import { LENS_HUB_ADDRESS } from "../consts.js";
 import type { LensProfileSchema } from "./type.js";
@@ -14,7 +13,10 @@ export type GetProfileMetadataParams = {
   profileId: bigint;
   client: ThirdwebClient;
   overrides?: {
-    lensHubAddress?: Hex;
+    /**
+     * Contract address for the LensHub contract
+     */
+    lensHubAddress?: string;
     chain?: Chain;
   };
 };

--- a/packages/thirdweb/src/extensions/lens/read/resolveAddress.test.ts
+++ b/packages/thirdweb/src/extensions/lens/read/resolveAddress.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { TEST_CLIENT } from "~test/test-clients.js";
+import { isAddress } from "../../../utils/address.js";
+import { resolveAddress } from "./resolveAddress.js";
+
+describe("resolve lens address", () => {
+  it("should resolve to correct address", async () => {
+    const address = await resolveAddress({
+      client: TEST_CLIENT,
+      name: "captain_jack",
+    });
+    // "captain_jack" is a valid localname so it should definitely resolve to a valid address
+    expect(isAddress(address)).toBe(true);
+  });
+
+  it("should throw if passed an invalid lens handle", async () => {
+    await expect(() =>
+      resolveAddress({ client: TEST_CLIENT, name: "vitalik.eth" }),
+    ).rejects.toThrowError(
+      "Could not fetch the wallet address for lens handle: vitalik.eth",
+    );
+  });
+});

--- a/packages/thirdweb/src/extensions/lens/read/resolveAddress.ts
+++ b/packages/thirdweb/src/extensions/lens/read/resolveAddress.ts
@@ -1,0 +1,121 @@
+import type { Chain } from "../../../chains/types.js";
+import type { ThirdwebClient } from "../../../client/client.js";
+import { ZERO_ADDRESS } from "../../../constants/addresses.js";
+import { getAddress, isAddress } from "../../../utils/address.js";
+import { withCache } from "../../../utils/promise/withCache.js";
+
+/**
+ * @extension LENS
+ */
+export type ResolveLensAddressParams = {
+  /**
+   * Either a full lens handle, or a lens localName
+   * Examples:
+   * 1. Full handle: "lens/vitalik"
+   * 2. Just local name: "vitalik"
+   */
+  name: string;
+  /**
+   * a [`ThirdwebClient`](https://portal.thirdweb.com/references/typescript/v5/ThirdwebClient)
+   */
+  client: ThirdwebClient;
+  /**
+   * Override parameters for Lens contract, defaults to LensHandle contract on Polygon
+   */
+  overrides?: {
+    /**
+     * The contract address of the [`LensHandle contract`](https://www.lens.xyz/docs/resources/smart-contracts)
+     */
+    lensHandleContractAddress?: string;
+    /**
+     * The chain which `lensHandleContractAddress` is deployed on
+     */
+    chain?: Chain;
+  };
+};
+
+/**
+ * Take in a Lens handle or local-name and return the wallet address behind that handle/local-name.
+ * For example, "lens/vitalik" is a handle, with "lens" being the namespace and "vitalik" being the local name
+ * @extension LENS
+ * @example
+ * ```ts
+ * import { resolveAddress } from "thirdweb/extensions/lens";
+ *
+ * const walletAddress = await resolveAddress({
+ *   name: "vitalik",
+ *   client,
+ * });
+ * ```
+ */
+export async function resolveAddress(
+  options: ResolveLensAddressParams,
+): Promise<string> {
+  const { name, overrides, client } = options;
+  if (isAddress(name)) {
+    return getAddress(name);
+  }
+  return withCache(
+    async (): Promise<string> => {
+      const [
+        { getContract },
+        { getTokenId },
+        { ownerOf },
+        { polygon },
+        { LENS_HANDLE_ADDRESS },
+      ] = await Promise.all([
+        import("../../../contract/contract.js"),
+        import("../__generated__/LensHandle/read/getTokenId.js"),
+        import("../../erc721/__generated__/IERC721A/read/ownerOf.js"),
+        import("../../../chains/chain-definitions/polygon.js"),
+        import("../consts.js"),
+      ]);
+      const contract = getContract({
+        address: overrides?.lensHandleContractAddress || LENS_HANDLE_ADDRESS,
+        chain: overrides?.chain || polygon,
+        client,
+      });
+      /**
+       * For better UX, we accept both handle and local name
+       * The difference: handle = <namespace>/<local-name>
+       * For example, "lens/vitalik" is a handle, with "lens" being the namespace and "vitalik" being the local name
+       * Currently there's only 1 namespace called "lens" but we should make sure the code can scale when there are more
+       *
+       * Since lens does not allow "/" in the name,
+       * if the string contains "/", it is either invalid, or it definitely contains the namespace
+       * In that case we remove the possible namespace because the `getTokenId` method only accepts localName
+       */
+      const isPossibleHandle = name.includes("/");
+      const localName = isPossibleHandle ? name.split("/")[1] : name;
+      if (!localName) {
+        throw new Error(`missing local name from ${name}`);
+      }
+      const tokenId = await getTokenId({ contract, localName });
+      if (!tokenId) {
+        throw new Error(
+          `Could not retrieve tokenId from localName: ${localName}`,
+        );
+      }
+
+      /**
+       * Another thing to note is that even if you enter an invalid localName,
+       * `getTokenId` still returns you a tokenId - so never rely on the result alone.
+       * Check if the tokenId truly exists using `exists` or in this case, `ownerOf`
+       */
+      const address = await ownerOf({ contract, tokenId }).catch(
+        () => ZERO_ADDRESS,
+      );
+      if (address === ZERO_ADDRESS) {
+        throw new Error(
+          `Could not fetch the wallet address for lens handle: ${name}`,
+        );
+      }
+      return address;
+    },
+    {
+      cacheKey: `lens:addr:${name}`,
+      // 1min cache
+      cacheTime: 60 * 1000,
+    },
+  );
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to enhance the `Lens` extension in the `thirdweb` package by adding functionality to resolve addresses based on lens handles.

### Detailed summary
- Added `resolveAddress` function to resolve wallet addresses for lens handles
- Updated contract address overrides for various lens-related contracts
- Improved testing for address resolution functionality

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->