### PR TITLE
[React Native] Fix: Retry fetching user shares

### DIFF
--- a/.changeset/six-items-sell.md
+++ b/.changeset/six-items-sell.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Automatic retries for React Native in-app wallet logins


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces automatic retries for React Native in-app wallet logins to handle potential failures during the process.

### Detailed summary
- Added automatic retries for in-app wallet logins in React Native
- Added retry logic in case of login failures to improve user experience and reliability

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->