### PR TITLE
[SDK] Fix: SocialProfiles type changed to SocialProfile[]

### DIFF
--- a/.changeset/seven-frogs-protect.md
+++ b/.changeset/seven-frogs-protect.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Updated SocialProfiles type to be SocialProfile[]

--- a/packages/thirdweb/src/exports/react.native.ts
+++ b/packages/thirdweb/src/exports/react.native.ts
@@ -105,7 +105,7 @@ export { useConnectionManager } from "../react/core/providers/connection-manager
 // Social
 export { useSocialProfiles } from "../react/core/social/useSocialProfiles.js";
 export type {
-  SocialProfiles,
+  SocialProfile,
   EnsProfile,
   FarcasterProfile,
   LensProfile,

--- a/packages/thirdweb/src/exports/react.ts
+++ b/packages/thirdweb/src/exports/react.ts
@@ -188,7 +188,7 @@ export { useSiweAuth } from "../react/core/hooks/auth/useSiweAuth.js";
 // Social
 export { useSocialProfiles } from "../react/core/social/useSocialProfiles.js";
 export type {
-  SocialProfiles,
+  SocialProfile,
   EnsProfile,
   FarcasterProfile,
   LensProfile,

--- a/packages/thirdweb/src/exports/social.ts
+++ b/packages/thirdweb/src/exports/social.ts
@@ -1,6 +1,6 @@
 export { getSocialProfiles } from "../social/profiles.js";
 export type {
-  SocialProfiles,
+  SocialProfile,
   EnsProfile,
   FarcasterProfile,
   LensProfile,

--- a/packages/thirdweb/src/social/profiles.ts
+++ b/packages/thirdweb/src/social/profiles.ts
@@ -1,7 +1,7 @@
 import type { ThirdwebClient } from "../client/client.js";
 import { getThirdwebBaseUrl } from "../utils/domains.js";
 import { getClientFetch } from "../utils/fetch.js";
-import type { SocialProfiles } from "./types.js";
+import type { SocialProfile } from "./types.js";
 
 /**
  * Fetches the wallet's available social profiles.
@@ -23,7 +23,7 @@ import type { SocialProfiles } from "./types.js";
 export async function getSocialProfiles(args: {
   address: string;
   client: ThirdwebClient;
-}): Promise<SocialProfiles> {
+}): Promise<SocialProfile[]> {
   const { address, client } = args;
 
   const clientFetch = getClientFetch(client);
@@ -42,5 +42,5 @@ export async function getSocialProfiles(args: {
     }
   }
 
-  return (await response.json()).data as SocialProfiles;
+  return (await response.json()).data as SocialProfile[];
 }

--- a/packages/thirdweb/src/social/types.ts
+++ b/packages/thirdweb/src/social/types.ts
@@ -34,10 +34,10 @@ export type EnsProfile = {
   telegram?: string;
 };
 
-export type SocialProfiles = {
+export type SocialProfile = {
   type: "farcaster" | "lens" | "ens";
   name?: string;
   avatar?: string;
   bio?: string;
   metadata?: FarcasterProfile | LensProfile | EnsProfile;
-}[];
+};


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added



<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `SocialProfiles` type to `SocialProfile[]` for consistency in the `thirdweb` package.

### Detailed summary
- Updated `SocialProfiles` type to `SocialProfile[]`
- Updated type imports and references in relevant files
- Modified `getSocialProfiles` function to return `SocialProfile[]`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->