### PR TITLE
[SDK] Fix: Remove useless caching

### DIFF
--- a/packages/thirdweb/src/utils/fetch.test.ts
+++ b/packages/thirdweb/src/utils/fetch.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ThirdwebClient } from "../client/client.js";
+import type { Ecosystem } from "../wallets/in-app/web/types.js";
+import {
+  IS_THIRDWEB_URL_CACHE,
+  getClientFetch,
+  isThirdwebUrl,
+} from "./fetch.js";
+
+// Mock fetch
+global.fetch = vi.fn();
+
+describe("getClientFetch", () => {
+  const mockClient: ThirdwebClient = {
+    clientId: "test-client-id",
+    secretKey: undefined,
+  };
+  const mockEcosystem: Ecosystem = { id: "ecosystem.test" };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("should set correct headers for thirdweb URLs", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue(new Response());
+    const clientFetch = getClientFetch(mockClient, mockEcosystem);
+    await clientFetch("https://api.thirdweb.com/test");
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://api.thirdweb.com/test",
+      expect.objectContaining({
+        headers: expect.any(Headers),
+      }),
+    );
+
+    // biome-ignore lint/suspicious/noExplicitAny: `any` type ok for tests
+    const headers = (global.fetch as any).mock.calls[0][1].headers;
+    expect(headers.get("x-client-id")).toBe("test-client-id");
+    expect(headers.get("x-ecosystem-id")).toBe("ecosystem.test");
+  });
+
+  it("should not set headers for non-thirdweb URLs", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue(new Response());
+    const clientFetch = getClientFetch(mockClient, mockEcosystem);
+    await clientFetch("https://example.com");
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://example.com",
+      expect.not.objectContaining({
+        headers: expect.any(Headers),
+      }),
+    );
+  });
+
+  it("should abort the request after timeout", async () => {
+    vi.useFakeTimers();
+    const abortSpy = vi.spyOn(AbortController.prototype, "abort");
+    const clientFetch = getClientFetch(mockClient);
+
+    const fetchPromise = clientFetch("https://api.thirdweb.com/test", {
+      requestTimeoutMs: 5000,
+    });
+    vi.advanceTimersByTime(5001);
+
+    await expect(fetchPromise).rejects.toThrow();
+    expect(abortSpy).toHaveBeenCalled();
+
+    vi.useRealTimers();
+  });
+});
+
+describe("isThirdwebUrl", () => {
+  it("should return true for thirdweb domains", () => {
+    expect(isThirdwebUrl("https://api.thirdweb.com")).toBe(true);
+    expect(isThirdwebUrl("https://example.ipfscdn.io")).toBe(true);
+  });
+
+  it("should return false for non-thirdweb domains", () => {
+    expect(isThirdwebUrl("https://example.com")).toBe(false);
+    expect(isThirdwebUrl("https://otherthirdweb.com")).toBe(false);
+  });
+
+  it("should handle invalid URLs", () => {
+    expect(isThirdwebUrl("not-a-url")).toBe(false);
+  });
+
+  it("should cache results", () => {
+    const url = "https://api.thirdweb.com";
+    isThirdwebUrl(url);
+    isThirdwebUrl(url);
+    // You might need to expose the cache to test this properly
+    expect(IS_THIRDWEB_URL_CACHE.get(url)).toBe(true);
+  });
+});

--- a/packages/thirdweb/src/utils/fetch.ts
+++ b/packages/thirdweb/src/utils/fetch.ts
@@ -10,20 +10,10 @@ import {
 
 const DEFAULT_REQUEST_TIMEOUT = 60000;
 
-const FETCH_CACHE = new WeakMap<
-  { client: ThirdwebClient; ecosystem?: Ecosystem },
-  (url: string, init?: RequestInit) => Promise<Response>
->();
-
 /**
  * @internal
  */
 export function getClientFetch(client: ThirdwebClient, ecosystem?: Ecosystem) {
-  if (FETCH_CACHE.has({ client, ecosystem })) {
-    // biome-ignore lint/style/noNonNullAssertion: the `has` above ensures that this will always be set
-    return FETCH_CACHE.get({ client, ecosystem })!;
-  }
-
   /**
    * @internal
    */
@@ -83,7 +73,6 @@ export function getClientFetch(client: ThirdwebClient, ecosystem?: Ecosystem) {
       }
     });
   }
-  FETCH_CACHE.set({ client, ecosystem }, fetchWithHeaders);
   return fetchWithHeaders;
 }
 
@@ -96,7 +85,7 @@ const THIRDWEB_DOMAINS = [
   ".thirdweb-dev.com",
 ] as const;
 
-const IS_THIRDWEB_URL_CACHE = new LruMap<boolean>(4096);
+export const IS_THIRDWEB_URL_CACHE = new LruMap<boolean>(4096);
 
 /**
  * @internal


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to refactor the `fetch.ts` file in the `thirdweb` package and add unit tests for `getClientFetch` and `isThirdwebUrl` functions.

### Detailed summary
- Removed `FETCH_CACHE` WeakMap
- Changed `IS_THIRDWEB_URL_CACHE` to be exported
- Added unit tests for `getClientFetch` and `isThirdwebUrl` functions

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->