### PR TITLE
Fix SolidityAddressInput value not displayed properly

### DIFF
--- a/apps/dashboard/src/contract-ui/components/solidity-inputs/address-input.tsx
+++ b/apps/dashboard/src/contract-ui/components/solidity-inputs/address-input.tsx
@@ -14,8 +14,9 @@ export const SolidityAddressInput: React.FC<SolidityInputProps> = ({
 }) => {
   const { name, ...restOfInputProps } = inputProps;
   const inputName = name as string;
+  const [_localInput, setLocalInput] = useState<string | undefined>();
   const inputNameWatch = form.watch(inputName);
-  const [localInput, setLocalInput] = useState(inputNameWatch);
+  const localInput = _localInput === undefined ? inputNameWatch : _localInput;
   const address = useActiveAccount()?.address;
 
   const ensQuery = useEns(localInput);


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a change in the way `localInput` is initialized in `address-input.tsx` to prevent unnecessary re-renders.

### Detailed summary
- Initialize `_localInput` with `useState` hook to prevent unnecessary re-renders
- Update the logic to set `localInput` based on `_localInput` value or `inputNameWatch`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->