### PR TITLE
[Dashboard] Fix types for contract published version

### DIFF
--- a/apps/dashboard/src/components/contract-components/published-contract/index.tsx
+++ b/apps/dashboard/src/components/contract-components/published-contract/index.tsx
@@ -59,7 +59,7 @@ export interface ExtendedPublishedContract extends PublishedContractType {
   name: string;
   displayName?: string;
   description: string;
-  version: string;
+  version: string | undefined;
   publisher: string;
   tags?: string[];
   logo?: string;
@@ -146,7 +146,7 @@ export const PublishedContract: React.FC<PublishedContractProps> = ({
       PublishedContractOG.toUrl({
         name: publishedContractName,
         description: contract.description,
-        version: contract.version,
+        version: contract.version || "latest",
         publisher: publisherEnsOrAddress,
         extension: extensionNames,
         license: licenses,

--- a/apps/dashboard/src/components/pages/publish.tsx
+++ b/apps/dashboard/src/components/pages/publish.tsx
@@ -91,7 +91,7 @@ export const PublishWithVersionPage: React.FC<PublishWithVersionPageProps> = ({
       <SelectContent>
         {availableVersions.map((v, idx) => {
           return (
-            <SelectItem value={v} key={v}>
+            <SelectItem value={v || "latest"} key={v}>
               {v}
               {idx === 0 && (
                 <span className="text-muted-foreground"> (latest) </span>


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `publish.tsx` and `published-contract/index.tsx` files to handle cases where version information is missing by defaulting to "latest".

### Detailed summary
- In `publish.tsx`, added a default value of "latest" for the version if not provided
- In `published-contract/index.tsx`, updated the `version` type to be `string | undefined` and added a default value of "latest" if version is missing

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->