### PR TITLE
[Playground] Fix: do not disconnect non in app wallets

### DIFF
--- a/apps/playground-web/src/components/in-app-wallet/sponsored-tx.tsx
+++ b/apps/playground-web/src/components/in-app-wallet/sponsored-tx.tsx
@@ -1,26 +1,16 @@
 "use client";
 
-import { useEffect } from "react";
 import { claimTo, getNFT, getOwnedNFTs } from "thirdweb/extensions/erc1155";
 import {
   MediaRenderer,
   TransactionButton,
   useActiveAccount,
-  useActiveWallet,
-  useDisconnect,
   useReadContract,
 } from "thirdweb/react";
 import { THIRDWEB_CLIENT } from "../../lib/client";
 import { editionDropContract, editionDropTokenId } from "./constants";
 
 export function SponsoredInAppTxPreview() {
-  const wallet = useActiveWallet();
-  const { disconnect } = useDisconnect();
-  useEffect(() => {
-    if (wallet && wallet.id !== "inApp") {
-      disconnect(wallet);
-    }
-  }, [wallet, disconnect]);
   const smartAccount = useActiveAccount();
   const { data: nft, isLoading: isNftLoading } = useReadContract(getNFT, {
     contract: editionDropContract,


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to remove unused code related to wallet management in the `SponsoredInAppTxPreview` component.

### Detailed summary
- Removed unused `useActiveWallet` and `useDisconnect` hooks
- Removed `useEffect` related to wallet management and disconnection

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->