### PR TITLE
[Dashboard] Fix single lazy mint form

### DIFF
--- a/apps/dashboard/src/contract-ui/tabs/nfts/components/lazy-mint-form.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/nfts/components/lazy-mint-form.tsx
@@ -1,3 +1,4 @@
+import { thirdwebClient } from "@/constants/client";
 import {
   Accordion,
   AccordionButton,
@@ -27,6 +28,7 @@ import type { ThirdwebContract } from "thirdweb";
 import { lazyMint as lazyMint721 } from "thirdweb/extensions/erc721";
 import { lazyMint as lazyMint1155 } from "thirdweb/extensions/erc1155";
 import { useActiveAccount, useSendAndConfirmTransaction } from "thirdweb/react";
+import { upload } from "thirdweb/storage";
 import {
   Button,
   FormErrorMessage,
@@ -142,23 +144,36 @@ export const LazyMintNftForm: React.FC<LazyMintNftFormParams> = ({
   return (
     <>
       <DrawerHeader>
-        <Heading>"Mint NFT"</Heading>
+        <Heading>Mint NFT</Heading>
       </DrawerHeader>
       <DrawerBody>
         <Stack
           spacing={6}
           as="form"
           id={LAZY_MINT_FORM_ID}
-          onSubmit={handleSubmit((data) => {
+          onSubmit={handleSubmit(async (data) => {
             if (!address) {
               onError("Please connect your wallet to mint.");
               return;
             }
-
+            let imageUri = "";
+            if (data.image) {
+              imageUri = await upload({
+                client: thirdwebClient,
+                files: [data.image],
+              });
+            }
+            let animationUri = "";
+            if (data.animation_url) {
+              animationUri = await upload({
+                client: thirdwebClient,
+                files: [data.animation_url],
+              });
+            }
             const dataWithCustom = {
               ...data,
-              image: data.image || data.customImage,
-              animation_url: data.animation_url || data.customAnimationUrl,
+              image: imageUri || data.customImage,
+              animation_url: animationUri || data.customAnimationUrl,
             };
 
             trackEvent({


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the ability to upload images and animations for lazy minting NFTs in the contract UI form.

### Detailed summary
- Added `upload` function import from `thirdweb/storage`.
- Modified form submission to upload image and animation URLs.
- Updated data handling for custom image and animation URLs.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->