### PR TITLE
[Remove] Modular Contracts category from explore data

### DIFF
--- a/apps/dashboard/src/data/explore.ts
+++ b/apps/dashboard/src/data/explore.ts
@@ -72,24 +72,6 @@ const DROPS = {
   ],
 } as const;
 
-const MODULAR_CONTRACTS = {
-  id: "modular-contracts",
-  name: "Drop",
-  displayName: "Modular Contracts (Beta)",
-  description:
-    "Collection of highly customizable and upgradeable smart contracts built with the modular contracts framework.",
-  isBeta: true,
-  contracts: [
-    "deployer.thirdweb.eth/ModularDropERC721",
-    "deployer.thirdweb.eth/ModularTokenERC721",
-    "deployer.thirdweb.eth/ModularDropERC1155",
-    "deployer.thirdweb.eth/ModularTokenERC1155",
-    "deployer.thirdweb.eth/ModularDropERC20",
-    "deployer.thirdweb.eth/ModularTokenERC20",
-    "deployer.thirdweb.eth/ModularOpenEditionERC721",
-  ],
-} as const;
-
 const MARKETS = {
   id: "marketplace",
   name: "Marketplace",
@@ -188,7 +170,6 @@ const SMART_WALLET = {
 
 const CATEGORIES = {
   [POPULAR.id]: POPULAR,
-  [MODULAR_CONTRACTS.id]: MODULAR_CONTRACTS,
   [NFTS.id]: NFTS,
   [MARKETS.id]: MARKETS,
   [DROPS.id]: DROPS,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to remove the `MODULAR_CONTRACTS` object from the `CATEGORIES` constant in `explore.ts`.

### Detailed summary
- Removed the `MODULAR_CONTRACTS` object from the `CATEGORIES` constant in `explore.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->