### PR TITLE
fix: handle BigInt serialization for ecosystem wallets

### DIFF
--- a/.changeset/proud-eggs-rule.md
+++ b/.changeset/proud-eggs-rule.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Handle biging serialization for ecosystem wallets

--- a/packages/thirdweb/src/wallets/in-app/web/lib/actions/sign-message.enclave.ts
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/actions/sign-message.enclave.ts
@@ -1,6 +1,7 @@
 import type { ThirdwebClient } from "../../../../../client/client.js";
 import { getThirdwebBaseUrl } from "../../../../../utils/domains.js";
 import { getClientFetch } from "../../../../../utils/fetch.js";
+import { stringify } from "../../../../../utils/json.js";
 import type { Ecosystem } from "../../types.js";
 import { getAuthToken } from "../get-auth-token.js";
 
@@ -28,7 +29,7 @@ export async function signMessage({
         "x-thirdweb-client-id": client.clientId,
         Authorization: `Bearer embedded-wallet-token:${authToken}`,
       },
-      body: JSON.stringify({
+      body: stringify({
         messagePayload: {
           message,
           isRaw,

--- a/packages/thirdweb/src/wallets/in-app/web/lib/actions/sign-transaction.enclave.ts
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/actions/sign-transaction.enclave.ts
@@ -2,6 +2,7 @@ import type { ThirdwebClient } from "../../../../../client/client.js";
 import { getThirdwebBaseUrl } from "../../../../../utils/domains.js";
 import type { Hex } from "../../../../../utils/encoding/hex.js";
 import { getClientFetch } from "../../../../../utils/fetch.js";
+import { stringify } from "../../../../../utils/json.js";
 import type { Ecosystem } from "../../types.js";
 import { getAuthToken } from "../get-auth-token.js";
 
@@ -27,7 +28,7 @@ export async function signTransaction({
         "x-thirdweb-client-id": client.clientId,
         Authorization: `Bearer embedded-wallet-token:${authToken}`,
       },
-      body: JSON.stringify({
+      body: stringify({
         transactionPayload: payload,
       }),
     },

--- a/packages/thirdweb/src/wallets/in-app/web/lib/actions/sign-typed-data.enclave.ts
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/actions/sign-typed-data.enclave.ts
@@ -3,6 +3,7 @@ import type { TypedDataDefinition } from "viem";
 import type { ThirdwebClient } from "../../../../../client/client.js";
 import { getThirdwebBaseUrl } from "../../../../../utils/domains.js";
 import { getClientFetch } from "../../../../../utils/fetch.js";
+import { stringify } from "../../../../../utils/json.js";
 import type { Ecosystem } from "../../types.js";
 import { getAuthToken } from "../get-auth-token.js";
 
@@ -30,7 +31,7 @@ export async function signTypedData<
         "x-thirdweb-client-id": client.clientId,
         Authorization: `Bearer embedded-wallet-token:${authToken}`,
       },
-      body: JSON.stringify({
+      body: stringify({
         ...payload,
       }),
     },


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to handle biging serialization for ecosystem wallets.

### Detailed summary
- Updated `signTypedData`, `signMessage`, and `signTransaction` functions to use `stringify` method for serialization
- Improved handling of ecosystem wallets in the `in-app/web` module

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->