### PR TITLE
[Dashboard] Migrate type ExtraPublishMetadata

### DIFF
--- a/.changeset/slow-queens-greet.md
+++ b/.changeset/slow-queens-greet.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Export type CoreMetadata

--- a/apps/dashboard/src/components/contract-components/contract-publish-form/landing-fieldset.tsx
+++ b/apps/dashboard/src/components/contract-components/contract-publish-form/landing-fieldset.tsx
@@ -11,7 +11,6 @@ import {
   Tabs,
   Textarea,
 } from "@chakra-ui/react";
-import type { ExtraPublishMetadata } from "@thirdweb-dev/sdk";
 import { compare, validate } from "compare-versions";
 import { FileInput } from "components/shared/FileInput";
 import { SolidityInput } from "contract-ui/components/solidity-inputs";
@@ -19,6 +18,7 @@ import { SelectOption } from "core-ui/batch-upload/lazy-mint-form/select-option"
 import { useImageFileOrUrl } from "hooks/useImageFileOrUrl";
 import { replaceIpfsUrl } from "lib/sdk";
 import { useFormContext } from "react-hook-form";
+import type { CoreMetadata } from "thirdweb/utils";
 import {
   Card,
   FormErrorMessage,
@@ -35,6 +35,10 @@ interface LandingFieldsetProps {
   latestVersion: string | undefined;
   placeholderVersion: string;
 }
+
+type ExtraPublishMetadata = Omit<CoreMetadata, "logo"> & {
+  logo?: File | string;
+};
 
 export const LandingFieldset: React.FC<LandingFieldsetProps> = ({
   latestVersion,

--- a/packages/thirdweb/src/exports/utils.ts
+++ b/packages/thirdweb/src/exports/utils.ts
@@ -21,7 +21,10 @@ export { getSaltHash } from "../utils/any-evm/get-salt-hash.js";
 export { isEIP155Enforced } from "../utils/any-evm/is-eip155-enforced.js";
 export { keccakId } from "../utils/any-evm/keccak-id.js";
 export { getKeylessTransaction } from "../utils/any-evm/keyless-transaction.js";
-export type { ExtendedMetadata } from "../utils/any-evm/deploy-metadata.js";
+export type {
+  CoreMetadata,
+  ExtendedMetadata,
+} from "../utils/any-evm/deploy-metadata.js";
 
 //signatures
 export {

--- a/packages/thirdweb/src/utils/any-evm/deploy-metadata.ts
+++ b/packages/thirdweb/src/utils/any-evm/deploy-metadata.ts
@@ -131,7 +131,7 @@ export type CompilerMetadata = Prettify<
   }
 >;
 
-export type ExtendedMetadata = {
+export type CoreMetadata = {
   name: string;
   version: string;
   metadataUri: string;
@@ -184,5 +184,8 @@ export type ExtendedMetadata = {
     }
   >;
   compositeAbi?: Abi;
+};
+
+export type ExtendedMetadata = CoreMetadata & {
   [key: string]: unknown;
 };


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on exporting a new type `CoreMetadata` and updating related types in the `deploy-metadata.ts` file. 

### Detailed summary
- Exported new type `CoreMetadata`
- Updated `ExtendedMetadata` type to extend `CoreMetadata`
- Updated exports in `utils.ts` to include `CoreMetadata` and `ExtendedMetadata`
- Added `CoreMetadata` import in `LandingFieldset` component
- Defined new type `ExtraPublishMetadata` in `LandingFieldset` component

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->