### PR TITLE
test: add individual event filtering test

### DIFF
--- a/packages/thirdweb/src/event/actions/get-events.test.ts
+++ b/packages/thirdweb/src/event/actions/get-events.test.ts
@@ -129,4 +129,17 @@ describe.runIf(process.env.TW_SECRET_KEY)("getEvents", () => {
     });
     expect(events.length).toBe(38);
   });
+
+  it("should get individual events with filters", async () => {
+    const events = await getContractEvents({
+      contract: DOODLES_CONTRACT,
+      fromBlock: FORK_BLOCK_NUMBER - 1000n,
+      events: [
+        transferEvent({
+          from: "0xB81965DdFdDA3923f292a47A1be83ba3A36B5133",
+        }),
+      ],
+    });
+    expect(events.length).toBe(2);
+  });
 });

--- a/packages/thirdweb/src/wallets/coinbase/coinbaseMobileSDK.ts
+++ b/packages/thirdweb/src/wallets/coinbase/coinbaseMobileSDK.ts
@@ -53,7 +53,6 @@ async function initSmartWalletProvider(
       "callbackURL is required. Set it when creating the coinbase wallet. Ex: createWallet('com.coinbase.wallet', { mobileConfig: { callbackUrl: 'https://example.com' }}",
     );
   }
-  console.log("initSmartWalletProvider", appDeeplinkUrl);
   const sdk = new EIP1193Provider({
     metadata: {
       appName: options?.appMetadata?.name || "thirdweb powered app",


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add a new test case for getting individual events with filters in the `get-events.test.ts` file.

### Detailed summary
- Added a new test case for getting individual events with filters
- Test case includes specific filter criteria such as contract, fromBlock, and events
- Asserts the number of events fetched to be 2

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->