### PR TITLE
fix: add idempotency key to faucet

### DIFF
--- a/apps/dashboard/src/app/api/testnet-faucet/can-claim/route.ts
+++ b/apps/dashboard/src/app/api/testnet-faucet/can-claim/route.ts
@@ -50,7 +50,7 @@ export const GET = async (req: NextRequest) => {
   if (!ipAddress) {
     return NextResponse.json(
       {
-        error: "Could not validate elligibility.",
+        error: "Could not validate eligibility.",
       },
       { status: 400 },
     );


### PR DESCRIPTION
Sets an idempotency key to Engine that prevents duplicate transactions _today_ (UTC).

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates error message spelling and adds idempotency key to prevent duplicate claims in the testnet faucet API.

### Detailed summary
- Fixed spelling error in error message
- Added idempotency key to prevent duplicate claims for the same chain/ip/time period

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->