### PR TITLE
Fixed onBack function on GetStartedScreen (when can't connect in any way)

### DIFF
--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/AnyWalletConnectUI.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/AnyWalletConnectUI.tsx
@@ -299,9 +299,7 @@ export function AnyWalletConnectUI(props: {
       locale={locale}
       wallet={props.wallet}
       walletInfo={walletInfo.data}
-      onBack={() => {
-        setScreen("main");
-      }}
+      onBack={props.onBack}
       client={props.client}
     />
   );


### PR DESCRIPTION
## Problem solved

When selecting a wallet that doesn't have a mobile app like Rabby or Backpack wallet and they aren't installed as browser extensions, the user is taken to GetStartedScreen (image attached). In this case, the GetStartedScreen's back button wasn't working.

This PR should fix that issue.

<img width="689" alt="Screenshot 2024-09-04 at 8 11 55 PM" src="https://github.com/user-attachments/assets/29ab5341-2698-4cb0-911e-88eede03c004">



<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `AnyWalletConnectUI.tsx` file to replace the `onBack` function with the one provided in the `props`.

### Detailed summary
- Replaced the `onBack` function with the one provided in the `props`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->