### PR TITLE
feat(dashboard): update apple-app-site-association for universal links

### DIFF
--- a/apps/dashboard/public/.well-known/apple-app-site-association
+++ b/apps/dashboard/public/.well-known/apple-app-site-association
@@ -1,9 +1,25 @@
 {
   "applinks": {
+    "apps": ["XYHGSFAMHX.com.thirdweb.demo"],
     "details": [
       {
         "appIDs": ["XYHGSFAMHX.com.thirdweb.demo"],
-        "paths": ["/mobile-wallet-protocol", "NOT *"]
+        "components": [
+          {
+            "#": "no_universal_links",
+            "exclude": true,
+            "comment": "Matches any URL with a fragment that equals no_universal_links and instructs the system not to open it as a universal link."
+          },
+          {
+            "/": "/mobile-wallet-protocol",
+            "comment": "Matches any URL with a path that starts with /mobile-wallet-protocol for coinbase wallet mobile redirects."
+          },
+          {
+            "/": "/dashboard/*",
+            "exclude": true,
+            "comment": "no universal link for dashboard"
+          }
+        ]
       }
     ]
   },


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added



<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `apple-app-site-association` file for the `com.thirdweb.demo` app with specific paths and exclusions for universal links.

### Detailed summary
- Added `apps` array with `"XYHGSFAMHX.com.thirdweb.demo"`
- Updated paths to components with specific comments and exclusions for universal links

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->