### PR TITLE
[TS SDK] Feature: Enable external redirect authentication for electron support

### DIFF
--- a/.changeset/cool-turkeys-refuse.md
+++ b/.changeset/cool-turkeys-refuse.md
@@ -1,0 +1,16 @@
+---
+"thirdweb": patch
+---
+
+Enable external redirects for electron support
+
+```ts
+import { authenticate } from "thirdweb/wallets/in-app";
+
+const result = await authenticate({
+  client,
+  strategy: "google",
+  redirectUrl: "https://example.org",
+  mode: "window"
+});
+```

--- a/packages/thirdweb/src/react/web/wallets/shared/ConnectWalletSocialOptions.tsx
+++ b/packages/thirdweb/src/react/web/wallets/shared/ConnectWalletSocialOptions.tsx
@@ -181,10 +181,11 @@ export const ConnectWalletSocialOptions = (
   // Need to trigger login on button click to avoid popup from being blocked
   const handleSocialLogin = async (strategy: SocialAuthOption) => {
     const walletConfig = wallet.getConfig();
+    const authMode = walletConfig?.auth?.mode ?? "popup";
     if (
       walletConfig &&
       "auth" in walletConfig &&
-      walletConfig?.auth?.mode === "redirect" &&
+      authMode !== "popup" &&
       !props.isLinking // We do not support redirects for linking
     ) {
       return loginWithOauthRedirect({
@@ -192,7 +193,7 @@ export const ConnectWalletSocialOptions = (
         client: props.client,
         ecosystem: ecosystemInfo,
         redirectUrl: walletConfig?.auth?.redirectUrl,
-        redirectExternally: walletConfig?.auth?.redirectExternally,
+        mode: authMode,
       });
     }
 

--- a/packages/thirdweb/src/react/web/wallets/shared/SocialLogin.tsx
+++ b/packages/thirdweb/src/react/web/wallets/shared/SocialLogin.tsx
@@ -48,10 +48,15 @@ export function SocialLogin(props: {
 
   const handleSocialLogin = async () => {
     const walletConfig = wallet.getConfig();
+    const authMode =
+      walletConfig && "auth" in walletConfig
+        ? walletConfig?.auth?.mode ?? "popup"
+        : "popup";
+
     if (
       walletConfig &&
       "auth" in walletConfig &&
-      walletConfig?.auth?.mode === "redirect" &&
+      authMode !== "popup" &&
       !props.isLinking // Redirect not supported for account linking (we need to maintain the aplication state)
     ) {
       return loginWithOauthRedirect({
@@ -64,7 +69,7 @@ export function SocialLogin(props: {
             }
           : undefined,
         redirectUrl: walletConfig?.auth?.redirectUrl,
-        redirectExternally: walletConfig?.auth?.redirectExternally,
+        mode: walletConfig?.auth?.mode,
       });
     }
 

--- a/packages/thirdweb/src/wallets/ecosystem/types.ts
+++ b/packages/thirdweb/src/wallets/ecosystem/types.ts
@@ -6,9 +6,8 @@ import type {
 export type EcosystemWalletCreationOptions = {
   partnerId?: string;
   auth?: {
-    mode?: "popup" | "redirect";
+    mode?: "popup" | "redirect" | "window";
     redirectUrl?: string;
-    redirectExternally?: boolean;
   };
 };
 

--- a/packages/thirdweb/src/wallets/in-app/core/authentication/getLoginPath.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/authentication/getLoginPath.ts
@@ -25,9 +25,17 @@ export const getLoginUrl = ({
   authOption: AuthOption | "wallet";
   client: ThirdwebClient;
   ecosystem?: Ecosystem;
-  mode?: "popup" | "redirect" | "mobile";
+  mode?: "popup" | "redirect" | "window";
   redirectUrl?: string;
 }) => {
+  if (mode === "popup" && redirectUrl) {
+    throw new Error("Redirect URL is not supported for popup mode");
+  }
+
+  if (mode === "window" && !redirectUrl) {
+    throw new Error("Redirect URL is required for window mode");
+  }
+
   const route = getLoginOptionRoute(authOption);
   let baseUrl = `${getThirdwebBaseUrl("inAppWallet")}/api/2024-05-05/login/${route}?clientId=${client.clientId}`;
   if (ecosystem?.partnerId) {
@@ -36,18 +44,12 @@ export const getLoginUrl = ({
     baseUrl = `${baseUrl}&ecosystemId=${ecosystem.id}`;
   }
 
-  if (mode === "redirect") {
+  // Always append redirectUrl to the baseUrl if mode is not popup
+  if (mode !== "popup") {
     const formattedRedirectUrl = new URL(redirectUrl || window.location.href);
     formattedRedirectUrl.searchParams.set("walletId", ecosystem?.id || "inApp");
     formattedRedirectUrl.searchParams.set("authProvider", authOption);
     baseUrl = `${baseUrl}&redirectUrl=${encodeURIComponent(formattedRedirectUrl.toString())}`;
-  }
-
-  if (mode === "mobile") {
-    if (!redirectUrl) {
-      throw new Error("Redirect URL is required for mobile authentication");
-    }
-    baseUrl = `${baseUrl}&redirectUrl=${encodeURIComponent(redirectUrl)}`;
   }
 
   return baseUrl;

--- a/packages/thirdweb/src/wallets/in-app/core/authentication/types.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/authentication/types.ts
@@ -30,6 +30,7 @@ export type SingleStepAuthArgsType =
       openedWindow?: Window;
       closeOpenedWindow?: (window: Window) => void;
       redirectUrl?: string;
+      mode?: "redirect" | "popup" | "window";
     }
   | { strategy: "jwt"; jwt: string; encryptionKey: string }
   | { strategy: "auth_endpoint"; payload: string; encryptionKey: string }

--- a/packages/thirdweb/src/wallets/in-app/core/interfaces/connector.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/interfaces/connector.ts
@@ -15,7 +15,11 @@ export interface InAppConnector {
   getAccount(): Promise<Account>;
   preAuthenticate(args: PreAuthArgsType): Promise<void>;
   // Authenticate generates an auth token, when redirecting it returns void as the user is redirected to a new page and the token is stored in the callback url
-  authenticateWithRedirect?(strategy: SocialAuthOption): void;
+  authenticateWithRedirect?(
+    strategy: SocialAuthOption,
+    mode?: "redirect" | "popup" | "window",
+    redirectUrl?: string,
+  ): void;
   // Login takes an auth token and connects a user with it
   loginWithAuthToken?(
     authResult: AuthStoredTokenWithCookieReturnType,

--- a/packages/thirdweb/src/wallets/in-app/core/wallet/index.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/wallet/index.ts
@@ -40,12 +40,16 @@ export async function connectInAppWallet(
   connector: InAppConnector,
 ): Promise<[Account, Chain]> {
   if (
-    createOptions?.auth?.mode === "redirect" &&
+    createOptions?.auth?.mode !== "popup" &&
     connector.authenticateWithRedirect
   ) {
     const strategy = options.strategy;
     if (socialAuthOptions.includes(strategy as SocialAuthOption)) {
-      connector.authenticateWithRedirect(strategy as SocialAuthOption);
+      connector.authenticateWithRedirect(
+        strategy as SocialAuthOption,
+        createOptions?.auth?.mode,
+        createOptions?.auth?.redirectUrl,
+      );
     }
   }
   // If we don't have authenticateWithRedirect then it's likely react native, so the default is to redirect and we can carry on

--- a/packages/thirdweb/src/wallets/in-app/core/wallet/types.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/wallet/types.ts
@@ -36,15 +36,11 @@ export type InAppWalletCreationOptions =
         /**
          * Whether to display the social auth prompt in a popup or redirect
          */
-        mode?: "popup" | "redirect";
+        mode?: "popup" | "redirect" | "window";
         /**
          * Optional url to redirect to after authentication
          */
         redirectUrl?: string;
-        /**
-         * Whether to handle the redirect in a new window
-         */
-        redirectExternally?: boolean;
         /**
          * The domain of the passkey to use for authentication
          */

--- a/packages/thirdweb/src/wallets/in-app/native/auth/native-auth.ts
+++ b/packages/thirdweb/src/wallets/in-app/native/auth/native-auth.ts
@@ -59,7 +59,7 @@ export async function authenticate(
   const loginUrl = getLoginUrl({
     authOption: auth.strategy,
     client,
-    mode: "mobile",
+    mode: "window",
     redirectUrl: auth.redirectUrl,
   });
 

--- a/packages/thirdweb/src/wallets/in-app/web/lib/auth/index.ts
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/auth/index.ts
@@ -156,7 +156,12 @@ export async function authenticate(
   >,
 ) {
   const connector = await getInAppWalletConnector(args.client, args.ecosystem);
-  if (args.redirect && connector.authenticateWithRedirect)
-    return connector.authenticateWithRedirect(args.strategy);
+  const isRedirect = args.redirect || args.mode !== "popup";
+  if (isRedirect && connector.authenticateWithRedirect && args.strategy)
+    return connector.authenticateWithRedirect(
+      args.strategy as SocialAuthOption,
+      args.mode,
+      args.redirectUrl,
+    );
   return connector.connect(args);
 }

--- a/packages/thirdweb/src/wallets/in-app/web/lib/auth/oauth.ts
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/auth/oauth.ts
@@ -31,16 +31,16 @@ export const loginWithOauthRedirect = (options: {
   client: ThirdwebClient;
   ecosystem?: Ecosystem;
   redirectUrl?: string;
-  redirectExternally?: boolean;
+  mode?: "redirect" | "popup" | "window";
 }): void => {
   const loginUrl = getLoginUrl({
     ...options,
-    mode: "redirect",
+    mode: options.mode || "redirect",
   });
-  if (options.redirectExternally === true) {
-    window.open(loginUrl);
-  } else {
+  if (options.mode === "redirect") {
     window.location.href = loginUrl;
+  } else {
+    window.open(loginUrl);
   }
 };
 

--- a/packages/thirdweb/src/wallets/in-app/web/lib/web-connector.ts
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/web-connector.ts
@@ -150,11 +150,17 @@ export class InAppWebConnector implements InAppConnector {
     });
   }
 
-  authenticateWithRedirect(strategy: SocialAuthOption): void {
+  authenticateWithRedirect(
+    strategy: SocialAuthOption,
+    mode?: "redirect" | "popup" | "window",
+    redirectUrl?: string,
+  ): void {
     loginWithOauthRedirect({
       authOption: strategy,
       client: this.wallet.client,
       ecosystem: this.wallet.ecosystem,
+      redirectUrl,
+      mode,
     });
   }
 


### PR DESCRIPTION
Adds the ability to pass a `redirectUrl` and `redirectExternally` boolean to `authenticate`. This will allow electron apps to authenticate with in-app wallet social auth.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `window` authentication mode and enables external redirects for electron support.

### Detailed summary
- Added `mode: "window"` to authentication options
- Updated `mode` options to include `"window"`
- Modified authentication methods to support `mode` parameter
- Updated redirect logic based on `mode` parameter

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->