### PR TITLE
feat: invalidate wallet balance after successful purchases

### DIFF
--- a/.changeset/ten-parrots-perform.md
+++ b/.changeset/ten-parrots-perform.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Invalidate balances on Pay success

--- a/packages/thirdweb/src/react/core/providers/invalidateWalletBalance.test.ts
+++ b/packages/thirdweb/src/react/core/providers/invalidateWalletBalance.test.ts
@@ -25,7 +25,7 @@ describe("invalidateWalletBalance", () => {
     invalidateWalletBalance(queryClient);
 
     expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
-      queryKey: ["walletBalance", undefined] as const,
+      queryKey: ["walletBalance"] as const,
     });
   });
 });

--- a/packages/thirdweb/src/react/core/providers/invalidateWalletBalance.ts
+++ b/packages/thirdweb/src/react/core/providers/invalidateWalletBalance.ts
@@ -7,6 +7,6 @@ export function invalidateWalletBalance(
   return queryClient.invalidateQueries({
     // invalidate any walletBalance queries for this chainId
     // TODO: add wallet address in here if we can get it somehow
-    queryKey: ["walletBalance", chainId] as const,
+    queryKey: chainId ? ["walletBalance", chainId] : ["walletBalance"],
   });
 }

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx
@@ -1,4 +1,5 @@
 import { IdCardIcon } from "@radix-ui/react-icons";
+import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useMemo, useState } from "react";
 import { trackPayEvent } from "../../../../../../analytics/track.js";
 import type { Chain } from "../../../../../../chains/types.js";
@@ -24,6 +25,7 @@ import { useWalletBalance } from "../../../../../core/hooks/others/useWalletBala
 import { useBuyWithCryptoQuote } from "../../../../../core/hooks/pay/useBuyWithCryptoQuote.js";
 import { useBuyWithFiatQuote } from "../../../../../core/hooks/pay/useBuyWithFiatQuote.js";
 import { useActiveAccount } from "../../../../../core/hooks/wallets/useActiveAccount.js";
+import { invalidateWalletBalance } from "../../../../../core/providers/invalidateWalletBalance.js";
 import type { SupportedTokens } from "../../../../../core/utils/defaultTokens.js";
 import { LoadingScreen } from "../../../../wallets/shared/LoadingScreen.js";
 import type { PayEmbedConnectOptions } from "../../../PayEmbed.js";
@@ -226,14 +228,17 @@ function BuyScreenContent(props: BuyScreenContentProps) {
 
   // screens ----------------------------
 
+  const queryClient = useQueryClient();
+
   const onSwapSuccess = useCallback(
     (_status: BuyWithCryptoStatus) => {
       props.payOptions.onPurchaseSuccess?.({
         type: "crypto",
         status: _status,
       });
+      invalidateWalletBalance(queryClient);
     },
-    [props.payOptions.onPurchaseSuccess],
+    [props.payOptions.onPurchaseSuccess, queryClient],
   );
 
   const onFiatSuccess = useCallback(
@@ -242,8 +247,9 @@ function BuyScreenContent(props: BuyScreenContentProps) {
         type: "fiat",
         status: _status,
       });
+      invalidateWalletBalance(queryClient);
     },
-    [props.payOptions.onPurchaseSuccess],
+    [props.payOptions.onPurchaseSuccess, queryClient],
   );
 
   if (screen.id === "connect-payer-wallet") {


### PR DESCRIPTION
Fixes CNCT-1861

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on invalidating wallet balances on successful payments in the `BuyScreen` component.

### Detailed summary
- Updated `invalidateWalletBalance` function to handle queryClient
- Added queryClient to `onSwapSuccess` and `onFiatSuccess` callbacks in `BuyScreenContent`
- Imported `invalidateWalletBalance` in `BuyScreen` component

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->