### PR TITLE
fix: guest auth should use random session Ids

### DIFF
--- a/.changeset/dry-dancers-camp.md
+++ b/.changeset/dry-dancers-camp.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix guest account creation uniqueness

--- a/packages/thirdweb/src/wallets/in-app/core/authentication/client-scoped-storage.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/authentication/client-scoped-storage.ts
@@ -3,6 +3,7 @@ import type { EcosystemWalletId } from "../../../wallet-types.js";
 import {
   AUTH_TOKEN_LOCAL_STORAGE_NAME,
   DEVICE_SHARE_LOCAL_STORAGE_NAME,
+  GUEST_SESSION_LOCAL_STORAGE_NAME,
   PASSKEY_CREDENTIAL_ID_LOCAL_STORAGE_NAME,
   WALLET_CONNECT_SESSIONS_LOCAL_STORAGE_NAME,
   WALLET_USER_ID_LOCAL_STORAGE_NAME,
@@ -153,6 +154,19 @@ export class ClientScopedStorage {
    */
   async removeWalletUserId(): Promise<boolean> {
     return this.removeItem(WALLET_USER_ID_LOCAL_STORAGE_NAME(this.key));
+  }
+
+  /**
+   * @internal
+   */
+  async getGuestSessionId(): Promise<string | null> {
+    return this.getItem(GUEST_SESSION_LOCAL_STORAGE_NAME(this.key));
+  }
+  /**
+   * @internal
+   */
+  async saveGuestSessionId(sessionId: string): Promise<void> {
+    await this.setItem(GUEST_SESSION_LOCAL_STORAGE_NAME(this.key), sessionId);
   }
 }
 

--- a/packages/thirdweb/src/wallets/in-app/core/constants/settings.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/constants/settings.ts
@@ -52,3 +52,9 @@ export const DEVICE_SHARE_LOCAL_STORAGE_NAME = (key: string, userId: string) =>
  */
 export const WALLET_CONNECT_SESSIONS_LOCAL_STORAGE_NAME = (key: string) =>
   `walletConnectSessions-${key}`;
+
+/**
+ * @internal
+ */
+export const GUEST_SESSION_LOCAL_STORAGE_NAME = (key: string) =>
+  `thirdweb_guest_session_id_${key}`;

--- a/packages/thirdweb/src/wallets/in-app/native/auth/native-auth.ts
+++ b/packages/thirdweb/src/wallets/in-app/native/auth/native-auth.ts
@@ -1,6 +1,7 @@
 import * as WebBrowser from "expo-web-browser";
 import type { Chain } from "../../../../chains/types.js";
 import type { ThirdwebClient } from "../../../../client/client.js";
+import { nativeLocalStorage } from "../../../../utils/storage/nativeStorage.js";
 import type { Wallet } from "../../../interfaces/wallet.js";
 import { getLoginUrl } from "../../core/authentication/getLoginPath.js";
 import { guestAuthenticate } from "../../core/authentication/guest.js";
@@ -166,6 +167,7 @@ export async function guestLogin(
   const { storedToken } = await guestAuthenticate({
     client,
     ecosystem,
+    storage: nativeLocalStorage,
   });
   try {
     const toStoreToken: AuthStoredTokenWithCookieReturnType["storedToken"] = {

--- a/packages/thirdweb/src/wallets/in-app/native/native-connector.ts
+++ b/packages/thirdweb/src/wallets/in-app/native/native-connector.ts
@@ -105,6 +105,7 @@ export class InAppNativeConnector implements InAppConnector {
         return guestAuthenticate({
           client: this.options.client,
           ecosystem: params.ecosystem,
+          storage: nativeLocalStorage,
         });
       }
       case "wallet": {

--- a/packages/thirdweb/src/wallets/in-app/web/lib/web-connector.ts
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/web-connector.ts
@@ -316,6 +316,7 @@ export class InAppWebConnector implements InAppConnector {
         return guestAuthenticate({
           client: this.client,
           ecosystem: this.ecosystem,
+          storage: webLocalStorage,
         });
       }
       case "wallet": {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing guest account creation by ensuring unique session IDs for guests, implementing local storage for session management, and improving the overall authentication process.

### Detailed summary
- Added `GUEST_SESSION_LOCAL_STORAGE_NAME` function for guest session ID storage.
- Updated `guestAuthenticate` to manage guest session IDs using `ClientScopedStorage`.
- Implemented methods `getGuestSessionId` and `saveGuestSessionId` in `ClientScopedStorage`.
- Used `nativeLocalStorage` for storing guest data in `native-connector.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->