### PR TITLE
[React SDK] Fix: Accessbility warnings

### DIFF
--- a/.changeset/khaki-lizards-watch.md
+++ b/.changeset/khaki-lizards-watch.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix accessibility warnings

--- a/packages/thirdweb/src/react/web/ui/components/Modal.tsx
+++ b/packages/thirdweb/src/react/web/ui/components/Modal.tsx
@@ -86,7 +86,7 @@ export const Modal: React.FC<{
         )}
 
         <FocusScope trapped={!props.hide}>
-          <Dialog.Content asChild>
+          <Dialog.Content asChild aria-describedby={undefined}>
             <DialogContent
               ref={contentRef}
               style={
@@ -102,6 +102,22 @@ export const Modal: React.FC<{
                     }
               }
             >
+              {/* Mimics Tailwind's sr-only tag */}
+              <Dialog.Title
+                style={{
+                  position: "absolute",
+                  width: "1px",
+                  height: "1px",
+                  padding: 0,
+                  margin: "-1px",
+                  overflow: "hidden",
+                  clip: "rect(0, 0, 0, 0)",
+                  whiteSpace: "nowrap",
+                  borderWidth: 0,
+                }}
+              >
+                Connect Modal
+              </Dialog.Title>
               {props.size === "compact" ? (
                 <DynamicHeight maxHeight={compactModalMaxHeight}>
                   {props.children}{" "}


### PR DESCRIPTION
Fixes #4313

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing accessibility warnings in the `Modal` component of `thirdweb`.

### Detailed summary
- Added `aria-describedby` attribute to `Dialog.Content`
- Added hidden `Dialog.Title` for screen readers to mimic Tailwind's `sr-only` class

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->