### PR TITLE
Docs: Fix table cell size on firefox

### DIFF
--- a/apps/portal/src/components/Document/Table.tsx
+++ b/apps/portal/src/components/Document/Table.tsx
@@ -14,7 +14,7 @@ export function Table(props: { children: React.ReactNode }) {
 
 export function Tr(props: { children: React.ReactNode }) {
 	return (
-		<tr className="border-b p-4 pb-3 pl-8 pt-0 text-left font-medium text-f-200">
+		<tr className="text-f-200 border-b p-4 pb-3 pl-8 pt-0 text-left font-medium">
 			{props.children}
 		</tr>
 	);
@@ -26,7 +26,7 @@ export function TBody(props: { children: React.ReactNode }) {
 
 export function Th(props: { children: React.ReactNode }) {
 	return (
-		<th className="border-b bg-b-700 p-4 pb-3 pl-8 text-left text-base font-semibold text-f-100">
+		<th className="bg-b-700 text-f-100 border-b p-4 pb-3 pl-8 text-left text-base font-semibold">
 			{props.children}
 		</th>
 	);
@@ -34,7 +34,7 @@ export function Th(props: { children: React.ReactNode }) {
 
 export function Td(props: { children: React.ReactNode }) {
 	return (
-		<td className="w-min p-4 pl-8 text-base leading-relaxed text-f-200">
+		<td className="text-f-200  p-4 pl-8 text-base leading-relaxed">
 			{props.children}
 		</td>
 	);


### PR DESCRIPTION
Fixes - https://linear.app/thirdweb/issue/CNCT-1751/fix-portal-table-cell-widths-on-firefox

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to rearrange the class names in the `Table.tsx` component for consistency and readability.

### Detailed summary
- Reordered class names in `Tr`, `Th`, and `Td` components for consistency and readability.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->