### PR TITLE
[Dashboard] Replace Chakra-ui's useClipboard

### DIFF
--- a/apps/dashboard/src/components/homepage/AnimatedCLICommand/AnimatedCLICommand.tsx
+++ b/apps/dashboard/src/components/homepage/AnimatedCLICommand/AnimatedCLICommand.tsx
@@ -1,6 +1,7 @@
-import { Icon, IconButton, useClipboard } from "@chakra-ui/react";
+import { Icon, IconButton } from "@chakra-ui/react";
 import { IoMdCheckmark } from "@react-icons/all-files/io/IoMdCheckmark";
 import { useTrack } from "hooks/analytics/useTrack";
+import { useClipboard } from "hooks/useClipboard";
 import { FiCopy } from "react-icons/fi";
 
 export const CopyButton: React.FC<{ text: string }> = ({ text }) => {

--- a/apps/dashboard/src/components/homepage/CodeBlock/index.tsx
+++ b/apps/dashboard/src/components/homepage/CodeBlock/index.tsx
@@ -5,11 +5,11 @@ import {
   Flex,
   Icon,
   IconButton,
-  useClipboard,
   useColorModeValue,
   useTheme,
 } from "@chakra-ui/react";
 import { IoMdCheckmark } from "@react-icons/all-files/io/IoMdCheckmark";
+import { useClipboard } from "hooks/useClipboard";
 import { Highlight, themes } from "prism-react-renderer";
 import { useEffect, useRef, useState } from "react";
 import { BsLightning } from "react-icons/bs";

--- a/apps/dashboard/src/contract-ui/tabs/embed/components/embed-setup.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/embed/components/embed-setup.tsx
@@ -8,11 +8,11 @@ import {
   Select,
   Stack,
   useBreakpointValue,
-  useClipboard,
 } from "@chakra-ui/react";
 import { IoMdCheckmark } from "@react-icons/all-files/io/IoMdCheckmark";
 import { useTrack } from "hooks/analytics/useTrack";
 import { useSupportedChainsRecord } from "hooks/chains/configureChains";
+import { useClipboard } from "hooks/useClipboard";
 import { useTxNotifications } from "hooks/useTxNotifications";
 import { useMemo } from "react";
 import { useForm } from "react-hook-form";

--- a/apps/dashboard/src/contract-ui/tabs/events/components/events-feed.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/events/components/events-feed.tsx
@@ -23,11 +23,11 @@ import {
   Stack,
   Switch,
   Tooltip,
-  useClipboard,
   useToast,
 } from "@chakra-ui/react";
 import { AiOutlineQuestionCircle } from "@react-icons/all-files/ai/AiOutlineQuestionCircle";
 import { AnimatePresence, motion } from "framer-motion";
+import { useClipboard } from "hooks/useClipboard";
 import { useSearchParams } from "next/navigation";
 import { useRouter } from "next/router";
 import { Fragment, useMemo, useState } from "react";

--- a/apps/dashboard/src/contract-ui/tabs/overview/components/LatestEvents.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/overview/components/LatestEvents.tsx
@@ -13,11 +13,11 @@ import {
   Spinner,
   Stack,
   Tooltip,
-  useClipboard,
   useToast,
 } from "@chakra-ui/react";
 import { useTabHref } from "contract-ui/utils";
 import { AnimatePresence, motion } from "framer-motion";
+import { useClipboard } from "hooks/useClipboard";
 import { useState } from "react";
 import { FiCopy } from "react-icons/fi";
 import type { ThirdwebContract } from "thirdweb";

--- a/apps/dashboard/src/contract-ui/tabs/overview/components/PermissionsTable.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/overview/components/PermissionsTable.tsx
@@ -8,11 +8,11 @@ import {
   Stack,
   Tag,
   Tooltip,
-  useClipboard,
   useToast,
 } from "@chakra-ui/react";
 import { useTabHref } from "contract-ui/utils";
 import { AnimatePresence, motion } from "framer-motion";
+import { useClipboard } from "hooks/useClipboard";
 import { useMemo } from "react";
 import { FiCopy } from "react-icons/fi";
 import { type ThirdwebContract, ZERO_ADDRESS } from "thirdweb";

--- a/apps/dashboard/src/contract-ui/tabs/permissions/components/permissions-editor.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/permissions/components/permissions-editor.tsx
@@ -13,10 +13,10 @@ import {
   InputRightAddon,
   Stack,
   Tooltip,
-  useClipboard,
   useToast,
 } from "@chakra-ui/react";
 import { DelayedDisplay } from "components/delayed-display/delayed-display";
+import { useClipboard } from "hooks/useClipboard";
 import { useState } from "react";
 import { useFieldArray, useFormContext } from "react-hook-form";
 import { BiPaste } from "react-icons/bi";

--- a/apps/dashboard/src/hooks/useClipboard.ts
+++ b/apps/dashboard/src/hooks/useClipboard.ts
@@ -1,0 +1,34 @@
+import { useCallback, useEffect, useState } from "react";
+
+/**
+ * todo: this hook is copied from the SDK, so might as well expose it from the SDK
+ * and use it here?
+ */
+export function useClipboard(text: string, delay = 1500) {
+  const [hasCopied, setHasCopied] = useState(false);
+
+  const onCopy = useCallback(async () => {
+    await navigator.clipboard.writeText(text);
+    setHasCopied(true);
+  }, [text]);
+
+  // legitimate usecase
+  // eslint-disable-next-line no-restricted-syntax
+  useEffect(() => {
+    let timeoutId: number | null = null;
+
+    if (hasCopied) {
+      timeoutId = window.setTimeout(() => {
+        setHasCopied(false);
+      }, delay);
+    }
+
+    return () => {
+      if (timeoutId) {
+        window.clearTimeout(timeoutId);
+      }
+    };
+  }, [hasCopied, delay]);
+
+  return { onCopy, hasCopied };
+}

--- a/apps/dashboard/src/tw-components/AddressCopyButton.tsx
+++ b/apps/dashboard/src/tw-components/AddressCopyButton.tsx
@@ -1,5 +1,6 @@
-import { Icon, Tooltip, useClipboard, useToast } from "@chakra-ui/react";
+import { Icon, Tooltip, useToast } from "@chakra-ui/react";
 import { useTrack } from "hooks/analytics/useTrack";
+import { useClipboard } from "hooks/useClipboard";
 import { FiCopy } from "react-icons/fi";
 import {
   Button,

--- a/apps/dashboard/src/tw-components/button.tsx
+++ b/apps/dashboard/src/tw-components/button.tsx
@@ -8,9 +8,9 @@ import {
   Link,
   forwardRef,
   useButtonGroup,
-  useClipboard,
 } from "@chakra-ui/react";
 import { useTrack } from "hooks/analytics/useTrack";
+import { useClipboard } from "hooks/useClipboard";
 import { forwardRef as reactForwardRef } from "react";
 import { FiCheck, FiCopy, FiExternalLink } from "react-icons/fi";
 import { fontWeights, letterSpacings, lineHeights } from "theme/typography";

--- a/apps/dashboard/src/tw-components/code-block.tsx
+++ b/apps/dashboard/src/tw-components/code-block.tsx
@@ -6,10 +6,10 @@ import {
   type CodeProps,
   Icon,
   IconButton,
-  useClipboard,
   useColorModeValue,
 } from "@chakra-ui/react";
 import { IoMdCheckmark } from "@react-icons/all-files/io/IoMdCheckmark";
+import { useClipboard } from "hooks/useClipboard";
 import { Highlight, Prism, themes } from "prism-react-renderer";
 import { FiCopy } from "react-icons/fi";
 import { Text } from "./text";


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add the `useClipboard` hook to various components and update existing imports.

### Detailed summary
- Added `useClipboard` hook to multiple components
- Updated imports for `useClipboard` hook
- Created `useClipboard` hook in `useClipboard.ts` file

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->