### PR TITLE
feat(ReactNative): respect icon theme color in wallet UI

### DIFF
--- a/.changeset/dull-rockets-joke.md
+++ b/.changeset/dull-rockets-joke.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+[ReactNative] Respect icon theme color in connect button and detail modal

--- a/packages/thirdweb/src/react/native/ui/components/WalletImage.tsx
+++ b/packages/thirdweb/src/react/native/ui/components/WalletImage.tsx
@@ -65,7 +65,14 @@ export const WalletImage = (props: {
   });
 
   const data = avatar || imageData || WALLET_ICON;
-  return <RNImage theme={props.theme} data={data} size={size} />;
+  return (
+    <RNImage
+      theme={props.theme}
+      data={data}
+      size={size}
+      color={props.theme.colors.accentButtonBg}
+    />
+  );
 };
 
 export function getAuthProviderImage(authProvider: string | null): string {


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added



<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on respecting the icon theme color in the connect button and detail modal in React Native. 

### Detailed summary
- Updated `WalletImage.tsx` to pass the theme color to the `RNImage` component for the connect button and detail modal.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->