### PR TITLE
[SDK] Add Pack extensions

### DIFF
--- a/.changeset/sixty-seals-tell.md
+++ b/.changeset/sixty-seals-tell.md
@@ -1,0 +1,57 @@
+---
+"thirdweb": minor
+---
+
+Add Pack extensions
+### Deploy Pack
+```ts
+import { deployPackContract } from "thirdweb/extensions/deploy";
+
+const packAddress = await deployPackContract({
+  account,
+  client,
+  chain,
+  params: {
+    name: "Pack contract name",
+    symbol: "PACK1155",
+  },
+});
+```
+
+### Create a Pack
+```ts
+import { createPack } from "thirdweb/extensions/pack";
+
+const transaction = createPack({
+  contract: packContract,
+  client,
+  recipient: "0x...",
+  tokenOwner: "0x...",
+  packMetadata: {
+    name: "Pack #1",
+    image: "image-of-pack-1",
+  },
+  openStartTimestamp: new Date(),
+  erc20Rewards: [
+    {
+      contractAddress: "0x...",
+      quantityPerReward: 1,
+      totalRewards: 1,
+    },
+  ],
+  erc721Rewards: [
+    {
+      contractAddress: "0x...",
+      tokenId: 0n,
+    },
+  ],
+  erc1155Rewards: [
+    {
+      contractAddress: "0x...",
+      tokenId: 0n,
+      quantityPerReward: 1,
+      totalRewards: 1,
+    },
+  ],
+});
+```

--- a/packages/thirdweb/scripts/generate/abis/pack/IPack.json
+++ b/packages/thirdweb/scripts/generate/abis/pack/IPack.json
@@ -1,0 +1,13 @@
+[
+  "event PackCreated(uint256 indexed packId, address recipient, uint256 totalPacksCreated)",
+  "event PackOpened(uint256 indexed packId, address indexed opener, uint256 numOfPacksOpened, (address assetContract, uint8 tokenType, uint256 tokenId, uint256 totalAmount)[] rewardUnitsDistributed)",
+  "event PackUpdated(uint256 indexed packId, address recipient, uint256 totalPacksCreated)",
+  "function createPack((address assetContract, uint8 tokenType, uint256 tokenId, uint256 totalAmount)[] contents, uint256[] numOfRewardUnits, string packUri, uint128 openStartTimestamp, uint128 amountDistributedPerOpen, address recipient) payable returns (uint256 packId, uint256 packTotalSupply)",
+  "function openPack(uint256 packId, uint256 amountToOpen) returns ((address assetContract, uint8 tokenType, uint256 tokenId, uint256 totalAmount)[])",
+  "function addPackContents(uint256 _packId, (address assetContract, uint8 tokenType, uint256 tokenId, uint256 totalAmount)[] _contents, uint256[] _numOfRewardUnits, address _recipient) payable returns (uint256 packTotalSupply, uint256 newSupplyAdded)",
+  "function getPackContents(uint256 _packId) view returns ((address assetContract, uint8 tokenType, uint256 tokenId, uint256 totalAmount)[] contents, uint256[] perUnitAmounts)",
+  "function getTokenCountOfBundle(uint256 _bundleId) view returns (uint256)",
+  "function getTokenOfBundle(uint256 _bundleId, uint256 index) view returns ((address assetContract, uint8 tokenType, uint256 tokenId, uint256 totalAmount))",
+  "function getUriOfBundle(uint256 _bundleId) view returns (string)",
+  "function canUpdatePack(uint256 _key) view returns (bool)"
+]

--- a/packages/thirdweb/scripts/generate/abis/pack/IPackVRFDirect.json
+++ b/packages/thirdweb/scripts/generate/abis/pack/IPackVRFDirect.json
@@ -1,0 +1,7 @@
+[
+  "event PackOpenRequested(address indexed opener, uint256 indexed packId, uint256 amountToOpen, uint256 requestId)",
+  "event PackRandomnessFulfilled(uint256 indexed packId, uint256 indexed requestId)",
+  "function canClaimRewards(address _opener) view returns (bool)",
+  "function claimRewards() returns ((address assetContract, uint8 tokenType, uint256 tokenId, uint256 totalAmount)[] rewardUnits)",
+  "function openPackAndClaimRewards(uint256 _packId, uint256 _amountToOpen, uint32 _callBackGasLimit) returns (uint256)"
+]

--- a/packages/thirdweb/scripts/generate/abis/prebuilts/Pack.json
+++ b/packages/thirdweb/scripts/generate/abis/prebuilts/Pack.json
@@ -1,0 +1,3 @@
+[
+  "function initialize(address _defaultAdmin, string _name, string _symbol, string _contractURI, address[] _trustedForwarders, address _royaltyRecipient, uint256 _royaltyBps)"
+]

--- a/packages/thirdweb/src/exports/deploys.ts
+++ b/packages/thirdweb/src/exports/deploys.ts
@@ -48,3 +48,9 @@ export {
 } from "../contract/deployment/deploy-with-abi.js";
 export { computePublishedContractAddress } from "../utils/any-evm/compute-published-contract-address.js";
 export { getRequiredTransactions } from "../extensions/prebuilts/get-required-transactions.js";
+
+export {
+  type PackContractParams,
+  type DeployPackContractOptions,
+  deployPackContract,
+} from "../extensions/prebuilts/deploy-pack.js";

--- a/packages/thirdweb/src/exports/extensions/pack.ts
+++ b/packages/thirdweb/src/exports/extensions/pack.ts
@@ -1,0 +1,42 @@
+// Write
+export {
+  createPack,
+  type CreatePackParams,
+} from "../../extensions/pack/__generated__/IPack/write/createPack.js";
+export {
+  PACK_TOKEN_TYPE,
+  type ERC20Reward,
+  type ERC721Reward,
+  type ERC1155Reward,
+  type CreateNewPackParams,
+  createNewPack,
+} from "../../extensions/pack/createNewPack.js";
+
+export {
+  openPack,
+  type OpenPackParams,
+} from "../../extensions/pack/__generated__/IPack/write/openPack.js";
+
+// Read
+export {
+  getTokenCountOfBundle,
+  type GetTokenCountOfBundleParams,
+} from "../../extensions/pack/__generated__/IPack/read/getTokenCountOfBundle.js";
+export {
+  getPackContents,
+  type GetPackContentsParams,
+} from "../../extensions/pack/__generated__/IPack/read/getPackContents.js";
+
+// Events
+export {
+  packCreatedEvent,
+  type PackCreatedEventFilters,
+} from "../../extensions/pack/__generated__/IPack/events/PackCreated.js";
+export {
+  packOpenedEvent,
+  type PackOpenedEventFilters,
+} from "../../extensions/pack/__generated__/IPack/events/PackOpened.js";
+export {
+  packUpdatedEvent,
+  type PackUpdatedEventFilters,
+} from "../../extensions/pack/__generated__/IPack/events/PackUpdated.js";

--- a/packages/thirdweb/src/extensions/pack/__generated__/IPack/events/PackCreated.ts
+++ b/packages/thirdweb/src/extensions/pack/__generated__/IPack/events/PackCreated.ts
@@ -1,0 +1,41 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+import type { AbiParameterToPrimitiveType } from "abitype";
+
+/**
+ * Represents the filters for the "PackCreated" event.
+ */
+export type PackCreatedEventFilters = Partial<{
+  packId: AbiParameterToPrimitiveType<{
+    type: "uint256";
+    name: "packId";
+    indexed: true;
+  }>;
+}>;
+
+/**
+ * Creates an event object for the PackCreated event.
+ * @param filters - Optional filters to apply to the event.
+ * @returns The prepared event object.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { packCreatedEvent } from "thirdweb/extensions/pack";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  packCreatedEvent({
+ *  packId: ...,
+ * })
+ * ],
+ * });
+ * ```
+ */
+export function packCreatedEvent(filters: PackCreatedEventFilters = {}) {
+  return prepareEvent({
+    signature:
+      "event PackCreated(uint256 indexed packId, address recipient, uint256 totalPacksCreated)",
+    filters,
+  });
+}

--- a/packages/thirdweb/src/extensions/pack/__generated__/IPack/events/PackOpened.ts
+++ b/packages/thirdweb/src/extensions/pack/__generated__/IPack/events/PackOpened.ts
@@ -1,0 +1,47 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+import type { AbiParameterToPrimitiveType } from "abitype";
+
+/**
+ * Represents the filters for the "PackOpened" event.
+ */
+export type PackOpenedEventFilters = Partial<{
+  packId: AbiParameterToPrimitiveType<{
+    type: "uint256";
+    name: "packId";
+    indexed: true;
+  }>;
+  opener: AbiParameterToPrimitiveType<{
+    type: "address";
+    name: "opener";
+    indexed: true;
+  }>;
+}>;
+
+/**
+ * Creates an event object for the PackOpened event.
+ * @param filters - Optional filters to apply to the event.
+ * @returns The prepared event object.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { packOpenedEvent } from "thirdweb/extensions/pack";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  packOpenedEvent({
+ *  packId: ...,
+ *  opener: ...,
+ * })
+ * ],
+ * });
+ * ```
+ */
+export function packOpenedEvent(filters: PackOpenedEventFilters = {}) {
+  return prepareEvent({
+    signature:
+      "event PackOpened(uint256 indexed packId, address indexed opener, uint256 numOfPacksOpened, (address assetContract, uint8 tokenType, uint256 tokenId, uint256 totalAmount)[] rewardUnitsDistributed)",
+    filters,
+  });
+}

--- a/packages/thirdweb/src/extensions/pack/__generated__/IPack/events/PackUpdated.ts
+++ b/packages/thirdweb/src/extensions/pack/__generated__/IPack/events/PackUpdated.ts
@@ -1,0 +1,41 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+import type { AbiParameterToPrimitiveType } from "abitype";
+
+/**
+ * Represents the filters for the "PackUpdated" event.
+ */
+export type PackUpdatedEventFilters = Partial<{
+  packId: AbiParameterToPrimitiveType<{
+    type: "uint256";
+    name: "packId";
+    indexed: true;
+  }>;
+}>;
+
+/**
+ * Creates an event object for the PackUpdated event.
+ * @param filters - Optional filters to apply to the event.
+ * @returns The prepared event object.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { packUpdatedEvent } from "thirdweb/extensions/pack";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  packUpdatedEvent({
+ *  packId: ...,
+ * })
+ * ],
+ * });
+ * ```
+ */
+export function packUpdatedEvent(filters: PackUpdatedEventFilters = {}) {
+  return prepareEvent({
+    signature:
+      "event PackUpdated(uint256 indexed packId, address recipient, uint256 totalPacksCreated)",
+    filters,
+  });
+}

--- a/packages/thirdweb/src/extensions/pack/__generated__/IPack/read/canUpdatePack.ts
+++ b/packages/thirdweb/src/extensions/pack/__generated__/IPack/read/canUpdatePack.ts
@@ -1,0 +1,125 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "canUpdatePack" function.
+ */
+export type CanUpdatePackParams = {
+  key: AbiParameterToPrimitiveType<{ type: "uint256"; name: "_key" }>;
+};
+
+export const FN_SELECTOR = "0xb0381b08" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_key",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bool",
+  },
+] as const;
+
+/**
+ * Checks if the `canUpdatePack` method is supported by the given contract.
+ * @param availableSelectors An array of 4byte function selectors of the contract. You can get this in various ways, such as using "whatsabi" or if you have the ABI of the contract available you can use it to generate the selectors.
+ * @returns A boolean indicating if the `canUpdatePack` method is supported.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { isCanUpdatePackSupported } from "thirdweb/extensions/pack";
+ * const supported = isCanUpdatePackSupported(["0x..."]);
+ * ```
+ */
+export function isCanUpdatePackSupported(availableSelectors: string[]) {
+  return detectMethod({
+    availableSelectors,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "canUpdatePack" function.
+ * @param options - The options for the canUpdatePack function.
+ * @returns The encoded ABI parameters.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { encodeCanUpdatePackParams } from "thirdweb/extensions/pack";
+ * const result = encodeCanUpdatePackParams({
+ *  key: ...,
+ * });
+ * ```
+ */
+export function encodeCanUpdatePackParams(options: CanUpdatePackParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.key]);
+}
+
+/**
+ * Encodes the "canUpdatePack" function into a Hex string with its parameters.
+ * @param options - The options for the canUpdatePack function.
+ * @returns The encoded hexadecimal string.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { encodeCanUpdatePack } from "thirdweb/extensions/pack";
+ * const result = encodeCanUpdatePack({
+ *  key: ...,
+ * });
+ * ```
+ */
+export function encodeCanUpdatePack(options: CanUpdatePackParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeCanUpdatePackParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the canUpdatePack function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { decodeCanUpdatePackResult } from "thirdweb/extensions/pack";
+ * const result = decodeCanUpdatePackResultResult("...");
+ * ```
+ */
+export function decodeCanUpdatePackResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "canUpdatePack" function on the contract.
+ * @param options - The options for the canUpdatePack function.
+ * @returns The parsed result of the function call.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { canUpdatePack } from "thirdweb/extensions/pack";
+ *
+ * const result = await canUpdatePack({
+ *  contract,
+ *  key: ...,
+ * });
+ *
+ * ```
+ */
+export async function canUpdatePack(
+  options: BaseTransactionOptions<CanUpdatePackParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.key],
+  });
+}

--- a/packages/thirdweb/src/extensions/pack/__generated__/IPack/read/getPackContents.ts
+++ b/packages/thirdweb/src/extensions/pack/__generated__/IPack/read/getPackContents.ts
@@ -1,0 +1,148 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "getPackContents" function.
+ */
+export type GetPackContentsParams = {
+  packId: AbiParameterToPrimitiveType<{ type: "uint256"; name: "_packId" }>;
+};
+
+export const FN_SELECTOR = "0x8d4c446a" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_packId",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "tuple[]",
+    name: "contents",
+    components: [
+      {
+        type: "address",
+        name: "assetContract",
+      },
+      {
+        type: "uint8",
+        name: "tokenType",
+      },
+      {
+        type: "uint256",
+        name: "tokenId",
+      },
+      {
+        type: "uint256",
+        name: "totalAmount",
+      },
+    ],
+  },
+  {
+    type: "uint256[]",
+    name: "perUnitAmounts",
+  },
+] as const;
+
+/**
+ * Checks if the `getPackContents` method is supported by the given contract.
+ * @param availableSelectors An array of 4byte function selectors of the contract. You can get this in various ways, such as using "whatsabi" or if you have the ABI of the contract available you can use it to generate the selectors.
+ * @returns A boolean indicating if the `getPackContents` method is supported.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { isGetPackContentsSupported } from "thirdweb/extensions/pack";
+ * const supported = isGetPackContentsSupported(["0x..."]);
+ * ```
+ */
+export function isGetPackContentsSupported(availableSelectors: string[]) {
+  return detectMethod({
+    availableSelectors,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "getPackContents" function.
+ * @param options - The options for the getPackContents function.
+ * @returns The encoded ABI parameters.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { encodeGetPackContentsParams } from "thirdweb/extensions/pack";
+ * const result = encodeGetPackContentsParams({
+ *  packId: ...,
+ * });
+ * ```
+ */
+export function encodeGetPackContentsParams(options: GetPackContentsParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.packId]);
+}
+
+/**
+ * Encodes the "getPackContents" function into a Hex string with its parameters.
+ * @param options - The options for the getPackContents function.
+ * @returns The encoded hexadecimal string.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { encodeGetPackContents } from "thirdweb/extensions/pack";
+ * const result = encodeGetPackContents({
+ *  packId: ...,
+ * });
+ * ```
+ */
+export function encodeGetPackContents(options: GetPackContentsParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeGetPackContentsParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the getPackContents function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { decodeGetPackContentsResult } from "thirdweb/extensions/pack";
+ * const result = decodeGetPackContentsResultResult("...");
+ * ```
+ */
+export function decodeGetPackContentsResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result);
+}
+
+/**
+ * Calls the "getPackContents" function on the contract.
+ * @param options - The options for the getPackContents function.
+ * @returns The parsed result of the function call.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { getPackContents } from "thirdweb/extensions/pack";
+ *
+ * const result = await getPackContents({
+ *  contract,
+ *  packId: ...,
+ * });
+ *
+ * ```
+ */
+export async function getPackContents(
+  options: BaseTransactionOptions<GetPackContentsParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.packId],
+  });
+}

--- a/packages/thirdweb/src/extensions/pack/__generated__/IPack/read/getTokenCountOfBundle.ts
+++ b/packages/thirdweb/src/extensions/pack/__generated__/IPack/read/getTokenCountOfBundle.ts
@@ -1,0 +1,129 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "getTokenCountOfBundle" function.
+ */
+export type GetTokenCountOfBundleParams = {
+  bundleId: AbiParameterToPrimitiveType<{ type: "uint256"; name: "_bundleId" }>;
+};
+
+export const FN_SELECTOR = "0xd0d2fe25" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_bundleId",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Checks if the `getTokenCountOfBundle` method is supported by the given contract.
+ * @param availableSelectors An array of 4byte function selectors of the contract. You can get this in various ways, such as using "whatsabi" or if you have the ABI of the contract available you can use it to generate the selectors.
+ * @returns A boolean indicating if the `getTokenCountOfBundle` method is supported.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { isGetTokenCountOfBundleSupported } from "thirdweb/extensions/pack";
+ * const supported = isGetTokenCountOfBundleSupported(["0x..."]);
+ * ```
+ */
+export function isGetTokenCountOfBundleSupported(availableSelectors: string[]) {
+  return detectMethod({
+    availableSelectors,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "getTokenCountOfBundle" function.
+ * @param options - The options for the getTokenCountOfBundle function.
+ * @returns The encoded ABI parameters.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { encodeGetTokenCountOfBundleParams } from "thirdweb/extensions/pack";
+ * const result = encodeGetTokenCountOfBundleParams({
+ *  bundleId: ...,
+ * });
+ * ```
+ */
+export function encodeGetTokenCountOfBundleParams(
+  options: GetTokenCountOfBundleParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [options.bundleId]);
+}
+
+/**
+ * Encodes the "getTokenCountOfBundle" function into a Hex string with its parameters.
+ * @param options - The options for the getTokenCountOfBundle function.
+ * @returns The encoded hexadecimal string.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { encodeGetTokenCountOfBundle } from "thirdweb/extensions/pack";
+ * const result = encodeGetTokenCountOfBundle({
+ *  bundleId: ...,
+ * });
+ * ```
+ */
+export function encodeGetTokenCountOfBundle(
+  options: GetTokenCountOfBundleParams,
+) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeGetTokenCountOfBundleParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the getTokenCountOfBundle function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { decodeGetTokenCountOfBundleResult } from "thirdweb/extensions/pack";
+ * const result = decodeGetTokenCountOfBundleResultResult("...");
+ * ```
+ */
+export function decodeGetTokenCountOfBundleResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "getTokenCountOfBundle" function on the contract.
+ * @param options - The options for the getTokenCountOfBundle function.
+ * @returns The parsed result of the function call.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { getTokenCountOfBundle } from "thirdweb/extensions/pack";
+ *
+ * const result = await getTokenCountOfBundle({
+ *  contract,
+ *  bundleId: ...,
+ * });
+ *
+ * ```
+ */
+export async function getTokenCountOfBundle(
+  options: BaseTransactionOptions<GetTokenCountOfBundleParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.bundleId],
+  });
+}

--- a/packages/thirdweb/src/extensions/pack/__generated__/IPack/read/getTokenOfBundle.ts
+++ b/packages/thirdweb/src/extensions/pack/__generated__/IPack/read/getTokenOfBundle.ts
@@ -1,0 +1,151 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "getTokenOfBundle" function.
+ */
+export type GetTokenOfBundleParams = {
+  bundleId: AbiParameterToPrimitiveType<{ type: "uint256"; name: "_bundleId" }>;
+  index: AbiParameterToPrimitiveType<{ type: "uint256"; name: "index" }>;
+};
+
+export const FN_SELECTOR = "0x1da799c9" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_bundleId",
+  },
+  {
+    type: "uint256",
+    name: "index",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "tuple",
+    components: [
+      {
+        type: "address",
+        name: "assetContract",
+      },
+      {
+        type: "uint8",
+        name: "tokenType",
+      },
+      {
+        type: "uint256",
+        name: "tokenId",
+      },
+      {
+        type: "uint256",
+        name: "totalAmount",
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Checks if the `getTokenOfBundle` method is supported by the given contract.
+ * @param availableSelectors An array of 4byte function selectors of the contract. You can get this in various ways, such as using "whatsabi" or if you have the ABI of the contract available you can use it to generate the selectors.
+ * @returns A boolean indicating if the `getTokenOfBundle` method is supported.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { isGetTokenOfBundleSupported } from "thirdweb/extensions/pack";
+ * const supported = isGetTokenOfBundleSupported(["0x..."]);
+ * ```
+ */
+export function isGetTokenOfBundleSupported(availableSelectors: string[]) {
+  return detectMethod({
+    availableSelectors,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "getTokenOfBundle" function.
+ * @param options - The options for the getTokenOfBundle function.
+ * @returns The encoded ABI parameters.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { encodeGetTokenOfBundleParams } from "thirdweb/extensions/pack";
+ * const result = encodeGetTokenOfBundleParams({
+ *  bundleId: ...,
+ *  index: ...,
+ * });
+ * ```
+ */
+export function encodeGetTokenOfBundleParams(options: GetTokenOfBundleParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.bundleId, options.index]);
+}
+
+/**
+ * Encodes the "getTokenOfBundle" function into a Hex string with its parameters.
+ * @param options - The options for the getTokenOfBundle function.
+ * @returns The encoded hexadecimal string.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { encodeGetTokenOfBundle } from "thirdweb/extensions/pack";
+ * const result = encodeGetTokenOfBundle({
+ *  bundleId: ...,
+ *  index: ...,
+ * });
+ * ```
+ */
+export function encodeGetTokenOfBundle(options: GetTokenOfBundleParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeGetTokenOfBundleParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the getTokenOfBundle function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { decodeGetTokenOfBundleResult } from "thirdweb/extensions/pack";
+ * const result = decodeGetTokenOfBundleResultResult("...");
+ * ```
+ */
+export function decodeGetTokenOfBundleResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "getTokenOfBundle" function on the contract.
+ * @param options - The options for the getTokenOfBundle function.
+ * @returns The parsed result of the function call.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { getTokenOfBundle } from "thirdweb/extensions/pack";
+ *
+ * const result = await getTokenOfBundle({
+ *  contract,
+ *  bundleId: ...,
+ *  index: ...,
+ * });
+ *
+ * ```
+ */
+export async function getTokenOfBundle(
+  options: BaseTransactionOptions<GetTokenOfBundleParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.bundleId, options.index],
+  });
+}

--- a/packages/thirdweb/src/extensions/pack/__generated__/IPack/read/getUriOfBundle.ts
+++ b/packages/thirdweb/src/extensions/pack/__generated__/IPack/read/getUriOfBundle.ts
@@ -1,0 +1,125 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "getUriOfBundle" function.
+ */
+export type GetUriOfBundleParams = {
+  bundleId: AbiParameterToPrimitiveType<{ type: "uint256"; name: "_bundleId" }>;
+};
+
+export const FN_SELECTOR = "0x61195e94" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_bundleId",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "string",
+  },
+] as const;
+
+/**
+ * Checks if the `getUriOfBundle` method is supported by the given contract.
+ * @param availableSelectors An array of 4byte function selectors of the contract. You can get this in various ways, such as using "whatsabi" or if you have the ABI of the contract available you can use it to generate the selectors.
+ * @returns A boolean indicating if the `getUriOfBundle` method is supported.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { isGetUriOfBundleSupported } from "thirdweb/extensions/pack";
+ * const supported = isGetUriOfBundleSupported(["0x..."]);
+ * ```
+ */
+export function isGetUriOfBundleSupported(availableSelectors: string[]) {
+  return detectMethod({
+    availableSelectors,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "getUriOfBundle" function.
+ * @param options - The options for the getUriOfBundle function.
+ * @returns The encoded ABI parameters.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { encodeGetUriOfBundleParams } from "thirdweb/extensions/pack";
+ * const result = encodeGetUriOfBundleParams({
+ *  bundleId: ...,
+ * });
+ * ```
+ */
+export function encodeGetUriOfBundleParams(options: GetUriOfBundleParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.bundleId]);
+}
+
+/**
+ * Encodes the "getUriOfBundle" function into a Hex string with its parameters.
+ * @param options - The options for the getUriOfBundle function.
+ * @returns The encoded hexadecimal string.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { encodeGetUriOfBundle } from "thirdweb/extensions/pack";
+ * const result = encodeGetUriOfBundle({
+ *  bundleId: ...,
+ * });
+ * ```
+ */
+export function encodeGetUriOfBundle(options: GetUriOfBundleParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeGetUriOfBundleParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the getUriOfBundle function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { decodeGetUriOfBundleResult } from "thirdweb/extensions/pack";
+ * const result = decodeGetUriOfBundleResultResult("...");
+ * ```
+ */
+export function decodeGetUriOfBundleResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "getUriOfBundle" function on the contract.
+ * @param options - The options for the getUriOfBundle function.
+ * @returns The parsed result of the function call.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { getUriOfBundle } from "thirdweb/extensions/pack";
+ *
+ * const result = await getUriOfBundle({
+ *  contract,
+ *  bundleId: ...,
+ * });
+ *
+ * ```
+ */
+export async function getUriOfBundle(
+  options: BaseTransactionOptions<GetUriOfBundleParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.bundleId],
+  });
+}

--- a/packages/thirdweb/src/extensions/pack/__generated__/IPack/write/addPackContents.ts
+++ b/packages/thirdweb/src/extensions/pack/__generated__/IPack/write/addPackContents.ts
@@ -1,0 +1,213 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "addPackContents" function.
+ */
+export type AddPackContentsParams = WithOverrides<{
+  packId: AbiParameterToPrimitiveType<{ type: "uint256"; name: "_packId" }>;
+  contents: AbiParameterToPrimitiveType<{
+    type: "tuple[]";
+    name: "_contents";
+    components: [
+      { type: "address"; name: "assetContract" },
+      { type: "uint8"; name: "tokenType" },
+      { type: "uint256"; name: "tokenId" },
+      { type: "uint256"; name: "totalAmount" },
+    ];
+  }>;
+  numOfRewardUnits: AbiParameterToPrimitiveType<{
+    type: "uint256[]";
+    name: "_numOfRewardUnits";
+  }>;
+  recipient: AbiParameterToPrimitiveType<{
+    type: "address";
+    name: "_recipient";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0xa96b1438" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_packId",
+  },
+  {
+    type: "tuple[]",
+    name: "_contents",
+    components: [
+      {
+        type: "address",
+        name: "assetContract",
+      },
+      {
+        type: "uint8",
+        name: "tokenType",
+      },
+      {
+        type: "uint256",
+        name: "tokenId",
+      },
+      {
+        type: "uint256",
+        name: "totalAmount",
+      },
+    ],
+  },
+  {
+    type: "uint256[]",
+    name: "_numOfRewardUnits",
+  },
+  {
+    type: "address",
+    name: "_recipient",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+    name: "packTotalSupply",
+  },
+  {
+    type: "uint256",
+    name: "newSupplyAdded",
+  },
+] as const;
+
+/**
+ * Checks if the `addPackContents` method is supported by the given contract.
+ * @param availableSelectors An array of 4byte function selectors of the contract. You can get this in various ways, such as using "whatsabi" or if you have the ABI of the contract available you can use it to generate the selectors.
+ * @returns A boolean indicating if the `addPackContents` method is supported.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { isAddPackContentsSupported } from "thirdweb/extensions/pack";
+ *
+ * const supported = isAddPackContentsSupported(["0x..."]);
+ * ```
+ */
+export function isAddPackContentsSupported(availableSelectors: string[]) {
+  return detectMethod({
+    availableSelectors,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "addPackContents" function.
+ * @param options - The options for the addPackContents function.
+ * @returns The encoded ABI parameters.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { encodeAddPackContentsParams } from "thirdweb/extensions/pack";
+ * const result = encodeAddPackContentsParams({
+ *  packId: ...,
+ *  contents: ...,
+ *  numOfRewardUnits: ...,
+ *  recipient: ...,
+ * });
+ * ```
+ */
+export function encodeAddPackContentsParams(options: AddPackContentsParams) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.packId,
+    options.contents,
+    options.numOfRewardUnits,
+    options.recipient,
+  ]);
+}
+
+/**
+ * Encodes the "addPackContents" function into a Hex string with its parameters.
+ * @param options - The options for the addPackContents function.
+ * @returns The encoded hexadecimal string.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { encodeAddPackContents } from "thirdweb/extensions/pack";
+ * const result = encodeAddPackContents({
+ *  packId: ...,
+ *  contents: ...,
+ *  numOfRewardUnits: ...,
+ *  recipient: ...,
+ * });
+ * ```
+ */
+export function encodeAddPackContents(options: AddPackContentsParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeAddPackContentsParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "addPackContents" function on the contract.
+ * @param options - The options for the "addPackContents" function.
+ * @returns A prepared transaction object.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { sendTransaction } from "thirdweb";
+ * import { addPackContents } from "thirdweb/extensions/pack";
+ *
+ * const transaction = addPackContents({
+ *  contract,
+ *  packId: ...,
+ *  contents: ...,
+ *  numOfRewardUnits: ...,
+ *  recipient: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * await sendTransaction({ transaction, account });
+ * ```
+ */
+export function addPackContents(
+  options: BaseTransactionOptions<
+    | AddPackContentsParams
+    | {
+        asyncParams: () => Promise<AddPackContentsParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [
+        resolvedOptions.packId,
+        resolvedOptions.contents,
+        resolvedOptions.numOfRewardUnits,
+        resolvedOptions.recipient,
+      ] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
+  });
+}

--- a/packages/thirdweb/src/extensions/pack/__generated__/IPack/write/createPack.ts
+++ b/packages/thirdweb/src/extensions/pack/__generated__/IPack/write/createPack.ts
@@ -1,0 +1,239 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "createPack" function.
+ */
+export type CreatePackParams = WithOverrides<{
+  contents: AbiParameterToPrimitiveType<{
+    type: "tuple[]";
+    name: "contents";
+    components: [
+      { type: "address"; name: "assetContract" },
+      { type: "uint8"; name: "tokenType" },
+      { type: "uint256"; name: "tokenId" },
+      { type: "uint256"; name: "totalAmount" },
+    ];
+  }>;
+  numOfRewardUnits: AbiParameterToPrimitiveType<{
+    type: "uint256[]";
+    name: "numOfRewardUnits";
+  }>;
+  packUri: AbiParameterToPrimitiveType<{ type: "string"; name: "packUri" }>;
+  openStartTimestamp: AbiParameterToPrimitiveType<{
+    type: "uint128";
+    name: "openStartTimestamp";
+  }>;
+  amountDistributedPerOpen: AbiParameterToPrimitiveType<{
+    type: "uint128";
+    name: "amountDistributedPerOpen";
+  }>;
+  recipient: AbiParameterToPrimitiveType<{
+    type: "address";
+    name: "recipient";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0x092e6075" as const;
+const FN_INPUTS = [
+  {
+    type: "tuple[]",
+    name: "contents",
+    components: [
+      {
+        type: "address",
+        name: "assetContract",
+      },
+      {
+        type: "uint8",
+        name: "tokenType",
+      },
+      {
+        type: "uint256",
+        name: "tokenId",
+      },
+      {
+        type: "uint256",
+        name: "totalAmount",
+      },
+    ],
+  },
+  {
+    type: "uint256[]",
+    name: "numOfRewardUnits",
+  },
+  {
+    type: "string",
+    name: "packUri",
+  },
+  {
+    type: "uint128",
+    name: "openStartTimestamp",
+  },
+  {
+    type: "uint128",
+    name: "amountDistributedPerOpen",
+  },
+  {
+    type: "address",
+    name: "recipient",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+    name: "packId",
+  },
+  {
+    type: "uint256",
+    name: "packTotalSupply",
+  },
+] as const;
+
+/**
+ * Checks if the `createPack` method is supported by the given contract.
+ * @param availableSelectors An array of 4byte function selectors of the contract. You can get this in various ways, such as using "whatsabi" or if you have the ABI of the contract available you can use it to generate the selectors.
+ * @returns A boolean indicating if the `createPack` method is supported.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { isCreatePackSupported } from "thirdweb/extensions/pack";
+ *
+ * const supported = isCreatePackSupported(["0x..."]);
+ * ```
+ */
+export function isCreatePackSupported(availableSelectors: string[]) {
+  return detectMethod({
+    availableSelectors,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "createPack" function.
+ * @param options - The options for the createPack function.
+ * @returns The encoded ABI parameters.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { encodeCreatePackParams } from "thirdweb/extensions/pack";
+ * const result = encodeCreatePackParams({
+ *  contents: ...,
+ *  numOfRewardUnits: ...,
+ *  packUri: ...,
+ *  openStartTimestamp: ...,
+ *  amountDistributedPerOpen: ...,
+ *  recipient: ...,
+ * });
+ * ```
+ */
+export function encodeCreatePackParams(options: CreatePackParams) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.contents,
+    options.numOfRewardUnits,
+    options.packUri,
+    options.openStartTimestamp,
+    options.amountDistributedPerOpen,
+    options.recipient,
+  ]);
+}
+
+/**
+ * Encodes the "createPack" function into a Hex string with its parameters.
+ * @param options - The options for the createPack function.
+ * @returns The encoded hexadecimal string.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { encodeCreatePack } from "thirdweb/extensions/pack";
+ * const result = encodeCreatePack({
+ *  contents: ...,
+ *  numOfRewardUnits: ...,
+ *  packUri: ...,
+ *  openStartTimestamp: ...,
+ *  amountDistributedPerOpen: ...,
+ *  recipient: ...,
+ * });
+ * ```
+ */
+export function encodeCreatePack(options: CreatePackParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeCreatePackParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "createPack" function on the contract.
+ * @param options - The options for the "createPack" function.
+ * @returns A prepared transaction object.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { sendTransaction } from "thirdweb";
+ * import { createPack } from "thirdweb/extensions/pack";
+ *
+ * const transaction = createPack({
+ *  contract,
+ *  contents: ...,
+ *  numOfRewardUnits: ...,
+ *  packUri: ...,
+ *  openStartTimestamp: ...,
+ *  amountDistributedPerOpen: ...,
+ *  recipient: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * await sendTransaction({ transaction, account });
+ * ```
+ */
+export function createPack(
+  options: BaseTransactionOptions<
+    | CreatePackParams
+    | {
+        asyncParams: () => Promise<CreatePackParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [
+        resolvedOptions.contents,
+        resolvedOptions.numOfRewardUnits,
+        resolvedOptions.packUri,
+        resolvedOptions.openStartTimestamp,
+        resolvedOptions.amountDistributedPerOpen,
+        resolvedOptions.recipient,
+      ] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
+  });
+}

--- a/packages/thirdweb/src/extensions/pack/__generated__/IPack/write/openPack.ts
+++ b/packages/thirdweb/src/extensions/pack/__generated__/IPack/write/openPack.ts
@@ -1,0 +1,168 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "openPack" function.
+ */
+export type OpenPackParams = WithOverrides<{
+  packId: AbiParameterToPrimitiveType<{ type: "uint256"; name: "packId" }>;
+  amountToOpen: AbiParameterToPrimitiveType<{
+    type: "uint256";
+    name: "amountToOpen";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0x914e126a" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "packId",
+  },
+  {
+    type: "uint256",
+    name: "amountToOpen",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "tuple[]",
+    components: [
+      {
+        type: "address",
+        name: "assetContract",
+      },
+      {
+        type: "uint8",
+        name: "tokenType",
+      },
+      {
+        type: "uint256",
+        name: "tokenId",
+      },
+      {
+        type: "uint256",
+        name: "totalAmount",
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Checks if the `openPack` method is supported by the given contract.
+ * @param availableSelectors An array of 4byte function selectors of the contract. You can get this in various ways, such as using "whatsabi" or if you have the ABI of the contract available you can use it to generate the selectors.
+ * @returns A boolean indicating if the `openPack` method is supported.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { isOpenPackSupported } from "thirdweb/extensions/pack";
+ *
+ * const supported = isOpenPackSupported(["0x..."]);
+ * ```
+ */
+export function isOpenPackSupported(availableSelectors: string[]) {
+  return detectMethod({
+    availableSelectors,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "openPack" function.
+ * @param options - The options for the openPack function.
+ * @returns The encoded ABI parameters.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { encodeOpenPackParams } from "thirdweb/extensions/pack";
+ * const result = encodeOpenPackParams({
+ *  packId: ...,
+ *  amountToOpen: ...,
+ * });
+ * ```
+ */
+export function encodeOpenPackParams(options: OpenPackParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.packId, options.amountToOpen]);
+}
+
+/**
+ * Encodes the "openPack" function into a Hex string with its parameters.
+ * @param options - The options for the openPack function.
+ * @returns The encoded hexadecimal string.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { encodeOpenPack } from "thirdweb/extensions/pack";
+ * const result = encodeOpenPack({
+ *  packId: ...,
+ *  amountToOpen: ...,
+ * });
+ * ```
+ */
+export function encodeOpenPack(options: OpenPackParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeOpenPackParams(options).slice(2)) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "openPack" function on the contract.
+ * @param options - The options for the "openPack" function.
+ * @returns A prepared transaction object.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { sendTransaction } from "thirdweb";
+ * import { openPack } from "thirdweb/extensions/pack";
+ *
+ * const transaction = openPack({
+ *  contract,
+ *  packId: ...,
+ *  amountToOpen: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * await sendTransaction({ transaction, account });
+ * ```
+ */
+export function openPack(
+  options: BaseTransactionOptions<
+    | OpenPackParams
+    | {
+        asyncParams: () => Promise<OpenPackParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [resolvedOptions.packId, resolvedOptions.amountToOpen] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
+  });
+}

--- a/packages/thirdweb/src/extensions/pack/__generated__/IPackVRFDirect/events/PackOpenRequested.ts
+++ b/packages/thirdweb/src/extensions/pack/__generated__/IPackVRFDirect/events/PackOpenRequested.ts
@@ -1,0 +1,49 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+import type { AbiParameterToPrimitiveType } from "abitype";
+
+/**
+ * Represents the filters for the "PackOpenRequested" event.
+ */
+export type PackOpenRequestedEventFilters = Partial<{
+  opener: AbiParameterToPrimitiveType<{
+    type: "address";
+    name: "opener";
+    indexed: true;
+  }>;
+  packId: AbiParameterToPrimitiveType<{
+    type: "uint256";
+    name: "packId";
+    indexed: true;
+  }>;
+}>;
+
+/**
+ * Creates an event object for the PackOpenRequested event.
+ * @param filters - Optional filters to apply to the event.
+ * @returns The prepared event object.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { packOpenRequestedEvent } from "thirdweb/extensions/pack";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  packOpenRequestedEvent({
+ *  opener: ...,
+ *  packId: ...,
+ * })
+ * ],
+ * });
+ * ```
+ */
+export function packOpenRequestedEvent(
+  filters: PackOpenRequestedEventFilters = {},
+) {
+  return prepareEvent({
+    signature:
+      "event PackOpenRequested(address indexed opener, uint256 indexed packId, uint256 amountToOpen, uint256 requestId)",
+    filters,
+  });
+}

--- a/packages/thirdweb/src/extensions/pack/__generated__/IPackVRFDirect/events/PackRandomnessFulfilled.ts
+++ b/packages/thirdweb/src/extensions/pack/__generated__/IPackVRFDirect/events/PackRandomnessFulfilled.ts
@@ -1,0 +1,49 @@
+import { prepareEvent } from "../../../../../event/prepare-event.js";
+import type { AbiParameterToPrimitiveType } from "abitype";
+
+/**
+ * Represents the filters for the "PackRandomnessFulfilled" event.
+ */
+export type PackRandomnessFulfilledEventFilters = Partial<{
+  packId: AbiParameterToPrimitiveType<{
+    type: "uint256";
+    name: "packId";
+    indexed: true;
+  }>;
+  requestId: AbiParameterToPrimitiveType<{
+    type: "uint256";
+    name: "requestId";
+    indexed: true;
+  }>;
+}>;
+
+/**
+ * Creates an event object for the PackRandomnessFulfilled event.
+ * @param filters - Optional filters to apply to the event.
+ * @returns The prepared event object.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { getContractEvents } from "thirdweb";
+ * import { packRandomnessFulfilledEvent } from "thirdweb/extensions/pack";
+ *
+ * const events = await getContractEvents({
+ * contract,
+ * events: [
+ *  packRandomnessFulfilledEvent({
+ *  packId: ...,
+ *  requestId: ...,
+ * })
+ * ],
+ * });
+ * ```
+ */
+export function packRandomnessFulfilledEvent(
+  filters: PackRandomnessFulfilledEventFilters = {},
+) {
+  return prepareEvent({
+    signature:
+      "event PackRandomnessFulfilled(uint256 indexed packId, uint256 indexed requestId)",
+    filters,
+  });
+}

--- a/packages/thirdweb/src/extensions/pack/__generated__/IPackVRFDirect/read/canClaimRewards.ts
+++ b/packages/thirdweb/src/extensions/pack/__generated__/IPackVRFDirect/read/canClaimRewards.ts
@@ -1,0 +1,125 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "canClaimRewards" function.
+ */
+export type CanClaimRewardsParams = {
+  opener: AbiParameterToPrimitiveType<{ type: "address"; name: "_opener" }>;
+};
+
+export const FN_SELECTOR = "0xa9b47a66" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "_opener",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bool",
+  },
+] as const;
+
+/**
+ * Checks if the `canClaimRewards` method is supported by the given contract.
+ * @param availableSelectors An array of 4byte function selectors of the contract. You can get this in various ways, such as using "whatsabi" or if you have the ABI of the contract available you can use it to generate the selectors.
+ * @returns A boolean indicating if the `canClaimRewards` method is supported.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { isCanClaimRewardsSupported } from "thirdweb/extensions/pack";
+ * const supported = isCanClaimRewardsSupported(["0x..."]);
+ * ```
+ */
+export function isCanClaimRewardsSupported(availableSelectors: string[]) {
+  return detectMethod({
+    availableSelectors,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "canClaimRewards" function.
+ * @param options - The options for the canClaimRewards function.
+ * @returns The encoded ABI parameters.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { encodeCanClaimRewardsParams } from "thirdweb/extensions/pack";
+ * const result = encodeCanClaimRewardsParams({
+ *  opener: ...,
+ * });
+ * ```
+ */
+export function encodeCanClaimRewardsParams(options: CanClaimRewardsParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.opener]);
+}
+
+/**
+ * Encodes the "canClaimRewards" function into a Hex string with its parameters.
+ * @param options - The options for the canClaimRewards function.
+ * @returns The encoded hexadecimal string.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { encodeCanClaimRewards } from "thirdweb/extensions/pack";
+ * const result = encodeCanClaimRewards({
+ *  opener: ...,
+ * });
+ * ```
+ */
+export function encodeCanClaimRewards(options: CanClaimRewardsParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeCanClaimRewardsParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the canClaimRewards function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { decodeCanClaimRewardsResult } from "thirdweb/extensions/pack";
+ * const result = decodeCanClaimRewardsResultResult("...");
+ * ```
+ */
+export function decodeCanClaimRewardsResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "canClaimRewards" function on the contract.
+ * @param options - The options for the canClaimRewards function.
+ * @returns The parsed result of the function call.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { canClaimRewards } from "thirdweb/extensions/pack";
+ *
+ * const result = await canClaimRewards({
+ *  contract,
+ *  opener: ...,
+ * });
+ *
+ * ```
+ */
+export async function canClaimRewards(
+  options: BaseTransactionOptions<CanClaimRewardsParams>,
+) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.opener],
+  });
+}

--- a/packages/thirdweb/src/extensions/pack/__generated__/IPackVRFDirect/write/claimRewards.ts
+++ b/packages/thirdweb/src/extensions/pack/__generated__/IPackVRFDirect/write/claimRewards.ts
@@ -1,0 +1,73 @@
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+export const FN_SELECTOR = "0x372500ab" as const;
+const FN_INPUTS = [] as const;
+const FN_OUTPUTS = [
+  {
+    type: "tuple[]",
+    name: "rewardUnits",
+    components: [
+      {
+        type: "address",
+        name: "assetContract",
+      },
+      {
+        type: "uint8",
+        name: "tokenType",
+      },
+      {
+        type: "uint256",
+        name: "tokenId",
+      },
+      {
+        type: "uint256",
+        name: "totalAmount",
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Checks if the `claimRewards` method is supported by the given contract.
+ * @param availableSelectors An array of 4byte function selectors of the contract. You can get this in various ways, such as using "whatsabi" or if you have the ABI of the contract available you can use it to generate the selectors.
+ * @returns A boolean indicating if the `claimRewards` method is supported.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { isClaimRewardsSupported } from "thirdweb/extensions/pack";
+ *
+ * const supported = isClaimRewardsSupported(["0x..."]);
+ * ```
+ */
+export function isClaimRewardsSupported(availableSelectors: string[]) {
+  return detectMethod({
+    availableSelectors,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Prepares a transaction to call the "claimRewards" function on the contract.
+ * @param options - The options for the "claimRewards" function.
+ * @returns A prepared transaction object.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { sendTransaction } from "thirdweb";
+ * import { claimRewards } from "thirdweb/extensions/pack";
+ *
+ * const transaction = claimRewards();
+ *
+ * // Send the transaction
+ * await sendTransaction({ transaction, account });
+ * ```
+ */
+export function claimRewards(options: BaseTransactionOptions) {
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}

--- a/packages/thirdweb/src/extensions/pack/__generated__/IPackVRFDirect/write/openPackAndClaimRewards.ts
+++ b/packages/thirdweb/src/extensions/pack/__generated__/IPackVRFDirect/write/openPackAndClaimRewards.ts
@@ -1,0 +1,177 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "openPackAndClaimRewards" function.
+ */
+export type OpenPackAndClaimRewardsParams = WithOverrides<{
+  packId: AbiParameterToPrimitiveType<{ type: "uint256"; name: "_packId" }>;
+  amountToOpen: AbiParameterToPrimitiveType<{
+    type: "uint256";
+    name: "_amountToOpen";
+  }>;
+  callBackGasLimit: AbiParameterToPrimitiveType<{
+    type: "uint32";
+    name: "_callBackGasLimit";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0xac296b3f" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "_packId",
+  },
+  {
+    type: "uint256",
+    name: "_amountToOpen",
+  },
+  {
+    type: "uint32",
+    name: "_callBackGasLimit",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "uint256",
+  },
+] as const;
+
+/**
+ * Checks if the `openPackAndClaimRewards` method is supported by the given contract.
+ * @param availableSelectors An array of 4byte function selectors of the contract. You can get this in various ways, such as using "whatsabi" or if you have the ABI of the contract available you can use it to generate the selectors.
+ * @returns A boolean indicating if the `openPackAndClaimRewards` method is supported.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { isOpenPackAndClaimRewardsSupported } from "thirdweb/extensions/pack";
+ *
+ * const supported = isOpenPackAndClaimRewardsSupported(["0x..."]);
+ * ```
+ */
+export function isOpenPackAndClaimRewardsSupported(
+  availableSelectors: string[],
+) {
+  return detectMethod({
+    availableSelectors,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "openPackAndClaimRewards" function.
+ * @param options - The options for the openPackAndClaimRewards function.
+ * @returns The encoded ABI parameters.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { encodeOpenPackAndClaimRewardsParams } from "thirdweb/extensions/pack";
+ * const result = encodeOpenPackAndClaimRewardsParams({
+ *  packId: ...,
+ *  amountToOpen: ...,
+ *  callBackGasLimit: ...,
+ * });
+ * ```
+ */
+export function encodeOpenPackAndClaimRewardsParams(
+  options: OpenPackAndClaimRewardsParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.packId,
+    options.amountToOpen,
+    options.callBackGasLimit,
+  ]);
+}
+
+/**
+ * Encodes the "openPackAndClaimRewards" function into a Hex string with its parameters.
+ * @param options - The options for the openPackAndClaimRewards function.
+ * @returns The encoded hexadecimal string.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { encodeOpenPackAndClaimRewards } from "thirdweb/extensions/pack";
+ * const result = encodeOpenPackAndClaimRewards({
+ *  packId: ...,
+ *  amountToOpen: ...,
+ *  callBackGasLimit: ...,
+ * });
+ * ```
+ */
+export function encodeOpenPackAndClaimRewards(
+  options: OpenPackAndClaimRewardsParams,
+) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeOpenPackAndClaimRewardsParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "openPackAndClaimRewards" function on the contract.
+ * @param options - The options for the "openPackAndClaimRewards" function.
+ * @returns A prepared transaction object.
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { sendTransaction } from "thirdweb";
+ * import { openPackAndClaimRewards } from "thirdweb/extensions/pack";
+ *
+ * const transaction = openPackAndClaimRewards({
+ *  contract,
+ *  packId: ...,
+ *  amountToOpen: ...,
+ *  callBackGasLimit: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * await sendTransaction({ transaction, account });
+ * ```
+ */
+export function openPackAndClaimRewards(
+  options: BaseTransactionOptions<
+    | OpenPackAndClaimRewardsParams
+    | {
+        asyncParams: () => Promise<OpenPackAndClaimRewardsParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [
+        resolvedOptions.packId,
+        resolvedOptions.amountToOpen,
+        resolvedOptions.callBackGasLimit,
+      ] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
+  });
+}

--- a/packages/thirdweb/src/extensions/pack/createNewPack.test.ts
+++ b/packages/thirdweb/src/extensions/pack/createNewPack.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from "vitest";
+import { ANVIL_CHAIN } from "~test/chains.js";
+import { TEST_CONTRACT_URI } from "~test/ipfs-uris.js";
+import { TEST_CLIENT } from "~test/test-clients.js";
+import { TEST_ACCOUNT_A } from "~test/test-wallets.js";
+import { getContract } from "../../contract/contract.js";
+import { download } from "../../storage/download.js";
+import { sendAndConfirmTransaction } from "../../transaction/actions/send-and-confirm-transaction.js";
+import { balanceOf as balanceOfERC20 } from "../erc20/__generated__/IERC20/read/balanceOf.js";
+import { approve } from "../erc20/write/approve.js";
+import { mintTo as mintToERC20 } from "../erc20/write/mintTo.js";
+import { balanceOf as balanceOfERC721 } from "../erc721/__generated__/IERC721A/read/balanceOf.js";
+import { ownerOf } from "../erc721/__generated__/IERC721A/read/ownerOf.js";
+import { setApprovalForAll } from "../erc721/__generated__/IERC721A/write/setApprovalForAll.js";
+import { mintTo as mintToERC721 } from "../erc721/write/mintTo.js";
+import { openPack } from "../erc1155/__generated__/IPack/write/openPack.js";
+import { getPackContents } from "../pack/__generated__/IPack/read/getPackContents.js";
+import { getTokenCountOfBundle } from "../pack/__generated__/IPack/read/getTokenCountOfBundle.js";
+import { getUriOfBundle } from "../pack/__generated__/IPack/read/getUriOfBundle.js";
+import { deployERC20Contract } from "../prebuilts/deploy-erc20.js";
+import { deployERC721Contract } from "../prebuilts/deploy-erc721.js";
+import { deployPackContract } from "../prebuilts/deploy-pack.js";
+import { createNewPack } from "./createNewPack.js";
+
+const account = TEST_ACCOUNT_A;
+const client = TEST_CLIENT;
+const chain = ANVIL_CHAIN;
+
+describe.runIf(process.env.TW_SECRET_KEY)("createPack", () => {
+  it("should create a Pack and open it to receive rewards", async () => {
+    const packAddress = await deployPackContract({
+      account,
+      client,
+      chain,
+      params: {
+        name: "pack-contract",
+      },
+    });
+
+    const packContract = getContract({
+      address: packAddress,
+      chain,
+      client,
+    });
+
+    const erc20Address = await deployERC20Contract({
+      client: TEST_CLIENT,
+      chain: ANVIL_CHAIN,
+      account: TEST_ACCOUNT_A,
+      type: "TokenERC20",
+      params: {
+        name: "Token",
+        contractURI: TEST_CONTRACT_URI,
+      },
+    });
+
+    const erc20Contract = getContract({ address: erc20Address, chain, client });
+
+    const erc721Address = await deployERC721Contract({
+      client: TEST_CLIENT,
+      chain: ANVIL_CHAIN,
+      account: TEST_ACCOUNT_A,
+      type: "TokenERC721",
+      params: {
+        name: "NFTCollection",
+        contractURI: TEST_CONTRACT_URI,
+      },
+    });
+
+    const erc721Contract = getContract({
+      address: erc721Address,
+      chain,
+      client,
+    });
+    // Mint some ERC20 tokens
+    await sendAndConfirmTransaction({
+      transaction: mintToERC20({
+        contract: erc20Contract,
+        to: account.address,
+        amount: "100",
+      }),
+      account,
+    });
+
+    // Set allowance for Pack contract
+    await sendAndConfirmTransaction({
+      transaction: approve({
+        contract: erc20Contract,
+        amount: "1000000000000000",
+        spender: packContract.address,
+      }),
+      account,
+    });
+
+    // Mint some ERC721 tokens
+    await sendAndConfirmTransaction({
+      transaction: mintToERC721({
+        contract: erc721Contract,
+        to: account.address,
+        nft: { name: "token #0" },
+      }),
+      account,
+    });
+
+    // set erc721 approval
+    await sendAndConfirmTransaction({
+      transaction: setApprovalForAll({
+        contract: erc721Contract,
+        approved: true,
+        operator: packContract.address,
+      }),
+      account,
+    });
+
+    // Create pack
+    await sendAndConfirmTransaction({
+      transaction: createNewPack({
+        contract: packContract,
+        erc20Rewards: [
+          {
+            contractAddress: erc20Contract.address,
+            totalRewards: 1,
+            quantityPerReward: 1,
+          },
+        ],
+        erc721Rewards: [
+          { contractAddress: erc721Contract.address, tokenId: 0n },
+        ],
+        client,
+        packMetadata: {
+          name: "Pack #0",
+        },
+        recipient: account.address,
+        tokenOwner: account.address,
+        openStartTimestamp: new Date(),
+        amountDistributedPerOpen: 1n,
+      }),
+      account,
+    });
+
+    // Read the info of the new Pack
+    const [
+      packContent,
+      tokenCountOfBundle,
+      bundleUri,
+      erc20BalanceAfterCreatePack,
+      erc721BalanceAfterCreatePack,
+    ] = await Promise.all([
+      getPackContents({ contract: packContract, packId: 0n }),
+      getTokenCountOfBundle({ contract: packContract, bundleId: 0n }),
+      getUriOfBundle({ contract: packContract, bundleId: 0n }),
+      balanceOfERC20({ contract: erc20Contract, address: account.address }),
+      balanceOfERC721({ contract: erc721Contract, owner: account.address }),
+    ]);
+
+    // After this, the account should have 99 ERC20 tokens, and 0 (zero) ERC721 token
+    expect(erc20BalanceAfterCreatePack).toBe(99n * 10n ** 18n);
+    expect(erc721BalanceAfterCreatePack).toBe(0n);
+
+    // Make sure the content is correct
+    expect(packContent).toStrictEqual([
+      [
+        {
+          assetContract: erc20Contract.address,
+          tokenType: 0,
+          tokenId: 0n,
+          totalAmount: 1000000000000000000n,
+        },
+        {
+          assetContract: erc721Contract.address,
+          tokenType: 1,
+          tokenId: 0n,
+          totalAmount: 1n,
+        },
+      ],
+      [1000000000000000000n, 1n],
+    ]);
+    expect(tokenCountOfBundle).toBe(2n);
+
+    // Make sure the Pack metadata is correct
+    expect(bundleUri).toBeDefined();
+    const metadata = await (await download({ client, uri: bundleUri })).json();
+    expect(metadata?.name).toBe("Pack #0");
+
+    // Make sure you can open the Pack, since the open-date was set to "now"
+    await sendAndConfirmTransaction({
+      account,
+      transaction: openPack({
+        contract: packContract,
+        packId: 0n,
+        amountToOpen: 1n,
+      }),
+    });
+
+    const [erc20Balance, erc721Owner] = await Promise.all([
+      balanceOfERC20({ contract: erc20Contract, address: account.address }),
+      ownerOf({ contract: erc721Contract, tokenId: 0n }),
+    ]);
+
+    // Since opening a Pack gives "random" rewards, in this case we can check if
+    // the recipient received either 1. <one ERC20 token>, or 2. <one ERC721 token>
+    expect(
+      erc20Balance === 100n * 10n ** 18n ||
+        erc721Owner.toLowerCase() === account.address.toLowerCase(),
+    ).toBe(true);
+  });
+});

--- a/packages/thirdweb/src/extensions/pack/createNewPack.ts
+++ b/packages/thirdweb/src/extensions/pack/createNewPack.ts
@@ -1,0 +1,433 @@
+import type { ThirdwebClient } from "../../client/client.js";
+import { type ThirdwebContract, getContract } from "../../contract/contract.js";
+import { upload } from "../../storage/upload.js";
+import type { BaseTransactionOptions } from "../../transaction/types.js";
+import type { NFTInput } from "../../utils/nft/parseNft.js";
+import { toUnits } from "../../utils/units.js";
+import type { AddPackContentsParams } from "./__generated__/IPack/write/addPackContents.js";
+import {
+  type CreatePackParams,
+  createPack,
+} from "./__generated__/IPack/write/createPack.js";
+
+export enum PACK_TOKEN_TYPE {
+  ERC20 = 0,
+  ERC721 = 1,
+  ERC1155 = 2,
+}
+
+export type ERC20Reward = {
+  contractAddress: string;
+  quantityPerReward: number | string;
+  totalRewards: number | string;
+};
+
+export type ERC721Reward = {
+  contractAddress: string;
+  tokenId: bigint;
+};
+
+export type ERC1155Reward = {
+  contractAddress: string;
+  tokenId: bigint;
+  quantityPerReward: number | string;
+  totalRewards: number | string;
+};
+
+/**
+ * @extension PACK
+ */
+export type CreateNewPackParams = {
+  client: ThirdwebClient;
+  contract: ThirdwebContract;
+  /**
+   * The address of the reward recipient
+   */
+  recipient: string;
+  /**
+   * The address of the entity who owns the tokens that are used as rewards.
+   * This is only used for checking token approval
+   */
+  tokenOwner: string;
+  /**
+   * The metadata (image, description, etc.) of the Pack.
+   * This is similar to an NFT's metadata
+   */
+  packMetadata: NFTInput | string;
+  amountDistributedPerOpen: bigint;
+  /**
+   * JavaScript Date object
+   */
+  openStartTimestamp: Date;
+  /**
+   * An array of ERC20 rewards, see type `ERC20Reward` for more info
+   */
+  erc20Rewards?: ERC20Reward[];
+  /**
+   * An array of ERC721 rewards, see type `ERC721Reward` for more info
+   */
+  erc721Rewards?: ERC721Reward[];
+  /**
+   * An array of ERC1155 rewards, see type `ERC1155Reward` for more info
+   */
+  erc1155Rewards?: ERC1155Reward[];
+};
+
+/**
+ * @extension PACK
+ * @example
+ * ```ts
+ * import { createNewPack } from "thirdweb/extensions/pack";
+ *
+ * const transaction = createNewPack({
+ *   contract: packContract,
+ *   client,
+ *   recipient: "0x...",
+ *   tokenOwner: "0x...",
+ *   packMetadata: {
+ *     name: "Pack #1",
+ *     image: "image-of-pack-1",
+ *   },
+ *   openStartTimestamp: new Date(),
+ *   erc20Rewards: [
+ *     {
+ *       contractAddress: "0x...",
+ *       quantityPerReward: 1,
+ *       totalRewards: 1,
+ *     },
+ *   ],
+ *   erc721Rewards: [
+ *     {
+ *       contractAddress: "0x...",
+ *       tokenId: 0n,
+ *     },
+ *   ],
+ *   erc1155Rewards: [
+ *     {
+ *       contractAddress: "0x...",
+ *       tokenId: 0n,
+ *       quantityPerReward: 1,
+ *       totalRewards: 1,
+ *     },
+ *   ],
+ * });
+ * ```
+ */
+export function createNewPack(
+  options: BaseTransactionOptions<CreateNewPackParams>,
+) {
+  return createPack({
+    contract: options.contract,
+    asyncParams: async () => getCreatePackParams(options),
+  });
+}
+
+/**
+ * @internal
+ */
+async function getCreatePackParams(
+  options: BaseTransactionOptions<CreateNewPackParams>,
+): Promise<CreatePackParams> {
+  const {
+    contract,
+    recipient,
+    packMetadata,
+    amountDistributedPerOpen,
+    openStartTimestamp,
+    erc20Rewards,
+    erc721Rewards,
+    erc1155Rewards,
+    tokenOwner,
+  } = options;
+  const [erc20Content, erc721Content, erc1155Content, packUri] =
+    await Promise.all([
+      processErc20Rewards({
+        packContract: contract,
+        content: erc20Rewards,
+        tokenOwner,
+      }),
+      processErc721Rewards({
+        packContract: contract,
+        content: erc721Rewards,
+        tokenOwner,
+      }),
+      processErc1155Rewards({
+        packContract: contract,
+        content: erc1155Rewards,
+        tokenOwner,
+      }),
+      typeof packMetadata === "string"
+        ? packMetadata
+        : upload({
+            client: options.contract.client,
+            files: [packMetadata],
+          }),
+    ]);
+  const contents = erc20Content.content
+    .concat(erc721Content.content)
+    .concat(erc1155Content.content);
+
+  const numOfRewardUnits = erc20Content.numOfRewardUnits
+    .concat(erc721Content.numOfRewardUnits)
+    .concat(erc1155Content.numOfRewardUnits);
+
+  return {
+    packUri,
+    recipient,
+    contents,
+    numOfRewardUnits,
+    // openStartTimestamp should be in seconds and not millisecond
+    openStartTimestamp: BigInt(Math.ceil(openStartTimestamp.getTime() / 1000)),
+    amountDistributedPerOpen,
+  };
+}
+
+/**
+ * @internal
+ */
+async function processErc20Rewards(options: {
+  content?: ERC20Reward[];
+  packContract: ThirdwebContract;
+  tokenOwner: string;
+}): Promise<{
+  content: AddPackContentsParams["contents"];
+  numOfRewardUnits: bigint[];
+}> {
+  const { content, packContract, tokenOwner } = options;
+  if (!content?.length) {
+    return {
+      content: [],
+      numOfRewardUnits: [],
+    };
+  }
+  const [{ allowance }, { decimals }] = await Promise.all([
+    import("../erc20/__generated__/IERC20/read/allowance.js"),
+    import("../erc20/__generated__/IERC20/read/decimals.js"),
+  ]);
+
+  const uniqueERC20Contracts = [
+    ...new Set(
+      content.map((o) =>
+        getContract({
+          address: o.contractAddress,
+          chain: packContract.chain,
+          client: packContract.client,
+        }),
+      ),
+    ),
+  ];
+
+  const data: Array<{
+    _allowance: bigint;
+    _decimals: number;
+    address: string;
+  }> = (
+    await Promise.all(
+      uniqueERC20Contracts.map((contract) => {
+        return Promise.all([
+          allowance({
+            contract,
+            spender: packContract.address,
+            owner: tokenOwner,
+          }),
+          decimals({ contract }).catch(() => undefined),
+          contract.address,
+        ]);
+      }),
+    )
+  ).map((item) => {
+    const [_allowance, _decimals, address] = item;
+    if (_decimals === undefined) {
+      throw new Error(
+        `Failed to get the decimals of contract: ${address}. Make sure it is a valid ERC20 contract`,
+      );
+    }
+    return {
+      _allowance,
+      _decimals,
+      address,
+    };
+  });
+  const numOfRewardUnits: bigint[] = [];
+  const result = content.map((item, index) => {
+    const { contractAddress, quantityPerReward, totalRewards } = item;
+    if (!totalRewards) {
+      throw new Error(
+        `Invalid totalRewards for contract: ${contractAddress} at index: ${index}`,
+      );
+    }
+    const _data = data.find((o) => o.address === contractAddress);
+    if (!_data) {
+      // This should never happen
+      throw new Error(`contractAddress not found: ${contractAddress}`);
+    }
+    const quantityInWei = toUnits(String(quantityPerReward), _data._decimals);
+    const totalRequired = quantityInWei * BigInt(totalRewards);
+    if (totalRequired > _data._allowance) {
+      throw new Error(
+        `The following ERC20 contract address do not have enough allowance for the Pack contract: ${contractAddress}`,
+      );
+    }
+    numOfRewardUnits.push(BigInt(item.totalRewards));
+    return {
+      assetContract: contractAddress,
+      tokenType: PACK_TOKEN_TYPE.ERC20,
+      tokenId: 0n, // hard-coded to `0n` for ERC20
+      totalAmount: totalRequired,
+    };
+  });
+
+  return {
+    content: result,
+    numOfRewardUnits,
+  };
+}
+
+/**
+ * @internal
+ */
+async function processErc721Rewards(options: {
+  content?: ERC721Reward[];
+  packContract: ThirdwebContract;
+  tokenOwner: string;
+}): Promise<{
+  content: AddPackContentsParams["contents"];
+  numOfRewardUnits: bigint[];
+}> {
+  const { content, packContract, tokenOwner } = options;
+  if (!content?.length) {
+    return {
+      content: [],
+      numOfRewardUnits: [],
+    };
+  }
+  const uniqueERC721Contracts = [
+    ...new Set(
+      content.map((o) => ({
+        contract: getContract({
+          address: o.contractAddress,
+          chain: packContract.chain,
+          client: packContract.client,
+        }),
+        tokenId: o.tokenId,
+      })),
+    ),
+  ];
+  const [{ isApprovedForAll }, { getApproved }] = await Promise.all([
+    import("../erc721/__generated__/IERC721A/read/isApprovedForAll.js"),
+    import("../erc721/__generated__/IERC721A/read/getApproved.js"),
+  ]);
+  const numOfRewardUnits: bigint[] = [];
+  const result = (
+    await Promise.all(
+      uniqueERC721Contracts.map(({ contract, tokenId }) => {
+        return Promise.all([
+          isApprovedForAll({
+            contract,
+            operator: packContract.address,
+            owner: tokenOwner,
+          }).catch(() => false),
+          getApproved({ contract, tokenId }).catch(() => ""),
+          contract.address,
+          tokenId,
+        ]);
+      }),
+    )
+  ).map((item) => {
+    const [_allApproved, _tokenApprove, address, tokenId] = item;
+    if (
+      !_allApproved &&
+      _tokenApprove.toLowerCase() !== packContract.address.toLowerCase()
+    ) {
+      throw new Error(
+        `TokenID: ${tokenId} from contract address ${address} is not approved to be used by this Pack contract.`,
+      );
+    }
+    numOfRewardUnits.push(1n);
+    return {
+      assetContract: address,
+      tokenType: PACK_TOKEN_TYPE.ERC721,
+      tokenId,
+      totalAmount: 1n,
+    };
+  });
+
+  return {
+    content: result,
+    numOfRewardUnits,
+  };
+}
+
+async function processErc1155Rewards(options: {
+  content?: ERC1155Reward[];
+  packContract: ThirdwebContract;
+  tokenOwner: string;
+}): Promise<{
+  content: AddPackContentsParams["contents"];
+  numOfRewardUnits: bigint[];
+}> {
+  const { content, packContract, tokenOwner } = options;
+  if (!content?.length) {
+    return {
+      content: [],
+      numOfRewardUnits: [],
+    };
+  }
+  const uniqueERC1155Contracts = [
+    ...new Set(
+      content.map((o) => ({
+        contract: getContract({
+          address: o.contractAddress,
+          chain: packContract.chain,
+          client: packContract.client,
+        }),
+        tokenId: o.tokenId,
+        quantityPerReward: o.quantityPerReward,
+        totalRewards: o.totalRewards,
+      })),
+    ),
+  ];
+  const { isApprovedForAll } = await import(
+    "../erc1155/__generated__/IERC1155/read/isApprovedForAll.js"
+  );
+  const numOfRewardUnits: bigint[] = [];
+  const result = (
+    await Promise.all(
+      uniqueERC1155Contracts.map(
+        ({ contract, tokenId, quantityPerReward, totalRewards }) => {
+          return Promise.all([
+            isApprovedForAll({
+              contract,
+              operator: packContract.address,
+              owner: tokenOwner,
+            }).catch(() => false),
+            contract.address,
+            tokenId,
+            quantityPerReward,
+            totalRewards,
+          ]);
+        },
+      ),
+    )
+  ).map((item) => {
+    const [_allApproved, address, tokenId, quantityPerReward, totalRewards] =
+      item;
+    if (!_allApproved) {
+      throw new Error(
+        `ERC1155 contract address ${address} is not approved to be used by this Pack contract.`,
+      );
+    }
+    numOfRewardUnits.push(BigInt(totalRewards));
+    return {
+      assetContract: address,
+      tokenType: PACK_TOKEN_TYPE.ERC1155,
+      tokenId,
+      totalAmount: BigInt(quantityPerReward) * BigInt(totalRewards),
+    };
+  });
+
+  return {
+    content: result,
+    numOfRewardUnits,
+  };
+}

--- a/packages/thirdweb/src/extensions/prebuilts/__generated__/Pack/write/initialize.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/__generated__/Pack/write/initialize.ts
@@ -1,0 +1,216 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { once } from "../../../../../utils/promise/once.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "initialize" function.
+ */
+export type InitializeParams = WithOverrides<{
+  defaultAdmin: AbiParameterToPrimitiveType<{
+    type: "address";
+    name: "_defaultAdmin";
+  }>;
+  name: AbiParameterToPrimitiveType<{ type: "string"; name: "_name" }>;
+  symbol: AbiParameterToPrimitiveType<{ type: "string"; name: "_symbol" }>;
+  contractURI: AbiParameterToPrimitiveType<{
+    type: "string";
+    name: "_contractURI";
+  }>;
+  trustedForwarders: AbiParameterToPrimitiveType<{
+    type: "address[]";
+    name: "_trustedForwarders";
+  }>;
+  royaltyRecipient: AbiParameterToPrimitiveType<{
+    type: "address";
+    name: "_royaltyRecipient";
+  }>;
+  royaltyBps: AbiParameterToPrimitiveType<{
+    type: "uint256";
+    name: "_royaltyBps";
+  }>;
+}>;
+
+export const FN_SELECTOR = "0x754b8fe7" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "_defaultAdmin",
+  },
+  {
+    type: "string",
+    name: "_name",
+  },
+  {
+    type: "string",
+    name: "_symbol",
+  },
+  {
+    type: "string",
+    name: "_contractURI",
+  },
+  {
+    type: "address[]",
+    name: "_trustedForwarders",
+  },
+  {
+    type: "address",
+    name: "_royaltyRecipient",
+  },
+  {
+    type: "uint256",
+    name: "_royaltyBps",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `initialize` method is supported by the given contract.
+ * @param availableSelectors An array of 4byte function selectors of the contract. You can get this in various ways, such as using "whatsabi" or if you have the ABI of the contract available you can use it to generate the selectors.
+ * @returns A boolean indicating if the `initialize` method is supported.
+ * @extension PREBUILTS
+ * @example
+ * ```ts
+ * import { isInitializeSupported } from "thirdweb/extensions/prebuilts";
+ *
+ * const supported = isInitializeSupported(["0x..."]);
+ * ```
+ */
+export function isInitializeSupported(availableSelectors: string[]) {
+  return detectMethod({
+    availableSelectors,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "initialize" function.
+ * @param options - The options for the initialize function.
+ * @returns The encoded ABI parameters.
+ * @extension PREBUILTS
+ * @example
+ * ```ts
+ * import { encodeInitializeParams } from "thirdweb/extensions/prebuilts";
+ * const result = encodeInitializeParams({
+ *  defaultAdmin: ...,
+ *  name: ...,
+ *  symbol: ...,
+ *  contractURI: ...,
+ *  trustedForwarders: ...,
+ *  royaltyRecipient: ...,
+ *  royaltyBps: ...,
+ * });
+ * ```
+ */
+export function encodeInitializeParams(options: InitializeParams) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.defaultAdmin,
+    options.name,
+    options.symbol,
+    options.contractURI,
+    options.trustedForwarders,
+    options.royaltyRecipient,
+    options.royaltyBps,
+  ]);
+}
+
+/**
+ * Encodes the "initialize" function into a Hex string with its parameters.
+ * @param options - The options for the initialize function.
+ * @returns The encoded hexadecimal string.
+ * @extension PREBUILTS
+ * @example
+ * ```ts
+ * import { encodeInitialize } from "thirdweb/extensions/prebuilts";
+ * const result = encodeInitialize({
+ *  defaultAdmin: ...,
+ *  name: ...,
+ *  symbol: ...,
+ *  contractURI: ...,
+ *  trustedForwarders: ...,
+ *  royaltyRecipient: ...,
+ *  royaltyBps: ...,
+ * });
+ * ```
+ */
+export function encodeInitialize(options: InitializeParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeInitializeParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "initialize" function on the contract.
+ * @param options - The options for the "initialize" function.
+ * @returns A prepared transaction object.
+ * @extension PREBUILTS
+ * @example
+ * ```ts
+ * import { sendTransaction } from "thirdweb";
+ * import { initialize } from "thirdweb/extensions/prebuilts";
+ *
+ * const transaction = initialize({
+ *  contract,
+ *  defaultAdmin: ...,
+ *  name: ...,
+ *  symbol: ...,
+ *  contractURI: ...,
+ *  trustedForwarders: ...,
+ *  royaltyRecipient: ...,
+ *  royaltyBps: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * await sendTransaction({ transaction, account });
+ * ```
+ */
+export function initialize(
+  options: BaseTransactionOptions<
+    | InitializeParams
+    | {
+        asyncParams: () => Promise<InitializeParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [
+        resolvedOptions.defaultAdmin,
+        resolvedOptions.name,
+        resolvedOptions.symbol,
+        resolvedOptions.contractURI,
+        resolvedOptions.trustedForwarders,
+        resolvedOptions.royaltyRecipient,
+        resolvedOptions.royaltyBps,
+      ] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
+  });
+}

--- a/packages/thirdweb/src/extensions/prebuilts/deploy-pack.test.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/deploy-pack.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { ANVIL_CHAIN } from "~test/chains.js";
+import { TEST_CLIENT } from "~test/test-clients.js";
+import { TEST_ACCOUNT_A } from "~test/test-wallets.js";
+import { isAddress } from "../../utils/address.js";
+import { deployPackContract } from "./deploy-pack.js";
+
+describe.runIf(process.env.TW_SECRET_KEY)("deploy-pack contract", () => {
+  it("should deploy Pack contract", async () => {
+    const address = await deployPackContract({
+      account: TEST_ACCOUNT_A,
+      client: TEST_CLIENT,
+      chain: ANVIL_CHAIN,
+      params: {
+        name: "pack-contract",
+      },
+    });
+    expect(address).toBeDefined();
+    expect(isAddress(address)).toBe(true);
+    // Further tests to verify the functionality of this contract
+    // are done in other Pack tests
+  });
+});

--- a/packages/thirdweb/src/extensions/prebuilts/deploy-pack.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/deploy-pack.ts
@@ -1,0 +1,173 @@
+import type { Chain } from "../../chains/types.js";
+import type { ThirdwebClient } from "../../client/client.js";
+import type { ThirdwebContract } from "../../contract/contract.js";
+import { deployViaAutoFactory } from "../../contract/deployment/deploy-via-autofactory.js";
+import {
+  getOrDeployInfraContract,
+  getOrDeployInfraForPublishedContract,
+} from "../../contract/deployment/utils/bootstrap.js";
+import { upload } from "../../storage/upload.js";
+import type { FileOrBufferOrString } from "../../storage/upload/types.js";
+import type { Prettify } from "../../utils/type-utils.js";
+import type { ClientAndChainAndAccount } from "../../utils/types.js";
+import { initialize } from "./__generated__/Pack/write/initialize.js";
+
+/**
+ * @extension DEPLOY
+ */
+export type PackContractParams = {
+  /**
+   * Name of the Pack contract
+   */
+  name: string;
+  /**
+   * Defaults to the deployer's address
+   */
+  royaltyRecipient?: string;
+  /**
+   * Defaults to 0 (zero)
+   */
+  royaltyBps?: number | string;
+
+  description?: string;
+  image?: FileOrBufferOrString;
+  external_link?: string;
+  social_urls?: Record<string, string>;
+  /**
+   * Defaults to an empty string ("")
+   */
+  symbol?: string;
+  contractURI?: string;
+  /**
+   * Defaults to the deployer's address
+   */
+  defaultAdmin?: string;
+  trustedForwarders?: string[];
+};
+
+/**
+ * @extension DEPLOY
+ */
+export type DeployPackContractOptions = Prettify<
+  ClientAndChainAndAccount & {
+    params: PackContractParams;
+  }
+>;
+
+/**
+ * Deploy a thirdweb Pack contract
+ * @param options params for deploying [`Pack contract`](https://thirdweb.com/thirdweb.eth/Pack)
+ * @returns
+ *
+ * @example
+ * ```ts
+ * import { deployPackContract } from "thirdweb/extensions/deploy";
+ *
+ * const packAddress = await deployPackContract({
+ *   account,
+ *   client,
+ *   chain,
+ *   params: {
+ *     name: "Pack contract name",
+ *     symbol: "PACK1155",
+ *   },
+ * });
+ * ```
+ */
+export async function deployPackContract(options: DeployPackContractOptions) {
+  const { chain, client, account, params } = options;
+  const [WETH, forwarder] = await Promise.all([
+    getOrDeployInfraContract({
+      chain,
+      client,
+      account,
+      contractId: "WETH9",
+    }),
+    getOrDeployInfraContract({
+      chain,
+      client,
+      account,
+      contractId: "Forwarder",
+    }),
+  ]);
+  const { cloneFactoryContract, implementationContract } =
+    await getOrDeployInfraForPublishedContract({
+      chain,
+      client,
+      account,
+      contractId: "Pack",
+      constructorParams: {
+        nativeTokenWrapper: WETH.address,
+        trustedForwarder: forwarder.address,
+      },
+    });
+  const initializeTransaction = await getInitializeTransaction({
+    client,
+    implementationContract,
+    params,
+    accountAddress: account.address,
+    chain,
+  });
+
+  return deployViaAutoFactory({
+    client,
+    chain,
+    account,
+    cloneFactoryContract,
+    initializeTransaction,
+  });
+}
+
+/**
+ * @internal
+ */
+async function getInitializeTransaction(options: {
+  client: ThirdwebClient;
+  implementationContract: ThirdwebContract;
+  params: PackContractParams;
+  accountAddress: string;
+  chain: Chain;
+}) {
+  const { params, implementationContract, accountAddress, client } = options;
+  const contractURI =
+    params.contractURI ||
+    (await upload({
+      client,
+      files: [
+        {
+          name: params.name,
+          description: params.description,
+          symbol: params.symbol || "",
+          image: params.image,
+          external_link: params.external_link,
+          social_urls: params.social_urls,
+        },
+      ],
+    })) ||
+    "";
+  let royaltyBps = 0n;
+  if (params.royaltyBps) {
+    const numberVal = Number(params.royaltyBps);
+    if (Number.isNaN(numberVal)) {
+      throw new Error("royaltyBps: Invalid royaltyBps value");
+    }
+    if (numberVal < 0 || numberVal > 100) {
+      throw new Error("royaltyBps: should be between 0 and 100");
+    }
+    // If is a float, make sure it only has 2 digit after the decimal point
+    if (numberVal % 1 !== 0 && !/^\d+(\.\d{1,2})?$/.test(String(numberVal))) {
+      throw new Error("royaltyBps: Maximum 2 decimal places allowed.");
+    }
+    royaltyBps = BigInt(numberVal * 100); // 21.12 -> 2112n
+  }
+  return initialize({
+    contract: implementationContract,
+    name: params.name,
+    symbol: params.symbol || "",
+    defaultAdmin: params.defaultAdmin || accountAddress,
+    royaltyRecipient: params.royaltyRecipient || accountAddress,
+    contractURI,
+    trustedForwarders: params.trustedForwarders || [],
+    royaltyBps,
+  });
+}

--- a/packages/thirdweb/src/extensions/split/read/getRecipientSplitPercentage.test.ts
+++ b/packages/thirdweb/src/extensions/split/read/getRecipientSplitPercentage.test.ts
@@ -2,12 +2,14 @@ import { describe, expect, it } from "vitest";
 import { ANVIL_CHAIN } from "~test/chains.js";
 import { TEST_CONTRACT_URI } from "~test/ipfs-uris.js";
 import { TEST_CLIENT } from "~test/test-clients.js";
-import { TEST_ACCOUNT_A } from "~test/test-wallets.js";
+import { TEST_ACCOUNT_C } from "~test/test-wallets.js";
 import { getContract } from "../../../contract/contract.js";
 import { deploySplitContract } from "../../../extensions/prebuilts/deploy-split.js";
 import { getRecipientSplitPercentage } from "./getRecipientSplitPercentage.js";
+
 const chain = ANVIL_CHAIN;
 const client = TEST_CLIENT;
+const account = TEST_ACCOUNT_C;
 
 describe.runIf(process.env.TW_SECRET_KEY)("getRecipientSplitPercentage", () => {
   it("should work", async () => {
@@ -16,7 +18,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("getRecipientSplitPercentage", () => {
       "0xA6f11e47dE28B3dB934e945daeb6F538E9019694",
     ];
     const address = await deploySplitContract({
-      account: TEST_ACCOUNT_A,
+      account,
       client: TEST_CLIENT,
       chain: ANVIL_CHAIN,
       params: {


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `Pack` extension to the `thirdweb` library, enhancing the deployment and management of pack contracts, including events, functions, and test cases for creating and handling packs.

### Detailed summary
- Added `Pack.json` and `IPackVRFDirect.json` ABIs.
- Introduced `deployPackContract`, `PackContractParams`, and `DeployPackContractOptions`.
- Implemented tests for deploying and interacting with `Pack` contracts.
- Added functions for pack management (create, open, add contents).
- Included new events related to pack actions (created, opened, updated).

> The following files were skipped due to too many changes: `packages/thirdweb/src/extensions/pack/createNewPack.test.ts`, `packages/thirdweb/src/extensions/prebuilts/__generated__/Pack/write/initialize.ts`, `packages/thirdweb/src/extensions/pack/__generated__/IPack/write/createPack.ts`, `packages/thirdweb/src/extensions/pack/createNewPack.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->