### PR TITLE
Fix body height issue in dashboard

### DIFF
--- a/apps/dashboard/src/@/styles/globals.css
+++ b/apps/dashboard/src/@/styles/globals.css
@@ -140,7 +140,10 @@
   }
 }
 
-body,
 html {
   height: 100%;
+}
+
+body {
+  min-height: 100%;
 }

--- a/apps/dashboard/src/app/team/[team_slug]/layout.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/layout.tsx
@@ -6,7 +6,7 @@ export default function RootTeamLayout(props: {
   params: { team_slug: string };
 }) {
   return (
-    <div className="min-h-full flex flex-col bg-background">
+    <div className="min-h-screen flex flex-col">
       <div className="grow flex flex-col">{props.children}</div>
       <TWAutoConnect />
       <AppFooter />


### PR DESCRIPTION
Fixes body not expanding to content size:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/yNOf1svJ8o3zjO7zQouZ/de2d88d4-db8c-4325-9135-8fc3d400a75b.png)



<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the global CSS to set a minimum height of 100% for the body element. Additionally, the layout component for team pages now uses `min-h-screen` instead of `min-h-full`.

### Detailed summary
- Set `min-height: 100%` for the body element in global CSS.
- Changed `min-h-full` to `min-h-screen` in the team layout component.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->