### PR TITLE
Pay - Stop polling after status is complete

### DIFF
--- a/packages/thirdweb/src/react/core/hooks/pay/useBuyWithCryptoStatus.ts
+++ b/packages/thirdweb/src/react/core/hooks/pay/useBuyWithCryptoStatus.ts
@@ -64,7 +64,13 @@ export function useBuyWithCryptoStatus(params?: BuyWithCryptoTransaction) {
       return getBuyWithCryptoStatus(params);
     },
     enabled: !!params,
-    refetchInterval: 5000,
+    refetchInterval: (query) => {
+      const status = (query.state.data as BuyWithCryptoStatus)?.status;
+      if (status === "COMPLETED" || status === "FAILED") {
+        return false;
+      }
+      return 5000;
+    },
     refetchIntervalInBackground: true,
     retry: true,
   });

--- a/packages/thirdweb/src/react/core/hooks/pay/useBuyWithFiatStatus.ts
+++ b/packages/thirdweb/src/react/core/hooks/pay/useBuyWithFiatStatus.ts
@@ -45,7 +45,23 @@ export function useBuyWithFiatStatus(
       return getBuyWithFiatStatus(params);
     },
     enabled: !!params,
-    refetchInterval: 5000,
+    refetchInterval: (query) => {
+      const data = query.state.data as BuyWithFiatStatus;
+      const status = data?.status;
+      if (
+        status === "ON_RAMP_TRANSFER_FAILED" ||
+        status === "PAYMENT_FAILED" ||
+        status === "CRYPTO_SWAP_COMPLETED" ||
+        // onRampToken and toToken being the same means there is no additional swap step
+        (status === "ON_RAMP_TRANSFER_COMPLETED" &&
+          data?.quote.toToken.chainId === data?.quote.onRampToken.chainId &&
+          data?.quote.toToken.tokenAddress.toLowerCase() ===
+            data?.quote.onRampToken.tokenAddress.toLowerCase())
+      ) {
+        return false;
+      }
+      return 5000;
+    },
     refetchIntervalInBackground: true,
     retry: true,
   });


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the `refetchInterval` logic in the `useBuyWithCryptoStatus` and `useBuyWithFiatStatus` hooks based on different status conditions.

### Detailed summary
- Updated `refetchInterval` logic in `useBuyWithCryptoStatus` hook based on status conditions
- Updated `refetchInterval` logic in `useBuyWithFiatStatus` hook based on status conditions

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->