### PR TITLE
Adds EIP-1271 Signature Validation Fallback

### DIFF
--- a/.changeset/stale-jobs-own.md
+++ b/.changeset/stale-jobs-own.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix smart contract wallet signature validation on older chains

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/locale/en.ts
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/locale/en.ts
@@ -95,7 +95,7 @@ const connectLocaleEn: ConnectLocale = {
     },
     signingScreen: {
       title: "Signing In",
-      prompt: "Sign the signature request in your wallet",
+      prompt: "Signing the signature request in your wallet",
       promptForSafe:
         "Sign signature request in your wallet & approve transaction in Safe",
       approveTransactionInSafe: "Approve transaction in Safe",


### PR DESCRIPTION
This PR EIP-1271 fallback for smart contract validation since not all chains support the deployless call used in 6792 flow.

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to fix smart contract wallet signature validation on older chains.

### Detailed summary
- Updated the prompt text for signing screen
- Added a fallback to EIP1271 validation for chains not supporting eth_call simulation
- Introduced a new function `verifyEip1271Signature` for EIP1271 signature validation

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->