### PR TITLE
[Dashboard] Add useDashboardOwnedNFTs hook

### DIFF
--- a/apps/dashboard/src/@3rdweb-sdk/react/hooks/useDashboardOwnedNFTs.ts
+++ b/apps/dashboard/src/@3rdweb-sdk/react/hooks/useDashboardOwnedNFTs.ts
@@ -1,0 +1,41 @@
+import { useQuery } from "@tanstack/react-query";
+import type { NFT, ThirdwebContract } from "thirdweb";
+import {
+  getOwnedNFTs as getOwnedERC721,
+  isERC721,
+} from "thirdweb/extensions/erc721";
+import { getOwnedNFTs as getOwnedERC1155 } from "thirdweb/extensions/erc1155";
+import invariant from "tiny-invariant";
+
+/**
+ * This hook is currently used for getting owned NFTs for Create DirectListing/English Auction
+ * It should only be used if our indexing solutions don't support the current network
+ */
+export function useDashboardOwnedNFTs({
+  contract,
+  owner,
+  disabled,
+}: { owner?: string; contract?: ThirdwebContract; disabled?: boolean }) {
+  return useQuery({
+    queryKey: [
+      "owned-nfts",
+      contract?.chain.id || "",
+      contract?.address || "",
+      owner || "",
+    ],
+    queryFn: async (): Promise<NFT[]> => {
+      invariant(contract, "Contract is required");
+      invariant(owner, "owner address is required");
+      const is721 = await isERC721({ contract });
+      if (is721) {
+        return getOwnedERC721({
+          contract,
+          owner,
+        });
+      }
+      // Else default to 1155
+      return getOwnedERC1155({ contract, address: owner });
+    },
+    enabled: !!contract && !!owner && !disabled,
+  });
+}

--- a/apps/dashboard/src/lib/wallet/nfts/types.ts
+++ b/apps/dashboard/src/lib/wallet/nfts/types.ts
@@ -63,7 +63,7 @@ type NFT = {
   owner: string;
   type: "ERC1155" | "ERC721";
   supply: string;
-  quantityOwned?: string;
+  quantityOwned?: bigint;
 };
 
 export type WalletNFT = NFT & {


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the `quantityOwned` type to `bigint` and introduce a new hook for fetching owned NFTs in the dashboard.

### Detailed summary
- Updated `quantityOwned` type to `bigint` in wallet NFTs.
- Added a new hook `useDashboardOwnedNFTs` for fetching owned NFTs.
- Removed unused imports and updated dependencies in `list-form.tsx`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->