### PR TITLE
Use formatNumber util for showing token balances

### DIFF
--- a/.changeset/silver-planes-warn.md
+++ b/.changeset/silver-planes-warn.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Show wallet balance with upto 5 decimal places in UI components

--- a/packages/thirdweb/src/react/native/ui/connect/ConnectedButton.tsx
+++ b/packages/thirdweb/src/react/native/ui/connect/ConnectedButton.tsx
@@ -1,4 +1,5 @@
 import { StyleSheet, View } from "react-native";
+import { formatNumber } from "../../../../utils/formatNumber.js";
 import type { Account, Wallet } from "../../../../wallets/interfaces/wallet.js";
 import { parseTheme } from "../../../core/design-system/CustomThemeProvider.js";
 import type { ConnectButtonProps } from "../../../core/hooks/connection/ConnectButtonProps.js";
@@ -64,7 +65,7 @@ export function ConnectedButton(
                 fontSize: fontSize.sm,
               }}
             >
-              {Number(balanceQuery.data.displayValue).toFixed(3)}{" "}
+              {formatBalanceOnButton(Number(balanceQuery.data.displayValue))}{" "}
               {balanceQuery.data?.symbol}
             </ThemedText>
           ) : (
@@ -78,6 +79,10 @@ export function ConnectedButton(
       </View>
     </ThemedButton>
   );
+}
+
+function formatBalanceOnButton(num: number) {
+  return formatNumber(num, num < 1 ? 5 : 4);
 }
 
 const styles = StyleSheet.create({

--- a/packages/thirdweb/src/react/native/ui/connect/ConnectedModal.tsx
+++ b/packages/thirdweb/src/react/native/ui/connect/ConnectedModal.tsx
@@ -3,6 +3,7 @@ import { Linking, StyleSheet, TouchableOpacity, View } from "react-native";
 import type { ThirdwebClient } from "../../../../client/client.js";
 import { getContract } from "../../../../contract/contract.js";
 import { isContractDeployed } from "../../../../utils/bytecode/is-contract-deployed.js";
+import { formatNumber } from "../../../../utils/formatNumber.js";
 import type { Account, Wallet } from "../../../../wallets/interfaces/wallet.js";
 import type { Theme } from "../../../core/design-system/index.js";
 import { useSiweAuth } from "../../../core/hooks/auth/useSiweAuth.js";
@@ -189,7 +190,7 @@ const AccountHeader = (props: ConnectedModalProps) => {
             fontSize: fontSize.sm,
           }}
         >
-          {Number(balanceQuery.data.displayValue).toFixed(3)}{" "}
+          {formatNumber(Number(balanceQuery.data.displayValue), 5)}{" "}
           {balanceQuery.data?.symbol}
         </ThemedText>
       ) : (

--- a/packages/thirdweb/src/react/native/ui/connect/TokenListScreen.tsx
+++ b/packages/thirdweb/src/react/native/ui/connect/TokenListScreen.tsx
@@ -1,6 +1,7 @@
 import { ScrollView, StyleSheet, TouchableOpacity, View } from "react-native";
 import type { Chain } from "../../../../chains/types.js";
 import type { ThirdwebClient } from "../../../../client/client.js";
+import { formatNumber } from "../../../../utils/formatNumber.js";
 import type { Theme } from "../../../core/design-system/index.js";
 import { useWalletBalance } from "../../../core/hooks/others/useWalletBalance.js";
 import { useActiveAccount } from "../../../core/hooks/wallets/useActiveAccount.js";
@@ -91,7 +92,7 @@ export const TokenRow = (props: {
           <>
             {balanceQuery.data ? (
               <ThemedText theme={theme} type="subtext">
-                {Number(balanceQuery.data.displayValue).toFixed(3)}{" "}
+                {formatBalanceOnButton(Number(balanceQuery.data.displayValue))}{" "}
                 {balanceQuery.data?.symbol}
               </ThemedText>
             ) : (
@@ -124,6 +125,10 @@ export const TokenRow = (props: {
     <View style={styles.tokenRowContainer}>{inner}</View>
   );
 };
+
+function formatBalanceOnButton(num: number) {
+  return formatNumber(num, num < 1 ? 5 : 4);
+}
 
 const styles = StyleSheet.create({
   listContainer: {

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/Details.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/Details.tsx
@@ -14,6 +14,7 @@ import type { Chain } from "../../../../chains/types.js";
 import type { ThirdwebClient } from "../../../../client/client.js";
 import { getContract } from "../../../../contract/contract.js";
 import { isContractDeployed } from "../../../../utils/bytecode/is-contract-deployed.js";
+import { formatNumber } from "../../../../utils/formatNumber.js";
 import type { Account, Wallet } from "../../../../wallets/interfaces/wallet.js";
 import type { SmartWalletOptions } from "../../../../wallets/smart/types.js";
 import type { AppMetadata } from "../../../../wallets/types.js";
@@ -246,9 +247,7 @@ export const ConnectedWalletDetails: React.FC<{
             color="secondaryText"
             weight={400}
           >
-            {Number.parseFloat(
-              Number(balanceQuery.data.displayValue).toFixed(3),
-            )}{" "}
+            {formatBalanceOnButton(Number(balanceQuery.data.displayValue))}{" "}
             {balanceQuery.data.symbol}
           </Text>
         ) : (
@@ -352,9 +351,7 @@ function DetailsModal(props: {
           {chainNameQuery.name || `Unknown chain #${walletChain?.id}`}
           <Text color="secondaryText" size="xs">
             {balanceQuery.data ? (
-              Number.parseFloat(
-                Number(balanceQuery.data.displayValue).toFixed(3),
-              )
+              formatNumber(Number(balanceQuery.data.displayValue), 5)
             ) : (
               <Skeleton height="1em" width="100px" />
             )}{" "}
@@ -914,6 +911,10 @@ function DetailsModal(props: {
       </WalletUIStatesProvider>
     </CustomThemeProvider>
   );
+}
+
+function formatBalanceOnButton(num: number) {
+  return formatNumber(num, num < 1 ? 5 : 4);
 }
 
 const WalletInfoButton = /* @__PURE__ */ StyledButton((_) => {

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/formatTokenBalance.ts
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/formatTokenBalance.ts
@@ -1,3 +1,5 @@
+import { formatNumber } from "../../../../../utils/formatNumber.js";
+
 /**
  * @internal
  * @param balanceData
@@ -13,7 +15,7 @@ export function formatTokenBalance(
   showSymbol = true,
 ) {
   return (
-    Number(balanceData.displayValue).toFixed(3) +
+    formatNumber(Number(balanceData.displayValue), 5) +
     (showSymbol ? ` ${balanceData.symbol}` : "")
   );
 }


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the UI components to display wallet balances with up to 5 decimal places.

### Detailed summary
- Updated UI components to show wallet balance with up to 5 decimal places
- Added `formatNumber` function for consistent balance formatting
- Introduced `formatBalanceOnButton` function for balance display on buttons

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->