### PR TITLE
cleanup posthog

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -75,7 +75,7 @@
     "nextjs-toploader": "^1.6.12",
     "papaparse": "^5.4.1",
     "pluralize": "^8.0.0",
-    "posthog-js-opensource": "npm:posthog-js@1.67.1",
+    "posthog-js": "1.67.1",
     "prism-react-renderer": "^2.3.1",
     "prismjs": "^1.29.0",
     "qrcode": "^1.5.3",

--- a/apps/dashboard/src/app/components/posthog-pageview.tsx
+++ b/apps/dashboard/src/app/components/posthog-pageview.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import { usePathname, useSearchParams } from "next/navigation";
-import { usePostHog } from "posthog-js-opensource/react";
+import { usePostHog } from "posthog-js/react";
 import { useEffect } from "react";
 
 export default function PostHogPageView(): null {

--- a/apps/dashboard/src/app/components/root-providers.tsx
+++ b/apps/dashboard/src/app/components/root-providers.tsx
@@ -1,7 +1,7 @@
 // app/providers.tsx
 "use client";
-import posthog from "posthog-js-opensource";
-import { PostHogProvider as PHProvider } from "posthog-js-opensource/react";
+import posthog from "posthog-js";
+import { PostHogProvider as PHProvider } from "posthog-js/react";
 
 if (typeof window !== "undefined") {
   posthog.init(

--- a/apps/dashboard/src/components/wallets/PosthogIdentifier.tsx
+++ b/apps/dashboard/src/components/wallets/PosthogIdentifier.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useThirdwebClient } from "@/constants/thirdweb.client";
-import posthog from "posthog-js-opensource";
+import posthog from "posthog-js";
 import { useEffect } from "react";
 import {
   useActiveAccount,

--- a/apps/dashboard/src/hooks/analytics/useTrack.ts
+++ b/apps/dashboard/src/hooks/analytics/useTrack.ts
@@ -1,5 +1,5 @@
 import { flatten } from "flat";
-import posthog from "posthog-js-opensource";
+import posthog from "posthog-js";
 import { useCallback } from "react";
 
 type TExtendedTrackParams = {

--- a/apps/dashboard/src/hooks/useBuildId.ts
+++ b/apps/dashboard/src/hooks/useBuildId.ts
@@ -1,4 +1,4 @@
-import posthog from "posthog-js-opensource";
+import posthog from "posthog-js";
 import { useCallback } from "react";
 
 export const useBuildId = () => {

--- a/apps/dashboard/src/pages/_app.tsx
+++ b/apps/dashboard/src/pages/_app.tsx
@@ -15,7 +15,7 @@ import {
 } from "next/font/google";
 import { useRouter } from "next/router";
 import { PageId } from "page-id";
-import posthogOpenSource from "posthog-js-opensource";
+import posthog from "posthog-js";
 import { memo, useEffect, useMemo, useRef } from "react";
 import { generateBreakpointTypographyCssVars } from "tw-components/utils/typography";
 import type { ThirdwebNextPage } from "utils/types";
@@ -107,7 +107,7 @@ const ConsoleAppWrapper: React.FC<AppPropsWithLayout> = ({
   // eslint-disable-next-line no-restricted-syntax
   useEffect(() => {
     // Init PostHog
-    posthogOpenSource.init(
+    posthog.init(
       process.env.NEXT_PUBLIC_POSTHOG_API_KEY ||
         "phc_hKK4bo8cHZrKuAVXfXGpfNSLSJuucUnguAgt2j6dgSV",
       {
@@ -119,12 +119,12 @@ const ConsoleAppWrapper: React.FC<AppPropsWithLayout> = ({
       },
     );
     // register the git commit sha on all subsequent events
-    posthogOpenSource.register({
+    posthog.register({
       tw_dashboard_version: process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA,
     });
     // defer session recording start by 2 seconds because it synchronously loads JS
     const t = setTimeout(() => {
-      posthogOpenSource.startSessionRecording();
+      posthog.startSessionRecording();
     }, 2_000);
     return () => {
       clearTimeout(t);
@@ -145,11 +145,11 @@ const ConsoleAppWrapper: React.FC<AppPropsWithLayout> = ({
     if (pageId === prevPageId.current) {
       return;
     }
-    posthogOpenSource.register({
+    posthog.register({
       page_id: pageId,
       previous_page_id: prevPageId.current,
     });
-    posthogOpenSource.capture("$pageview");
+    posthog.capture("$pageview");
     return () => {
       prevPageId.current = pageId;
     };

--- a/apps/dashboard/src/utils/errorParser.tsx
+++ b/apps/dashboard/src/utils/errorParser.tsx
@@ -1,5 +1,5 @@
 import { Flex, Link } from "@chakra-ui/react";
-import posthog from "posthog-js-opensource";
+import posthog from "posthog-js";
 import { Text } from "tw-components";
 
 const PLEASE_REACH_OUT_MESSAGE = (

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -36,7 +36,7 @@
     "next": "14.2.12",
     "nextjs-toploader": "^1.6.12",
     "node-html-parser": "^6.1.13",
-    "posthog-js": "1.161.6",
+    "posthog-js": "1.67.1",
     "prettier": "^3.3.2",
     "react": "18.3.1",
     "react-dom": "18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,7 +184,7 @@ importers:
         version: 4.1.0(react@18.3.1)
       '@sentry/nextjs':
         specifier: 8.30.0
-        version: 8.30.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.26.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.53.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.26.0(@opentelemetry/api@1.9.0))(next@14.2.12(@babel/core@7.25.2)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.94.0(@swc/core@1.7.26)(esbuild@0.23.1))
+        version: 8.30.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.26.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.53.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.26.0(@opentelemetry/api@1.9.0))(next@14.2.12(@babel/core@7.25.2)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1))
       '@shazow/whatsabi':
         specifier: ^0.14.1
         version: 0.14.1(@noble/hashes@1.5.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
@@ -269,9 +269,9 @@ importers:
       pluralize:
         specifier: ^8.0.0
         version: 8.0.0
-      posthog-js-opensource:
-        specifier: npm:posthog-js@1.67.1
-        version: posthog-js@1.67.1
+      posthog-js:
+        specifier: 1.67.1
+        version: 1.67.1
       prism-react-renderer:
         specifier: ^2.3.1
         version: 2.4.0(react@18.3.1)
@@ -340,7 +340,7 @@ importers:
         version: 2.5.2
       tailwindcss-animate:
         specifier: ^1.0.7
-        version: 1.0.7(tailwindcss@3.4.12(ts-node@10.9.2(@types/node@20.14.9)(typescript@5.6.2)))
+        version: 1.0.7(tailwindcss@3.4.12(ts-node@10.9.2(@swc/core@1.7.26(@swc/helpers@0.5.5))(@types/node@20.14.9)(typescript@5.6.2)))
       thirdweb:
         specifier: workspace:*
         version: link:../../packages/thirdweb
@@ -389,7 +389,7 @@ importers:
         version: 8.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@storybook/nextjs':
         specifier: 8.3.1
-        version: 8.3.1(@swc/core@1.7.26)(esbuild@0.23.1)(next@14.2.12(@babel/core@7.25.2)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(type-fest@4.26.1)(typescript@5.6.2)(webpack-hot-middleware@2.26.1)(webpack@5.94.0(@swc/core@1.7.26)(esbuild@0.23.1))
+        version: 8.3.1(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1)(next@14.2.12(@babel/core@7.25.2)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(type-fest@4.26.1)(typescript@5.6.2)(webpack-hot-middleware@2.26.1)(webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1))
       '@storybook/react':
         specifier: 8.3.1
         version: 8.3.1(@storybook/test@8.3.1(storybook@8.3.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@5.6.2)
@@ -437,7 +437,7 @@ importers:
         version: 10.4.20(postcss@8.4.47)
       checkly:
         specifier: ^4.8.1
-        version: 4.9.0(@swc/core@1.7.26)(@types/node@20.14.9)(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@5.0.10)
+        version: 4.9.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(@types/node@20.14.9)(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@5.0.10)
       eslint:
         specifier: 8.57.0
         version: 8.57.0
@@ -461,7 +461,7 @@ importers:
         version: 8.3.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       tailwindcss:
         specifier: 3.4.12
-        version: 3.4.12(ts-node@10.9.2(@types/node@20.14.9)(typescript@5.6.2))
+        version: 3.4.12(ts-node@10.9.2(@swc/core@1.7.26(@swc/helpers@0.5.5))(@types/node@20.14.9)(typescript@5.6.2))
       typescript:
         specifier: 5.6.2
         version: 5.6.2
@@ -573,10 +573,10 @@ importers:
         version: 8.4.47
       tailwindcss:
         specifier: 3.4.12
-        version: 3.4.12(ts-node@10.9.2(@types/node@20.14.9)(typescript@5.6.2))
+        version: 3.4.12(ts-node@10.9.2(@swc/core@1.7.26(@swc/helpers@0.5.5))(@types/node@20.14.9)(typescript@5.6.2))
       tailwindcss-animate:
         specifier: ^1.0.7
-        version: 1.0.7(tailwindcss@3.4.12(ts-node@10.9.2(@types/node@20.14.9)(typescript@5.6.2)))
+        version: 1.0.7(tailwindcss@3.4.12(ts-node@10.9.2(@swc/core@1.7.26(@swc/helpers@0.5.5))(@types/node@20.14.9)(typescript@5.6.2)))
       typescript:
         specifier: 5.6.2
         version: 5.6.2
@@ -588,13 +588,13 @@ importers:
         version: 1.0.0(react@18.3.1)
       '@mdx-js/loader':
         specifier: ^2.3.0
-        version: 2.3.0(webpack@5.94.0)
+        version: 2.3.0(webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5)))
       '@mdx-js/react':
         specifier: ^2.3.0
         version: 2.3.0(react@18.3.1)
       '@next/mdx':
         specifier: ^13.5.6
-        version: 13.5.6(@mdx-js/loader@2.3.0(webpack@5.94.0))(@mdx-js/react@2.3.0(react@18.3.1))
+        version: 13.5.6(@mdx-js/loader@2.3.0(webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))))(@mdx-js/react@2.3.0(react@18.3.1))
       '@radix-ui/react-dialog':
         specifier: 1.1.1
         version: 1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -644,8 +644,8 @@ importers:
         specifier: ^6.1.13
         version: 6.1.13
       posthog-js:
-        specifier: 1.161.6
-        version: 1.161.6
+        specifier: 1.67.1
+        version: 1.67.1
       prettier:
         specifier: ^3.3.2
         version: 3.3.3
@@ -678,7 +678,7 @@ importers:
         version: 2.5.2
       tailwindcss-animate:
         specifier: ^1.0.7
-        version: 1.0.7(tailwindcss@3.4.12(ts-node@10.9.2(@types/node@20.14.9)(typescript@5.6.2)))
+        version: 1.0.7(tailwindcss@3.4.12(ts-node@10.9.2(@swc/core@1.7.26(@swc/helpers@0.5.5))(@types/node@20.14.9)(typescript@5.6.2)))
       thirdweb:
         specifier: workspace:*
         version: link:../../packages/thirdweb
@@ -733,7 +733,7 @@ importers:
         version: 1.2.4
       eslint-plugin-tailwindcss:
         specifier: ^3.15.1
-        version: 3.17.4(tailwindcss@3.4.12(ts-node@10.9.2(@types/node@20.14.9)(typescript@5.6.2)))
+        version: 3.17.4(tailwindcss@3.4.12(ts-node@10.9.2(@swc/core@1.7.26(@swc/helpers@0.5.5))(@types/node@20.14.9)(typescript@5.6.2)))
       next-sitemap:
         specifier: ^4.2.3
         version: 4.2.3(next@14.2.12(@opentelemetry/api@1.9.0)(@playwright/test@1.47.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
@@ -742,7 +742,7 @@ importers:
         version: 8.4.47
       tailwindcss:
         specifier: 3.4.12
-        version: 3.4.12(ts-node@10.9.2(@types/node@20.14.9)(typescript@5.6.2))
+        version: 3.4.12(ts-node@10.9.2(@swc/core@1.7.26(@swc/helpers@0.5.5))(@types/node@20.14.9)(typescript@5.6.2))
       tsx:
         specifier: ^4.19.1
         version: 4.19.1
@@ -811,7 +811,7 @@ importers:
         version: 2.5.2
       tailwindcss-animate:
         specifier: ^1.0.7
-        version: 1.0.7(tailwindcss@3.4.12(ts-node@10.9.2(@types/node@20.14.9)(typescript@5.6.2)))
+        version: 1.0.7(tailwindcss@3.4.12(ts-node@10.9.2(@swc/core@1.7.26(@swc/helpers@0.5.5))(@types/node@20.14.9)(typescript@5.6.2)))
       thirdweb:
         specifier: workspace:*
         version: link:../../packages/thirdweb
@@ -842,7 +842,7 @@ importers:
         version: 8.4.47
       tailwindcss:
         specifier: 3.4.12
-        version: 3.4.12(ts-node@10.9.2(@types/node@20.14.9)(typescript@5.6.2))
+        version: 3.4.12(ts-node@10.9.2(@swc/core@1.7.26(@swc/helpers@0.5.5))(@types/node@20.14.9)(typescript@5.6.2))
       typescript:
         specifier: 5.6.2
         version: 5.6.2
@@ -12943,18 +12943,12 @@ packages:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
 
-  posthog-js@1.161.6:
-    resolution: {integrity: sha512-UO0z/YTuan55Kl5Yg9Xs5x1PKUkm2zGKUNPioznb4GLRcxFnLBkWoeKQXNro2YZsYJvK+MY8jlF3cdGa8BZ8/Q==}
-
   posthog-js@1.67.1:
     resolution: {integrity: sha512-gvdCVrrxoRYbtNTCUt2/YdZ+tfSfzcl72ym/dtRVCYJpwlCUIKnNJ3E2g7Bbw1+Ki6CvGxdu9r7jHIWnvJAMuw==}
     deprecated: This version of posthog-js is deprecated, please update posthog-js, and do not use this version! Check out our JS docs at https://posthog.com/docs/libraries/js
 
   preact@10.23.2:
     resolution: {integrity: sha512-kKYfePf9rzKnxOAKDpsWhg/ysrHPqT+yQ7UW4JjdnqjFIeNUnNcEJvhuA8fDenxAGWzUqtd51DfVg7xp/8T9NA==}
-
-  preact@10.24.0:
-    resolution: {integrity: sha512-aK8Cf+jkfyuZ0ZZRG9FbYqwmEiGQ4y/PUO4SuTWoyWL244nZZh7bd5h2APd4rSNDYTBNghg1L+5iJN3Skxtbsw==}
 
   prebuild-install@7.1.2:
     resolution: {integrity: sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==}
@@ -15393,9 +15387,6 @@ packages:
 
   web-tree-sitter@0.20.3:
     resolution: {integrity: sha512-zKGJW9r23y3BcJusbgvnOH2OYAW40MXAOi9bi3Gcc7T4Gms9WWgXF8m6adsJWpGJEhgOzCrfiz1IzKowJWrtYw==}
-
-  web-vitals@4.2.3:
-    resolution: {integrity: sha512-/CFAm1mNxSmOj6i0Co+iGFJ58OS4NRGVP+AWS/l509uIK5a1bSoIVaHz/ZumpHTfHSZBpgrJ+wjfpAOrTHok5Q==}
 
   webauthn-p256@0.0.5:
     resolution: {integrity: sha512-drMGNWKdaixZNobeORVIqq7k5DsRC9FnG201K2QjeOoQLmtSDaSsVZdkg6n5jUALJKcAG++zBPJXmv6hy0nWFg==}
@@ -22376,11 +22367,11 @@ snapshots:
       jju: 1.4.0
       read-yaml-file: 1.1.0
 
-  '@mdx-js/loader@2.3.0(webpack@5.94.0)':
+  '@mdx-js/loader@2.3.0(webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5)))':
     dependencies:
       '@mdx-js/mdx': 2.3.0
       source-map: 0.7.4
-      webpack: 5.94.0
+      webpack: 5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))
     transitivePeerDependencies:
       - supports-color
 
@@ -22536,11 +22527,11 @@ snapshots:
     dependencies:
       glob: 10.3.10
 
-  '@next/mdx@13.5.6(@mdx-js/loader@2.3.0(webpack@5.94.0))(@mdx-js/react@2.3.0(react@18.3.1))':
+  '@next/mdx@13.5.6(@mdx-js/loader@2.3.0(webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))))(@mdx-js/react@2.3.0(react@18.3.1))':
     dependencies:
       source-map: 0.7.4
     optionalDependencies:
-      '@mdx-js/loader': 2.3.0(webpack@5.94.0)
+      '@mdx-js/loader': 2.3.0(webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5)))
       '@mdx-js/react': 2.3.0(react@18.3.1)
 
   '@next/swc-darwin-arm64@14.2.12':
@@ -22699,7 +22690,7 @@ snapshots:
       widest-line: 3.1.0
       wrap-ansi: 7.0.0
 
-  '@oclif/core@2.8.11(@swc/core@1.7.26)(@types/node@20.14.9)(typescript@5.6.2)':
+  '@oclif/core@2.8.11(@swc/core@1.7.26(@swc/helpers@0.5.5))(@types/node@20.14.9)(typescript@5.6.2)':
     dependencies:
       '@types/cli-progress': 3.11.5
       ansi-escapes: 4.3.2
@@ -22725,7 +22716,7 @@ snapshots:
       strip-ansi: 6.0.1
       supports-color: 8.1.1
       supports-hyperlinks: 2.3.0
-      ts-node: 10.9.2(@swc/core@1.7.26)(@types/node@20.14.9)(typescript@5.6.2)
+      ts-node: 10.9.2(@swc/core@1.7.26(@swc/helpers@0.5.5))(@types/node@20.14.9)(typescript@5.6.2)
       tslib: 2.7.0
       widest-line: 3.1.0
       wordwrap: 1.0.0
@@ -22762,10 +22753,10 @@ snapshots:
     dependencies:
       '@oclif/core': 1.26.2
 
-  '@oclif/plugin-not-found@2.3.23(@swc/core@1.7.26)(@types/node@20.14.9)(typescript@5.6.2)':
+  '@oclif/plugin-not-found@2.3.23(@swc/core@1.7.26(@swc/helpers@0.5.5))(@types/node@20.14.9)(typescript@5.6.2)':
     dependencies:
       '@oclif/color': 1.0.13
-      '@oclif/core': 2.8.11(@swc/core@1.7.26)(@types/node@20.14.9)(typescript@5.6.2)
+      '@oclif/core': 2.8.11(@swc/core@1.7.26(@swc/helpers@0.5.5))(@types/node@20.14.9)(typescript@5.6.2)
       fast-levenshtein: 3.0.0
       lodash: 4.17.21
     transitivePeerDependencies:
@@ -22790,9 +22781,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@oclif/plugin-warn-if-update-available@2.0.24(@swc/core@1.7.26)(@types/node@20.14.9)(typescript@5.6.2)':
+  '@oclif/plugin-warn-if-update-available@2.0.24(@swc/core@1.7.26(@swc/helpers@0.5.5))(@types/node@20.14.9)(typescript@5.6.2)':
     dependencies:
-      '@oclif/core': 2.8.11(@swc/core@1.7.26)(@types/node@20.14.9)(typescript@5.6.2)
+      '@oclif/core': 2.8.11(@swc/core@1.7.26(@swc/helpers@0.5.5))(@types/node@20.14.9)(typescript@5.6.2)
       chalk: 4.1.2
       debug: 4.3.6(supports-color@8.1.1)
       fs-extra: 9.1.0
@@ -23127,7 +23118,7 @@ snapshots:
     dependencies:
       playwright: 1.47.1
 
-  '@pmmmwh/react-refresh-webpack-plugin@0.5.15(react-refresh@0.14.2)(type-fest@4.26.1)(webpack-hot-middleware@2.26.1)(webpack@5.94.0(@swc/core@1.7.26)(esbuild@0.23.1))':
+  '@pmmmwh/react-refresh-webpack-plugin@0.5.15(react-refresh@0.14.2)(type-fest@4.26.1)(webpack-hot-middleware@2.26.1)(webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1))':
     dependencies:
       ansi-html: 0.0.9
       core-js-pure: 3.38.1
@@ -23137,7 +23128,7 @@ snapshots:
       react-refresh: 0.14.2
       schema-utils: 4.2.0
       source-map: 0.7.4
-      webpack: 5.94.0(@swc/core@1.7.26)(esbuild@0.23.1)
+      webpack: 5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1)
     optionalDependencies:
       type-fest: 4.26.1
       webpack-hot-middleware: 2.26.1
@@ -24750,7 +24741,7 @@ snapshots:
       '@sentry/types': 8.30.0
       '@sentry/utils': 8.30.0
 
-  '@sentry/nextjs@8.30.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.26.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.53.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.26.0(@opentelemetry/api@1.9.0))(next@14.2.12(@babel/core@7.25.2)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.94.0(@swc/core@1.7.26)(esbuild@0.23.1))':
+  '@sentry/nextjs@8.30.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.26.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.53.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.26.0(@opentelemetry/api@1.9.0))(next@14.2.12(@babel/core@7.25.2)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1))':
     dependencies:
       '@opentelemetry/instrumentation-http': 0.53.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.27.0
@@ -24762,14 +24753,14 @@ snapshots:
       '@sentry/types': 8.30.0
       '@sentry/utils': 8.30.0
       '@sentry/vercel-edge': 8.30.0
-      '@sentry/webpack-plugin': 2.22.3(webpack@5.94.0(@swc/core@1.7.26)(esbuild@0.23.1))
+      '@sentry/webpack-plugin': 2.22.3(webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1))
       chalk: 3.0.0
       next: 14.2.12(@babel/core@7.25.2)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       resolve: 1.22.8
       rollup: 3.29.4
       stacktrace-parser: 0.1.10
     optionalDependencies:
-      webpack: 5.94.0(@swc/core@1.7.26)(esbuild@0.23.1)
+      webpack: 5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/core'
@@ -24848,12 +24839,12 @@ snapshots:
       '@sentry/types': 8.30.0
       '@sentry/utils': 8.30.0
 
-  '@sentry/webpack-plugin@2.22.3(webpack@5.94.0(@swc/core@1.7.26)(esbuild@0.23.1))':
+  '@sentry/webpack-plugin@2.22.3(webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1))':
     dependencies:
       '@sentry/bundler-plugin-core': 2.22.3
       unplugin: 1.0.1
       uuid: 9.0.1
-      webpack: 5.94.0(@swc/core@1.7.26)(esbuild@0.23.1)
+      webpack: 5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -25501,7 +25492,7 @@ snapshots:
       - supports-color
       - webpack-sources
 
-  '@storybook/builder-webpack5@8.3.1(@swc/core@1.7.26)(esbuild@0.23.1)(storybook@8.3.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@5.6.2)':
+  '@storybook/builder-webpack5@8.3.1(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1)(storybook@8.3.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@5.6.2)':
     dependencies:
       '@storybook/core-webpack': 8.3.1(storybook@8.3.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@types/node': 22.5.5
@@ -25510,25 +25501,25 @@ snapshots:
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.4.1
       constants-browserify: 1.0.0
-      css-loader: 6.11.0(webpack@5.94.0(@swc/core@1.7.26)(esbuild@0.23.1))
+      css-loader: 6.11.0(webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1))
       es-module-lexer: 1.5.4
       express: 4.21.0
-      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.6.2)(webpack@5.94.0(@swc/core@1.7.26)(esbuild@0.23.1))
+      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.6.2)(webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1))
       fs-extra: 11.2.0
-      html-webpack-plugin: 5.6.0(webpack@5.94.0(@swc/core@1.7.26)(esbuild@0.23.1))
+      html-webpack-plugin: 5.6.0(webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1))
       magic-string: 0.30.11
       path-browserify: 1.0.1
       process: 0.11.10
       semver: 7.6.3
       storybook: 8.3.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      style-loader: 3.3.4(webpack@5.94.0(@swc/core@1.7.26)(esbuild@0.23.1))
-      terser-webpack-plugin: 5.3.10(@swc/core@1.7.26)(esbuild@0.23.1)(webpack@5.94.0(@swc/core@1.7.26)(esbuild@0.23.1))
+      style-loader: 3.3.4(webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1))
+      terser-webpack-plugin: 5.3.10(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1)(webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1))
       ts-dedent: 2.2.0
       url: 0.11.4
       util: 0.12.5
       util-deprecate: 1.0.2
-      webpack: 5.94.0(@swc/core@1.7.26)(esbuild@0.23.1)
-      webpack-dev-middleware: 6.1.3(webpack@5.94.0(@swc/core@1.7.26)(esbuild@0.23.1))
+      webpack: 5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1)
+      webpack-dev-middleware: 6.1.3(webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1))
       webpack-hot-middleware: 2.26.1
       webpack-virtual-modules: 0.6.2
     optionalDependencies:
@@ -25604,7 +25595,7 @@ snapshots:
     dependencies:
       storybook: 8.3.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
 
-  '@storybook/nextjs@8.3.1(@swc/core@1.7.26)(esbuild@0.23.1)(next@14.2.12(@babel/core@7.25.2)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(type-fest@4.26.1)(typescript@5.6.2)(webpack-hot-middleware@2.26.1)(webpack@5.94.0(@swc/core@1.7.26)(esbuild@0.23.1))':
+  '@storybook/nextjs@8.3.1(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1)(next@14.2.12(@babel/core@7.25.2)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(type-fest@4.26.1)(typescript@5.6.2)(webpack-hot-middleware@2.26.1)(webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1))':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.25.2)
@@ -25619,32 +25610,32 @@ snapshots:
       '@babel/preset-react': 7.24.7(@babel/core@7.25.2)
       '@babel/preset-typescript': 7.24.7(@babel/core@7.25.2)
       '@babel/runtime': 7.25.6
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(react-refresh@0.14.2)(type-fest@4.26.1)(webpack-hot-middleware@2.26.1)(webpack@5.94.0(@swc/core@1.7.26)(esbuild@0.23.1))
-      '@storybook/builder-webpack5': 8.3.1(@swc/core@1.7.26)(esbuild@0.23.1)(storybook@8.3.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@5.6.2)
-      '@storybook/preset-react-webpack': 8.3.1(@storybook/test@8.3.1(storybook@8.3.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)))(@swc/core@1.7.26)(esbuild@0.23.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@5.6.2)
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(react-refresh@0.14.2)(type-fest@4.26.1)(webpack-hot-middleware@2.26.1)(webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1))
+      '@storybook/builder-webpack5': 8.3.1(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1)(storybook@8.3.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@5.6.2)
+      '@storybook/preset-react-webpack': 8.3.1(@storybook/test@8.3.1(storybook@8.3.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)))(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@5.6.2)
       '@storybook/react': 8.3.1(@storybook/test@8.3.1(storybook@8.3.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@5.6.2)
       '@storybook/test': 8.3.1(storybook@8.3.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@types/node': 22.5.5
       '@types/semver': 7.5.8
-      babel-loader: 9.2.1(@babel/core@7.25.2)(webpack@5.94.0(@swc/core@1.7.26)(esbuild@0.23.1))
-      css-loader: 6.11.0(webpack@5.94.0(@swc/core@1.7.26)(esbuild@0.23.1))
+      babel-loader: 9.2.1(@babel/core@7.25.2)(webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1))
+      css-loader: 6.11.0(webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1))
       find-up: 5.0.0
       fs-extra: 11.2.0
       image-size: 1.1.1
       loader-utils: 3.3.1
       next: 14.2.12(@babel/core@7.25.2)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      node-polyfill-webpack-plugin: 2.0.1(webpack@5.94.0(@swc/core@1.7.26)(esbuild@0.23.1))
+      node-polyfill-webpack-plugin: 2.0.1(webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1))
       pnp-webpack-plugin: 1.7.0(typescript@5.6.2)
       postcss: 8.4.47
-      postcss-loader: 8.1.1(postcss@8.4.47)(typescript@5.6.2)(webpack@5.94.0(@swc/core@1.7.26)(esbuild@0.23.1))
+      postcss-loader: 8.1.1(postcss@8.4.47)(typescript@5.6.2)(webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-refresh: 0.14.2
       resolve-url-loader: 5.0.0
-      sass-loader: 13.3.3(webpack@5.94.0(@swc/core@1.7.26)(esbuild@0.23.1))
+      sass-loader: 13.3.3(webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1))
       semver: 7.6.3
       storybook: 8.3.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      style-loader: 3.3.4(webpack@5.94.0(@swc/core@1.7.26)(esbuild@0.23.1))
+      style-loader: 3.3.4(webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1))
       styled-jsx: 5.1.6(@babel/core@7.25.2)(react@18.3.1)
       ts-dedent: 2.2.0
       tsconfig-paths: 4.2.0
@@ -25652,7 +25643,7 @@ snapshots:
     optionalDependencies:
       sharp: 0.33.5
       typescript: 5.6.2
-      webpack: 5.94.0(@swc/core@1.7.26)(esbuild@0.23.1)
+      webpack: 5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1)
     transitivePeerDependencies:
       - '@rspack/core'
       - '@swc/core'
@@ -25672,11 +25663,11 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@storybook/preset-react-webpack@8.3.1(@storybook/test@8.3.1(storybook@8.3.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)))(@swc/core@1.7.26)(esbuild@0.23.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@5.6.2)':
+  '@storybook/preset-react-webpack@8.3.1(@storybook/test@8.3.1(storybook@8.3.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)))(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@5.6.2)':
     dependencies:
       '@storybook/core-webpack': 8.3.1(storybook@8.3.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@storybook/react': 8.3.1(@storybook/test@8.3.1(storybook@8.3.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@5.6.2)
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.6.2)(webpack@5.94.0(@swc/core@1.7.26)(esbuild@0.23.1))
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.6.2)(webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1))
       '@types/node': 22.5.5
       '@types/semver': 7.5.8
       find-up: 5.0.0
@@ -25689,7 +25680,7 @@ snapshots:
       semver: 7.6.3
       storybook: 8.3.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       tsconfig-paths: 4.2.0
-      webpack: 5.94.0(@swc/core@1.7.26)(esbuild@0.23.1)
+      webpack: 5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1)
     optionalDependencies:
       typescript: 5.6.2
     transitivePeerDependencies:
@@ -25704,7 +25695,7 @@ snapshots:
     dependencies:
       storybook: 8.3.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
 
-  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.6.2)(webpack@5.94.0(@swc/core@1.7.26)(esbuild@0.23.1))':
+  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.6.2)(webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1))':
     dependencies:
       debug: 4.3.7(supports-color@8.1.1)
       endent: 2.1.0
@@ -25714,7 +25705,7 @@ snapshots:
       react-docgen-typescript: 2.2.2(typescript@5.6.2)
       tslib: 2.7.0
       typescript: 5.6.2
-      webpack: 5.94.0(@swc/core@1.7.26)(esbuild@0.23.1)
+      webpack: 5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -26165,7 +26156,7 @@ snapshots:
   '@swc/core-win32-x64-msvc@1.7.26':
     optional: true
 
-  '@swc/core@1.7.26':
+  '@swc/core@1.7.26(@swc/helpers@0.5.5)':
     dependencies:
       '@swc/counter': 0.1.3
       '@swc/types': 0.1.12
@@ -26180,6 +26171,7 @@ snapshots:
       '@swc/core-win32-arm64-msvc': 1.7.26
       '@swc/core-win32-ia32-msvc': 1.7.26
       '@swc/core-win32-x64-msvc': 1.7.26
+      '@swc/helpers': 0.5.5
     optional: true
 
   '@swc/counter@0.1.3': {}
@@ -27786,12 +27778,12 @@ snapshots:
     dependencies:
       '@babel/core': 7.25.2
 
-  babel-loader@9.2.1(@babel/core@7.25.2)(webpack@5.94.0(@swc/core@1.7.26)(esbuild@0.23.1)):
+  babel-loader@9.2.1(@babel/core@7.25.2)(webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1)):
     dependencies:
       '@babel/core': 7.25.2
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
-      webpack: 5.94.0(@swc/core@1.7.26)(esbuild@0.23.1)
+      webpack: 5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1)
 
   babel-plugin-macros@3.1.0:
     dependencies:
@@ -28275,13 +28267,13 @@ snapshots:
 
   check-error@2.1.1: {}
 
-  checkly@4.9.0(@swc/core@1.7.26)(@types/node@20.14.9)(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@5.0.10):
+  checkly@4.9.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(@types/node@20.14.9)(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@5.0.10):
     dependencies:
-      '@oclif/core': 2.8.11(@swc/core@1.7.26)(@types/node@20.14.9)(typescript@5.6.2)
+      '@oclif/core': 2.8.11(@swc/core@1.7.26(@swc/helpers@0.5.5))(@types/node@20.14.9)(typescript@5.6.2)
       '@oclif/plugin-help': 5.1.20
-      '@oclif/plugin-not-found': 2.3.23(@swc/core@1.7.26)(@types/node@20.14.9)(typescript@5.6.2)
+      '@oclif/plugin-not-found': 2.3.23(@swc/core@1.7.26(@swc/helpers@0.5.5))(@types/node@20.14.9)(typescript@5.6.2)
       '@oclif/plugin-plugins': 5.4.4
-      '@oclif/plugin-warn-if-update-available': 2.0.24(@swc/core@1.7.26)(@types/node@20.14.9)(typescript@5.6.2)
+      '@oclif/plugin-warn-if-update-available': 2.0.24(@swc/core@1.7.26(@swc/helpers@0.5.5))(@types/node@20.14.9)(typescript@5.6.2)
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.6.2)
       acorn: 8.8.1
       acorn-walk: 8.2.0
@@ -28765,7 +28757,7 @@ snapshots:
 
   css-color-keywords@1.0.0: {}
 
-  css-loader@6.11.0(webpack@5.94.0(@swc/core@1.7.26)(esbuild@0.23.1)):
+  css-loader@6.11.0(webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.47)
       postcss: 8.4.47
@@ -28776,7 +28768,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.6.3
     optionalDependencies:
-      webpack: 5.94.0(@swc/core@1.7.26)(esbuild@0.23.1)
+      webpack: 5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1)
 
   css-select@4.3.0:
     dependencies:
@@ -29687,11 +29679,11 @@ snapshots:
 
   eslint-plugin-svg-jsx@1.2.4: {}
 
-  eslint-plugin-tailwindcss@3.17.4(tailwindcss@3.4.12(ts-node@10.9.2(@types/node@20.14.9)(typescript@5.6.2))):
+  eslint-plugin-tailwindcss@3.17.4(tailwindcss@3.4.12(ts-node@10.9.2(@swc/core@1.7.26(@swc/helpers@0.5.5))(@types/node@20.14.9)(typescript@5.6.2))):
     dependencies:
       fast-glob: 3.3.2
       postcss: 8.4.47
-      tailwindcss: 3.4.12(ts-node@10.9.2(@types/node@20.14.9)(typescript@5.6.2))
+      tailwindcss: 3.4.12(ts-node@10.9.2(@swc/core@1.7.26(@swc/helpers@0.5.5))(@types/node@20.14.9)(typescript@5.6.2))
 
   eslint-scope@5.1.1:
     dependencies:
@@ -30393,7 +30385,7 @@ snapshots:
       cross-spawn: 7.0.3
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.6.2)(webpack@5.94.0(@swc/core@1.7.26)(esbuild@0.23.1)):
+  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.6.2)(webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1)):
     dependencies:
       '@babel/code-frame': 7.24.7
       chalk: 4.1.2
@@ -30408,7 +30400,7 @@ snapshots:
       semver: 7.6.3
       tapable: 2.2.1
       typescript: 5.6.2
-      webpack: 5.94.0(@swc/core@1.7.26)(esbuild@0.23.1)
+      webpack: 5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1)
 
   form-data-encoder@2.1.4: {}
 
@@ -30938,7 +30930,7 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  html-webpack-plugin@5.6.0(webpack@5.94.0(@swc/core@1.7.26)(esbuild@0.23.1)):
+  html-webpack-plugin@5.6.0(webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -30946,7 +30938,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.2.1
     optionalDependencies:
-      webpack: 5.94.0(@swc/core@1.7.26)(esbuild@0.23.1)
+      webpack: 5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1)
 
   htmlparser2@3.10.1:
     dependencies:
@@ -33519,7 +33511,7 @@ snapshots:
       util: 0.11.1
       vm-browserify: 1.1.2
 
-  node-polyfill-webpack-plugin@2.0.1(webpack@5.94.0(@swc/core@1.7.26)(esbuild@0.23.1)):
+  node-polyfill-webpack-plugin@2.0.1(webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1)):
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -33546,7 +33538,7 @@ snapshots:
       url: 0.11.4
       util: 0.12.5
       vm-browserify: 1.1.2
-      webpack: 5.94.0(@swc/core@1.7.26)(esbuild@0.23.1)
+      webpack: 5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1)
 
   node-releases@2.0.18: {}
 
@@ -34152,22 +34144,22 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.4.47
 
-  postcss-load-config@4.0.2(postcss@8.4.47)(ts-node@10.9.2(@types/node@20.14.9)(typescript@5.6.2)):
+  postcss-load-config@4.0.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.7.26(@swc/helpers@0.5.5))(@types/node@20.14.9)(typescript@5.6.2)):
     dependencies:
       lilconfig: 3.1.2
       yaml: 2.5.1
     optionalDependencies:
       postcss: 8.4.47
-      ts-node: 10.9.2(@swc/core@1.7.26)(@types/node@20.14.9)(typescript@5.6.2)
+      ts-node: 10.9.2(@swc/core@1.7.26(@swc/helpers@0.5.5))(@types/node@20.14.9)(typescript@5.6.2)
 
-  postcss-loader@8.1.1(postcss@8.4.47)(typescript@5.6.2)(webpack@5.94.0(@swc/core@1.7.26)(esbuild@0.23.1)):
+  postcss-loader@8.1.1(postcss@8.4.47)(typescript@5.6.2)(webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1)):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.6.2)
       jiti: 1.21.6
       postcss: 8.4.47
       semver: 7.6.3
     optionalDependencies:
-      webpack: 5.94.0(@swc/core@1.7.26)(esbuild@0.23.1)
+      webpack: 5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1)
     transitivePeerDependencies:
       - typescript
 
@@ -34226,19 +34218,11 @@ snapshots:
     dependencies:
       xtend: 4.0.2
 
-  posthog-js@1.161.6:
-    dependencies:
-      fflate: 0.4.8
-      preact: 10.24.0
-      web-vitals: 4.2.3
-
   posthog-js@1.67.1:
     dependencies:
       fflate: 0.4.8
 
   preact@10.23.2: {}
-
-  preact@10.24.0: {}
 
   prebuild-install@7.1.2:
     dependencies:
@@ -35455,10 +35439,10 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@13.3.3(webpack@5.94.0(@swc/core@1.7.26)(esbuild@0.23.1)):
+  sass-loader@13.3.3(webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1)):
     dependencies:
       neo-async: 2.6.2
-      webpack: 5.94.0(@swc/core@1.7.26)(esbuild@0.23.1)
+      webpack: 5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1)
 
   satori@0.10.9:
     dependencies:
@@ -36001,9 +35985,9 @@ snapshots:
 
   structured-headers@0.4.1: {}
 
-  style-loader@3.3.4(webpack@5.94.0(@swc/core@1.7.26)(esbuild@0.23.1)):
+  style-loader@3.3.4(webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1)):
     dependencies:
-      webpack: 5.94.0(@swc/core@1.7.26)(esbuild@0.23.1)
+      webpack: 5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1)
 
   style-to-object@0.4.4:
     dependencies:
@@ -36152,11 +36136,11 @@ snapshots:
 
   tailwind-merge@2.5.2: {}
 
-  tailwindcss-animate@1.0.7(tailwindcss@3.4.12(ts-node@10.9.2(@types/node@20.14.9)(typescript@5.6.2))):
+  tailwindcss-animate@1.0.7(tailwindcss@3.4.12(ts-node@10.9.2(@swc/core@1.7.26(@swc/helpers@0.5.5))(@types/node@20.14.9)(typescript@5.6.2))):
     dependencies:
-      tailwindcss: 3.4.12(ts-node@10.9.2(@types/node@20.14.9)(typescript@5.6.2))
+      tailwindcss: 3.4.12(ts-node@10.9.2(@swc/core@1.7.26(@swc/helpers@0.5.5))(@types/node@20.14.9)(typescript@5.6.2))
 
-  tailwindcss@3.4.12(ts-node@10.9.2(@types/node@20.14.9)(typescript@5.6.2)):
+  tailwindcss@3.4.12(ts-node@10.9.2(@swc/core@1.7.26(@swc/helpers@0.5.5))(@types/node@20.14.9)(typescript@5.6.2)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -36175,7 +36159,7 @@ snapshots:
       postcss: 8.4.47
       postcss-import: 15.1.0(postcss@8.4.47)
       postcss-js: 4.0.1(postcss@8.4.47)
-      postcss-load-config: 4.0.2(postcss@8.4.47)(ts-node@10.9.2(@types/node@20.14.9)(typescript@5.6.2))
+      postcss-load-config: 4.0.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.7.26(@swc/helpers@0.5.5))(@types/node@20.14.9)(typescript@5.6.2))
       postcss-nested: 6.0.1(postcss@8.4.47)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.8
@@ -36266,17 +36250,28 @@ snapshots:
       ansi-escapes: 4.3.2
       supports-hyperlinks: 2.3.0
 
-  terser-webpack-plugin@5.3.10(@swc/core@1.7.26)(esbuild@0.23.1)(webpack@5.94.0(@swc/core@1.7.26)(esbuild@0.23.1)):
+  terser-webpack-plugin@5.3.10(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1)(webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
       terser: 5.32.0
-      webpack: 5.94.0(@swc/core@1.7.26)(esbuild@0.23.1)
+      webpack: 5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1)
     optionalDependencies:
-      '@swc/core': 1.7.26
+      '@swc/core': 1.7.26(@swc/helpers@0.5.5)
       esbuild: 0.23.1
+
+  terser-webpack-plugin@5.3.10(@swc/core@1.7.26(@swc/helpers@0.5.5))(webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.25
+      jest-worker: 27.5.1
+      schema-utils: 3.3.0
+      serialize-javascript: 6.0.2
+      terser: 5.32.0
+      webpack: 5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))
+    optionalDependencies:
+      '@swc/core': 1.7.26(@swc/helpers@0.5.5)
 
   terser-webpack-plugin@5.3.10(webpack@5.94.0):
     dependencies:
@@ -36436,7 +36431,7 @@ snapshots:
 
   ts-mixer@6.0.4: {}
 
-  ts-node@10.9.2(@swc/core@1.7.26)(@types/node@20.14.9)(typescript@5.6.2):
+  ts-node@10.9.2(@swc/core@1.7.26(@swc/helpers@0.5.5))(@types/node@20.14.9)(typescript@5.6.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -36454,7 +36449,7 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optionalDependencies:
-      '@swc/core': 1.7.26
+      '@swc/core': 1.7.26(@swc/helpers@0.5.5)
 
   ts-pnp@1.2.0(typescript@5.6.2):
     optionalDependencies:
@@ -37282,8 +37277,6 @@ snapshots:
   web-tree-sitter@0.20.3:
     optional: true
 
-  web-vitals@4.2.3: {}
-
   webauthn-p256@0.0.5:
     dependencies:
       '@noble/curves': 1.4.0
@@ -37314,7 +37307,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  webpack-dev-middleware@6.1.3(webpack@5.94.0(@swc/core@1.7.26)(esbuild@0.23.1)):
+  webpack-dev-middleware@6.1.3(webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1)):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3
@@ -37322,7 +37315,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.2.0
     optionalDependencies:
-      webpack: 5.94.0(@swc/core@1.7.26)(esbuild@0.23.1)
+      webpack: 5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1)
 
   webpack-hot-middleware@2.26.1:
     dependencies:
@@ -37366,7 +37359,7 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpack@5.94.0(@swc/core@1.7.26)(esbuild@0.23.1):
+  webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5)):
     dependencies:
       '@types/estree': 1.0.5
       '@webassemblyjs/ast': 1.12.1
@@ -37388,7 +37381,37 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(@swc/core@1.7.26)(esbuild@0.23.1)(webpack@5.94.0(@swc/core@1.7.26)(esbuild@0.23.1))
+      terser-webpack-plugin: 5.3.10(@swc/core@1.7.26(@swc/helpers@0.5.5))(webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5)))
+      watchpack: 2.4.2
+      webpack-sources: 3.2.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+
+  webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1):
+    dependencies:
+      '@types/estree': 1.0.5
+      '@webassemblyjs/ast': 1.12.1
+      '@webassemblyjs/wasm-edit': 1.12.1
+      '@webassemblyjs/wasm-parser': 1.12.1
+      acorn: 8.12.1
+      acorn-import-attributes: 1.9.5(acorn@8.12.1)
+      browserslist: 4.23.3
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.17.1
+      es-module-lexer: 1.5.4
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.0
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 3.3.0
+      tapable: 2.2.1
+      terser-webpack-plugin: 5.3.10(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1)(webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.5))(esbuild@0.23.1))
       watchpack: 2.4.2
       webpack-sources: 3.2.3
     transitivePeerDependencies:


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update `posthog-js` dependencies and replace `posthog-js-opensource` with `posthog-js` across the codebase.

### Detailed summary
- Updated `posthog-js` version to "1.67.1"
- Replaced `posthog-js-opensource` with `posthog-js` in multiple files
- Updated dependencies in `package.json` files

> The following files were skipped due to too many changes: `pnpm-lock.yaml`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->