### PR TITLE
chore: social named export

### DIFF
--- a/.changeset/breezy-melons-sniff.md
+++ b/.changeset/breezy-melons-sniff.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Export thirdweb/social functions and types

--- a/packages/thirdweb/package.json
+++ b/packages/thirdweb/package.json
@@ -118,6 +118,11 @@
       "import": "./dist/esm/exports/modules.js",
       "default": "./dist/cjs/exports/modules.js"
     },
+    "./social": {
+      "types": "./dist/types/exports/social.d.ts",
+      "import": "./dist/esm/exports/social.js",
+      "default": "./dist/cjs/exports/social.js"
+    },
     "./package.json": "./package.json"
   },
   "typesVersions": {
@@ -138,7 +143,8 @@
       "utils": ["./dist/types/exports/utils.d.ts"],
       "wallets": ["./dist/types/exports/wallets.d.ts"],
       "wallets/*": ["./dist/types/exports/wallets/*.d.ts"],
-      "modules": ["./dist/types/exports/modules.d.ts"]
+      "modules": ["./dist/types/exports/modules.d.ts"],
+      "social": ["./dist/types/exports/social.d.ts"]
     }
   },
   "browser": {

--- a/packages/thirdweb/src/exports/social.ts
+++ b/packages/thirdweb/src/exports/social.ts
@@ -1,2 +1,7 @@
 export { getSocialProfiles } from "../social/profiles.js";
-export { type SocialProfiles } from "../social/types.js";
+export type {
+  SocialProfiles,
+  EnsProfile,
+  FarcasterProfile,
+  LensProfile,
+} from "../social/types.js";


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to export specific social functions and types in the `thirdweb` package.

### Detailed summary
- Exported `SocialProfiles`, `EnsProfile`, `FarcasterProfile`, and `LensProfile` from `social/types.js`
- Added export paths for social types in `package.json`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->