### PR TITLE
Fix connect button border in firefox

### DIFF
--- a/.changeset/seven-gorillas-speak.md
+++ b/.changeset/seven-gorillas-speak.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix connect button border on firefox browser

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/Details.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/Details.tsx
@@ -214,6 +214,7 @@ export const ConnectedWalletDetails: React.FC<{
           border: `1px solid ${theme.colors.borderColor}`,
           textOverflow: "ellipsis",
           width: "115px",
+          height: "50px",
           whiteSpace: "nowrap",
           borderRadius: `0 ${radius.md} ${radius.md} 0`,
         }}


### PR DESCRIPTION
Corrects an issue with the border visibility in firefox by explicitly specifying the div height

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the connect button border issue on Firefox browser in the `Details.tsx` file of the `ConnectWallet` component.

### Detailed summary
- Increased height of the connect button to 50px for better visibility
- Adjusted border radius to `0 ${radius.md} ${radius.md} 0` for a consistent look

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->