### PR TITLE
fix(inApp): fix passkeyDomain prop not being respected on login web

### DIFF
--- a/.changeset/selfish-adults-jump.md
+++ b/.changeset/selfish-adults-jump.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix passkey domain not being respected on login

--- a/packages/thirdweb/src/wallets/in-app/core/authentication/types.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/authentication/types.ts
@@ -47,14 +47,6 @@ export type SingleStepAuthArgsType =
        * Optional name of the passkey to create, defaults to a generated name
        */
       passkeyName?: string;
-      /**
-       * Optional domain, defaults to current window location.
-       * NOTE: this is required on native platforms.
-       */
-      domain?: {
-        displayName: string;
-        hostname: string;
-      };
     }
   | {
       strategy: "wallet";

--- a/packages/thirdweb/src/wallets/in-app/web/lib/web-connector.ts
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/web-connector.ts
@@ -314,8 +314,8 @@ export class InAppWebConnector implements InAppConnector {
       passkeyClient,
       storage,
       rp: {
-        id: args.domain?.hostname ?? window.location.hostname,
-        name: args.domain?.displayName ?? window.document.title,
+        id: this.passkeyDomain ?? window.location.hostname,
+        name: this.passkeyDomain ?? window.document.title,
       },
     });
   }


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the issue where the passkey domain was not being respected during login in the `thirdweb` package.

### Detailed summary
- Added `passkeyName` property in authentication types
- Removed `domain` property in authentication types
- Updated `web-connector.ts` to use `passkeyDomain` for `rp` object's id and name

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->