### PR TITLE
Improve getNFTs compatibility for ERC1155 contracts

### DIFF
--- a/.changeset/plenty-pears-prove.md
+++ b/.changeset/plenty-pears-prove.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+make getNFTs work for more ERC1155 contracts

--- a/packages/thirdweb/src/extensions/erc1155/read/getNFTs.ts
+++ b/packages/thirdweb/src/extensions/erc1155/read/getNFTs.ts
@@ -1,3 +1,4 @@
+import { maxUint256 } from "viem";
 import type { BaseTransactionOptions } from "../../../transaction/types.js";
 import { min } from "../../../utils/bigint.js";
 import type { NFT } from "../../../utils/nft/parseNft.js";
@@ -44,7 +45,9 @@ export async function getNFTs(
 ): Promise<NFT[]> {
   const start = BigInt(options.start || 0);
   const count = BigInt(options.count || DEFAULT_QUERY_ALL_COUNT);
-  const totalCount = await nextTokenIdToMint(options);
+  // try to get the totalCount (non-standard) - if this fails then just use maxUint256
+  const totalCount = await nextTokenIdToMint(options).catch(() => maxUint256);
+  // get the maxId to query up to (either the totalCount or the start + count, whichever is smaller)
   const maxId = min(totalCount, start + count);
 
   const promises: ReturnType<typeof getNFT>[] = [];


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on improving the `getNFTs` function to work with more ERC1155 contracts.

### Detailed summary
- Updated `getNFTs` function to handle totalCount retrieval failure
- Calculated maxId to query up to based on totalCount or start + count

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->