### PR TITLE
Unity 4.20.1

### DIFF
--- a/legacy_packages/unity-js-bridge/src/thirdweb-bridge.ts
+++ b/legacy_packages/unity-js-bridge/src/thirdweb-bridge.ts
@@ -174,7 +174,7 @@ class ThirdwebBridge implements TWBridge {
       // biome-ignore lint/suspicious/noExplicitAny: TODO: fix use of any
       (globalThis as any).X_SDK_PLATFORM = "unity";
       // biome-ignore lint/suspicious/noExplicitAny: TODO: fix use of any
-      (globalThis as any).X_SDK_VERSION = "4.18.0";
+      (globalThis as any).X_SDK_VERSION = "4.20.1";
       // biome-ignore lint/suspicious/noExplicitAny: TODO: fix use of any
       (globalThis as any).X_SDK_OS = browser?.os ?? "unknown";
     }


### PR DESCRIPTION
Namely just a chains update

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the Unity SDK version from 4.18.0 to 4.20.1 and sets the SDK OS to the browser's OS or "unknown" if not available.

### Detailed summary
- Updated Unity SDK version from "4.18.0" to "4.20.1"
- Set SDK OS to browser's OS or "unknown" if not available

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->