### PR TITLE
Add/Fix options for hiding buttons on details modal on useWalletDetailsModal

### DIFF
--- a/.changeset/tough-bees-arrive.md
+++ b/.changeset/tough-bees-arrive.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Add options for hiding buttons on details modal on useWalletDetailsModal

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/ConnectButton.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/ConnectButton.tsx
@@ -544,9 +544,6 @@ function ConnectButtonInner(
         showAllWallets: props.showAllWallets,
         walletConnect: props.walletConnect,
         wallets: props.wallets,
-        hideReceiveFunds: props.detailsModal?.hideReceiveFunds,
-        hideSendFunds: props.detailsModal?.hideSendFunds,
-        hideBuyFunds: props.detailsModal?.hideBuyFunds,
       }}
     />
   );

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/Details.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/Details.tsx
@@ -1150,9 +1150,6 @@ export type DetailsModalConnectOptions = {
   chains?: Chain[];
   recommendedWallets?: Wallet[];
   showAllWallets?: boolean;
-  hideSendFunds?: boolean;
-  hideReceiveFunds?: boolean;
-  hideBuyFunds?: boolean;
 };
 
 export type UseWalletDetailsModalOptions = {
@@ -1376,6 +1373,27 @@ export type UseWalletDetailsModalOptions = {
    * Use custom avatar URL for the connected wallet image in the `ConnectButton` Details Modal, overriding ENS avatar or Blobbie icon.
    */
   connectedAccountAvatarUrl?: string;
+
+  /**
+   * Hide the "Send Funds" button in the Details Modal.
+   *
+   * By default the "Send Funds" button is shown.
+   */
+  hideSendFunds?: boolean;
+
+  /**
+   * Hide the "Receive Funds" button in the Details Modal.
+   *
+   * By default the "Receive Funds" button is shown.
+   */
+  hideReceiveFunds?: boolean;
+
+  /**
+   * Hide the "Buy Funds" button in the Details Modal.
+   *
+   * By default the "Buy Funds" button is shown.
+   */
+  hideBuyFunds?: boolean;
 };
 
 /**
@@ -1430,6 +1448,9 @@ export function useWalletDetailsModal() {
               showTestnetFaucet: props.showTestnetFaucet,
               connectedAccountName: props.connectedAccountName,
               connectedAccountAvatarUrl: props.connectedAccountAvatarUrl,
+              hideBuyFunds: props.hideBuyFunds,
+              hideReceiveFunds: props.hideReceiveFunds,
+              hideSendFunds: props.hideSendFunds,
             }}
             displayBalanceToken={props.displayBalanceToken}
             theme={props.theme || "dark"}


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds options to hide buttons on the details modal in the `ConnectWallet` feature.

### Detailed summary
- Added options to hide "Send Funds," "Receive Funds," and "Buy Funds" buttons on the details modal in `ConnectWallet` feature.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->