### PR TITLE
New zksolc metadata format

### DIFF
--- a/.changeset/gold-moons-exercise.md
+++ b/.changeset/gold-moons-exercise.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Handle new zksolc metadata format

--- a/apps/dashboard/src/components/contract-components/contract-deploy-form/custom-contract.tsx
+++ b/apps/dashboard/src/components/contract-components/contract-deploy-form/custom-contract.tsx
@@ -37,6 +37,7 @@ import {
 } from "thirdweb/deploys";
 import { useActiveAccount, useActiveWalletChain } from "thirdweb/react";
 import { upload } from "thirdweb/storage";
+import { isZkSyncChain } from "thirdweb/utils";
 import { FormHelperText, FormLabel, Heading, Text } from "tw-components";
 import { useCustomFactoryAbi, useFunctionParamsFromABI } from "../hooks";
 import { addContractToMultiChainRegistry } from "../utils";
@@ -385,6 +386,8 @@ export const CustomContractForm: React.FC<CustomContractFormProps> = ({
         throw new Error("no chain");
       }
 
+      const compilerType = isZkSyncChain(walletChain) ? "zksolc" : "solc";
+
       let _contractURI = "";
 
       if (hasContractURI && params.contractMetadata) {
@@ -449,6 +452,7 @@ export const CustomContractForm: React.FC<CustomContractFormProps> = ({
           deployMetadata: m,
           initializeParams: params.moduleData[m.name],
         })),
+        compilerType,
       });
     },
   });

--- a/packages/thirdweb/src/contract/actions/compiler-metadata.ts
+++ b/packages/thirdweb/src/contract/actions/compiler-metadata.ts
@@ -18,6 +18,7 @@ export type CompilerMetadata = {
   };
   licenses: string[];
   isPartialAbi?: boolean;
+  zk_version?: string;
 };
 
 /**
@@ -26,29 +27,37 @@ export type CompilerMetadata = {
  * @returns The formatted metadata.
  * @internal
  */
-// biome-ignore lint/suspicious/noExplicitAny: TODO: fix later
-export function formatCompilerMetadata(metadata: any): CompilerMetadata {
-  const compilationTarget = metadata.settings.compilationTarget;
+export function formatCompilerMetadata(
+  // biome-ignore lint/suspicious/noExplicitAny: TODO: fix later
+  metadata: any,
+  compilerType?: "solc" | "zksolc",
+): CompilerMetadata {
+  let meta = metadata;
+  if (compilerType === "zksolc") {
+    meta = metadata.source_metadata || meta;
+  }
+  const compilationTarget = meta.settings.compilationTarget;
   const targets = Object.keys(compilationTarget);
   const name = compilationTarget[targets[0] as keyof typeof compilationTarget];
   const info = {
-    title: metadata.output.devdoc.title,
-    author: metadata.output.devdoc.author,
-    details: metadata.output.devdoc.detail,
-    notice: metadata.output.userdoc.notice,
+    title: meta.output.devdoc.title,
+    author: meta.output.devdoc.author,
+    details: meta.output.devdoc.detail,
+    notice: meta.output.userdoc.notice,
   };
   const licenses: string[] = [
     ...new Set(
       // biome-ignore lint/suspicious/noExplicitAny: TODO: fix later
-      Object.entries(metadata.sources).map(([, src]) => (src as any).license),
+      Object.entries(meta.sources).map(([, src]) => (src as any).license),
     ),
   ];
   return {
     name,
-    abi: metadata?.output?.abi || [],
-    metadata,
+    abi: meta?.output?.abi || [],
+    metadata: meta,
     info,
     licenses,
-    isPartialAbi: metadata.isPartialAbi,
+    isPartialAbi: meta.isPartialAbi,
+    zk_version: metadata.zk_version,
   };
 }

--- a/packages/thirdweb/src/contract/deployment/publisher.ts
+++ b/packages/thirdweb/src/contract/deployment/publisher.ts
@@ -24,6 +24,7 @@ export async function fetchPublishedContractMetadata(options: {
   contractId: string;
   publisher?: string;
   version?: string;
+  compilerType?: "solc" | "zksolc";
 }): Promise<FetchDeployMetadataResult> {
   const cacheKey = `${options.contractId}-${options.publisher}-${options.version}`;
   return withCache(
@@ -33,6 +34,7 @@ export async function fetchPublishedContractMetadata(options: {
         publisherAddress: options.publisher || THIRDWEB_DEPLOYER,
         contractId: options.contractId,
         version: options.version,
+        compilerType: options.compilerType,
       });
       if (!publishedContract.publishMetadataUri) {
         throw new Error(
@@ -42,6 +44,7 @@ export async function fetchPublishedContractMetadata(options: {
       const data = await fetchDeployMetadata({
         client: options.client,
         uri: publishedContract.publishMetadataUri,
+        compilerType: options.compilerType,
       });
       return data;
     },
@@ -211,6 +214,7 @@ type FetchPublishedContractOptions = {
   contractId: string;
   version?: string;
   client: ThirdwebClient;
+  compilerType?: "solc" | "zksolc";
 };
 
 /**

--- a/packages/thirdweb/src/contract/deployment/utils/bootstrap.ts
+++ b/packages/thirdweb/src/contract/deployment/utils/bootstrap.ts
@@ -27,6 +27,7 @@ export async function getOrDeployInfraForPublishedContract(
     constructorParams?: Record<string, unknown>;
     publisher?: string;
     version?: string;
+    compilerType?: "solc" | "zksolc";
   },
 ): Promise<{
   cloneFactoryContract: ThirdwebContract;
@@ -40,6 +41,7 @@ export async function getOrDeployInfraForPublishedContract(
     constructorParams,
     publisher,
     version,
+    compilerType,
   } = args;
 
   if (isZkSyncChain(chain)) {
@@ -50,9 +52,10 @@ export async function getOrDeployInfraForPublishedContract(
     });
     const compilerMetadata = await fetchPublishedContractMetadata({
       client,
-      contractId: `${contractId}_ZkSync`, // different contract id for zkSync
+      contractId,
       publisher,
       version,
+      compilerType,
     });
     const implementationContract = await zkDeployContractDeterministic({
       chain,

--- a/packages/thirdweb/src/exports/utils.ts
+++ b/packages/thirdweb/src/exports/utils.ts
@@ -22,6 +22,7 @@ export { isEIP155Enforced } from "../utils/any-evm/is-eip155-enforced.js";
 export { keccakId } from "../utils/any-evm/keccak-id.js";
 export { getKeylessTransaction } from "../utils/any-evm/keyless-transaction.js";
 export type { ExtendedMetadata } from "../utils/any-evm/deploy-metadata.js";
+export { isZkSyncChain } from "../utils/any-evm/zksync/isZkSyncChain.js";
 
 //signatures
 export {

--- a/packages/thirdweb/src/extensions/prebuilts/deploy-published.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/deploy-published.ts
@@ -33,6 +33,7 @@ export type DeployPublishedContractOptions = {
   version?: string;
   implementationConstructorParams?: Record<string, unknown>;
   salt?: string;
+  compilerType?: "solc" | "zksolc";
 };
 
 /**
@@ -92,12 +93,14 @@ export async function deployPublishedContract(
     version,
     implementationConstructorParams,
     salt,
+    compilerType,
   } = options;
   const deployMetadata = await fetchPublishedContractMetadata({
     client,
-    contractId: isZkSyncChain(chain) ? `${contractId}_ZkSync` : contractId,
+    contractId,
     publisher,
     version,
+    compilerType,
   });
 
   return deployContractfromDeployMetadata({
@@ -108,6 +111,7 @@ export async function deployPublishedContract(
     initializeParams: contractParams,
     implementationConstructorParams,
     salt,
+    compilerType,
   });
 }
 
@@ -126,6 +130,7 @@ export type DeployContractfromDeployMetadataOptions = {
     initializeParams?: Record<string, unknown>;
   }[];
   salt?: string;
+  compilerType?: "solc" | "zksolc";
 };
 
 /**
@@ -143,6 +148,7 @@ export async function deployContractfromDeployMetadata(
     implementationConstructorParams,
     modules,
     salt,
+    compilerType,
   } = options;
   switch (deployMetadata?.deployType) {
     case "standard": {
@@ -176,6 +182,7 @@ export async function deployContractfromDeployMetadata(
               client,
             })),
           publisher: deployMetadata.publisher,
+          compilerType,
         });
 
       const initializeTransaction = await getInitializeTransaction({


### PR DESCRIPTION
## Problem solved

Handle new zksolc metadata format
ref: ipfs://QmS6ehXYWKJEJq3LBSfG2ujKPzQQJooNE7L375zyFbpxmw

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces support for a new `zksolc` compiler type, enhancing the handling of zkSync metadata and related functionalities across various components in the `thirdweb` package.

### Detailed summary
- Added `compilerType` option to multiple functions and types.
- Implemented handling for `zksolc` metadata format in `fetchDeployMetadata`.
- Updated `formatCompilerMetadata` to process `zksolc` metadata.
- Adjusted contract deployment and metadata fetching logic to accommodate `zksolc`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->