### PR TITLE
[Update] Refactor useWalletNFTs hook and NFT handling

### DIFF
--- a/apps/dashboard/src/@3rdweb-sdk/react/hooks/useWalletNFTs.ts
+++ b/apps/dashboard/src/@3rdweb-sdk/react/hooks/useWalletNFTs.ts
@@ -1,24 +1,17 @@
 import type { WalletNFTApiReturn } from "pages/api/wallet/nfts/[chainId]";
-import { useActiveAccount } from "thirdweb/react";
 import { useQueryWithNetwork } from "./query/useQueryWithNetwork";
-import { useDashboardEVMChainId } from "./useActiveChainId";
 
-export function useWalletNFTs(walletAddress?: string) {
-  const activeChainId = useDashboardEVMChainId();
-  const connectedAddress = useActiveAccount()?.address;
-
-  const address = walletAddress || connectedAddress;
-
+export function useWalletNFTs(walletAddress?: string, chainId?: number) {
   return useQueryWithNetwork(
-    ["walletNfts", address],
+    ["walletNfts", walletAddress],
     async () => {
       const response = await fetch(
-        `/api/wallet/nfts/${activeChainId}?owner=${address}`,
+        `/api/wallet/nfts/${chainId}?owner=${walletAddress}`,
       );
       return (await response.json()) as WalletNFTApiReturn;
     },
     {
-      enabled: !!address && !!activeChainId,
+      enabled: !!walletAddress && !!chainId,
     },
   );
 }

--- a/apps/dashboard/src/app/layout.tsx
+++ b/apps/dashboard/src/app/layout.tsx
@@ -5,14 +5,15 @@ import { cn } from "@/lib/utils";
 import type { Metadata } from "next";
 import PlausibleProvider from "next-plausible";
 import dynamic from "next/dynamic";
-import { Inter as interFont } from "next/font/google";
+import { Inter } from "next/font/google";
 import NextTopLoader from "nextjs-toploader";
 import { PostHogProvider } from "./components/root-providers";
 import { AppRouterProviders } from "./providers";
 
-const fontSans = interFont({
+const fontSans = Inter({
   subsets: ["latin"],
   variable: "--font-sans",
+  display: "swap",
 });
 
 export const metadata: Metadata = {

--- a/apps/dashboard/src/components/wallets/ConnectWalletMiniPlayground/MiniPlayground.tsx
+++ b/apps/dashboard/src/components/wallets/ConnectWalletMiniPlayground/MiniPlayground.tsx
@@ -11,10 +11,7 @@ import {
 } from "@chakra-ui/react";
 import { ChakraNextImage } from "components/Image";
 import { useTrack } from "hooks/analytics/useTrack";
-import {
-  Londrina_Solid as londrinaSolidConstructor,
-  Source_Serif_4 as sourceSerif4Constructor,
-} from "next/font/google";
+import { Londrina_Solid, Source_Serif_4 } from "next/font/google";
 import { useEffect, useMemo, useState } from "react";
 import { FiChevronRight } from "react-icons/fi";
 import {
@@ -41,14 +38,16 @@ import { ThemeButton } from "../ConnectWalletPlayground/ThemeButton";
 import { usePlaygroundTheme } from "../ConnectWalletPlayground/usePlaygroundTheme";
 
 // If loading a variable font, you don't need to specify the font weight
-const nounsDaoFont = londrinaSolidConstructor({
+const nounsDaoFont = Londrina_Solid({
   subsets: ["latin"],
   weight: ["900", "400"],
+  display: "swap",
 });
 
-const web3WarriorsFont = sourceSerif4Constructor({
+const web3WarriorsFont = Source_Serif_4({
   subsets: ["latin"],
   weight: ["400", "500", "600", "700"],
+  display: "swap",
 });
 
 type WalletIdSubset =

--- a/apps/dashboard/src/contract-ui/tabs/account/components/nfts-owned.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/account/components/nfts-owned.tsx
@@ -1,21 +1,28 @@
 import { useWalletNFTs } from "@3rdweb-sdk/react";
 import { NFTCards } from "contract-ui/tabs/overview/components/NFTCards";
+import type { ThirdwebContract } from "thirdweb";
 import { Text } from "tw-components";
 
 interface NftsOwnedProps {
-  address: string;
+  contract: ThirdwebContract;
 }
 
-export const NftsOwned: React.FC<NftsOwnedProps> = ({ address }) => {
-  const { data: walletNFTs, isLoading: isWalletNFTsLoading } =
-    useWalletNFTs(address);
+export const NftsOwned: React.FC<NftsOwnedProps> = ({ contract }) => {
+  const { data: walletNFTs, isLoading: isWalletNFTsLoading } = useWalletNFTs(
+    contract.address,
+    contract.chain.id,
+  );
 
   const nfts = walletNFTs?.result || [];
   const error = walletNFTs?.error;
 
   return nfts.length !== 0 ? (
     <NFTCards
-      nfts={nfts}
+      nfts={nfts.map((nft) => ({
+        ...nft,
+        contractAddress: nft.contractAddress,
+        chainId: contract.chain.id,
+      }))}
       allNfts
       isLoading={isWalletNFTsLoading}
       trackingCategory="account_nfts_owned"

--- a/apps/dashboard/src/contract-ui/tabs/account/page.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/account/page.tsx
@@ -61,7 +61,7 @@ export const AccountPage: React.FC<AccountPageProps> = ({
       <Flex direction="row" justify="space-between" align="center">
         <Heading size="title.sm">NFTs owned</Heading>
       </Flex>
-      <NftsOwned address={contract.address} />
+      <NftsOwned contract={contract} />
     </Flex>
   );
 };

--- a/apps/dashboard/src/contract-ui/tabs/listings/components/list-form.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/listings/components/list-form.tsx
@@ -100,7 +100,12 @@ export const CreateListingsForm: React.FC<CreateListingsFormProps> = ({
       isAlchemySupported(chainId) ||
       isMoralisSupported(chainId));
 
-  const { data: walletNFTs, isLoading: isWalletNFTsLoading } = useWalletNFTs();
+  const account = useActiveAccount();
+
+  const { data: walletNFTs, isLoading: isWalletNFTsLoading } = useWalletNFTs(
+    account?.address,
+    chainId,
+  );
   const sendAndConfirmTx = useSendAndConfirmTransaction();
 
   const form = useForm<ListForm>({
@@ -116,8 +121,6 @@ export const CreateListingsForm: React.FC<CreateListingsFormProps> = ({
       listingDurationInSeconds: (60 * 60 * 24 * 30).toString(),
     },
   });
-
-  const account = useActiveAccount();
 
   const selectedContract = form.watch("selected.contractAddress")
     ? getContract({
@@ -141,7 +144,7 @@ export const CreateListingsForm: React.FC<CreateListingsFormProps> = ({
 
   const isSelected = (nft: WalletNFT) => {
     return (
-      form.watch("selected")?.tokenId === nft.tokenId &&
+      form.watch("selected")?.id === nft.id &&
       form.watch("selected")?.contractAddress === nft.contractAddress
     );
   };
@@ -229,7 +232,7 @@ export const CreateListingsForm: React.FC<CreateListingsFormProps> = ({
             const transaction = createListing({
               contract,
               assetContractAddress: formData.selected.contractAddress,
-              tokenId: BigInt(formData.selected.tokenId),
+              tokenId: BigInt(formData.selected.id),
               currencyContractAddress: formData.currencyContractAddress,
               quantity: BigInt(formData.quantity),
               startTimestamp: formData.startTimestamp,
@@ -276,7 +279,7 @@ export const CreateListingsForm: React.FC<CreateListingsFormProps> = ({
             const transaction = createAuction({
               contract,
               assetContractAddress: formData.selected.contractAddress,
-              tokenId: BigInt(formData.selected.tokenId),
+              tokenId: BigInt(formData.selected.id),
               startTimestamp: formData.startTimestamp,
               currencyContractAddress: formData.currencyContractAddress,
               endTimestamp: new Date(
@@ -392,7 +395,7 @@ export const CreateListingsForm: React.FC<CreateListingsFormProps> = ({
                   boxShadow="none"
                   shouldWrapChildren
                   placement="left-end"
-                  key={nft.contractAddress + nft.tokenId}
+                  key={nft.contractAddress + nft.id}
                   label={<ListLabel nft={nft} />}
                 >
                   <Box
@@ -517,7 +520,7 @@ export const CreateListingsForm: React.FC<CreateListingsFormProps> = ({
         </>
       )}
 
-      {!form.watch("selected.tokenId") && (
+      {!form.watch("selected.id") && (
         <Alert>
           <CircleAlertIcon className="size-4" />
           <AlertTitle>No NFT selected</AlertTitle>

--- a/apps/dashboard/src/contract-ui/tabs/listings/components/list-label.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/listings/components/list-label.tsx
@@ -19,7 +19,7 @@ export const ListLabel: React.FC<ListLabelProps> = ({ nft }) => {
           {shortenIfAddress(nft.contractAddress)}
         </ListItem>
         <ListItem>
-          <strong>Token ID: </strong> {nft.tokenId}
+          <strong>Token ID: </strong> {nft.id.toString()}
         </ListItem>
         <ListItem>
           <>

--- a/apps/dashboard/src/contract-ui/tabs/overview/components/NFTDetails.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/overview/components/NFTDetails.tsx
@@ -1,7 +1,8 @@
 import { Flex, useBreakpointValue } from "@chakra-ui/react";
 import { useTabHref } from "contract-ui/utils";
 import type { ThirdwebContract } from "thirdweb";
-import { getNFTs } from "thirdweb/extensions/erc721";
+import * as ERC721 from "thirdweb/extensions/erc721";
+import * as ERC1155 from "thirdweb/extensions/erc1155";
 import { useReadContract } from "thirdweb/react";
 import { Heading, TrackedLink, type TrackedLinkProps } from "tw-components";
 import { NFTCards } from "./NFTCards";
@@ -9,20 +10,25 @@ import { NFTCards } from "./NFTCards";
 interface NFTDetailsProps {
   contract: ThirdwebContract;
   trackingCategory: TrackedLinkProps["category"];
+  isErc721: boolean;
 }
 
 export const NFTDetails: React.FC<NFTDetailsProps> = ({
   contract,
   trackingCategory,
+  isErc721,
 }) => {
   const isMobile = useBreakpointValue({ base: true, md: false });
   const nftsHref = useTabHref("nfts");
 
-  const nftQuery = useReadContract(getNFTs, {
-    contract,
-    count: 5,
-    includeOwners: true,
-  });
+  const nftQuery = useReadContract(
+    isErc721 ? ERC721.getNFTs : ERC1155.getNFTs,
+    {
+      contract,
+      count: 5,
+      includeOwners: false,
+    },
+  );
 
   const displayableNFTs =
     nftQuery.data
@@ -47,8 +53,11 @@ export const NFTDetails: React.FC<NFTDetailsProps> = ({
         </TrackedLink>
       </Flex>
       <NFTCards
-        contractAddress={contract.address}
-        nfts={displayableNFTs}
+        nfts={displayableNFTs.map((t) => ({
+          ...t,
+          contractAddress: contract.address,
+          chainId: contract.chain.id,
+        }))}
         trackingCategory={trackingCategory}
         isLoading={nftQuery.isLoading}
       />

--- a/apps/dashboard/src/contract-ui/tabs/overview/page.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/overview/page.tsx
@@ -55,6 +55,7 @@ export const ContractOverviewPage: React.FC<ContractOverviewPageProps> = ({
           <NFTDetails
             contract={contract}
             trackingCategory={TRACKING_CATEGORY}
+            isErc721={isErc721}
           />
         )}
         {isErc20 && <TokenDetails contract={contract} />}

--- a/apps/dashboard/src/lib/wallet/nfts/alchemy.ts
+++ b/apps/dashboard/src/lib/wallet/nfts/alchemy.ts
@@ -36,8 +36,8 @@ export async function transformAlchemyResponseToNFT(
 
         try {
           return {
+            id: BigInt(alchemyNFT.id.tokenId),
             contractAddress: alchemyNFT.contract.address,
-            tokenId: alchemyNFT.id.tokenId,
             metadata: shouldDownloadURI(rawUri)
               ? await StorageSingleton.downloadJSON(
                   handleArbitraryTokenURI(rawUri),
@@ -46,6 +46,7 @@ export async function transformAlchemyResponseToNFT(
             owner,
             supply: alchemyNFT.balance || "1",
             type: alchemyNFT.id.tokenMetadata.tokenType,
+            tokenURI: rawUri,
           } as WalletNFT;
         } catch {
           return undefined as unknown as WalletNFT;

--- a/apps/dashboard/src/lib/wallet/nfts/moralis.ts
+++ b/apps/dashboard/src/lib/wallet/nfts/moralis.ts
@@ -31,6 +31,7 @@ export async function transformMoralisResponseToNFT(
       moralisResponse.result.map(async (moralisNft) => {
         try {
           return {
+            id: BigInt(moralisNft.token_id),
             contractAddress: moralisNft.token_address,
             tokenId: moralisNft.token_id,
             metadata: shouldDownloadURI(moralisNft.token_uri)
@@ -39,6 +40,7 @@ export async function transformMoralisResponseToNFT(
                 )
               : moralisNft.token_uri,
             owner,
+            tokenURI: moralisNft.token_uri,
             supply: moralisNft.amount || "1",
             type: moralisNft.contract_type,
           } as WalletNFT;

--- a/apps/dashboard/src/lib/wallet/nfts/simpleHash.ts
+++ b/apps/dashboard/src/lib/wallet/nfts/simpleHash.ts
@@ -30,6 +30,7 @@ export async function transformSimpleHashResponseToNFT(
       simpleHashResponse.nfts.map(async (simpleHashNft) => {
         try {
           return {
+            id: BigInt(simpleHashNft.token_id),
             contractAddress: simpleHashNft.contract_address,
             tokenId: simpleHashNft.token_id,
             metadata: {
@@ -49,6 +50,7 @@ export async function transformSimpleHashResponseToNFT(
             owner: walletAddress,
             supply: simpleHashNft.token_count.toString(),
             type: simpleHashNft.contract.type,
+            tokenURI: simpleHashNft.extra_metadata.metadata_original_url,
           } as WalletNFT;
         } catch {
           return undefined as unknown as WalletNFT;

--- a/apps/dashboard/src/lib/wallet/nfts/types.ts
+++ b/apps/dashboard/src/lib/wallet/nfts/types.ts
@@ -1,3 +1,4 @@
+import type { NFT } from "thirdweb";
 import {
   arbitrum,
   arbitrumNova,
@@ -50,25 +51,8 @@ import {
   zoraSepolia,
 } from "thirdweb/chains";
 
-type NFT = {
-  metadata: {
-    name?: string;
-    description?: string;
-    image?: string | null;
-    animation_url?: string | null;
-    external_url?: string | null;
-    background_color?: string;
-    properties?: Record<string, unknown> | Array<Record<string, unknown>>;
-  } & Record<string, unknown>;
-  owner: string;
-  type: "ERC1155" | "ERC721";
-  supply: string;
-  quantityOwned?: bigint;
-};
-
 export type WalletNFT = NFT & {
   contractAddress: string;
-  tokenId: string;
 };
 
 // List: https://docs.alchemy.com/reference/nft-api-faq


### PR DESCRIPTION
### TL;DR

Refactored wallet NFT handling and improved font loading across the dashboard.

### What changed?

- Updated `useWalletNFTs` hook to accept `chainId` as a parameter
- Modified `NftsOwned` component to use contract chain ID
- Refactored font loading in `layout.tsx` and `MiniPlayground.tsx`
- Updated NFT data structures to use `id` instead of `tokenId`
- Adjusted NFT card rendering to include chain ID and contract address
- Modified Alchemy, Moralis, and SimpleHash NFT transformations

### How to test?

1. Test the wallet NFT fetching functionality with different chain IDs
2. Verify that NFT cards display correctly in the dashboard
3. Check font loading performance in various components
4. Ensure that NFT details are correctly displayed in listings and overview pages

### Why make this change?

This change improves the consistency of NFT handling across the dashboard, enhances font loading performance, and provides better support for multi-chain NFT display. It also aligns the NFT data structure with the latest ThirdWeb SDK conventions, using `id` instead of `tokenId`.

---



<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance NFT handling in the dashboard by adding ERC721 support and improving NFT data transformations.

### Detailed summary
- Added `isErc721` prop to NFT components
- Enhanced NFT data transformations with `tokenURI`
- Updated font imports and usage
- Improved handling of NFT ownership and contract details

> The following files were skipped due to too many changes: `apps/dashboard/src/contract-ui/tabs/overview/components/NFTCards.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->