### PR TITLE
[Refactor] Replace StorageSingleton with thirdweb storage download

### DIFF
--- a/apps/dashboard/src/lib/wallet/nfts/alchemy.ts
+++ b/apps/dashboard/src/lib/wallet/nfts/alchemy.ts
@@ -1,4 +1,5 @@
-import { StorageSingleton } from "lib/sdk";
+import { thirdwebClient } from "@/constants/client";
+import { download } from "thirdweb/storage";
 import type { NFTMetadata } from "thirdweb/utils";
 import { handleArbitraryTokenURI, shouldDownloadURI } from "./tokenUri";
 import {
@@ -39,9 +40,12 @@ export async function transformAlchemyResponseToNFT(
             id: BigInt(alchemyNFT.id.tokenId),
             contractAddress: alchemyNFT.contract.address,
             metadata: shouldDownloadURI(rawUri)
-              ? await StorageSingleton.downloadJSON(
-                  handleArbitraryTokenURI(rawUri),
-                )
+              ? await download({
+                  uri: handleArbitraryTokenURI(rawUri),
+                  client: thirdwebClient,
+                })
+                  .then((res) => res.json())
+                  .catch(() => ({}))
               : rawUri,
             owner,
             supply: alchemyNFT.balance || "1",

--- a/apps/dashboard/src/lib/wallet/nfts/moralis.ts
+++ b/apps/dashboard/src/lib/wallet/nfts/moralis.ts
@@ -1,4 +1,5 @@
-import { StorageSingleton } from "lib/sdk";
+import { thirdwebClient } from "@/constants/client";
+import { download } from "thirdweb/storage";
 import { handleArbitraryTokenURI, shouldDownloadURI } from "./tokenUri";
 import {
   type GenerateURLParams,
@@ -35,9 +36,12 @@ export async function transformMoralisResponseToNFT(
             contractAddress: moralisNft.token_address,
             tokenId: moralisNft.token_id,
             metadata: shouldDownloadURI(moralisNft.token_uri)
-              ? await StorageSingleton.downloadJSON(
-                  handleArbitraryTokenURI(moralisNft.token_uri),
-                )
+              ? await download({
+                  uri: handleArbitraryTokenURI(moralisNft.token_uri),
+                  client: thirdwebClient,
+                })
+                  .then((res) => res.json())
+                  .catch(() => ({}))
               : moralisNft.token_uri,
             owner,
             tokenURI: moralisNft.token_uri,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates NFT transformation functions in `alchemy.ts` and `moralis.ts` to use `thirdwebClient` for downloading metadata.

### Detailed summary
- Updated metadata download using `thirdwebClient`
- Replaced `StorageSingleton` with `download` function from `thirdweb/storage`
- Improved error handling for metadata download

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->