### PR TITLE
[React SDK] Fix: Hide in-app wallet connection option in pay embed

### DIFF
--- a/.changeset/happy-pandas-kick.md
+++ b/.changeset/happy-pandas-kick.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Hide in-app wallet connection in Pay Embed

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx
@@ -265,7 +265,7 @@ function BuyScreenContent(props: BuyScreenContentProps) {
             : props.connectOptions?.showAllWallets
         }
         walletConnect={props.connectOptions?.walletConnect}
-        wallets={props.connectOptions?.wallets}
+        wallets={props.connectOptions?.wallets?.filter((w) => w.id !== "inApp")}
       />
     );
   }

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/WalletSwitcherConnectionScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/WalletSwitcherConnectionScreen.tsx
@@ -38,7 +38,7 @@ export function WalletSwitcherConnectionScreen(
     getDefaultWallets({
       appMetadata: props.appMetadata,
       chains: props.chains,
-    });
+    }).filter((w) => w.id !== "inApp");
 
   const screenSetup = useSetupScreen({
     size: "compact",


### PR DESCRIPTION
The PayEmbed is missing the proper context to handle in-app wallet connections. Given this is an unlikely user use case, we'll disable it for now until the PayEmbed can be fully refactored.

CNCT-1762

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on hiding the in-app wallet connection in the Pay Embed feature of the `WalletSwitcherConnectionScreen.tsx` and filtering out the in-app wallet from the wallet options in the `BuyScreen.tsx`.

### Detailed summary
- Hide in-app wallet connection in Pay Embed feature
- Filter out in-app wallet from wallet options in Buy Screen

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->