### PR TITLE
feat(dashboard): add apple universal link association

### DIFF
--- a/apps/dashboard/public/.well-known/apple-app-site-association
+++ b/apps/dashboard/public/.well-known/apple-app-site-association
@@ -1,5 +1,12 @@
 {
-  "applinks": {},
+  "applinks": {
+    "details": [
+      {
+        "appIDs": ["XYHGSFAMHX.com.thirdweb.demo"],
+        "paths": ["/mobile-wallet-protocol", "NOT *"]
+      }
+    ]
+  },
   "webcredentials": {
     "apps": ["XYHGSFAMHX.com.thirdweb.demo"]
   },


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added



<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds specific details to the `apple-app-site-association` file for the `XYHGSFAMHX.com.thirdweb.demo` app, including paths for mobile wallet protocol.

### Detailed summary
- Added details for `XYHGSFAMHX.com.thirdweb.demo` in `apple-app-site-association`
- Included paths for `/mobile-wallet-protocol` and excluded `NOT *`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->