### PR TITLE
Buy Fiat Currency selection updates in Pay UI

### DIFF
--- a/.changeset/wicked-lemons-knock.md
+++ b/.changeset/wicked-lemons-knock.md
@@ -1,0 +1,66 @@
+---
+"thirdweb": patch
+---
+
+- Pay UI now selects the fiat currency based on the user's location / timezone
+
+- Add Japanese Yen (JPY) as a supported fiat currency for thirdweb Pay
+
+- Added option to configure the default fiat currency for the Pay UI
+
+Examples
+
+```tsx
+<PayEmbed
+  client={client}
+  payOptions={{
+    buyWithFiat: {
+      prefillSource: {
+        currency: "CAD",
+      },
+    },
+  }}
+/>
+```
+
+```tsx
+<ConnectButton
+  client={client}
+  detailsModal={{
+    payOptions: {
+      buyWithFiat: {
+        prefillSource: {
+          currency: "JPY",
+        },
+      },
+    },
+  }}
+/>
+```
+
+```ts
+const sendTransaction = useSendTransaction({
+  payModal: {
+    buyWithFiat: {
+      prefillSource: {
+        currency: "CAD",
+      },
+    },
+  },
+});
+```
+
+```tsx
+<TransactionButton
+  transaction={() => someTx}
+  payModal={{
+    buyWithFiat: {
+      prefillSource: {
+        currency: "CAD",
+      },
+    },
+  }}
+>
+  some tx
+</TransactionButton>
+```

--- a/packages/thirdweb/src/pay/buyWithFiat/getQuote.ts
+++ b/packages/thirdweb/src/pay/buyWithFiat/getQuote.ts
@@ -38,7 +38,7 @@ export type GetBuyWithFiatQuoteParams = {
   /**
    * Symbol of the fiat currency to buy the token with.
    */
-  fromCurrencySymbol: "USD" | "CAD" | "GBP" | "EUR";
+  fromCurrencySymbol: "USD" | "CAD" | "GBP" | "EUR" | "JPY";
 
   /**
    * The maximum slippage in basis points (bps) allowed for the transaction.

--- a/packages/thirdweb/src/react/core/hooks/connection/ConnectButtonProps.ts
+++ b/packages/thirdweb/src/react/core/hooks/connection/ConnectButtonProps.ts
@@ -82,6 +82,9 @@ export type PayUIOptions = Prettify<
     buyWithFiat?:
       | {
           testMode?: boolean;
+          prefillSource?: {
+            currency?: "USD" | "CAD" | "GBP" | "EUR" | "JPY";
+          };
         }
       | false;
 

--- a/packages/thirdweb/src/react/core/hooks/transaction/useSendTransaction.ts
+++ b/packages/thirdweb/src/react/core/hooks/transaction/useSendTransaction.ts
@@ -49,6 +49,9 @@ export type SendTransactionPayModalConfig =
       buyWithFiat?:
         | false
         | {
+            prefillSource?: {
+              currency?: "USD" | "CAD" | "GBP" | "EUR" | "JPY";
+            };
             testMode?: boolean;
           };
       purchaseData?: object;

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/icons/currencies/JPYIcon.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/icons/currencies/JPYIcon.tsx
@@ -1,0 +1,21 @@
+import type { IconFC } from "../types.js";
+
+export const JPYIcon: IconFC = (props) => {
+  return (
+    <svg
+      width={props.size}
+      height={props.size}
+      viewBox="0 0 32 32"
+      xmlns="http://www.w3.org/2000/svg"
+      role="presentation"
+    >
+      <g fill="none" fill-rule="evenodd">
+        <circle cx="16" cy="16" fill="#a81b1b" r="16" />
+        <path
+          d="M17.548 18.711v1.878h5.063v2.288h-5.063V25.5h-3.096v-2.623H9.389v-2.288h5.063v-1.878H9.389v-2.288h4.171L7.5 7.5h3.752l4.8 7.534L20.853 7.5H24.5l-6.086 8.923h4.197v2.288z"
+          fill="#ffffff"
+        />
+      </g>
+    </svg>
+  );
+};

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/fiat/currencies.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/fiat/currencies.tsx
@@ -2,23 +2,24 @@ import { RadiobuttonIcon } from "@radix-ui/react-icons";
 import { CADIcon } from "../../../icons/currencies/CADIcon.js";
 import { EURIcon } from "../../../icons/currencies/EURIcon.js";
 import { GBPIcon } from "../../../icons/currencies/GBPIcon.js";
+import { JPYIcon } from "../../../icons/currencies/JPYIcon.js";
 import { USDIcon } from "../../../icons/currencies/USDIcon.js";
 import type { IconFC } from "../../../icons/types.js";
 
 export type CurrencyMeta = {
-  shorthand: "USD" | "CAD" | "GBP" | "EUR";
+  shorthand: "USD" | "CAD" | "GBP" | "EUR" | "JPY";
   name: string;
   icon: IconFC;
 };
 
-export const defaultSelectedCurrency: CurrencyMeta = {
+export const usdCurrency: CurrencyMeta = {
   shorthand: "USD",
   name: "US Dollar",
   icon: USDIcon,
 };
 
 export const currencies: CurrencyMeta[] = [
-  defaultSelectedCurrency,
+  usdCurrency,
   {
     shorthand: "CAD",
     name: "Canadian Dollar",
@@ -33,6 +34,11 @@ export const currencies: CurrencyMeta[] = [
     shorthand: "EUR",
     name: "Euro",
     icon: EURIcon,
+  },
+  {
+    shorthand: "JPY",
+    name: "Japanese Yen",
+    icon: JPYIcon,
   },
 ];
 


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces support for Japanese Yen (JPY) as a fiat currency option in the Pay UI. 

### Detailed summary
- Added prefillSource option with JPY currency support in ConnectButtonProps and useSendTransaction
- Added JPYIcon component for JPY currency visualization
- Updated getQuote to include JPY in supported fiat currencies
- Updated currency selection screens to include JPY
- Added examples and configuration options for JPY currency selection

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->