### PR TITLE
[React] Feature: Adds TOS confirmation checkbox

### DIFF
--- a/.changeset/kind-clouds-heal.md
+++ b/.changeset/kind-clouds-heal.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Adds prop to require TOS or Privacy Policy acceptance before connecting to an in-app wallet

--- a/apps/playground-web/src/app/connect/sign-in/button/LeftSection.tsx
+++ b/apps/playground-web/src/app/connect/sign-in/button/LeftSection.tsx
@@ -146,22 +146,41 @@ export function LeftSection(props: {
             </div>
           </div>
 
-          {/* Thirdweb Branding */}
-          <section className="flex items-center gap-2">
-            <Checkbox
-              id="show-thirdweb-branding"
-              checked={connectOptions.ShowThirdwebBranding}
-              onCheckedChange={(checkState) => {
-                setConnectOptions((v) => ({
-                  ...v,
-                  ShowThirdwebBranding: checkState === true,
-                }));
-              }}
-            />
-            <Label htmlFor="show-thirdweb-branding">
-              Show thirdweb branding
-            </Label>
-          </section>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6 md:gap-4">
+            {/* Thirdweb Branding */}
+            <section className="flex items-center gap-2">
+              <Checkbox
+                id="show-thirdweb-branding"
+                checked={connectOptions.ShowThirdwebBranding}
+                onCheckedChange={(checkState) => {
+                  setConnectOptions((v) => ({
+                    ...v,
+                    ShowThirdwebBranding: checkState === true,
+                  }));
+                }}
+              />
+              <Label htmlFor="show-thirdweb-branding">
+                Show thirdweb branding
+              </Label>
+            </section>
+
+            {/* Require Approval */}
+            <section className="flex items-center gap-2">
+              <Checkbox
+                id="show-thirdweb-branding"
+                checked={connectOptions.requireApproval}
+                onCheckedChange={(checkState) => {
+                  setConnectOptions((v) => ({
+                    ...v,
+                    requireApproval: checkState === true,
+                  }));
+                }}
+              />
+              <Label htmlFor="show-thirdweb-branding">
+                Require TOS approval
+              </Label>
+            </section>
+          </div>
         </div>
       </CollapsibleSection>
 

--- a/apps/playground-web/src/app/connect/sign-in/button/RightSection.tsx
+++ b/apps/playground-web/src/app/connect/sign-in/button/RightSection.tsx
@@ -152,6 +152,7 @@ export function RightSection(props: {
               termsOfServiceUrl={connectOptions.termsOfServiceLink}
               privacyPolicyUrl={connectOptions.privacyPolicyLink}
               showThirdwebBranding={connectOptions.ShowThirdwebBranding}
+              requireApproval={connectOptions.requireApproval}
             />
             {/* Fake X icon to make it looks exactly like a modal  */}
             <XIcon
@@ -179,6 +180,7 @@ export function RightSection(props: {
               termsOfServiceUrl: connectOptions.termsOfServiceLink,
               privacyPolicyUrl: connectOptions.privacyPolicyLink,
               showThirdwebBranding: connectOptions.ShowThirdwebBranding,
+              requireApproval: connectOptions.requireApproval,
             }}
             wallets={wallets}
             auth={connectOptions.enableAuth ? playgroundAuth : undefined}

--- a/apps/playground-web/src/app/connect/sign-in/button/page.tsx
+++ b/apps/playground-web/src/app/connect/sign-in/button/page.tsx
@@ -46,6 +46,7 @@ const defaultConnectOptions: ConnectPlaygroundOptions = {
   enableAccountAbstraction: false,
   buttonLabel: undefined,
   ShowThirdwebBranding: true,
+  requireApproval: false,
 };
 
 export default function Page() {

--- a/apps/playground-web/src/app/connect/sign-in/components/types.ts
+++ b/apps/playground-web/src/app/connect/sign-in/components/types.ts
@@ -22,4 +22,5 @@ export type ConnectPlaygroundOptions = {
   privacyPolicyLink: string | undefined;
   buttonLabel: string | undefined;
   ShowThirdwebBranding: boolean;
+  requireApproval: boolean;
 };

--- a/packages/thirdweb/src/react/core/hooks/connection/ConnectButtonProps.ts
+++ b/packages/thirdweb/src/react/core/hooks/connection/ConnectButtonProps.ts
@@ -388,6 +388,19 @@ export type ConnectButton_connectModalOptions = {
   privacyPolicyUrl?: string;
 
   /**
+   * Require terms of service and privacy policy to be accepted before connecting an in-app wallet.
+   *
+   * By default it's `false`
+   * @example
+   * ```tsx
+   * <ConnectButton connectModal={{
+   *  requireApproval: true
+   * }} />
+   * ```
+   */
+  requireApproval?: boolean;
+
+  /**
    * Customize the welcome screen. This prop is only applicable when modalSize prop is set to "wide". On "wide" Modal size, a welcome screen is shown on the right side of the modal.
    *
    * This screen can be customized in two ways

--- a/packages/thirdweb/src/react/core/hooks/connection/ConnectEmbedProps.ts
+++ b/packages/thirdweb/src/react/core/hooks/connection/ConnectEmbedProps.ts
@@ -202,6 +202,11 @@ export type ConnectEmbedProps = {
   privacyPolicyUrl?: string;
 
   /**
+   * If provided, users will be required to accept the Terms of Service before connecting an in-app wallet.
+   */
+  requireApproval?: boolean;
+
+  /**
    * Callback to be called on successful connection of wallet - including auto-connect.
    * The callback is called with the connected wallet
    *

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/ConnectButton.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/ConnectButton.tsx
@@ -346,6 +346,7 @@ export function ConnectButton(props: ConnectButtonProps) {
           showThirdwebBranding: props.connectModal?.showThirdwebBranding,
           termsOfServiceUrl: props.connectModal?.termsOfServiceUrl,
           privacyPolicyUrl: props.connectModal?.privacyPolicyUrl,
+          requireApproval: props.connectModal?.requireApproval,
         }}
         welcomeScreen={props.connectModal?.welcomeScreen}
         size={size}

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/AnyWalletConnectUI.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/AnyWalletConnectUI.tsx
@@ -59,6 +59,7 @@ export function AnyWalletConnectUI(props: {
     showThirdwebBranding?: boolean;
     termsOfServiceUrl?: string;
     privacyPolicyUrl?: string;
+    requireApproval?: boolean;
   };
   walletConnect:
     | {

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/ConnectEmbed.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/ConnectEmbed.tsx
@@ -229,11 +229,13 @@ export function ConnectEmbed(props: ConnectEmbedProps) {
       termsOfServiceUrl: props.termsOfServiceUrl,
       title: undefined,
       titleIconUrl: undefined,
+      requireApproval: props.requireApproval,
     };
   }, [
     props.privacyPolicyUrl,
     props.showThirdwebBranding,
     props.termsOfServiceUrl,
+    props.requireApproval,
   ]);
 
   const autoConnectComp = props.autoConnect !== false && (

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/ConnectModal.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/ConnectModal.tsx
@@ -34,6 +34,7 @@ type ConnectModalOptions = {
     showThirdwebBranding?: boolean;
     termsOfServiceUrl?: string;
     privacyPolicyUrl?: string;
+    requireApproval?: boolean;
   };
   connectLocale: ConnectLocale;
   client: ThirdwebClient;

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/ConnectModalContent.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/ConnectModalContent.tsx
@@ -51,6 +51,7 @@ export const ConnectModalContent = (props: {
     showThirdwebBranding?: boolean;
     termsOfServiceUrl?: string;
     privacyPolicyUrl?: string;
+    requireApproval?: boolean;
   };
   welcomeScreen: WelcomeScreen | undefined;
   connectLocale: ConnectLocale;

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/TOS.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/TOS.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { spacing } from "../../../../core/design-system/index.js";
 import { Container } from "../../components/basic.js";
 import { Link } from "../../components/text.js";
 import { Text } from "../../components/text.js";
@@ -11,10 +12,14 @@ export function TOS(props: {
   termsOfServiceUrl?: string;
   privacyPolicyUrl?: string;
   locale: ConnectLocale["agreement"];
+  requireApproval?: boolean;
+  isApproved?: boolean;
+  onApprove?: () => void;
 }) {
-  const { termsOfServiceUrl, privacyPolicyUrl, locale } = props;
+  const { termsOfServiceUrl, privacyPolicyUrl, locale, requireApproval } =
+    props;
 
-  if (!termsOfServiceUrl && !privacyPolicyUrl) {
+  if (!termsOfServiceUrl && !privacyPolicyUrl && !requireApproval) {
     return null;
   }
 
@@ -32,6 +37,18 @@ export function TOS(props: {
           maxWidth: "250px",
         }}
       >
+        {requireApproval && (
+          <input
+            style={{
+              transform: "translateY(3px)",
+              marginRight: spacing["3xs"],
+            }}
+            type="checkbox"
+            onChange={props.onApprove}
+            checked={props.isApproved}
+            disabled={!requireApproval}
+          />
+        )}
         {locale.prefix}{" "}
         {termsOfServiceUrl && (
           <Link
@@ -52,6 +69,11 @@ export function TOS(props: {
           <Link inline size="xs" href={privacyPolicyUrl} target="_blank">
             {locale.privacyPolicy}
           </Link>
+        )}
+        {!privacyPolicyUrl && !termsOfServiceUrl && (
+          <Text inline size="xs">
+            Terms of Service and Privacy Policy
+          </Text>
         )}
       </Text>
     </Container>

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/WalletSelector.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/WalletSelector.tsx
@@ -67,6 +67,7 @@ export type WalletSelectorProps = {
     showThirdwebBranding?: boolean;
     termsOfServiceUrl?: string;
     privacyPolicyUrl?: string;
+    requireApproval?: boolean;
   };
   client: ThirdwebClient;
   connectLocale: ConnectLocale;
@@ -136,6 +137,8 @@ const WalletSelectorInner: React.FC<WalletSelectorProps> = (props) => {
   const { walletIdsToHide } = props;
   const isCompact = props.size === "compact";
   const [isWalletGroupExpanded, setIsWalletGroupExpanded] = useState(false);
+  // This is only used if requireApproval is true
+  const [approvedTOS, setApprovedTOS] = useState(false);
 
   const installedWallets = getInstalledWallets();
   const propsWallets = props.wallets;
@@ -253,11 +256,16 @@ const WalletSelectorInner: React.FC<WalletSelectorProps> = (props) => {
   );
 
   const tos =
-    props.meta.termsOfServiceUrl || props.meta.privacyPolicyUrl ? (
+    props.meta.requireApproval ||
+    props.meta.termsOfServiceUrl ||
+    props.meta.privacyPolicyUrl ? (
       <TOS
         termsOfServiceUrl={props.meta.termsOfServiceUrl}
         privacyPolicyUrl={props.meta.privacyPolicyUrl}
         locale={props.connectLocale.agreement}
+        requireApproval={props.meta.requireApproval}
+        isApproved={approvedTOS}
+        onApprove={() => setApprovedTOS(!approvedTOS)}
       />
     ) : undefined;
 
@@ -280,6 +288,7 @@ const WalletSelectorInner: React.FC<WalletSelectorProps> = (props) => {
         chain={props.chain}
         showAllWallets={props.showAllWallets}
         diableSelectionDataReset={props.disableSelectionDataReset}
+        disabled={props.meta.requireApproval && !approvedTOS}
       />
     );
 
@@ -308,6 +317,7 @@ const WalletSelectorInner: React.FC<WalletSelectorProps> = (props) => {
           chain={props.chain}
           showAllWallets={props.showAllWallets}
           diableSelectionDataReset={props.disableSelectionDataReset}
+          disabled={props.meta.requireApproval && !approvedTOS}
         />
       );
 
@@ -352,6 +362,7 @@ const WalletSelectorInner: React.FC<WalletSelectorProps> = (props) => {
               chain={props.chain}
               showAllWallets={props.showAllWallets}
               diableSelectionDataReset={props.disableSelectionDataReset}
+              disabled={props.meta.requireApproval && !approvedTOS}
             />
             {eoaWallets.length > 0 && (
               <>
@@ -423,6 +434,7 @@ const WalletSelectorInner: React.FC<WalletSelectorProps> = (props) => {
                     chain={props.chain}
                     showAllWallets={props.showAllWallets}
                     diableSelectionDataReset={props.disableSelectionDataReset}
+                    disabled={props.meta.requireApproval && !approvedTOS}
                   />
                 </Container>
 
@@ -462,6 +474,7 @@ const WalletSelectorInner: React.FC<WalletSelectorProps> = (props) => {
             chain={props.chain}
             showAllWallets={props.showAllWallets}
             diableSelectionDataReset={props.disableSelectionDataReset}
+            disabled={props.meta.requireApproval && !approvedTOS}
           />
         );
 
@@ -586,6 +599,8 @@ const WalletSelection: React.FC<{
   client: ThirdwebClient;
   chain: Chain | undefined;
   diableSelectionDataReset?: boolean;
+  // If true, all options will be disabled. Used for things like requiring TOS approval.
+  disabled?: boolean;
 }> = (props) => {
   const wallets = sortWallets(props.wallets, props.recommendedWallets);
   const { screen } = useScreenContext();
@@ -618,6 +633,7 @@ const WalletSelection: React.FC<{
                   size={props.size}
                   recommendedWallets={props.recommendedWallets}
                   chain={props.chain}
+                  disabled={props.disabled}
                 />
               </Suspense>
             ) : (

--- a/packages/thirdweb/src/react/web/wallets/ecosystem/EcosystemWalletFormUI.tsx
+++ b/packages/thirdweb/src/react/web/wallets/ecosystem/EcosystemWalletFormUI.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { useState } from "react";
 import type { Chain } from "../../../../chains/types.js";
 import type { ThirdwebClient } from "../../../../client/client.js";
 import type { Wallet } from "../../../../wallets/interfaces/wallet.js";
@@ -26,6 +27,7 @@ export type EcosystemWalletFormUIProps = {
     showThirdwebBranding?: boolean;
     termsOfServiceUrl?: string;
     privacyPolicyUrl?: string;
+    requireApproval?: boolean;
   };
   client: ThirdwebClient;
   chain: Chain | undefined;
@@ -39,6 +41,8 @@ export type EcosystemWalletFormUIProps = {
 export function EcosystemWalletFormUIScreen(props: EcosystemWalletFormUIProps) {
   const isCompact = props.size === "compact";
   const { initialScreen, screen } = useScreenContext();
+  // This is only used when requireApproval is true to accept the TOS
+  const [isApproved, setIsApproved] = useState(false);
 
   const onBack =
     screen === props.wallet && initialScreen === props.wallet
@@ -75,7 +79,10 @@ export function EcosystemWalletFormUIScreen(props: EcosystemWalletFormUIProps) {
         center="y"
         p={isCompact ? undefined : "lg"}
       >
-        <ConnectWalletSocialOptions {...props} />
+        <ConnectWalletSocialOptions
+          disabled={props.meta.requireApproval && !isApproved}
+          {...props}
+        />
       </Container>
 
       {isCompact &&
@@ -88,6 +95,11 @@ export function EcosystemWalletFormUIScreen(props: EcosystemWalletFormUIProps) {
           termsOfServiceUrl={props.meta.termsOfServiceUrl}
           privacyPolicyUrl={props.meta.privacyPolicyUrl}
           locale={props.connectLocale.agreement}
+          requireApproval={props.meta.requireApproval}
+          onApprove={() => {
+            setIsApproved(!isApproved);
+          }}
+          isApproved={isApproved}
         />
 
         {props.meta.showThirdwebBranding !== false && <PoweredByThirdweb />}

--- a/packages/thirdweb/src/react/web/wallets/in-app/InAppWalletFormUI.tsx
+++ b/packages/thirdweb/src/react/web/wallets/in-app/InAppWalletFormUI.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { useState } from "react";
 import type { Chain } from "../../../../chains/types.js";
 import type { ThirdwebClient } from "../../../../client/client.js";
 import type { Wallet } from "../../../../wallets/interfaces/wallet.js";
@@ -28,6 +29,7 @@ export type InAppWalletFormUIProps = {
     showThirdwebBranding?: boolean;
     termsOfServiceUrl?: string;
     privacyPolicyUrl?: string;
+    requireApproval?: boolean;
   };
   client: ThirdwebClient;
   chain: Chain | undefined;
@@ -40,6 +42,8 @@ export type InAppWalletFormUIProps = {
 export function InAppWalletFormUIScreen(props: InAppWalletFormUIProps) {
   const isCompact = props.size === "compact";
   const { initialScreen, screen } = useScreenContext();
+  // This is only used when requireApproval is true to accept the TOS
+  const [isApproved, setIsApproved] = useState(false);
 
   const isInitialScreen =
     screen === props.wallet && initialScreen === props.wallet;
@@ -84,7 +88,6 @@ export function InAppWalletFormUIScreen(props: InAppWalletFormUIProps) {
         ) : (
           <ModalHeader onBack={onBack} title={props.inAppWalletLocale.signIn} />
         ))}
-
       <Container
         expand
         flex="column"
@@ -94,6 +97,7 @@ export function InAppWalletFormUIScreen(props: InAppWalletFormUIProps) {
         <ConnectWalletSocialOptions
           {...props}
           locale={props.inAppWalletLocale}
+          disabled={props.meta?.requireApproval && !isApproved}
         />
       </Container>
 
@@ -101,12 +105,16 @@ export function InAppWalletFormUIScreen(props: InAppWalletFormUIProps) {
         (props.meta?.showThirdwebBranding !== false ||
           props.meta?.termsOfServiceUrl ||
           props.meta?.privacyPolicyUrl) && <Spacer y="xl" />}
-
       <Container flex="column" gap="lg">
         <TOS
           termsOfServiceUrl={props.meta?.termsOfServiceUrl}
           privacyPolicyUrl={props.meta?.privacyPolicyUrl}
           locale={props.connectLocale.agreement}
+          requireApproval={props.meta?.requireApproval}
+          onApprove={() => {
+            setIsApproved(!isApproved);
+          }}
+          isApproved={isApproved}
         />
 
         {props.meta?.showThirdwebBranding !== false && <PoweredByThirdweb />}

--- a/packages/thirdweb/src/react/web/wallets/in-app/InAppWalletSelectionUI.tsx
+++ b/packages/thirdweb/src/react/web/wallets/in-app/InAppWalletSelectionUI.tsx
@@ -25,6 +25,8 @@ function InAppWalletSelectionUI(props: {
   recommendedWallets: Wallet[] | undefined;
   chain: Chain | undefined;
   size: "compact" | "wide";
+  // If true, all options will be disabled. Used for things like requiring TOS approval.
+  disabled?: boolean;
 }) {
   const { screen } = useScreenContext();
   const setData = useSetSelectionData();
@@ -59,6 +61,7 @@ function InAppWalletSelectionUI(props: {
 
   return (
     <ConnectWalletSocialOptions
+      disabled={props.disabled}
       locale={locale}
       wallet={props.wallet}
       done={props.done}

--- a/packages/thirdweb/src/react/web/wallets/shared/ConnectWalletSocialOptions.tsx
+++ b/packages/thirdweb/src/react/web/wallets/shared/ConnectWalletSocialOptions.tsx
@@ -76,6 +76,8 @@ export type ConnectWalletSocialOptionsProps = {
   client: ThirdwebClient;
   size: "compact" | "wide";
   isLinking?: boolean;
+  // If true, all options will be disabled. Used for things like requiring TOS approval.
+  disabled?: boolean;
 };
 
 /**
@@ -313,6 +315,7 @@ export const ConnectWalletSocialOptions = (
                 data-variant={showOnlyIcons ? "icon" : "full"}
                 key={loginMethod}
                 variant={"outline"}
+                disabled={props.disabled}
                 onClick={() => {
                   handleSocialLogin(loginMethod as SocialAuthOption);
                 }}
@@ -354,6 +357,7 @@ export const ConnectWalletSocialOptions = (
                 }
                 return undefined;
               }}
+              disabled={props.disabled}
               emptyErrorMessage={emptyErrorMessage}
               submitButtonText={locale.submitEmail}
             />
@@ -393,6 +397,7 @@ export const ConnectWalletSocialOptions = (
 
                 return undefined;
               }}
+              disabled={props.disabled}
               emptyErrorMessage={emptyErrorMessage}
               submitButtonText={locale.submitEmail}
             />


### PR DESCRIPTION
## Problem solved

A developer needs the ability to require all users to accept their TOS before creating an in-app wallet so they have the ability to use their emails. This PR adds a flag `requireApproval` on the modal and embed options. When enabled, all login methods will be disabled until the checkbox is selected.
<img width="566" alt="Screenshot 2024-08-27 at 1 41 07 PM" src="https://github.com/user-attachments/assets/6534a3fb-f119-4c55-b0e2-c8ccd2dcf237">

## To Test
- Open playground Sign-In page
- Under "Modal Options", set "Require TOS approval" to true
- Attempt to login with and without checking the approval confirmation

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a feature to require Terms of Service or Privacy Policy approval before connecting to an in-app wallet.

### Detailed summary
- Added `requireApproval` prop to enforce TOS or Privacy Policy acceptance
- Updated components to handle the new prop for wallet connection approval

> The following files were skipped due to too many changes: `packages/thirdweb/src/react/web/ui/ConnectWallet/WalletSelector.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->