### PR TITLE
[React SDK] Fix: Properly read current wallet erc20 balance

### DIFF
--- a/.changeset/unlucky-socks-repeat.md
+++ b/.changeset/unlucky-socks-repeat.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix ERC20 balance read when showing pay modal

--- a/packages/thirdweb/src/react/core/hooks/transaction/useSendTransaction.ts
+++ b/packages/thirdweb/src/react/core/hooks/transaction/useSendTransaction.ts
@@ -10,6 +10,7 @@ import type { WaitForReceiptOptions } from "../../../../transaction/actions/wait
 import type { PreparedTransaction } from "../../../../transaction/prepare-transaction.js";
 import { resolvePromisedValue } from "../../../../utils/promise/resolve-promised-value.js";
 import type { Wallet } from "../../../../wallets/interfaces/wallet.js";
+import { getTokenBalance } from "../../../../wallets/utils/getTokenBalance.js";
 import { getWalletBalance } from "../../../../wallets/utils/getWalletBalance.js";
 import type { LocaleId } from "../../../web/ui/types.js";
 import type { Theme } from "../../design-system/index.js";
@@ -175,10 +176,11 @@ export function useSendTransactionCore(args: {
                 chain: tx.chain,
               }),
               _erc20Value?.tokenAddress
-                ? getWalletBalance({
+                ? getTokenBalance({
                     client: tx.client,
-                    address: account.address,
+                    account,
                     chain: tx.chain,
+                    tokenAddress: _erc20Value.tokenAddress,
                   })
                 : undefined,
               getTotalTxCostForBuy(tx, account.address),


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing ERC20 balance read when displaying pay modal.

### Detailed summary
- Updated `useSendTransactionCore` to use `getTokenBalance` instead of `getWalletBalance` for ERC20 token balance retrieval.
- Passed `account` object instead of `address` to `getTokenBalance` function.
- Provided `tokenAddress` parameter to `getTokenBalance` function when ERC20 token address is available.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->