### PR TITLE
fix(dashboard): update Expo Starter repo URL

### DIFF
--- a/apps/dashboard/src/pages/templates.tsx
+++ b/apps/dashboard/src/pages/templates.tsx
@@ -236,7 +236,7 @@ export const templates: TemplateCardProps[] = [
     id: "expo-starter",
     title: "Expo Starter",
     homepage: "",
-    repo: "https://github.com/thirdweb-example/node-starter",
+    repo: "https://github.com/thirdweb-example/expo-starter",
     description:
       "Starter kit to build with Expo and thirdweb without additional initial configuration.",
     img: "/assets/templates/expo-starter.png",


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the repository link in the Expo Starter template page from a Node.js starter to an Expo starter.

### Detailed summary
- Updated repository link from `https://github.com/thirdweb-example/node-starter` to `https://github.com/thirdweb-example/expo-starter`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->