### PR TITLE
Fix getFunctionId implementation

### DIFF
--- a/.changeset/twenty-hairs-act.md
+++ b/.changeset/twenty-hairs-act.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix getFunctionId

--- a/packages/thirdweb/src/utils/function-id.ts
+++ b/packages/thirdweb/src/utils/function-id.ts
@@ -1,11 +1,9 @@
-import { sha256 } from "@noble/hashes/sha256";
-import { uint8ArrayToHex } from "./encoding/hex.js";
+import { randomBytesHex } from "./random.js";
 
 // biome-ignore lint/suspicious/noExplicitAny: the whoel point here is to accept anything
 type AnyFunction = (...args: any[]) => any;
 
-// WeakMap should be fine, if we de-reference the function, it should be garbage collected
-const functionIdCache = new WeakMap<AnyFunction, string>();
+const functionIdCache = new Map<AnyFunction, string>();
 
 /**
  * Retrieves the unique identifier for a given function.
@@ -20,7 +18,7 @@ export function getFunctionId(fn: AnyFunction) {
     // biome-ignore lint/style/noNonNullAssertion: the `has` above ensures that this will always be set
     return functionIdCache.get(fn)!;
   }
-  const id = uint8ArrayToHex(sha256(fn.toString()));
+  const id = randomBytesHex();
   functionIdCache.set(fn, id);
   return id;
 }


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates `getFunctionId` in `function-id.ts` to use `randomBytesHex` instead of `uint8ArrayToHex` for generating unique function identifiers.

### Detailed summary
- Updated `getFunctionId` to use `randomBytesHex` instead of `uint8ArrayToHex`
- Changed `functionIdCache` from WeakMap to Map

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->