### PR TITLE
feat(playground): update ecosystem for prod

### DIFF
--- a/apps/playground-web/src/components/in-app-wallet/ecosystem.tsx
+++ b/apps/playground-web/src/components/in-app-wallet/ecosystem.tsx
@@ -4,12 +4,14 @@ import { ecosystemWallet } from "thirdweb/wallets";
 import { StyledConnectEmbed } from "../styled-connect-embed";
 
 const getEcosystem = () => {
-  if (process.env.NEXT_PUBLIC_IN_APP_WALLET_URL?.endsWith(".thirdweb.com")) {
-    // prod ecosystem
-    return "ecosystem.new-age";
+  if (
+    process.env.NEXT_PUBLIC_IN_APP_WALLET_URL?.endsWith(".thirdweb-dev.com")
+  ) {
+    // dev ecosystem
+    return "ecosystem.bonfire-development";
   }
-  // dev ecosystem
-  return "ecosystem.bonfire-development";
+  // prod ecosystem
+  return "ecosystem.new-age";
 };
 
 export function EcosystemConnectEmbed(


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added



<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the ecosystem returned based on the environment in the `getEcosystem` function.

### Detailed summary
- Updated the ecosystem returned based on the environment in `getEcosystem` function.
- Changed the URL check to `.thirdweb-dev.com` for dev ecosystem.
- Updated the return values for dev and prod ecosystems.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->