### PR TITLE
add dev domains in pay playground to test

### DIFF
--- a/apps/playground-web/src/app/connect/pay/page.tsx
+++ b/apps/playground-web/src/app/connect/pay/page.tsx
@@ -7,6 +7,15 @@ import { CodeExample } from "../../../components/code/code-example";
 import { BuyMerchPreview } from "../../../components/pay/direct-payment";
 import { StyledPayEmbedPreview } from "../../../components/pay/embed";
 import { PayTransactionButtonPreview } from "../../../components/pay/transaction-button";
+import { setThirdwebDomains } from "thirdweb/utils";
+
+setThirdwebDomains({
+  pay: 'pay.thirdweb-dev.com',
+  rpc: 'rpc.thirdweb-dev.com',
+  inAppWallet: 'embedded-wallet.thirdweb-dev.com',
+});
+
+
 
 export const metadata: Metadata = {
   metadataBase,
@@ -16,7 +25,7 @@ export const metadata: Metadata = {
 };
 
 export default function Page() {
-  return (
+    return (
     <main className="flex-1 content-center relative py-12 md:py-24 lg:py-32 xl:py-48 space-y-12 md:space-y-24">
       <section className="container px-4 md:px-6">
         <div className="grid gap-10 lg:grid-cols-[1fr_400px] lg:gap-12 xl:grid-cols-[1fr_600px]">

--- a/apps/playground-web/src/app/connect/pay/page.tsx
+++ b/apps/playground-web/src/app/connect/pay/page.tsx
@@ -3,19 +3,17 @@ import { metadataBase } from "@/lib/constants";
 import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
+import { setThirdwebDomains } from "thirdweb/utils";
 import { CodeExample } from "../../../components/code/code-example";
 import { BuyMerchPreview } from "../../../components/pay/direct-payment";
 import { StyledPayEmbedPreview } from "../../../components/pay/embed";
 import { PayTransactionButtonPreview } from "../../../components/pay/transaction-button";
-import { setThirdwebDomains } from "thirdweb/utils";
 
 setThirdwebDomains({
-  pay: 'pay.thirdweb-dev.com',
-  rpc: 'rpc.thirdweb-dev.com',
-  inAppWallet: 'embedded-wallet.thirdweb-dev.com',
+  pay: "pay.thirdweb-dev.com",
+  rpc: "rpc.thirdweb-dev.com",
+  inAppWallet: "embedded-wallet.thirdweb-dev.com",
 });
-
-
 
 export const metadata: Metadata = {
   metadataBase,
@@ -25,7 +23,7 @@ export const metadata: Metadata = {
 };
 
 export default function Page() {
-    return (
+  return (
     <main className="flex-1 content-center relative py-12 md:py-24 lg:py-32 xl:py-48 space-y-12 md:space-y-24">
       <section className="container px-4 md:px-6">
         <div className="grid gap-10 lg:grid-cols-[1fr_400px] lg:gap-12 xl:grid-cols-[1fr_600px]">

--- a/apps/playground-web/src/components/pay/direct-payment.tsx
+++ b/apps/playground-web/src/components/pay/direct-payment.tsx
@@ -4,6 +4,15 @@ import { base } from "thirdweb/chains";
 import { PayEmbed, getDefaultToken } from "thirdweb/react";
 import { THIRDWEB_CLIENT } from "../../lib/client";
 import { StyledConnectButton } from "../styled-connect-button";
+import { setThirdwebDomains } from "thirdweb/utils";
+
+setThirdwebDomains({
+  domains: {
+    pay: 'pay.thirdweb-dev.com',
+    rpc: 'rpc.thirdweb-dev.com',
+    inAppWallet: 'embedded-wallet.thirdweb-dev.com',
+  }
+});
 
 export function BuyMerchPreview() {
   return (

--- a/apps/playground-web/src/components/pay/direct-payment.tsx
+++ b/apps/playground-web/src/components/pay/direct-payment.tsx
@@ -7,11 +7,9 @@ import { THIRDWEB_CLIENT } from "../../lib/client";
 import { StyledConnectButton } from "../styled-connect-button";
 
 setThirdwebDomains({
-  domains: {
-    pay: "pay.thirdweb-dev.com",
-    rpc: "rpc.thirdweb-dev.com",
-    inAppWallet: "embedded-wallet.thirdweb-dev.com",
-  },
+  pay: "pay.thirdweb-dev.com",
+  rpc: "rpc.thirdweb-dev.com",
+  inAppWallet: "embedded-wallet.thirdweb-dev.com",
 });
 
 export function BuyMerchPreview() {

--- a/apps/playground-web/src/components/pay/direct-payment.tsx
+++ b/apps/playground-web/src/components/pay/direct-payment.tsx
@@ -2,16 +2,16 @@
 
 import { base } from "thirdweb/chains";
 import { PayEmbed, getDefaultToken } from "thirdweb/react";
+import { setThirdwebDomains } from "thirdweb/utils";
 import { THIRDWEB_CLIENT } from "../../lib/client";
 import { StyledConnectButton } from "../styled-connect-button";
-import { setThirdwebDomains } from "thirdweb/utils";
 
 setThirdwebDomains({
   domains: {
-    pay: 'pay.thirdweb-dev.com',
-    rpc: 'rpc.thirdweb-dev.com',
-    inAppWallet: 'embedded-wallet.thirdweb-dev.com',
-  }
+    pay: "pay.thirdweb-dev.com",
+    rpc: "rpc.thirdweb-dev.com",
+    inAppWallet: "embedded-wallet.thirdweb-dev.com",
+  },
 });
 
 export function BuyMerchPreview() {

--- a/apps/playground-web/src/components/pay/embed.tsx
+++ b/apps/playground-web/src/components/pay/embed.tsx
@@ -4,6 +4,15 @@ import { THIRDWEB_CLIENT } from "@/lib/client";
 import { useTheme } from "next-themes";
 import { PayEmbed } from "thirdweb/react";
 
+import { setThirdwebDomains } from "thirdweb/utils";
+
+setThirdwebDomains({
+  pay: 'pay.thirdweb-dev.com',
+  rpc: 'rpc.thirdweb-dev.com',
+  inAppWallet: 'embedded-wallet.thirdweb-dev.com',
+});
+
+
 export function StyledPayEmbedPreview() {
   const { theme } = useTheme();
 

--- a/apps/playground-web/src/components/pay/embed.tsx
+++ b/apps/playground-web/src/components/pay/embed.tsx
@@ -7,11 +7,10 @@ import { PayEmbed } from "thirdweb/react";
 import { setThirdwebDomains } from "thirdweb/utils";
 
 setThirdwebDomains({
-  pay: 'pay.thirdweb-dev.com',
-  rpc: 'rpc.thirdweb-dev.com',
-  inAppWallet: 'embedded-wallet.thirdweb-dev.com',
+  pay: "pay.thirdweb-dev.com",
+  rpc: "rpc.thirdweb-dev.com",
+  inAppWallet: "embedded-wallet.thirdweb-dev.com",
 });
-
 
 export function StyledPayEmbedPreview() {
   const { theme } = useTheme();

--- a/apps/playground-web/src/components/pay/transaction-button.tsx
+++ b/apps/playground-web/src/components/pay/transaction-button.tsx
@@ -11,14 +11,14 @@ import {
   useActiveAccount,
   useReadContract,
 } from "thirdweb/react";
+import { setThirdwebDomains } from "thirdweb/utils";
 import { THIRDWEB_CLIENT } from "../../lib/client";
 import { StyledConnectButton } from "../styled-connect-button";
-import { setThirdwebDomains } from "thirdweb/utils";
 
 setThirdwebDomains({
-  pay: 'pay.thirdweb-dev.com',
-  rpc: 'rpc.thirdweb-dev.com',
-  inAppWallet: 'embedded-wallet.thirdweb-dev.com',
+  pay: "pay.thirdweb-dev.com",
+  rpc: "rpc.thirdweb-dev.com",
+  inAppWallet: "embedded-wallet.thirdweb-dev.com",
 });
 
 const nftContract = getContract({

--- a/apps/playground-web/src/components/pay/transaction-button.tsx
+++ b/apps/playground-web/src/components/pay/transaction-button.tsx
@@ -13,6 +13,13 @@ import {
 } from "thirdweb/react";
 import { THIRDWEB_CLIENT } from "../../lib/client";
 import { StyledConnectButton } from "../styled-connect-button";
+import { setThirdwebDomains } from "thirdweb/utils";
+
+setThirdwebDomains({
+  pay: 'pay.thirdweb-dev.com',
+  rpc: 'rpc.thirdweb-dev.com',
+  inAppWallet: 'embedded-wallet.thirdweb-dev.com',
+});
 
 const nftContract = getContract({
   address: "0x827c1c3889923015C1FC31BF677D00FbE6F01D52",

--- a/apps/playground-web/src/lib/client.ts
+++ b/apps/playground-web/src/lib/client.ts
@@ -4,6 +4,6 @@ export const THIRDWEB_CLIENT = createThirdwebClient(
   process.env.THIRDWEB_SECRET_KEY
     ? { secretKey: process.env.THIRDWEB_SECRET_KEY }
     : {
-        clientId: process.env.NEXT_PUBLIC_THIRDWEB_CLIENT_ID as string,
+        clientId: process.env.NEXT_PUBLIC_THIRDWEB_CLIENT_ID_DEV as string,
       },
 );


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the client IDs and set thirdweb domains for development environment across multiple components in the playground-web app.

### Detailed summary
- Updated `clientId` in `client.ts`
- Added `setThirdwebDomains` for development environment in `embed.tsx`, `direct-payment.tsx`, `transaction-button.tsx`, and `page.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->