### PR TITLE
Don't retry quotes on Route not found and internal server errors

### DIFF
--- a/.changeset/three-peaches-raise.md
+++ b/.changeset/three-peaches-raise.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+No retries on permanent failures on Pay quotes

--- a/packages/thirdweb/src/react/core/hooks/pay/useBuyWithCryptoQuote.ts
+++ b/packages/thirdweb/src/react/core/hooks/pay/useBuyWithCryptoQuote.ts
@@ -94,7 +94,13 @@ export function useBuyWithCryptoQuote(
       }
       try {
         // biome-ignore lint/suspicious/noExplicitAny: <explanation>
-        if ((error as any).error.code === "MINIMUM_PURCHASE_AMOUNT") {
+        const serverError = (error as any).error;
+
+        if (serverError.code === "MINIMUM_PURCHASE_AMOUNT") {
+          return false;
+        }
+
+        if (serverError.statusCode === 404 || serverError.statusCode >= 500) {
           return false;
         }
       } catch {

--- a/packages/thirdweb/src/react/core/hooks/pay/useBuyWithCryptoQuote.ts
+++ b/packages/thirdweb/src/react/core/hooks/pay/useBuyWithCryptoQuote.ts
@@ -18,6 +18,15 @@ export type BuyWithCryptoQuoteQueryOptions = Omit<
 >;
 
 /**
+ * @internal
+ */
+type BuyWithCryptoQuoteError = {
+  status: string;
+  code: string;
+  statusCode: number;
+};
+
+/**
  * Hook to get a price quote for performing a "Buy with crypto" transaction that allows users to buy a token with another token - aka a swap.
  *
  * The price quote is an object of type [`BuyWithCryptoQuote`](https://portal.thirdweb.com/references/typescript/v5/BuyWithCryptoQuote).
@@ -94,7 +103,7 @@ export function useBuyWithCryptoQuote(
       }
       try {
         // biome-ignore lint/suspicious/noExplicitAny: <explanation>
-        const serverError = (error as any).error;
+        const serverError = (error as any).error as BuyWithCryptoQuoteError;
 
         if (serverError.code === "MINIMUM_PURCHASE_AMOUNT") {
           return false;

--- a/packages/thirdweb/src/react/core/hooks/pay/useBuyWithFiatQuote.ts
+++ b/packages/thirdweb/src/react/core/hooks/pay/useBuyWithFiatQuote.ts
@@ -18,6 +18,15 @@ export type BuyWithFiatQuoteQueryOptions = Omit<
 >;
 
 /**
+ * @internal
+ */
+type BuyWithFiatQuoteError = {
+  status: string;
+  code: string;
+  statusCode: number;
+};
+
+/**
  * Hook to get a price quote for performing a "Buy with Fiat" transaction that allows users to buy a token with fiat currency.
  *
  * The price quote is an object of type [`BuyWithFiatQuote`](https://portal.thirdweb.com/references/typescript/v5/BuyWithFiatQuote).
@@ -82,7 +91,7 @@ export function useBuyWithFiatQuote(
       }
       try {
         // biome-ignore lint/suspicious/noExplicitAny: <explanation>
-        const serverError = (error as any).error;
+        const serverError = (error as any).error as BuyWithFiatQuoteError;
 
         if (serverError.code === "MINIMUM_PURCHASE_AMOUNT") {
           return false;

--- a/packages/thirdweb/src/react/core/hooks/pay/useBuyWithFiatQuote.ts
+++ b/packages/thirdweb/src/react/core/hooks/pay/useBuyWithFiatQuote.ts
@@ -82,7 +82,13 @@ export function useBuyWithFiatQuote(
       }
       try {
         // biome-ignore lint/suspicious/noExplicitAny: <explanation>
-        if ((error as any).error.code === "MINIMUM_PURCHASE_AMOUNT") {
+        const serverError = (error as any).error;
+
+        if (serverError.code === "MINIMUM_PURCHASE_AMOUNT") {
+          return false;
+        }
+
+        if (serverError.statusCode === 404 || serverError.statusCode >= 500) {
           return false;
         }
       } catch {


### PR DESCRIPTION
## Problem solved

On thirdweb Pay, if the server returns a 404 (Route not found) or 500+ (Internal server error), do not attempt to fetch the quote again

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing error handling for price quotes in the `useBuyWithFiatQuote` and `useBuyWithCryptoQuote` hooks.

### Detailed summary
- Added `BuyWithFiatQuoteError` and `BuyWithCryptoQuoteError` types for error handling
- Improved error handling logic for specific error codes and status codes
- Removed retries on permanent failures for Pay quotes

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->