### PR TITLE
feat(pay): only show pay modal if the active account doesnt have enough funds

### DIFF
--- a/.changeset/chatty-knives-attend.md
+++ b/.changeset/chatty-knives-attend.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Only show pay modal if active wallet does not have enough funds for a paid transaction


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the user experience by only showing the payment modal if the active wallet lacks sufficient funds for a transaction.

### Detailed summary
- Added logic to show pay modal only when wallet balance is insufficient for the transaction
- Utilized `getWalletBalance` function to check wallet balance before showing modal

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->