### PR TITLE
[SDK] Add tests for ethers5 Adapter

### DIFF
--- a/packages/thirdweb/src/adapters/ethers5.ts
+++ b/packages/thirdweb/src/adapters/ethers5.ts
@@ -274,7 +274,7 @@ export const ethers5Adapter = /* @__PURE__ */ (() => {
  * @returns The ethers.js provider.
  * @internal
  */
-function toEthersProvider(
+export function toEthersProvider(
   ethers: Ethers5,
   client: ThirdwebClient,
   chain: Chain,
@@ -299,7 +299,7 @@ function toEthersProvider(
  * @returns A Promise that resolves to an ethers.js Contract.
  * @internal
  */
-async function toEthersContract<abi extends Abi = []>(
+export async function toEthersContract<abi extends Abi = []>(
   ethers: Ethers5,
   twContract: ThirdwebContract<abi>,
 ): Promise<ethers5.Contract> {
@@ -336,7 +336,7 @@ type FromEthersContractOptions = {
  * @returns A promise that resolves to a ThirdwebContract instance.
  * @internal
  */
-async function fromEthersContract<abi extends Abi>(
+export async function fromEthersContract<abi extends Abi>(
   options: FromEthersContractOptions,
 ): Promise<ThirdwebContract<abi>> {
   return getContract({


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to export functions `toEthersProvider`, `toEthersContract`, and `fromEthersContract` in `ethers5.ts` for external use. 

### Detailed summary
- Exported `toEthersProvider`, `toEthersContract`, and `fromEthersContract` functions in `ethers5.ts`
- Updated imports in `ethers5.test.ts`
- Added tests for `toEthersContract` and `fromEthersContract`
- Added new imports and function calls in `ethers5.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->