### PR TITLE
chore: allow disabling a chain's faucet

### DIFF
--- a/apps/dashboard/src/app/api/testnet-faucet/can-claim/route.ts
+++ b/apps/dashboard/src/app/api/testnet-faucet/can-claim/route.ts
@@ -8,6 +8,9 @@ const NEXT_PUBLIC_THIRDWEB_ENGINE_FAUCET_WALLET =
   process.env.NEXT_PUBLIC_THIRDWEB_ENGINE_FAUCET_WALLET;
 const THIRDWEB_ACCESS_TOKEN = process.env.THIRDWEB_ACCESS_TOKEN;
 
+// Comma-separated list of chain IDs to disable faucet for.
+const DISABLE_FAUCET_CHAIN_IDS = process.env.DISABLE_FAUCET_CHAIN_IDS;
+
 // Note: This handler cannot use "edge" runtime because of Redis usage.
 export const GET = async (req: NextRequest) => {
   const searchParams = req.nextUrl.searchParams;
@@ -33,10 +36,22 @@ export const GET = async (req: NextRequest) => {
     );
   }
 
+  // Check if faucet is disabled for this chain.
+  let isFaucetDisabled = false;
+  if (DISABLE_FAUCET_CHAIN_IDS) {
+    try {
+      const disableFaucetChainIds = DISABLE_FAUCET_CHAIN_IDS.split(",").map(
+        (chainId) => Number.parseInt(chainId.trim()),
+      );
+      isFaucetDisabled = disableFaucetChainIds.includes(chainId);
+    } catch {}
+  }
+
   if (
     !THIRDWEB_ENGINE_URL ||
     !NEXT_PUBLIC_THIRDWEB_ENGINE_FAUCET_WALLET ||
-    !THIRDWEB_ACCESS_TOKEN
+    !THIRDWEB_ACCESS_TOKEN ||
+    isFaucetDisabled
   ) {
     const res: CanClaimResponseType = {
       canClaim: false,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to add functionality to disable the faucet for specific chain IDs in the testnet faucet API route.

### Detailed summary
- Added `DISABLE_FAUCET_CHAIN_IDS` environment variable for disabling faucet for specific chain IDs.
- Implemented logic to check if the faucet is disabled for a particular chain ID before allowing claims.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->