### PR TITLE
Revert "Dashboard: Allow more domains (#4192)"

### DIFF
--- a/apps/dashboard/src/components/settings/ApiKeys/validations.ts
+++ b/apps/dashboard/src/components/settings/ApiKeys/validations.ts
@@ -11,8 +11,7 @@ const nameValidation = z
 const domainsValidation = z.string().refine(
   (str) =>
     validStrList(str, (domain) => {
-      // This isn't the strictest validation, but users keep running into cases where the validation is TOO strict
-      return domain.includes(":") || RE_DOMAIN.test(domain);
+      return domain.split(":")[0] === "localhost" || RE_DOMAIN.test(domain);
     }),
   {
     message: "Some of the domains are invalid",


### PR DESCRIPTION
This reverts commit 4bf82965461570bffd4ec21bb4e295bb8ed3e751.

## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the validation logic for domains in the `ApiKeys` component to allow "localhost" as a valid domain.

### Detailed summary
- Updated domain validation to allow "localhost" as a valid domain.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->