### PR TITLE
FIX: In-App Metadata Image Display

### DIFF
--- a/.changeset/new-shirts-pump.md
+++ b/.changeset/new-shirts-pump.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix custom image metadata on in-app wallets

--- a/packages/thirdweb/src/react/web/wallets/shared/ConnectWalletSocialOptions.tsx
+++ b/packages/thirdweb/src/react/web/wallets/shared/ConnectWalletSocialOptions.tsx
@@ -34,6 +34,7 @@ import {
 import { useSetSelectionData } from "../../providers/wallet-ui-states-provider.js";
 import { WalletTypeRowButton } from "../../ui/ConnectWallet/WalletTypeRowButton.js";
 import { Img } from "../../ui/components/Img.js";
+import { Spacer } from "../../ui/components/Spacer.js";
 import { TextDivider } from "../../ui/components/TextDivider.js";
 import { Container } from "../../ui/components/basic.js";
 import { Button } from "../../ui/components/buttons.js";
@@ -90,6 +91,13 @@ export const ConnectWalletSocialOptions = (
   ) => void;
 
   const themeObj = useCustomTheme();
+  const optionalImageMetadata = useMemo(
+    () =>
+      props.wallet.id === "inApp"
+        ? props.wallet.getConfig()?.metadata?.image
+        : undefined,
+    [props.wallet],
+  );
 
   const loginMethodsLabel = {
     google: locale.signInWithGoogle,
@@ -261,6 +269,19 @@ export const ConnectWalletSocialOptions = (
         position: "relative",
       }}
     >
+      {optionalImageMetadata && (
+        <>
+          <Img
+            client={props.client}
+            src={optionalImageMetadata.src}
+            alt={optionalImageMetadata.alt}
+            width={`${optionalImageMetadata.width}`}
+            height={`${optionalImageMetadata.height}`}
+            style={{ margin: "auto" }}
+          />
+          <Spacer y="xxs" />
+        </>
+      )}
       {/* Social Login */}
       {hasSocialLogins && (
         <Container


### PR DESCRIPTION
At some point the in-app metadata image got removed. This re-adds the image to the connect UI when specified on the `InApp` constructor.

<img width="637" alt="Screenshot 2024-08-20 at 11 13 19 AM" src="https://github.com/user-attachments/assets/f31e378c-113d-427d-ab2b-c5cf29c10465">
Fixes #4148

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing custom image metadata display on in-app wallets.

### Detailed summary
- Added `optionalImageMetadata` to retrieve image metadata for in-app wallets
- Conditionally render custom image in `ConnectWalletSocialOptions` component

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->