### PR TITLE
[Dashboard] Revert erc1155 claim-tab to v4

### DIFF
--- a/apps/dashboard/src/contract-ui/tabs/nfts/components/claim-tab.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/nfts/components/claim-tab.tsx
@@ -1,5 +1,6 @@
 import { thirdwebClient } from "@/constants/client";
 import { Flex, FormControl, Input } from "@chakra-ui/react";
+import { useClaimNFT, useContract } from "@thirdweb-dev/react";
 import { TransactionButton } from "components/buttons/TransactionButton";
 import { useTrack } from "hooks/analytics/useTrack";
 import { useTxNotifications } from "hooks/useTxNotifications";
@@ -9,7 +10,6 @@ import { toast } from "sonner";
 import { ZERO_ADDRESS, getContract } from "thirdweb";
 import { useActiveAccount } from "thirdweb/react";
 import { FormErrorMessage, FormHelperText, FormLabel } from "tw-components";
-import { useClaimNFT, useContract } from "@thirdweb-dev/react";
 
 interface ClaimTabProps {
   contractAddress: string;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to refactor the `ClaimTabERC1155` component in the NFT dashboard to use the `useClaimNFT` hook from `@thirdweb-dev/react`.

### Detailed summary
- Refactored to use `useClaimNFT` hook instead of `claimTo` function
- Removed `useSendAndConfirmTransaction` hook
- Added `contractV4Query` and `claimNftV4` hooks for contract interaction

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->