### PR TITLE
[Playground] Refactor: Move ThirdwebProvider to each individual page for separate context

### DIFF
--- a/apps/playground-web/src/app/connect/account-abstraction/connect/page.tsx
+++ b/apps/playground-web/src/app/connect/account-abstraction/connect/page.tsx
@@ -1,3 +1,4 @@
+import ThirdwebProvider from "@/components/thirdweb-provider";
 import { metadataBase } from "@/lib/constants";
 import type { Metadata } from "next";
 import {
@@ -16,24 +17,26 @@ export const metadata: Metadata = {
 
 export default function Page() {
   return (
-    <main className="pb-20 container px-0">
-      <APIHeader
-        title="Account Abstraction"
-        description={
-          <>
-            Let users connect to their smart accounts with any wallet and unlock
-            gas sponsorship, batched transactions, session keys and full wallet
-            programmability.
-          </>
-        }
-        docsLink="https://portal.thirdweb.com/connect/account-abstraction/overview"
-        heroLink="/account-abstraction.png"
-      />
+    <ThirdwebProvider>
+      <main className="pb-20 container px-0">
+        <APIHeader
+          title="Account Abstraction"
+          description={
+            <>
+              Let users connect to their smart accounts with any wallet and
+              unlock gas sponsorship, batched transactions, session keys and
+              full wallet programmability.
+            </>
+          }
+          docsLink="https://portal.thirdweb.com/connect/account-abstraction/overview"
+          heroLink="/account-abstraction.png"
+        />
 
-      <section className="space-y-8">
-        <ConnectSmartAccount />
-      </section>
-    </main>
+        <section className="space-y-8">
+          <ConnectSmartAccount />
+        </section>
+      </main>
+    </ThirdwebProvider>
   );
 }
 

--- a/apps/playground-web/src/app/connect/account-abstraction/native-aa/page.tsx
+++ b/apps/playground-web/src/app/connect/account-abstraction/native-aa/page.tsx
@@ -1,3 +1,4 @@
+import ThirdwebProvider from "@/components/thirdweb-provider";
 import { metadataBase } from "@/lib/constants";
 import type { Metadata } from "next";
 import { SponsoredTxZksyncPreview } from "../../../../components/account-abstraction/sponsored-tx-zksync";
@@ -13,24 +14,26 @@ export const metadata: Metadata = {
 
 export default function Page() {
   return (
-    <main className="pb-20 container px-0">
-      <APIHeader
-        title="Account Abstraction"
-        description={
-          <>
-            Let users connect to their smart accounts with any wallet and unlock
-            gas sponsorship, batched transactions, session keys and full wallet
-            programmability.
-          </>
-        }
-        docsLink="https://portal.thirdweb.com/connect/account-abstraction/overview"
-        heroLink="/account-abstraction.png"
-      />
+    <ThirdwebProvider>
+      <main className="pb-20 container px-0">
+        <APIHeader
+          title="Account Abstraction"
+          description={
+            <>
+              Let users connect to their smart accounts with any wallet and
+              unlock gas sponsorship, batched transactions, session keys and
+              full wallet programmability.
+            </>
+          }
+          docsLink="https://portal.thirdweb.com/connect/account-abstraction/overview"
+          heroLink="/account-abstraction.png"
+        />
 
-      <section className="space-y-8">
-        <SponsoredZksyncTx />
-      </section>
-    </main>
+        <section className="space-y-8">
+          <SponsoredZksyncTx />
+        </section>
+      </main>
+    </ThirdwebProvider>
   );
 }
 

--- a/apps/playground-web/src/app/connect/account-abstraction/sponsor/page.tsx
+++ b/apps/playground-web/src/app/connect/account-abstraction/sponsor/page.tsx
@@ -1,3 +1,4 @@
+import ThirdwebProvider from "@/components/thirdweb-provider";
 import { metadataBase } from "@/lib/constants";
 import type { Metadata } from "next";
 import { SponsoredTxPreview } from "../../../../components/account-abstraction/sponsored-tx";
@@ -13,24 +14,26 @@ export const metadata: Metadata = {
 
 export default function Page() {
   return (
-    <main className="pb-20 container px-0">
-      <APIHeader
-        title="Account Abstraction"
-        description={
-          <>
-            Let users connect to their smart accounts with any wallet and unlock
-            gas sponsorship, batched transactions, session keys and full wallet
-            programmability.
-          </>
-        }
-        docsLink="https://portal.thirdweb.com/connect/account-abstraction/overview"
-        heroLink="/account-abstraction.png"
-      />
+    <ThirdwebProvider>
+      <main className="pb-20 container px-0">
+        <APIHeader
+          title="Account Abstraction"
+          description={
+            <>
+              Let users connect to their smart accounts with any wallet and
+              unlock gas sponsorship, batched transactions, session keys and
+              full wallet programmability.
+            </>
+          }
+          docsLink="https://portal.thirdweb.com/connect/account-abstraction/overview"
+          heroLink="/account-abstraction.png"
+        />
 
-      <section className="space-y-8">
-        <SponsoredTx />
-      </section>
-    </main>
+        <section className="space-y-8">
+          <SponsoredTx />
+        </section>
+      </main>
+    </ThirdwebProvider>
   );
 }
 

--- a/apps/playground-web/src/app/connect/auth/page.tsx
+++ b/apps/playground-web/src/app/connect/auth/page.tsx
@@ -3,6 +3,7 @@ export const dynamic = "force-dynamic";
 import { BasicAuthPreview } from "@/components/auth/basic-auth";
 import { GatedContentPreview } from "@/components/auth/gated-content";
 import { CodeExample } from "@/components/code/code-example";
+import ThirdwebProvider from "@/components/thirdweb-provider";
 import { metadataBase } from "@/lib/constants";
 import type { Metadata } from "next";
 import { APIHeader } from "../../../components/blocks/APIHeader";
@@ -15,30 +16,32 @@ export const metadata: Metadata = {
 
 export default function Page() {
   return (
-    <main className="pb-20 container px-0">
-      <APIHeader
-        title="Auth"
-        description={
-          <>
-            Authenticate users to your backend using only their wallet. This is
-            a secure and easy way to authenticate users without requiring them
-            to create an additional account.
-          </>
-        }
-        docsLink="https://portal.thirdweb.com/typescript/v5/auth"
-        heroLink="/auth.png"
-      />
+    <ThirdwebProvider>
+      <main className="pb-20 container px-0">
+        <APIHeader
+          title="Auth"
+          description={
+            <>
+              Authenticate users to your backend using only their wallet. This
+              is a secure and easy way to authenticate users without requiring
+              them to create an additional account.
+            </>
+          }
+          docsLink="https://portal.thirdweb.com/typescript/v5/auth"
+          heroLink="/auth.png"
+        />
 
-      <section className="space-y-8">
-        <BasicAuth />
-      </section>
+        <section className="space-y-8">
+          <BasicAuth />
+        </section>
 
-      <div className="h-14" />
+        <div className="h-14" />
 
-      <section className="space-y-8">
-        <GatedContent />
-      </section>
-    </main>
+        <section className="space-y-8">
+          <GatedContent />
+        </section>
+      </main>
+    </ThirdwebProvider>
   );
 }
 

--- a/apps/playground-web/src/app/connect/blockchain-api/page.tsx
+++ b/apps/playground-web/src/app/connect/blockchain-api/page.tsx
@@ -4,6 +4,7 @@ import { WatchEventPreview } from "@/components/blockchain-api/watch-event-previ
 import { WriteContractExtensionPreview } from "@/components/blockchain-api/write-contract-extension";
 import { WriteContractRawPreview } from "@/components/blockchain-api/write-contract-raw";
 import { CodeExample } from "@/components/code/code-example";
+import ThirdwebProvider from "@/components/thirdweb-provider";
 import { metadataBase } from "@/lib/constants";
 import type { Metadata } from "next";
 import { APIHeader } from "../../../components/blocks/APIHeader";
@@ -17,47 +18,49 @@ export const metadata: Metadata = {
 
 export default function Page() {
   return (
-    <main className="pb-20 container px-0">
-      <APIHeader
-        title="Blockchain API"
-        description={
-          <>
-            Performant, reliable and type safe API to read write to any contract
-            on any EVM chain through our RPC Edge endpoints.
-          </>
-        }
-        docsLink="https://portal.thirdweb.com/typescript/v5"
-        heroLink="/blockchain-api.png"
-      />
+    <ThirdwebProvider>
+      <main className="pb-20 container px-0">
+        <APIHeader
+          title="Blockchain API"
+          description={
+            <>
+              Performant, reliable and type safe API to read write to any
+              contract on any EVM chain through our RPC Edge endpoints.
+            </>
+          }
+          docsLink="https://portal.thirdweb.com/typescript/v5"
+          heroLink="/blockchain-api.png"
+        />
 
-      <section className="space-y-8">
-        <ReadContractRaw />
-      </section>
+        <section className="space-y-8">
+          <ReadContractRaw />
+        </section>
 
-      <div className="h-14" />
+        <div className="h-14" />
 
-      <section className="space-y-8">
-        <ReadContractExtension />
-      </section>
+        <section className="space-y-8">
+          <ReadContractExtension />
+        </section>
 
-      <div className="h-14" />
+        <div className="h-14" />
 
-      <section className="space-y-8">
-        <WriteContractExtension />
-      </section>
+        <section className="space-y-8">
+          <WriteContractExtension />
+        </section>
 
-      <div className="h-14" />
+        <div className="h-14" />
 
-      <section className="space-y-8">
-        <WriteContractRaw />
-      </section>
+        <section className="space-y-8">
+          <WriteContractRaw />
+        </section>
 
-      <div className="h-14" />
+        <div className="h-14" />
 
-      <section className="space-y-8">
-        <WatchEvent />
-      </section>
-    </main>
+        <section className="space-y-8">
+          <WatchEvent />
+        </section>
+      </main>
+    </ThirdwebProvider>
   );
 }
 

--- a/apps/playground-web/src/app/connect/in-app-wallet/page.tsx
+++ b/apps/playground-web/src/app/connect/in-app-wallet/page.tsx
@@ -1,4 +1,5 @@
 import { CodeExample } from "@/components/code/code-example";
+import ThirdwebProvider from "@/components/thirdweb-provider";
 import { metadataBase } from "@/lib/constants";
 import type { Metadata } from "next";
 import { APIHeader } from "../../../components/blocks/APIHeader";
@@ -14,29 +15,31 @@ export const metadata: Metadata = {
 
 export default function Page() {
   return (
-    <main className="pb-20 container px-0">
-      <APIHeader
-        title="Onboard users to web3"
-        description={
-          <>
-            Onboard anyone with flexible auth options, secure account recovery,
-            and smart account integration.
-          </>
-        }
-        docsLink="https://portal.thirdweb.com/connect/in-app-wallet/overview"
-        heroLink="/in-app-wallet.png"
-      />
+    <ThirdwebProvider>
+      <main className="pb-20 container px-0">
+        <APIHeader
+          title="Onboard users to web3"
+          description={
+            <>
+              Onboard anyone with flexible auth options, secure account
+              recovery, and smart account integration.
+            </>
+          }
+          docsLink="https://portal.thirdweb.com/connect/in-app-wallet/overview"
+          heroLink="/in-app-wallet.png"
+        />
 
-      <section className="space-y-8">
-        <AnyAuth />
-      </section>
+        <section className="space-y-8">
+          <AnyAuth />
+        </section>
 
-      <div className="h-14" />
+        <div className="h-14" />
 
-      <section className="space-y-8">
-        <SponsoredInAppTx />
-      </section>
-    </main>
+        <section className="space-y-8">
+          <SponsoredInAppTx />
+        </section>
+      </main>
+    </ThirdwebProvider>
   );
 }
 

--- a/apps/playground-web/src/app/connect/pay/page.tsx
+++ b/apps/playground-web/src/app/connect/pay/page.tsx
@@ -1,3 +1,4 @@
+import ThirdwebProvider from "@/components/thirdweb-provider";
 import { metadataBase } from "@/lib/constants";
 import type { Metadata } from "next";
 import { APIHeader } from "../../../components/blocks/APIHeader";
@@ -15,35 +16,37 @@ export const metadata: Metadata = {
 
 export default function Page() {
   return (
-    <main className="pb-20 container px-0">
-      <APIHeader
-        title="The easiest way for users to transact in your app"
-        description={
-          <>
-            Onramp users with credit card &amp; cross-chain crypto payments —
-            and generate revenue for each user transaction.
-          </>
-        }
-        docsLink="https://portal.thirdweb.com/connect/pay/get-started"
-        heroLink="/pay.png"
-      />
+    <ThirdwebProvider>
+      <main className="pb-20 container px-0">
+        <APIHeader
+          title="The easiest way for users to transact in your app"
+          description={
+            <>
+              Onramp users with credit card &amp; cross-chain crypto payments —
+              and generate revenue for each user transaction.
+            </>
+          }
+          docsLink="https://portal.thirdweb.com/connect/pay/get-started"
+          heroLink="/pay.png"
+        />
 
-      <section className="space-y-8">
-        <StyledPayEmbed />
-      </section>
+        <section className="space-y-8">
+          <StyledPayEmbed />
+        </section>
 
-      <div className="h-14" />
+        <div className="h-14" />
 
-      <section className="space-y-8">
-        <BuyMerch />
-      </section>
+        <section className="space-y-8">
+          <BuyMerch />
+        </section>
 
-      <div className="h-14" />
+        <div className="h-14" />
 
-      <section className="space-y-8">
-        <BuyOnchainAsset />
-      </section>
-    </main>
+        <section className="space-y-8">
+          <BuyOnchainAsset />
+        </section>
+      </main>
+    </ThirdwebProvider>
   );
 }
 

--- a/apps/playground-web/src/app/connect/sign-in/button/page.tsx
+++ b/apps/playground-web/src/app/connect/sign-in/button/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import ThirdwebProvider from "@/components/thirdweb-provider";
 import { useState } from "react";
 import { APIHeader } from "../../../../components/blocks/APIHeader";
 import type { ConnectPlaygroundOptions } from "../components/types";
@@ -54,31 +55,34 @@ export default function Page() {
     useState<ConnectPlaygroundOptions>(defaultConnectOptions);
 
   return (
-    <div className="">
-      <APIHeader
-        title="Connect Button"
-        description={
-          <>
-            A fully featured wallet connection component that allows to Connect
-            to 350+ external wallets, connect via email, phone number, passkey
-            or social logins, Convert any wallet to a ERC4337 smart wallet for
-            gasless transactions and provides SIWE (Sign In With Ethereum)
-          </>
-        }
-        docsLink="https://portal.thirdweb.com/connect/sign-in/overview"
-        heroLink="/connectors.png"
-      />
+    <ThirdwebProvider>
+      <div className="">
+        <APIHeader
+          title="Connect Button"
+          description={
+            <>
+              A fully featured wallet connection component that allows to
+              Connect to 350+ external wallets, connect via email, phone number,
+              passkey or social logins, Convert any wallet to a ERC4337 smart
+              wallet for gasless transactions and provides SIWE (Sign In With
+              Ethereum)
+            </>
+          }
+          docsLink="https://portal.thirdweb.com/connect/sign-in/overview"
+          heroLink="/connectors.png"
+        />
 
-      <div className="flex flex-col-reverse xl:flex-row xl:min-h-[900px] gap-6 xl:gap-6 relative">
-        <div className="grow xl:border-r xl:pr-6 pb-10 border-b xl:border-b-0 xl:mb-0">
-          <LeftSection
-            connectOptions={connectOptions}
-            setConnectOptions={setConnectOptions}
-          />
+        <div className="flex flex-col-reverse xl:flex-row xl:min-h-[900px] gap-6 xl:gap-6 relative">
+          <div className="grow xl:border-r xl:pr-6 pb-10 border-b xl:border-b-0 xl:mb-0">
+            <LeftSection
+              connectOptions={connectOptions}
+              setConnectOptions={setConnectOptions}
+            />
+          </div>
+
+          <RightSection connectOptions={connectOptions} />
         </div>
-
-        <RightSection connectOptions={connectOptions} />
       </div>
-    </div>
+    </ThirdwebProvider>
   );
 }

--- a/apps/playground-web/src/app/connect/sign-in/embed/page.tsx
+++ b/apps/playground-web/src/app/connect/sign-in/embed/page.tsx
@@ -1,5 +1,6 @@
 import { CodeExample } from "@/components/code/code-example";
 import { StyledConnectEmbed } from "@/components/styled-connect-embed";
+import ThirdwebProvider from "@/components/thirdweb-provider";
 import { metadataBase } from "@/lib/constants";
 import type { Metadata } from "next";
 import { APIHeader } from "../../../../components/blocks/APIHeader";
@@ -13,22 +14,24 @@ export const metadata: Metadata = {
 
 export default function Page() {
   return (
-    <main className="pb-20 container px-0">
-      <APIHeader
-        title="Sign in"
-        description={
-          <>
-            Create a login experience tailor-made for your app. Add your wallets
-            of choice, enable web2 sign-in options and create a modal that fits
-            your brand.
-          </>
-        }
-        docsLink="https://portal.thirdweb.com/connect/sign-in/overview"
-        heroLink="/connectors.png"
-      />
+    <ThirdwebProvider>
+      <main className="pb-20 container px-0">
+        <APIHeader
+          title="Sign in"
+          description={
+            <>
+              Create a login experience tailor-made for your app. Add your
+              wallets of choice, enable web2 sign-in options and create a modal
+              that fits your brand.
+            </>
+          }
+          docsLink="https://portal.thirdweb.com/connect/sign-in/overview"
+          heroLink="/connectors.png"
+        />
 
-      <EmbedComponent />
-    </main>
+        <EmbedComponent />
+      </main>
+    </ThirdwebProvider>
   );
 }
 

--- a/apps/playground-web/src/app/connect/sign-in/headless/page.tsx
+++ b/apps/playground-web/src/app/connect/sign-in/headless/page.tsx
@@ -1,6 +1,7 @@
 import { APIHeader } from "@/components/blocks/APIHeader";
 import { CodeExample } from "@/components/code/code-example";
 import { HooksPreview } from "@/components/sign-in/hooks";
+import ThirdwebProvider from "@/components/thirdweb-provider";
 import { metadataBase } from "@/lib/constants";
 import type { Metadata } from "next";
 
@@ -13,22 +14,24 @@ export const metadata: Metadata = {
 
 export default function Page() {
   return (
-    <main className="pb-20 container px-0">
-      <APIHeader
-        title="Sign in"
-        description={
-          <>
-            Create a login experience tailor-made for your app. Add your wallets
-            of choice, enable web2 sign-in options and create a modal that fits
-            your brand.
-          </>
-        }
-        docsLink="https://portal.thirdweb.com/connect/sign-in/overview"
-        heroLink="/connectors.png"
-      />
+    <ThirdwebProvider>
+      <main className="pb-20 container px-0">
+        <APIHeader
+          title="Sign in"
+          description={
+            <>
+              Create a login experience tailor-made for your app. Add your
+              wallets of choice, enable web2 sign-in options and create a modal
+              that fits your brand.
+            </>
+          }
+          docsLink="https://portal.thirdweb.com/connect/sign-in/overview"
+          heroLink="/connectors.png"
+        />
 
-      <Hooks />
-    </main>
+        <Hooks />
+      </main>
+    </ThirdwebProvider>
   );
 }
 

--- a/apps/playground-web/src/app/providers.tsx
+++ b/apps/playground-web/src/app/providers.tsx
@@ -3,7 +3,6 @@
 import { ThemeProvider as NextThemesProvider } from "next-themes";
 import type { ThemeProviderProps } from "next-themes/dist/types";
 import type * as React from "react";
-import { ThirdwebProvider } from "thirdweb/react";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
@@ -13,7 +12,7 @@ export const Providers: React.FC<React.PropsWithChildren> = ({ children }) => {
   return (
     <QueryClientProvider client={queryClient}>
       <ThemeProvider attribute="class" defaultTheme="dark">
-        <ThirdwebProvider>{children}</ThirdwebProvider>
+        {children}
       </ThemeProvider>
     </QueryClientProvider>
   );

--- a/apps/playground-web/src/components/account-abstraction/connect-smart-account.tsx
+++ b/apps/playground-web/src/components/account-abstraction/connect-smart-account.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useEffect } from "react";
 import { baseSepolia } from "thirdweb/chains";
 import {
   useActiveAccount,
@@ -16,14 +15,6 @@ import { StyledConnectButton } from "../styled-connect-button";
 import { Button } from "../ui/button";
 
 export function ConnectSmartAccountPreview() {
-  // force disconnect if not smart wallet already
-  const wallet = useActiveWallet();
-  const { disconnect } = useDisconnect();
-  useEffect(() => {
-    if (wallet && wallet.id !== "smart") {
-      disconnect(wallet);
-    }
-  }, [wallet, disconnect]);
   return (
     <div className="flex flex-col">
       <StyledConnectButton

--- a/apps/playground-web/src/components/account-abstraction/sponsored-tx-zksync.tsx
+++ b/apps/playground-web/src/components/account-abstraction/sponsored-tx-zksync.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { getContract } from "thirdweb";
 import { zkSyncSepolia } from "thirdweb/chains";
 import { claimTo, getNFT, getOwnedNFTs } from "thirdweb/extensions/erc1155";
@@ -9,9 +9,6 @@ import {
   MediaRenderer,
   TransactionButton,
   useActiveAccount,
-  useActiveWallet,
-  useActiveWalletChain,
-  useDisconnect,
   useReadContract,
 } from "thirdweb/react";
 import { shortenHex } from "thirdweb/utils";
@@ -28,18 +25,6 @@ const editionDropTokenId = 0n;
 
 export function SponsoredTxZksyncPreview() {
   const [txHash, setTxHash] = useState<string | null>(null);
-  const wallet = useActiveWallet();
-  const { disconnect } = useDisconnect();
-  const activeChain = useActiveWalletChain();
-  useEffect(() => {
-    if (
-      wallet &&
-      (wallet.id !== "smart" ||
-        (activeChain && activeChain?.id !== zkSyncSepolia.id))
-    ) {
-      disconnect(wallet);
-    }
-  }, [wallet, disconnect, activeChain]);
   const smartAccount = useActiveAccount();
   const { data: nft, isLoading: isNftLoading } = useReadContract(getNFT, {
     contract: editionDropContract,

--- a/apps/playground-web/src/components/account-abstraction/sponsored-tx.tsx
+++ b/apps/playground-web/src/components/account-abstraction/sponsored-tx.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { getContract } from "thirdweb";
 import { baseSepolia } from "thirdweb/chains";
 import { claimTo, getNFT, getOwnedNFTs } from "thirdweb/extensions/erc1155";
@@ -9,8 +9,6 @@ import {
   MediaRenderer,
   TransactionButton,
   useActiveAccount,
-  useActiveWallet,
-  useDisconnect,
   useReadContract,
 } from "thirdweb/react";
 import { shortenHex } from "thirdweb/utils";
@@ -29,13 +27,6 @@ export const editionDropContract = getContract({
 
 export function SponsoredTxPreview() {
   const [txHash, setTxHash] = useState<string | null>(null);
-  const wallet = useActiveWallet();
-  const { disconnect } = useDisconnect();
-  useEffect(() => {
-    if (wallet && wallet.id !== "smart") {
-      disconnect(wallet);
-    }
-  }, [wallet, disconnect]);
   const smartAccount = useActiveAccount();
   const { data: nft, isLoading: isNftLoading } = useReadContract(getNFT, {
     contract: editionDropContract,

--- a/apps/playground-web/src/components/thirdweb-provider.tsx
+++ b/apps/playground-web/src/components/thirdweb-provider.tsx
@@ -1,0 +1,9 @@
+"use client";
+import { ThirdwebProvider as _ThirdwebProvider } from "thirdweb/react";
+
+// This is a wrapper for the ThirdwebProvider to be used individually on each page
+export default function ThirdwebProvider({
+  children,
+}: { children: React.ReactNode }) {
+  return <_ThirdwebProvider>{children}</_ThirdwebProvider>;
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to refactor the usage of the `ThirdwebProvider` component across different pages in the `playground-web` app.

### Detailed summary
- Added `ThirdwebProvider` component to wrap main content in various pages for consistent usage.
- Removed redundant wallet checks and disconnect functions in `ConnectSmartAccountPreview`, `SponsoredTxPreview`, and `SponsoredTxZksyncPreview`.
- Updated page components to use `ThirdwebProvider` for better code organization and consistency.

> The following files were skipped due to too many changes: `apps/playground-web/src/app/connect/in-app-wallet/page.tsx`, `apps/playground-web/src/app/connect/pay/page.tsx`, `apps/playground-web/src/app/connect/auth/page.tsx`, `apps/playground-web/src/app/connect/sign-in/button/page.tsx`, `apps/playground-web/src/app/connect/blockchain-api/page.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->