### PR TITLE
feat: allow sending smart wallet transactions in parallel

### DIFF
--- a/.changeset/rich-poems-exist.md
+++ b/.changeset/rich-poems-exist.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Allow smart wallet transactions to be sent in parallel

--- a/packages/thirdweb/src/wallets/smart/index.ts
+++ b/packages/thirdweb/src/wallets/smart/index.ts
@@ -45,6 +45,7 @@ import {
 } from "./lib/calls.js";
 import { getDefaultAccountFactory } from "./lib/constants.js";
 import {
+  clearAccountDeploying,
   createUnsignedUserOp,
   signUserOp,
   waitForUserOpReceipt,
@@ -596,6 +597,9 @@ async function _sendUserOp(args: {
     ...options,
     userOpHash,
   });
+
+  // reset the isDeploying flag after every transaction
+  clearAccountDeploying(options.accountContract);
 
   return {
     client: options.client,

--- a/packages/thirdweb/src/wallets/smart/smart-wallet-integration.test.ts
+++ b/packages/thirdweb/src/wallets/smart/smart-wallet-integration.test.ts
@@ -301,5 +301,60 @@ describe.runIf(process.env.TW_SECRET_KEY).sequential(
       });
       expect(balance).toEqual(1n);
     });
+
+    it("can execute a 2 tx in parallel", async () => {
+      const newSmartWallet = smartWallet({
+        chain,
+        gasless: true,
+        overrides: {
+          accountSalt: "test",
+        },
+      });
+      const newSmartAccount = await newSmartWallet.connect({
+        client: TEST_CLIENT,
+        personalAccount,
+      });
+      console.log("newSmartAccount", newSmartAccount.address);
+      const newSmartAccountContract = getContract({
+        address: newSmartAccount.address,
+        chain,
+        client,
+      });
+      let isDeployed = await isContractDeployed(newSmartAccountContract);
+      expect(isDeployed).toEqual(false);
+
+      // sending transactions in parallel should deploy the account and not cause errors
+      const txs = await Promise.all([
+        sendAndConfirmTransaction({
+          transaction: claimTo({
+            contract,
+            quantity: 1n,
+            to: newSmartAccount.address,
+            tokenId: 0n,
+          }),
+          account: newSmartAccount,
+        }),
+        sendAndConfirmTransaction({
+          transaction: claimTo({
+            contract,
+            quantity: 1n,
+            to: newSmartAccount.address,
+            tokenId: 0n,
+          }),
+          account: newSmartAccount,
+        }),
+      ]);
+      expect(txs.length).toEqual(2);
+      expect(txs.every((t) => t.transactionHash.length === 66)).toBe(true);
+
+      isDeployed = await isContractDeployed(newSmartAccountContract);
+      expect(isDeployed).toEqual(true);
+      const balance = await balanceOf({
+        contract,
+        owner: newSmartAccountContract.address,
+        tokenId: 0n,
+      });
+      expect(balance).toEqual(2n);
+    });
   },
 );

--- a/packages/thirdweb/src/wallets/smart/smart-wallet-zksync.test.ts
+++ b/packages/thirdweb/src/wallets/smart/smart-wallet-zksync.test.ts
@@ -74,7 +74,7 @@ describe.runIf(process.env.TW_SECRET_KEY).skip(
         personalAccount,
       });
       const zkCandySmartWalletAddress = zkCandySmartAccount.address;
-      const preparedTx = await prepareTransaction({
+      const preparedTx = prepareTransaction({
         chain: defineChain(302),
         client: client,
         to: zkCandySmartWalletAddress,


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enabling parallel transactions for smart wallets in the Thirdweb package.

### Detailed summary
- Allow smart wallet transactions to be sent in parallel
- Added function to mark, clear, and check deploying status of accounts
- Implemented logic to wait for account deployment before sending transactions in parallel

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->