### PR TITLE
[Docs] Feature: Automatically unroll function inputs and outputs

### DIFF
--- a/apps/portal/src/app/references/components/TDoc/fetchDocs/fetchDocBySlug.ts
+++ b/apps/portal/src/app/references/components/TDoc/fetchDocs/fetchDocBySlug.ts
@@ -1,0 +1,12 @@
+import { fetchTypeScriptDoc } from "./fetchTypeScriptDoc";
+import { getSlugToDocMap } from "../utils/slugs";
+
+
+export default async function fetchDocBySlug(slug: string) {
+	const doc = await fetchTypeScriptDoc("v5");
+	const slugToDoc = getSlugToDocMap(doc);
+
+	const selectedDoc = slug && slugToDoc[slug];
+
+  return selectedDoc;
+}

--- a/packages/thirdweb/src/transaction/actions/send-transaction.ts
+++ b/packages/thirdweb/src/transaction/actions/send-transaction.ts
@@ -5,13 +5,22 @@ import type { GaslessOptions } from "./gasless/types.js";
 import { toSerializableTransaction } from "./to-serializable-transaction.js";
 import type { WaitForReceiptOptions } from "./wait-for-tx-receipt.js";
 
-export type SendTransactionOptions = {
+/** Send transaction options */
+export interface SendTransactionOptions {
+  /**
+   * The account to send the transaction with
+   */
   account: Account;
-  // TODO: update this to `Transaction<"prepared">` once the type is available to ensure only prepared transactions are accepted
+  /**
+   * The prepared transaction to send
+   */
   // biome-ignore lint/suspicious/noExplicitAny: library function that accepts any prepared transaction type
   transaction: PreparedTransaction<any>;
+  /**
+   * Gasless options for the transaction, if applicable
+   */
   gasless?: GaslessOptions;
-};
+}
 
 /**
  * Sends a transaction using the provided account.


### PR DESCRIPTION
## Problem solved

Previously we made no attempt to unroll function inputs and outputs in the docs. This made things difficult to quickly scan since every function has a typed input and output object you would have to navigate to.

This PR is a first attempt at basic unrolling functionality of these typed inputs and outputs.

Before:
<img width="929" alt="Screenshot 2024-08-21 at 3 20 24 PM" src="https://github.com/user-attachments/assets/e73eae8b-98b5-40c9-8f63-f17e3a0a63d7">

After:
<img width="933" alt="Screenshot 2024-08-21 at 3 20 49 PM" src="https://github.com/user-attachments/assets/b5d8d847-9c70-45ec-aaf6-95b4215b3418">

As an additional readability bonus, the input and output sections now start as an open accordion.

Note: There are still improvements to be made especially on functions with more complex types. These functions' interfaces should be simplified in future versions.

## Next Steps
Future features should add nested input descriptions (supported by typedoc but not `typedoc-better-json`). Future SDK versions should use simpler, explicitly typed inputs and outputs to simplify the unrolling process (and easier LSP support for users).

## To Test
Open the preview URL, click around to various functions and inspect the parameter and return types

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances TypeScript documentation fetching, refactors transaction options to an interface, and adds detailed type information to function components.

### Detailed summary
- Added `fetchTypeScriptDoc` and `getSlugToDocMap` functions for TypeScript documentation fetching
- Refactored `SendTransactionOptions` to an interface with detailed comments
- Improved type information rendering in function components with `ReturnsTDoc` and `ParameterTDoc` functions

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->