### PR TITLE
[Refactor] Update useQuery implementation across multiple hooks

### DIFF
--- a/apps/dashboard/src/@3rdweb-sdk/react/hooks/useApi.ts
+++ b/apps/dashboard/src/@3rdweb-sdk/react/hooks/useApi.ts
@@ -270,9 +270,9 @@ interface UseAccountInput {
 export function useAccount({ refetchInterval }: UseAccountInput = {}) {
   const { user, isLoggedIn } = useLoggedInUser();
 
-  return useQuery(
-    accountKeys.me(user?.address as string),
-    async () => {
+  return useQuery({
+    queryKey: accountKeys.me(user?.address as string),
+    queryFn: async () => {
       const res = await fetch(`${THIRDWEB_API_HOST}/v1/account/me`, {
         method: "GET",
         headers: {
@@ -287,19 +287,17 @@ export function useAccount({ refetchInterval }: UseAccountInput = {}) {
 
       return json.data as Account;
     },
-    {
-      enabled: !!user?.address && isLoggedIn,
-      refetchInterval: refetchInterval ?? false,
-    },
-  );
+    enabled: !!user?.address && isLoggedIn,
+    refetchInterval: refetchInterval ?? false,
+  });
 }
 
 export function useAccountUsage() {
   const { user, isLoggedIn } = useLoggedInUser();
 
-  return useQuery(
-    accountKeys.usage(user?.address as string),
-    async () => {
+  return useQuery({
+    queryKey: accountKeys.usage(user?.address as string),
+    queryFn: async () => {
       const res = await fetch(`${THIRDWEB_API_HOST}/v1/account/usage`, {
         method: "GET",
         headers: {
@@ -314,16 +312,16 @@ export function useAccountUsage() {
 
       return json.data as UsageBillableByService;
     },
-    { enabled: !!user?.address && isLoggedIn },
-  );
+    enabled: !!user?.address && isLoggedIn,
+  });
 }
 
 export function useAccountCredits() {
   const { user, isLoggedIn } = useLoggedInUser();
 
-  return useQuery(
-    accountKeys.credits(user?.address as string),
-    async () => {
+  return useQuery({
+    queryKey: accountKeys.credits(user?.address as string),
+    queryFn: async () => {
       const res = await fetch(`${THIRDWEB_API_HOST}/v1/account/credits`, {
         method: "GET",
 
@@ -346,16 +344,19 @@ export function useAccountCredits() {
 
       return credits;
     },
-    { enabled: !!user?.address && isLoggedIn },
-  );
+    enabled: !!user?.address && isLoggedIn,
+  });
 }
 
 export function useWalletStats(clientId: string | undefined) {
   const { user, isLoggedIn } = useLoggedInUser();
 
-  return useQuery(
-    accountKeys.walletStats(user?.address as string, clientId as string),
-    async () => {
+  return useQuery({
+    queryKey: accountKeys.walletStats(
+      user?.address as string,
+      clientId as string,
+    ),
+    queryFn: async () => {
       const res = await fetch(
         `${THIRDWEB_API_HOST}/v1/account/wallets?clientId=${clientId}`,
         {
@@ -374,8 +375,8 @@ export function useWalletStats(clientId: string | undefined) {
 
       return json.data as WalletStats;
     },
-    { enabled: !!clientId && !!user?.address && isLoggedIn },
-  );
+    enabled: !!clientId && !!user?.address && isLoggedIn,
+  });
 }
 
 export function useUpdateAccount() {
@@ -494,9 +495,9 @@ export function useUpdateNotifications() {
 export function useCreateBillingSession(enabled = false) {
   const { user } = useLoggedInUser();
 
-  return useQuery(
-    accountKeys.billingSession(user?.address as string),
-    async () => {
+  return useQuery({
+    queryKey: accountKeys.billingSession(user?.address as string),
+    queryFn: async () => {
       invariant(user?.address, "walletAddress is required");
 
       const res = await fetch(
@@ -517,8 +518,8 @@ export function useCreateBillingSession(enabled = false) {
 
       return json.data;
     },
-    { enabled },
-  );
+    enabled,
+  });
 }
 
 export function useConfirmEmail() {
@@ -636,9 +637,9 @@ export function useCreatePaymentMethod() {
 
 export function useApiKeys() {
   const { user, isLoggedIn } = useLoggedInUser();
-  return useQuery(
-    apiKeys.keys(user?.address as string),
-    async () => {
+  return useQuery({
+    queryKey: apiKeys.keys(user?.address as string),
+    queryFn: async () => {
       const res = await fetch(`${THIRDWEB_API_HOST}/v1/keys`, {
         method: "GET",
 
@@ -653,8 +654,8 @@ export function useApiKeys() {
       }
       return json.data as ApiKey[];
     },
-    { enabled: !!user?.address && isLoggedIn },
-  );
+    enabled: !!user?.address && isLoggedIn,
+  });
 }
 
 export function useCreateApiKey() {
@@ -884,9 +885,9 @@ export function useRevokeAuthorizedWallet() {
 export function useAuthorizedWallets() {
   const { user, isLoggedIn } = useLoggedInUser();
 
-  return useQuery(
-    authorizedWallets.authorizedWallets(user?.address as string),
-    async () => {
+  return useQuery({
+    queryKey: authorizedWallets.authorizedWallets(user?.address as string),
+    queryFn: async () => {
       const res = await fetch(`${THIRDWEB_API_HOST}/v1/authorized-wallets`, {
         method: "GET",
 
@@ -902,8 +903,9 @@ export function useAuthorizedWallets() {
 
       return json.data as AuthorizedWallet[];
     },
-    { enabled: !!user?.address && isLoggedIn, cacheTime: 0 },
-  );
+    enabled: !!user?.address && isLoggedIn,
+    cacheTime: 0,
+  });
 }
 
 /**

--- a/apps/dashboard/src/@3rdweb-sdk/react/hooks/useDashboardContractMetadata.tsx
+++ b/apps/dashboard/src/@3rdweb-sdk/react/hooks/useDashboardContractMetadata.tsx
@@ -12,9 +12,9 @@ import { getContractMetadata, name, symbol } from "thirdweb/extensions/common";
  * 2. our API endpoint
  */
 export function useDashboardContractMetadata(contract: ThirdwebContract) {
-  return useQuery(
-    ["contract-metadata-header", contract.chain.id, contract.address],
-    async () => {
+  return useQuery({
+    queryKey: ["contract-metadata-header", contract.chain.id, contract.address],
+    queryFn: async () => {
       const [contractMetadata, _name, _symbol, compilerMetadata] =
         await Promise.all([
           getContractMetadata({ contract }).catch(() => ({
@@ -50,5 +50,5 @@ export function useDashboardContractMetadata(contract: ThirdwebContract) {
         contractType: compilerMetadata?.name || "",
       };
     },
-  );
+  });
 }

--- a/apps/dashboard/src/@3rdweb-sdk/react/hooks/useEmbeddedWallets.ts
+++ b/apps/dashboard/src/@3rdweb-sdk/react/hooks/useEmbeddedWallets.ts
@@ -25,12 +25,12 @@ export type EmbeddedWalletUser = {
 export function useEmbeddedWallets(clientId: string) {
   const { user, isLoggedIn } = useLoggedInUser();
 
-  return useQuery(
-    embeddedWalletsKeys.embeddedWallets(
+  return useQuery({
+    queryKey: embeddedWalletsKeys.embeddedWallets(
       user?.address as string,
       clientId as string,
     ),
-    async () => {
+    queryFn: async () => {
       const res = await fetch(
         `${THIRDWEB_EWS_API_HOST}/api/thirdweb/embedded-wallet?clientId=${clientId}&lastAccessedAt=0`,
         {
@@ -46,6 +46,6 @@ export function useEmbeddedWallets(clientId: string) {
 
       return json.walletUsers as EmbeddedWalletUser[];
     },
-    { enabled: !!user?.address && isLoggedIn && !!clientId },
-  );
+    enabled: !!user?.address && isLoggedIn && !!clientId,
+  });
 }

--- a/apps/dashboard/src/@3rdweb-sdk/react/hooks/useEngine.ts
+++ b/apps/dashboard/src/@3rdweb-sdk/react/hooks/useEngine.ts
@@ -55,9 +55,9 @@ const getEngineRequestHeaders = (token: string | null): HeadersInit => {
 export function useEngineInstances() {
   const { user, isLoggedIn } = useLoggedInUser();
 
-  return useQuery(
-    engineKeys.instances(user?.address as string),
-    async (): Promise<EngineInstance[]> => {
+  return useQuery({
+    queryKey: engineKeys.instances(user?.address as string),
+    queryFn: async (): Promise<EngineInstance[]> => {
       const res = await fetch(`${THIRDWEB_API_HOST}/v1/engine`, {
         method: "GET",
       });
@@ -79,8 +79,8 @@ export function useEngineInstances() {
         };
       });
     },
-    { enabled: !!user?.address && isLoggedIn },
-  );
+    enabled: !!user?.address && isLoggedIn,
+  });
 }
 
 // GET Requests
@@ -100,9 +100,9 @@ export type BackendWallet = {
 export function useEngineBackendWallets(instance: string) {
   const token = useLoggedInUser().user?.jwt ?? null;
 
-  return useQuery(
-    [engineKeys.backendWallets(instance)],
-    async () => {
+  return useQuery({
+    queryKey: [engineKeys.backendWallets(instance)],
+    queryFn: async () => {
       const res = await fetch(`${instance}backend-wallet/get-all?limit=50`, {
         method: "GET",
         headers: getEngineRequestHeaders(token),
@@ -112,8 +112,8 @@ export function useEngineBackendWallets(instance: string) {
 
       return (json.result as BackendWallet[]) || [];
     },
-    { enabled: !!instance && !!token },
-  );
+    enabled: !!instance && !!token,
+  });
 }
 
 export interface EngineSystemHealth {
@@ -382,9 +382,9 @@ type TransactionResponse = {
 export function useEngineTransactions(instance: string, autoUpdate: boolean) {
   const token = useLoggedInUser().user?.jwt ?? null;
 
-  return useQuery(
-    engineKeys.transactions(instance),
-    async () => {
+  return useQuery({
+    queryKey: engineKeys.transactions(instance),
+    queryFn: async () => {
       const res = await fetch(`${instance}transaction/get-all`, {
         method: "GET",
         headers: getEngineRequestHeaders(token),
@@ -394,11 +394,10 @@ export function useEngineTransactions(instance: string, autoUpdate: boolean) {
 
       return (json.result as TransactionResponse) || {};
     },
-    {
-      enabled: !!instance && !!token,
-      refetchInterval: autoUpdate ? 4_000 : false,
-    },
-  );
+
+    enabled: !!instance && !!token,
+    refetchInterval: autoUpdate ? 4_000 : false,
+  });
 }
 
 type WalletConfig =
@@ -423,9 +422,9 @@ type WalletConfig =
 export function useEngineWalletConfig(instance: string) {
   const token = useLoggedInUser().user?.jwt ?? null;
 
-  return useQuery(
-    engineKeys.walletConfig(instance),
-    async () => {
+  return useQuery({
+    queryKey: engineKeys.walletConfig(instance),
+    queryFn: async () => {
       const res = await fetch(`${instance}configuration/wallets`, {
         method: "GET",
         headers: getEngineRequestHeaders(token),
@@ -435,8 +434,8 @@ export function useEngineWalletConfig(instance: string) {
 
       return (json.result as WalletConfig) || {};
     },
-    { enabled: !!instance && !!token },
-  );
+    enabled: !!instance && !!token,
+  });
 }
 
 type CurrencyValue = {
@@ -456,9 +455,9 @@ export function useEngineBackendWalletBalance(
 
   invariant(chainId, "chainId is required");
 
-  return useQuery(
-    engineKeys.backendWalletBalance(address, chainId),
-    async () => {
+  return useQuery({
+    queryKey: engineKeys.backendWalletBalance(address, chainId),
+    queryFn: async () => {
       const res = await fetch(
         `${instance}backend-wallet/${chainId}/${address}/get-balance`,
         {
@@ -471,8 +470,8 @@ export function useEngineBackendWalletBalance(
 
       return (json.result as CurrencyValue) || {};
     },
-    { enabled: !!instance && !!address && !!chainId && !!token },
-  );
+    enabled: !!instance && !!address && !!chainId && !!token,
+  });
 }
 
 export type EngineAdmin = {
@@ -485,9 +484,9 @@ export function useEnginePermissions(instance: string) {
   const token = useLoggedInUser().user?.jwt ?? null;
   const address = useActiveAccount()?.address;
 
-  return useQuery(
-    engineKeys.permissions(instance),
-    async () => {
+  return useQuery({
+    queryKey: engineKeys.permissions(instance),
+    queryFn: async () => {
       const res = await fetch(`${instance}auth/permissions/get-all`, {
         method: "GET",
         headers: getEngineRequestHeaders(token),
@@ -501,10 +500,9 @@ export function useEnginePermissions(instance: string) {
 
       return (json.result as EngineAdmin[]) || [];
     },
-    {
-      enabled: !!instance && !!token && !!address,
-    },
-  );
+
+    enabled: !!instance && !!token && !!address,
+  });
 }
 
 export type AccessToken = {
@@ -519,9 +517,9 @@ export type AccessToken = {
 export function useEngineAccessTokens(instance: string) {
   const token = useLoggedInUser().user?.jwt ?? null;
 
-  return useQuery(
-    engineKeys.accessTokens(instance),
-    async () => {
+  return useQuery({
+    queryKey: engineKeys.accessTokens(instance),
+    queryFn: async () => {
       const res = await fetch(`${instance}auth/access-tokens/get-all`, {
         method: "GET",
         headers: getEngineRequestHeaders(token),
@@ -531,8 +529,8 @@ export function useEngineAccessTokens(instance: string) {
 
       return (json.result as AccessToken[]) || [];
     },
-    { enabled: !!instance && !!token },
-  );
+    enabled: !!instance && !!token,
+  });
 }
 
 export type KeypairAlgorithm = "ES256" | "RS256" | "PS256";
@@ -549,9 +547,9 @@ export type Keypair = {
 export function useEngineKeypairs(instance: string) {
   const token = useLoggedInUser().user?.jwt ?? null;
 
-  return useQuery(
-    engineKeys.keypairs(instance),
-    async () => {
+  return useQuery({
+    queryKey: engineKeys.keypairs(instance),
+    queryFn: async () => {
       const res = await fetch(`${instance}auth/keypair/get-all`, {
         method: "GET",
         headers: getEngineRequestHeaders(token),
@@ -561,8 +559,8 @@ export function useEngineKeypairs(instance: string) {
 
       return (json.result as Keypair[]) || [];
     },
-    { enabled: !!instance && !!token },
-  );
+    enabled: !!instance && !!token,
+  });
 }
 
 type AddKeypairInput = {
@@ -645,9 +643,9 @@ export type EngineRelayer = {
 export function useEngineRelayer(instance: string) {
   const token = useLoggedInUser().user?.jwt ?? null;
 
-  return useQuery(
-    engineKeys.relayers(instance),
-    async () => {
+  return useQuery({
+    queryKey: engineKeys.relayers(instance),
+    queryFn: async () => {
       const res = await fetch(`${instance}relayer/get-all`, {
         method: "GET",
         headers: getEngineRequestHeaders(token),
@@ -657,8 +655,8 @@ export function useEngineRelayer(instance: string) {
 
       return (json.result as EngineRelayer[]) || [];
     },
-    { enabled: !!instance && !!token },
-  );
+    enabled: !!instance && !!token,
+  });
 }
 
 export type CreateRelayerInput = {
@@ -782,9 +780,9 @@ export interface EngineWebhook {
 export function useEngineWebhooks(instance: string) {
   const token = useLoggedInUser().user?.jwt ?? null;
 
-  return useQuery(
-    engineKeys.webhooks(instance),
-    async () => {
+  return useQuery({
+    queryKey: engineKeys.webhooks(instance),
+    queryFn: async () => {
       const res = await fetch(`${instance}webhooks/get-all`, {
         method: "GET",
         headers: getEngineRequestHeaders(token),
@@ -794,8 +792,8 @@ export function useEngineWebhooks(instance: string) {
 
       return (json.result as EngineWebhook[]) || [];
     },
-    { enabled: !!instance && !!token },
-  );
+    enabled: !!instance && !!token,
+  });
 }
 
 // POST REQUESTS
@@ -1241,9 +1239,9 @@ export function useEngineSendTokens(instance: string) {
 export function useEngineCorsConfiguration(instance: string) {
   const token = useLoggedInUser().user?.jwt ?? null;
 
-  return useQuery(
-    engineKeys.corsUrls(instance),
-    async () => {
+  return useQuery({
+    queryKey: engineKeys.corsUrls(instance),
+    queryFn: async () => {
       const res = await fetch(`${instance}configuration/cors`, {
         method: "GET",
         headers: getEngineRequestHeaders(token),
@@ -1253,8 +1251,8 @@ export function useEngineCorsConfiguration(instance: string) {
 
       return (json.result as string[]) || [];
     },
-    { enabled: !!instance && !!token },
-  );
+    enabled: !!instance && !!token,
+  });
 }
 
 interface SetCorsUrlInput {
@@ -1297,9 +1295,9 @@ export function useEngineIpAllowlistConfiguration(instance: string) {
   // if engine instance is not updated to have IP_ALLOWLIST
   const { data: health } = useEngineSystemHealth(instance);
 
-  return useQuery(
-    engineKeys.ipAllowlist(instance),
-    async () => {
+  return useQuery({
+    queryKey: engineKeys.ipAllowlist(instance),
+    queryFn: async () => {
       const res = await fetch(`${instance}configuration/ip-allowlist`, {
         method: "GET",
         headers: getEngineRequestHeaders(token),
@@ -1308,11 +1306,10 @@ export function useEngineIpAllowlistConfiguration(instance: string) {
       const json = await res.json();
       return (json.result as string[]) || [];
     },
-    {
-      enabled:
-        !!instance && !!token && health?.features?.includes("IP_ALLOWLIST"),
-    },
-  );
+
+    enabled:
+      !!instance && !!token && health?.features?.includes("IP_ALLOWLIST"),
+  });
 }
 
 interface SetIpAllowlistInput {
@@ -1365,9 +1362,9 @@ export interface EngineContractSubscription {
 
 export function useEngineContractSubscription(instance: string) {
   const token = useLoggedInUser().user?.jwt ?? null;
-  return useQuery(
-    engineKeys.contractSubscriptions(instance),
-    async () => {
+  return useQuery({
+    queryKey: engineKeys.contractSubscriptions(instance),
+    queryFn: async () => {
       const res = await fetch(`${instance}contract-subscriptions/get-all`, {
         method: "GET",
         headers: getEngineRequestHeaders(token),
@@ -1376,10 +1373,9 @@ export function useEngineContractSubscription(instance: string) {
       const json = await res.json();
       return json.result as EngineContractSubscription[];
     },
-    {
-      enabled: !!instance && !!token,
-    },
-  );
+
+    enabled: !!instance && !!token,
+  });
 }
 
 export interface AddContractSubscriptionInput {
@@ -1465,9 +1461,9 @@ export function useEngineSubscriptionsLastBlock(
 ) {
   const token = useLoggedInUser().user?.jwt ?? null;
 
-  return useQuery(
-    engineKeys.contractSubscriptionsLastBlock(instanceUrl, chainId),
-    async () => {
+  return useQuery({
+    queryKey: engineKeys.contractSubscriptionsLastBlock(instanceUrl, chainId),
+    queryFn: async () => {
       const response = await fetch(
         `${instanceUrl}contract-subscriptions/last-block?chain=${chainId}`,
         {
@@ -1479,11 +1475,10 @@ export function useEngineSubscriptionsLastBlock(
       const json = await response.json();
       return json.result.lastBlock as number;
     },
-    {
-      enabled: !!instanceUrl && !!token,
-      refetchInterval: autoUpdate ? 5_000 : false,
-    },
-  );
+
+    enabled: !!instanceUrl && !!token,
+    refetchInterval: autoUpdate ? 5_000 : false,
+  });
 }
 
 export interface EngineResourceMetrics {
@@ -1500,9 +1495,9 @@ export interface EngineResourceMetrics {
 export function useEngineSystemMetrics(engineId: string) {
   const [enabled, setEnabled] = useState(true);
 
-  return useQuery(
-    engineKeys.systemMetrics(engineId),
-    async () => {
+  return useQuery({
+    queryKey: engineKeys.systemMetrics(engineId),
+    queryFn: async () => {
       const res = await fetch(
         `${THIRDWEB_API_HOST}/v1/engine/${engineId}/metrics`,
       );
@@ -1513,10 +1508,9 @@ export function useEngineSystemMetrics(engineId: string) {
       const json = (await res.json()) as EngineResourceMetrics;
       return json;
     },
-    {
-      // Poll every 5s unless disabled.
-      enabled,
-      refetchInterval: 5_000,
-    },
-  );
+
+    // Poll every 5s unless disabled.
+    enabled,
+    refetchInterval: 5_000,
+  });
 }

--- a/apps/dashboard/src/@3rdweb-sdk/react/hooks/useRegistry.ts
+++ b/apps/dashboard/src/@3rdweb-sdk/react/hooks/useRegistry.ts
@@ -16,9 +16,9 @@ import { useActiveAccount } from "thirdweb/react";
 import invariant from "tiny-invariant";
 
 function useMultiChainRegContractList(walletAddress?: string) {
-  return useQuery(
-    ["dashboard-registry", walletAddress, "multichain-contract-list"],
-    async () => {
+  return useQuery({
+    queryKey: ["dashboard-registry", walletAddress, "multichain-contract-list"],
+    queryFn: async () => {
       invariant(walletAddress, "walletAddress is required");
       const contracts = await getAllMultichainRegistry({
         contract: MULTICHAIN_REGISTRY_CONTRACT,
@@ -27,10 +27,9 @@ function useMultiChainRegContractList(walletAddress?: string) {
 
       return contracts;
     },
-    {
-      enabled: !!walletAddress,
-    },
-  );
+
+    enabled: !!walletAddress,
+  });
 }
 
 interface Options {

--- a/apps/dashboard/src/components/contract-components/hooks.ts
+++ b/apps/dashboard/src/components/contract-components/hooks.ts
@@ -232,9 +232,9 @@ export function useDefaultForwarders() {
 export function useContractPrePublishMetadata(uri: string, address?: string) {
   const contractIdIpfsHash = toContractIdIpfsHash(uri);
 
-  return useQuery(
-    ["pre-publish-metadata", uri, address],
-    async () => {
+  return useQuery({
+    queryKey: ["pre-publish-metadata", uri, address],
+    queryFn: async () => {
       invariant(address, "address is not defined");
       // TODO: Make this nicer.
       invariant(uri !== "ipfs://undefined", "uri can't be undefined");
@@ -246,10 +246,9 @@ export function useContractPrePublishMetadata(uri: string, address?: string) {
         ?.getPublisher()
         .fetchPrePublishMetadata(contractIdIpfsHash, address);
     },
-    {
-      enabled: !!uri && !!address,
-    },
-  );
+
+    enabled: !!uri && !!address,
+  });
 }
 
 async function fetchFullPublishMetadata(
@@ -281,9 +280,9 @@ export function useContractFullPublishMetadata(uri: string) {
   );
   const queryClient = useQueryClient();
 
-  return useQuery(
-    ["full-publish-metadata", uri],
-    async () => {
+  return useQuery({
+    queryKey: ["full-publish-metadata", uri],
+    queryFn: async () => {
       invariant(sdk, "sdk is not defined");
       // TODO: Make this nicer.
       invariant(uri !== "ipfs://undefined", "uri can't be undefined");
@@ -293,10 +292,9 @@ export function useContractFullPublishMetadata(uri: string) {
         queryClient,
       );
     },
-    {
-      enabled: !!uri && !!sdk,
-    },
-  );
+
+    enabled: !!uri && !!sdk,
+  });
 }
 
 async function fetchPublisherProfile(publisherAddress?: string | null) {
@@ -380,13 +378,12 @@ export function useAllVersions(
     polygon.id,
     getDashboardChainRpc(polygon.id, undefined),
   );
-  return useQuery(
-    ["all-releases", publisherAddress, contractName],
-    () => fetchAllVersions(sdk, publisherAddress, contractName),
-    {
-      enabled: !!publisherAddress && !!contractName && !!sdk,
-    },
-  );
+  return useQuery({
+    queryKey: ["all-releases", publisherAddress, contractName],
+    queryFn: () => fetchAllVersions(sdk, publisherAddress, contractName),
+
+    enabled: !!publisherAddress && !!contractName && !!sdk,
+  });
 }
 
 export function usePublishedContractsFromDeploy(
@@ -397,12 +394,12 @@ export function usePublishedContractsFromDeploy(
   const cId = chainId || activeChainId;
   const chainInfo = useSupportedChain(cId || -1);
 
-  return useQuery(
-    (networkKeys.chain(cId) as readonly unknown[]).concat([
+  return useQuery({
+    queryKey: (networkKeys.chain(cId) as readonly unknown[]).concat([
       "release-from-deploy",
       contractAddress,
     ]),
-    async () => {
+    queryFn: async () => {
       invariant(contractAddress, "contractAddress is not defined");
       invariant(cId, "chain not defined");
 
@@ -426,11 +423,10 @@ export function usePublishedContractsFromDeploy(
         .getPublisher()
         .resolvePublishMetadataFromCompilerMetadata(contractUri);
     },
-    {
-      enabled: !!contractAddress && !!cId && !!chainInfo,
-      retry: false,
-    },
-  );
+
+    enabled: !!contractAddress && !!cId && !!chainInfo,
+    retry: false,
+  });
 }
 
 export async function fetchPublishedContractInfo(
@@ -447,13 +443,12 @@ export function usePublishedContractInfo(contract: PublishedContract) {
     polygon.id,
     getDashboardChainRpc(polygon.id, undefined),
   );
-  return useQuery(
-    ["released-contract", contract],
-    () => fetchPublishedContractInfo(sdk, contract),
-    {
-      enabled: !!contract,
-    },
-  );
+  return useQuery({
+    queryKey: ["released-contract", contract],
+    queryFn: () => fetchPublishedContractInfo(sdk, contract),
+
+    enabled: !!contract,
+  });
 }
 export function usePublishedContractFunctions(contract: PublishedContract) {
   const publishedContractInfo = usePublishedContractInfo(contract);
@@ -957,9 +952,9 @@ export function useTransactionsForDeploy(publishMetadataOrUri: string) {
   const sdk = useSDK();
   const chainId = useActiveWalletChain()?.id;
 
-  const queryResult = useQuery<DeploymentTransaction[]>(
-    ["transactions-for-deploy", publishMetadataOrUri, chainId],
-    async () => {
+  const queryResult = useQuery<DeploymentTransaction[]>({
+    queryKey: ["transactions-for-deploy", publishMetadataOrUri, chainId],
+    queryFn: async () => {
       invariant(sdk, "sdk not provided");
 
       // Handle separately for ZkSync
@@ -973,10 +968,9 @@ export function useTransactionsForDeploy(publishMetadataOrUri: string) {
           : `ipfs://${publishMetadataOrUri}`,
       );
     },
-    {
-      enabled: !!publishMetadataOrUri && !!sdk,
-    },
-  );
+
+    enabled: !!publishMetadataOrUri && !!sdk,
+  });
 
   return queryResult;
 }
@@ -1046,18 +1040,16 @@ export function usePublishedContractsQuery(
     getDashboardChainRpc(polygon.id, undefined),
   );
   const queryClient = useQueryClient();
-  return useQuery<PublishedContractDetails[]>(
-    ["published-contracts", address, feature],
-    () => {
+  return useQuery<PublishedContractDetails[]>({
+    queryKey: ["published-contracts", address, feature],
+    queryFn: () => {
       invariant(sdk, "sdk not provided");
       return feature && feature.length > 0
         ? fetchPublishedContractsWithFeature(sdk, queryClient, feature, address)
         : fetchPublishedContracts(sdk, queryClient, address);
     },
-    {
-      enabled: !!address && !!sdk,
-    },
-  );
+    enabled: !!address && !!sdk,
+  });
 }
 
 const ALWAYS_SUGGESTED = ["ContractMetadata", "Permissions"];
@@ -1187,14 +1179,13 @@ export function useContractEvents(abi: Abi) {
 
 export function useCustomFactoryAbi(contractAddress: string, chainId: number) {
   const chain = useSupportedChain(chainId);
-  return useQuery(
-    ["custom-factory-abi", { contractAddress, chainId }],
-    async () => {
+  return useQuery({
+    queryKey: ["custom-factory-abi", { contractAddress, chainId }],
+    queryFn: async () => {
       const sdk = getThirdwebSDK(chainId, getDashboardChainRpc(chainId, chain));
       return (await sdk.getContract(contractAddress)).abi;
     },
-    {
-      enabled: !!contractAddress && !!chainId,
-    },
-  );
+
+    enabled: !!contractAddress && !!chainId,
+  });
 }

--- a/apps/dashboard/src/components/contract-components/published-contract/index.tsx
+++ b/apps/dashboard/src/components/contract-components/published-contract/index.tsx
@@ -179,9 +179,9 @@ Deploy it in one click`,
     return url.href;
   }, [publishedContractName, currentRoute]);
 
-  const sources = useQuery(
-    ["sources", contract],
-    async () => {
+  const sources = useQuery({
+    queryKey: ["sources", contract],
+    queryFn: async () => {
       invariant(
         contractPublishMetadata.data?.compilerMetadata?.sources,
         "no compilerMetadata sources available",
@@ -205,8 +205,8 @@ Deploy it in one click`,
         .slice()
         .reverse();
     },
-    { enabled: !!contractPublishMetadata.data?.compilerMetadata?.sources },
-  );
+    enabled: !!contractPublishMetadata.data?.compilerMetadata?.sources,
+  });
 
   const title = useMemo(() => {
     let clearType = "";

--- a/apps/dashboard/src/components/pay/PayAnalytics/hooks/usePayNewCustomers.ts
+++ b/apps/dashboard/src/components/pay/PayAnalytics/hooks/usePayNewCustomers.ts
@@ -31,9 +31,9 @@ export function usePayNewCustomers(options: {
 }) {
   const { user } = useLoggedInUser();
 
-  return useQuery(
-    ["usePayNewCustomers", user?.address, options],
-    async () => {
+  return useQuery({
+    queryKey: ["usePayNewCustomers", user?.address, options],
+    queryFn: async () => {
       const searchParams = new URLSearchParams();
       searchParams.append("intervalType", options.intervalType);
       searchParams.append("clientId", options.clientId);
@@ -58,6 +58,6 @@ export function usePayNewCustomers(options: {
 
       return resJSON.result.data;
     },
-    { enabled: !!user?.jwt },
-  );
+    enabled: !!user?.jwt,
+  });
 }

--- a/apps/dashboard/src/components/pay/PayAnalytics/hooks/usePayVolume.ts
+++ b/apps/dashboard/src/components/pay/PayAnalytics/hooks/usePayVolume.ts
@@ -62,9 +62,9 @@ export function usePayVolume(options: {
 }) {
   const { user } = useLoggedInUser();
 
-  return useQuery(
-    ["usePayVolume", user?.address, options],
-    async () => {
+  return useQuery({
+    queryKey: ["usePayVolume", user?.address, options],
+    queryFn: async () => {
       const searchParams = new URLSearchParams();
       searchParams.append("intervalType", options.intervalType);
       searchParams.append("clientId", options.clientId);
@@ -89,6 +89,7 @@ export function usePayVolume(options: {
 
       return resJSON.result.data;
     },
-    { enabled: !!user?.jwt, retry: false },
-  );
+    enabled: !!user?.jwt,
+    retry: false,
+  });
 }

--- a/apps/dashboard/src/components/smart-wallets/AccountFactories/index.tsx
+++ b/apps/dashboard/src/components/smart-wallets/AccountFactories/index.tsx
@@ -14,14 +14,14 @@ import { FactoryContracts } from "./factory-contracts";
 const useFactories = () => {
   const { user, isLoggedIn } = useLoggedInUser();
   const configuredChains = useSupportedChains();
-  return useQuery(
-    [
+  return useQuery({
+    queryKey: [
       "dashboard-registry",
       user?.address,
       "multichain-contract-list",
       "factories",
     ],
-    async () => {
+    queryFn: async () => {
       invariant(user?.address, "user should be logged in");
       const polygonSDK = getThirdwebSDK(
         polygon.id,
@@ -42,10 +42,9 @@ const useFactories = () => {
 
       return contractWithExtensions.filter((f) => f !== null);
     },
-    {
-      enabled: !!user?.address && isLoggedIn,
-    },
-  );
+
+    enabled: !!user?.address && isLoggedIn,
+  });
 };
 
 interface AccountFactoriesProps {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates multiple files to use the `useQuery` function with an object parameter instead of an array, and includes improvements like `queryKey` and `queryFn`.

### Detailed summary
- Updated `useQuery` calls to use object parameter format
- Added `queryKey` and `queryFn` for better readability and flexibility
- Removed unnecessary array concatenations and enabled options

> The following files were skipped due to too many changes: `apps/dashboard/src/components/contract-components/hooks.ts`, `apps/dashboard/src/@3rdweb-sdk/react/hooks/useEngine.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->