### PR TITLE
[Update] Refactor setOverrides() call and IPFS URL resolution

### DIFF
--- a/apps/dashboard/src/app/layout.tsx
+++ b/apps/dashboard/src/app/layout.tsx
@@ -7,8 +7,12 @@ import PlausibleProvider from "next-plausible";
 import dynamic from "next/dynamic";
 import { Inter } from "next/font/google";
 import NextTopLoader from "nextjs-toploader";
+import { setOverrides } from "../lib/vercel-utils";
 import { PostHogProvider } from "./components/root-providers";
 import { AppRouterProviders } from "./providers";
+
+// run this on app load
+setOverrides();
 
 const fontSans = Inter({
   subsets: ["latin"],

--- a/apps/dashboard/src/app/providers.tsx
+++ b/apps/dashboard/src/app/providers.tsx
@@ -5,11 +5,18 @@ import { DashboardThirdwebProviderSetup } from "components/app-layouts/provider-
 import { AllChainsProvider } from "contexts/all-chains";
 import { ChainsProvider } from "contexts/configured-chains";
 import { ThemeProvider } from "next-themes";
+import { useEffect } from "react";
 import { ThirdwebProvider } from "thirdweb/react";
+import { setOverrides } from "../lib/vercel-utils";
 
 const queryClient = new QueryClient();
 
 export function AppRouterProviders(props: { children: React.ReactNode }) {
+  // run this ONCE on app load
+  // eslint-disable-next-line no-restricted-syntax
+  useEffect(() => {
+    setOverrides();
+  }, []);
   return (
     <QueryClientProvider client={queryClient}>
       <AllChainsProvider>

--- a/apps/dashboard/src/components/explore/contract-card/index.tsx
+++ b/apps/dashboard/src/components/explore/contract-card/index.tsx
@@ -2,20 +2,22 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton, SkeletonContainer } from "@/components/ui/skeleton";
 import { TrackedLinkTW } from "@/components/ui/tracked-link";
+import { thirdwebClient } from "@/constants/client";
 import { cn } from "@/lib/utils";
 import {
   type QueryClient,
   useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
+import { moduleToBase64 } from "app/(dashboard)/published-contract/utils/module-base-64";
 import { ensQuery } from "components/contract-components/hooks";
 import { getDashboardChainRpc } from "lib/rpc";
-import { getThirdwebSDK, replaceIpfsUrl } from "lib/sdk";
+import { getThirdwebSDK } from "lib/sdk";
 import { RocketIcon, ShieldCheckIcon } from "lucide-react";
 import Link from "next/link";
 import { polygon } from "thirdweb/chains";
+import { resolveScheme } from "thirdweb/storage";
 import invariant from "tiny-invariant";
-import { moduleToBase64 } from "../../../app/(dashboard)/published-contract/utils/module-base-64";
 import { ContractPublisher, replaceDeployerAddress } from "../publisher";
 
 interface ContractCardProps {
@@ -134,7 +136,10 @@ export const ContractCard: React.FC<ContractCardProps> = ({
               <Link
                 target="_blank"
                 className="text-success-text flex items-center gap-1 text-sm z-1 hover:underline font-medium relative"
-                href={replaceIpfsUrl(publishedContractResult.data?.audit || "")}
+                href={resolveScheme({
+                  uri: publishedContractResult.data.audit,
+                  client: thirdwebClient,
+                })}
               >
                 <ShieldCheckIcon className="size-4" />
                 Audited

--- a/apps/dashboard/src/lib/vercel-utils.ts
+++ b/apps/dashboard/src/lib/vercel-utils.ts
@@ -67,5 +67,3 @@ export function setOverrides() {
     social: THIRDWEB_SOCIAL_API_DOMAIN,
   });
 }
-
-setOverrides();

--- a/apps/dashboard/src/pages/_app.tsx
+++ b/apps/dashboard/src/pages/_app.tsx
@@ -24,6 +24,7 @@ import chakraTheme from "../theme";
 import "@/styles/globals.css";
 import { DashboardRouterTopProgressBar } from "@/lib/DashboardRouter";
 import { AnnouncementBanner } from "../components/notices/AnnouncementBanner";
+import { setOverrides } from "../lib/vercel-utils";
 
 const inter = interConstructor({
   subsets: ["latin"],
@@ -51,6 +52,9 @@ const chakraThemeWithFonts = {
 
 const fontSizeCssVars = generateBreakpointTypographyCssVars();
 
+// run this on app load
+setOverrides();
+
 type AppPropsWithLayout = AppProps<{ dehydratedState?: DehydratedState }> & {
   Component: ThirdwebNextPage;
 };
@@ -59,6 +63,11 @@ const ConsoleAppWrapper: React.FC<AppPropsWithLayout> = ({
   Component,
   pageProps,
 }) => {
+  // run this ONCE on app load
+  // eslint-disable-next-line no-restricted-syntax
+  useEffect(() => {
+    setOverrides();
+  }, []);
   const router = useRouter();
   const { shouldReload } = useBuildId();
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to refactor the app initialization process by moving the `setOverrides` function call to run only once on app load.

### Detailed summary
- Moved `setOverrides` function call to run once on app load in multiple files
- Updated imports and added `useEffect` to ensure `setOverrides` runs only once
- Refactored `replaceIpfsUrl` function to use `resolveScheme` with `thirdwebClient`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->