### PR TITLE
Remove Coming Soon on Pay webhooks dashboard event type

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/dashboard/connect/pay/components/webhooks.client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/dashboard/connect/pay/components/webhooks.client.tsx
@@ -1,6 +1,5 @@
 import { CopyTextButton } from "@/components/ui/CopyTextButton";
 import { Spinner } from "@/components/ui/Spinner/Spinner";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -247,9 +246,7 @@ function CreateWebhookButton(props: PropsWithChildren<WebhooksPageProps>) {
 
             {/* Note: this is a "fake" form field since there is nothing to select yet */}
             <FormItem>
-              <FormLabel>
-                Event Type <Badge variant="outline">Coming Soon</Badge>
-              </FormLabel>
+              <FormLabel>Event Type</FormLabel>
               <Select disabled defaultValue="purchase_complete">
                 <SelectTrigger className="w-full">
                   <SelectValue placeholder="Purchase Complete" />


### PR DESCRIPTION
## Problem solved

Removes "Coming Soon" badge - confusing UI

<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes the `Badge` component from the `CreateWebhookButton` in the `webhooks.client.tsx` file and simplifies the form field for the "Event Type".

### Detailed summary
- Removed the `Badge` component and simplified the form field for "Event Type" in `CreateWebhookButton` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->