### PR TITLE
feat(pay): allow customizing PayEmbed metadata for top-up flow

### DIFF
--- a/.changeset/thin-bees-hunt.md
+++ b/.changeset/thin-bees-hunt.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Allow customizing PayEmbed metadata for top-up flow

--- a/packages/thirdweb/src/react/core/hooks/connection/ConnectButtonProps.ts
+++ b/packages/thirdweb/src/react/core/hooks/connection/ConnectButtonProps.ts
@@ -113,6 +113,13 @@ export type PayUIOptions = Prettify<
             status: BuyWithFiatStatus;
           },
     ) => void;
+    /**
+     * Customize the display of the PayEmbed UI.
+     */
+    metadata?: {
+      name?: string;
+      image?: string;
+    };
   } & (FundWalletOptions | DirectPaymentOptions | TranasctionOptions)
 >;
 
@@ -145,13 +152,6 @@ export type DirectPaymentOptions = {
    * The payment information
    */
   paymentInfo: PaymentInfo;
-  /**
-   * Customize the display of the PayEmbed UI.
-   */
-  metadata?: {
-    name?: string;
-    image?: string;
-  };
 };
 
 export type TranasctionOptions = {
@@ -160,13 +160,6 @@ export type TranasctionOptions = {
    * The transaction to be executed.
    */
   transaction: PreparedTransaction;
-  /**
-   * Customize the display of the PayEmbed UI.
-   */
-  metadata?: {
-    name?: string;
-    image?: string;
-  };
 };
 
 /**


### PR DESCRIPTION
fixes CNCT-1860


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to allow customizing PayEmbed metadata for the top-up flow.

### Detailed summary
- Added a `metadata` property to customize the display of the PayEmbed UI in `ConnectButtonProps.ts`
- Removed `metadata` property duplication in `DirectPaymentOptions` and `TransactionOptions`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->