### PR TITLE
Remove sidebar on contracts page in teams layout

### DIFF
--- a/apps/dashboard/src/app/team/[team_slug]/[project_slug]/contracts/layout.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/[project_slug]/contracts/layout.tsx
@@ -1,29 +1,5 @@
-import { Sidebar } from "@/components/blocks/Sidebar";
-import { ConnectMobileSidebar } from "../connect/ConnectMobileSidebar";
-
 export default function Layout(props: {
-  params: {
-    team_slug: string;
-    project_slug: string;
-  };
   children: React.ReactNode;
 }) {
-  const { team_slug, project_slug } = props.params;
-
-  const links: { label: string; href: string }[] = [
-    {
-      label: "Contracts",
-      href: `/team/${team_slug}/${project_slug}/contracts`,
-    },
-  ];
-
-  return (
-    <div className="h-full container flex gap-4">
-      <Sidebar links={links} />
-      <div className="grow max-sm:pt-6 max-sm:w-full">
-        <ConnectMobileSidebar links={links} />
-        {props.children}
-      </div>
-    </div>
-  );
+  return <div className="container">{props.children}</div>;
 }


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to simplify the layout component in the contracts section of the dashboard.

### Detailed summary
- Removed unnecessary sidebar and mobile sidebar components.
- Updated the layout to only render children inside a container div.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->