### PR TITLE
fix: deterministic direct deploys

### DIFF
--- a/packages/thirdweb/src/contract/deployment/deploy-with-abi.ts
+++ b/packages/thirdweb/src/contract/deployment/deploy-with-abi.ts
@@ -122,7 +122,7 @@ export async function deployContract(
   if (options.salt !== undefined) {
     // Deploy with CREATE2 if salt is provided
     const info = await computeDeploymentInfoFromBytecode(options);
-    sendAndConfirmTransaction({
+    await sendAndConfirmTransaction({
       account: options.account,
       transaction: prepareTransaction({
         chain: options.chain,
@@ -135,6 +135,7 @@ export async function deployContract(
       bytecode: options.bytecode,
       encodedArgs: info.encodedArgs,
       create2FactoryAddress: info.create2FactoryAddress,
+      salt: options.salt,
     });
   }
 

--- a/packages/thirdweb/src/extensions/prebuilts/deploy-published.test.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/deploy-published.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { ANVIL_CHAIN } from "../../../test/src/chains.js";
 import { TEST_CLIENT } from "../../../test/src/test-clients.js";
 import { TEST_ACCOUNT_A } from "../../../test/src/test-wallets.js";
+import { isContractDeployed } from "../../utils/bytecode/is-contract-deployed.js";
 import { ENTRYPOINT_ADDRESS_v0_6 } from "../../wallets/smart/lib/constants.js";
 import { deployPublishedContract } from "./deploy-published.js";
 
@@ -38,7 +39,13 @@ describe.runIf(process.env.TW_SECRET_KEY)(
         },
         salt: "test",
       });
-      expect(address).toBe("0x75fc461544723c0dac7b46256027878e82ddc2cb");
+      expect(address).toBe("0x8a9e25cbf6daa2b56cc0df4669195b8c8c20cda8");
+      const isDeployed = await isContractDeployed({
+        client: TEST_CLIENT,
+        chain: ANVIL_CHAIN,
+        address,
+      });
+      expect(isDeployed).toBe(true);
     });
 
     it("should deploy a published autofactory contract", async () => {
@@ -69,6 +76,12 @@ describe.runIf(process.env.TW_SECRET_KEY)(
         salt: "test",
       });
       expect(address).toBe("0x777151741260F8d4098dD492e45FdB536F442672");
+      const isDeployed = await isContractDeployed({
+        client: TEST_CLIENT,
+        chain: ANVIL_CHAIN,
+        address,
+      });
+      expect(isDeployed).toBe(true);
     });
 
     // TODO: Replace these tests' live contracts with mocks


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing contract deployment functionality by adding support for CREATE2 deployment with salt. 

### Detailed summary
- Added support for deploying contracts with salt using CREATE2
- Imported `isContractDeployed` function for checking contract deployment status
- Updated test cases to check contract deployment status after deployment

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->