### PR TITLE
Set default auth mode to prevent double popup

### DIFF
--- a/.changeset/tame-badgers-drum.md
+++ b/.changeset/tame-badgers-drum.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix popup and window auth modes conflicting on firefox

--- a/packages/thirdweb/src/wallets/in-app/core/wallet/index.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/wallet/index.ts
@@ -40,7 +40,9 @@ export async function connectInAppWallet(
   connector: InAppConnector,
 ): Promise<[Account, Chain]> {
   if (
+    // if auth mode is not specified, the default is popup
     createOptions?.auth?.mode !== "popup" &&
+    createOptions?.auth?.mode !== undefined &&
     connector.authenticateWithRedirect
   ) {
     const strategy = options.strategy;


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR fixes a conflict between popup and window auth modes on Firefox for the `thirdweb` package.

### Detailed summary
- Set default auth mode to "popup" if not specified
- Resolve conflict between popup and window auth modes on Firefox

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->