### PR TITLE
Hide Buy Funds section on testnet chain pages

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/(chainPage)/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/(chainPage)/page.tsx
@@ -45,13 +45,12 @@ export default async function Page(props: {
         </section>
       )}
 
-      {/* Buy Funds */}
-      {chain.services.find((c) => c.service === "pay" && c.enabled) && (
+      {/* Faucet / Buy Funds */}
+      {chain.testnet ? (
+        <FaucetSection chain={chain} />
+      ) : chain.services.find((c) => c.service === "pay" && c.enabled) ? (
         <BuyFundsSection chain={chain} />
-      )}
-
-      {/* Faucet */}
-      {chain.testnet && <FaucetSection chain={chain} />}
+      ) : null}
 
       {/* Chain Overview */}
       <ChainOverviewSection chain={chain} />


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a conditional rendering logic to show either a Faucet or Buy Funds section based on the chain's testnet status. It also updates the comment for Buy Funds section.

### Detailed summary
- Added conditional rendering for Faucet or Buy Funds section based on chain's testnet status
- Updated comment for Buy Funds section

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->