### PR TITLE
More storage slots for proxy resolution

### DIFF
--- a/.changeset/great-chefs-whisper.md
+++ b/.changeset/great-chefs-whisper.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+More storage slots for proxy resolution

--- a/packages/thirdweb/src/utils/bytecode/resolveImplementation.test.ts
+++ b/packages/thirdweb/src/utils/bytecode/resolveImplementation.test.ts
@@ -8,6 +8,8 @@ import {
 import { ANVIL_CHAIN } from "../../../test/src/chains.js";
 import { TEST_CLIENT } from "../../../test/src/test-clients.js";
 import {
+  BASE_USDC_IMPLEMENTATION,
+  BASE_USDC_PROXY_CONTRACT,
   NFT_DROP_CONTRACT,
   NFT_DROP_IMPLEMENTATION,
   POLYGON_USDT_IMPLEMENTATION,
@@ -28,6 +30,13 @@ describe("Resolve implementation", async () => {
     const resolved = resolveImplementation(POLYGON_USDT_PROXY_CONTRACT);
     expect((await resolved).address).to.equal(
       POLYGON_USDT_IMPLEMENTATION.toLowerCase(),
+    );
+  });
+
+  it("should extract implementation address for base USDC proxy contract", async () => {
+    const resolved = resolveImplementation(BASE_USDC_PROXY_CONTRACT);
+    expect((await resolved).address).to.equal(
+      BASE_USDC_IMPLEMENTATION.toLowerCase(),
     );
   });
 

--- a/packages/thirdweb/test/globalSetup.ts
+++ b/packages/thirdweb/test/globalSetup.ts
@@ -1,6 +1,6 @@
 import { sha256 } from "@noble/hashes/sha256";
 import { startProxy } from "@viem/anvil";
-import { FORK_BLOCK_NUMBER, OPTIMISM_FORK_BLOCK_NUMBER, POLYGON_FORK_BLOCK_NUMBER } from "./src/chains.js";
+import { FORK_BLOCK_NUMBER, OPTIMISM_FORK_BLOCK_NUMBER, POLYGON_FORK_BLOCK_NUMBER, BASE_FORK_BLOCK_NUMBER } from "./src/chains.js";
 
 require("dotenv-mono").load();
 
@@ -76,11 +76,27 @@ export default async function globalSetup() {
     },
   });
 
+  const shutdownBase = await startProxy({
+    port: 8650,
+    options: {
+      chainId: 8453,
+      forkUrl: SECRET_KEY
+        ? `https://8453.rpc.thirdweb.com/${clientId}`
+        : "https://mainnet.base.org",
+      forkHeader: SECRET_KEY ? { "x-secret-key": SECRET_KEY } : {},
+      forkChainId: 8453,
+      forkBlockNumber: BASE_FORK_BLOCK_NUMBER,
+      noMining: true,
+      startTimeout: 20000,
+    },
+  });
+
   return async () => {
     await shutdownMainnet();
     await shutdownMainnetWithMining();
     await shutdownOptimism();
     await shutdownAnvil();
     await shutdownPolygon();
+    await shutdownBase();
   };
 }

--- a/packages/thirdweb/test/src/chains.ts
+++ b/packages/thirdweb/test/src/chains.ts
@@ -1,4 +1,5 @@
 import { anvil } from "../../src/chains/chain-definitions/anvil.js";
+import { base } from "../../src/chains/chain-definitions/base.js";
 import { ethereum } from "../../src/chains/chain-definitions/ethereum.js";
 import { polygon } from "../../src/chains/chain-definitions/polygon.js";
 import { optimism } from "../../src/chains/chain-definitions/optimism.js";
@@ -11,6 +12,7 @@ export const FORKED_ETHEREUM_WITH_MINING_RPC = `http://127.0.0.1:8646/${poolId}`
 export const FORKED_OPTIMISM_RPC = `http://127.0.0.1:8647/${poolId}`;
 export const ANVIL_RPC = `http://127.0.0.1:8648/${poolId}`;
 export const FORKED_POLYGON_RPC = `http://127.0.0.1:8649/${poolId}`;
+export const FORKED_BASE_RPC = `http://127.0.0.1:8650/${poolId}`;
 
 export const FORKED_ETHEREUM_CHAIN = defineChain({
   ...ethereum,
@@ -42,6 +44,13 @@ export const ANVIL_CHAIN = defineChain({
   rpc: ANVIL_RPC,
 });
 
+export const FORKED_BASE_CHAIN = defineChain({
+  ...base,
+  // override the rpc url
+  rpc: FORKED_BASE_RPC,
+});
+
 export const FORK_BLOCK_NUMBER = 19139495n;
 export const OPTIMISM_FORK_BLOCK_NUMBER = 117525204n;
 export const POLYGON_FORK_BLOCK_NUMBER = 61430000n;
+export const BASE_FORK_BLOCK_NUMBER = 19559480n;

--- a/packages/thirdweb/test/src/test-contracts.ts
+++ b/packages/thirdweb/test/src/test-contracts.ts
@@ -1,6 +1,6 @@
 import { getContract } from "../../src/contract/contract.js";
 import { USDT_ABI } from "./abis/usdt.js";
-import { FORKED_ETHEREUM_CHAIN, FORKED_POLYGON_CHAIN } from "./chains.js";
+import { FORKED_ETHEREUM_CHAIN, FORKED_POLYGON_CHAIN, FORKED_BASE_CHAIN } from "./chains.js";
 import { TEST_CLIENT } from "./test-clients.js";
 
 // ERC20
@@ -12,6 +12,11 @@ export const USDT_CONTRACT_ADDRESS =
   "0xc2132d05d31c914a87c6611c10748aeb04b58e8f";
 
   export const POLYGON_USDT_IMPLEMENTATION = "0x7FFB3d637014488b63fb9858E279385685AFc1e2";
+
+  export const BASE_USDC_CONTRACT_ADDRESS =
+  "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+
+  export const BASE_USDC_IMPLEMENTATION = "0x2ce6311ddae708829bc0784c967b7d77d19fd779";
 
 export const USDT_CONTRACT = getContract({
   client: TEST_CLIENT,
@@ -30,6 +35,12 @@ export const POLYGON_USDT_PROXY_CONTRACT = getContract({
   client: TEST_CLIENT,
   address: POLYGON_USDT_CONTRACT_ADDRESS,
   chain: FORKED_POLYGON_CHAIN,
+});
+
+export const BASE_USDC_PROXY_CONTRACT = getContract({
+  client: TEST_CLIENT,
+  address: BASE_USDC_CONTRACT_ADDRESS,
+  chain: FORKED_BASE_CHAIN,
 });
 
 // ERC721


### PR DESCRIPTION
## Problem solved

Add another storage slot for proxy resolution:

keccak256("org.zeppelinos.proxy.implementation")

ref: https://basescan.org/address/0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913#code

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance proxy resolution in the `thirdweb` package by adding more storage slots for implementation addresses.

### Detailed summary
- Added more storage slots for proxy resolution in `resolveImplementation.test.ts`
- Updated proxy resolution for base USDC contract in `resolveImplementation.test.ts`
- Updated global setup with base proxy in `globalSetup.ts`
- Added base USDC proxy contract in `test-contracts.ts`
- Added base chain definitions and RPC in `chains.ts`
- Enhanced proxy resolution in `resolveImplementation.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->