### PR TITLE
Fix starter template link for modular contracts

### DIFF
--- a/apps/portal/src/app/contracts/modular-contracts/overview/page.mdx
+++ b/apps/portal/src/app/contracts/modular-contracts/overview/page.mdx
@@ -61,4 +61,4 @@ Modular contracts is a framework that enables the creation of highly customizabl
 </div>
 
 ### Templates
-[Extenion Starter Template](https://github.com/thirdweb-example/modular-contract-module-starter)
+[Extenion Starter Template](https://github.com/thirdweb-example/modular-contract-extension-starter)


### PR DESCRIPTION
## Problem solved
Current template link 404s, this fixes the link to resolve to the correct repo



<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the link to the Extension Starter Template in the `page.mdx` file of the Modular Contracts Overview.

### Detailed summary
- Updated the link from `modular-contract-module-starter` to `modular-contract-extension-starter` for the Extension Starter Template.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->