### PR TITLE
[SDK] Document the claim behavior where claiming address is the same as PrimarySaleRecipient address

### DIFF
--- a/packages/thirdweb/src/extensions/erc1155/drops/write/claimTo.test.ts
+++ b/packages/thirdweb/src/extensions/erc1155/drops/write/claimTo.test.ts
@@ -6,6 +6,7 @@ import { TEST_ACCOUNT_A, TEST_ACCOUNT_B } from "~test/test-wallets.js";
 import { TEST_CONTRACT_URI } from "~test/ipfs-uris.js";
 import { NATIVE_TOKEN_ADDRESS } from "../../../../constants/addresses.js";
 import { getContract } from "../../../../contract/contract.js";
+import { deployERC20Contract } from "../../../../extensions/prebuilts/deploy-erc20.js";
 import { deployERC1155Contract } from "../../../../extensions/prebuilts/deploy-erc1155.js";
 import { sendAndConfirmTransaction } from "../../../../transaction/actions/send-and-confirm-transaction.js";
 import { totalSupply } from "../../__generated__/IERC1155/read/totalSupply.js";
@@ -112,5 +113,73 @@ describe.runIf(process.env.TW_SECRET_KEY)("erc1155 claimTo extension", () => {
     await sendAndConfirmTransaction({ transaction, account: TEST_ACCOUNT_B });
     const supplyCount = await totalSupply({ contract, id: 0n });
     expect(supplyCount).toBe(50n);
+  });
+
+  /**
+   * This is to document the behavior where one can claim without paying if the claiming address
+   * is the same as the PrimaryRecipientAddress, because of this Solidity code:
+   * ```solidity
+   * // CurrencyTransferLib.sol
+   * function safeTransferERC20(address _currency, address _from, address _to, uint256 _amount) internal {
+   *   if (_from == _to) {
+   *     return;
+   *   }
+   *   ...
+   * }
+   * ```
+   */
+  it("address that is the same with PrimaryFeeRecipient can claim without paying ERC20", async () => {
+    const tokenAddress = await deployERC20Contract({
+      client,
+      chain,
+      account,
+      type: "TokenERC20",
+      params: {
+        name: "token20",
+        contractURI: TEST_CONTRACT_URI,
+      },
+    });
+    const address = await deployERC1155Contract({
+      client,
+      chain,
+      account,
+      type: "DropERC1155",
+      params: {
+        name: "Edition Drop",
+        contractURI: TEST_CONTRACT_URI,
+        saleRecipient: account.address,
+      },
+    });
+    const contract = getContract({
+      address,
+      client,
+      chain,
+    });
+    const lazyMintTx = lazyMint({ contract, nfts: [{ name: "token 0" }] });
+    await sendAndConfirmTransaction({ transaction: lazyMintTx, account });
+    const setClaimTx = setClaimConditions({
+      contract,
+      tokenId: 0n,
+      phases: [
+        {
+          maxClaimableSupply: 100n,
+          maxClaimablePerWallet: 100n,
+          currencyAddress: tokenAddress,
+          price: 1000,
+          startTime: new Date(),
+        },
+      ],
+    });
+    await sendAndConfirmTransaction({ transaction: setClaimTx, account });
+
+    const transaction = claimTo({
+      contract,
+      tokenId: 0n,
+      quantity: 1n,
+      to: account.address,
+    });
+    await sendAndConfirmTransaction({ transaction, account });
+    const supplyCount = await totalSupply({ contract, id: 0n });
+    expect(supplyCount).toBe(1n);
   });
 });


### PR DESCRIPTION
Internal discussion: https://thirdwebdev.slack.com/archives/C04LA5X7FNE/p1718033032416319

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add a test case for claiming ERC20 without payment if the claiming address matches the PrimaryRecipientAddress.

### Detailed summary
- Added a test case for claiming ERC20 without payment if the claiming address matches the PrimaryRecipientAddress.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->