### PR TITLE
[Update] Open contract links in new tab instead of router navigation

### DIFF
--- a/apps/dashboard/src/components/contract-components/contract-table/index.tsx
+++ b/apps/dashboard/src/components/contract-components/contract-table/index.tsx
@@ -1,5 +1,4 @@
 import { Spinner, Table, Tbody, Td, Th, Thead, Tr } from "@chakra-ui/react";
-import { useRouter } from "next/router";
 import { useMemo } from "react";
 import { type Column, type Row, useTable } from "react-table";
 import { Text } from "tw-components";
@@ -111,8 +110,6 @@ interface TableRowProps {
 }
 
 const TableRow: React.FC<TableRowProps> = ({ row, context }) => {
-  const router = useRouter();
-
   return (
     <Tr
       borderBottomWidth={1}
@@ -127,13 +124,8 @@ const TableRow: React.FC<TableRowProps> = ({ row, context }) => {
       }}
       pointerEvents={row?.original?.contractId ? "auto" : "none"}
       onClick={() => {
-        router.push(
-          actionUrlPath(context, row.original.contractId),
-          undefined,
-          {
-            scroll: true,
-          },
-        );
+        // always open in new tab
+        window.open(actionUrlPath(context, row.original.contractId));
       }}
       {...row.getRowProps()}
     >


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update the `TableRow` component in `contract-table/index.tsx` to open links in a new tab instead of using `router.push`.

### Detailed summary
- Removed `useRouter` import
- Replaced `router.push` with `window.open` to open links in a new tab

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->