### PR TITLE
[Update] Fix baseURI extraction logic and refactor lazy mint form

### DIFF
--- a/.changeset/flat-ads-look.md
+++ b/.changeset/flat-ads-look.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+fix baseURI extraction logic

--- a/apps/dashboard/src/contract-ui/tabs/nfts/components/lazy-mint-form.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/nfts/components/lazy-mint-form.tsx
@@ -1,4 +1,3 @@
-import { thirdwebClient } from "@/constants/client";
 import {
   Accordion,
   AccordionButton,
@@ -28,7 +27,6 @@ import type { ThirdwebContract } from "thirdweb";
 import { lazyMint as lazyMint721 } from "thirdweb/extensions/erc721";
 import { lazyMint as lazyMint1155 } from "thirdweb/extensions/erc1155";
 import { useActiveAccount, useSendAndConfirmTransaction } from "thirdweb/react";
-import { upload } from "thirdweb/storage";
 import {
   Button,
   FormErrorMessage,
@@ -156,32 +154,13 @@ export const LazyMintNftForm: React.FC<LazyMintNftFormParams> = ({
               onError("Please connect your wallet to mint.");
               return;
             }
-            let imageUri = "";
-            if (data.image) {
-              imageUri = await upload({
-                client: thirdwebClient,
-                files: [data.image],
-              });
-            }
-            let animationUri = "";
-            if (data.animation_url) {
-              animationUri = await upload({
-                client: thirdwebClient,
-                files: [data.animation_url],
-              });
-            }
-            const dataWithCustom = {
-              ...data,
-              image: imageUri || data.customImage,
-              animation_url: animationUri || data.customAnimationUrl,
-            };
 
             trackEvent({
               category: "nft",
               action: "lazy-mint",
               label: "attempt",
             });
-            const nfts = [parseAttributes(dataWithCustom)];
+            const nfts = [parseAttributes(data)];
             const transaction = isErc721
               ? lazyMint721({ contract, nfts })
               : lazyMint1155({ contract, nfts });

--- a/packages/thirdweb/src/utils/ipfs.test.ts
+++ b/packages/thirdweb/src/utils/ipfs.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { createThirdwebClient } from "../client/client.js";
-import { findIPFSCidFromUri, resolveScheme } from "./ipfs.js";
+import {
+  findIPFSCidFromUri,
+  getBaseUriFromBatch,
+  resolveScheme,
+} from "./ipfs.js";
 
 describe("resolveScheme", () => {
   it("should resolve ipfs scheme when not passing a gateway override", () => {
@@ -68,5 +72,57 @@ describe("resolveScheme", () => {
     const cid = "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi";
     const uri = `ipfs://${cid}`;
     expect(findIPFSCidFromUri(uri)).toBe(cid);
+  });
+});
+
+describe("getBaseUriFromBatch", () => {
+  it("should return the base uri", () => {
+    const batchOfUris = ["ipfs://Qm.../0", "ipfs://Qm.../1", "ipfs://Qm.../2"];
+    const baseUri = getBaseUriFromBatch(batchOfUris);
+    expect(baseUri).toMatchInlineSnapshot(`"ipfs://Qm.../"`);
+  });
+  it("should throw if the batch is empty", () => {
+    expect(() => getBaseUriFromBatch([])).toThrowErrorMatchingInlineSnapshot(
+      "[Error: Batch of URIs is empty]",
+    );
+  });
+
+  it("should throw if an element of the array does not have the same base", () => {
+    const batchOfUris = ["ipfs://Qm.../0", "ipfs://Qm.../1", "ipfs://Qm2.../2"];
+    expect(() =>
+      getBaseUriFromBatch(batchOfUris),
+    ).toThrowErrorMatchingInlineSnapshot(
+      "[Error: All URIs in the batch must have the same base URI]",
+    );
+  });
+
+  it("should work with a custom domain", () => {
+    const batchOfUris = [
+      "https://example.com/0",
+      "https://example.com/1",
+      "https://example.com/2",
+    ];
+    const baseUri = getBaseUriFromBatch(batchOfUris);
+    expect(baseUri).toMatchInlineSnapshot(`"https://example.com/"`);
+  });
+
+  it("should work with a custom domain and path", () => {
+    const batchOfUris = [
+      "https://example.com/path/0",
+      "https://example.com/path/1",
+      "https://example.com/path/2",
+    ];
+    const baseUri = getBaseUriFromBatch(batchOfUris);
+    expect(baseUri).toMatchInlineSnapshot(`"https://example.com/path/"`);
+  });
+
+  it("should work with a custom domain and path with trailing slash", () => {
+    const batchOfUris = [
+      "https://example.com/path/0/",
+      "https://example.com/path/1/",
+      "https://example.com/path/2/",
+    ];
+    const baseUri = getBaseUriFromBatch(batchOfUris);
+    expect(baseUri).toMatchInlineSnapshot(`"https://example.com/path/"`);
   });
 });


### PR DESCRIPTION
FIXES: DASH-210

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the baseURI extraction logic in the `LazyMintNftForm` component. 

### Detailed summary
- Removed unnecessary image and animation URI handling
- Updated `parseAttributes` data handling
- Refactored `getBaseUriFromBatch` function in `ipfs.ts`
- Added tests for `getBaseUriFromBatch` in `ipfs.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->