### PR TITLE
[Playground] Chore: Allow overriding default domains with env vars

### DIFF
--- a/apps/playground-web/src/lib/client.ts
+++ b/apps/playground-web/src/lib/client.ts
@@ -1,4 +1,14 @@
 import { createThirdwebClient } from "thirdweb";
+import { setThirdwebDomains } from "thirdweb/utils";
+
+setThirdwebDomains({
+  inAppWallet: process.env.NEXT_PUBLIC_IN_APP_WALLET_URL,
+  rpc: process.env.NEXT_PUBLIC_RPC_URL,
+  social: process.env.NEXT_PUBLIC_SOCIAL_URL,
+  storage: process.env.NEXT_PUBLIC_STORAGE_URL,
+  bundler: process.env.NEXT_PUBLIC_BUNDLER_URL,
+  pay: process.env.NEXT_PUBLIC_PAY_URL,
+});
 
 export const THIRDWEB_CLIENT = createThirdwebClient(
   process.env.THIRDWEB_SECRET_KEY


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to set Thirdweb domains dynamically based on environment variables.

### Detailed summary
- Added import for `setThirdwebDomains` from "thirdweb/utils"
- Dynamically set Thirdweb domains using environment variables for inAppWallet, rpc, social, storage, bundler, and pay
- Utilized environment variable for Thirdweb secret key in creating Thirdweb client

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->