### PR TITLE
Fix Explorer page component re-renders

### DIFF
--- a/.changeset/purple-hairs-end.md
+++ b/.changeset/purple-hairs-end.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Export `isGetNFTSupported` extension from "thirdweb/erc1155/extensions"

--- a/apps/dashboard/src/contract-ui/hooks/useRouteConfig.tsx
+++ b/apps/dashboard/src/contract-ui/hooks/useRouteConfig.tsx
@@ -114,8 +114,17 @@ export function useContractRouteConfig(
     contract,
   });
   const analyticsSupported = useAnalyticsSupportedForChain(contract.chain.id);
-  const isERC721Query = useReadContract(ERC721Ext.isERC721, { contract });
-  const isERC1155Query = useReadContract(ERC1155Ext.isERC1155, { contract });
+
+  const isERC721 = useMemo(
+    () => ERC721Ext.isGetNFTSupported(functionSelectors),
+    [functionSelectors],
+  );
+
+  const isERC1155 = useMemo(
+    () => ERC1155Ext.isGetNFTSupported(functionSelectors),
+    [functionSelectors],
+  );
+
   const isERC20 = useMemo(
     () => ERC20Ext.isERC20(functionSelectors),
     [functionSelectors],
@@ -251,11 +260,11 @@ export function useContractRouteConfig(
       // others only matter if claim conditions are detected
       if (hasClaimConditions) {
         // if erc721 its that
-        if (isERC721Query.data) {
+        if (isERC721) {
           return "erc721";
         }
         // if erc1155 its that
-        if (isERC1155Query.data) {
+        if (isERC1155) {
           return "erc1155";
         }
         // otherwise it has to be erc20
@@ -265,8 +274,8 @@ export function useContractRouteConfig(
       return null;
     }, [
       hasClaimConditions,
-      isERC721Query.data,
-      isERC1155Query.data,
+      isERC721,
+      isERC1155,
       isDirectListing,
       isEnglishAuction,
     ]);
@@ -281,9 +290,9 @@ export function useContractRouteConfig(
           contract={contract}
           hasDirectListings={isDirectListing}
           hasEnglishAuctions={isEnglishAuction}
-          isErc1155={isERC1155Query.data || false}
+          isErc1155={isERC1155}
           isErc20={isERC20}
-          isErc721={isERC721Query.data || false}
+          isErc721={isERC721}
           isPermissionsEnumerable={isPermissionsEnumerable}
         />
       ),
@@ -326,7 +335,7 @@ export function useContractRouteConfig(
       isEnabled:
         embedType !== null
           ? "enabled"
-          : isERC721Query.isLoading || isERC1155Query.isLoading
+          : functionSelectorQuery.isLoading
             ? "loading"
             : "disabled",
       component: () => (
@@ -352,16 +361,13 @@ export function useContractRouteConfig(
       title: "NFTs",
       path: "nfts",
       isEnabled:
-        isERC721Query.data || isERC1155Query.data
+        isERC721 || isERC1155
           ? "enabled"
-          : isERC721Query.isLoading || isERC1155Query.isLoading
+          : functionSelectorQuery.isLoading
             ? "loading"
             : "disabled",
       component: () => (
-        <LazyContractNFTPage
-          contract={contract}
-          isErc721={isERC721Query.data || false}
-        />
+        <LazyContractNFTPage contract={contract} isErc721={isERC721} />
       ),
     },
     {

--- a/packages/thirdweb/src/exports/extensions/erc1155.ts
+++ b/packages/thirdweb/src/exports/extensions/erc1155.ts
@@ -6,6 +6,7 @@ export {
 } from "../../extensions/erc1155/__generated__/IERC1155/read/balanceOfBatch.js";
 export {
   getNFT,
+  isGetNFTSupported,
   type GetNFTParams,
 } from "../../extensions/erc1155/read/getNFT.js";
 export {


### PR DESCRIPTION
FIXES: DASH-207

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to export the `isGetNFTSupported` extension from "thirdweb/erc1155/extensions".

### Detailed summary
- Export `isGetNFTSupported` extension from `thirdweb/erc1155/extensions`
- Update references to `isERC721Query` and `isERC1155Query` with new implementations using `useMemo`
- Update props in `useContractRouteConfig` related to ERC721 and ERC1155
- Replace loading checks for ERC721 and ERC1155 with `functionSelectorQuery.isLoading`
- Simplify component usage in `useContractRouteConfig` for NFTs

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->