### PR TITLE
[Dashboard] Fix styling for no-image NFT

### DIFF
--- a/apps/dashboard/src/tw-components/nft-media.tsx
+++ b/apps/dashboard/src/tw-components/nft-media.tsx
@@ -18,10 +18,12 @@ export const NFTMediaWithEmptyState: React.FC<{
   if (!(props.metadata.image || props.metadata.animation_url)) {
     return (
       <div
+        style={{
+          width: props.width,
+          height: props.height,
+        }}
         className={cn(
-          "overflow-hidden rounded-xl object-contain flex-shrink-0 border grid place-items-center",
-          props.width && `w-[${props.width}]`,
-          props.height && `h-[${props.height}]`,
+          "overflow-hidden rounded-xl object-contain flex-shrink-0 border border-border grid place-items-center",
           props.className,
         )}
       >


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the styling of the `nft-media` component in the dashboard app to dynamically set width and height based on props.

### Detailed summary
- Dynamically set width and height of the component based on props
- Updated className to include border styling for consistency

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->