### PR TITLE
Stricter correctness rules in biome

### DIFF
--- a/apps/dashboard/src/@/components/color-mode-toggle.tsx
+++ b/apps/dashboard/src/@/components/color-mode-toggle.tsx
@@ -4,7 +4,6 @@ import { Button } from "@/components/ui/button";
 import { ClientOnly } from "components/ClientOnly/ClientOnly";
 import { Moon, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
-import * as React from "react";
 import { Skeleton } from "./ui/skeleton";
 
 export function ColorModeToggle() {

--- a/apps/dashboard/src/@/components/ui/CodeBlock.tsx
+++ b/apps/dashboard/src/@/components/ui/CodeBlock.tsx
@@ -1,5 +1,4 @@
 import { Highlight } from "prism-react-renderer";
-import React from "react";
 import { cn } from "../../lib/utils";
 import { CopyButton } from "./CopyButton";
 import { Card } from "./card";

--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/(chainPage)/components/server/ChainOverviewSection.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/(chainPage)/components/server/ChainOverviewSection.tsx
@@ -1,7 +1,6 @@
 import { CopyTextButton } from "@/components/ui/CopyTextButton";
 import { ExternalLinkIcon } from "lucide-react";
 import Link from "next/link";
-import React from "react";
 import type { ChainMetadata } from "thirdweb/chains";
 import { ChainLiveStats } from "../client/live-stats";
 import { SectionTitle } from "./SectionTitle";

--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/(chainPage)/popular/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/(chainPage)/popular/page.tsx
@@ -1,6 +1,5 @@
 import { type SortBy, fetchTopContracts } from "lib/search";
 import { CircleAlertIcon } from "lucide-react";
-import React from "react";
 import { TrendingContractSection } from "../../../../trending/components/trending-table";
 import { getChain } from "../../../utils";
 

--- a/apps/dashboard/src/app/(dashboard)/support/components/create-ticket.action.ts
+++ b/apps/dashboard/src/app/(dashboard)/support/components/create-ticket.action.ts
@@ -73,7 +73,7 @@ function prepareEmailBody(
 }
 
 export async function createTicketAction(
-  previousState: State,
+  _previousState: State,
   formData: FormData,
 ) {
   const cookieManager = cookies();

--- a/apps/dashboard/src/app/(dashboard)/tools/hex-converter/components/HexConverter.tsx
+++ b/apps/dashboard/src/app/(dashboard)/tools/hex-converter/components/HexConverter.tsx
@@ -21,7 +21,7 @@ export const HexConverter = () => {
         setHex(toHex(args.dec));
         setDec(args.dec);
       }
-    } catch (e) {}
+    } catch {}
   };
 
   return (

--- a/apps/dashboard/src/app/(dashboard)/tools/wei-converter/components/WeiConverter.tsx
+++ b/apps/dashboard/src/app/(dashboard)/tools/wei-converter/components/WeiConverter.tsx
@@ -26,7 +26,7 @@ export const WeiConverter = () => {
       setWei(_wei.toString());
       setGwei(toTokens(_wei, 9));
       setEther(toEther(_wei));
-    } catch (e) {}
+    } catch {}
   };
 
   return (

--- a/apps/dashboard/src/app/login/auth-actions.ts
+++ b/apps/dashboard/src/app/login/auth-actions.ts
@@ -141,7 +141,7 @@ function isValidRedirectPath(encodedPath: string): boolean {
     // ensure the path always starts with a _single_ slash
     // dobule slash could be interpreted as `//example.com` which is not allowed
     return decodedPath.startsWith("/") && !decodedPath.startsWith("//");
-  } catch (e) {
+  } catch {
     // If decoding fails, return false
     return false;
   }

--- a/apps/dashboard/src/components/buttons/MismatchButton.tsx
+++ b/apps/dashboard/src/components/buttons/MismatchButton.tsx
@@ -417,7 +417,7 @@ const MismatchNotice: React.FC<{
       try {
         await switchNetwork(chainV5);
         onClose(true);
-      } catch (e) {
+      } catch {
         //  failed to switch network
         onClose(false);
       }

--- a/apps/dashboard/src/components/configure-networks/Form/RpcInput.tsx
+++ b/apps/dashboard/src/components/configure-networks/Form/RpcInput.tsx
@@ -15,7 +15,7 @@ export const RpcInput: React.FC<{
         try {
           new URL(value);
           return true;
-        } catch (e) {
+        } catch {
           return false;
         }
       },

--- a/apps/dashboard/src/components/contract-components/contract-deploy-form/custom-contract.tsx
+++ b/apps/dashboard/src/components/contract-components/contract-deploy-form/custom-contract.tsx
@@ -458,7 +458,7 @@ const CustomContractForm: React.FC<CustomContractFormProps> = ({
                     contractAddress: deployedContractAddress,
                     chainId: selectedChain,
                   });
-                } catch (e) {
+                } catch {
                   // ignore
                 }
 

--- a/apps/dashboard/src/components/contract-components/hooks.ts
+++ b/apps/dashboard/src/components/contract-components/hooks.ts
@@ -905,7 +905,7 @@ export function useCustomContractDeployMutation(options: {
           });
 
           deployStatusModal.nextStep();
-        } catch (e) {
+        } catch {
           // failed to set metadata - for now just close the modal
           deployStatusModal.close();
           // not re-throwing the error, this is not technically a failure to deploy, just to set metadata - the contract is deployed already at this stage
@@ -927,7 +927,7 @@ export function useCustomContractDeployMutation(options: {
 
           deployStatusModal.nextStep();
         }
-      } catch (e) {
+      } catch {
         // failed to add to dashboard - for now just close the modal
         deployStatusModal.close();
         router.replace(`/${chainId}/${contractAddress}`);

--- a/apps/dashboard/src/components/engine/configuration/cors.tsx
+++ b/apps/dashboard/src/components/engine/configuration/cors.tsx
@@ -90,7 +90,7 @@ const parseOriginFromUrl = (url: string) => {
       throw new Error("Missing or invalid protocol");
     }
     return origin;
-  } catch (e) {
+  } catch {
     throw new Error(`Invalid URL: "${url}"`);
   }
 };

--- a/apps/dashboard/src/components/shared/BigNumberInput.tsx
+++ b/apps/dashboard/src/components/shared/BigNumberInput.tsx
@@ -68,7 +68,7 @@ export const BigNumberInput: React.FC<BigNumberInputProps> = ({
     try {
       newValue = utils.parseUnits(_value, decimals);
       parsedMax = utils.parseUnits(_max, decimals);
-    } catch (e) {
+    } catch {
       // don't update the input on invalid values
       return;
     }

--- a/apps/dashboard/src/contexts/configured-chains.tsx
+++ b/apps/dashboard/src/contexts/configured-chains.tsx
@@ -140,7 +140,7 @@ export function ChainsProvider(props: { children: React.ReactNode }) {
         RECENTLY_USED_CHAIN_IDS_KEY,
         JSON.stringify(recentlyUsedChainIds),
       );
-    } catch (e) {
+    } catch {
       localStorage.clear();
       localStorage.setItem(
         RECENTLY_USED_CHAIN_IDS_KEY,
@@ -171,7 +171,7 @@ export function ChainsProvider(props: { children: React.ReactNode }) {
       ) as number[];
 
       setRecentlyUsedChainIds(_recentlyUsedChainIds);
-    } catch (e) {
+    } catch {
       localStorage.removeItem(RECENTLY_USED_CHAIN_IDS_KEY);
     }
   }, [isSupportedChainsReady]);
@@ -328,7 +328,7 @@ const chainStorage = {
     try {
       const networkListStr = localStorage.getItem(key);
       return networkListStr ? JSON.parse(networkListStr) : [];
-    } catch (e) {
+    } catch {
       // if parsing error, clear dirty storage
       localStorage.removeItem(key);
     }
@@ -340,7 +340,7 @@ const chainStorage = {
     const value = JSON.stringify(networkList);
     try {
       localStorage.setItem(key, value);
-    } catch (e) {
+    } catch {
       // if storage limit exceed
       // clear entire local storage and then try again
       localStorage.clear();

--- a/apps/dashboard/src/contract-ui/components/solidity-inputs/helpers.ts
+++ b/apps/dashboard/src/contract-ui/components/solidity-inputs/helpers.ts
@@ -82,7 +82,7 @@ export const validateInt = (value: any, solidityType: string) => {
         message: `Value is higher than what ${solidityType} can store.`,
       };
     }
-  } catch (error) {
+  } catch {
     return {
       type: "pattern",
       message: "Input is not a valid number.",
@@ -113,7 +113,7 @@ const isValidBytes = (value: string, solidityType: string) => {
     try {
       const arrayify = JSON.parse(value);
       return isBytesType ? !!arrayify.length : arrayify.length === maxLength;
-    } catch (error) {
+    } catch {
       return false;
     }
   }

--- a/apps/dashboard/src/contract-ui/components/solidity-inputs/int-input.tsx
+++ b/apps/dashboard/src/contract-ui/components/solidity-inputs/int-input.tsx
@@ -36,7 +36,7 @@ export const SolidityIntInput: React.FC<SolidityInputWithTypeProps> = ({
         shouldValidate: true,
       });
       form.clearErrors(inputName);
-    } catch (e) {
+    } catch {
       form.setError(inputName, {
         type: "pattern",
         message: "Can't be converted to WEI.",

--- a/apps/dashboard/src/contract-ui/components/solidity-inputs/raw-input.tsx
+++ b/apps/dashboard/src/contract-ui/components/solidity-inputs/raw-input.tsx
@@ -39,7 +39,7 @@ export const SolidityRawInput: React.FC<SolidityInputWithTypeProps> = ({
         } else {
           form.clearErrors(inputName);
         }
-      } catch (error) {
+      } catch {
         form.setError(inputName, invalidInputError);
       }
     } else {

--- a/apps/dashboard/src/contract-ui/components/solidity-inputs/tuple-input.tsx
+++ b/apps/dashboard/src/contract-ui/components/solidity-inputs/tuple-input.tsx
@@ -41,7 +41,7 @@ export const SolidityTupleInput: React.FC<SolidityInputWithTypeProps> = ({
         } else {
           form.clearErrors(inputName);
         }
-      } catch (error) {
+      } catch {
         form.setError(inputName, invalidInputError);
       }
     } else {

--- a/apps/dashboard/src/contract-ui/tabs/embed/components/embed-setup.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/embed/components/embed-setup.tsx
@@ -75,7 +75,7 @@ const isValidUrl = (url: string | undefined) => {
   try {
     new URL(url);
     return true;
-  } catch (e) {
+  } catch {
     return false;
   }
 };

--- a/apps/dashboard/src/contract-ui/tabs/settings/components/metadata.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/settings/components/metadata.tsx
@@ -55,7 +55,7 @@ function extractDomain(url: string) {
     const domain =
       segments.length > 2 ? segments[segments.length - 2] : segments[0];
     return domain;
-  } catch (error) {
+  } catch {
     return null;
   }
 }

--- a/apps/dashboard/src/core-ui/batch-upload/batch-lazy-mint.tsx
+++ b/apps/dashboard/src/core-ui/batch-upload/batch-lazy-mint.tsx
@@ -122,7 +122,7 @@ export const BatchLazyMint: ComponentWithChildren<BatchLazyMintProps> = (
         await processInputData(acceptedFiles, (data) =>
           form.setValue("metadatas", data),
         );
-      } catch (err) {
+      } catch {
         form.setError("metadatas", {
           message: "Invalid metadata files",
           type: "validate",

--- a/apps/dashboard/src/hooks/analytics/useTrack.ts
+++ b/apps/dashboard/src/hooks/analytics/useTrack.ts
@@ -34,7 +34,7 @@ export function useTrack() {
 
     try {
       posthog.capture(catActLab, flatten(restDataSafe));
-    } catch (e) {
+    } catch {
       // ignore - we just don't want to trigger an error in the app if posthog fails
     }
   }, []);

--- a/apps/dashboard/src/hooks/chains/useRpcValidation.ts
+++ b/apps/dashboard/src/hooks/chains/useRpcValidation.ts
@@ -59,7 +59,7 @@ export function useRpcValidation(rpcUrl: string) {
           mainnet: !r.testnet,
           infoURL: "infoURL" in r ? r.infoURL : undefined,
         });
-      } catch (err) {
+      } catch {
         setExistingChain(null);
       }
 

--- a/apps/dashboard/src/lib/rpc.ts
+++ b/apps/dashboard/src/lib/rpc.ts
@@ -21,7 +21,7 @@ export function getDashboardChainRpc(
       }
     }
     return rpcUrl;
-  } catch (e) {
+  } catch {
     // if this fails we already know there's no possible rpc url available so we should just return an empty string
     return "";
   }

--- a/apps/dashboard/src/lib/sdk.ts
+++ b/apps/dashboard/src/lib/sdk.ts
@@ -6,7 +6,7 @@ import {
 } from "@/constants/env";
 import { type SDKOptions, ThirdwebSDK } from "@thirdweb-dev/sdk";
 import {
-  type GatewayUrls,
+  // type GatewayUrls,
   type IStorageDownloader,
   type SingleDownloadOptions,
   StorageDownloader,
@@ -34,7 +34,7 @@ const defaultDownloader = new StorageDownloader({
 class SpecialDownloader implements IStorageDownloader {
   async download(
     url: string,
-    gatewayUrls?: GatewayUrls,
+    // gatewayUrls?: GatewayUrls,
     options?: SingleDownloadOptions,
   ): Promise<Response> {
     if (url.startsWith("ipfs://")) {
@@ -68,7 +68,7 @@ class SpecialDownloader implements IStorageDownloader {
         ProxyHostNames.add(u.hostname);
 
         throw new Error("not ok");
-      } catch (e) {
+      } catch {
         // this is a bit scary but hey, it works
         return fetch(`${getAbsoluteUrl()}/api/proxy?url=${u.toString()}`);
       }

--- a/apps/dashboard/src/lib/wallet/nfts/alchemy.ts
+++ b/apps/dashboard/src/lib/wallet/nfts/alchemy.ts
@@ -47,7 +47,7 @@ export async function transformAlchemyResponseToNFT(
             supply: alchemyNFT.balance || "1",
             type: alchemyNFT.id.tokenMetadata.tokenType,
           } as WalletNFT;
-        } catch (e) {
+        } catch {
           return undefined as unknown as WalletNFT;
         }
       }),

--- a/apps/dashboard/src/lib/wallet/nfts/moralis.ts
+++ b/apps/dashboard/src/lib/wallet/nfts/moralis.ts
@@ -42,7 +42,7 @@ export async function transformMoralisResponseToNFT(
             supply: moralisNft.amount || "1",
             type: moralisNft.contract_type,
           } as WalletNFT;
-        } catch (e) {
+        } catch {
           return undefined as unknown as WalletNFT;
         }
       }),

--- a/apps/dashboard/src/lib/wallet/nfts/simpleHash.ts
+++ b/apps/dashboard/src/lib/wallet/nfts/simpleHash.ts
@@ -50,7 +50,7 @@ export async function transformSimpleHashResponseToNFT(
             supply: simpleHashNft.token_count.toString(),
             type: simpleHashNft.contract.type,
           } as WalletNFT;
-        } catch (e) {
+        } catch {
           return undefined as unknown as WalletNFT;
         }
       }),

--- a/apps/dashboard/src/pages/[chain_id]/[...paths].tsx
+++ b/apps/dashboard/src/pages/[chain_id]/[...paths].tsx
@@ -429,7 +429,7 @@ export const getStaticProps: GetStaticProps<EVMContractProps> = async (ctx) => {
       } else if (isErc1155) {
         detectedExtension = "erc1155";
       }
-    } catch (e) {
+    } catch {
       // ignore, most likely requires import
     }
   }

--- a/apps/dashboard/src/pages/dashboard/connect/analytics.tsx
+++ b/apps/dashboard/src/pages/dashboard/connect/analytics.tsx
@@ -357,7 +357,7 @@ const DashboardConnectAnalytics: ThirdwebNextPage = () => {
                         strokeWidth={2}
                         stroke={"var(--chakra-colors-backgroundHighlight)"}
                       >
-                        {pieChartData.map((entry, index) => (
+                        {pieChartData.map((_entry, index) => (
                           <Cell
                             // biome-ignore lint/suspicious/noArrayIndexKey: FIXME
                             key={index}

--- a/apps/dashboard/src/pages/dashboard/engine/import.tsx
+++ b/apps/dashboard/src/pages/dashboard/engine/import.tsx
@@ -55,7 +55,7 @@ const Page: ThirdwebNextPage = () => {
 
       toast.success("Engine imported successfully");
       router.push("/dashboard/engine");
-    } catch (e) {
+    } catch {
       toast.error(
         "Error importing Engine. Please check if the details are correct.",
       );

--- a/apps/dashboard/src/pages/profile/[profileAddress].tsx
+++ b/apps/dashboard/src/pages/profile/[profileAddress].tsx
@@ -253,7 +253,7 @@ export const getStaticProps: GetStaticProps<UserPageProps> = async (ctx) => {
     const info = await queryClient.fetchQuery(ensQuery(checksummedAddress));
     address = info.address;
     ensName = info.ensName;
-  } catch (e) {
+  } catch {
     // if profileAddress is not a valid address, ensQuery throws
     // in that case - redirect to 404
     return {

--- a/apps/dashboard/src/pages/template/[id].tsx
+++ b/apps/dashboard/src/pages/template/[id].tsx
@@ -725,7 +725,7 @@ export const getStaticProps: GetStaticProps<TemplatePageProps> = async (
         template,
       },
     };
-  } catch (error) {
+  } catch {
     return {
       notFound: true,
     };

--- a/apps/dashboard/src/tw-components/card.tsx
+++ b/apps/dashboard/src/tw-components/card.tsx
@@ -37,7 +37,7 @@ function getBorderRadius(
   try {
     // biome-ignore lint/suspicious/noExplicitAny: FIXME
     return (borderRadiusMap as any)[borderRadius as any];
-  } catch (e) {
+  } catch {
     return borderRadius;
   }
 }

--- a/apps/dashboard/src/utils/fetchChain.ts
+++ b/apps/dashboard/src/utils/fetchChain.ts
@@ -11,7 +11,7 @@ export async function fetchChain(
   if (res.ok) {
     try {
       return (await res.json()).data as ChainMetadata;
-    } catch (err) {
+    } catch {
       return null;
     }
   }
@@ -25,7 +25,7 @@ export async function fetchAllChains() {
   if (res.ok) {
     try {
       return (await res.json()).data as ChainMetadata[];
-    } catch (err) {
+    } catch {
       return [];
     }
   }

--- a/apps/playground-web/src/app/connect/auth/page.tsx
+++ b/apps/playground-web/src/app/connect/auth/page.tsx
@@ -15,9 +15,7 @@ export const metadata: Metadata = {
   description: "lorem ipsum",
 };
 
-export default function Page({
-  searchParams,
-}: { searchParams: { message: string } }) {
+export default function Page() {
   return (
     <main className="flex-1 content-center relative py-12 md:py-24 lg:py-32 xl:py-48 space-y-12 md:space-y-24">
       <section className="container px-4 md:px-6">
@@ -169,7 +167,7 @@ export async function GatedContentPreview() {
   // Finally! We can load the gated content for them now
   return (
     <div>
-      Congratulations!  
+      Congratulations!
       You can see this message because you own more than 10 TWCOIN.
     </div>
   );

--- a/apps/playground-web/src/app/features/Header.tsx
+++ b/apps/playground-web/src/app/features/Header.tsx
@@ -1,4 +1,3 @@
-import { ThemeSelector } from "@/components/theme-selector";
 import { ThirdwebIcon } from "@/icons/thirdweb";
 import { GithubIcon } from "lucide-react";
 import Link from "next/link";

--- a/apps/playground-web/src/app/page.tsx
+++ b/apps/playground-web/src/app/page.tsx
@@ -5,9 +5,8 @@ import {
   WalletsInAppIcon,
   WalletsSmartIcon,
 } from "@/icons";
-import { CodeIcon, ConstructionIcon } from "lucide-react";
+import { CodeIcon } from "lucide-react";
 import Link from "next/link";
-import type { PropsWithChildren } from "react";
 
 export default function Page() {
   return (
@@ -88,17 +87,3 @@ function ArticleCardIndex(props: {
     </Link>
   );
 }
-
-const ComingSoonWrapper: React.FC<PropsWithChildren> = ({ children }) => {
-  return (
-    <div className="relative pointer-events-none rounded-lg overflow-hidden">
-      {children}
-      <div className="absolute top-0 left-0 h-full w-full backdrop-blur-[2px] bg-color-overlay">
-        <div className="flex items-center justify-center h-full space-x-2">
-          <ConstructionIcon className="opacity-80" strokeWidth={1} />
-          <p className="font-semibold">Coming Soon</p>
-        </div>
-      </div>
-    </div>
-  );
-};

--- a/apps/playground-web/src/components/account-abstraction/sponsored-tx.tsx
+++ b/apps/playground-web/src/components/account-abstraction/sponsored-tx.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useTheme } from "next-themes";
 import { useEffect } from "react";
 import { claimTo, getNFT, getOwnedNFTs } from "thirdweb/extensions/erc1155";
 import {
@@ -22,7 +21,6 @@ export function SponsoredTxPreview() {
       disconnect(wallet);
     }
   }, [wallet, disconnect]);
-  const { theme } = useTheme();
   const smartAccount = useActiveAccount();
   const { data: nft, isLoading: isNftLoading } = useReadContract(getNFT, {
     contract: editionDropContract,

--- a/apps/playground-web/src/components/in-app-wallet/connect-button.tsx
+++ b/apps/playground-web/src/components/in-app-wallet/connect-button.tsx
@@ -2,7 +2,6 @@
 
 import { THIRDWEB_CLIENT } from "@/lib/client";
 import { useTheme } from "next-themes";
-import { baseSepolia } from "thirdweb/chains";
 import { ConnectButton } from "thirdweb/react";
 import type { ConnectButtonProps } from "thirdweb/react";
 import { inAppWallet } from "thirdweb/wallets/in-app";

--- a/apps/playground-web/src/components/in-app-wallet/sponsored-tx.tsx
+++ b/apps/playground-web/src/components/in-app-wallet/sponsored-tx.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useTheme } from "next-themes";
 import { useEffect } from "react";
 import { claimTo, getNFT, getOwnedNFTs } from "thirdweb/extensions/erc1155";
 import {
@@ -22,7 +21,6 @@ export function SponsoredInAppTxPreview() {
       disconnect(wallet);
     }
   }, [wallet, disconnect]);
-  const { theme } = useTheme();
   const smartAccount = useActiveAccount();
   const { data: nft, isLoading: isNftLoading } = useReadContract(getNFT, {
     contract: editionDropContract,

--- a/apps/playground-web/src/components/sign-in/custom.tsx
+++ b/apps/playground-web/src/components/sign-in/custom.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { ConnectButton } from "thirdweb/react";
-import { darkTheme, lightTheme } from "thirdweb/react";
+import { darkTheme } from "thirdweb/react";
 import { THIRDWEB_CLIENT } from "../../lib/client";
 
 export const CustomizedConnect = () => {

--- a/apps/playground-web/src/components/theme-selector.tsx
+++ b/apps/playground-web/src/components/theme-selector.tsx
@@ -9,7 +9,6 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Moon, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
-import * as React from "react";
 
 export function ThemeSelector() {
   const { setTheme } = useTheme();

--- a/apps/wallet-ui/src/components/NftCard.tsx
+++ b/apps/wallet-ui/src/components/NftCard.tsx
@@ -1,5 +1,4 @@
 import type { Erc721Token } from "@/types/Erc721Token";
-import React from "react";
 import { shortenAddress } from "thirdweb/utils";
 import { getChain } from "../lib/chains";
 import { ChainIcon } from "./ChainIcon";

--- a/apps/wallet-ui/src/components/NftModal.tsx
+++ b/apps/wallet-ui/src/components/NftModal.tsx
@@ -7,7 +7,7 @@ import { useParams } from "next/navigation";
 import { useMemo } from "react";
 import React from "react";
 import { useForm } from "react-hook-form";
-import { Toaster, toast } from "sonner";
+import { toast } from "sonner";
 import type { Address } from "thirdweb";
 import { defineChain, getContract, isAddress, sendTransaction } from "thirdweb";
 import type { ChainMetadata } from "thirdweb/chains";

--- a/apps/wallet-ui/src/lib/assets/erc20.ts
+++ b/apps/wallet-ui/src/lib/assets/erc20.ts
@@ -23,7 +23,7 @@ export async function getErc20Tokens({
     .map((id) => {
       try {
         return `${chainIdToName(id)},`;
-      } catch (e) {
+      } catch {
         // Ignore unsupported chains when fetching assets
       }
     })

--- a/apps/wallet-ui/src/lib/assets/erc721.ts
+++ b/apps/wallet-ui/src/lib/assets/erc721.ts
@@ -23,7 +23,7 @@ export async function getErc721Tokens({
     .map((id) => {
       try {
         return `${chainIdToName(id)},`;
-      } catch (e) {
+      } catch {
         // Ignore unsupported chains when fetching assets
       }
     })

--- a/apps/wallet-ui/src/lib/revalidate.ts
+++ b/apps/wallet-ui/src/lib/revalidate.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { revalidatePath, revalidateTag } from "next/cache";
+import { revalidateTag } from "next/cache";
 
 export async function revalidate(tag: string) {
   revalidateTag(tag);

--- a/biome.json
+++ b/biome.json
@@ -8,7 +8,11 @@
     "rules": {
       "recommended": true,
       "correctness": {
-        "useHookAtTopLevel": "error"
+        "useHookAtTopLevel": "error",
+        "noNewSymbol": "error",
+        "noUnusedImports": "error",
+        "noUnusedVariables": "error",
+        "useArrayLiterals": "error"
       }
     }
   },

--- a/legacy_packages/unity-js-bridge/src/thirdweb-bridge.ts
+++ b/legacy_packages/unity-js-bridge/src/thirdweb-bridge.ts
@@ -534,7 +534,7 @@ class ThirdwebBridge implements TWBridge {
           (arg.startsWith("{") || arg.startsWith("["))
           ? JSON.parse(arg)
           : arg;
-      } catch (e) {
+      } catch {
         return arg;
       }
     });
@@ -586,7 +586,7 @@ class ThirdwebBridge implements TWBridge {
         try {
           typeOrAbi = JSON.parse(firstArg[1]); // try to parse ABI
           isAbi = true;
-        } catch (e) {
+        } catch {
           typeOrAbi = firstArg[1];
           isAbi = false;
         }
@@ -716,7 +716,7 @@ class ThirdwebBridge implements TWBridge {
           (arg.startsWith("{") || arg.startsWith("["))
           ? JSON.parse(arg)
           : arg;
-      } catch (e) {
+      } catch {
         return arg;
       }
     });
@@ -727,7 +727,7 @@ class ThirdwebBridge implements TWBridge {
       if (firstArg.length > 1) {
         try {
           typeOrAbi = JSON.parse(firstArg[1]); // try to parse ABI
-        } catch (e) {
+        } catch {
           typeOrAbi = firstArg[1];
         }
       }
@@ -1017,7 +1017,7 @@ class ThirdwebBridge implements TWBridge {
           stroke-width="4"
         />
       </svg>
-      
+
       <style>
         body,
         html {
@@ -1025,23 +1025,23 @@ class ThirdwebBridge implements TWBridge {
           margin: 0;
           padding: 0;
         }
-      
+
         body {
           display: flex;
           justify-content: center;
           align-items: center;
         }
-      
+
         .loader {
           width: 15vw;
           height: 15vw;
           animation: spin 2s linear infinite;
         }
-      
+
         .loader circle {
           animation: loading 1.5s linear infinite;
         }
-      
+
         @keyframes loading {
           0% {
             stroke-dasharray: 1, 150;
@@ -1056,7 +1056,7 @@ class ThirdwebBridge implements TWBridge {
             stroke-dashoffset: -124;
           }
         }
-      
+
         @keyframes spin {
           100% {
             transform: rotate(360deg);

--- a/packages/service-utils/src/cf-worker/index.ts
+++ b/packages/service-utils/src/cf-worker/index.ts
@@ -213,5 +213,5 @@ export async function logHttpRequest({
     if (statusMessage) {
       console.log(`statusMessage=${statusMessage}`);
     }
-  } catch (err) {}
+  } catch {}
 }

--- a/packages/service-utils/src/core/api.ts
+++ b/packages/service-utils/src/core/api.ts
@@ -111,7 +111,7 @@ export async function fetchKeyMetadataFromApi(
   try {
     text = await response.text();
     return JSON.parse(text);
-  } catch (e) {
+  } catch {
     throw new Error(
       `Error fetching key metadata from API: ${response.status} - ${text}`,
     );
@@ -140,7 +140,7 @@ export async function fetchAccountFromApi(
   try {
     text = await response.text();
     return JSON.parse(text);
-  } catch (e) {
+  } catch {
     throw new Error(
       `Error fetching account from API: ${response.status} - ${text}`,
     );

--- a/packages/service-utils/src/core/authorize/index.ts
+++ b/packages/service-utils/src/core/authorize/index.ts
@@ -92,7 +92,7 @@ export async function authorize(
             accountMeta = parsed;
           }
         }
-      } catch (err) {
+      } catch {
         // ignore errors, proceed as if not in cache
       }
     }
@@ -181,7 +181,7 @@ export async function authorize(
           apiKeyMeta = parsed;
         }
       }
-    } catch (err) {
+    } catch {
       // ignore errors, proceed as if not in cache
     }
   }

--- a/packages/service-utils/src/node/index.ts
+++ b/packages/service-utils/src/node/index.ts
@@ -216,5 +216,5 @@ export function logHttpRequest({
         latencyMs,
       }),
     );
-  } catch (err) {}
+  } catch {}
 }

--- a/packages/thirdweb/src/auth/verify-hash.ts
+++ b/packages/thirdweb/src/auth/verify-hash.ts
@@ -111,7 +111,7 @@ export async function verifyHash({
 
     const hexResult = isHex(result) ? toBytes(result) : result;
     return equalBytes(hexResult, toBytes("0x1"));
-  } catch (error) {
+  } catch {
     // Some chains do not support the eth_call simulation and will fail, so we fall back to regular EIP1271 validation
     const validEip1271 = await verifyEip1271Signature({
       hash,

--- a/packages/thirdweb/src/cli/commands/generate/generate.ts
+++ b/packages/thirdweb/src/cli/commands/generate/generate.ts
@@ -181,7 +181,7 @@ export type ${uppercaseFirstLetter(f.name)}Params = {
  * @example
  * \`\`\`
  * import { ${f.name} } from "TODO";
- * 
+ *
  * const transaction = ${f.name}(${
    f.inputs.length > 0
      ? `{\n * ${f.inputs
@@ -191,10 +191,10 @@ export type ${uppercaseFirstLetter(f.name)}Params = {
          .join("\n * ")}\n * }`
      : ""
  });
- * 
+ *
  * // Send the transaction
  * ...
- * 
+ *
  * \`\`\`
  */
 export function ${f.name}(
@@ -239,7 +239,7 @@ export type ${uppercaseFirstLetter(f.name)}Params = {
  * @example
  * \`\`\`
  * import { ${f.name} } from "TODO";
- * 
+ *
  * const result = await ${f.name}(${
    f.inputs.length > 0
      ? `{\n * ${f.inputs
@@ -249,7 +249,7 @@ export type ${uppercaseFirstLetter(f.name)}Params = {
          .join("\n * ")}\n * }`
      : ""
  });
- * 
+ *
  * \`\`\`
  */
 export async function ${f.name}(
@@ -295,7 +295,7 @@ export type ${uppercaseFirstLetter(e.name)}EventFilters = Partial<{
  * \`\`\`
  * import { getContractEvents } from "thirdweb";
  * import { ${eventNameToPreparedEventName(e.name)} } from "TODO";
- * 
+ *
  * const events = await getContractEvents({
  * contract,
  * events: [
@@ -309,7 +309,7 @@ export type ${uppercaseFirstLetter(e.name)}EventFilters = Partial<{
  * ],
  * });
  * \`\`\`
- */ 
+ */
 export function ${eventNameToPreparedEventName(e.name)}(${
     indexedInputs.length > 0
       ? `filters: ${uppercaseFirstLetter(e.name)}EventFilters = {}`
@@ -348,7 +348,7 @@ async function prettifyCode(code: string, options: Options) {
   try {
     const { format } = await import("prettier/standalone.js");
     return await format(code, options);
-  } catch (e) {
+  } catch {
     if (!printedPrettierWarning) {
       console.info("Prettier not found, skipping code formatting.");
     }

--- a/packages/thirdweb/src/contract/actions/resolve-abi.ts
+++ b/packages/thirdweb/src/contract/actions/resolve-abi.ts
@@ -47,7 +47,7 @@ export function resolveContractAbi<abi extends Abi>(
     // try to get it from the api
     try {
       return await resolveAbiFromContractApi(contract, contractApiBaseUrl);
-    } catch (e) {
+    } catch {
       // if that fails, try to resolve it from the bytecode
       return await resolveCompositeAbi(contract as ThirdwebContract);
     }

--- a/packages/thirdweb/src/contract/verification/constructor-params.ts
+++ b/packages/thirdweb/src/contract/verification/constructor-params.ts
@@ -115,7 +115,7 @@ export async function fetchConstructorParams(
     // sanity check that the constructor params are valid
     // TODO: should we sanity check after each attempt?
     decodeAbiParameters(constructorParamTypes, `0x${constructorArgs}`);
-  } catch (e) {
+  } catch {
     throw new Error(
       "Verifying this contract requires it to be published. Run `npx thirdweb publish` to publish this contract, then try again.",
     );

--- a/packages/thirdweb/src/extensions/erc20/read/getCurrencyMetadata.ts
+++ b/packages/thirdweb/src/extensions/erc20/read/getCurrencyMetadata.ts
@@ -51,7 +51,7 @@ export async function getCurrencyMetadata(
       symbol: symbol_,
       decimals: decimals_,
     };
-  } catch (e) {
+  } catch {
     throw new Error("Invalid currency token");
   }
 }

--- a/packages/thirdweb/src/extensions/erc721/lazyMinting/write/createDelayedRevealBatch.ts
+++ b/packages/thirdweb/src/extensions/erc721/lazyMinting/write/createDelayedRevealBatch.ts
@@ -1,5 +1,4 @@
 import { encodePacked } from "viem/utils";
-import type { ThirdwebContract } from "../../../../contract/contract.js";
 import { upload } from "../../../../storage/upload.js";
 import type { BaseTransactionOptions } from "../../../../transaction/types.js";
 import { encodeAbiParameters } from "../../../../utils/abi/encodeAbiParameters.js";

--- a/packages/thirdweb/src/extensions/vote/read/proposalExists.ts
+++ b/packages/thirdweb/src/extensions/vote/read/proposalExists.ts
@@ -20,7 +20,7 @@ export async function proposalExists(
   try {
     await state(options);
     return true;
-  } catch (e) {
+  } catch {
     // If it throws an error then the proposal(id) doesn't exist
     return false;
   }

--- a/packages/thirdweb/src/react/core/hooks/transaction/useSendTransaction.ts
+++ b/packages/thirdweb/src/react/core/hooks/transaction/useSendTransaction.ts
@@ -225,7 +225,7 @@ export async function getTotalTxCostForBuy(
 
     // add 10% extra gas cost to the estimate to ensure user buys enough to cover the tx cost
     return gasCost.wei + bufferCost + (txValue || 0n);
-  } catch (e) {
+  } catch {
     if (from) {
       // try again without passing from
       return await getTotalTxCostForBuy(tx);

--- a/packages/thirdweb/src/react/core/hooks/wallets/useAutoConnect.ts
+++ b/packages/thirdweb/src/react/core/hooks/wallets/useAutoConnect.ts
@@ -115,7 +115,7 @@ export function useAutoConnectCore(
       try {
         await handleWalletConnection(wallet);
         manager.addConnectedWallet(wallet);
-      } catch (e) {
+      } catch {
         // no-op
       }
     }

--- a/packages/thirdweb/src/react/core/hooks/wallets/useSendToken.ts
+++ b/packages/thirdweb/src/react/core/hooks/wallets/useSendToken.ts
@@ -69,7 +69,7 @@ export function useSendToken(client: ThirdwebClient) {
           client,
           name: receiverAddress,
         });
-      } catch (e) {
+      } catch {
         throw new Error("Failed to resolve address");
       }
 

--- a/packages/thirdweb/src/react/core/utils/timeoutPromise.test.ts
+++ b/packages/thirdweb/src/react/core/utils/timeoutPromise.test.ts
@@ -58,7 +58,7 @@ describe("timeoutPromise", () => {
     });
     try {
       await timeoutPromise(mockPromise, options);
-    } catch (error) {}
+    } catch {}
     expect(clearTimeoutSpy).toHaveBeenCalled();
     clearTimeoutSpy.mockRestore();
   });

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/main/useBuyTxStates.ts
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/main/useBuyTxStates.ts
@@ -155,7 +155,7 @@ export async function getTransactionGasCost(
     // Note: get tx.value AFTER estimateGasCost
     // add 10% extra gas cost to the estimate to ensure user buys enough to cover the tx cost
     return gasCost.wei + bufferCost;
-  } catch (e) {
+  } catch {
     if (from) {
       // try again without passing from
       return await getTransactionGasCost(tx);

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/WalletConnectReceiverScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/WalletConnectReceiverScreen.tsx
@@ -60,7 +60,7 @@ export function WalletConnectReceiverScreen(props: {
           },
         });
         return client;
-      } catch (e) {
+      } catch {
         setErrorConnecting("Failed to establish WalletConnect connection");
         return;
       }
@@ -164,7 +164,7 @@ export function WalletConnectReceiverScreen(props: {
                           uri: value,
                           walletConnectClient,
                         });
-                      } catch (e) {
+                      } catch {
                         setErrorConnecting(
                           "Error creating WalletConnect session",
                         );

--- a/packages/thirdweb/src/storage/upload/mobile.ts
+++ b/packages/thirdweb/src/storage/upload/mobile.ts
@@ -77,7 +77,7 @@ export async function uploadBatchMobile(
           let body: any;
           try {
             body = JSON.parse(xhr.responseText);
-          } catch (err) {
+          } catch {
             return reject(
               new Error("Failed to parse JSON from upload response"),
             );

--- a/packages/thirdweb/src/utils/extensions/airdrop/fetch-proofs-erc1155.ts
+++ b/packages/thirdweb/src/utils/extensions/airdrop/fetch-proofs-erc1155.ts
@@ -81,7 +81,7 @@ export async function fetchProofsERC1155(options: {
       uri: constructedShardUri,
     });
     shardData = await shard.json();
-  } catch (e) {
+  } catch {
     // if the file can't be fetched it means claimer not in merkle tree
     return null;
   }

--- a/packages/thirdweb/src/utils/extensions/airdrop/fetch-proofs-erc20.ts
+++ b/packages/thirdweb/src/utils/extensions/airdrop/fetch-proofs-erc20.ts
@@ -83,7 +83,7 @@ export async function fetchProofsERC20(options: {
       uri: constructedShardUri,
     });
     shardData = await shard.json();
-  } catch (e) {
+  } catch {
     // if the file can't be fetched it means claimer not in merkle tree
     return null;
   }

--- a/packages/thirdweb/src/utils/extensions/airdrop/fetch-proofs-erc721.ts
+++ b/packages/thirdweb/src/utils/extensions/airdrop/fetch-proofs-erc721.ts
@@ -81,7 +81,7 @@ export async function fetchProofsERC721(options: {
       uri: constructedShardUri,
     });
     shardData = await shard.json();
-  } catch (e) {
+  } catch {
     // if the file can't be fetched it means claimer not in merkle tree
     return null;
   }

--- a/packages/thirdweb/src/utils/extensions/drops/fetch-proofs-for-claimers.ts
+++ b/packages/thirdweb/src/utils/extensions/drops/fetch-proofs-for-claimers.ts
@@ -53,7 +53,7 @@ export async function fetchProofsForClaimer(options: {
       uri: constructedShardUri,
     });
     shardData = await shard.json();
-  } catch (e) {
+  } catch {
     // if the file can't be fetched it means claimer not in merkle tree
     return null;
   }

--- a/packages/thirdweb/src/utils/nft/fetchTokenMetadata.ts
+++ b/packages/thirdweb/src/utils/nft/fetchTokenMetadata.ts
@@ -63,7 +63,7 @@ export async function fetchTokenMetadata(
           ),
         })
       ).json();
-    } catch (err) {
+    } catch {
       // otherwise attempt the second format
       return await (
         await download({

--- a/packages/thirdweb/src/wallets/in-app/native/helpers/auth/middleware.ts
+++ b/packages/thirdweb/src/wallets/in-app/native/helpers/auth/middleware.ts
@@ -64,7 +64,7 @@ export async function postAuth({
     try {
       // existing device share
       await getDeviceShare(client.clientId);
-    } catch (e) {
+    } catch {
       const _recoveryCode = await getRecoveryCode(
         storedToken,
         client,
@@ -116,7 +116,7 @@ export async function postAuthUserManaged(
     try {
       // existing device share
       await getDeviceShare(client.clientId);
-    } catch (e) {
+    } catch {
       // trying to recreate device share from recovery code to derive wallet
       try {
         await setUpShareForNewDevice({
@@ -155,7 +155,7 @@ async function getRecoveryCode(
     }
     try {
       return await getCognitoRecoveryPasswordV2(client);
-    } catch (e) {
+    } catch {
       return await getCognitoRecoveryPasswordV1(client).catch(() => {
         throw new Error("Something went wrong getting cognito recovery code");
       });

--- a/packages/thirdweb/src/wallets/in-app/native/helpers/storage/local.ts
+++ b/packages/thirdweb/src/wallets/in-app/native/helpers/storage/local.ts
@@ -131,7 +131,7 @@ export async function getWalletUserDetails(
   try {
     const parsed = JSON.parse(result);
     return parsed;
-  } catch (e) {
+  } catch {
     return undefined;
   }
 }

--- a/packages/thirdweb/src/wallets/in-app/native/helpers/wallet/retrieval.ts
+++ b/packages/thirdweb/src/wallets/in-app/native/helpers/wallet/retrieval.ts
@@ -152,7 +152,7 @@ async function getShares<
     deviceShareToReturn = deviceShare.toRetrieve
       ? (await getDeviceShare(client.clientId)).deviceShare
       : undefined;
-  } catch (e) {
+  } catch {
     throw new Error(DEVICE_SHARE_MISSING_MESSAGE);
   }
 

--- a/packages/thirdweb/src/wallets/smart/index.ts
+++ b/packages/thirdweb/src/wallets/smart/index.ts
@@ -261,7 +261,7 @@ async function createSmartAccount(
           params: [originalMsgHash],
         });
         factorySupports712 = true;
-      } catch (e) {
+      } catch {
         // ignore
       }
 
@@ -349,7 +349,7 @@ async function createSmartAccount(
           params: [originalMsgHash],
         });
         factorySupports712 = true;
-      } catch (e) {
+      } catch {
         // ignore
       }
 

--- a/packages/thirdweb/src/wallets/utils/chains.ts
+++ b/packages/thirdweb/src/wallets/utils/chains.ts
@@ -16,7 +16,7 @@ export function getValidPublicRPCUrl(chain: ChainMetadata) {
         url.search = "";
       }
       return url.toString();
-    } catch (e) {
+    } catch {
       return rpc;
     }
   });

--- a/packages/thirdweb/src/wallets/wallet-connect/receiver/index.ts
+++ b/packages/thirdweb/src/wallets/wallet-connect/receiver/index.ts
@@ -344,7 +344,7 @@ export async function disconnectWalletConnectSession(options: {
         message: "Disconnected",
       },
     });
-  } catch (error) {
+  } catch {
     // ignore, the session doesn't exist already
   }
 }


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to remove unnecessary error handling blocks in catch clauses across multiple files.

### Detailed summary
- Removed empty catch blocks without error parameter
- Updated error handling in various functions
- Simplified error handling logic

> The following files were skipped due to too many changes: `apps/dashboard/src/utils/fetchChain.ts`, `packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/main/useBuyTxStates.ts`, `packages/thirdweb/src/react/core/hooks/transaction/useSendTransaction.ts`, `packages/thirdweb/src/auth/verify-hash.ts`, `packages/thirdweb/src/contract/verification/constructor-params.ts`, `apps/wallet-ui/src/components/NftModal.tsx`, `apps/playground-web/src/components/in-app-wallet/connect-button.tsx`, `apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/(chainPage)/components/server/ChainOverviewSection.tsx`, `packages/thirdweb/src/extensions/erc721/lazyMinting/write/createDelayedRevealBatch.ts`, `packages/thirdweb/src/react/web/ui/ConnectWallet/screens/WalletConnectReceiverScreen.tsx`, `apps/dashboard/src/contract-ui/components/solidity-inputs/helpers.ts`, `packages/service-utils/src/core/api.ts`, `apps/playground-web/src/components/in-app-wallet/sponsored-tx.tsx`, `apps/playground-web/src/components/account-abstraction/sponsored-tx.tsx`, `apps/playground-web/src/app/connect/auth/page.tsx`, `apps/dashboard/src/components/contract-components/hooks.ts`, `packages/thirdweb/src/wallets/in-app/native/helpers/auth/middleware.ts`, `apps/dashboard/src/lib/sdk.ts`, `apps/playground-web/src/app/page.tsx`, `apps/dashboard/src/contexts/configured-chains.tsx`, `legacy_packages/unity-js-bridge/src/thirdweb-bridge.ts`, `packages/thirdweb/src/cli/commands/generate/generate.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->