### PR TITLE
feat(pay): show pay modal when insufficient balance for gas cost

### DIFF
--- a/apps/playground-web/src/components/pay/transaction-button.tsx
+++ b/apps/playground-web/src/components/pay/transaction-button.tsx
@@ -65,6 +65,9 @@ export function PayTransactionButtonPreview() {
                 to: account?.address || "",
               });
             }}
+            onError={(e) => {
+              console.error(e);
+            }}
             payModal={{
               theme: theme === "light" ? "light" : "dark",
             }}

--- a/packages/thirdweb/src/react/core/hooks/transaction/useSendTransaction.ts
+++ b/packages/thirdweb/src/react/core/hooks/transaction/useSendTransaction.ts
@@ -1,7 +1,9 @@
 import { type UseMutationResult, useMutation } from "@tanstack/react-query";
 import type { Chain } from "../../../../chains/types.js";
+import { getGasPrice } from "../../../../gas/get-gas-price.js";
 import type { BuyWithCryptoStatus } from "../../../../pay/buyWithCrypto/getStatus.js";
 import type { BuyWithFiatStatus } from "../../../../pay/buyWithFiat/getStatus.js";
+import { estimateGasCost } from "../../../../transaction/actions/estimate-gas-cost.js";
 import type { GaslessOptions } from "../../../../transaction/actions/gasless/types.js";
 import { sendTransaction } from "../../../../transaction/actions/send-transaction.js";
 import type { WaitForReceiptOptions } from "../../../../transaction/actions/wait-for-tx-receipt.js";
@@ -12,6 +14,7 @@ import { getWalletBalance } from "../../../../wallets/utils/getWalletBalance.js"
 import type { LocaleId } from "../../../web/ui/types.js";
 import type { Theme } from "../../design-system/index.js";
 import type { SupportedTokens } from "../../utils/defaultTokens.js";
+import { hasSponsoredTransactionsEnabled } from "../../utils/wallet.js";
 
 /**
  * Configuration for the "Pay Modal" that opens when the user doesn't have enough funds to send a transaction.
@@ -158,16 +161,31 @@ export function useSendTransactionCore(args: {
             const nativeValue = _nativeValue || 0n;
             const erc20Value = _erc20Value?.amountWei || 0n;
 
-            const balance = await getWalletBalance({
-              client: tx.client,
-              address: account.address,
-              chain: tx.chain,
-              tokenAddress: _erc20Value?.tokenAddress,
-            });
+            const [nativeBalance, erc20Balance, gasCost] = await Promise.all([
+              getWalletBalance({
+                client: tx.client,
+                address: account.address,
+                chain: tx.chain,
+              }),
+              _erc20Value?.tokenAddress
+                ? getWalletBalance({
+                    client: tx.client,
+                    address: account.address,
+                    chain: tx.chain,
+                  })
+                : undefined,
+              getTotalTxCostForBuy(tx, account.address),
+            ]);
+
+            const gasSponsored = hasSponsoredTransactionsEnabled(wallet);
+            const txGasCost = gasSponsored ? 0n : gasCost;
+            const nativeCost = nativeValue + txGasCost;
 
             const shouldShowModal =
-              (erc20Value > 0n && balance.value < erc20Value) ||
-              (nativeValue > 0n && balance.value < nativeValue);
+              (erc20Value > 0n &&
+                erc20Balance &&
+                erc20Balance.value < erc20Value) ||
+              (nativeCost > 0n && nativeBalance.value < nativeCost);
 
             if (shouldShowModal) {
               showPayModal({
@@ -188,4 +206,43 @@ export function useSendTransactionCore(args: {
       });
     },
   });
+}
+
+export async function getTotalTxCostForBuy(
+  tx: PreparedTransaction,
+  from?: string,
+) {
+  try {
+    const gasCost = await estimateGasCost({
+      transaction: tx,
+      from,
+    });
+
+    const bufferCost = gasCost.wei / 10n;
+
+    // Note: get tx.value AFTER estimateGasCost
+    const txValue = await resolvePromisedValue(tx.value);
+
+    // add 10% extra gas cost to the estimate to ensure user buys enough to cover the tx cost
+    return gasCost.wei + bufferCost + (txValue || 0n);
+  } catch (e) {
+    if (from) {
+      // try again without passing from
+      return await getTotalTxCostForBuy(tx);
+    }
+    // fallback if both fail, use the tx value + 2M * gas price
+    const value = await resolvePromisedValue(tx.value);
+
+    const gasPrice = await getGasPrice({
+      client: tx.client,
+      chain: tx.chain,
+    });
+
+    const buffer = 2_000_000n * gasPrice;
+
+    if (!value) {
+      return 0n + buffer;
+    }
+    return value + buffer;
+  }
 }


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added



<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance transaction handling in the `TransactionButton` component and `useSendTransaction` hook.

### Detailed summary
- Added error logging in `TransactionButton` component.
- Imported and used `estimateGasCost` function in `useSendTransaction` hook.
- Implemented `getTotalTxCostForBuy` function for calculating total transaction cost.
- Introduced `hasSponsoredTransactionsEnabled` check in `useSendTransaction` hook.
- Updated logic to determine when to show the pay modal in `useSendTransaction` hook.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->