### PR TITLE
Remove permissions form field in ecosystem partners page + UI adjusments

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/[slug]/(active)/components/client/AddPartnerDialogButton.tsx
+++ b/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/[slug]/(active)/components/client/AddPartnerDialogButton.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { PlusIcon } from "lucide-react";
+import { useState } from "react";
+import type { Ecosystem } from "../../../../types";
+import { AddPartnerForm } from "./add-partner-form.client";
+
+export function AddPartnerDialogButton(props: {
+  ecosystem: Ecosystem;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button className="gap-2 max-sm:w-full">
+          <PlusIcon className="size-4" />
+          Add Partner
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader className="mb-2">
+          <DialogTitle className="text-2xl font-semibold tracking-tight">
+            Add Partner
+          </DialogTitle>
+        </DialogHeader>
+        <AddPartnerForm
+          ecosystem={props.ecosystem}
+          onPartnerAdded={() => setOpen(false)}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/[slug]/(active)/components/client/add-partner-form.client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/[slug]/(active)/components/client/add-partner-form.client.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { Spinner } from "@/components/ui/Spinner/Spinner";
 import { Button } from "@/components/ui/button";
 import {
   Form,
@@ -6,17 +7,10 @@ import {
   FormDescription,
   FormField,
   FormItem,
+  FormLabel,
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { ToolTipLabel } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
@@ -26,14 +20,17 @@ import type { Ecosystem } from "../../../../types";
 import { partnerFormSchema } from "../../constants";
 import { useAddPartner } from "../../hooks/use-add-partner";
 
-export function AddPartnerForm({ ecosystem }: { ecosystem: Ecosystem }) {
+export function AddPartnerForm({
+  ecosystem,
+  onPartnerAdded,
+}: { ecosystem: Ecosystem; onPartnerAdded: () => void }) {
   const form = useForm<z.input<typeof partnerFormSchema>>({
     resolver: zodResolver(partnerFormSchema),
   });
 
   const { mutateAsync: addPartner, isPending } = useAddPartner({
     onSuccess: () => {
-      form.reset();
+      onPartnerAdded();
     },
     onError: (error) => {
       const message =
@@ -57,18 +54,18 @@ export function AddPartnerForm({ ecosystem }: { ecosystem: Ecosystem }) {
             allowlistedBundleIds: values.bundleIds
               .split(/,| /)
               .filter((d) => d.length > 0),
-            permissions: [values.permissions],
           });
         })}
-        className="flex flex-col gap-2 lg:flex-row"
+        className="flex flex-col gap-6"
       >
-        <div className="grid gap-2 lg:grid-cols-12 grow">
+        <div className="flex flex-col gap-4">
           <FormField
             control={form.control}
             name="name"
             defaultValue="" // Note: you *must* provide a default value here or the field won't reset
             render={({ field }) => (
-              <FormItem className="col-span-4 lg:col-span-3">
+              <FormItem>
+                <FormLabel> App Name </FormLabel>
                 <FormControl>
                   <Input
                     placeholder="App name"
@@ -94,22 +91,16 @@ export function AddPartnerForm({ ecosystem }: { ecosystem: Ecosystem }) {
             name="domains"
             defaultValue="" // Note: you *must* provide a default value here or the field won't reset
             render={({ field }) => (
-              <FormItem className="col-span-4 lg:col-span-4">
+              <FormItem>
+                <FormLabel> Domains </FormLabel>
                 <FormControl>
-                  <>
-                    <Input placeholder="Domains" className="peer" {...field} />
-                    <FormDescription
-                      className={cn(
-                        "hidden text-xs transition-all lg:block lg:-translate-y-4 lg:opacity-0 peer-focus-visible:opacity-100 peer-focus-visible:translate-y-0",
-                        form.formState.errors.domains?.message &&
-                          "text-destructive lg:translate-y-0 lg:opacity-100 block", // If there are errors show them rather than the tip
-                      )}
-                    >
-                      {form.formState.errors.domains?.message ??
-                        "Space or comma-separated list of regex domains (e.g. *.example.com)"}
-                    </FormDescription>
-                  </>
+                  <Input placeholder="Domains" className="peer" {...field} />
                 </FormControl>
+
+                <FormDescription>
+                  Space or comma-separated list of regex domains (e.g.
+                  *.example.com)
+                </FormDescription>
               </FormItem>
             )}
           />
@@ -118,75 +109,24 @@ export function AddPartnerForm({ ecosystem }: { ecosystem: Ecosystem }) {
             name="bundleIds"
             defaultValue="" // Note: you *must* provide a default value here or the field won't reset
             render={({ field }) => (
-              <FormItem className="col-span-4 lg:col-span-3">
+              <FormItem>
+                <FormLabel> Bundle ID </FormLabel>
                 <FormControl>
-                  <>
-                    <Input
-                      placeholder="Bundle ID"
-                      className="peer"
-                      {...field}
-                    />
-                    <FormDescription
-                      className={cn(
-                        "hidden text-xs transition-all lg:block lg:-translate-y-4 lg:opacity-0 peer-focus-visible:opacity-100 peer-focus-visible:translate-y-0",
-                        form.formState.errors.bundleIds?.message &&
-                          "text-destructive translate-y-0 opacity-100 block",
-                      )}
-                    >
-                      {form.formState.errors.bundleIds?.message ??
-                        "Space or comma-separated list of bundle IDs"}
-                    </FormDescription>
-                  </>
+                  <Input placeholder="Bundle ID" className="peer" {...field} />
                 </FormControl>
+
+                <FormDescription>
+                  Space or comma-separated list of bundle IDs
+                </FormDescription>
+
                 <FormMessage />
               </FormItem>
             )}
           />
-          <FormField
-            control={form.control}
-            name="permissions"
-            defaultValue="PROMPT_USER_V1" // Note: you *must* provide a default value here or the field won't reset
-            render={({ field }) => (
-              <FormItem className="col-span-4 lg:col-span-2">
-                <Select
-                  onValueChange={field.onChange}
-                  defaultValue={field.value}
-                >
-                  <ToolTipLabel label="Should wallet actions prompt the user for approval?">
-                    <FormControl>
-                      <SelectTrigger className="w-full">
-                        <SelectValue placeholder="Wallet prompts" />
-                      </SelectTrigger>
-                    </FormControl>
-                  </ToolTipLabel>
-                  <SelectContent>
-                    <SelectItem value="FULL_CONTROL_V1">
-                      Never prompt
-                    </SelectItem>
-                    <SelectItem value="PROMPT_USER_V1">Prompt user</SelectItem>
-                  </SelectContent>
-
-                  <FormDescription
-                    className={cn(
-                      "hidden text-xs transition-all lg:block lg:-translate-y-4 lg:opacity-0 peer-focus-visible:opacity-100 peer-focus-visible:translate-y-0",
-                      form.formState.errors.permissions?.message &&
-                        "text-destructive lg:translate-y-0 lg:opacity-100 block", // If there are errors show them rather than the tip
-                    )}
-                  >
-                    {form.formState.errors.permissions?.message ??
-                      "Wallet signing"}
-                  </FormDescription>
-                </Select>
-              </FormItem>
-            )}
-          />
         </div>
-        <Button
-          disabled={isPending}
-          type="submit"
-          variant="outline"
-          className="w-full lg:w-auto"
-        >
+
+        <Button disabled={isPending} type="submit" className="w-full gap-2">
+          {isPending && <Spinner className="size-4" />}
           Add
         </Button>
       </form>

--- a/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/[slug]/(active)/components/client/update-partner-form.client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/[slug]/(active)/components/client/update-partner-form.client.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { Spinner } from "@/components/ui/Spinner/Spinner";
 import { Button } from "@/components/ui/button";
 import {
   Form,
@@ -6,20 +7,12 @@ import {
   FormDescription,
   FormField,
   FormItem,
+  FormLabel,
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { ToolTipLabel } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Loader2 } from "lucide-react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import type { z } from "zod";
@@ -38,7 +31,6 @@ export function UpdatePartnerForm({
       name: partner.name,
       domains: partner.allowlistedDomains.join(","),
       bundleIds: partner.allowlistedBundleIds.join(","),
-      permissions: partner.permissions[0],
     },
   });
 
@@ -70,18 +62,18 @@ export function UpdatePartnerForm({
             allowlistedBundleIds: values.bundleIds
               .split(/,| /)
               .filter((d) => d.length > 0),
-            permissions: [values.permissions],
           });
         })}
         className="flex flex-col gap-4"
       >
-        <div className="grid gap-4 grow">
+        <div className="flex flex-col gap-5 grow">
           <FormField
             control={form.control}
             name="name"
             defaultValue="" // Note: you *must* provide a default value here or the field won't reset
             render={({ field }) => (
               <FormItem className="col-span-4">
+                <FormLabel> Name </FormLabel>
                 <FormControl>
                   <Input
                     placeholder="App name"
@@ -108,21 +100,20 @@ export function UpdatePartnerForm({
             defaultValue="" // Note: you *must* provide a default value here or the field won't reset
             render={({ field }) => (
               <FormItem className="col-span-4 lg:col-span-4">
+                <FormLabel> Domains </FormLabel>
                 <FormControl>
-                  <>
-                    <Input placeholder="Domains" className="peer" {...field} />
-                    <FormDescription
-                      className={cn(
-                        "text-xs block",
-                        form.formState.errors.domains?.message &&
-                          "text-destructive translate-y-0 opacity-100 block", // If there are errors show them rather than the tip
-                      )}
-                    >
-                      {form.formState.errors.domains?.message ??
-                        "Space or comma-separated list of regex domains (e.g. *.example.com)"}
-                    </FormDescription>
-                  </>
+                  <Input placeholder="Domains" className="peer" {...field} />
                 </FormControl>
+                <FormDescription
+                  className={cn(
+                    "text-xs block",
+                    form.formState.errors.domains?.message &&
+                      "text-destructive translate-y-0 opacity-100 block", // If there are errors show them rather than the tip
+                  )}
+                >
+                  {form.formState.errors.domains?.message ??
+                    "Space or comma-separated list of regex domains (e.g. *.example.com)"}
+                </FormDescription>
               </FormItem>
             )}
           />
@@ -132,75 +123,32 @@ export function UpdatePartnerForm({
             defaultValue="" // Note: you *must* provide a default value here or the field won't reset
             render={({ field }) => (
               <FormItem className="col-span-4">
+                <FormLabel> Bundle ID </FormLabel>
                 <FormControl>
-                  <>
-                    <Input
-                      placeholder="Bundle ID"
-                      className="peer"
-                      {...field}
-                    />
-                    <FormDescription
-                      className={cn(
-                        "text-xs block",
-                        form.formState.errors.bundleIds?.message &&
-                          "text-destructive block",
-                      )}
-                    >
-                      {form.formState.errors.bundleIds?.message ??
-                        "Space or comma-separated list of bundle IDs"}
-                    </FormDescription>
-                  </>
+                  <Input placeholder="Bundle ID" className="peer" {...field} />
                 </FormControl>
+                <FormDescription
+                  className={cn(
+                    "text-xs block",
+                    form.formState.errors.bundleIds?.message &&
+                      "text-destructive block",
+                  )}
+                >
+                  {form.formState.errors.bundleIds?.message ??
+                    "Space or comma-separated list of bundle IDs"}
+                </FormDescription>
                 <FormMessage />
               </FormItem>
             )}
           />
-          <FormField
-            control={form.control}
-            name="permissions"
-            defaultValue="PROMPT_USER_V1" // Note: you *must* provide a default value here or the field won't reset
-            render={({ field }) => (
-              <FormItem className="col-span-4">
-                <Select
-                  onValueChange={field.onChange}
-                  defaultValue={field.value}
-                >
-                  <ToolTipLabel label="Should wallet actions prompt the user for approval?">
-                    <FormControl>
-                      <SelectTrigger className="w-full">
-                        <SelectValue placeholder="Wallet prompts" />
-                      </SelectTrigger>
-                    </FormControl>
-                  </ToolTipLabel>
-                  <SelectContent>
-                    <SelectItem value="FULL_CONTROL_V1">
-                      Never prompt
-                    </SelectItem>
-                    <SelectItem value="PROMPT_USER_V1">Prompt user</SelectItem>
-                  </SelectContent>
-
-                  <FormDescription
-                    className={cn(
-                      "hidden text-xs transition-all peer-focus-visible:opacity-100 peer-focus-visible:translate-y-0",
-                      form.formState.errors.permissions?.message &&
-                        "text-destructive block", // If there are errors show them rather than the tip
-                    )}
-                  >
-                    {form.formState.errors.permissions?.message ??
-                      "Wallet signing"}
-                  </FormDescription>
-                </Select>
-              </FormItem>
-            )}
-          />
         </div>
+
         <Button
           disabled={isPending}
           type="submit"
-          variant="outline"
-          className="w-full"
+          className="w-full gap-2 mt-4"
         >
-          {isPending && <Loader2 className="size-4 mr-1 animate-spin" />}
+          {isPending && <Spinner className="size-4" />}
           Update
         </Button>
       </form>

--- a/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/[slug]/(active)/components/client/update-partner-modal.client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/[slug]/(active)/components/client/update-partner-modal.client.tsx
@@ -20,11 +20,8 @@ export function UpdatePartnerModal({
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger>{children}</DialogTrigger>
-      <DialogContent
-        className="w-[90vw] sm:w-auto z-[10001]"
-        dialogOverlayClassName="z-[10000]"
-      >
-        <DialogHeader>
+      <DialogContent className="z-[10001]" dialogOverlayClassName="z-[10000]">
+        <DialogHeader className="mb-2">
           <DialogTitle>Update {partner.name}</DialogTitle>
         </DialogHeader>
         <UpdatePartnerForm

--- a/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/[slug]/(active)/components/server/ecosystem-partners-section.tsx
+++ b/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/[slug]/(active)/components/server/ecosystem-partners-section.tsx
@@ -1,24 +1,28 @@
 import type { Ecosystem } from "../../../../types";
-import { AddPartnerForm } from "../client/add-partner-form.client";
+import { AddPartnerDialogButton } from "../client/AddPartnerDialogButton";
 import { PartnersTable } from "./partners-table";
 
 export function EcosystemPartnersSection({
   ecosystem,
 }: { ecosystem: Ecosystem }) {
   return (
-    <section className="flex flex-col gap-4">
-      <div className="flex flex-col gap-1">
-        <h4 className="text-2xl font-semibold text-foreground">
-          Ecosystem partners
-        </h4>
-        <p className="text-sm text-muted-foreground">
-          Configure apps that can use your wallet. Creating a partner will
-          generate a unique partner ID that can access your ecosystem. You will
-          need to generate at least one partner ID for use in your own app.
-        </p>
+    <section className="flex flex-col gap-8 lg:gap-6">
+      <div className="flex lg:justify-between gap-6 lg:items-start flex-col lg:flex-row">
+        <div className="flex flex-col gap-1">
+          <h4 className="text-2xl font-semibold text-foreground">
+            Ecosystem partners
+          </h4>
+          <p className="text-sm text-muted-foreground leading-normal">
+            Configure apps that can use your wallet. Creating a partner will
+            generate a unique partner ID that can access your ecosystem. <br />{" "}
+            You will need to generate at least one partner ID for use in your
+            own app.
+          </p>
+        </div>
+
+        <AddPartnerDialogButton ecosystem={ecosystem} />
       </div>
 
-      <AddPartnerForm ecosystem={ecosystem} />
       <PartnersTable ecosystem={ecosystem} />
     </section>
   );

--- a/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/[slug]/(active)/components/server/partners-table.tsx
+++ b/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/[slug]/(active)/components/server/partners-table.tsx
@@ -44,9 +44,7 @@ export function PartnersTable({ ecosystem }: { ecosystem: Ecosystem }) {
             <TableHead className="hidden md:table-cell">Domains</TableHead>
             <TableHead className="hidden md:table-cell">Bundle ID</TableHead>
             <TableHead className="hidden sm:table-cell">Partner ID</TableHead>
-            <TableHead className="hidden lg:table-cell">
-              Wallet Prompts
-            </TableHead>
+
             {/* Empty space for delete button */}
             <th className="table-cell" />
           </TableRow>
@@ -108,11 +106,7 @@ function PartnerRow(props: {
           </div>
         </ToolTipLabel>
       </TableCell>
-      <TableCell className="hidden align-top lg:table-cell">
-        {props.partner.permissions.includes("PROMPT_USER_V1")
-          ? "Prompt user"
-          : "Never prompt"}
-      </TableCell>
+
       <td className="table-cell py-1 align-middle">
         <div className="flex gap-1.5 pr-1.5 justify-end">
           <UpdatePartnerModal

--- a/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/[slug]/(active)/constants.ts
+++ b/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/[slug]/(active)/constants.ts
@@ -1,6 +1,4 @@
 import z from "zod";
-import type { PartnerPermission } from "../../types";
-import { isValidPermission } from "./utils";
 
 const isDomainRegex =
   /^(?:\*|(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)*(?:\*(?:\.[a-z0-9][a-z0-9-]{0,61}[a-z0-9](?:\.[a-z0-9][a-z0-9-]{0,61}[a-z0-9])*)?)|(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]|localhost(?::\d{1,5})?)$/;
@@ -32,10 +30,4 @@ export const partnerFormSchema = z.object({
         .filter((d) => d.length > 0)
         .join(","),
     ),
-  permissions: z.custom<PartnerPermission>(
-    (value) => isValidPermission(value),
-    {
-      message: "Invalid permissions setting",
-    },
-  ),
 });

--- a/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/[slug]/(active)/hooks/use-add-partner.ts
+++ b/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/[slug]/(active)/hooks/use-add-partner.ts
@@ -11,7 +11,6 @@ type AddPartnerParams = {
   name: string;
   allowlistedDomains: string[];
   allowlistedBundleIds: string[];
-  permissions: ["PROMPT_USER_V1" | "FULL_CONTROL_V1"];
 };
 
 export function useAddPartner(
@@ -44,7 +43,8 @@ export function useAddPartner(
             name: params.name,
             allowlistedDomains: params.allowlistedDomains,
             allowlistedBundleIds: params.allowlistedBundleIds,
-            permissions: params.permissions,
+            // TODO - remove the requirement for permissions in API endpoint
+            permissions: ["FULL_CONTROL_V1"],
           }),
         },
       );

--- a/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/[slug]/(active)/hooks/use-update-partner.ts
+++ b/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/[slug]/(active)/hooks/use-update-partner.ts
@@ -12,7 +12,6 @@ type UpdatePartnerParams = {
   name: string;
   allowlistedDomains: string[];
   allowlistedBundleIds: string[];
-  permissions: ["PROMPT_USER_V1" | "FULL_CONTROL_V1"];
 };
 
 export function useUpdatePartner(
@@ -45,7 +44,6 @@ export function useUpdatePartner(
             name: params.name,
             allowlistedDomains: params.allowlistedDomains,
             allowlistedBundleIds: params.allowlistedBundleIds,
-            permissions: params.permissions,
           }),
         },
       );

--- a/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/[slug]/(active)/utils.ts
+++ b/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/[slug]/(active)/utils.ts
@@ -1,6 +1,0 @@
-import type { PartnerPermission } from "../../types.ts";
-
-export const isValidPermission = (
-  permission: string,
-): permission is PartnerPermission =>
-  ["FULL_CONTROL_V1", "PROMPT_USER_V1"].includes(permission);

--- a/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/types.ts
+++ b/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/types.ts
@@ -11,7 +11,7 @@ export type Ecosystem = {
   updatedAt: string;
 };
 
-export type PartnerPermission = "PROMPT_USER_V1" | "FULL_CONTROL_V1";
+type PartnerPermission = "PROMPT_USER_V1" | "FULL_CONTROL_V1";
 export type Partner = {
   id: string;
   name: string;

--- a/apps/dashboard/src/app/(dashboard)/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/layout.tsx
@@ -5,7 +5,7 @@ import { ErrorProvider } from "../../contexts/error-handler";
 export default function DashboardLayout(props: { children: React.ReactNode }) {
   return (
     <ErrorProvider>
-      <div className="flex flex-col h-full bg-background">
+      <div className="flex flex-col min-h-screen bg-background">
         <DashboardHeader />
         <main className="grow">{props.children}</main>
         <AppFooter />


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes unnecessary permissions and refactors UI components in the dashboard ecosystem feature.

### Detailed summary
- Removed unnecessary `PartnerPermission` export
- Updated UI components in the dashboard layout
- Refactored hooks for updating and adding partners
- Updated UI components for partner-related modals and dialogs

> The following files were skipped due to too many changes: `apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/[slug]/(active)/components/client/add-partner-form.client.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->