### PR TITLE
refactor: Fix address slicing in CopyAddressButton component

### DIFF
--- a/apps/dashboard/src/@/components/ui/CopyAddressButton.tsx
+++ b/apps/dashboard/src/@/components/ui/CopyAddressButton.tsx
@@ -16,7 +16,7 @@ export function CopyAddressButton(props: {
     | "ghost";
   copyIconPosition: "left" | "right";
 }) {
-  const shortenedAddress = `${props.address.slice(0, 6)}...${props.address.slice(4)}`;
+  const shortenedAddress = `${props.address.slice(0, 6)}...${props.address.slice(-4)}`;
 
   return (
     <CopyTextButton


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `CopyAddressButton.tsx` file in the dashboard app to correctly shorten the address by displaying the last 4 characters instead of the first 4.

### Detailed summary
- Updated `shortenedAddress` logic to display the last 4 characters of the address.


> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->