### PR TITLE
[React] Fix: hides guest accounts from linked profiles

### DIFF
--- a/.changeset/quiet-mangos-wave.md
+++ b/.changeset/quiet-mangos-wave.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+React: Hides guest accounts from linked profiles screen

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/LinkedProfilesScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/LinkedProfilesScreen.tsx
@@ -88,13 +88,16 @@ export function LinkedProfilesScreen(props: {
               </Text>
             </MenuButton>
             <Spacer y="xs" />
-            {connectedProfiles?.map((profile) => (
-              <LinkedProfile
-                key={`${profile.type}-${getProfileDisplayName(profile)}`}
-                profile={profile}
-                client={props.client}
-              />
-            ))}
+            {/* Exclude guest as a profile */}
+            {connectedProfiles
+              ?.filter((profile) => profile.type !== "guest")
+              .map((profile) => (
+                <LinkedProfile
+                  key={`${profile.type}-${getProfileDisplayName(profile)}`}
+                  profile={profile}
+                  client={props.client}
+                />
+              ))}
           </Container>
           <Spacer y="md" />
         </Container>


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on hiding guest accounts from the linked profiles screen in the React application.

### Detailed summary
- Updated LinkedProfilesScreen to exclude guest profiles from being displayed
- Implemented filtering logic to exclude guest profiles from the connected profiles list

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->