### PR TITLE
[Dashboard] Remove v4 type: OptionalPropertiesInput

### DIFF
--- a/apps/dashboard/src/components/contract-pages/forms/properties.shared.tsx
+++ b/apps/dashboard/src/components/contract-pages/forms/properties.shared.tsx
@@ -9,7 +9,6 @@ import {
   Stack,
   Tooltip,
 } from "@chakra-ui/react";
-import type { OptionalPropertiesInput } from "@thirdweb-dev/sdk";
 import { FileInput } from "components/shared/FileInput";
 import { useEffect } from "react";
 import {
@@ -27,10 +26,13 @@ import {
 } from "react-hook-form";
 import { FiPlus, FiSlash, FiTrash, FiUpload, FiX } from "react-icons/fi";
 import { Button, FormErrorMessage, FormLabel } from "tw-components";
-import type { z } from "zod";
+
+type OptionalPropertiesInput = {
+  [key: string]: string | number;
+};
 
 interface IPropertyFieldValues extends FieldValues {
-  attributes?: z.input<typeof OptionalPropertiesInput>;
+  attributes?: OptionalPropertiesInput;
 }
 
 interface IPropertiesFormControlProps<


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to refactor the type definition for `attributes` in the `IPropertyFieldValues` interface.

### Detailed summary
- Refactored the type definition for `attributes` in the `IPropertyFieldValues` interface to use a custom type `OptionalPropertiesInput` instead of `z.input<typeof OptionalPropertiesInput>`.
- Defined `OptionalPropertiesInput` as an object type with keys of type string or number.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->