### PR TITLE
Hides smart account admin wallets in connection manager

### DIFF
--- a/.changeset/tricky-boxes-approve.md
+++ b/.changeset/tricky-boxes-approve.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+React SDK: The connect modal's connect management screen now hides smart account admin wallets by default

--- a/packages/thirdweb/src/wallets/manager/index.ts
+++ b/packages/thirdweb/src/wallets/manager/index.ts
@@ -136,10 +136,10 @@ export function createConnectionManager(storage: AsyncStorage) {
         personalAccount: wallet.getAccount(),
         client: options.client,
       });
+    } else {
+      // add personal wallet to connected wallets list IF this isn't a smart wallet
+      addConnectedWallet(personalWallet);
     }
-
-    // add personal wallet to connected wallets list
-    addConnectedWallet(personalWallet);
 
     if (personalWallet.id !== "smart") {
       await storage.setItem(LAST_ACTIVE_EOA_ID, personalWallet.id);


### PR DESCRIPTION
## Problem solved

When connecting a smart account in the connect modal we now hide the admin account to prevent any confusion. The admin account should never be surfaced to the user unless the developer explicitly wants it to be.

## To Test
1. In playground, try to connect in the AA page. Note only the smart account shows on the wallet switcher screen.
2. In playground, try to connect to a normal in-app wallet. Note the in-app wallet still shows in the wallet switcher.



<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the React SDK to hide smart account admin wallets by default in the connect management screen.

### Detailed summary
- Updated React SDK to hide smart account admin wallets by default in connect management screen
- Removed adding personal wallet to connected wallets list if it's a smart wallet
- Added condition to add personal wallet to connected wallets list only if it's not a smart wallet

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->