### PR TITLE
[Portal] Update useSendTransaction docs

### DIFF
--- a/packages/thirdweb/src/react/web/hooks/transaction/useSendTransaction.tsx
+++ b/packages/thirdweb/src/react/web/hooks/transaction/useSendTransaction.tsx
@@ -19,7 +19,7 @@ import { TransactionModal } from "../../ui/TransactionButton/TransactionModal.js
  * Refer to [`SendTransactionConfig`](https://portal.thirdweb.com/references/typescript/v5/SendTransactionConfig) for more details.
  * @example
  *
- * ### Using a prepared contract call
+ * ### Sending a prepared contract call
  *
  * ```tsx
  * import { useSendTransaction } from "thirdweb/react";
@@ -83,11 +83,12 @@ import { TransactionModal } from "../../ui/TransactionButton/TransactionModal.js
  * const { mutate: sendTx, data: transactionResult } = useSendTransaction();
  *
  * const onClick = () => {
+ *   // Send 0.1 SepoliaETH to an address
  *   const transaction = prepareTransaction({
- *       contract,
- *       to: "0x...",
- *       value: toWei("0.1"),
- *     }),
+ *     to: "0x...",
+ *     value: toWei("0.1"),
+ *     chain: sepolia,
+ *     client: thirdwebClient,
  *   });
  *   sendTx(transaction);
  * };


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the example and improve clarity in the `useSendTransaction` hook by changing "Using a prepared contract call" to "Sending a prepared contract call".

### Detailed summary
- Updated the example to reflect sending a prepared contract call
- Added `chain` and `client` properties to the `transaction` object

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->