### PR TITLE
External redirect v2

### DIFF
--- a/.changeset/sour-feet-protect.md
+++ b/.changeset/sour-feet-protect.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Added external redirect support for authenticateWithRedirect. Created new connectExternal function for wallets

--- a/packages/thirdweb/src/wallets/in-app/core/interfaces/connector.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/interfaces/connector.ts
@@ -15,7 +15,7 @@ export interface InAppConnector {
   getAccount(): Promise<Account>;
   preAuthenticate(args: PreAuthArgsType): Promise<void>;
   // Authenticate generates an auth token, when redirecting it returns void as the user is redirected to a new page and the token is stored in the callback url
-  authenticateWithRedirect?(strategy: SocialAuthOption): void;
+  authenticateWithRedirect?(strategy: SocialAuthOption, redirectUrl?: string, redirectExternally?: boolean): void;
   // Login takes an auth token and connects a user with it
   loginWithAuthToken?(
     authResult: AuthStoredTokenWithCookieReturnType,

--- a/packages/thirdweb/src/wallets/in-app/core/wallet/ecosystem-core.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/wallet/ecosystem-core.ts
@@ -69,6 +69,30 @@ export function createEcosystemWallet(args: {
       // return only the account
       return account;
     },
+    connectExternal: async (options) => {
+      const { connectInAppWallet } = await import("./index.js");
+
+      const connector = await getOrCreateInAppWalletConnector(
+        options.client,
+        connectorFactory,
+        {
+          id,
+          partnerId: createOptions?.partnerId,
+        },
+      );
+
+      if (createOptions?.auth?.redirectExternally !== true) {
+        throw new Error('Invalid function, please use connect instead');
+      }
+
+      await connectInAppWallet(
+        options,
+        createOptions,
+        connector,
+      );
+      // set the states
+      client = options.client;
+    },
     connect: async (options) => {
       const { connectInAppWallet } = await import("./index.js");
 
@@ -81,6 +105,10 @@ export function createEcosystemWallet(args: {
         },
       );
 
+      if (createOptions?.auth?.redirectExternally === true) {
+        throw new Error('Invalid function, please use connectExternal instead');
+      }
+
       const [connectedAccount, connectedChain] = await connectInAppWallet(
         options,
         createOptions,
@@ -88,7 +116,7 @@ export function createEcosystemWallet(args: {
       );
       // set the states
       client = options.client;
-      account = connectedAccount;
+      account = connectedAccount!;
       chain = connectedChain;
       trackConnect({
         client: options.client,

--- a/packages/thirdweb/src/wallets/in-app/core/wallet/in-app-core.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/wallet/in-app-core.ts
@@ -116,12 +116,35 @@ export function createInAppWallet(args: {
       // return only the account
       return account;
     },
+    connectExternal: async (options) => {
+      const { connectInAppWallet } = await import("./index.js");
+      const connector = await getOrCreateInAppWalletConnector(
+        options.client,
+        connectorFactory,
+      );
+
+      if (createOptions?.auth?.redirectExternally !== true) {
+        throw new Error('Invalid function, please use connect instead');
+      }
+
+      await connectInAppWallet(
+        options,
+        createOptions,
+        connector,
+      );
+      // set the states
+      client = options.client;
+    },
     connect: async (options) => {
       const { connectInAppWallet } = await import("./index.js");
       const connector = await getOrCreateInAppWalletConnector(
         options.client,
         connectorFactory,
       );
+
+      if (createOptions?.auth?.redirectExternally === true) {
+        throw new Error('Invalid function, please use connectExternal instead');
+      }
 
       const [connectedAccount, connectedChain] = await connectInAppWallet(
         options,
@@ -130,7 +153,7 @@ export function createInAppWallet(args: {
       );
       // set the states
       client = options.client;
-      account = connectedAccount;
+      account = connectedAccount!;
       chain = connectedChain;
       trackConnect({
         client: options.client,

--- a/packages/thirdweb/src/wallets/in-app/core/wallet/index.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/wallet/index.ts
@@ -38,14 +38,18 @@ export async function connectInAppWallet(
     | CreateWalletArgs<"inApp">[1]
     | CreateWalletArgs<EcosystemWalletId>[1],
   connector: InAppConnector,
-): Promise<[Account, Chain]> {
+): Promise<[Account | undefined, Chain | undefined]> {
   if (
     createOptions?.auth?.mode === "redirect" &&
     connector.authenticateWithRedirect
   ) {
     const strategy = options.strategy;
     if (socialAuthOptions.includes(strategy as SocialAuthOption)) {
-      connector.authenticateWithRedirect(strategy as SocialAuthOption);
+      connector.authenticateWithRedirect(strategy as SocialAuthOption, createOptions?.auth?.redirectUrl, createOptions?.auth?.redirectExternally);
+      // Return [undefined, undefined] here if authenticating externally and redirecting back into the app
+      if (createOptions?.auth?.redirectExternally === true) {
+        return [undefined, undefined];
+      }
     }
   }
   // If we don't have authenticateWithRedirect then it's likely react native, so the default is to redirect and we can carry on

--- a/packages/thirdweb/src/wallets/in-app/web/lib/auth/index.ts
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/auth/index.ts
@@ -152,11 +152,13 @@ export async function authenticate(
         client: ThirdwebClient;
         ecosystem?: Ecosystem;
         redirect: boolean;
+        redirectUrl?: string;
+        redirectExternally?: boolean;
       }
   >,
 ) {
   const connector = await getInAppWalletConnector(args.client, args.ecosystem);
   if (args.redirect && connector.authenticateWithRedirect)
-    return connector.authenticateWithRedirect(args.strategy);
+    return connector.authenticateWithRedirect(args.strategy, args?.redirectUrl, args?.redirectExternally);
   return connector.connect(args);
 }

--- a/packages/thirdweb/src/wallets/in-app/web/lib/web-connector.ts
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/web-connector.ts
@@ -150,11 +150,13 @@ export class InAppWebConnector implements InAppConnector {
     });
   }
 
-  authenticateWithRedirect(strategy: SocialAuthOption): void {
+  authenticateWithRedirect(strategy: SocialAuthOption, redirectUrl?: string, redirectExternally?: boolean): void {
     loginWithOauthRedirect({
       authOption: strategy,
       client: this.wallet.client,
       ecosystem: this.wallet.ecosystem,
+      redirectUrl,
+      redirectExternally,
     });
   }
 

--- a/packages/thirdweb/src/wallets/interfaces/wallet.ts
+++ b/packages/thirdweb/src/wallets/interfaces/wallet.ts
@@ -83,6 +83,11 @@ export type Wallet<TWalletId extends WalletId = WalletId> = {
    */
   autoConnect(options: WalletAutoConnectionOption<TWalletId>): Promise<Account>;
   /**
+   * Prompt the user to connect the wallet outside of the app.
+   * @param options - Options to connect the wallet. Depending on the wallet id, The options can be different. MUST include the auth params redirectExternal and redirectUrl
+   */
+  connectExternal?(options: WalletConnectionOption<TWalletId>): Promise<void>;
+  /**
    * Prompt the user to connect the wallet.
    * @param options - Options to connect the wallet. Depending on the wallet id, The options can be different.
    */


### PR DESCRIPTION
## Problem solved

- Added the external redirect params to `authenticateWithRedirect` that were missing in my previous PR: https://github.com/thirdweb-dev/js/pull/4099
- Created a new `connectExternal` function that calls `authenticateWithRedirect` but returns no `Account` since it has to wait for `redirectUrl` webpage to redirect back into the app. Switching the return result of `connect` to `Account | undefined` would cause a lot of breaking changes

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances wallet functionality by adding external redirect support for authentication and introduces a new function to connect wallets externally.

### Detailed summary
- Added `redirectUrl` and `redirectExternally` parameters to `authenticateWithRedirect` function
- Created `connectExternal` function for wallets to prompt external connection
- Updated interfaces and implementations for external wallet connection
- Added error handling for incorrect usage of `connectExternal` and `connect` functions

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->