### PR TITLE
[Update] Refactor ethers adapter and pin ethers version

### DIFF
--- a/apps/dashboard/next-env.d.ts
+++ b/apps/dashboard/next-env.d.ts
@@ -3,4 +3,4 @@
 /// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -65,7 +65,7 @@
     "color": "^4.2.3",
     "compare-versions": "^6.1.0",
     "date-fns": "^3.6.0",
-    "ethers": "^5.7.2",
+    "ethers": "5.7.2",
     "flat": "^6.0.1",
     "framer-motion": "^11.2.12",
     "fuse.js": "7.0.0",

--- a/apps/dashboard/src/components/app-layouts/provider-setup.tsx
+++ b/apps/dashboard/src/components/app-layouts/provider-setup.tsx
@@ -12,12 +12,13 @@ import {
 import { useQueryClient } from "@tanstack/react-query";
 import { ThirdwebSDKProvider } from "@thirdweb-dev/react";
 import type { Signer } from "ethers";
+import * as ethers from "ethers";
 import { useSupportedChains } from "hooks/chains/configureChains";
 import { useNativeColorMode } from "hooks/useNativeColorMode";
 import { getDashboardChainRpc } from "lib/rpc";
 import { StorageSingleton } from "lib/sdk";
 import { useEffect, useMemo, useState } from "react";
-import { ethers5Adapter } from "thirdweb/adapters/ethers5";
+import { toEthersSigner } from "thirdweb/adapters/ethers5";
 import { type ChainMetadata, ethereum } from "thirdweb/chains";
 import {
   useActiveAccount,
@@ -130,11 +131,12 @@ function useEthersSigner() {
         return;
       }
       try {
-        const s = await ethers5Adapter.signer.toEthers({
-          account: activeAccount,
-          chain: activeChain,
-          client: thirdwebClient,
-        });
+        const s = await toEthersSigner(
+          ethers,
+          thirdwebClient,
+          activeAccount,
+          activeChain,
+        );
         if (active) {
           setSigner(s);
         }

--- a/legacy_packages/auth/package.json
+++ b/legacy_packages/auth/package.json
@@ -98,7 +98,7 @@
     "eslint-plugin-inclusive-language": "^2.2.1",
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-tsdoc": "^0.3.0",
-    "ethers": "^5.7.2",
+    "ethers": "5.7.2",
     "express": "^4.19.2",
     "fastify": "^4.28.0",
     "next": "14.2.8",

--- a/legacy_packages/cli/package.json
+++ b/legacy_packages/cli/package.json
@@ -41,7 +41,7 @@
     "commander": "^9.5.0",
     "detect-package-manager": "^2.0.1",
     "enquirer": "^2.4.1",
-    "ethers": "^5.7.2",
+    "ethers": "5.7.2",
     "got": "11.8.5",
     "inquirer": "^8.2.6",
     "js-yaml": "^4.1.0",

--- a/legacy_packages/contracts-js/package.json
+++ b/legacy_packages/contracts-js/package.json
@@ -439,7 +439,7 @@
     "@thirdweb-dev/tsconfig": "workspace:*",
     "@typechain/ethers-v5": "10.0.0",
     "eslint-config-thirdweb": "workspace:*",
-    "ethers": "^5.7.2",
+    "ethers": "5.7.2",
     "typechain": "^8.3.2",
     "typescript": "5.5.4"
   },

--- a/legacy_packages/crypto/package.json
+++ b/legacy_packages/crypto/package.json
@@ -37,7 +37,7 @@
     "crypto-js": "^4.2.0",
     "eslint": "8.57.0",
     "eslint-config-thirdweb": "workspace:*",
-    "ethers": "^5.7.2",
+    "ethers": "5.7.2",
     "js-awe": "^1.0.65",
     "tinybench": "^2.6.0",
     "typescript": "5.5.4",

--- a/legacy_packages/payments/package.json
+++ b/legacy_packages/payments/package.json
@@ -38,7 +38,7 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "ethers": "^5.7.2"
+    "ethers": "5.7.2"
   },
   "devDependencies": {
     "@preconstruct/cli": "2.7.0",

--- a/legacy_packages/react-core/package.json
+++ b/legacy_packages/react-core/package.json
@@ -75,7 +75,7 @@
     "eslint-plugin-inclusive-language": "^2.2.1",
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-tsdoc": "^0.3.0",
-    "ethers": "^5.7.2",
+    "ethers": "5.7.2",
     "react": "18.3.1",
     "typedoc-gen": "workspace:*",
     "typescript": "5.5.4"

--- a/legacy_packages/react/package.json
+++ b/legacy_packages/react/package.json
@@ -92,7 +92,7 @@
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-svg-jsx": "^1.2.4",
     "eslint-plugin-tsdoc": "^0.3.0",
-    "ethers": "^5.7.2",
+    "ethers": "5.7.2",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "stream": "npm:stream-browserify@^3.0.0",

--- a/legacy_packages/sdk/package.json
+++ b/legacy_packages/sdk/package.json
@@ -101,7 +101,7 @@
     "eslint-plugin-inclusive-language": "^2.2.1",
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-tsdoc": "^0.3.0",
-    "ethers": "^5.7.2",
+    "ethers": "5.7.2",
     "ethers-aws-kms-signer": "^1.3.2",
     "hardhat": "^2.22.2",
     "mocha": "10.5.1",

--- a/legacy_packages/unity-js-bridge/package.json
+++ b/legacy_packages/unity-js-bridge/package.json
@@ -19,7 +19,7 @@
     "@thirdweb-dev/storage": "workspace:*",
     "@thirdweb-dev/wallets": "workspace:*",
     "detect-browser": "^5.3.0",
-    "ethers": "^5.7.2"
+    "ethers": "5.7.2"
   },
   "devDependencies": {
     "@thirdweb-dev/tsconfig": "workspace:*",

--- a/legacy_packages/wallets/package.json
+++ b/legacy_packages/wallets/package.json
@@ -599,7 +599,7 @@
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-tsdoc": "^0.3.0",
     "ethereum-provider": "^0.7.7",
-    "ethers": "^5.7.2",
+    "ethers": "5.7.2",
     "ethers-aws-kms-signer": "^1.3.2",
     "hardhat": "^2.22.2",
     "tweetnacl": "^1.0.3",

--- a/packages/thirdweb/src/adapters/ethers5.ts
+++ b/packages/thirdweb/src/adapters/ethers5.ts
@@ -354,7 +354,9 @@ export async function fromEthersContract<abi extends Abi>(
  * @returns - A Promise that resolves to an Account object.
  * @internal
  */
-async function fromEthersSigner(signer: ethers5.Signer): Promise<Account> {
+export async function fromEthersSigner(
+  signer: ethers5.Signer,
+): Promise<Account> {
   const address = await signer.getAddress();
   const account: Account = {
     address,

--- a/packages/thirdweb/src/adapters/ethers6.ts
+++ b/packages/thirdweb/src/adapters/ethers6.ts
@@ -235,7 +235,7 @@ export const ethers6Adapter = /* @__PURE__ */ (() => {
  * @returns The ethers.js provider.
  * @internal
  */
-function toEthersProvider(
+export function toEthersProvider(
   ethers: Ethers6,
   client: ThirdwebClient,
   chain: Chain,
@@ -260,7 +260,7 @@ function toEthersProvider(
  * @returns A Promise that resolves to an ethers.js Contract.
  * @internal
  */
-async function toEthersContract<abi extends Abi = []>(
+export async function toEthersContract<abi extends Abi = []>(
   ethers: Ethers6,
   twContract: ThirdwebContract<abi>,
   account?: Account,
@@ -302,7 +302,7 @@ type FromEthersContractOptions = {
  * @returns A promise that resolves to a ThirdwebContract instance.
  * @internal
  */
-async function fromEthersContract<abi extends Abi>({
+export async function fromEthersContract<abi extends Abi>({
   client,
   ethersContract,
   chain,
@@ -321,7 +321,9 @@ async function fromEthersContract<abi extends Abi>({
  * @returns - A Promise that resolves to an Account object.
  * @internal
  */
-async function fromEthersSigner(signer: ethers6.Signer): Promise<Account> {
+export async function fromEthersSigner(
+  signer: ethers6.Signer,
+): Promise<Account> {
   const address = await signer.getAddress();
   const account: Account = {
     address,

--- a/packages/thirdweb/src/exports/adapters/ethers5.ts
+++ b/packages/thirdweb/src/exports/adapters/ethers5.ts
@@ -1,1 +1,8 @@
-export { ethers5Adapter } from "../../adapters/ethers5.js";
+export {
+  ethers5Adapter,
+  fromEthersContract,
+  toEthersContract,
+  toEthersProvider,
+  toEthersSigner,
+  fromEthersSigner,
+} from "../../adapters/ethers5.js";

--- a/packages/thirdweb/src/exports/adapters/ethers6.ts
+++ b/packages/thirdweb/src/exports/adapters/ethers6.ts
@@ -1,1 +1,8 @@
-export { ethers6Adapter } from "../../adapters/ethers6.js";
+export {
+  ethers6Adapter,
+  toEthersSigner,
+  fromEthersContract,
+  fromEthersSigner,
+  toEthersContract,
+  toEthersProvider,
+} from "../../adapters/ethers6.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -261,7 +261,7 @@ importers:
         specifier: ^3.6.0
         version: 3.6.0
       ethers:
-        specifier: ^5.7.2
+        specifier: 5.7.2
         version: 5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       flat:
         specifier: ^6.0.1
@@ -1160,7 +1160,7 @@ importers:
         specifier: ^0.3.0
         version: 0.3.0
       ethers:
-        specifier: ^5.7.2
+        specifier: 5.7.2
         version: 5.7.2(bufferutil@4.0.8)(utf-8-validate@6.0.4)
       express:
         specifier: ^4.19.2
@@ -1232,7 +1232,7 @@ importers:
         specifier: ^2.4.1
         version: 2.4.1
       ethers:
-        specifier: ^5.7.2
+        specifier: 5.7.2
         version: 5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       got:
         specifier: 11.8.5
@@ -1357,7 +1357,7 @@ importers:
         specifier: workspace:*
         version: link:../eslint-config-thirdweb
       ethers:
-        specifier: ^5.7.2
+        specifier: 5.7.2
         version: 5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       typechain:
         specifier: ^8.3.2
@@ -1394,7 +1394,7 @@ importers:
         specifier: workspace:*
         version: link:../eslint-config-thirdweb
       ethers:
-        specifier: ^5.7.2
+        specifier: 5.7.2
         version: 5.7.2(bufferutil@4.0.8)(utf-8-validate@6.0.4)
       js-awe:
         specifier: ^1.0.65
@@ -1491,7 +1491,7 @@ importers:
   legacy_packages/payments:
     dependencies:
       ethers:
-        specifier: ^5.7.2
+        specifier: 5.7.2
         version: 5.7.2(bufferutil@4.0.8)(utf-8-validate@6.0.4)
     devDependencies:
       '@preconstruct/cli':
@@ -1646,7 +1646,7 @@ importers:
         specifier: ^0.3.0
         version: 0.3.0
       ethers:
-        specifier: ^5.7.2
+        specifier: 5.7.2
         version: 5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       react:
         specifier: 18.3.1
@@ -1746,7 +1746,7 @@ importers:
         specifier: ^0.3.0
         version: 0.3.0
       ethers:
-        specifier: ^5.7.2
+        specifier: 5.7.2
         version: 5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       react:
         specifier: 18.3.1
@@ -1897,7 +1897,7 @@ importers:
         specifier: ^0.3.0
         version: 0.3.0
       ethers:
-        specifier: ^5.7.2
+        specifier: 5.7.2
         version: 5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       ethers-aws-kms-signer:
         specifier: ^1.3.2
@@ -2000,7 +2000,7 @@ importers:
         specifier: ^5.3.0
         version: 5.3.0
       ethers:
-        specifier: ^5.7.2
+        specifier: 5.7.2
         version: 5.7.2(bufferutil@4.0.8)(utf-8-validate@6.0.4)
     devDependencies:
       '@thirdweb-dev/tsconfig':
@@ -2182,7 +2182,7 @@ importers:
         specifier: ^0.7.7
         version: 0.7.7
       ethers:
-        specifier: ^5.7.2
+        specifier: 5.7.2
         version: 5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       ethers-aws-kms-signer:
         specifier: ^1.3.2


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `ethers` package version to `5.7.2` across multiple packages and adds new exports related to `ethers5` and `ethers6` adapters.

### Detailed summary
- Updated `ethers` package version to `5.7.2` in various package.json files
- Added new exports for `ethers5` and `ethers6` adapters
- Updated import statements in `provider-setup.tsx` and `ethers5.ts`
- Modified `pnpm-lock.yaml` to reflect the updated `ethers` package version

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->