### PR TITLE
Add props for hiding send, receive and buy buttons on ConnectButton

### DIFF
--- a/.changeset/old-lions-happen.md
+++ b/.changeset/old-lions-happen.md
@@ -1,0 +1,15 @@
+---
+"thirdweb": patch
+---
+
+Add props for hiding "Send", "Receive" and "Send" buttons in Connect Details Modal UI for `ConnectButton` component. By default, all buttons are visible in the modal.
+
+```tsx
+<ConnectButton
+  detailsModal={{
+    hideSendFunds: false,
+    hideReceiveFunds: true,
+    hideBuyFunds: false,
+  }}
+/>
+```

--- a/packages/thirdweb/src/react/core/hooks/connection/ConnectButtonProps.ts
+++ b/packages/thirdweb/src/react/core/hooks/connection/ConnectButtonProps.ts
@@ -288,6 +288,27 @@ export type ConnectButton_detailsModalOptions = {
    * Use custom avatar URL for the connected wallet image in the `ConnectButton` Details Modal, overriding ENS avatar or Blobbie icon.
    */
   connectedAccountAvatarUrl?: string;
+
+  /**
+   * Hide the "Send Funds" button in the `ConnectButton` Details Modal.
+   *
+   * By default the "Send Funds" button is shown.
+   */
+  hideSendFunds?: boolean;
+
+  /**
+   * Hide the "Receive Funds" button in the `ConnectButton` Details Modal.
+   *
+   * By default the "Receive Funds" button is shown.
+   */
+  hideReceiveFunds?: boolean;
+
+  /**
+   * Hide the "Buy Funds" button in the `ConnectButton` Details Modal.
+   *
+   * By default the "Buy Funds" button is shown.
+   */
+  hideBuyFunds?: boolean;
 };
 
 /**

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/ConnectButton.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/ConnectButton.tsx
@@ -544,6 +544,9 @@ function ConnectButtonInner(
         showAllWallets: props.showAllWallets,
         walletConnect: props.walletConnect,
         wallets: props.wallets,
+        hideReceiveFunds: props.detailsModal?.hideReceiveFunds,
+        hideSendFunds: props.detailsModal?.hideSendFunds,
+        hideBuyFunds: props.detailsModal?.hideBuyFunds,
       }}
     />
   );

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/Details.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/Details.tsx
@@ -373,6 +373,11 @@ function DetailsModal(props: {
   const avatarSrc =
     props.detailsModal?.connectedAccountAvatarUrl ?? ensAvatarQuery.data;
 
+  const { hideSendFunds, hideReceiveFunds, hideBuyFunds } =
+    props.detailsModal || {};
+
+  const hideAllButtons = hideSendFunds && hideReceiveFunds && hideBuyFunds;
+
   const avatarContent = (
     <Container
       style={{
@@ -438,7 +443,16 @@ function DetailsModal(props: {
   let content = (
     <div>
       <Spacer y="xs" />
-      <Container p="lg" gap="sm" flex="row" center="y">
+      <Container
+        px="lg"
+        gap="sm"
+        flex="row"
+        center="y"
+        style={{
+          paddingTop: spacing.lg,
+          paddingBottom: hideAllButtons ? spacing.md : spacing.lg,
+        }}
+      >
         {props.detailsModal?.hideSwitchWallet ? (
           avatarContent
         ) : (
@@ -481,81 +495,99 @@ function DetailsModal(props: {
           <InAppWalletUserInfo client={client} locale={locale} />
         </Container>
       </Container>
-      <Container px="lg">
-        {/* Send, Receive, Swap */}
-        <Container
-          style={{
-            display: "grid",
-            gridTemplateColumns: "1fr 1fr 1fr",
-            gap: spacing.xs,
-          }}
-        >
-          <Button
-            variant="outline"
-            style={{
-              fontSize: fontSize.sm,
-              display: "flex",
-              gap: spacing.xs,
-              alignItems: "center",
-              padding: spacing.sm,
-            }}
-            onClick={() => {
-              setScreen("send");
-            }}
-          >
-            <Container color="secondaryText" flex="row" center="both">
-              <PaperPlaneIcon
-                width={iconSize.sm}
-                height={iconSize.sm}
-                style={{
-                  transform: "translateY(-10%) rotate(-45deg) ",
-                }}
-              />
-            </Container>
 
-            {locale.send}
-          </Button>
+      {!hideAllButtons && (
+        <>
+          <Container px="lg">
+            {/* Send, Receive, Swap */}
+            <Container
+              style={{
+                display: "flex",
+                gap: spacing.xs,
+              }}
+            >
+              {!hideSendFunds && (
+                <Button
+                  variant="outline"
+                  style={{
+                    fontSize: fontSize.sm,
+                    display: "flex",
+                    gap: spacing.xs,
+                    alignItems: "center",
+                    padding: spacing.sm,
+                    flex: 1,
+                  }}
+                  onClick={() => {
+                    setScreen("send");
+                  }}
+                >
+                  <Container color="secondaryText" flex="row" center="both">
+                    <PaperPlaneIcon
+                      width={iconSize.sm}
+                      height={iconSize.sm}
+                      style={{
+                        transform: "translateY(-10%) rotate(-45deg) ",
+                      }}
+                    />
+                  </Container>
 
-          <Button
-            variant="outline"
-            style={{
-              fontSize: fontSize.sm,
-              display: "flex",
-              gap: spacing.xs,
-              alignItems: "center",
-              padding: spacing.sm,
-            }}
-            onClick={() => {
-              setScreen("receive");
-            }}
-          >
-            <Container color="secondaryText" flex="row" center="both">
-              <PinBottomIcon width={iconSize.sm} height={iconSize.sm} />{" "}
-            </Container>
-            {locale.receive}{" "}
-          </Button>
+                  {locale.send}
+                </Button>
+              )}
 
-          <Button
-            variant="outline"
-            style={{
-              fontSize: fontSize.sm,
-              display: "flex",
-              gap: spacing.xs,
-              alignItems: "center",
-              padding: spacing.sm,
-            }}
-            onClick={() => {
-              setScreen("buy");
-            }}
-          >
-            <Container color="secondaryText" flex="row" center="both">
-              <PlusIcon width={iconSize.sm} height={iconSize.sm} />
+              {!hideReceiveFunds && (
+                <Button
+                  variant="outline"
+                  style={{
+                    fontSize: fontSize.sm,
+                    display: "flex",
+                    gap: spacing.xs,
+                    alignItems: "center",
+                    padding: spacing.sm,
+                    flex: 1,
+                  }}
+                  onClick={() => {
+                    setScreen("receive");
+                  }}
+                >
+                  <Container color="secondaryText" flex="row" center="both">
+                    <PinBottomIcon
+                      width={iconSize.sm}
+                      height={iconSize.sm}
+                    />{" "}
+                  </Container>
+                  {locale.receive}{" "}
+                </Button>
+              )}
+
+              {!hideBuyFunds && (
+                <Button
+                  variant="outline"
+                  style={{
+                    fontSize: fontSize.sm,
+                    display: "flex",
+                    gap: spacing.xs,
+                    alignItems: "center",
+                    padding: spacing.sm,
+                    flex: 1,
+                  }}
+                  onClick={() => {
+                    setScreen("buy");
+                  }}
+                >
+                  <Container color="secondaryText" flex="row" center="both">
+                    <PlusIcon width={iconSize.sm} height={iconSize.sm} />
+                  </Container>
+                  {locale.buy}
+                </Button>
+              )}
             </Container>
-            {locale.buy}
-          </Button>
-        </Container>
-      </Container>
-      <Spacer y="md" />
+          </Container>
+
+          <Spacer y="md" />
+        </>
+      )}
+
       <Container px="md">
         <Container
           flex="column"
@@ -1122,6 +1154,9 @@ export type DetailsModalConnectOptions = {
   chains?: Chain[];
   recommendedWallets?: Wallet[];
   showAllWallets?: boolean;
+  hideSendFunds?: boolean;
+  hideReceiveFunds?: boolean;
+  hideBuyFunds?: boolean;
 };
 
 export type UseWalletDetailsModalOptions = {

--- a/packages/thirdweb/src/stories/ConnectButton/hideButtons.stories.tsx
+++ b/packages/thirdweb/src/stories/ConnectButton/hideButtons.stories.tsx
@@ -1,0 +1,83 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ConnectButton } from "../../react/web/ui/ConnectWallet/ConnectButton.js";
+import { storyClient } from "../utils.js";
+
+const meta = {
+  title: "Connect/ConnectButton/hide buttons",
+  component: ConnectButton,
+  parameters: {
+    layout: "centered",
+  },
+  args: {
+    client: storyClient,
+  },
+} satisfies Meta<typeof ConnectButton>;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const HideSend: Story = {
+  args: {
+    detailsModal: {
+      hideSendFunds: true,
+    },
+  },
+};
+
+export const HideReceive: Story = {
+  args: {
+    detailsModal: {
+      hideReceiveFunds: true,
+    },
+  },
+};
+
+export const HideBuy: Story = {
+  args: {
+    detailsModal: {
+      hideBuyFunds: true,
+    },
+  },
+};
+
+export const HideSendReceive: Story = {
+  args: {
+    detailsModal: {
+      hideSendFunds: true,
+      hideReceiveFunds: true,
+    },
+  },
+};
+
+export const HideSendBuy: Story = {
+  args: {
+    detailsModal: {
+      hideSendFunds: true,
+      hideBuyFunds: true,
+    },
+  },
+};
+
+export const HideReceiveBuy: Story = {
+  args: {
+    detailsModal: {
+      hideReceiveFunds: true,
+      hideBuyFunds: true,
+    },
+  },
+};
+
+export const HideSendReceiveBuy: Story = {
+  args: {
+    detailsModal: {
+      hideSendFunds: true,
+      hideReceiveFunds: true,
+      hideBuyFunds: true,
+    },
+  },
+};
+
+export default meta;

--- a/packages/thirdweb/src/stories/ConnectButton/themes.stories.tsx
+++ b/packages/thirdweb/src/stories/ConnectButton/themes.stories.tsx
@@ -1,14 +1,13 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { ConnectButton } from "../react/web/ui/ConnectWallet/ConnectButton.js";
-import { storyClient } from "./utils.js";
+import { ConnectButton } from "../../react/web/ui/ConnectWallet/ConnectButton.js";
+import { storyClient } from "../utils.js";
 
 const meta = {
-  title: "Connect/ConnectButton",
+  title: "Connect/ConnectButton/themes",
   component: ConnectButton,
   parameters: {
     layout: "centered",
   },
-  tags: ["autodocs"],
   args: {
     client: storyClient,
   },


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding the ability to hide "Send", "Receive", and "Buy" buttons in the Connect Details Modal UI for the `ConnectButton` component.

### Detailed summary
- Added props to hide "Send", "Receive", and "Buy" buttons in the Connect Details Modal UI
- Updated `ConnectButtonProps` with new boolean props for hiding buttons
- Modified `Details.tsx` to conditionally show or hide the buttons based on props

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->