### PR TITLE
Add missing posthogCloud.init on app router

### DIFF
--- a/apps/dashboard/src/app/components/root-providers.tsx
+++ b/apps/dashboard/src/app/components/root-providers.tsx
@@ -1,9 +1,22 @@
 // app/providers.tsx
 "use client";
+import posthogCloud from "posthog-js";
 import posthog from "posthog-js-opensource";
 import { PostHogProvider as PHProvider } from "posthog-js-opensource/react";
 
 if (typeof window !== "undefined") {
+  posthogCloud.init(
+    process.env.NEXT_PUBLIC_POSTHOG_CLOUD_API_KEY ||
+      "phc_oXH0qpLTaotkIQP5MdaWhtoOXvh1Iba7yNSQrLgWbLN",
+    {
+      api_host: "https://pg.paper.xyz",
+      autocapture: false,
+      debug: false,
+      capture_pageview: false,
+      disable_session_recording: true,
+    },
+  );
+
   posthog.init(
     process.env.NEXT_PUBLIC_POSTHOG_API_KEY ||
       "phc_hKK4bo8cHZrKuAVXfXGpfNSLSJuucUnguAgt2j6dgSV",


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds PostHog analytics providers for both PostHog Cloud and open-source versions in a React app.

### Detailed summary
- Added PostHog Cloud provider initialization with specific configurations
- Added PostHog open-source provider initialization with default configurations

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->