### PR TITLE
[SDK] ERC1155 ClaimTo test with Allowlist

### DIFF
--- a/packages/thirdweb/src/extensions/erc1155/drops/write/claimTo.test.ts
+++ b/packages/thirdweb/src/extensions/erc1155/drops/write/claimTo.test.ts
@@ -1,13 +1,11 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { ANVIL_CHAIN } from "~test/chains.js";
 import { TEST_CLIENT } from "~test/test-clients.js";
-import { TEST_ACCOUNT_A } from "~test/test-wallets.js";
+import { TEST_ACCOUNT_A, TEST_ACCOUNT_B } from "~test/test-wallets.js";
 
+import { TEST_CONTRACT_URI } from "~test/ipfs-uris.js";
 import { NATIVE_TOKEN_ADDRESS } from "../../../../constants/addresses.js";
-import {
-  type ThirdwebContract,
-  getContract,
-} from "../../../../contract/contract.js";
+import { getContract } from "../../../../contract/contract.js";
 import { deployERC1155Contract } from "../../../../extensions/prebuilts/deploy-erc1155.js";
 import { sendAndConfirmTransaction } from "../../../../transaction/actions/send-and-confirm-transaction.js";
 import { totalSupply } from "../../__generated__/IERC1155/read/totalSupply.js";
@@ -15,13 +13,12 @@ import { lazyMint } from "../../write/lazyMint.js";
 import { claimTo } from "./claimTo.js";
 import { setClaimConditions } from "./setClaimConditions.js";
 
-let contract: ThirdwebContract;
 const account = TEST_ACCOUNT_A;
 const client = TEST_CLIENT;
 const chain = ANVIL_CHAIN;
 
 describe.runIf(process.env.TW_SECRET_KEY)("erc1155 claimTo extension", () => {
-  beforeEach(async () => {
+  it("should claim the nft", async () => {
     const address = await deployERC1155Contract({
       client,
       chain,
@@ -29,17 +26,16 @@ describe.runIf(process.env.TW_SECRET_KEY)("erc1155 claimTo extension", () => {
       type: "DropERC1155",
       params: {
         name: "Edition Drop",
+        contractURI: TEST_CONTRACT_URI,
       },
     });
-    contract = getContract({
+    const contract = getContract({
       address,
       client,
       chain,
     });
-
-    const transaction = lazyMint({ contract, nfts: [{ name: "token 0" }] });
-    await sendAndConfirmTransaction({ transaction, account });
-
+    const lazyMintTx = lazyMint({ contract, nfts: [{ name: "token 0" }] });
+    await sendAndConfirmTransaction({ transaction: lazyMintTx, account });
     const setClaimTx = setClaimConditions({
       contract,
       tokenId: 0n,
@@ -53,21 +49,68 @@ describe.runIf(process.env.TW_SECRET_KEY)("erc1155 claimTo extension", () => {
         },
       ],
     });
-
     await sendAndConfirmTransaction({ transaction: setClaimTx, account });
-  });
 
-  it("should claim the nft", async () => {
     const transaction = claimTo({
       contract,
       tokenId: 0n,
       quantity: 1n,
       to: account.address,
     });
-
     await sendAndConfirmTransaction({ transaction, account });
-
     const supplyCount = await totalSupply({ contract, id: 0n });
     expect(supplyCount).toBe(1n);
+  });
+
+  it("should claim with allowlist", async () => {
+    const address = await deployERC1155Contract({
+      client,
+      chain,
+      account,
+      type: "DropERC1155",
+      params: {
+        name: "Edition Drop",
+        contractURI: TEST_CONTRACT_URI,
+      },
+    });
+    const contract = getContract({
+      address,
+      client,
+      chain,
+    });
+    const lazyMintTx = lazyMint({ contract, nfts: [{ name: "token 0" }] });
+    await sendAndConfirmTransaction({ transaction: lazyMintTx, account });
+    const setClaimTx = setClaimConditions({
+      contract,
+      tokenId: 0n,
+      phases: [
+        {
+          maxClaimableSupply: 100n,
+          maxClaimablePerWallet: 5n,
+          currencyAddress: NATIVE_TOKEN_ADDRESS,
+          price: 0.06,
+          startTime: new Date(),
+          overrideList: [
+            {
+              address: TEST_ACCOUNT_B.address,
+              maxClaimable: "50",
+              price: "0.3",
+              currencyAddress: NATIVE_TOKEN_ADDRESS,
+            },
+          ],
+        },
+      ],
+    });
+    await sendAndConfirmTransaction({ transaction: setClaimTx, account });
+
+    const transaction = claimTo({
+      contract,
+      tokenId: 0n,
+      quantity: 50n,
+      to: TEST_ACCOUNT_B.address,
+    });
+    await sendAndConfirmTransaction({ transaction, account: TEST_ACCOUNT_B });
+    const supplyCount = await totalSupply({ contract, id: 0n });
+    expect(supplyCount).toBe(50n);
   });
 });


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance the ERC1155 claimTo extension by adding support for claiming NFTs with an allowlist feature.

### Detailed summary
- Added support for claiming NFTs with an allowlist feature
- Updated tests to include the allowlist functionality
- Adjusted transaction handling for claiming NFTs

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->