### PR TITLE
[SDK] Allow specifying "to" and "from" props for the ClaimButton

### DIFF
--- a/.changeset/two-ghosts-bake.md
+++ b/.changeset/two-ghosts-bake.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Allow to specify "from" and "to" props for the ClaimButton

--- a/packages/thirdweb/src/react/web/ui/prebuilt/thirdweb/ClaimButton/index.tsx
+++ b/packages/thirdweb/src/react/web/ui/prebuilt/thirdweb/ClaimButton/index.tsx
@@ -232,8 +232,9 @@ export async function getERC721ClaimTo({
 
   return claimTo({
     contract,
-    to: account?.address || "",
+    to: claimParams.to || account?.address || "",
     quantity: claimParams.quantity,
+    from: claimParams.from,
   });
 }
 
@@ -255,9 +256,10 @@ export async function getERC1155ClaimTo({
 
   return claimTo({
     contract,
-    to: account?.address || "",
+    to: claimParams.to || account?.address || "",
     quantity: claimParams.quantity,
     tokenId: claimParams.tokenId,
+    from: claimParams.from,
   });
 }
 
@@ -282,15 +284,17 @@ export async function getERC20ClaimTo({
   if ("quantity" in claimParams) {
     return claimTo({
       contract,
-      to: account?.address || "",
+      to: claimParams.to || account?.address || "",
       quantity: claimParams.quantity,
+      from: claimParams.from,
     });
   }
   if ("quantityInWei" in claimParams) {
     return claimTo({
       contract,
-      to: account?.address || "",
+      to: claimParams.to || account?.address || "",
       quantityInWei: claimParams.quantityInWei,
+      from: claimParams.from,
     });
   }
   throw new Error("Missing quantity or quantityInWei");

--- a/packages/thirdweb/src/react/web/ui/prebuilt/thirdweb/ClaimButton/types.ts
+++ b/packages/thirdweb/src/react/web/ui/prebuilt/thirdweb/ClaimButton/types.ts
@@ -1,20 +1,23 @@
 import type { Chain } from "../../../../../../chains/types.js";
 import type { ThirdwebClient } from "../../../../../../client/client.js";
+import type { ClaimToParams as ClaimToParams721 } from "../../../../../../extensions/erc721/drops/write/claimTo.js";
+import type { ClaimToParams as ClaimToParams1155 } from "../../../../../../extensions/erc1155/drops/write/claimTo.js";
 import type { TransactionButtonProps } from "../../../../../core/hooks/transaction/transaction-button-utils.js";
 
-export type Erc721ClaimParams = {
+export type Erc721ClaimParams = Omit<ClaimToParams721, "to"> & {
   type: "ERC721";
-  quantity: bigint;
+  to?: string;
 };
 
-export type Erc1155ClaimParams = {
+export type Erc1155ClaimParams = Omit<ClaimToParams1155, "to"> & {
   type: "ERC1155";
-  quantity: bigint;
-  tokenId: bigint;
+  to?: string;
 };
 
 export type Erc20ClaimParams = {
   type: "ERC20";
+  to?: string;
+  from?: string;
 } & ({ quantityInWei: bigint } | { quantity: string });
 
 export type ClaimParams =


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance the `ClaimButton` component by allowing users to specify "from" and "to" props for different types of claims.

### Detailed summary
- Added the ability to specify "from" and "to" props for `ClaimButton`
- Updated `Erc721ClaimParams`, `Erc1155ClaimParams`, and `Erc20ClaimParams` types
- Modified functions to use the new "from" and "to" props for claims

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->