### PR TITLE
Add theme switcher in dashboard storybook preview

### DIFF
--- a/apps/dashboard/.storybook/preview.tsx
+++ b/apps/dashboard/.storybook/preview.tsx
@@ -1,10 +1,12 @@
 import type { Preview } from "@storybook/react";
 import "@/styles/globals.css";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MoonIcon, SunIcon } from "lucide-react";
 import { Inter as interFont } from "next/font/google";
-// biome-ignore lint/correctness/noUnusedImports: <explanation>
-import React, { useEffect } from "react";
-import { cn } from "../src/@/lib/utils";
+// biome-ignore lint/style/useImportType: <explanation>
+import React, { useState } from "react";
+import { useEffect } from "react";
+import { Button } from "../src/@/components/ui/button";
 
 // Note: Wrapping the Stoy with AppRouterProviders makes the storybook server time SUPER SLOW
 // so let's just not have it there - all stories should be independent from context anyway and just rely on props
@@ -28,19 +30,49 @@ const preview: Preview = {
 
   decorators: [
     (Story) => {
-      useEffect(() => {
-        document.body.className = cn(
-          "font-sans antialiased",
-          fontSans.variable,
-        );
-      });
       return (
-        <QueryClientProvider client={queryClient}>
+        <StoryLayout>
           <Story />
-        </QueryClientProvider>
+        </StoryLayout>
       );
     },
   ],
 };
 
 export default preview;
+
+function StoryLayout(props: {
+  children: React.ReactNode;
+}) {
+  const [theme, setTheme] = useState<"light" | "dark">("dark");
+
+  useEffect(() => {
+    document.body.className = `font-sans antialiased ${fontSans.variable} ${theme === "dark" ? " dark" : ""}`;
+  }, [theme]);
+
+  return (
+    <div>
+      <div className="flex justify-end p-4 border-b mb-5 gap-2">
+        <Button
+          onClick={() => setTheme("dark")}
+          size="sm"
+          variant={theme === "dark" ? "default" : "ghost"}
+        >
+          <MoonIcon className="size-5" />
+        </Button>
+
+        <Button
+          onClick={() => setTheme("light")}
+          size="sm"
+          variant={theme === "light" ? "default" : "ghost"}
+        >
+          <SunIcon className="size-5" />
+        </Button>
+      </div>
+
+      <QueryClientProvider client={queryClient}>
+        {props.children}
+      </QueryClientProvider>
+    </div>
+  );
+}

--- a/apps/dashboard/src/app/components/Header/TeamHeader/TeamHeaderUI.stories.tsx
+++ b/apps/dashboard/src/app/components/Header/TeamHeader/TeamHeaderUI.stories.tsx
@@ -4,7 +4,7 @@ import type { Project } from "../../../../@/api/projects";
 import type { Team } from "../../../../@/api/team";
 import { Button } from "../../../../@/components/ui/button";
 import { Separator } from "../../../../@/components/ui/separator";
-import { BadgeContainer, useSetStoryTheme } from "../../../../stories/utils";
+import { BadgeContainer } from "../../../../stories/utils";
 import { TeamHeaderDesktopUI, TeamHeaderMobileUI } from "./TeamHeaderUI";
 
 const meta = {
@@ -20,38 +20,27 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Dark: Story = {
-  args: {
-    theme: "dark",
-  },
+export const AllVariants: Story = {
+  args: {},
 };
 
-export const Light: Story = {
-  args: {
-    theme: "light",
-  },
-};
-
-function Story(props: { theme: "light" | "dark" }) {
-  useSetStoryTheme(props.theme);
-
+function Story() {
   return (
     <div className="dark:bg-zinc-900 bg-zinc-300 p-6">
       <h2 className="text-3xl mb-6 font-semibold tracking-tight">Desktop</h2>
-      <Variants theme={props.theme} type="desktop" />
+      <Variants type="desktop" />
       <Separator className="my-10" />
       <h2 className="mt-10 mb-6 text-3xl font-semibold tracking-tight">
         Mobile
       </h2>
       <div className="w-[400px]">
-        <Variants theme={props.theme} type="mobile" />
+        <Variants type="mobile" />
       </div>
     </div>
   );
 }
 
 function Variants(props: {
-  theme: "light" | "dark";
   type: "mobile" | "desktop";
 }) {
   const Comp =
@@ -59,7 +48,7 @@ function Variants(props: {
 
   return (
     <ThirdwebProvider>
-      <div className={`flex flex-col gap-6 ${props.theme}`}>
+      <div className={"flex flex-col gap-6"}>
         <BadgeContainer label="Team, Free">
           <Comp
             teamsAndProjects={teamsAndProjects}

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/settings/general/DangerSettingCard.stories.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/settings/general/DangerSettingCard.stories.tsx
@@ -15,26 +15,13 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Dark: Story = {
-  args: {
-    theme: "dark",
-  },
+export const AllVariants: Story = {
+  args: {},
 };
 
-export const Light: Story = {
-  args: {
-    theme: "light",
-  },
-};
-
-function Story(props: { theme: "light" | "dark" }) {
+function Story() {
   return (
-    <div
-      className={`min-h-screen bg-background text-foreground ${
-        props.theme === "light" ? "light" : "dark"
-      }`}
-      data-theme={props.theme}
-    >
+    <div className="min-h-screen bg-background text-foreground">
       <div className="lg:p-10 container max-w-[1000px] flex flex-col gap-8">
         <BadgeContainer label="Base">
           <DangerSettingCard

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/settings/general/GeneralSettingsPage.stories.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/settings/general/GeneralSettingsPage.stories.tsx
@@ -21,16 +21,8 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Dark: Story = {
-  args: {
-    theme: "dark",
-  },
-};
-
-export const Light: Story = {
-  args: {
-    theme: "light",
-  },
+export const AllVariants: Story = {
+  args: {},
 };
 
 const testTeam: Team = {
@@ -45,12 +37,9 @@ const testTeam: Team = {
   billingPlan: "free",
 };
 
-function Story(props: { theme: "light" | "dark" }) {
+function Story() {
   return (
-    <div
-      className={`bg-background min-h-screen text-foreground ${props.theme === "light" ? "light" : "dark"}`}
-      data-theme={props.theme}
-    >
+    <div className="bg-background min-h-screen text-foreground">
       <SettingsLayout
         params={{
           team_slug: testTeam.slug,

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/settings/general/SettingsCard.stories.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/settings/general/SettingsCard.stories.tsx
@@ -15,24 +15,13 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Dark: Story = {
-  args: {
-    theme: "dark",
-  },
+export const AllVariants: Story = {
+  args: {},
 };
 
-export const Light: Story = {
-  args: {
-    theme: "light",
-  },
-};
-
-function Story(props: { theme: "light" | "dark" }) {
+function Story() {
   return (
-    <div
-      className={"min-h-screen bg-background text-foreground"}
-      data-theme={props.theme}
-    >
+    <div className="min-h-screen bg-background text-foreground">
       <div className="lg:p-10 container max-w-[1100px] flex flex-col gap-10">
         <BadgeContainer label="No Header">
           <SettingsCard

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/settings/general/Sidebar.stories.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/settings/general/Sidebar.stories.tsx
@@ -17,26 +17,15 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Dark: Story = {
+export const AllVariants: Story = {
   args: {
     theme: "dark",
   },
 };
 
-export const Light: Story = {
-  args: {
-    theme: "light",
-  },
-};
-
-function Story(props: { theme: "light" | "dark" }) {
+function Story() {
   return (
-    <div
-      className={`min-h-screen bg-zinc-800 text-foreground ${
-        props.theme === "light" ? "light" : "dark"
-      }`}
-      data-theme={props.theme}
-    >
+    <div className={"min-h-screen bg-zinc-800 text-foreground"}>
       <div className="lg:p-10 container max-w-[1100px]">
         <div className="grid gap-8 grid-cols-2">
           <HighlightContainer title="Desktop">

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/settings/members/TeamMembersSettingsPage.stories.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/settings/members/TeamMembersSettingsPage.stories.tsx
@@ -2,10 +2,7 @@ import type { Team } from "@/api/team";
 import type { TeamAccountRole, TeamMember } from "@/api/team-members";
 import { Toaster } from "@/components/ui/sonner";
 import type { Meta, StoryObj } from "@storybook/react";
-import {
-  BadgeContainer,
-  useSetStoryTheme,
-} from "../../../../../../../stories/utils";
+import { BadgeContainer } from "../../../../../../../stories/utils";
 import SettingsLayout from "../layout";
 import { InviteSection } from "./InviteSection";
 import { ManageMembersSection } from "./ManageMembersSection";
@@ -24,16 +21,8 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Dark: Story = {
-  args: {
-    theme: "dark",
-  },
-};
-
-export const Light: Story = {
-  args: {
-    theme: "light",
-  },
+export const AllVariants: Story = {
+  args: {},
 };
 
 const freeTeam: Team = {
@@ -87,13 +76,9 @@ const membersStub: TeamMember[] = [
   createMemberStub("3", "OWNER"),
 ];
 
-function Story(props: { theme: "light" | "dark" }) {
-  useSetStoryTheme(props.theme);
+function Story() {
   return (
-    <div
-      className={`bg-background min-h-screen text-foreground ${props.theme === "light" ? "light" : "dark"}`}
-      data-theme={props.theme}
-    >
+    <div className="bg-background min-h-screen text-foreground">
       <SettingsLayout
         params={{
           team_slug: freeTeam.slug,

--- a/apps/dashboard/src/components/settings/Account/Billing/GatedSwitch.stories.tsx
+++ b/apps/dashboard/src/components/settings/Account/Billing/GatedSwitch.stories.tsx
@@ -4,7 +4,7 @@ import { BadgeContainer } from "../../../../stories/utils";
 import { GatedSwitch } from "./GatedSwitch";
 
 const meta = {
-  title: "Shadcn/blocks/GatedSwitch",
+  title: "Billing/GatedSwitch",
   component: Variants,
   parameters: {
     layout: "centered",
@@ -14,26 +14,15 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Dark: Story = {
+export const AllVariants: Story = {
   args: {
     theme: "dark",
   },
 };
 
-export const Light: Story = {
-  args: {
-    theme: "light",
-  },
-};
-
-function Variants(props: {
-  theme: "light" | "dark";
-}) {
+function Variants() {
   return (
-    <div
-      data-theme={props.theme}
-      className="bg-background p-7 min-h-screen text-foreground"
-    >
+    <div className="bg-background p-7 min-h-screen text-foreground">
       <div className="flex flex-col gap-8">
         <BadgeContainer label="upgradeRequired">
           <GatedSwitch upgradeRequired />

--- a/apps/dashboard/src/stories/Button.stories.tsx
+++ b/apps/dashboard/src/stories/Button.stories.tsx
@@ -3,35 +3,24 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 const meta = {
   title: "Shadcn/Buttons",
-  component: Variants,
+  component: Component,
   parameters: {
     layout: "centered",
   },
-} satisfies Meta<typeof Variants>;
+} satisfies Meta<typeof Component>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Light: Story = {
+export const Variants: Story = {
   args: {
     theme: "light",
   },
 };
 
-export const Dark: Story = {
-  args: {
-    theme: "dark",
-  },
-};
-
-function Variants(props: {
-  theme: "light" | "dark";
-}) {
+function Component() {
   return (
-    <div
-      data-theme={props.theme}
-      className="min-h-screen bg-background p-6 text-foreground"
-    >
+    <div className="min-h-screen bg-background p-6 text-foreground">
       <div className="flex gap-6">
         <Button> Default </Button>
         <Button variant="primary"> Primary </Button>

--- a/apps/dashboard/src/stories/utils.tsx
+++ b/apps/dashboard/src/stories/utils.tsx
@@ -1,15 +1,4 @@
-import { useLayoutEffect } from "react";
 import { Badge } from "../@/components/ui/badge";
-
-export function useSetStoryTheme(theme: "light" | "dark") {
-  useLayoutEffect(() => {
-    if (theme === "light") {
-      document.documentElement.classList.remove("dark");
-    } else {
-      document.documentElement.classList.add("dark");
-    }
-  }, [theme]);
-}
 
 export function StoryBadge(props: {
   label: string;


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes the `useSetStoryTheme` function and updates components to remove theme props in Storybook stories.

### Detailed summary
- Removed `useSetStoryTheme` function
- Updated components to remove theme props in Storybook stories

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->