### PR TITLE
[Dashboard] useVote to v5

### DIFF
--- a/.changeset/polite-experts-design.md
+++ b/.changeset/polite-experts-design.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Update tsdocs for Vote extensions

--- a/apps/dashboard/src/@3rdweb-sdk/react/hooks/useVote.ts
+++ b/apps/dashboard/src/@3rdweb-sdk/react/hooks/useVote.ts
@@ -1,18 +1,36 @@
-import { useContract, useContractMetadata, useSDK } from "@thirdweb-dev/react";
-import type { Vote, VoteType } from "@thirdweb-dev/sdk";
-import { useActiveAccount } from "thirdweb/react";
+import { thirdwebClient } from "lib/thirdweb-client";
+import { type ThirdwebContract, getContract, toTokens } from "thirdweb";
+import {
+  balanceOf,
+  decimals,
+  delegate,
+  delegates,
+} from "thirdweb/extensions/erc20";
+import {
+  type VoteType,
+  canExecute,
+  castVoteWithReason,
+  executeProposal,
+  getAll,
+  hasVoted,
+  propose,
+  token,
+} from "thirdweb/extensions/vote";
+import { useActiveAccount, useSendAndConfirmTransaction } from "thirdweb/react";
 import invariant from "tiny-invariant";
-import type { RequiredParam } from "utils/types";
 import { voteKeys } from "../cache-keys";
 import {
   useMutationWithInvalidate,
   useQueryWithNetwork,
 } from "./query/useQueryWithNetwork";
 
-export function useVoteProposalList(contract?: Vote) {
+export function useVoteProposalList(contract?: ThirdwebContract) {
   return useQueryWithNetwork(
-    voteKeys.proposals(contract?.getAddress()),
-    async () => await contract?.getAll(),
+    voteKeys.proposals(contract?.address || ""),
+    async () => {
+      invariant(contract, "contract is required");
+      return await getAll({ contract });
+    },
     {
       enabled: !!contract,
     },
@@ -20,17 +38,20 @@ export function useVoteProposalList(contract?: Vote) {
 }
 
 export function useHasVotedOnProposal(
-  contract: RequiredParam<Vote>,
-  proposalId: string,
+  contract: ThirdwebContract,
+  proposalId: bigint,
 ) {
-  const address = useActiveAccount()?.address;
+  const userAddress = useActiveAccount()?.address;
   return useQueryWithNetwork(
     voteKeys.userHasVotedOnProposal(
-      proposalId,
-      contract?.getAddress(),
-      address,
+      proposalId.toString(),
+      contract.address,
+      userAddress,
     ),
-    async () => await contract?.hasVoted(proposalId, address),
+    async () => {
+      invariant(userAddress, "address is required");
+      return await hasVoted({ contract, proposalId, account: userAddress });
+    },
     {
       enabled: !!contract,
     },
@@ -38,65 +59,83 @@ export function useHasVotedOnProposal(
 }
 
 export function useCanExecuteProposal(
-  contract: RequiredParam<Vote>,
-  proposalId: string,
+  contract: ThirdwebContract,
+  proposalId: bigint,
 ) {
   return useQueryWithNetwork(
-    voteKeys.canExecuteProposal(proposalId, contract?.getAddress()),
-    async () => await contract?.canExecute(proposalId),
+    voteKeys.canExecuteProposal(proposalId.toString(), contract.address),
+    async () => await canExecute({ contract, proposalId }),
     {
       enabled: !!contract,
     },
   );
 }
 
-export function useTokensDelegated(contract?: Vote) {
-  const sdk = useSDK();
-  const address = useActiveAccount()?.address;
+export function useTokensDelegated(contract: ThirdwebContract) {
+  const userAddress = useActiveAccount()?.address;
 
   return useQueryWithNetwork(
-    voteKeys.delegation(contract?.getAddress(), address),
+    voteKeys.delegation(contract.address, userAddress),
     async () => {
-      invariant(address, "address is required");
-      invariant(contract, "vote contract is required");
-
-      const metadata = await contract?.metadata.get();
-      const tokenAddress = metadata?.voting_token_address;
-      const tokenContract = await sdk?.getToken(tokenAddress);
-      const delegation = await tokenContract?.getDelegationOf(address);
-      return delegation?.toLowerCase() === address.toLowerCase();
+      invariant(userAddress, "wallet address is required");
+      const tokenAddress = await token({ contract });
+      if (!tokenAddress) {
+        throw new Error("Expected a delegated token address");
+      }
+      const tokenContract = getContract({
+        address: tokenAddress,
+        chain: contract.chain,
+        client: thirdwebClient,
+      });
+      const delegatedAddress = await delegates({
+        contract: tokenContract,
+        account: userAddress,
+      });
+      return delegatedAddress?.toLowerCase() === userAddress.toLowerCase();
     },
     {
-      enabled: !!contract && !!address,
+      enabled: !!contract && !!userAddress,
     },
   );
 }
 
-export function useVoteTokenBalances(contract?: Vote, addresses?: string[]) {
-  const { data } = useContractMetadata(contract);
-  const tokenContract = useContract(
-    data?.voting_token_address,
-    "token",
-  ).contract;
-
+export function useVoteTokenBalances(
+  contract: ThirdwebContract,
+  addresses: string[],
+) {
   return useQueryWithNetwork(
-    voteKeys.balances(contract?.getAddress(), addresses),
-    async () => {
-      invariant(data, "contract metadata is required");
-      invariant(tokenContract, "voting contract is required");
-      invariant(addresses, "addresses are required");
-
-      const balances = addresses.map(async (address) => {
+    voteKeys.balances(contract.address, addresses),
+    async (): Promise<
+      Array<{ address: string; balance: string; decimals: number }>
+    > => {
+      invariant(addresses.length, "addresses are required");
+      const tokenAddress = await token({ contract });
+      if (!tokenAddress) {
+        throw new Error("Expected a delegated token address");
+      }
+      const tokenContract = getContract({
+        address: tokenAddress,
+        chain: contract.chain,
+        client: thirdwebClient,
+      });
+      const _decimals = await decimals({ contract: tokenContract });
+      const balanceData = await Promise.all(
+        addresses.map((address) =>
+          balanceOf({ contract: tokenContract, address }),
+        ),
+      );
+      const balances = addresses.map((address, index) => {
+        const balance = balanceData[index] || 0n;
         return {
           address,
-          balance: (await tokenContract.balanceOf(address)).displayValue,
+          balance: toTokens(balance, _decimals),
+          decimals: _decimals,
         };
       });
-
       return await Promise.all(balances);
     },
     {
-      enabled: !!data && !!contract && !!addresses?.length,
+      enabled: addresses.length > 0,
     },
   );
 }
@@ -105,45 +144,80 @@ export interface IProposalInput {
   description: string;
 }
 
-export function useProposalCreateMutation(contractAddress?: string) {
-  const voteContract = useContract(contractAddress, "vote").contract;
+/**
+ * This hook is a simplified version meant to use on the Dashboard
+ * since _currently_ the dashboard only supports creating proposals with descriptions
+ *
+ * todo: make an extension in the SDK that is more robust and user-friendly ?
+ */
+export function useProposalCreateMutation(contract: ThirdwebContract) {
+  const { mutateAsync } = useSendAndConfirmTransaction();
   return useMutationWithInvalidate(
-    (proposal: IProposalInput) => {
-      invariant(voteContract, "contract is required");
+    async (proposal: IProposalInput) => {
       const { description } = proposal;
-      return voteContract.propose(description);
+      const transaction = propose({
+        contract,
+        description,
+        targets: [contract.address],
+        values: [0n],
+        calldatas: ["0x"],
+      });
+      return await mutateAsync(transaction);
     },
     {
       onSuccess: (_data, _options, _variables, invalidate) => {
-        return invalidate([voteKeys.proposals(contractAddress)]);
+        return invalidate([voteKeys.proposals(contract.address)]);
       },
     },
   );
 }
 
-export function useDelegateMutation(contract?: Vote) {
-  const sdk = useSDK();
-  const address = useActiveAccount()?.address;
-
-  const contractAddress = contract?.getAddress();
-
+export function useDelegateMutation(contract: ThirdwebContract) {
+  const userAddress = useActiveAccount()?.address;
+  const { mutateAsync } = useSendAndConfirmTransaction();
   return useMutationWithInvalidate(
     async () => {
-      invariant(address, "address is required");
-      invariant(contractAddress, "contract address is required");
-      invariant(contract, "vote contract is required");
-
-      const metadata = await contract?.metadata.get();
-      const tokenAddress = metadata?.voting_token_address;
-      const tokenContract = await sdk?.getToken(tokenAddress);
-      return tokenContract?.delegateTo(address);
+      invariant(userAddress, "address is required");
+      const tokenAddress = await token({ contract });
+      if (!tokenAddress) {
+        throw new Error("Expected a delegated token address");
+      }
+      const tokenContract = getContract({
+        address: tokenAddress,
+        chain: contract.chain,
+        client: thirdwebClient,
+      });
+      const transaction = delegate({
+        contract: tokenContract,
+        delegatee: userAddress,
+      });
+      return await mutateAsync(transaction);
     },
     {
       onSuccess: (_data, _options, _variables, invalidate) => {
-        return invalidate([voteKeys.delegation(contractAddress, address)]);
+        return invalidate([voteKeys.delegation(contract.address, userAddress)]);
       },
     },
   );
+}
+
+/**
+ * Get the decimals of the voting erc20 token
+ */
+export function useVotingTokenDecimals(contract: ThirdwebContract) {
+  return useMutationWithInvalidate(async () => {
+    const tokenAddress = await token({ contract });
+    if (!tokenAddress) {
+      throw new Error("Expected a delegated token address");
+    }
+    const tokenContract = getContract({
+      address: tokenAddress,
+      chain: contract.chain,
+      client: thirdwebClient,
+    });
+    const _decimals = await decimals({ contract: tokenContract });
+    return _decimals;
+  });
 }
 
 interface IVoteCast {
@@ -152,47 +226,61 @@ interface IVoteCast {
 }
 
 export function useCastVoteMutation(
-  contract: RequiredParam<Vote>,
-  proposalId: string,
+  contract: ThirdwebContract,
+  proposalId: bigint,
 ) {
   const address = useActiveAccount()?.address;
-  const contractAddress = contract?.getAddress();
-
+  const contractAddress = contract.address;
+  const { mutateAsync } = useSendAndConfirmTransaction();
   return useMutationWithInvalidate(
-    async (vote: IVoteCast) => {
+    async (voteItem: IVoteCast) => {
       invariant(contract, "contract is required");
       invariant(address, "address is required");
-      const { voteType, reason } = vote;
-      return contract.vote(proposalId, voteType, reason);
+      const { voteType, reason } = voteItem;
+      const transaction = castVoteWithReason({
+        contract,
+        proposalId,
+        support: voteType,
+        reason: reason ?? "",
+      });
+      return await mutateAsync(transaction);
     },
     {
       onSuccess: (_data, _options, _variables, invalidate) => {
         return invalidate([
           voteKeys.proposals(contractAddress),
-          voteKeys.userHasVotedOnProposal(proposalId, contractAddress, address),
-          voteKeys.canExecuteProposal(proposalId, contractAddress),
+          voteKeys.userHasVotedOnProposal(
+            proposalId.toString(),
+            contractAddress,
+            address,
+          ),
+          voteKeys.canExecuteProposal(proposalId.toString(), contractAddress),
         ]);
       },
     },
   );
 }
 
+/**
+ * This hook is a simplified version for the Dashboard
+ * It doesn't pass any extra info to the execute function
+ */
 export function useExecuteProposalMutation(
-  contract: RequiredParam<Vote>,
-  proposalId: string,
+  contract: ThirdwebContract,
+  proposalId: bigint,
 ) {
-  const contractAddress = contract?.getAddress();
-
+  const contractAddress = contract.address;
+  const mutation = useSendAndConfirmTransaction();
   return useMutationWithInvalidate(
     async () => {
-      invariant(contract, "contract is required");
-      return contract.execute(proposalId);
+      const transaction = executeProposal({ contract, proposalId });
+      return await mutation.mutateAsync(transaction);
     },
     {
       onSuccess: (_data, _options, _variables, invalidate) => {
         return invalidate([
           voteKeys.proposals(contractAddress),
-          voteKeys.canExecuteProposal(proposalId, contractAddress),
+          voteKeys.canExecuteProposal(proposalId.toString(), contractAddress),
         ]);
       },
     },

--- a/apps/dashboard/src/contract-ui/tabs/proposals/components/delegate-button.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/proposals/components/delegate-button.tsx
@@ -1,15 +1,15 @@
+import { ToolTipLabel } from "@/components/ui/tooltip";
 import {
   useDelegateMutation,
   useTokensDelegated,
 } from "@3rdweb-sdk/react/hooks/useVote";
-import { Tooltip } from "@chakra-ui/react";
-import type { Vote } from "@thirdweb-dev/sdk";
 import { TransactionButton } from "components/buttons/TransactionButton";
 import { useTrack } from "hooks/analytics/useTrack";
 import { useTxNotifications } from "hooks/useTxNotifications";
+import type { ThirdwebContract } from "thirdweb";
 
 interface VoteButtonProps {
-  contract?: Vote;
+  contract: ThirdwebContract;
 }
 
 export const DelegateButton: React.FC<VoteButtonProps> = ({ contract }) => {
@@ -28,7 +28,7 @@ export const DelegateButton: React.FC<VoteButtonProps> = ({ contract }) => {
   }
 
   return (
-    <Tooltip label="You need to delegate tokens to this contract before you can make proposals and vote.">
+    <ToolTipLabel label="You need to delegate tokens to this contract before you can make proposals and vote.">
       <TransactionButton
         transactionCount={1}
         onClick={() =>
@@ -56,6 +56,6 @@ export const DelegateButton: React.FC<VoteButtonProps> = ({ contract }) => {
       >
         Delegate Tokens
       </TransactionButton>
-    </Tooltip>
+    </ToolTipLabel>
   );
 };

--- a/apps/dashboard/src/contract-ui/tabs/proposals/components/proposal-button.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/proposals/components/proposal-button.tsx
@@ -1,13 +1,13 @@
 import { useProposalCreateMutation } from "@3rdweb-sdk/react/hooks/useVote";
 import { Icon, useDisclosure } from "@chakra-ui/react";
-import type { Vote } from "@thirdweb-dev/sdk";
 import { TransactionButton } from "components/buttons/TransactionButton";
 import { FiPlus } from "react-icons/fi";
+import type { ThirdwebContract } from "thirdweb";
 import { Button, Drawer } from "tw-components";
 import { CreateProposalForm } from "./proposal-form";
 
 interface VoteButtonProps {
-  contract?: Vote;
+  contract: ThirdwebContract;
 }
 
 const PROPOSAL_FORM_ID = "proposal-form-id";
@@ -15,7 +15,7 @@ const PROPOSAL_FORM_ID = "proposal-form-id";
 export const ProposalButton: React.FC<VoteButtonProps> = ({ contract }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
 
-  const propose = useProposalCreateMutation(contract?.getAddress());
+  const propose = useProposalCreateMutation(contract);
 
   return (
     <>

--- a/apps/dashboard/src/contract-ui/tabs/proposals/page.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/proposals/page.tsx
@@ -10,8 +10,8 @@ import {
   StatLabel,
   StatNumber,
 } from "@chakra-ui/react";
-import { useContract } from "@thirdweb-dev/react";
 import { useMemo } from "react";
+import type { ThirdwebContract } from "thirdweb";
 import { useActiveAccount } from "thirdweb/react";
 import { Card, Heading } from "tw-components";
 import { DelegateButton } from "./components/delegate-button";
@@ -19,60 +19,40 @@ import { Proposal } from "./components/proposal";
 import { ProposalButton } from "./components/proposal-button";
 
 interface ProposalsPageProps {
-  contractAddress?: string;
+  contract: ThirdwebContract;
 }
 
 export const ContractProposalsPage: React.FC<ProposalsPageProps> = ({
-  contractAddress,
+  contract,
 }) => {
   const address = useActiveAccount()?.address;
-  const contractQuery = useContract(contractAddress, "vote");
-
-  const data = useVoteProposalList(contractQuery.contract);
+  const data = useVoteProposalList(contract);
 
   const balanceAddresses: string[] = useMemo(() => {
-    return [address, contractAddress].filter((a) => !!a) as string[];
-  }, [address, contractAddress]);
+    return [address, contract.address].filter((a) => !!a) as string[];
+  }, [address, contract.address]);
 
-  const proposals = useMemo(() => {
-    if (!data.data || data.data.length < 1) {
-      return [];
-    }
+  const proposals = useMemo(() => (data.data || []).reverse(), [data]);
 
-    const allProposals = data.data;
-    return allProposals.map(
-      (p, index) => allProposals[allProposals.length - 1 - index],
-    );
-  }, [data]);
+  const { data: balances } = useVoteTokenBalances(contract, balanceAddresses);
 
-  const { data: balances } = useVoteTokenBalances(
-    contractQuery.contract,
-    balanceAddresses,
-  );
-
-  if (contractQuery.isLoading) {
-    // TODO build a skeleton for this
-    return <div>Loading...</div>;
-  }
-
-  if (!contractQuery?.contract) {
+  if (!contract) {
     return null;
   }
-
   return (
     <Flex direction="column" gap={6}>
       <Flex direction="row" justify="space-between" align="center">
         <Heading size="title.sm">Proposals</Heading>
         <Flex gap={4}>
-          <DelegateButton contract={contractQuery.contract} />
-          <ProposalButton contract={contractQuery.contract} />
+          <DelegateButton contract={contract} />
+          <ProposalButton contract={contract} />
         </Flex>
       </Flex>
       <Stack spacing={4}>
         {proposals.map((proposal) => (
           <Proposal
             key={proposal.proposalId.toString()}
-            contract={contractQuery.contract}
+            contract={contract}
             proposal={proposal}
           />
         ))}

--- a/packages/thirdweb/src/extensions/vote/read/getAll.ts
+++ b/packages/thirdweb/src/extensions/vote/read/getAll.ts
@@ -42,7 +42,7 @@ export type ProposalItem = {
    */
   stateLabel: string | undefined;
   /**
-   * The current vote info. See type ProposalVoteInfo for more context
+   * The current vote info. See type [`ProposalVoteInfo`](https://portal.thirdweb.com/references/typescript/v5/ProposalItem) for more context
    */
   votes: ProposalVoteInfo;
   /**

--- a/packages/thirdweb/src/extensions/vote/read/getProposalVoteCounts.ts
+++ b/packages/thirdweb/src/extensions/vote/read/getProposalVoteCounts.ts
@@ -12,6 +12,7 @@ export type ProposalVoteInfo = { [K in keyof typeof VoteType]: bigint };
  * Get the info about Against, For and Abstain votes of a proposal
  * @param options
  * @returns the object containing the info about Against, For and Abstain votes of a proposal
+ * Note: the count is displayed in "wei"
  * @extension VOTE
  * @example
  * ```ts
@@ -21,9 +22,9 @@ export type ProposalVoteInfo = { [K in keyof typeof VoteType]: bigint };
  *
  * // Example result
  * {
- *   against: 12n, // 12 users voted against the proposal
- *   for: 104n, // 104 users support the proposal
- *   abstain: 3n, // 3 users voted abstain on this proposal
+ *   for: 12000000000000000000n, // 12 tokens (with a decimals of 18) were used to vote "for"
+ *   against: 7000000000000000000n, // 7 tokens (with a decimals of 18) were used to vote "against"
+ *   abstain: 0n, // no user has voted abstain on this proposal
  * }
  * ```
  */


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates TypeScript documentation for the Vote extensions and refactors contract-related components to use `ThirdwebContract`.

### Detailed summary
- Updated TypeScript docs for Vote extensions
- Refactored components to use `ThirdwebContract`
- Improved display of voting token amounts in proposals

> The following files were skipped due to too many changes: `apps/dashboard/src/@3rdweb-sdk/react/hooks/useVote.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->