### PR TITLE
react: add hideSwitchWallet param to wallet details modal

### DIFF
--- a/.changeset/forty-knives-reply.md
+++ b/.changeset/forty-knives-reply.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Added `hideSwitchWallet` param to wallet details modal

--- a/packages/thirdweb/src/react/core/hooks/connection/ConnectButtonProps.ts
+++ b/packages/thirdweb/src/react/core/hooks/connection/ConnectButtonProps.ts
@@ -230,6 +230,19 @@ export type ConnectButton_detailsModalOptions = {
   networkSelector?: NetworkSelectorProps;
 
   /**
+   * Hide the "Switch Wallet" button in the `ConnectButton` Details Modal.
+   *
+   * By default it is `false`
+   * @example
+   * ```tsx
+   * <ConnectButton detailsModal={{
+   *  hideSwitchWallet: true
+   * }} />
+   * ```
+   */
+  hideSwitchWallet?: boolean;
+
+  /**
    * Hide the "Disconnect Wallet" button in the `ConnectButton` Details Modal.
    *
    * By default it is `false`

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/Details.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/Details.tsx
@@ -374,84 +374,91 @@ function DetailsModal(props: {
     </MenuButton>
   );
 
+  const avatarContent = (
+    <Container
+      style={{
+        position: "relative",
+        height: `${iconSize.xl}px`,
+        width: `${iconSize.xl}px`,
+      }}
+    >
+      <Container
+        style={{
+          width: "100%",
+          height: "100%",
+          borderRadius: "100%",
+          overflow: "hidden",
+        }}
+      >
+        {ensAvatarQuery.data ? (
+          <img
+            src={ensAvatarQuery.data}
+            style={{
+              width: iconSize.xxl,
+              height: iconSize.xxl,
+            }}
+            alt=""
+          />
+        ) : (
+          activeAccount && (
+            <Blobbie
+              address={activeAccount.address}
+              size={Number(iconSize.xxl)}
+            />
+          )
+        )}
+      </Container>
+      <Container
+        style={{
+          position: "absolute",
+          bottom: -2,
+          right: -2,
+        }}
+      >
+        <IconContainer
+          style={{
+            background: theme.colors.modalBg,
+          }}
+          padding="4px"
+        >
+          {activeWallet && (
+            <WalletImage
+              style={{ borderRadius: 0 }}
+              id={activeWallet.id}
+              client={client}
+              size="12"
+            />
+          )}
+        </IconContainer>
+      </Container>
+    </Container>
+  );
+
   let content = (
     <div>
       <Spacer y="xs" />
       <Container p="lg" gap="sm" flex="row" center="y">
-        <ToolTip tip="Switch wallet">
-          <div
-            style={{
-              cursor: "pointer",
-            }}
-            onKeyDown={(e) => {
-              if (e.key === "w") {
-                setScreen("wallet-manager");
-              }
-            }}
-            onClick={() => {
-              setScreen("wallet-manager");
-            }}
-          >
-            <Container
+        {props.detailsModal?.hideSwitchWallet ? (
+          avatarContent
+        ) : (
+          <ToolTip tip="Switch wallet">
+            <div
               style={{
-                position: "relative",
-                height: `${iconSize.xl}px`,
-                width: `${iconSize.xl}px`,
+                cursor: "pointer",
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "w") {
+                  setScreen("wallet-manager");
+                }
+              }}
+              onClick={() => {
+                setScreen("wallet-manager");
               }}
             >
-              <Container
-                style={{
-                  width: "100%",
-                  height: "100%",
-                  borderRadius: "100%",
-                  overflow: "hidden",
-                }}
-              >
-                {ensAvatarQuery.data ? (
-                  <img
-                    src={ensAvatarQuery.data}
-                    style={{
-                      width: iconSize.xxl,
-                      height: iconSize.xxl,
-                    }}
-                    alt=""
-                  />
-                ) : (
-                  activeAccount && (
-                    <Blobbie
-                      address={activeAccount.address}
-                      size={Number(iconSize.xxl)}
-                    />
-                  )
-                )}
-              </Container>
-              <Container
-                style={{
-                  position: "absolute",
-                  bottom: -2,
-                  right: -2,
-                }}
-              >
-                <IconContainer
-                  style={{
-                    background: theme.colors.modalBg,
-                  }}
-                  padding="4px"
-                >
-                  {activeWallet && (
-                    <WalletImage
-                      style={{ borderRadius: 0 }}
-                      id={activeWallet.id}
-                      client={client}
-                      size="12"
-                    />
-                  )}
-                </IconContainer>
-              </Container>
-            </Container>
-          </div>
-        </ToolTip>
-
+              {avatarContent}
+            </div>
+          </ToolTip>
+        )}
         <Container flex="column" gap="3xs">
           <div
             style={{
@@ -1258,6 +1265,13 @@ export type UseWalletDetailsModalOptions = {
   hideDisconnect?: boolean;
 
   /**
+   * Hide the "Switch Wallet" button in the Wallet Details Modal.
+   *
+   * By default it is `false`
+   */
+  hideSwitchWallet?: boolean;
+
+  /**
    * Callback to be called when a wallet is disconnected by clicking the "Disconnect Wallet" button in the Wallet Details Modal.
    *
    * ```tsx
@@ -1363,6 +1377,7 @@ export function useWalletDetailsModal() {
             detailsModal={{
               footer: props.footer,
               hideDisconnect: props.hideDisconnect,
+              hideSwitchWallet: props.hideSwitchWallet,
               networkSelector: props.networkSelector,
               payOptions: props.payOptions,
               showTestnetFaucet: props.showTestnetFaucet,


### PR DESCRIPTION
Adds a parameter to the `ConnectButton` and `WalletDetailsModal` components to enable hiding the "Switch wallet" tooltip  and on-click action to navigate a user to the wallet manager screen.

Rationale: for applications that will be powered by account abstraction and Thirdweb Engine, we want to disable the user from being able to switch the active wallet to a non-smart account.

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add a new parameter `hideSwitchWallet` to the wallet details modal in the `ConnectButton` component.

### Detailed summary
- Added `hideSwitchWallet` param to `ConnectButton` Details Modal
- Updated `ConnectButtonProps.ts` to include `hideSwitchWallet` option
- Modified `Details.tsx` to conditionally render the "Switch Wallet" button based on the new parameter
- Updated `useWalletDetailsModal` to pass `hideSwitchWallet` option to the modal configuration

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->