### PR TITLE
[Dashboard] Handle loading state for marketplace ui

### DIFF
--- a/apps/dashboard/src/contract-ui/tabs/listings/components/list-form.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/listings/components/list-form.tsx
@@ -215,6 +215,7 @@ export const CreateListingsForm: React.FC<CreateListingsFormProps> = ({
             try {
               await sendAndConfirmTx.mutateAsync(approveTx);
             } catch {
+              setIsFormLoading(false);
               return toast.error("Failed to approve NFT for marketplace");
             }
           }


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a `setIsFormLoading(false)` call when catching an error in approving NFT for the marketplace.

### Detailed summary
- Added `setIsFormLoading(false)` call when catching an error in approving NFT for the marketplace.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->