### PR TITLE
Resolve implementation from matic proxy implementation slot

### DIFF
--- a/.changeset/weak-pans-attack.md
+++ b/.changeset/weak-pans-attack.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+resolve implementation for matic proxy implementation slot

--- a/packages/thirdweb/src/utils/bytecode/resolveImplementation.test.ts
+++ b/packages/thirdweb/src/utils/bytecode/resolveImplementation.test.ts
@@ -10,6 +10,8 @@ import { TEST_CLIENT } from "../../../test/src/test-clients.js";
 import {
   NFT_DROP_CONTRACT,
   NFT_DROP_IMPLEMENTATION,
+  POLYGON_USDT_IMPLEMENTATION,
+  POLYGON_USDT_PROXY_CONTRACT,
 } from "../../../test/src/test-contracts.js";
 import { TEST_ACCOUNT_A } from "../../../test/src/test-wallets.js";
 import { getContract } from "../../contract/contract.js";
@@ -20,6 +22,13 @@ describe("Resolve implementation", async () => {
   it("should extract implementation address for minimal proxy contract", async () => {
     const resolved = resolveImplementation(NFT_DROP_CONTRACT);
     expect((await resolved).address).to.equal(NFT_DROP_IMPLEMENTATION);
+  });
+
+  it("should extract implementation address for matic proxy contract", async () => {
+    const resolved = resolveImplementation(POLYGON_USDT_PROXY_CONTRACT);
+    expect((await resolved).address).to.equal(
+      POLYGON_USDT_IMPLEMENTATION.toLowerCase(),
+    );
   });
 
   it("should extract implementation address for ERC1967 proxy contract", async () => {

--- a/packages/thirdweb/test/globalSetup.ts
+++ b/packages/thirdweb/test/globalSetup.ts
@@ -1,6 +1,6 @@
 import { sha256 } from "@noble/hashes/sha256";
 import { startProxy } from "@viem/anvil";
-import { FORK_BLOCK_NUMBER, OPTIMISM_FORK_BLOCK_NUMBER } from "./src/chains.js";
+import { FORK_BLOCK_NUMBER, OPTIMISM_FORK_BLOCK_NUMBER, POLYGON_FORK_BLOCK_NUMBER } from "./src/chains.js";
 
 require("dotenv-mono").load();
 
@@ -61,10 +61,26 @@ export default async function globalSetup() {
     port: 8648,
   });
 
+  const shutdownPolygon = await startProxy({
+    port: 8649,
+    options: {
+      chainId: 137,
+      forkUrl: SECRET_KEY
+        ? `https://137.rpc.thirdweb.com/${clientId}`
+        : "https://polygon-rpc.com",
+      forkHeader: SECRET_KEY ? { "x-secret-key": SECRET_KEY } : {},
+      forkChainId: 137,
+      forkBlockNumber: POLYGON_FORK_BLOCK_NUMBER,
+      noMining: true,
+      startTimeout: 20000,
+    },
+  });
+
   return async () => {
     await shutdownMainnet();
     await shutdownMainnetWithMining();
     await shutdownOptimism();
     await shutdownAnvil();
+    await shutdownPolygon();
   };
 }

--- a/packages/thirdweb/test/src/chains.ts
+++ b/packages/thirdweb/test/src/chains.ts
@@ -1,5 +1,6 @@
 import { anvil } from "../../src/chains/chain-definitions/anvil.js";
 import { ethereum } from "../../src/chains/chain-definitions/ethereum.js";
+import { polygon } from "../../src/chains/chain-definitions/polygon.js";
 import { optimism } from "../../src/chains/chain-definitions/optimism.js";
 import { defineChain } from "../../src/chains/utils.js";
 
@@ -9,11 +10,18 @@ export const FORKED_ETHEREUM_RPC = `http://127.0.0.1:8645/${poolId}`;
 export const FORKED_ETHEREUM_WITH_MINING_RPC = `http://127.0.0.1:8646/${poolId}`;
 export const FORKED_OPTIMISM_RPC = `http://127.0.0.1:8647/${poolId}`;
 export const ANVIL_RPC = `http://127.0.0.1:8648/${poolId}`;
+export const FORKED_POLYGON_RPC = `http://127.0.0.1:8649/${poolId}`;
 
 export const FORKED_ETHEREUM_CHAIN = defineChain({
   ...ethereum,
   // override the rpc url
   rpc: FORKED_ETHEREUM_RPC,
+});
+
+export const FORKED_POLYGON_CHAIN = defineChain({
+  ...polygon,
+  // override the rpc url
+  rpc: FORKED_POLYGON_RPC,
 });
 
 export const FORKED_ETHEREUM_CHAIN_WITH_MINING = defineChain({
@@ -36,3 +44,4 @@ export const ANVIL_CHAIN = defineChain({
 
 export const FORK_BLOCK_NUMBER = 19139495n;
 export const OPTIMISM_FORK_BLOCK_NUMBER = 117525204n;
+export const POLYGON_FORK_BLOCK_NUMBER = 61430000n;

--- a/packages/thirdweb/test/src/test-contracts.ts
+++ b/packages/thirdweb/test/src/test-contracts.ts
@@ -1,12 +1,17 @@
 import { getContract } from "../../src/contract/contract.js";
 import { USDT_ABI } from "./abis/usdt.js";
-import { FORKED_ETHEREUM_CHAIN } from "./chains.js";
+import { FORKED_ETHEREUM_CHAIN, FORKED_POLYGON_CHAIN } from "./chains.js";
 import { TEST_CLIENT } from "./test-clients.js";
 
 // ERC20
 
 export const USDT_CONTRACT_ADDRESS =
   "0xdAC17F958D2ee523a2206206994597C13D831ec7";
+
+  export const POLYGON_USDT_CONTRACT_ADDRESS =
+  "0xc2132d05d31c914a87c6611c10748aeb04b58e8f";
+
+  export const POLYGON_USDT_IMPLEMENTATION = "0x7FFB3d637014488b63fb9858E279385685AFc1e2";
 
 export const USDT_CONTRACT = getContract({
   client: TEST_CLIENT,
@@ -19,6 +24,12 @@ export const USDT_CONTRACT_WITH_ABI = getContract({
   address: USDT_CONTRACT_ADDRESS,
   chain: FORKED_ETHEREUM_CHAIN,
   abi: USDT_ABI,
+});
+
+export const POLYGON_USDT_PROXY_CONTRACT = getContract({
+  client: TEST_CLIENT,
+  address: POLYGON_USDT_CONTRACT_ADDRESS,
+  chain: FORKED_POLYGON_CHAIN,
 });
 
 // ERC721


### PR DESCRIPTION
## Problem solved

keccak256("matic.network.proxy.implementation") - used in polygon USDT proxy: https://polygonscan.com/address/0xc2132d05d31c914a87c6611c10748aeb04b58e8f#code

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to implement resolution for Matic proxy contracts and update test contracts and chains for Polygon integration.

### Detailed summary
- Added resolution for Matic proxy contract implementation slot
- Updated test contracts for Polygon USDT integration
- Updated global setup for Polygon proxy shutdown
- Added support for Polygon chain in test contracts
- Updated implementation resolution for Polygon USDT proxy contract

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->