### PR TITLE
Matic -> POL

### DIFF
--- a/.changeset/young-jokes-run.md
+++ b/.changeset/young-jokes-run.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Polygon Matic is now POL

--- a/packages/thirdweb/src/chains/chain-definitions/polygon.ts
+++ b/packages/thirdweb/src/chains/chain-definitions/polygon.ts
@@ -6,7 +6,7 @@ import { defineChain } from "../utils.js";
 export const polygon = /*@__PURE__*/ defineChain({
   id: 137,
   name: "Polygon",
-  nativeCurrency: { name: "MATIC", symbol: "MATIC", decimals: 18 },
+  nativeCurrency: { name: "POL", symbol: "POL", decimals: 18 },
   blockExplorers: [
     {
       name: "PolygonScan",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the native currency symbol for Polygon Matic to POL.

### Detailed summary
- Updated native currency symbol for Polygon Matic from MATIC to POL.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->