### PR TITLE
style(dashboard): add padding to partners table

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/[slug]/(active)/components/server/partners-table.tsx
+++ b/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/[slug]/(active)/components/server/partners-table.tsx
@@ -53,7 +53,7 @@ export function PartnersTable({ ecosystem }: { ecosystem: Ecosystem }) {
         </TableHeader>
         <TableBody>
           {[...partners].reverse().map((partner: Partner) => (
-            <EcosystemRow
+            <PartnerRow
               key={partner.id}
               partner={partner}
               ecosystem={ecosystem}
@@ -65,7 +65,7 @@ export function PartnersTable({ ecosystem }: { ecosystem: Ecosystem }) {
   );
 }
 
-function EcosystemRow(props: {
+function PartnerRow(props: {
   partner: Partner;
   ecosystem: Ecosystem;
 }) {
@@ -114,7 +114,7 @@ function EcosystemRow(props: {
           : "Never prompt"}
       </TableCell>
       <td className="table-cell py-1 align-middle">
-        <div className="flex gap-1.5 justify-end">
+        <div className="flex gap-1.5 pr-1.5 justify-end">
           <UpdatePartnerModal
             partner={props.partner}
             ecosystem={props.ecosystem}


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to rename `EcosystemRow` component to `PartnerRow` and update styling in the `PartnersTable` component.

### Detailed summary
- Renamed `EcosystemRow` component to `PartnerRow`.
- Updated styling in the `PartnersTable` component by adding `pr-1.5` class to a `div` element.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->