### PR TITLE
[Dashboard] Remove type UploadProgressEvent

### DIFF
--- a/apps/dashboard/src/contract-ui/tabs/nfts/components/batch-lazy-mint-button.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/nfts/components/batch-lazy-mint-button.tsx
@@ -6,9 +6,11 @@ import {
   useDelayedRevealLazyMint,
   useLazyMint,
 } from "@thirdweb-dev/react";
-import type { UploadProgressEvent } from "@thirdweb-dev/sdk";
 import { BatchLazyMint } from "core-ui/batch-upload/batch-lazy-mint";
-import { ProgressBox } from "core-ui/batch-upload/progress-box";
+import {
+  ProgressBox,
+  type UploadProgressEvent,
+} from "core-ui/batch-upload/progress-box";
 import { useTrack } from "hooks/analytics/useTrack";
 import { useTxNotifications } from "hooks/useTxNotifications";
 import { useState } from "react";

--- a/apps/dashboard/src/core-ui/batch-upload/progress-box.tsx
+++ b/apps/dashboard/src/core-ui/batch-upload/progress-box.tsx
@@ -2,10 +2,11 @@ import { Flex, Progress } from "@chakra-ui/react";
 import { useEffect, useState } from "react";
 import { Text } from "tw-components";
 
-type UploadProgressEvent = {
+export type UploadProgressEvent = {
   progress: number;
   total: number;
 };
+
 interface ProgressBoxProps {
   progress: UploadProgressEvent;
 }


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to export the `UploadProgressEvent` type and reorganize imports in `batch-lazy-mint-button.tsx`.

### Detailed summary
- Export `UploadProgressEvent` type from `progress-box.tsx`
- Update imports in `batch-lazy-mint-button.tsx` for `ProgressBox` and `UploadProgressEvent`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->