### PR TITLE
Fix TWTable whitespace wrapping

### DIFF
--- a/apps/dashboard/src/components/shared/TWTable.tsx
+++ b/apps/dashboard/src/components/shared/TWTable.tsx
@@ -115,7 +115,7 @@ export function TWTable<TRowData>(tableProps: TWTableProps<TRowData>) {
   });
 
   return (
-    <ScrollShadow className="border border-border rounded-lg overflow-hidden">
+    <ScrollShadow className="border border-border rounded-lg overflow-hidden whitespace-nowrap">
       <table className="w-full border-collapse tabular-nums lining-nums align-top">
         <thead className="bg-muted/50 border-b border-border">
           {table.getHeaderGroups().map((headerGroup) => (


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds the `whitespace-nowrap` class to the `ScrollShadow` component in `TWTable.tsx` to prevent text wrapping.

### Detailed summary
- Added `whitespace-nowrap` class to prevent text wrapping in `ScrollShadow` component.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->