### PR TITLE
Fix Get started with deploying contract card click, increase gap between steps

### DIFF
--- a/apps/dashboard/src/app/team/[team_slug]/[project_slug]/contracts/_components/GetStartedWithContractsDeploy.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/[project_slug]/contracts/_components/GetStartedWithContractsDeploy.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { TabButtons } from "@/components/ui/tabs";
+import { useDashboardRouter } from "@/lib/DashboardRouter";
 import { CustomConnectWallet } from "@3rdweb-sdk/react/components/connect-wallet";
 import Image from "next/image";
 import { useMemo, useState } from "react";
@@ -49,6 +50,7 @@ type ContentItem = {
 
 const DeployOptions = () => {
   const [showImportModal, setShowImportModal] = useState(false);
+  const router = useDashboardRouter();
   const trackEvent = useTrack();
 
   const content: Record<string, ContentItem> = useMemo(
@@ -111,6 +113,10 @@ const DeployOptions = () => {
         role="button"
         onClick={() => {
           activeTabContent.onClick?.();
+          if (activeTabContent.href) {
+            router.push(activeTabContent.href);
+          }
+
           trackEvent({
             category: "your_contracts",
             action: "click",

--- a/apps/dashboard/src/components/dashboard/StepsCard.tsx
+++ b/apps/dashboard/src/components/dashboard/StepsCard.tsx
@@ -57,7 +57,7 @@ export const StepsCard: React.FC<StepsCardProps> = ({
         </p>
       </div>
 
-      <div className="flex flex-col gap-3 w-full">
+      <div className="flex flex-col gap-5 w-full">
         {steps.map(({ children, ...step }, index) => {
           const showChildren =
             !step.completed || (step.completed && step.showCompletedChildren);


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR increases the gap between elements in `StepsCard.tsx` and adds a new `useDashboardRouter` hook in `GetStartedWithContractsDeploy.tsx`.

### Detailed summary
- Increased gap between elements in `StepsCard.tsx`
- Added `useDashboardRouter` hook in `GetStartedWithContractsDeploy.tsx` for navigation
- Added router push on active tab content click

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->