### PR TITLE
chore(docs): update embedded wallet API endpoint

### DIFF
--- a/apps/portal/src/app/connect/ecosystems/pregenerate-wallets/page.mdx
+++ b/apps/portal/src/app/connect/ecosystems/pregenerate-wallets/page.mdx
@@ -3,7 +3,7 @@
 To pregenerate an embedded wallet, you can make a `POST` request to the following endpoint:
 
 ```
-https://embedded-wallet.thirdweb-dev.com/api/v1/pregenerate
+https://embedded-wallet.thirdweb.com/api/v1/pregenerate
 ```
 
 ### Request Body
@@ -26,9 +26,9 @@ You need to include the following headers:
 Here's an example curl command to pregenerate an embedded wallet:
 
 ```bash
-curl -X POST 'https://embedded-wallet.thirdweb-dev.com/api/v1/pregenerate' \
+curl -X POST 'https://embedded-wallet.thirdweb.com/api/v1/pregenerate' \
   -H 'x-ecosystem-id: ecosystem.example-eco-123' \
-  -H 'x-secret-key: 9f8e7d6c5b4a3f2e1d0c9b8a7f6e5d4c3b2a1f0e9d8c7b6a5f4e3d2c1b0a9f8e7' \
+  -H 'x-secret-key: 9f8e7d6c5b4a3f2e1d0c9b8a7ffge434b2a1f0e9d8c7b6a5f4e3d2c1b0a9f8e7' \
   -H 'Content-Type: application/json' \
   -d '{
     "strategy": "email",


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added



<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the API endpoint URL for pregenerating wallets from `thirdweb-dev.com` to `thirdweb.com`.

### Detailed summary
- Updated the API endpoint URL from `thirdweb-dev.com` to `thirdweb.com` for pregenerating wallets.
- Updated the `x-secret-key` header value in the example curl command.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->