### PR TITLE
[Update] Replace redirect with notFound for 404 handling

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/(chain)/utils.ts
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/utils.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { redirect } from "next/navigation";
+import { notFound } from "next/navigation";
 import type { ChainCTAProps } from "./[chain_id]/(chainPage)/components/server/cta-card";
 import zeroGCTA from "./temp-assets/0gCTA.png";
 import zeroGBanner from "./temp-assets/0gLabsBanner.png";
@@ -89,7 +89,7 @@ export async function getChain(
   ]);
 
   if (!chain.data) {
-    redirect("/404");
+    notFound();
   }
   return {
     ...chain.data,

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/layout.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/layout.tsx
@@ -1,7 +1,7 @@
 import { getProjects } from "@/api/projects";
 import { getTeams } from "@/api/team";
 import { TabPathLinks } from "@/components/ui/tabs";
-import { redirect } from "next/navigation";
+import { notFound } from "next/navigation";
 import { TeamHeader } from "../../components/TeamHeader/TeamHeader";
 
 export default async function TeamLayout(props: {
@@ -18,8 +18,7 @@ export default async function TeamLayout(props: {
   );
 
   if (!team) {
-    // not a valid team, redirect back to 404
-    redirect("/404");
+    notFound();
   }
 
   return (

--- a/apps/dashboard/src/app/team/[team_slug]/[project_slug]/connect/account-abstraction/page.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/[project_slug]/connect/account-abstraction/page.tsx
@@ -11,14 +11,14 @@ export default async function Page(props: {
   const project = await getProject(team_slug, project_slug);
 
   if (!project) {
-    return notFound();
+    notFound();
   }
 
   // THIS IS A WORKAROUND - project does not have `services` info - so we fetch APIKey object.
   const apiKey = await getAPIKey(project.id);
 
   if (!apiKey) {
-    return notFound();
+    notFound();
   }
 
   return (

--- a/apps/dashboard/src/app/team/[team_slug]/[project_slug]/connect/analytics/page.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/[project_slug]/connect/analytics/page.tsx
@@ -15,7 +15,7 @@ export default async function Page(props: {
   );
 
   if (!project) {
-    return notFound();
+    notFound();
   }
 
   return (

--- a/apps/dashboard/src/app/team/[team_slug]/[project_slug]/connect/in-app-wallets/page.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/[project_slug]/connect/in-app-wallets/page.tsx
@@ -17,7 +17,7 @@ export default async function Page(props: {
   );
 
   if (!project) {
-    return notFound();
+    notFound();
   }
 
   const TRACKING_CATEGORY = "team/in-app-wallets";

--- a/apps/dashboard/src/app/team/[team_slug]/[project_slug]/connect/pay/page.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/[project_slug]/connect/pay/page.tsx
@@ -15,7 +15,7 @@ export default async function Page(props: {
   );
 
   if (!project) {
-    return notFound();
+    notFound();
   }
 
   return (

--- a/apps/dashboard/src/app/team/[team_slug]/[project_slug]/layout.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/[project_slug]/layout.tsx
@@ -1,7 +1,7 @@
 import { getProjects } from "@/api/projects";
 import { getTeams } from "@/api/team";
 import { TabPathLinks } from "@/components/ui/tabs";
-import { redirect } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { TeamHeader } from "../../components/TeamHeader/TeamHeader";
 
 export default async function TeamLayout(props: {
@@ -14,7 +14,7 @@ export default async function TeamLayout(props: {
 
   if (!team) {
     // not a valid team, redirect back to 404
-    redirect("/404");
+    notFound();
   }
 
   const teamsAndProjects = await Promise.all(

--- a/apps/dashboard/src/app/team/page.tsx
+++ b/apps/dashboard/src/app/team/page.tsx
@@ -1,5 +1,5 @@
 import { getTeams } from "@/api/team";
-import { redirect } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 
 export default async function TeamRootPage() {
   // get all teams, then go to the first team
@@ -7,7 +7,7 @@ export default async function TeamRootPage() {
 
   const firstTeam = teams[0];
   if (!firstTeam) {
-    return redirect("/404");
+    notFound();
   }
   redirect(`/team/${firstTeam.slug}`);
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to replace redirect functions with `notFound` function for consistency and clarity in error handling.

### Detailed summary
- Replaced `redirect` with `notFound` function in multiple files for error handling consistency.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->