### PR TITLE
Fix Conditionally rendered hook error in Buy with Fiat flow

### DIFF
--- a/.changeset/thirty-bottles-jump.md
+++ b/.changeset/thirty-bottles-jump.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix Conditionally rendered hook error when Buying funds using fiat

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/fiat/FiatFlow.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/fiat/FiatFlow.tsx
@@ -68,6 +68,16 @@ export function FiatFlow(props: {
     props.openedWindow,
   );
 
+  const onPostOnrampSuccess = useCallback(() => {
+    // report the status of fiat status instead of post onramp swap status when post onramp swap is successful
+    getBuyWithFiatStatus({
+      intentId: props.quote.intentId,
+      client: props.client,
+    }).then((status) => {
+      props.onSuccess(status);
+    });
+  }, [props.onSuccess, props.quote.intentId, props.client]);
+
   if (screen.id === "step-1") {
     return (
       <FiatSteps
@@ -109,16 +119,6 @@ export function FiatFlow(props: {
       />
     );
   }
-
-  const onPostOnrampSuccess = useCallback(() => {
-    // report the status of fiat status instead of post onramp swap status when post onramp swap is successful
-    getBuyWithFiatStatus({
-      intentId: props.quote.intentId,
-      client: props.client,
-    }).then((status) => {
-      props.onSuccess(status);
-    });
-  }, [props.onSuccess, props.quote.intentId, props.client]);
 
   if (screen.id === "postonramp-swap") {
     return (


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing a conditionally rendered hook error when buying funds using fiat.

### Detailed summary
- Added a new `onPostOnrampSuccess` function to handle successful post onramp swaps
- Modified the logic to report the status of fiat instead of post onramp swap status

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->