### PR TITLE
Update page.mdx - Install Expo Modules update command

### DIFF
--- a/apps/portal/src/app/react-native/v0/installation/page.mdx
+++ b/apps/portal/src/app/react-native/v0/installation/page.mdx
@@ -44,7 +44,7 @@ export const metadata = createMetadata({
 Our wallets package uses the Expo Modules API, please [configure it](https://docs.expo.dev/modules/overview/) in your app:
 
 ```bash
-npx install-expo-modules@latest
+npx install expo-modules@latest
 ```
 
 Move into your `/ios` folder and run the following command to install ios required pods:
@@ -137,7 +137,7 @@ Now, we can add the dependencies:
 Our wallets package uses the Expo Modules API, please [configure it](https://docs.expo.dev/modules/overview/) in your app:
 
 ```bash
-npx install-expo-modules@latest
+npx installxpo-modules@latest
 ```
 
 </TabsContent>


### PR DESCRIPTION
There was a - for install and expo. So it was trying to download the dependency "install-expo-modules@latest"

## Problem solved

Short description of the bug fixed or feature added



<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the command `npx install-expo-modules@latest` to `npx install expo-modules@latest` and fix a typo in the command `npx install-expo-modules@latest`.

### Detailed summary
- Updated command from `npx install-expo-modules@latest` to `npx install expo-modules@latest`
- Fixed typo in command `npx install-expo-modules@latest` to `npx install expo-modules@latest`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->