### PR TITLE
[SDK] Feature: Export uri parsing utils

### DIFF
--- a/.changeset/mean-owls-nail.md
+++ b/.changeset/mean-owls-nail.md
@@ -1,0 +1,20 @@
+---
+"thirdweb": minor
+---
+
+Adds parseAvatarRecord and parseNftUri utilities
+
+```ts
+import { parseAvatarRecord } from "thirdweb/extensions/ens";
+import { parseNftUri } from "thirdweb/extensions/common";
+
+const avatarUrl = await parseAvatarRecord({
+  client,
+  uri: "...",
+});
+
+const nftUri = await parseNftUri({
+  client,
+  uri: "...",
+});
+```

--- a/packages/thirdweb/src/exports/extensions/common.ts
+++ b/packages/thirdweb/src/exports/extensions/common.ts
@@ -13,6 +13,7 @@ export {
   symbol,
   isSymbolSupported,
 } from "../../extensions/common/read/symbol.js";
+export { parseNftUri } from "../../utils/nft/parseNft.js";
 
 // write
 export {

--- a/packages/thirdweb/src/exports/extensions/ens.ts
+++ b/packages/thirdweb/src/exports/extensions/ens.ts
@@ -9,6 +9,11 @@ export {
 } from "../../extensions/ens/resolve-avatar.js";
 
 export {
+  parseAvatarRecord,
+  type ParseAvatarOptions,
+} from "../../utils/ens/avatar.js";
+
+export {
   type ResolveTextOptions,
   resolveText,
 } from "../../extensions/ens/resolve-text.js";

--- a/packages/thirdweb/src/utils/nft/parseNft.ts
+++ b/packages/thirdweb/src/utils/nft/parseNft.ts
@@ -1,4 +1,8 @@
+import { getCachedChain } from "../../chains/utils.js";
+import type { ThirdwebClient } from "../../client/client.js";
+import { getContract } from "../../contract/contract.js";
 import type { FileOrBufferOrString } from "../../storage/upload/types.js";
+import { isAddress } from "../address.js";
 import type { Prettify } from "../type-utils.js";
 
 /**
@@ -93,5 +97,90 @@ export function parseNFT(base: NFTMetadata, options: ParseNFTOptions): NFT {
       };
     default:
       throw new Error("Invalid NFT type");
+  }
+}
+
+/**
+ * Parses an NFT URI.
+ * @param options - The options for parsing an NFT URI.
+ * @param options.client - The Thirdweb client.
+ * @param options.uri - The NFT URI to parse.
+ * @returns A promise that resolves to the NFT URI, or null if the URI could not be parsed.
+ *
+ * @example
+ * ```ts
+ * import { parseNftUri } from "thirdweb/utils/ens";
+ * const nftUri = await parseNftUri({
+ *    client,
+ *    uri: "eip155:1/erc1155:0xb32979486938aa9694bfc898f35dbed459f44424/10063",
+ * });
+ *
+ * console.log(nftUri); // ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/
+ * ```
+ *
+ * @extension ENS
+ *
+ */
+export async function parseNftUri(options: {
+  client: ThirdwebClient;
+  uri: string;
+}): Promise<string | null> {
+  let uri = options.uri;
+  // parse valid nft spec (CAIP-22/CAIP-29)
+  // @see: https://github.com/ChainAgnostic/CAIPs/tree/master/CAIPs
+  if (uri.startsWith("did:nft:")) {
+    // convert DID to CAIP
+    uri = uri.replace("did:nft:", "").replace(/_/g, "/");
+  }
+
+  const [reference = "", asset_namespace = "", tokenID = ""] = uri.split("/");
+  const [eip_namespace, chainID] = reference.split(":");
+  const [erc_namespace, contractAddress] = asset_namespace.split(":");
+
+  if (!eip_namespace || eip_namespace.toLowerCase() !== "eip155") {
+    throw new Error(
+      `Invalid EIP namespace, expected EIP155, got: "${eip_namespace}"`,
+    );
+  }
+  if (!chainID) {
+    throw new Error("Chain ID not found");
+  }
+  if (!contractAddress || !isAddress(contractAddress)) {
+    throw new Error("Contract address not found");
+  }
+  if (!tokenID) {
+    throw new Error("Token ID not found");
+  }
+  const chain = getCachedChain(Number(chainID));
+  const contract = getContract({
+    client: options.client,
+    chain,
+    address: contractAddress,
+  });
+  switch (erc_namespace) {
+    case "erc721": {
+      const { getNFT } = await import("../../extensions/erc721/read/getNFT.js");
+      const nft = await getNFT({
+        contract,
+        tokenId: BigInt(tokenID),
+      });
+      return nft.metadata.image ?? null;
+    }
+    case "erc1155": {
+      const { getNFT } = await import(
+        "../../extensions/erc1155/read/getNFT.js"
+      );
+      const nft = await getNFT({
+        contract,
+        tokenId: BigInt(tokenID),
+      });
+      return nft.metadata.image ?? null;
+    }
+
+    default: {
+      throw new Error(
+        `Invalid ERC namespace, expected ERC721 or ERC1155, got: "${erc_namespace}"`,
+      );
+    }
   }
 }


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds utilities `parseAvatarRecord` and `parseNftUri` for parsing ENS avatar records and NFT URIs, enhancing avatar resolution capabilities.

### Detailed summary
- Added `parseAvatarRecord` and `parseNftUri` utilities for ENS avatar records and NFT URIs
- Updated `parseNftUri` to parse NFT URIs and fetch NFT metadata
- Updated `parseAvatarRecord` to support ENS avatar records, NFT URIs, and HTTPS/IPFS URIs

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->