### PR TITLE
[SDK] Fix: Switch active connection on wallet account change

### DIFF
--- a/packages/thirdweb/src/wallets/manager/index.ts
+++ b/packages/thirdweb/src/wallets/manager/index.ts
@@ -153,6 +153,11 @@ export function createConnectionManager(storage: AsyncStorage) {
     const connectedWallet = await handleConnection(wallet, options);
     options?.onConnect?.(connectedWallet);
     handleSetActiveWallet(connectedWallet);
+    wallet.subscribe("accountChanged", async () => {
+      const newConnectedWallet = await handleConnection(wallet, options);
+      options?.onConnect?.(newConnectedWallet);
+      handleSetActiveWallet(newConnectedWallet);
+    });
     return connectedWallet;
   };
 


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add a subscription to handle account changes in the wallet manager.

### Detailed summary
- Added subscription for "accountChanged" event in wallet manager
- Calls `handleConnection` on account change
- Updates connected wallet and calls `onConnect` and `handleSetActiveWallet` on account change

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->