### PR TITLE
feat(adapters): add documentation and examples for ethers5, ethers6, and viem adapters

### DIFF
--- a/packages/thirdweb/src/adapters/ethers5.ts
+++ b/packages/thirdweb/src/adapters/ethers5.ts
@@ -44,9 +44,55 @@ function assertEthers5(
   }
 }
 
+/**
+ * The ethers5 adapter provides a way to convert between Thirdweb contracts, accounts, and providers.
+ * @example
+ *
+ * ### Converting a Thirdweb account to an ethers.js signer
+ * ```ts
+ * import { ethers5Adapter } from "thirdweb/adapters/ethers5";
+ * const signer = await ethers5Adapter.signer.toEthers({ client, chain, account });
+ * ```
+ *
+ * ### Converting an ethers.js signer into a Thirdweb account
+ * ```ts
+ * import { ethers5Adapter } from "thirdweb/adapters/ethers5";
+ * const account = ethers5Adapter.signer.fromEthers({ signer });
+ * ```
+ *
+ * ### Converting a Thirdweb contract to an ethers.js Contract
+ * ```ts
+ * import { ethers5Adapter } from "thirdweb/adapters/ethers5";
+ * const ethersContract = await ethers5Adapter.contract.toEthers({ thirdwebContract });
+ * ```
+ *
+ * ### Converting a Thirdweb client and chain ID into an ethers.js provider
+ * ```ts
+ * import { ethers5Adapter } from "thirdweb/adapters/ethers5";
+ * const provider = ethers5Adapter.provider.toEthers({ client, chain });
+ * ```
+ */
 export const ethers5Adapter = /* @__PURE__ */ (() => {
   const ethers = universalethers;
   return {
+    /**
+     * Converts a Thirdweb client and chain ID into an ethers.js provider.
+     * @param options - The options for converting the Thirdweb client and chain ID into an ethers.js provider.
+     * @param options.client - The Thirdweb client.
+     * @param options.chain - The chain.
+     * @returns The ethers.js provider.
+     * @example
+     * ```ts
+     * import { ethers5Adapter } from "thirdweb/adapters/ethers5";
+     * const provider = ethers5Adapter.provider.toEthers({ client, chainId });
+     * ```
+     *
+     * Once you have converted a thirdweb Client to ethers Provider,
+     * you can use it like any other ethers provider:
+     * ```ts
+     * const blockNumber = await provider.getBlockNumber();
+     * ```
+     */
     provider: {
       /**
        * Converts a Thirdweb client and chain ID into an ethers.js provider.
@@ -71,6 +117,30 @@ export const ethers5Adapter = /* @__PURE__ */ (() => {
         return toEthersProvider(ethers, options.client, options.chain);
       },
     },
+    /**
+     * Converts a ThirdwebContract to an ethers.js Contract or the other way around.
+     * @example
+     *
+     * ### toEthers
+     * ```ts
+     * import { ethers5Adapter } from "thirdweb/adapters/ethers5";
+     * const ethersContract = await ethers5Adapter.contract.toEthers({
+     *   thirdwebContract,
+     * });
+     * ```
+     *
+     * ### fromEthers
+     * ```ts
+     * import { ethers5Adapter } from "thirdweb/adapters/ethers5";
+     *
+     * const twContract = await ethers5Adapter.contract.fromEthers({
+     *  client,
+     *  ethersContract,
+     *  chain: defineChain(1), // Replace with your chain
+     * });
+     * ```
+     *
+     */
     contract: {
       /**
        * Converts a ThirdwebContract to an ethers.js Contract.
@@ -111,7 +181,7 @@ export const ethers5Adapter = /* @__PURE__ */ (() => {
        * ```ts
        * import { ethers5Adapter } from "thirdweb/adapters/ethers5";
        *
-       * const twContract = await ethers5Adapter.contract.fromEthersContract({
+       * const twContract = await ethers5Adapter.contract.fromEthers({
        *  client,
        *  ethersContract,
        *  chain: defineChain(1), // Replace with your chain
@@ -123,6 +193,22 @@ export const ethers5Adapter = /* @__PURE__ */ (() => {
         return fromEthersContract(options);
       },
     },
+    /**
+     * Converts an ethers5 Signer into a Wallet object or the other way around.
+     * @example
+     *
+     * ### fromEthers
+     * ```ts
+     * import { ethers5Adapter } from "thirdweb/adapters/ethers5";
+     * const wallet = await ethers5Adapter.signer.fromEthers({ signer });
+     * ```
+     *
+     * ### toEthers
+     * ```ts
+     * import { ethers5Adapter } from "thirdweb/adapters/ethers5";
+     * const signer = await ethers5Adapter.signer.toEthers({ client, chain, account });
+     * ```
+     */
     signer: {
       /**
        * Converts an ethers5 Signer into a Wallet object.

--- a/packages/thirdweb/src/adapters/ethers6.ts
+++ b/packages/thirdweb/src/adapters/ethers6.ts
@@ -45,10 +45,50 @@ function assertEthers6(
   }
 }
 
+/**
+ * The ethers6 adapter provides a way to convert between Thirdweb contracts, accounts, and providers.
+ * @example
+ *
+ * ### Converting a Thirdweb account to an ethers.js signer
+ * ```ts
+ * import { ethers6Adapter } from "thirdweb/adapters/ethers6";
+ * const signer = await ethers6Adapter.signer.toEthers({ client, chain, account });
+ * ```
+ *
+ * ### Converting an ethers.js signer into a Thirdweb account
+ * ```ts
+ * import { ethers6Adapter } from "thirdweb/adapters/ethers6";
+ * const account = ethers6Adapter.signer.fromEthers({ signer });
+ * ```
+ *
+ * ### Converting a Thirdweb contract to an ethers.js Contract
+ * ```ts
+ * import { ethers6Adapter } from "thirdweb/adapters/ethers6";
+ * const ethersContract = await ethers6Adapter.contract.toEthers({ thirdwebContract });
+ * ```
+ *
+ * ### Converting a Thirdweb client and chain ID into an ethers.js provider
+ * ```ts
+ * import { ethers6Adapter } from "thirdweb/adapters/ethers6";
+ * const provider = ethers6Adapter.provider.toEthers({ client, chain });
+ * ```
+ */
 export const ethers6Adapter = /* @__PURE__ */ (() => {
   const ethers = universalethers;
 
   return {
+    /**
+     * Converts a Thirdweb client and chain ID into an ethers.js provider.
+     * @param options - The options for converting the Thirdweb client and chain ID into an ethers.js provider.
+     * @param options.client - The Thirdweb client.
+     * @param options.chain - The chain.
+     * @returns The ethers.js provider.
+     * @example
+     * ```ts
+     * import { ethers6Adapter } from "thirdweb/adapters/ethers6";
+     * const provider = ethers6Adapter.provider.toEthers({ client, chain });
+     * ```
+     */
     provider: {
       /**
        * Converts a Thirdweb client and chain ID into an ethers.js provider.
@@ -67,12 +107,29 @@ export const ethers6Adapter = /* @__PURE__ */ (() => {
         return toEthersProvider(ethers, options.client, options.chain);
       },
     },
+    /**
+     * Converts a ThirdwebContract to an ethers.js Contract or the other way around.
+     * @example
+     *
+     * ### toEthers
+     * ```ts
+     * import { ethers6Adapter } from "thirdweb/adapters/ethers6";
+     * const ethersContract = await ethers6Adapter.contract.toEthers({ thirdwebContract, account });
+     * ```
+     *
+     * ### fromEthers
+     * ```ts
+     * import { ethers6Adapter } from "thirdweb/adapters";
+     * const contract = ethers6Adapter.contract.fromEthers({ client, chain, ethersContract });
+     * ```
+     */
     contract: {
       /**
        * Converts a ThirdwebContract to an ethers.js Contract.
-       * @param options - The options for converting the ThirdwebContract to an ethers.js Contract.
+       * @param options - The options for converting a ThirdwebContract to an ethers.js Contract.
        * @param options.thirdwebContract - The ThirdwebContract to convert.
-       * @returns A Promise that resolves to an ethers.js Contract.
+       * @param options.account - The account to use for signing the transaction.
+       * @returns The ethers.js Contract.
        * @example
        * ```ts
        * import { ethers6Adapter } from "thirdweb/adapters/ethers6";
@@ -91,18 +148,15 @@ export const ethers6Adapter = /* @__PURE__ */ (() => {
         );
       },
       /**
-       * Creates a ThirdwebContract instance from an ethers.js contract.
-       * @param options - The options for creating the ThirdwebContract instance.
-       * @returns A promise that resolves to a ThirdwebContract instance.
+       * Creates a ThirdwebContract from an ethers.js Contract.
+       * @param options - The options for creating a ThirdwebContract from an ethers.js Contract.
+       * @param options.ethersContract - The ethers.js Contract to convert.
+       * @param options.chain - The chain.
+       * @returns The ThirdwebContract.
        * @example
        * ```ts
        * import { ethers6Adapter } from "thirdweb/adapters/ethers6";
-       *
-       * const twContract = await ethers6Adapter.contract.fromEthersContract({
-       *  client,
-       *  ethersContract,
-       *  chainId,
-       * });
+       * const contract = ethers6Adapter.contract.fromEthers({ ethersContract, chain });
        * ```
        */
       fromEthers: (options: FromEthersContractOptions) => {
@@ -110,6 +164,22 @@ export const ethers6Adapter = /* @__PURE__ */ (() => {
         return fromEthersContract(options);
       },
     },
+    /**
+     * Converts an ethers6 Signer into an Wallet object or the other way around.
+     * @example
+     *
+     * ### fromEthersSigner
+     * ```ts
+     * import { ethers6Adapter } from "thirdweb/adapters/ethers6";
+     * const signer = ethers6Adapter.signer.fromEthersSigner({ signer });
+     * ```
+     *
+     * ### toEthersSigner
+     * ```ts
+     * import { ethers6Adapter } from "thirdweb/adapters/ethers6";
+     * const signer = await ethers6Adapter.signer.toEthers({ client, chain, account });
+     * ```
+     */
     signer: {
       /**
        * Converts an ethers6 Signer into an Wallet object.
@@ -119,7 +189,7 @@ export const ethers6Adapter = /* @__PURE__ */ (() => {
        * @example
        * ```ts
        * import { ethers6Adapter } from "thirdweb/adapters/ethers6";
-       * const wallet = await ethers6Adapter.signer.fromEthersSigner({ signer });
+       * const wallet = ethers6Adapter.signer.fromEthers({ signer });
        * ```
        */
       fromEthers: (options: { signer: ethers6.Signer }) => {

--- a/packages/thirdweb/src/adapters/viem.ts
+++ b/packages/thirdweb/src/adapters/viem.ts
@@ -21,34 +21,87 @@ import { sendTransaction } from "../transaction/actions/send-transaction.js";
 import { prepareTransaction } from "../transaction/prepare-transaction.js";
 import type { Account } from "../wallets/interfaces/wallet.js";
 
+/**
+ * Converts thirdweb accounts and contracts to viem wallet clients and contract objects or the other way around.
+ * @example
+ *
+ * ### Converting a thirdweb account to a viem wallet client
+ *
+ * ```ts
+ * import { viemAdapter } from "thirdweb/adapters/viem";
+ *
+ * const walletClient = viemAdapter.walletClient.toViem({
+ *  account,
+ *  client,
+ *  chain: ethereum,
+ * });
+ * ```
+ *
+ * ### Converting a viem wallet client to a thirdweb account
+ * ```ts
+ * import { viemAdapter } from "thirdweb/adapters";
+ *
+ * const account = viemAdapter.walletClient.fromViem({
+ *   walletClient,
+ * });
+ * ```
+ *
+ * ### Converting a thirdweb contract to a viem contract
+ * ```ts
+ * import { viemAdapter } from "thirdweb/adapters";
+ *  const viemContract = await viemAdapter.contract.toViem({ thirdwebContract });
+ * ```
+ *
+ * ### Converting a viem contract to a thirdweb contract
+ * ```ts
+ * import { viemAdapter } from "thirdweb/adapters/viem";
+ *
+ * const contract = viemAdapter.contract.fromViem({
+ *  viemContract: viemContract,
+ *  chain: ethereum,
+ *  client,
+ * });
+ * ```
+ *
+ * ### Converting a thirdweb client to a public viem client
+ * ```ts
+ * import { viemAdapter } from "thirdweb/adapters";
+ *
+ * const publicClient = viemAdapter.publicClient.toViem({
+ *  chain: ethereum,
+ *  client,
+ * });
+ * ```
+ *
+ */
 export const viemAdapter = {
+  /**
+   * Creates a ThirdwebContract from a Viem contract or the other way around.
+   * @param options - The options for creating the contract.
+   * @returns The ThirdwebContract.
+   * @example
+   *
+   * ### fromViem
+   *
+   * ```ts
+   * import { viemAdapter } from "thirdweb/adapters/viem";
+   *
+   * const contract = viemAdapter.contract.fromViem({
+   *  viemContract: viemContract,
+   *  chain: ethereum,
+   *  client,
+   * });
+   * ```
+   *
+   * ### toViem
+   *
+   * ```ts
+   * import { viemAdapter } from "thirdweb/adapters";
+   *  const viemContract = await viemAdapter.contract.toViem({ thirdwebContract });
+   * ```
+   */
   contract: {
-    /**
-     * Creates a ThirdwebContract from a Viem contract.
-     * @param options - The options for creating the contract.
-     * @returns The ThirdwebContract.
-     * @example
-     * ```ts
-     * import { viemAdapter } from "thirdweb/adapters/viem";
-     *
-     * const contract = viemAdapter.contract.fromViem({
-     *  viemContract: viemContract,
-     *  chain: ethereum,
-     *  client,
-     * });
-     * ```
-     */
     fromViem: fromViemContract,
-    /**
-     * Converts a ThirdwebContract instance to a Viem contract representation.
-     * @param contract The ThirdwebContract instance to convert.
-     * @returns A promise that resolves to the Viem contract representation.
-     * @example
-     * ```ts
-     * import { viemAdapter } from "thirdweb/adapters";
-     *  const viemContract = await viemAdapter.contract.toViem({ thirdwebContract });
-     * ```
-     */
     toViem: toViemContract,
   },
 
@@ -70,35 +123,55 @@ export const viemAdapter = {
     toViem: toViemPublicClient,
   },
 
+  /**
+   * Converts a thirdweb account to a Viem Wallet client or the other way around.
+   * @param options - The options for creating the Viem Wallet client.
+   * @returns The Viem Wallet client.
+   * @example
+   *
+   * ### toViem
+   * ```ts
+   * import { viemAdapter } from "thirdweb/adapters/viem";
+   *
+   * const walletClient = viemAdapter.walletClient.toViem({
+   *  account,
+   *  client,
+   *  chain: ethereum,
+   * });
+   * ```
+   *
+   * ### fromViem
+   * ```ts
+   * import { viemAdapter } from "thirdweb/adapters";
+   *
+   * const account = viemAdapter.walletClient.fromViem({
+   *   walletClient,
+   * });
+   * ```
+   */
   walletClient: {
     /**
-     * Converts options to a Viem Wallet client.
-     * @param options - The options for creating the Viem Wallet client.
-     * @returns The Viem Wallet client.
+     * Converts a Thirdweb wallet to a Viem wallet client.
+     * @param options - The options for converting a Thirdweb wallet to a Viem wallet client.
+     * @param options.account - The Thirdweb wallet to convert.
+     * @returns A Promise that resolves to a Viem wallet client.
      * @example
      * ```ts
-     * import { viemAdapter } from "thirdweb/adapters/viem";
-     *
-     * const walletClient = viemAdapter.walletClient.toViem({
-     *  account,
-     *  client,
-     *  chain: ethereum,
-     * });
+     * import { viemAdapter } from "thirdweb/adapters";
+     * const walletClient = viemAdapter.walletClient.toViem({ account, client, chain });
      * ```
      */
     toViem: toViemWalletClient,
-
     /**
-     * Converts a Viem Wallet client to an Account.
-     * @param options - The options for creating the Account.
-     * @returns The Account.
+     * Converts a Viem wallet client to a Thirdweb wallet.
+     * @param options - The options for converting a Viem wallet client to a Thirdweb wallet.
+     * @param options.walletClient - The Viem wallet client to convert.
+     * @returns A Promise that resolves to a Thirdweb wallet.
      * @example
      * ```ts
-     * import { viemAdapter } from "thirdweb/adapters/viem";
-     *
-     * const account = viemAdapter.walletClient.fromViem({
-     *   walletClient,
-     * });
+     * import { viemAdapter } from "thirdweb/adapters";
+     * const account = viemAdapter.walletClient.fromViem({ walletClient });
+     * ```
      */
     fromViem: fromViemWalletClient,
   },


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to introduce adapters for converting between Thirdweb and ethers.js/viem objects.

### Detailed summary
- Added `ethers5Adapter` for converting between Thirdweb and ethers.js objects.
- Added `ethers6Adapter` for converting between Thirdweb and ethers.js objects.
- Added `viemAdapter` for converting between Thirdweb and viem objects.

> The following files were skipped due to too many changes: `packages/thirdweb/src/adapters/viem.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->