### PR TITLE
[React] Feature: Shows the social provider name in details modal

### DIFF
--- a/.changeset/nasty-doors-fold.md
+++ b/.changeset/nasty-doors-fold.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Displays the social login provider in the details modal

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/Details.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/Details.tsx
@@ -20,7 +20,11 @@ import { formatNumber } from "../../../../utils/formatNumber.js";
 import { webLocalStorage } from "../../../../utils/storage/webStorage.js";
 import type { Account, Wallet } from "../../../../wallets/interfaces/wallet.js";
 import type { SmartWalletOptions } from "../../../../wallets/smart/types.js";
-import type { AppMetadata } from "../../../../wallets/types.js";
+import {
+  type AppMetadata,
+  type SocialAuthOption,
+  socialAuthOptions,
+} from "../../../../wallets/types.js";
 import type { WalletId } from "../../../../wallets/wallet-types.js";
 import {
   CustomThemeProvider,
@@ -1070,6 +1074,15 @@ function InAppWalletUserInfo(props: {
       const lastAuthProvider = await getLastAuthProvider(webLocalStorage);
       if (lastAuthProvider === "guest") {
         return "Guest";
+      }
+      if (
+        lastAuthProvider &&
+        (activeWallet?.id === "inApp" || activeWallet?.id === "smart") &&
+        socialAuthOptions.includes(lastAuthProvider as SocialAuthOption)
+      ) {
+        return (
+          lastAuthProvider.slice(0, 1).toUpperCase() + lastAuthProvider.slice(1)
+        );
       }
       return walletInfo?.name;
     },


### PR DESCRIPTION
![Screenshot 2024-09-19 at 2 22 09 PM](https://github.com/user-attachments/assets/9c8a14e9-3328-4e6f-8d56-0c420bdeea17)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on displaying the social login provider in the details modal for wallet connections.

### Detailed summary
- Added display of social login provider in details modal
- Updated imports for `AppMetadata` and `SocialAuthOption`
- Implemented logic to show social login provider in `InAppWalletUserInfo` function based on conditions

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->