### PR TITLE
fix: improve ABI resolution fallback

### DIFF
--- a/.changeset/loud-beds-pull.md
+++ b/.changeset/loud-beds-pull.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix abi resolution fallback


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to fix the ABI resolution fallback mechanism in the `resolve-abi.ts` file.

### Detailed summary
- Removed unused imports
- Updated ABI resolution logic using new functions
- Improved error handling for empty bytecodes
- Refactored the merging and filtering of ABI arrays

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->