### PR TITLE
Fix ecosystem partners table

### DIFF
--- a/apps/dashboard/.eslintrc.js
+++ b/apps/dashboard/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
     "plugin:import/typescript",
     "plugin:@next/next/recommended",
     "plugin:promise/recommended",
-    "plugin:storybook/recommended"
+    "plugin:storybook/recommended",
   ],
   rules: {
     "react-compiler/react-compiler": "error",
@@ -86,6 +86,12 @@ module.exports = {
             importNames: ["useRouter"],
             message:
               'Use `import { useDashboardRouter } from "@/lib/DashboardRouter";` instead',
+          },
+          {
+            name: "lucide-react",
+            importNames: ["Link", "Table"],
+            message:
+              'This is likely a mistake. If you really want to import this - postfix the imported name with Icon. Example - "LinkIcon"',
           },
         ],
       },

--- a/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/[slug]/(active)/components/server/partners-table.tsx
+++ b/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/[slug]/(active)/components/server/partners-table.tsx
@@ -3,6 +3,7 @@ import { CopyButton } from "@/components/ui/CopyButton";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
+  Table,
   TableBody,
   TableCell,
   TableContainer,
@@ -12,7 +13,7 @@ import {
 } from "@/components/ui/table";
 import { ToolTipLabel } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
-import { Pencil, Table, Trash2 } from "lucide-react";
+import { Pencil, Trash2 } from "lucide-react";
 import Link from "next/link";
 import { toast } from "sonner";
 import type { Ecosystem, Partner } from "../../../../types";


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates ESLint rules and fixes an incorrect import in the `partners-table.tsx` file.

### Detailed summary
- Updated ESLint rules to include `lucide-react` import message
- Removed `Table` import from `lucide-react` in `partners-table.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->