### PR TITLE
Fix '0' rendered in Contract Overview page

### DIFF
--- a/apps/dashboard/src/contract-ui/tabs/overview/components/ContractChecklist.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/overview/components/ContractChecklist.tsx
@@ -31,7 +31,7 @@ export const ContractChecklist: React.FC<ContractChecklistProps> = (props) => {
   return (
     // if no permissions, simply return null (do not fail open)
     <AdminOnly contract={props.contract} failOpen={false}>
-      {functionSelectorQuery.data?.length && (
+      {!!functionSelectorQuery.data?.length && (
         <Inner functionSelectors={functionSelectorQuery.data} {...props} />
       )}
     </AdminOnly>


### PR DESCRIPTION
Because `0 && <div />` returns `0` and react renders `0` 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `ContractChecklist.tsx` file to ensure that the component renders correctly even when there are no function selectors.

### Detailed summary
- Updated the conditional rendering to ensure the component renders when `functionSelectorQuery.data` is empty.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->