### PR TITLE
[SDK] Fix jsdoc for getCLaimParams

### DIFF
--- a/.changeset/green-otters-judge.md
+++ b/.changeset/green-otters-judge.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix jsdoc for getClaimParams

--- a/packages/thirdweb/src/utils/extensions/drops/get-claim-params.ts
+++ b/packages/thirdweb/src/utils/extensions/drops/get-claim-params.ts
@@ -34,7 +34,7 @@ export type GetClaimParamsOptions = {
  * @extension ERC1155
  * @example
  * ```ts
- * import { getClaimParams } from "thirdweb/extensions/erc1155";
+ * import { getClaimParams } from "thirdweb/utils";
  *
  * const claimParams = await getClaimParams({
  *  contract,


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the JSDoc for the `getClaimParams` function in `get-claim-params.ts` file.

### Detailed summary
- Updated JSDoc for `getClaimParams` function
- Changed import path from "thirdweb/extensions/erc1155" to "thirdweb/utils"

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->