### PR TITLE
[TS SDK] Fix: Include MainnetZ in legacy chain list

### DIFF
--- a/.changeset/gold-spoons-float.md
+++ b/.changeset/gold-spoons-float.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Include from address in in-app wallet transactions

--- a/packages/thirdweb/src/gas/fee-data.ts
+++ b/packages/thirdweb/src/gas/fee-data.ts
@@ -34,6 +34,8 @@ const FORCE_GAS_PRICE_CHAIN_IDS = [
   9372, // Oasys Testnet
   841, // Taraxa Mainnet
   842, // Taraxa Testnet
+  2016, // MainnetZ Mainnet
+  9768, // MainnetZ Testnet
 ];
 
 /**

--- a/packages/thirdweb/src/wallets/in-app/web/lib/in-app-account.ts
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/in-app-account.ts
@@ -223,6 +223,7 @@ export class IFrameWallet {
         nonce: tx.nonce,
         chainId: tx.chainId,
       };
+
       if (tx.maxFeePerGas) {
         // ethers (in the iframe) rejects any type 0 trasaction with unknown keys
         // TODO remove this once iframe is upgraded to v5


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on including the from address in in-app wallet transactions.

### Detailed summary
- Added from address in in-app wallet transactions
- Updated gas fee data for MainnetZ Mainnet and Testnet

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->