### PR TITLE
.net 2.1 docs hotfix

### DIFF
--- a/apps/portal/src/app/dotnet/wallets/providers/ecosystem-wallet/page.mdx
+++ b/apps/portal/src/app/dotnet/wallets/providers/ecosystem-wallet/page.mdx
@@ -131,12 +131,8 @@ await wallet.SendOTP();
 **Submit OTP:** Once the user receives the OTP, they submit it back to the application, which then calls LoginWithOtp on the EcosystemWallet instance to verify the OTP and complete the login process.
 
 ```csharp
-var (address, canRetry) = await wallet.LoginWithOtp("userEnteredOTP");
-if (address != null) {
-    // Login successful
-} else if (canRetry) {
-    // Ask user to retry entering OTP
-}
+var address = await wallet.LoginWithOtp("userEnteredOTP");
+// If this fails, feel free to catch and take in another OTP and retry the login process
 ```
 
 ## Example


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR simplifies the OTP login process in the `page.mdx` file by removing the `canRetry` check and providing a suggestion for retrying OTP entry.

### Detailed summary
- Removed `canRetry` variable check
- Updated comments for retrying OTP entry in case of failure

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->