### PR TITLE
[Update] Make bundle ID regex case-insensitive

### DIFF
--- a/apps/dashboard/src/utils/regex.ts
+++ b/apps/dashboard/src/utils/regex.ts
@@ -6,4 +6,5 @@ export const RE_DOMAIN = new RegExp(
   /(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]/,
 );
 
-export const RE_BUNDLE_ID = new RegExp(/^[a-z0-9.-]{3,64}$/);
+// bundle are case sensitive (/i) and can only contain letters, numbers, hyphens, and periods
+export const RE_BUNDLE_ID = new RegExp(/^[a-z0-9.-]{3,64}$/i);


### PR DESCRIPTION
BLOCKED BY: https://github.com/thirdweb-dev/api-server/pull/1019

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the regular expression `RE_BUNDLE_ID` in `regex.ts` to make bundle IDs case-insensitive and allow only letters, numbers, hyphens, and periods.

### Detailed summary
- Updated `RE_BUNDLE_ID` to be case-insensitive
- Limited bundle IDs to letters, numbers, hyphens, and periods

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->