### PR TITLE
Fix getClaimConditions for ERC20, ERC721, and ERC1155

### DIFF
--- a/.changeset/stale-lamps-deliver.md
+++ b/.changeset/stale-lamps-deliver.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+fix `getClaimConditions` extension for erc20, erc721 and erc1155

--- a/packages/thirdweb/src/extensions/erc1155/drops/read/getClaimConditions.ts
+++ b/packages/thirdweb/src/extensions/erc1155/drops/read/getClaimConditions.ts
@@ -27,7 +27,7 @@ export async function getClaimConditions(
     const conditionPromises: Array<
       ReturnType<typeof MultiById.getClaimConditionById>
     > = [];
-    for (let i = startId; i < count; i++) {
+    for (let i = startId; i < startId + count; i++) {
       conditionPromises.push(
         MultiById.getClaimConditionById({
           ...options,

--- a/packages/thirdweb/src/extensions/erc20/drops/read/getClaimConditions.ts
+++ b/packages/thirdweb/src/extensions/erc20/drops/read/getClaimConditions.ts
@@ -24,7 +24,7 @@ export async function getClaimConditions(
     const conditionPromises: Array<
       ReturnType<typeof MultiById.getClaimConditionById>
     > = [];
-    for (let i = startId; i < count; i++) {
+    for (let i = startId; i < startId + count; i++) {
       conditionPromises.push(
         MultiById.getClaimConditionById({
           ...options,

--- a/packages/thirdweb/src/extensions/erc721/drops/read/getClaimConditions.ts
+++ b/packages/thirdweb/src/extensions/erc721/drops/read/getClaimConditions.ts
@@ -24,7 +24,7 @@ export async function getClaimConditions(
     const conditionPromises: Array<
       ReturnType<typeof MultiById.getClaimConditionById>
     > = [];
-    for (let i = startId; i < count; i++) {
+    for (let i = startId; i < startId + count; i++) {
       conditionPromises.push(
         MultiById.getClaimConditionById({
           ...options,


### PR DESCRIPTION
FIXES: DASH-249

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the `getClaimConditions` extension for ERC20, ERC721, and ERC1155 in the `thirdweb` package.

### Detailed summary
- Updated loop condition to correctly iterate over items
- Fixed `getClaimConditions` extension for ERC20, ERC721, and ERC1155

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->