### PR TITLE
Fix default "Pay with" chain

### DIFF
--- a/.changeset/wet-socks-jog.md
+++ b/.changeset/wet-socks-jog.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Update default source chain selection in PayEmbed

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx
@@ -185,12 +185,22 @@ function BuyScreenContent(props: BuyScreenContentProps) {
       return undefined;
     }
 
+    const supportedSources = supportedSourcesQuery.data;
+    if (supportedSources[0]?.chain) {
+      setFromChain(supportedSources[0]?.chain);
+    }
+
     return createSupportedTokens(
-      supportedSourcesQuery.data,
+      supportedSources,
       payOptions,
       props.supportedTokens,
     );
-  }, [props.supportedTokens, supportedSourcesQuery.data, payOptions]);
+  }, [
+    props.supportedTokens,
+    supportedSourcesQuery.data,
+    payOptions,
+    setFromChain,
+  ]);
 
   const enabledPaymentMethods = useEnabledPaymentMethods({
     payOptions: props.payOptions,


### PR DESCRIPTION
## Problem solved

When supported source chains is updated, update `fromChain` to take the first chain on the supported sources list instead of defaulting to `polygon`

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the default source chain selection in `PayEmbed`.

### Detailed summary
- Updated default source chain selection logic in `BuyScreen.tsx`
- Refactored dependencies in the `useEffect` hook for better readability

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->