### PR TITLE
Add Engine Alerts to dashboard

### DIFF
--- a/apps/dashboard/src/@/styles/globals.css
+++ b/apps/dashboard/src/@/styles/globals.css
@@ -147,3 +147,17 @@ html {
 body {
   min-height: 100%;
 }
+
+/* Fix colors on autofilled inputs  */
+input:-webkit-autofill,
+input:-webkit-autofill:hover,
+input:-webkit-autofill:focus,
+input:-webkit-autofill:active {
+  /* Revert text color */
+  -webkit-text-fill-color: hsl(var(--foreground)) !important;
+  color: hsl(var(--foreground)) !important;
+  caret-color: hsl(var(--foreground)) !important;
+
+  /* Revert background color */
+  transition: background-color 5000s ease-in-out 0s;
+}

--- a/apps/dashboard/src/@3rdweb-sdk/react/cache-keys.ts
+++ b/apps/dashboard/src/@3rdweb-sdk/react/cache-keys.ts
@@ -104,4 +104,11 @@ export const engineKeys = {
     [...engineKeys.all, engineId, "systemMetrics"] as const,
   queueMetrics: (engineId: string) =>
     [...engineKeys.all, engineId, "queueMetrics"] as const,
+
+  alertRules: (engineId: string) =>
+    [...engineKeys.all, engineId, "alertRules"] as const,
+  alerts: (engineId: string) =>
+    [...engineKeys.all, engineId, "alerts"] as const,
+  notificationChannels: (engineId: string) =>
+    [...engineKeys.all, engineId, "notificationChannels"] as const,
 };

--- a/apps/dashboard/src/app/team/[team_slug]/[project_slug]/engine/(instance)/[engineId]/alerts/page.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/[project_slug]/engine/(instance)/[engineId]/alerts/page.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { WithEngineInstance } from "components/engine/EnginePageLayout";
+import { EngineAlertsPage } from "../../../../../../../../components/engine/alerts/EngineAlertsPage";
+import type { EngineInstancePageProps } from "../types";
+
+export default function Page(props: EngineInstancePageProps) {
+  const { params } = props;
+
+  return (
+    <WithEngineInstance
+      engineId={props.params.engineId}
+      content={(res) => <EngineAlertsPage instance={res.instance} />}
+      rootPath={`/team/${params.team_slug}/${params.project_slug}/engine`}
+    />
+  );
+}

--- a/apps/dashboard/src/components/engine/EnginePageLayout.tsx
+++ b/apps/dashboard/src/components/engine/EnginePageLayout.tsx
@@ -47,12 +47,16 @@ const sidebarLinkMeta: Array<{ pathId: string; label: string }> = [
     label: "Webhooks",
   },
   {
-    pathId: "configuration",
-    label: "Configuration",
-  },
-  {
     pathId: "metrics",
     label: "Metrics",
+  },
+  {
+    pathId: "alerts",
+    label: "Alerts",
+  },
+  {
+    pathId: "configuration",
+    label: "Configuration",
   },
 ];
 

--- a/apps/dashboard/src/components/engine/alerts/EngineAlertDialogForm.tsx
+++ b/apps/dashboard/src/components/engine/alerts/EngineAlertDialogForm.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import { Spinner } from "@/components/ui/Spinner/Spinner";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import {
+  type EngineAlertRule,
+  EngineNotificationChannelTypeConfig,
+} from "../../../@3rdweb-sdk/react/hooks/useEngine";
+
+const alertFormSchema = z.object({
+  subscriptionRoutes: z.array(z.string()),
+  type: z.enum(
+    Object.keys(EngineNotificationChannelTypeConfig) as [
+      keyof typeof EngineNotificationChannelTypeConfig,
+    ],
+  ),
+  value: z.string(),
+});
+
+type EngineAlertFormValues = z.infer<typeof alertFormSchema>;
+
+export function EngineAlertDialogForm(props: {
+  alertRules: EngineAlertRule[];
+  title: string;
+  values: EngineAlertFormValues | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  submitButton: {
+    isLoading: boolean;
+    label: string;
+    onSubmit: (value: EngineAlertFormValues) => void;
+  };
+}) {
+  const form = useForm<z.infer<typeof alertFormSchema>>({
+    resolver: zodResolver(alertFormSchema),
+    defaultValues: {
+      subscriptionRoutes: ["alert.*"],
+      type: "slack",
+    },
+    values: props.values ?? undefined,
+  });
+
+  function onSubmit(values: z.infer<typeof alertFormSchema>) {
+    props.submitButton.onSubmit(values);
+  }
+
+  const alertRuleOptions: EngineAlertRule[] = [
+    {
+      id: "_all_alerts",
+      routingKey: "alert.*",
+      title: "All alerts",
+      description: "Get notified of all alerts.",
+      createdAt: new Date(),
+      pausedAt: null,
+    },
+    ...props.alertRules,
+  ];
+
+  const selectedAlertRule = alertRuleOptions.find(
+    (alertRule) =>
+      alertRule.routingKey === form.getValues("subscriptionRoutes")[0],
+  );
+
+  return (
+    <Dialog open={props.open} onOpenChange={props.onOpenChange}>
+      <DialogContent
+        className="p-0 z-[10001]"
+        dialogOverlayClassName="z-[10000]"
+      >
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)}>
+            <div className="p-6">
+              <DialogHeader className="mb-4">
+                <DialogTitle className="text-2xl font-semibold tracking-tight">
+                  {props.title}
+                </DialogTitle>
+              </DialogHeader>
+
+              <div className="flex flex-col gap-5">
+                {/* Alert Rule */}
+                <FormField
+                  control={form.control}
+                  name="subscriptionRoutes"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Alert Rule</FormLabel>
+                      <FormControl>
+                        <Select
+                          onValueChange={(value) => field.onChange([value])}
+                          value={field.value[0] ?? "alert.*"}
+                        >
+                          <SelectTrigger>
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent className="z-[10001]">
+                            <SelectGroup>
+                              {alertRuleOptions.map((option) => (
+                                <SelectItem
+                                  key={option.id}
+                                  value={option.routingKey}
+                                >
+                                  {option.title}
+                                </SelectItem>
+                              ))}
+                            </SelectGroup>
+                          </SelectContent>
+                        </Select>
+                      </FormControl>
+
+                      <FormMessage />
+
+                      {selectedAlertRule?.description && (
+                        <FormDescription>
+                          {selectedAlertRule.description}
+                        </FormDescription>
+                      )}
+                    </FormItem>
+                  )}
+                />
+
+                {/* Notification Type */}
+                <FormField
+                  control={form.control}
+                  name="type"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Notification Type</FormLabel>
+                      <FormControl>
+                        <Select
+                          onValueChange={field.onChange}
+                          value={field.value}
+                        >
+                          <SelectTrigger className="mt-1">
+                            <SelectValue placeholder="Select Notification Type" />
+                          </SelectTrigger>
+                          <SelectContent className="z-[10001]">
+                            <SelectGroup>
+                              {Object.entries(
+                                EngineNotificationChannelTypeConfig,
+                              ).map(([type, config]) => (
+                                <SelectItem key={type} value={type}>
+                                  {config.display}
+                                </SelectItem>
+                              ))}
+                            </SelectGroup>
+                          </SelectContent>
+                        </Select>
+                      </FormControl>
+
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                {/* Value (webhook URL, Slack URL, email address, etc.) */}
+                <FormField
+                  control={form.control}
+                  name="value"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>
+                        {EngineNotificationChannelTypeConfig[
+                          form.getValues("type")
+                        ].valueDisplay ?? "Value"}
+                      </FormLabel>
+                      <FormControl>
+                        <Input
+                          type={
+                            form.getValues("type") === "email"
+                              ? "email"
+                              : "text"
+                          }
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+            </div>
+
+            <DialogFooter className="p-6 bg-muted/50 border-t border-border mt-4 gap-4 lg:gap-2 ">
+              <Button
+                variant="outline"
+                onClick={() => {
+                  props.onOpenChange(false);
+                }}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                className="min-w-28 gap-2"
+                disabled={props.submitButton.isLoading}
+              >
+                {props.submitButton.isLoading && <Spinner className="size-4" />}
+                {props.submitButton.label}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/dashboard/src/components/engine/alerts/EngineAlertsPage.tsx
+++ b/apps/dashboard/src/components/engine/alerts/EngineAlertsPage.tsx
@@ -1,0 +1,29 @@
+import {
+  type EngineInstance,
+  useEngineAlertRules,
+} from "@3rdweb-sdk/react/hooks/useEngine";
+import { ManageEngineAlertsSection } from "./ManageEngineAlerts";
+import { RecentEngineAlertsSection } from "./RecentEngineAlerts";
+
+export function EngineAlertsPage(props: {
+  instance: EngineInstance;
+}) {
+  const alertRulesQuery = useEngineAlertRules(props.instance.id);
+  const alertRules = alertRulesQuery.data ?? [];
+
+  return (
+    <div>
+      <ManageEngineAlertsSection
+        alertRules={alertRules}
+        engineId={props.instance.id}
+        alertRulesIsLoading={alertRulesQuery.isLoading}
+      />
+      <div className="h-8" />
+      <RecentEngineAlertsSection
+        alertRules={alertRules}
+        engineId={props.instance.id}
+        alertRulesIsLoading={alertRulesQuery.isLoading}
+      />
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/engine/alerts/EngineDeleteAlertModal.tsx
+++ b/apps/dashboard/src/components/engine/alerts/EngineDeleteAlertModal.tsx
@@ -1,0 +1,52 @@
+import { Spinner } from "@/components/ui/Spinner/Spinner";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { DialogDescription } from "@radix-ui/react-dialog";
+
+export function EngineDeleteAlertModal(props: {
+  onConfirm: () => void;
+  isPending: boolean;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  return (
+    <Dialog open={props.open} onOpenChange={props.onOpenChange}>
+      <DialogContent className="p-0">
+        <DialogHeader className="mb-4 p-6">
+          <DialogTitle className="text-2xl font-semibold tracking-tight">
+            Delete Alert
+          </DialogTitle>
+
+          <DialogDescription>
+            You will no longer receive notifications from this webhook.
+          </DialogDescription>
+        </DialogHeader>
+
+        <DialogFooter className="p-6 bg-muted/50 border-t border-border gap-4 lg:gap-2">
+          <Button
+            variant="outline"
+            onClick={() => {
+              props.onOpenChange(false);
+            }}
+          >
+            Cancel
+          </Button>
+          <Button
+            className="min-w-28 gap-2"
+            variant="destructive"
+            onClick={props.onConfirm}
+          >
+            {props.isPending && <Spinner className="size-4" />}
+            Delete Webhook
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/dashboard/src/components/engine/alerts/ManageEngineAlerts.stories.tsx
+++ b/apps/dashboard/src/components/engine/alerts/ManageEngineAlerts.stories.tsx
@@ -1,0 +1,131 @@
+import type {
+  CreateNotificationChannelInput,
+  EngineNotificationChannel,
+} from "@3rdweb-sdk/react/hooks/useEngine";
+import type { Meta, StoryObj } from "@storybook/react";
+import { useMutation } from "@tanstack/react-query";
+import { Toaster } from "sonner";
+import {
+  createEngineAlertRuleStub,
+  createEngineNotificationChannelStub,
+} from "../../../stories/stubs";
+import { BadgeContainer, mobileViewport } from "../../../stories/utils";
+import { ManageEngineAlertsSectionUI } from "./ManageEngineAlerts";
+
+const meta = {
+  title: "engine/alerts/manage",
+  component: Story,
+  parameters: {
+    nextjs: {
+      appDirectory: true,
+    },
+  },
+} satisfies Meta<typeof Story>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Desktop: Story = {
+  args: {},
+};
+
+export const Mobile: Story = {
+  args: {},
+  parameters: {
+    viewport: mobileViewport("iphone14"),
+  },
+};
+
+function Story() {
+  const createEngineAlertMutation = useMutation({
+    mutationFn: async (values: CreateNotificationChannelInput) => {
+      console.log("creating alert using input:", values);
+
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
+      const channelStub: EngineNotificationChannel = {
+        createdAt: new Date(),
+        id: "new-channel",
+        pausedAt: null,
+        subscriptionRoutes: values.subscriptionRoutes,
+        value: values.value,
+        type: values.type,
+      };
+
+      console.log("created channel:", channelStub);
+      return channelStub;
+    },
+  });
+
+  async function deleteAlert(alertId: string) {
+    console.log("deleting alert:", alertId);
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+
+  return (
+    <div className="py-6 container max-w-[1154px] flex flex-col gap-14">
+      <BadgeContainer label="2 Alerts">
+        <ManageEngineAlertsSectionUI
+          isLoading={false}
+          onAlertsUpdated={() => {}}
+          engineId="test-engine-id"
+          createAlertMutation={createEngineAlertMutation}
+          deleteAlert={deleteAlert}
+          alertRules={[
+            createEngineAlertRuleStub("foo"),
+            createEngineAlertRuleStub("bar"),
+          ]}
+          notificationChannels={[
+            createEngineNotificationChannelStub("foo"),
+            createEngineNotificationChannelStub("foo", {
+              pausedAt: null,
+            }),
+          ]}
+        />
+      </BadgeContainer>
+
+      <BadgeContainer label="No Alerts">
+        <ManageEngineAlertsSectionUI
+          alertRules={[
+            createEngineAlertRuleStub("foo"),
+            createEngineAlertRuleStub("bar"),
+          ]}
+          engineId="test-engine-id"
+          notificationChannels={[]}
+          isLoading={false}
+          onAlertsUpdated={() => {}}
+          createAlertMutation={createEngineAlertMutation}
+          deleteAlert={deleteAlert}
+        />
+      </BadgeContainer>
+
+      <BadgeContainer label="Loading">
+        <ManageEngineAlertsSectionUI
+          alertRules={[
+            createEngineAlertRuleStub("foo"),
+            createEngineAlertRuleStub("bar"),
+          ]}
+          engineId="test-engine-id"
+          notificationChannels={[]}
+          isLoading={true}
+          onAlertsUpdated={() => {}}
+          createAlertMutation={createEngineAlertMutation}
+          deleteAlert={deleteAlert}
+        />
+      </BadgeContainer>
+
+      <BadgeContainer label="No Alert Rules">
+        <ManageEngineAlertsSectionUI
+          alertRules={[]}
+          engineId="test-engine-id"
+          notificationChannels={[]}
+          isLoading={false}
+          onAlertsUpdated={() => {}}
+          createAlertMutation={createEngineAlertMutation}
+          deleteAlert={deleteAlert}
+        />
+      </BadgeContainer>
+      <Toaster richColors />
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/engine/alerts/ManageEngineAlerts.tsx
+++ b/apps/dashboard/src/components/engine/alerts/ManageEngineAlerts.tsx
@@ -1,0 +1,383 @@
+"use client";
+import { CopyTextButton } from "@/components/ui/CopyTextButton";
+import { Spinner } from "@/components/ui/Spinner/Spinner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { ToolTipLabel } from "@/components/ui/tooltip";
+import {
+  type CreateNotificationChannelInput,
+  type EngineAlertRule,
+  type EngineNotificationChannel,
+  useEngineCreateNotificationChannel,
+  useEngineDeleteNotificationChannel,
+  useEngineNotificationChannels,
+} from "@3rdweb-sdk/react/hooks/useEngine";
+import { type UseMutationResult, useMutation } from "@tanstack/react-query";
+import { formatDate } from "date-fns";
+import { EllipsisVerticalIcon, PlusIcon } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { EngineAlertDialogForm } from "./EngineAlertDialogForm";
+import { EngineDeleteAlertModal } from "./EngineDeleteAlertModal";
+
+type CreateAlertMutation = UseMutationResult<
+  EngineNotificationChannel,
+  unknown,
+  CreateNotificationChannelInput,
+  unknown
+>;
+
+export function ManageEngineAlertsSection(props: {
+  alertRules: EngineAlertRule[];
+  alertRulesIsLoading: boolean;
+  engineId: string;
+}) {
+  const notificationChannelsQuery = useEngineNotificationChannels(
+    props.engineId,
+  );
+  const deleteAlertMutation = useEngineDeleteNotificationChannel(
+    props.engineId,
+  );
+
+  const createAlertMutation = useEngineCreateNotificationChannel(
+    props.engineId,
+  );
+
+  // not passing the mutation to avoid multiple rows sharing the same mutation state, we create the new mutation for each row instead in each component instead
+  async function deleteAlert(notificationChannelId: string) {
+    return deleteAlertMutation.mutate(notificationChannelId);
+  }
+
+  return (
+    <ManageEngineAlertsSectionUI
+      alertRules={props.alertRules}
+      engineId={props.engineId}
+      notificationChannels={notificationChannelsQuery.data ?? []}
+      isLoading={
+        notificationChannelsQuery.isLoading || props.alertRulesIsLoading
+      }
+      onAlertsUpdated={() => {
+        notificationChannelsQuery.refetch();
+      }}
+      createAlertMutation={createAlertMutation}
+      deleteAlert={deleteAlert}
+    />
+  );
+}
+
+export function ManageEngineAlertsSectionUI(props: {
+  alertRules: EngineAlertRule[];
+  engineId: string;
+  notificationChannels: EngineNotificationChannel[];
+  isLoading: boolean;
+  onAlertsUpdated: () => void;
+  createAlertMutation: CreateAlertMutation;
+  deleteAlert: (notificationChannelId: string) => Promise<void>;
+}) {
+  const {
+    engineId,
+    notificationChannels,
+    isLoading,
+    onAlertsUpdated,
+    createAlertMutation,
+    deleteAlert,
+  } = props;
+
+  return (
+    <section>
+      <div className="flex gap-4 lg:gap-6 flex-col lg:flex-row justify-between">
+        <div>
+          <h2 className="text-2xl font-semibold tracking-tight mb-1">
+            Manage Alerts
+          </h2>
+          <p className="text-muted-foreground">
+            Get notified when alerts are triggered on your Engine instance.
+          </p>
+        </div>
+
+        <CreateAlertButton
+          engineId={engineId}
+          alertRules={props.alertRules}
+          onSuccess={onAlertsUpdated}
+          createAlertMutation={createAlertMutation}
+        />
+      </div>
+
+      <div className="h-5" />
+
+      {notificationChannels.length === 0 || isLoading ? (
+        <div className="flex justify-center items-center min-h-[200px] w-full border border-border rounded-lg">
+          {isLoading ? <Spinner className="size-8" /> : "No alerts set up yet."}
+        </div>
+      ) : (
+        <EngineAlertsTableUI
+          engineId={engineId}
+          alertRules={props.alertRules}
+          notificationChannels={notificationChannels}
+          onAlertsUpdated={props.onAlertsUpdated}
+          deleteAlert={deleteAlert}
+        />
+      )}
+    </section>
+  );
+}
+
+function EngineAlertsTableUI(props: {
+  engineId: string;
+  alertRules: EngineAlertRule[];
+  notificationChannels: EngineNotificationChannel[];
+  onAlertsUpdated: () => void;
+  deleteAlert: (notificationChannelId: string) => Promise<void>;
+}) {
+  return (
+    <TableContainer>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Status</TableHead>
+            <TableHead>Alert Rule</TableHead>
+            <TableHead>Notification Type</TableHead>
+            <TableHead>Created At</TableHead>
+            <TableHead />
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {props.notificationChannels.map((notificationChannel) => {
+            const isPaused = notificationChannel.pausedAt !== null;
+
+            return (
+              <TableRow key={notificationChannel.id}>
+                <TableCell>
+                  <Badge
+                    variant={isPaused ? "warning" : "default"}
+                    className="text-sm"
+                  >
+                    {isPaused ? "Paused" : "Active"}
+                  </Badge>
+                </TableCell>
+
+                <TableCell>
+                  {getMatchingAlertRules(
+                    notificationChannel.subscriptionRoutes,
+                    props.alertRules,
+                  ).map((alertRule) => (
+                    <p key={alertRule.routingKey}>{alertRule.title}</p>
+                  ))}
+                </TableCell>
+
+                <TableCell>
+                  <Badge variant="outline" className="text-sm capitalize">
+                    {notificationChannel.type}
+                  </Badge>
+
+                  <CopyTextButton
+                    textToCopy={notificationChannel.value}
+                    textToShow={truncateValue(notificationChannel.value)}
+                    copyIconPosition="left"
+                    tooltip="Copy"
+                    variant="ghost"
+                    iconClassName="size-3"
+                    className="-translate-x-2 max-w-[250px] text-muted-foreground"
+                  />
+                </TableCell>
+
+                <TableCell className="text-muted-foreground">
+                  {formatDate(
+                    new Date(notificationChannel.createdAt),
+                    "MMM dd, yyyy",
+                  )}
+                </TableCell>
+
+                <TableCell className="text-muted-foreground">
+                  <AlertOptionsButton
+                    alertRules={props.alertRules}
+                    engineId={props.engineId}
+                    notificationChannel={notificationChannel}
+                    onDeleteSuccess={props.onAlertsUpdated}
+                    deleteAlert={props.deleteAlert}
+                  />
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}
+
+function CreateAlertButton(props: {
+  engineId: string;
+  alertRules: EngineAlertRule[];
+  onSuccess: () => void;
+  createAlertMutation: CreateAlertMutation;
+}) {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const { createAlertMutation } = props;
+
+  return (
+    <>
+      <ToolTipLabel
+        label={
+          props.alertRules.length === 0
+            ? "This feature is only available for cloud-hosted Engines."
+            : undefined
+        }
+      >
+        <Button
+          onClick={() => {
+            setIsModalOpen(true);
+          }}
+          className="gap-2"
+          disabled={props.alertRules.length === 0}
+        >
+          <PlusIcon className="size-4" />
+          Add Alert
+        </Button>
+      </ToolTipLabel>
+
+      <EngineAlertDialogForm
+        alertRules={props.alertRules}
+        open={isModalOpen}
+        onOpenChange={setIsModalOpen}
+        title="Add Alert"
+        submitButton={{
+          label: "Add Alert",
+          isLoading: createAlertMutation.isPending,
+          onSubmit: (values) => {
+            const addPromise = createAlertMutation.mutateAsync(values);
+
+            toast.promise(addPromise, {
+              success: "Alert added successfully",
+              error: "Failed to add alert",
+            });
+
+            addPromise.then(() => {
+              setIsModalOpen(false);
+              props.onSuccess();
+            });
+          },
+        }}
+        values={null}
+      />
+    </>
+  );
+}
+
+function AlertOptionsButton(props: {
+  alertRules: EngineAlertRule[];
+  engineId: string;
+  notificationChannel: EngineNotificationChannel;
+  onDeleteSuccess: () => void;
+  deleteAlert: (notificationChannelId: string) => Promise<void>;
+}) {
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const deleteMutation = useMutation({
+    mutationFn: props.deleteAlert,
+  });
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button size="icon" variant="ghost">
+            <EllipsisVerticalIcon className="size-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent className="min-w-36">
+          <DropdownMenuItem
+            className="text-destructive-text hover:!bg-destructive"
+            onClick={() => {
+              setIsDeleteModalOpen(true);
+            }}
+          >
+            Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <EngineDeleteAlertModal
+        isPending={deleteMutation.isPending}
+        onConfirm={() => {
+          const deletePromise = deleteMutation.mutateAsync(
+            props.notificationChannel.id,
+          );
+
+          toast.promise(deletePromise, {
+            success: "Alert Deleted Successfully",
+            error: "Failed To Delete Alert",
+          });
+          deletePromise.then(() => {
+            setIsDeleteModalOpen(false);
+            props.onDeleteSuccess();
+          });
+        }}
+        open={isDeleteModalOpen}
+        onOpenChange={setIsDeleteModalOpen}
+      />
+    </>
+  );
+}
+
+const getMatchingAlertRules = (
+  subscriptionRoutes: string[],
+  alertRules: EngineAlertRule[],
+): EngineAlertRule[] => {
+  const results: EngineAlertRule[] = [];
+
+  for (const alertRule of alertRules) {
+    for (const subscriptionRoute of subscriptionRoutes) {
+      if (isRoutingKeyMatch(subscriptionRoute, alertRule.routingKey)) {
+        results.push(alertRule);
+        break;
+      }
+    }
+  }
+
+  return results;
+};
+
+/**
+ * Check if routingKey matches subscriptionRoute.
+ *
+ * Example: exact match
+ *  `alert.stuck-nonce` matches `alert.stuck-nonce`
+ *
+ * Example: wildcard
+ *  `alert.*` matches `alert.stuck-nonce`
+ */
+const isRoutingKeyMatch = (
+  subscriptionRoute: string,
+  alertRoutingKey: string,
+): boolean => {
+  if (!subscriptionRoute.includes("*")) {
+    // Check exact match if no wildcard.
+    return subscriptionRoute === alertRoutingKey;
+  }
+
+  const [prefix, suffix] = subscriptionRoute.split("*");
+  if (prefix && !subscriptionRoute.startsWith(prefix)) return false;
+  if (suffix && !subscriptionRoute.endsWith(suffix)) return false;
+
+  return true;
+};
+
+const truncateValue = (str: string): string => {
+  if (str.length <= 16) return str;
+  return `${str.slice(0, 12)}...${str.slice(-4)}`;
+};

--- a/apps/dashboard/src/components/engine/alerts/RecentEngineAlerts.stories.tsx
+++ b/apps/dashboard/src/components/engine/alerts/RecentEngineAlerts.stories.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Toaster } from "sonner";
+import {
+  createEngineAlertRuleStub,
+  createEngineAlertStub,
+} from "../../../stories/stubs";
+import { BadgeContainer, mobileViewport } from "../../../stories/utils";
+import { RecentEngineAlertsSectionUI } from "./RecentEngineAlerts";
+
+const meta = {
+  title: "engine/alerts/recent",
+  component: Story,
+  parameters: {
+    nextjs: {
+      appDirectory: true,
+    },
+  },
+} satisfies Meta<typeof Story>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Desktop: Story = {
+  args: {},
+};
+
+export const Mobile: Story = {
+  args: {},
+  parameters: {
+    viewport: mobileViewport("iphone14"),
+  },
+};
+
+function Story() {
+  return (
+    <div className="py-6 container max-w-[1154px] flex flex-col gap-14">
+      <BadgeContainer label="3 Alerts">
+        <RecentEngineAlertsSectionUI
+          isLoading={false}
+          onAlertsUpdated={() => {}}
+          alertRules={[createEngineAlertRuleStub("foo")]}
+          alerts={[
+            createEngineAlertStub("foo"),
+            createEngineAlertStub("foo", {
+              status: "firing",
+            }),
+            createEngineAlertStub("foo", {
+              status: "resolved",
+            }),
+          ]}
+        />
+      </BadgeContainer>
+
+      <BadgeContainer label="No Alerts">
+        <RecentEngineAlertsSectionUI
+          isLoading={false}
+          alertRules={[]}
+          alerts={[]}
+          onAlertsUpdated={() => {}}
+        />
+      </BadgeContainer>
+
+      <BadgeContainer label="Loading">
+        <RecentEngineAlertsSectionUI
+          isLoading={true}
+          alertRules={[]}
+          alerts={[]}
+          onAlertsUpdated={() => {}}
+        />
+      </BadgeContainer>
+
+      <Toaster richColors />
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/engine/alerts/RecentEngineAlerts.tsx
+++ b/apps/dashboard/src/components/engine/alerts/RecentEngineAlerts.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { Spinner } from "@/components/ui/Spinner/Spinner";
+import { Badge, type BadgeProps } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  type EngineAlert,
+  type EngineAlertRule,
+  useEngineAlerts,
+} from "@3rdweb-sdk/react/hooks/useEngine";
+import { formatDistance } from "date-fns";
+import { useMemo } from "react";
+
+export function RecentEngineAlertsSection(props: {
+  alertRules: EngineAlertRule[];
+  alertRulesIsLoading: boolean;
+  engineId: string;
+}) {
+  // TODO - pagination
+  // required : return the total number of alerts in response from API
+  const alertsQuery = useEngineAlerts(props.engineId, 100, 0);
+  const alerts = alertsQuery.data ?? [];
+
+  return (
+    <RecentEngineAlertsSectionUI
+      alertRules={props.alertRules}
+      alerts={alerts}
+      isLoading={alertsQuery.isLoading || props.alertRulesIsLoading}
+      onAlertsUpdated={() => {
+        alertsQuery.refetch();
+      }}
+    />
+  );
+}
+
+export function RecentEngineAlertsSectionUI(props: {
+  alertRules: EngineAlertRule[];
+  alerts: EngineAlert[];
+  isLoading: boolean;
+  onAlertsUpdated: () => void;
+}) {
+  const { alerts, isLoading } = props;
+  return (
+    <section>
+      <h2 className="text-2xl font-semibold tracking-tight mb-1">
+        Recent Alerts
+      </h2>
+
+      <div className="h-2" />
+
+      {alerts.length === 0 || isLoading ? (
+        <div className="flex justify-center items-center min-h-[200px] w-full border border-border rounded-lg">
+          {isLoading ? <Spinner className="size-8" /> : "No alerts triggered."}
+        </div>
+      ) : (
+        <RecentEngineAlertsTableUI
+          alertRules={props.alertRules}
+          alerts={alerts}
+          onAlertsUpdated={props.onAlertsUpdated}
+        />
+      )}
+    </section>
+  );
+}
+
+function RecentEngineAlertsTableUI(props: {
+  alertRules: EngineAlertRule[];
+  alerts: EngineAlert[];
+  onAlertsUpdated: () => void;
+}) {
+  const alertRulesMap = useMemo(() => {
+    const map: Record<string, EngineAlertRule> = {};
+    for (const alertRule of props.alertRules) {
+      map[alertRule.id] = alertRule;
+    }
+    return map;
+  }, [props.alertRules]);
+
+  return (
+    <TableContainer>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Alert Trigger</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead>Timestamp</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {props.alerts.map((alert) => {
+            let variant: BadgeProps["variant"];
+            let status: string;
+            if (alert.status === "pending") {
+              variant = "warning";
+              status = "Pending";
+            } else if (alert.status === "firing") {
+              variant = "destructive";
+              status = "Triggered";
+            } else if (alert.status === "resolved") {
+              variant = "success";
+              status = "Resolved";
+            } else {
+              return null;
+            }
+
+            return (
+              <TableRow key={alert.id}>
+                <TableCell>{alertRulesMap[alert.alertRuleId]?.title}</TableCell>
+
+                <TableCell>
+                  <Badge variant={variant} className="text-sm">
+                    {status}
+                  </Badge>
+                </TableCell>
+
+                <TableCell className="text-muted-foreground">
+                  {formatDistance(
+                    new Date(alert.endsAt ?? alert.startsAt),
+                    new Date(),
+                    { addSuffix: true },
+                  )}
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}

--- a/apps/dashboard/src/components/engine/system-metrics/index.tsx
+++ b/apps/dashboard/src/components/engine/system-metrics/index.tsx
@@ -70,37 +70,48 @@ export const EngineSystemMetrics: React.FC<EngineStatusProps> = ({
     );
   }
 
-  let queueMetricsPanel = <Spinner className="h-4 w-4" />;
-  if (!queueMetricsQuery.data || queueMetricsQuery.isError) {
-    queueMetricsPanel = <p>N/A</p>;
-  } else {
+  let queueMetricsPanel = (
+    <div className="border border-border rounded-lg min-h-[200px] flex items-center justify-center">
+      <Spinner className="size-6" />
+    </div>
+  );
+
+  if (
+    !queueMetricsQuery.isPending &&
+    (!queueMetricsQuery.data || queueMetricsQuery.isError)
+  ) {
+    queueMetricsPanel = (
+      <div className="border border-border rounded-lg min-h-[200px] flex items-center justify-center">
+        No Data Available
+      </div>
+    );
+  } else if (queueMetricsQuery.data) {
     const numQueued = queueMetricsQuery.data.result.queued;
     const numPending = queueMetricsQuery.data.result.pending;
     const msToSend = queueMetricsQuery.data.result.latency?.msToSend;
     const msToMine = queueMetricsQuery.data.result.latency?.msToMine;
 
     queueMetricsPanel = (
-      <Card p={16}>
-        <Stack spacing={4}>
+      <Card p={8}>
+        <Stack spacing={6}>
           <Flex gap={2} align="center">
-            <Icon as={FaChartArea} />
             <Heading size="title.md">Queue Metrics</Heading>
           </Flex>
 
-          <div className="flex gap-x-24">
+          <div className="flex flex-col lg:flex-row gap-6 lg:gap-12">
             <div className="flex-col gap-y-4">
-              <h2 className="font-semibold"># queued</h2>
-              <p>{numQueued}</p>
+              <h2 className="font-semibold"> Queued</h2>
+              <p className="text-muted-foreground">{numQueued}</p>
             </div>
             <div className="flex-col gap-y-4">
-              <h2 className="font-semibold"># pending</h2>
-              <p>{numPending}</p>
+              <h2 className="font-semibold">Pending</h2>
+              <p className="text-muted-foreground">{numPending}</p>
             </div>
 
             {msToSend && (
               <div className="flex-col gap-y-4">
                 <h2 className="font-semibold">Time to send</h2>
-                <p>
+                <p className="text-muted-foreground">
                   p50 {(msToSend.p50 / 1000).toFixed(2)}s, p90{" "}
                   {(msToSend.p90 / 1000).toFixed(2)}s
                 </p>
@@ -109,8 +120,10 @@ export const EngineSystemMetrics: React.FC<EngineStatusProps> = ({
             {msToMine && (
               <div className="flex-col gap-y-4">
                 <h2 className="font-semibold">Time to mine</h2>
-                p50 {(msToMine.p50 / 1000).toFixed(2)}s, p90{" "}
-                {(msToMine.p90 / 1000).toFixed(2)}s
+                <p className="text-muted-foreground">
+                  p50 {(msToMine.p50 / 1000).toFixed(2)}s, p90{" "}
+                  {(msToMine.p90 / 1000).toFixed(2)}s
+                </p>
               </div>
             )}
           </div>

--- a/apps/dashboard/src/pages/dashboard/engine/[engineId]/alerts.tsx
+++ b/apps/dashboard/src/pages/dashboard/engine/[engineId]/alerts.tsx
@@ -1,0 +1,6 @@
+import { createEnginePage } from "components/engine/EnginePage";
+import { EngineAlertsPage } from "../../../../components/engine/alerts/EngineAlertsPage";
+
+export default createEnginePage(({ instance }) => (
+  <EngineAlertsPage instance={instance} />
+));

--- a/apps/dashboard/src/stories/stubs.ts
+++ b/apps/dashboard/src/stories/stubs.ts
@@ -1,6 +1,11 @@
 import type { Project } from "@/api/projects";
 import type { Team } from "@/api/team";
 import type { ApiKey, ApiKeyService } from "@3rdweb-sdk/react/hooks/useApi";
+import type {
+  EngineAlert,
+  EngineAlertRule,
+  EngineNotificationChannel,
+} from "@3rdweb-sdk/react/hooks/useEngine";
 
 function projectStub(id: string, teamId: string) {
   const project: Project = {
@@ -105,4 +110,49 @@ export function createApiKeyStub() {
   };
 
   return apiKeyStub;
+}
+
+export function createEngineAlertRuleStub(
+  id: string,
+  overrides: Partial<EngineAlertRule> = {},
+): EngineAlertRule {
+  return {
+    title: `Alert Rule ${id}`,
+    routingKey: `alert.${id}`,
+    description: `This is a description for alert rule ${id}`,
+    id: `alert-rule-${id}`,
+    createdAt: new Date(),
+    pausedAt: null,
+    ...overrides,
+  };
+}
+
+export function createEngineNotificationChannelStub(
+  id: string,
+  overrides: Partial<EngineNotificationChannel> = {},
+): EngineNotificationChannel {
+  return {
+    id: Math.random().toString(),
+    subscriptionRoutes: [`alert.${id}`],
+    type: "slack",
+    value:
+      "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
+    createdAt: new Date(),
+    pausedAt: new Date(),
+    ...overrides,
+  };
+}
+
+export function createEngineAlertStub(
+  id: string,
+  overrides: Partial<EngineAlert> = {},
+): EngineAlert {
+  return {
+    alertRuleId: `alert-rule-${id}`,
+    endsAt: new Date(),
+    id: Math.random().toString(),
+    startsAt: new Date(),
+    status: "pending",
+    ...overrides,
+  };
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds alerts functionality to the dashboard, including creating alert rules, managing alerts, and displaying recent alerts.

### Detailed summary
- Added alerts functionality to the dashboard
- Created `EngineAlertsPage` and `EngineDeleteAlertModal` components
- Updated cache keys for alerts
- Added styles for autofilled inputs
- Implemented recent alerts section with pagination
- Added stubs for engine alerts, alert rules, and notification channels

> The following files were skipped due to too many changes: `apps/dashboard/src/components/engine/alerts/RecentEngineAlerts.tsx`, `apps/dashboard/src/components/engine/alerts/ManageEngineAlerts.stories.tsx`, `apps/dashboard/src/@3rdweb-sdk/react/hooks/useEngine.ts`, `apps/dashboard/src/components/engine/alerts/EngineAlertDialogForm.tsx`, `apps/dashboard/src/components/engine/alerts/ManageEngineAlerts.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->