### PR TITLE
[Dashboard] Explorer to show transaction error message

### DIFF
--- a/apps/dashboard/src/components/contract-functions/interactive-abi-function.tsx
+++ b/apps/dashboard/src/components/contract-functions/interactive-abi-function.tsx
@@ -70,6 +70,9 @@ function formatResponseData(data: unknown): string {
 }
 
 function formatError(error: Error): string {
+  if ((error as Error).message) {
+    return (error as Error).message;
+  }
   // biome-ignore lint/suspicious/noExplicitAny: FIXME
   if ((error as any).reason) {
     // biome-ignore lint/suspicious/noExplicitAny: FIXME


### PR DESCRIPTION
## Problem solved

Before:
<img width="747" alt="image" src="https://github.com/user-attachments/assets/ea60b693-70f9-4a20-8d31-246dc428e580">

After:
<img width="746" alt="image" src="https://github.com/user-attachments/assets/58fd622f-0aad-403f-976e-d06ac01ae0e2">

<!-- start pr-codex -->

---

## PR-Codex overview
This PR improves error handling in the `formatError` function in `interactive-abi-function.tsx`.

### Detailed summary
- Improved error handling by checking for `message` property in `Error` object
- Removed unnecessary casting to `any` for error object properties

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->