### PR TITLE
[Playground] Feature: Track tab state in URL

### DIFF
--- a/apps/playground-web/src/app/connect/sign-in/button/RightSection.tsx
+++ b/apps/playground-web/src/app/connect/sign-in/button/RightSection.tsx
@@ -1,5 +1,6 @@
 import { XIcon } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useEffect, useMemo } from "react";
 import { ethereum } from "thirdweb/chains";
 import {
   ConnectButton,
@@ -20,10 +21,19 @@ import type { ConnectPlaygroundOptions } from "../components/types";
 
 export function RightSection(props: {
   connectOptions: ConnectPlaygroundOptions;
+  tab?: string;
 }) {
-  const [previewTab, setPreviewTab] = useState<"modal" | "button" | "code">(
-    "modal",
+  const router = useRouter();
+  const previewTab = useMemo(
+    () =>
+      ["modal", "button", "code"].includes(props.tab || "")
+        ? (props.tab as "modal" | "button" | "code")
+        : "modal",
+    [props.tab],
   );
+  const setPreviewTab = (tab: "modal" | "button" | "code") => {
+    router.push(`/connect/sign-in?tab=${tab}`);
+  };
   const { connectOptions } = props;
   const wallet = useActiveWallet();
   const account = useActiveAccount();

--- a/apps/playground-web/src/app/connect/sign-in/button/page.tsx
+++ b/apps/playground-web/src/app/connect/sign-in/button/page.tsx
@@ -50,7 +50,9 @@ const defaultConnectOptions: ConnectPlaygroundOptions = {
   requireApproval: false,
 };
 
-export default function Page() {
+export default function Page({
+  searchParams,
+}: { searchParams: { tab: string } }) {
   const [connectOptions, setConnectOptions] =
     useState<ConnectPlaygroundOptions>(defaultConnectOptions);
 
@@ -80,7 +82,10 @@ export default function Page() {
             />
           </div>
 
-          <RightSection connectOptions={connectOptions} />
+          <RightSection
+            tab={searchParams.tab}
+            connectOptions={connectOptions}
+          />
         </div>
       </div>
     </ThirdwebProvider>


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add a `tab` parameter to the `Page` component and update the `RightSection` component to handle tab navigation.

### Detailed summary
- Added `tab` parameter to `Page` component
- Updated `RightSection` component to handle tab navigation
- Used `useRouter` for navigation in `RightSection`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->