### PR TITLE
[Dashboard] Add `from` to `claimTo`

### DIFF
--- a/apps/dashboard/src/contract-ui/tabs/nfts/components/claim-form.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/nfts/components/claim-form.tsx
@@ -105,6 +105,7 @@ export const NFTClaimForm: React.FC<NFTClaimFormProps> = ({ contract }) => {
                 contract,
                 to: d.to,
                 quantity: BigInt(d.amount),
+                from: account.address,
               });
 
               const approveTx = await getApprovalForTransaction({

--- a/apps/dashboard/src/contract-ui/tabs/tokens/components/claim-form.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/tokens/components/claim-form.tsx
@@ -108,6 +108,7 @@ export const TokenClaimForm: React.FC<TokenClaimFormProps> = ({ contract }) => {
                   contract,
                   to: d.to,
                   quantity: d.amount,
+                  from: account.address,
                 });
 
                 const approveTx = await getApprovalForTransaction({


### PR DESCRIPTION
Jake did mention sometimes we have issues with allowlist if `from` is not specified.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `claim-form.tsx` file in both `tokens` and `nfts` components to include the `from` field with the account address.

### Detailed summary
- Added `from: account.address` field in `claim-form.tsx` for both tokens and NFTs components.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->