### PR TITLE
test: conditionally run tests based on TW_SECRET_KEY

### DIFF
--- a/packages/thirdweb/src/extensions/erc721/lazyMinting/write/createAndReveal.test.ts
+++ b/packages/thirdweb/src/extensions/erc721/lazyMinting/write/createAndReveal.test.ts
@@ -29,7 +29,7 @@ const realNFTs = [
   },
 ];
 
-describe("createAndReveal", () => {
+describe.runIf(process.env.TW_SECRET_KEY)("createAndReveal", () => {
   let contract: ThirdwebContract;
   beforeAll(async () => {
     const address = await deployERC721Contract({

--- a/packages/thirdweb/src/extensions/modules/MintableERC1155/mintableERC1155.test.ts
+++ b/packages/thirdweb/src/extensions/modules/MintableERC1155/mintableERC1155.test.ts
@@ -21,7 +21,7 @@ import { getInstalledModules } from "../__generated__/IModularCore/read/getInsta
 import { grantMinterRole } from "../common/grantMinterRole.js";
 import * as MintableERC1155 from "./index.js";
 
-describe("ModularTokenERC1155", () => {
+describe.runIf(process.env.TW_SECRET_KEY)("ModularTokenERC1155", () => {
   let contract: ThirdwebContract;
   beforeAll(async () => {
     const address = await deployModularContract({

--- a/packages/thirdweb/src/extensions/modules/MintableERC20/mintableERC20.test.ts
+++ b/packages/thirdweb/src/extensions/modules/MintableERC20/mintableERC20.test.ts
@@ -16,7 +16,7 @@ import { getInstalledModules } from "../__generated__/IModularCore/read/getInsta
 import { grantMinterRole } from "../common/grantMinterRole.js";
 import * as MintableERC20 from "./index.js";
 
-describe("ModularTokenERC20", () => {
+describe.runIf(process.env.TW_SECRET_KEY)("ModularTokenERC20", () => {
   let contract: ThirdwebContract;
   beforeAll(async () => {
     const address = await deployModularContract({

--- a/packages/thirdweb/src/extensions/modules/MintableERC721/mintableERC721.test.ts
+++ b/packages/thirdweb/src/extensions/modules/MintableERC721/mintableERC721.test.ts
@@ -20,7 +20,7 @@ import { getInstalledModules } from "../__generated__/IModularCore/read/getInsta
 import { grantMinterRole } from "../common/grantMinterRole.js";
 import * as MintableERC721 from "./index.js";
 
-describe("ModularTokenERC721", () => {
+describe.runIf(process.env.TW_SECRET_KEY)("ModularTokenERC721", () => {
   let contract: ThirdwebContract;
   beforeAll(async () => {
     const address = await deployModularContract({


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates test descriptions to run only if a secret key is present. 

### Detailed summary
- Updated test descriptions to run only if a secret key is present
- Renamed test suites for ERC721, ERC20, ERC721, and ERC1155 modules to include the secret key condition

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->