### PR TITLE
test: Add createAndReveal test for ERC721 lazy minting

### DIFF
--- a/.changeset/warm-actors-behave.md
+++ b/.changeset/warm-actors-behave.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix erc721 delayed reveal simulation error

--- a/packages/thirdweb/src/extensions/erc721/lazyMinting/write/createAndReveal.test.ts
+++ b/packages/thirdweb/src/extensions/erc721/lazyMinting/write/createAndReveal.test.ts
@@ -1,0 +1,84 @@
+import { beforeAll, describe, it } from "vitest";
+import { expect } from "vitest";
+import { ANVIL_CHAIN } from "../../../../../test/src/chains.js";
+import { TEST_CLIENT } from "../../../../../test/src/test-clients.js";
+import { TEST_ACCOUNT_A } from "../../../../../test/src/test-wallets.js";
+import {
+  type ThirdwebContract,
+  getContract,
+} from "../../../../contract/contract.js";
+import { sendAndConfirmTransaction } from "../../../../transaction/actions/send-and-confirm-transaction.js";
+import { deployERC721Contract } from "../../../prebuilts/deploy-erc721.js";
+import { getNFT } from "../../read/getNFT.js";
+import { createDelayedRevealBatch } from "./createDelayedRevealBatch.js";
+import { reveal } from "./reveal.js";
+
+const placeholderNFT = {
+  name: "Hidden NFT",
+  description: "Will be revealed next week!",
+};
+
+const realNFTs = [
+  {
+    name: "Common NFT #1",
+    description: "Common NFT, one of many.",
+  },
+  {
+    name: "Super Rare NFT #2",
+    description: "You got a Super Rare NFT!",
+  },
+];
+
+describe("createAndReveal", () => {
+  let contract: ThirdwebContract;
+  beforeAll(async () => {
+    const address = await deployERC721Contract({
+      client: TEST_CLIENT,
+      chain: ANVIL_CHAIN,
+      account: TEST_ACCOUNT_A,
+      type: "DropERC721",
+      params: {
+        name: "Test NFT",
+        description: "Test NFT Description",
+        contractURI: "",
+      },
+    });
+    contract = getContract({
+      chain: ANVIL_CHAIN,
+      address,
+      client: TEST_CLIENT,
+    });
+  });
+
+  it("should create and reveal a batch", async () => {
+    const tx = createDelayedRevealBatch({
+      contract,
+      metadata: realNFTs,
+      password: "password",
+      placeholderMetadata: placeholderNFT,
+    });
+    await sendAndConfirmTransaction({
+      transaction: tx,
+      account: TEST_ACCOUNT_A,
+    });
+    const nft = await getNFT({
+      contract,
+      tokenId: 0n,
+    });
+    expect(nft.metadata.name).toBe(placeholderNFT.name);
+    const revealTx = reveal({
+      contract,
+      batchId: 0n,
+      password: "password",
+    });
+    await sendAndConfirmTransaction({
+      transaction: revealTx,
+      account: TEST_ACCOUNT_A,
+    });
+    const nftAfterReveal = await getNFT({
+      contract,
+      tokenId: 0n,
+    });
+    expect(nftAfterReveal.metadata.name).toBe(realNFTs[0]?.name);
+  });
+});

--- a/packages/thirdweb/src/extensions/erc721/lazyMinting/write/reveal.test.ts
+++ b/packages/thirdweb/src/extensions/erc721/lazyMinting/write/reveal.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import { ANVIL_CHAIN } from "../../../../../test/src/chains.js";
 import { TEST_CLIENT } from "../../../../../test/src/test-clients.js";
 import {
@@ -6,14 +6,6 @@ import {
   getContract,
 } from "../../../../contract/contract.js";
 import { reveal } from "./reveal.js";
-
-const mocks = vi.hoisted(() => ({
-  simulateTransaction: vi.fn(),
-}));
-
-vi.mock("../../../../transaction/actions/simulate.js", () => ({
-  simulateTransaction: mocks.simulateTransaction,
-}));
 
 describe("reveal", () => {
   let contract: ThirdwebContract;
@@ -33,41 +25,5 @@ describe("reveal", () => {
     };
 
     expect(() => reveal(options)).toThrowError("Password is required");
-  });
-
-  it("should successfully prepare a reveal transaction", async () => {
-    const options = {
-      contract,
-      batchId: 1n,
-      password: "securepassword",
-    };
-
-    mocks.simulateTransaction.mockResolvedValue(
-      "ipfs://correctly_decrypted_uri/",
-    );
-
-    const tx = reveal(options);
-    if (typeof tx.data === "function") {
-      await tx.data();
-    }
-
-    expect(mocks.simulateTransaction).toHaveBeenCalled();
-  });
-
-  it("should throw an error if the decrypted URI is invalid", async () => {
-    const options = {
-      contract,
-      batchId: 1n,
-      password: "securepassword",
-    };
-
-    mocks.simulateTransaction.mockResolvedValue("invalid_uri");
-
-    const tx = reveal(options);
-    if (typeof tx.data === "function") {
-      expect(tx.data()).rejects.toThrow("Invalid reveal password");
-    } else {
-      throw new Error("Something went wrong");
-    }
   });
 });

--- a/packages/thirdweb/src/extensions/erc721/lazyMinting/write/reveal.ts
+++ b/packages/thirdweb/src/extensions/erc721/lazyMinting/write/reveal.ts
@@ -1,4 +1,3 @@
-import { simulateTransaction } from "../../../../transaction/actions/simulate.js";
 import type { BaseTransactionOptions } from "../../../../transaction/types.js";
 import { reveal as generatedReveal } from "../../__generated__/IDelayedReveal/write/reveal.js";
 import { hashDelayedRevealPassword } from "../helpers/hashDelayedRevealBatch.js";
@@ -44,28 +43,6 @@ export function reveal(options: BaseTransactionOptions<RevealParams>) {
         options.password,
         options.contract,
       );
-
-      const transaction = generatedReveal({
-        contract: options.contract,
-        asyncParams: async () => ({
-          identifier: options.batchId,
-          key,
-        }),
-      });
-
-      let decryptedUri: string;
-      try {
-        decryptedUri = await simulateTransaction({
-          transaction,
-        });
-      } catch (error) {
-        throw new Error("Reveal failed", { cause: error });
-      }
-
-      if (!decryptedUri.includes("://") || decryptedUri.slice(-1) !== "/") {
-        throw new Error("Invalid reveal password");
-      }
-
       return {
         identifier: options.batchId,
         key,


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR fixes an error in simulating delayed reveal for ERC721 tokens.

### Detailed summary
- Fixed error in simulating ERC721 delayed reveal
- Updated tests for `reveal` function
- Added test for creating and revealing a batch of ERC721 tokens

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->