### PR TITLE
[SDK] Add GaslessOptions to useSendAndConfirmTransaction

### DIFF
--- a/.changeset/stale-ligers-fly.md
+++ b/.changeset/stale-ligers-fly.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Add GaslessOptions to useSendAndConfirmTransaction

--- a/packages/thirdweb/src/react/core/hooks/transaction/useSendAndConfirmTransaction.ts
+++ b/packages/thirdweb/src/react/core/hooks/transaction/useSendAndConfirmTransaction.ts
@@ -1,8 +1,20 @@
 import { type UseMutationResult, useMutation } from "@tanstack/react-query";
+import type { GaslessOptions } from "../../../../transaction/actions/gasless/types.js";
 import { sendAndConfirmTransaction } from "../../../../transaction/actions/send-and-confirm-transaction.js";
 import type { PreparedTransaction } from "../../../../transaction/prepare-transaction.js";
 import type { TransactionReceipt } from "../../../../transaction/types.js";
 import { useActiveAccount } from "../wallets/useActiveAccount.js";
+
+/**
+ * Configuration for the `useSendTransaction` hook.
+ */
+export type SendAndConfirmTransactionConfig = {
+  /**
+   * Configuration for gasless transactions.
+   * Refer to [`GaslessOptions`](https://portal.thirdweb.com/references/typescript/v5/GaslessOptions) for more details.
+   */
+  gasless?: GaslessOptions;
+};
 
 /**
  * A hook to send a transaction.
@@ -15,14 +27,26 @@ import { useActiveAccount } from "../wallets/useActiveAccount.js";
  * // later
  * sendAndConfirmTx(tx);
  * ```
+ *
+ *
+ * ### Gasless usage with [thirdweb Engine](https://portal.thirdweb.com/engine)
+ * ```tsx
+ * import { useSendAndConfirmTransaction } from "thirdweb/react";
+ * const mutation = useSendAndConfirmTransaction({
+ *   gasless: {
+ *     provider: "engine",
+ *     relayerUrl: "https://thirdweb.engine-***.thirdweb.com/relayer/***",
+ *     relayerForwarderAddress: "0x...",
+ *   }
+ * });
+ * ```
  * @transaction
  */
-export function useSendAndConfirmTransaction(): UseMutationResult<
-  TransactionReceipt,
-  Error,
-  PreparedTransaction
-> {
+export function useSendAndConfirmTransaction(
+  config: SendAndConfirmTransactionConfig = {},
+): UseMutationResult<TransactionReceipt, Error, PreparedTransaction> {
   const account = useActiveAccount();
+  const { gasless } = config;
   return useMutation({
     mutationFn: async (transaction) => {
       if (!account) {
@@ -31,6 +55,7 @@ export function useSendAndConfirmTransaction(): UseMutationResult<
       return await sendAndConfirmTransaction({
         transaction,
         account,
+        gasless,
       });
     },
   });

--- a/packages/thirdweb/src/react/native/hooks/transaction/useSendTransaction.tsx
+++ b/packages/thirdweb/src/react/native/hooks/transaction/useSendTransaction.tsx
@@ -19,6 +19,17 @@ import { useSwitchActiveWalletChain } from "../../../core/hooks/wallets/useSwitc
  * sendTx(tx);
  * ```
  *
+ * ### Gasless usage with [thirdweb Engine](https://portal.thirdweb.com/engine)
+ * ```tsx
+ * import { useSendTransaction } from "thirdweb/react";
+ * const mutation = useSendTransaction({
+ *   gasless: {
+ *     provider: "engine",
+ *     relayerUrl: "https://thirdweb.engine-***.thirdweb.com/relayer/***",
+ *     relayerForwarderAddress: "0x...",
+ *   }
+ * });
+ * ```
  * @transaction
  */
 export function useSendTransaction(config: SendTransactionConfig = {}) {

--- a/packages/thirdweb/src/react/web/ui/TransactionButton/index.tsx
+++ b/packages/thirdweb/src/react/web/ui/TransactionButton/index.tsx
@@ -15,6 +15,8 @@ import { Button } from "../components/buttons.js";
  * @param props - The props for this component.
  * Refer to [TransactionButtonProps](https://portal.thirdweb.com/references/typescript/v5/TransactionButtonProps) for details.
  * @example
+ *
+ * ### Basic usage
  * ```tsx
  * <TransactionButton
  *   transaction={() => {}}
@@ -24,7 +26,8 @@ import { Button } from "../components/buttons.js";
  *   Confirm Transaction
  * </TransactionButton>
  * ```
- * Customize the styling by passing the `unstyled` prop and your inline styles and/or classes:
+ *
+ * ### Customize the styling by passing the `unstyled` prop and your inline styles and/or classes:
  * ```tsx
  * <TransactionButton
  *   transaction={() => {}}
@@ -35,7 +38,7 @@ import { Button } from "../components/buttons.js";
  * </TransactionButton>
  * ```
  *
- * Handle errors
+ * ### Handle errors
  * ```tsx
  * <TransactionButton
  *   transaction={() => ...}
@@ -48,7 +51,7 @@ import { Button } from "../components/buttons.js";
  * </TransactionButton>
  * ```
  *
- * Alert when a transaction is sent
+ * ### Alert when a transaction is sent
  * ```tsx
  * <TransactionButton
  *   transaction={() => ...}
@@ -61,7 +64,7 @@ import { Button } from "../components/buttons.js";
  * </TransactionButton>
  * ```
  *
- * Alert when a transaction is completed
+ * ### Alert when a transaction is completed
  * ```tsx
  * <TransactionButton
  *   transaction={() => ...}
@@ -75,7 +78,7 @@ import { Button } from "../components/buttons.js";
  * </TransactionButton>
  * ```
  *
- * The onClick prop, if provided, will be called before the transaction is sent.
+ * ### The onClick prop, if provided, will be called before the transaction is sent.
  * ```tsx
  * <TransactionButton
  *   onClick={() => alert("Transaction is about to be sent")}
@@ -85,7 +88,7 @@ import { Button } from "../components/buttons.js";
  * </TransactionButton>
  * ```
  *
- * Attach custom Pay metadata
+ * ### Attach custom Pay metadata
  * ```tsx
  * <TransactionButton
  *   payModal={{
@@ -94,6 +97,19 @@ import { Button } from "../components/buttons.js";
  *       name: "Van Gogh Starry Night",
  *       image: "https://unsplash.com/starry-night.png"
  *     }
+ *   }}
+ * >
+ *   ...
+ * </TransactionButton>
+ * ```
+ *
+ * ### Gasless usage with [thirdweb Engine](https://portal.thirdweb.com/engine)
+ * ```tsx
+ * <TransactionButton
+ *   gasless={{
+ *     provider: "engine",
+ *     relayerUrl: "https://thirdweb.engine-***.thirdweb.com/relayer/***",
+ *     relayerForwarderAddress: "0x...",
  *   }}
  * >
  *   ...

--- a/packages/thirdweb/src/transaction/actions/send-and-confirm-transaction.ts
+++ b/packages/thirdweb/src/transaction/actions/send-and-confirm-transaction.ts
@@ -12,12 +12,27 @@ import { waitForReceipt } from "./wait-for-tx-receipt.js";
  * @throws An error if the wallet is not connected.
  * @transaction
  * @example
+ *
+ * ### Basic usage
  * ```ts
  * import { sendAndConfirmTransaction } from "thirdweb";
  *
  * const transactionReceipt = await sendAndConfirmTransaction({
  *  account,
  *  transaction
+ * });
+ * ```
+ *
+ * ### Gasless usage with [thirdweb Engine](https://portal.thirdweb.com/engine)
+ * ```ts
+ * const transactionReceipt = await sendAndConfirmTransaction({
+ *  account,
+ *  transaction,
+ *  gasless: {
+ *    provider: "engine",
+ *    relayerUrl: "https://thirdweb.engine-***.thirdweb.com/relayer/***",
+ *    relayerForwarderAddress: "0x...",
+ *  }
  * });
  * ```
  */

--- a/packages/thirdweb/src/transaction/actions/send-transaction.ts
+++ b/packages/thirdweb/src/transaction/actions/send-transaction.ts
@@ -99,6 +99,19 @@ export type SendTransactionOptions = {
  *  transaction,
  * });
  * ```
+ *
+ * ### Gasless usage with [thirdweb Engine](https://portal.thirdweb.com/engine)
+ * ```ts
+ * const { transactionHash } = await sendTransaction({
+ *  account,
+ *  transaction,
+ *  gasless: {
+ *    provider: "engine",
+ *    relayerUrl: "https://thirdweb.engine-***.thirdweb.com/relayer/***",
+ *    relayerForwarderAddress: "0x...",
+ *  }
+ * });
+ * ```
  */
 export async function sendTransaction(
   options: SendTransactionOptions,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to add support for gasless transactions with the `thirdweb Engine` in various transaction-related functions and hooks.

### Detailed summary
- Added `GaslessOptions` for gasless transactions in `sendTransaction`
- Updated `useSendTransaction` to support gasless transactions
- Added gasless transaction support in `sendAndConfirmTransaction`
- Updated `useSendAndConfirmTransaction` for gasless transactions
- Added gasless usage examples in `TransactionButton`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->