### PR TITLE
[SDK] Add tests for `updateMetadata` extensions

### DIFF
--- a/packages/thirdweb/src/extensions/erc1155/drops/write/updateMetadata.test.ts
+++ b/packages/thirdweb/src/extensions/erc1155/drops/write/updateMetadata.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { ANVIL_CHAIN } from "~test/chains.js";
+import { TEST_CLIENT } from "~test/test-clients.js";
+import { TEST_ACCOUNT_A } from "~test/test-wallets.js";
+
+import { TEST_CONTRACT_URI } from "~test/ipfs-uris.js";
+import { getContract } from "../../../../contract/contract.js";
+import { deployERC1155Contract } from "../../../../extensions/prebuilts/deploy-erc1155.js";
+import { sendAndConfirmTransaction } from "../../../../transaction/actions/send-and-confirm-transaction.js";
+import { getNFTs } from "../../read/getNFTs.js";
+import { lazyMint } from "../../write/lazyMint.js";
+import { updateMetadata } from "./updateMetadata.js";
+
+const account = TEST_ACCOUNT_A;
+const client = TEST_CLIENT;
+const chain = ANVIL_CHAIN;
+describe.runIf(process.env.TW_SECRET_KEY)("updateMetadata ERC1155", () => {
+  it("should update metadata", async () => {
+    const address = await deployERC1155Contract({
+      client,
+      chain,
+      account,
+      type: "DropERC1155",
+      params: {
+        name: "Edition Drop",
+        contractURI: TEST_CONTRACT_URI,
+      },
+    });
+    const contract = getContract({
+      address,
+      client,
+      chain,
+    });
+    const lazyMintTx = lazyMint({
+      contract,
+      nfts: [{ name: "token 0" }, { name: "token 1" }, { name: "token 2" }],
+    });
+    await sendAndConfirmTransaction({ transaction: lazyMintTx, account });
+
+    const updateTx = updateMetadata({
+      contract,
+      targetTokenId: 1n,
+      newMetadata: { name: "token 1 - updated" },
+      client,
+    });
+    await sendAndConfirmTransaction({ transaction: updateTx, account });
+
+    const nfts = await getNFTs({ contract });
+
+    expect(nfts.length).toBe(3);
+    expect(nfts[0]?.metadata.name).toBe("token 0");
+    expect(nfts[1]?.metadata.name).toBe("token 1 - updated");
+    expect(nfts[2]?.metadata.name).toBe("token 2");
+  });
+});

--- a/packages/thirdweb/src/extensions/erc1155/drops/write/updateMetadata.ts
+++ b/packages/thirdweb/src/extensions/erc1155/drops/write/updateMetadata.ts
@@ -109,12 +109,13 @@ export async function getUpdateMetadataParams(
  * const transaction = updateMetadata({
  *  contract,
  *  targetTokenId: 0n,
+ *  client: thirdwebClient,
  *  newMetadata: {
  *    name: "this is the new nft name",
  *    description: "...",
  *    image: "new image uri"
  *    // ...
- *  }
+ *  },
  * });
  *
  * await sendTransaction({ transaction, account });

--- a/packages/thirdweb/src/extensions/erc721/drops/write/updateMetadata.test.ts
+++ b/packages/thirdweb/src/extensions/erc721/drops/write/updateMetadata.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { ANVIL_CHAIN } from "~test/chains.js";
+import { TEST_CLIENT } from "~test/test-clients.js";
+import { TEST_ACCOUNT_A } from "~test/test-wallets.js";
+
+import { TEST_CONTRACT_URI } from "~test/ipfs-uris.js";
+import { getContract } from "../../../../contract/contract.js";
+import { deployERC721Contract } from "../../../../extensions/prebuilts/deploy-erc721.js";
+import { sendAndConfirmTransaction } from "../../../../transaction/actions/send-and-confirm-transaction.js";
+import { getNFTs } from "../../read/getNFTs.js";
+import { lazyMint } from "../../write/lazyMint.js";
+import { updateMetadata } from "./updateMetadata.js";
+
+const account = TEST_ACCOUNT_A;
+const client = TEST_CLIENT;
+const chain = ANVIL_CHAIN;
+
+describe.runIf(process.env.TW_SECRET_KEY)("updateMetadata ERC721", () => {
+  it("should update metadata", async () => {
+    const address = await deployERC721Contract({
+      client,
+      chain,
+      account,
+      type: "DropERC721",
+      params: {
+        name: "NFT Drop",
+        contractURI: TEST_CONTRACT_URI,
+      },
+    });
+    const contract = getContract({
+      address,
+      client,
+      chain,
+    });
+    const lazyMintTx = lazyMint({
+      contract,
+      nfts: [{ name: "token 0" }, { name: "token 1" }, { name: "token 2" }],
+    });
+    await sendAndConfirmTransaction({ transaction: lazyMintTx, account });
+
+    const updateTx = updateMetadata({
+      contract,
+      targetTokenId: 1n,
+      newMetadata: { name: "token 1 - updated" },
+      client,
+    });
+    await sendAndConfirmTransaction({ transaction: updateTx, account });
+
+    const nfts = await getNFTs({ contract });
+
+    expect(nfts.length).toBe(3);
+    expect(nfts[0]?.metadata.name).toBe("token 0");
+    expect(nfts[1]?.metadata.name).toBe("token 1 - updated");
+    expect(nfts[2]?.metadata.name).toBe("token 2");
+  });
+});

--- a/packages/thirdweb/src/extensions/erc721/drops/write/updateMetadata.ts
+++ b/packages/thirdweb/src/extensions/erc721/drops/write/updateMetadata.ts
@@ -106,6 +106,7 @@ export async function getUpdateMetadataParams(
  * const transaction = updateMetadata({
  *  contract,
  *  targetTokenId: 0n,
+ *  client: thirdwebClient,
  *  newMetadata: {
  *    name: "this is the new nft name",
  *    description: "...",


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the metadata of ERC721 and ERC1155 NFTs by adding a `client` parameter to the `updateMetadata` function.

### Detailed summary
- Added `client` parameter to `updateMetadata` function in ERC721 and ERC1155 NFTs update metadata files
- Updated test files to include necessary imports and test cases for metadata updates

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->