### PR TITLE
Set auth token everywhere ThirdwebProvider is used

### DIFF
--- a/apps/dashboard/src/app/api/auth/get-auth-token/route.ts
+++ b/apps/dashboard/src/app/api/auth/get-auth-token/route.ts
@@ -1,0 +1,58 @@
+import { COOKIE_PREFIX_TOKEN } from "@/constants/cookie";
+import { cookies } from "next/headers";
+import { type NextRequest, NextResponse } from "next/server";
+import { getAddress } from "thirdweb/utils";
+
+const THIRDWEB_API_HOST =
+  process.env.NEXT_PUBLIC_THIRDWEB_API_HOST || "https://api.thirdweb.com";
+
+export type GetAuthTokenResponse = {
+  jwt: string | null;
+};
+
+function respond(jwt: string | null) {
+  const responseObj: GetAuthTokenResponse = {
+    jwt,
+  };
+  return NextResponse.json(responseObj);
+}
+
+export const GET = async (req: NextRequest) => {
+  const address = req.nextUrl.searchParams.get("address");
+  const cookieStore = cookies();
+
+  if (!address) {
+    return NextResponse.json(
+      {
+        error: "address is required",
+      },
+      {
+        status: 400,
+      },
+    );
+  }
+
+  const authCookieName = COOKIE_PREFIX_TOKEN + getAddress(address);
+
+  // check if we have a token for the address
+  const token = cookieStore.get(authCookieName)?.value;
+
+  // no auth token found for the address
+  if (!token) {
+    return respond(null);
+  }
+
+  // check token validity
+  const accountRes = await fetch(`${THIRDWEB_API_HOST}/v1/account/me`, {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  if (accountRes.status !== 200) {
+    return respond(null);
+  }
+
+  return respond(token);
+};

--- a/apps/dashboard/src/app/components/SetAuthHeaderForSDK.tsx
+++ b/apps/dashboard/src/app/components/SetAuthHeaderForSDK.tsx
@@ -1,0 +1,38 @@
+import { useQuery } from "@tanstack/react-query";
+import { useEffect } from "react";
+import { useActiveAccount } from "thirdweb/react";
+import type { GetAuthTokenResponse } from "../api/auth/get-auth-token/route";
+
+function useAuthHeader() {
+  const account = useActiveAccount();
+  return useQuery({
+    queryKey: ["authHeader", account?.address],
+    queryFn: async () => {
+      if (!account) {
+        throw new Error("No account");
+      }
+      const res = await fetch(
+        `/api/auth/get-auth-token?address=${account.address}`,
+      );
+      if (!res.ok) {
+        throw new Error("Failed to get auth token");
+      }
+      const json = (await res.json()) as GetAuthTokenResponse;
+      return json.jwt;
+    },
+    enabled: !!account,
+    retry: false,
+  });
+}
+
+export function SetAuthHeaderForSDK() {
+  const authHeaderQuery = useAuthHeader();
+  // eslint-disable-next-line no-restricted-syntax
+  useEffect(() => {
+    if (authHeaderQuery.data) {
+      window.TW_AUTH_TOKEN = authHeaderQuery.data;
+    }
+  }, [authHeaderQuery.data]);
+
+  return null;
+}

--- a/apps/dashboard/src/app/providers.tsx
+++ b/apps/dashboard/src/app/providers.tsx
@@ -7,6 +7,7 @@ import { ThemeProvider } from "next-themes";
 import { useEffect } from "react";
 import { ThirdwebProvider } from "thirdweb/react";
 import { setOverrides } from "../lib/vercel-utils";
+import { SetAuthHeaderForSDK } from "./components/SetAuthHeaderForSDK";
 
 const queryClient = new QueryClient();
 
@@ -21,6 +22,7 @@ export function AppRouterProviders(props: { children: React.ReactNode }) {
       <AllChainsProvider>
         <ChainsProvider>
           <ThirdwebProvider>
+            <SetAuthHeaderForSDK />
             <ThemeProvider attribute="class" defaultTheme="dark">
               {props.children}
             </ThemeProvider>

--- a/apps/dashboard/src/components/app-layouts/providers.tsx
+++ b/apps/dashboard/src/components/app-layouts/providers.tsx
@@ -2,11 +2,17 @@
 import { useNativeColorMode } from "hooks/useNativeColorMode";
 import { ThirdwebProvider } from "thirdweb/react";
 import type { ComponentWithChildren } from "types/component-with-children";
+import { SetAuthHeaderForSDK } from "../../app/components/SetAuthHeaderForSDK";
 
 export const DashboardThirdwebProvider: ComponentWithChildren = ({
   children,
 }) => {
   useNativeColorMode();
 
-  return <ThirdwebProvider>{children}</ThirdwebProvider>;
+  return (
+    <ThirdwebProvider>
+      <SetAuthHeaderForSDK />
+      {children}
+    </ThirdwebProvider>
+  );
 };


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces authentication headers for the SDK, enhances API token retrieval, and updates provider components.

### Detailed summary
- Added `SetAuthHeaderForSDK` component for setting authentication headers
- Enhanced API token retrieval logic in `get-auth-token/route.ts`
- Updated provider components to include `SetAuthHeaderForSDK`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->