### PR TITLE
fix(pay): allow topping up from a different wallet with the same currency

### DIFF
--- a/.changeset/fifty-geckos-switch.md
+++ b/.changeset/fifty-geckos-switch.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Allow topping up from a different wallet with the same currency

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx
@@ -1120,7 +1120,8 @@ function SwapScreenContent(props: {
 
   function showSwapFlow() {
     if (
-      props.payOptions.mode === "direct_payment" &&
+      (props.payOptions.mode === "direct_payment" ||
+        props.payOptions.mode === "fund_wallet") &&
       !isNotEnoughBalance &&
       !swapRequired
     ) {

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/ConfirmationScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/ConfirmationScreen.tsx
@@ -126,7 +126,7 @@ export function SwapConfirmationScreen(props: {
 
       {/* Send to  */}
       {isDifferentRecipient && (
-        <ConfirmItem label="Seller">
+        <ConfirmItem label="Receiver">
           <Text color="primaryText" size="sm">
             {ensName.data || shortenAddress(receiver)}
           </Text>

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/usePayerSetup.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/usePayerSetup.tsx
@@ -23,8 +23,6 @@ export function usePayerSetup() {
       const account = wallet.getAccount();
       const chain = wallet.getChain();
       if (account && chain) {
-        console.log("updated to", account, chain);
-
         setPayer({
           account,
           chain,


### PR DESCRIPTION
Fixes CNCT-1835

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `thirdweb` package by allowing topping up from a different wallet with the same currency.

### Detailed summary
- Enable topping up from a different wallet with the same currency
- Update label from "Seller" to "Receiver" in ConfirmationScreen
- Modify condition in showSwapFlow to include "fund_wallet" mode

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->