### PR TITLE
Dashboard: Allow more domains

### DIFF
--- a/apps/dashboard/src/components/settings/ApiKeys/validations.ts
+++ b/apps/dashboard/src/components/settings/ApiKeys/validations.ts
@@ -11,7 +11,8 @@ const nameValidation = z
 const domainsValidation = z.string().refine(
   (str) =>
     validStrList(str, (domain) => {
-      return domain.split(":")[0] === "localhost" || RE_DOMAIN.test(domain);
+      // This isn't the strictest validation, but users keep running into cases where the validation is TOO strict
+      return domain.includes(":") || RE_DOMAIN.test(domain);
     }),
   {
     message: "Some of the domains are invalid",


### PR DESCRIPTION
Requested for electron app domains

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the domain validation logic in `validations.ts` to be less strict and allow domains with colons.

### Detailed summary
- Updated domain validation to allow domains with colons
- Added a comment explaining the reason for the less strict validation

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->