### PR TITLE
Fix _defaultAdmin not prefilled with connected wallet address

### DIFF
--- a/apps/dashboard/src/components/contract-components/contract-deploy-form/custom-contract.tsx
+++ b/apps/dashboard/src/components/contract-components/contract-deploy-form/custom-contract.tsx
@@ -184,6 +184,18 @@ export const CustomContractForm: React.FC<CustomContractFormProps> = ({
               chainId: walletChain?.id,
             },
           );
+
+          // if _defaultAdmin is not prefilled with activeAccount address with the replaceTemplateValues, do it here
+          // because _defaultAdmin is hidden in the form
+          if (
+            param.name === "_defaultAdmin" &&
+            param.type === "address" &&
+            !acc[param.name] &&
+            activeAccount
+          ) {
+            acc[param.name] = activeAccount.address;
+          }
+
           return acc;
         },
         {} as Record<string, string>,


### PR DESCRIPTION
Not sure if this is the proper solution 

refer to - https://linear.app/thirdweb/issue/DASH-255/custom-contract-deployment-issue-via-dashboard#comment-6afa6f35

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to prefill the `_defaultAdmin` parameter with the active account address if it's not already filled, in the custom contract deployment form.

### Detailed summary
- Prefills `_defaultAdmin` with active account address if not already filled.
- Enhances user experience by auto-filling a hidden form field.


> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->