### PR TITLE
[Update] Refactor NFT drawer tabs and contract interactions

### DIFF
--- a/apps/dashboard/src/contract-ui/tabs/claim-conditions/components/claim-conditions-form/index.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/claim-conditions/components/claim-conditions-form/index.tsx
@@ -25,7 +25,6 @@ import {
 } from "@thirdweb-dev/sdk";
 import { TransactionButton } from "components/buttons/TransactionButton";
 import { TooltipBox } from "components/configure-networks/Form/TooltipBox";
-import { detectFeatures } from "components/contract-components/utils";
 import { SnapshotUpload } from "contract-ui/tabs/claim-conditions/components/snapshot-upload";
 import { useTrack } from "hooks/analytics/useTrack";
 import { useTxNotifications } from "hooks/useTxNotifications";
@@ -178,11 +177,16 @@ export function useClaimConditionsFormContext() {
   return data;
 }
 
+// TODO: refactor, this is no longer supported
+const isClaimPhaseV1 = false;
+
 interface ClaimConditionsFormProps {
   contract: DropContract;
   tokenId?: string;
   isColumn?: true;
   contractV5: ThirdwebContract;
+  isErc20: boolean;
+  isMultiPhase: boolean;
 }
 
 export const ClaimConditionsForm: React.FC<ClaimConditionsFormProps> = ({
@@ -190,41 +194,9 @@ export const ClaimConditionsForm: React.FC<ClaimConditionsFormProps> = ({
   tokenId,
   isColumn,
   contractV5,
+  isErc20,
+  isMultiPhase,
 }) => {
-  const isMultiPhase = useMemo(
-    () =>
-      detectFeatures(contract, [
-        // erc721
-        "ERC721ClaimPhasesV1",
-        "ERC721ClaimPhasesV2",
-        // erc1155
-        "ERC1155ClaimPhasesV1",
-        "ERC1155ClaimPhasesV2",
-        // erc 20
-        "ERC20ClaimPhasesV1",
-        "ERC20ClaimPhasesV2",
-      ]),
-    [contract],
-  );
-  const isClaimPhaseV1 = useMemo(
-    () =>
-      detectFeatures(contract, [
-        // erc721
-        "ERC721ClaimConditionsV1",
-        "ERC721ClaimPhasesV1",
-        // erc1155
-        "ERC1155ClaimConditionsV1",
-        "ERC1155ClaimPhasesV1",
-        // erc20
-        "ERC20ClaimConditionsV1",
-        "ERC20ClaimPhasesV1",
-      ]),
-    [contract],
-  );
-  const isErc20 = useMemo(
-    () => detectFeatures(contract, ["ERC20"]),
-    [contract],
-  );
   const walletAddress = useActiveAccount()?.address;
   const trackEvent = useTrack();
   const [resetFlag, setResetFlag] = useState(false);

--- a/apps/dashboard/src/contract-ui/tabs/claim-conditions/components/claim-conditions.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/claim-conditions/components/claim-conditions.tsx
@@ -12,6 +12,7 @@ interface ClaimConditionsProps {
   contractInfo: {
     hasNewClaimConditions: boolean;
     isErc20: boolean;
+    isMultiPhase: boolean;
   };
 }
 export const ClaimConditions: React.FC<ClaimConditionsProps> = ({
@@ -58,10 +59,12 @@ export const ClaimConditions: React.FC<ClaimConditionsProps> = ({
           {/* Set Claim Conditions */}
           {contractQuery.contract && (
             <ClaimConditionsForm
+              isErc20={contractInfo.isErc20}
               contract={contractQuery.contract}
               tokenId={tokenId}
               isColumn={isColumn}
               contractV5={contract}
+              isMultiPhase={contractInfo.isMultiPhase}
             />
           )}
         </Flex>

--- a/apps/dashboard/src/contract-ui/tabs/claim-conditions/page.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/claim-conditions/page.tsx
@@ -9,6 +9,7 @@ interface ContractClaimConditionsPageProps {
   claimconditionExtensionDetection: ExtensionDetectedState;
   isERC20: boolean;
   hasNewClaimConditions: boolean;
+  isMultiPhase: boolean;
 }
 
 export const ContractClaimConditionsPage: React.FC<
@@ -18,6 +19,7 @@ export const ContractClaimConditionsPage: React.FC<
   claimconditionExtensionDetection,
   isERC20,
   hasNewClaimConditions,
+  isMultiPhase,
 }) => {
   if (!claimconditionExtensionDetection) {
     return (
@@ -49,7 +51,7 @@ export const ContractClaimConditionsPage: React.FC<
     <Flex direction="column" gap={6}>
       <ClaimConditions
         contract={contract}
-        contractInfo={{ isErc20: isERC20, hasNewClaimConditions }}
+        contractInfo={{ isErc20: isERC20, hasNewClaimConditions, isMultiPhase }}
       />
     </Flex>
   );

--- a/apps/dashboard/src/contract-ui/tabs/nfts/components/airdrop-tab.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/nfts/components/airdrop-tab.tsx
@@ -1,4 +1,3 @@
-import { thirdwebClient } from "@/constants/client";
 import { Flex, Icon, Stack, useDisclosure } from "@chakra-ui/react";
 import { TransactionButton } from "components/buttons/TransactionButton";
 import {
@@ -7,37 +6,26 @@ import {
 } from "contract-ui/tabs/nfts/components/airdrop-upload";
 import { useTrack } from "hooks/analytics/useTrack";
 import { useTxNotifications } from "hooks/useTxNotifications";
-import { useV5DashboardChain } from "lib/v5-adapter";
 import { useForm } from "react-hook-form";
 import { BsCircleFill } from "react-icons/bs";
 import { FiUpload } from "react-icons/fi";
-import { getContract } from "thirdweb";
+import type { ThirdwebContract } from "thirdweb";
 import { multicall } from "thirdweb/extensions/common";
 import { balanceOf, encodeSafeTransferFrom } from "thirdweb/extensions/erc1155";
 import { useActiveAccount, useSendAndConfirmTransaction } from "thirdweb/react";
 import { Button, Text } from "tw-components";
 
 interface AirdropTabProps {
-  contractAddress: string;
+  contract: ThirdwebContract;
   tokenId: string;
-  chainId: number;
 }
 
 /**
  * This component must only take in ERC1155 contracts
  */
-const AirdropTab: React.FC<AirdropTabProps> = ({
-  contractAddress,
-  tokenId,
-  chainId,
-}) => {
+const AirdropTab: React.FC<AirdropTabProps> = ({ contract, tokenId }) => {
   const account = useActiveAccount();
-  const chain = useV5DashboardChain(chainId);
-  const contract = getContract({
-    address: contractAddress,
-    chain: chain,
-    client: thirdwebClient,
-  });
+
   const address = useActiveAccount()?.address;
   const { handleSubmit, setValue, watch, reset, formState } = useForm<{
     addresses: AirdropAddressInput[];
@@ -66,7 +54,7 @@ const AirdropTab: React.FC<AirdropTabProps> = ({
             category: "nft",
             action: "airdrop",
             label: "attempt",
-            contractAddress,
+            contract_address: contract.address,
             token_id: tokenId,
           });
           const totalOwned = await balanceOf({
@@ -101,7 +89,7 @@ const AirdropTab: React.FC<AirdropTabProps> = ({
                 category: "nft",
                 action: "airdrop",
                 label: "success",
-                contract_address: contractAddress,
+                contract_address: contract.address,
                 token_id: tokenId,
               });
               onSuccess();
@@ -112,7 +100,7 @@ const AirdropTab: React.FC<AirdropTabProps> = ({
                 category: "nft",
                 action: "airdrop",
                 label: "success",
-                contract_address: contractAddress,
+                contract_address: contract.address,
                 token_id: tokenId,
                 error,
               });

--- a/apps/dashboard/src/contract-ui/tabs/nfts/components/burn-tab.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/nfts/components/burn-tab.tsx
@@ -1,11 +1,9 @@
-import { thirdwebClient } from "@/constants/client";
 import { FormControl, Input, Stack } from "@chakra-ui/react";
 import { TransactionButton } from "components/buttons/TransactionButton";
 import { useTrack } from "hooks/analytics/useTrack";
 import { useTxNotifications } from "hooks/useTxNotifications";
-import { useV5DashboardChain } from "lib/v5-adapter";
 import { useForm } from "react-hook-form";
-import { getContract } from "thirdweb";
+import type { ThirdwebContract } from "thirdweb";
 import { burn as burn721, isERC721 } from "thirdweb/extensions/erc721";
 import { burn as burn1155, isERC1155 } from "thirdweb/extensions/erc1155";
 import {
@@ -23,17 +21,11 @@ import {
 
 interface BurnTabProps {
   tokenId: string;
-  contractAddress: string;
-  chainId: number;
+  contract: ThirdwebContract;
 }
 
-const BurnTab: React.FC<BurnTabProps> = ({
-  contractAddress,
-  chainId,
-  tokenId,
-}) => {
+const BurnTab: React.FC<BurnTabProps> = ({ contract, tokenId }) => {
   const account = useActiveAccount();
-  const chain = useV5DashboardChain(chainId);
   const trackEvent = useTrack();
   const {
     register,
@@ -45,11 +37,7 @@ const BurnTab: React.FC<BurnTabProps> = ({
     defaultValues: { amount: "1" },
   });
   const invalidateContractQuery = useInvalidateContractQuery();
-  const contract = getContract({
-    address: contractAddress,
-    chain: chain,
-    client: thirdwebClient,
-  });
+
   const { onSuccess, onError } = useTxNotifications(
     "Burn successful",
     "Error burning",
@@ -90,8 +78,8 @@ const BurnTab: React.FC<BurnTabProps> = ({
               onSuccess();
               if (contract) {
                 invalidateContractQuery({
-                  chainId,
-                  contractAddress,
+                  chainId: contract.chain.id,
+                  contractAddress: contract.address,
                 });
               }
               reset();

--- a/apps/dashboard/src/contract-ui/tabs/nfts/components/claim-tab.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/nfts/components/claim-tab.tsx
@@ -1,39 +1,25 @@
-import { thirdwebClient } from "@/constants/client";
 import { Flex, FormControl, Input } from "@chakra-ui/react";
 import { TransactionButton } from "components/buttons/TransactionButton";
 import { useTrack } from "hooks/analytics/useTrack";
 import { useTxNotifications } from "hooks/useTxNotifications";
-import { useV5DashboardChain } from "lib/v5-adapter";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
-import { ZERO_ADDRESS, getContract } from "thirdweb";
+import { type ThirdwebContract, ZERO_ADDRESS } from "thirdweb";
 import { getApprovalForTransaction } from "thirdweb/extensions/erc20";
 import { claimTo } from "thirdweb/extensions/erc1155";
 import { useActiveAccount, useSendAndConfirmTransaction } from "thirdweb/react";
 import { FormErrorMessage, FormHelperText, FormLabel } from "tw-components";
 
 interface ClaimTabProps {
-  contractAddress: string;
-  chainId: number;
+  contract: ThirdwebContract;
   tokenId: string;
 }
 
-const ClaimTabERC1155: React.FC<ClaimTabProps> = ({
-  contractAddress,
-  chainId,
-  tokenId,
-}) => {
+const ClaimTabERC1155: React.FC<ClaimTabProps> = ({ contract, tokenId }) => {
   const trackEvent = useTrack();
   const address = useActiveAccount()?.address;
   const form = useForm<{ to: string; amount: string }>({
     defaultValues: { amount: "1", to: address },
-  });
-  const chain = useV5DashboardChain(chainId);
-
-  const contract = getContract({
-    address: contractAddress,
-    chain: chain,
-    client: thirdwebClient,
   });
 
   const { onSuccess, onError } = useTxNotifications(

--- a/apps/dashboard/src/contract-ui/tabs/nfts/components/mint-supply-tab.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/nfts/components/mint-supply-tab.tsx
@@ -1,26 +1,19 @@
-import { thirdwebClient } from "@/constants/client";
 import { FormControl, Input, Stack } from "@chakra-ui/react";
 import { TransactionButton } from "components/buttons/TransactionButton";
 import { useTrack } from "hooks/analytics/useTrack";
 import { useTxNotifications } from "hooks/useTxNotifications";
-import { useV5DashboardChain } from "lib/v5-adapter";
 import { useForm } from "react-hook-form";
-import { getContract } from "thirdweb";
+import type { ThirdwebContract } from "thirdweb";
 import { mintAdditionalSupplyTo } from "thirdweb/extensions/erc1155";
 import { useActiveAccount, useSendAndConfirmTransaction } from "thirdweb/react";
 import { FormErrorMessage, FormHelperText, FormLabel } from "tw-components";
 
 interface MintSupplyTabProps {
-  contractAddress: string;
-  chainId: number;
+  contract: ThirdwebContract;
   tokenId: string;
 }
 
-const MintSupplyTab: React.FC<MintSupplyTabProps> = ({
-  contractAddress,
-  chainId,
-  tokenId,
-}) => {
+const MintSupplyTab: React.FC<MintSupplyTabProps> = ({ contract, tokenId }) => {
   const trackEvent = useTrack();
   const {
     register,
@@ -30,12 +23,7 @@ const MintSupplyTab: React.FC<MintSupplyTabProps> = ({
   } = useForm<{ to: string; amount: string }>({
     defaultValues: { amount: "1" },
   });
-  const chain = useV5DashboardChain(chainId);
-  const contract = getContract({
-    address: contractAddress,
-    chain: chain,
-    client: thirdwebClient,
-  });
+
   const address = useActiveAccount()?.address;
   const { mutate, isPending } = useSendAndConfirmTransaction();
   const { onSuccess, onError } = useTxNotifications(

--- a/apps/dashboard/src/contract-ui/tabs/nfts/components/transfer-tab.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/nfts/components/transfer-tab.tsx
@@ -1,12 +1,10 @@
-import { thirdwebClient } from "@/constants/client";
 import { FormControl, Input, Stack } from "@chakra-ui/react";
 import { TransactionButton } from "components/buttons/TransactionButton";
 import { SolidityInput } from "contract-ui/components/solidity-inputs";
 import { useTrack } from "hooks/analytics/useTrack";
 import { useTxNotifications } from "hooks/useTxNotifications";
-import { useV5DashboardChain } from "lib/v5-adapter";
 import { useForm } from "react-hook-form";
-import { ZERO_ADDRESS, getContract } from "thirdweb";
+import { type ThirdwebContract, ZERO_ADDRESS } from "thirdweb";
 import { transferFrom } from "thirdweb/extensions/erc721";
 import { isERC1155, safeTransferFrom } from "thirdweb/extensions/erc1155";
 import {
@@ -16,23 +14,13 @@ import {
 } from "thirdweb/react";
 import { FormErrorMessage, FormHelperText, FormLabel } from "tw-components";
 interface TransferTabProps {
-  contractAddress: string;
-  chainId: number;
+  contract: ThirdwebContract;
   tokenId: string;
 }
 
-const TransferTab: React.FC<TransferTabProps> = ({
-  contractAddress,
-  chainId,
-  tokenId,
-}) => {
+const TransferTab: React.FC<TransferTabProps> = ({ contract, tokenId }) => {
   const account = useActiveAccount();
-  const chain = useV5DashboardChain(chainId);
-  const contract = getContract({
-    address: contractAddress,
-    chain: chain,
-    client: thirdwebClient,
-  });
+
   const trackEvent = useTrack();
   const form = useForm<{ to: string; amount: string }>({
     defaultValues: { to: "", amount: "1" },


### PR DESCRIPTION
### TL;DR

Refactored NFT-related components and hooks to improve code organization and reduce redundancy.

### What changed?

- Consolidated imports from `thirdweb/extensions` modules
- Removed redundant contract creation and feature detection logic
- Updated component props to directly pass `ThirdwebContract` instead of separate address and chain ID
- Simplified conditional rendering based on contract type (ERC721 vs ERC1155)
- Moved some feature detection logic to parent components
- Updated `useNFTDrawerTabs` hook to use new contract prop structure

### How to test?

1. Navigate to the NFT management pages in the dashboard
2. Verify that all NFT-related functionality (minting, burning, transferring, etc.) works as expected for both ERC721 and ERC1155 tokens
3. Check that the NFT drawer displays the correct tabs and options based on the contract type and user permissions
4. Ensure that claim conditions and multi-phase claim conditions are correctly detected and displayed

### Why make this change?

This refactoring improves code maintainability and reduces duplication. By centralizing contract-related logic and simplifying component interfaces, it becomes easier to manage and extend NFT functionality across the dashboard. The changes also prepare the codebase for potential future enhancements and make it more consistent with other parts of the application.

---

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces support for multi-phase claims in ERC20 contracts across various components.

### Detailed summary
- Added `isMultiPhase` boolean in claim conditions for ERC20 contracts
- Updated components to handle `isMultiPhase` flag for ERC20 contracts

> The following files were skipped due to too many changes: `apps/dashboard/src/contract-ui/tabs/nfts/components/airdrop-tab.tsx`, `apps/dashboard/src/core-ui/nft-drawer/useNftDrawerTabs.tsx`, `apps/dashboard/src/contract-ui/hooks/useRouteConfig.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->