### PR TITLE
fix: Return 402 status if payment required

### DIFF
--- a/.changeset/nice-experts-greet.md
+++ b/.changeset/nice-experts-greet.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+fix: Return 402 status if payment required

--- a/packages/service-utils/src/core/usageLimit/index.ts
+++ b/packages/service-utils/src/core/usageLimit/index.ts
@@ -34,7 +34,7 @@ export async function usageLimit(
   ) {
     return {
       usageLimited: true,
-      status: 403,
+      status: 402,
       errorMessage: `You've used all of your total usage credits for Storage Pinning. Please add your payment method at https://thirdweb.com/dashboard/settings/billing.`,
       errorCode: "PAYMENT_METHOD_REQUIRED",
     };
@@ -47,7 +47,7 @@ export async function usageLimit(
   ) {
     return {
       usageLimited: true,
-      status: 403,
+      status: 402,
       errorMessage: `You've used all of your total usage credits for Embedded Wallets. Please add your payment method at https://thirdweb.com/dashboard/settings/billing.`,
       errorCode: "PAYMENT_METHOD_REQUIRED",
     };

--- a/packages/service-utils/src/core/usageLimit/usageLimit.test.ts
+++ b/packages/service-utils/src/core/usageLimit/usageLimit.test.ts
@@ -64,7 +64,7 @@ describe("usageLimit", () => {
 
     expect(result).toEqual({
       usageLimited: true,
-      status: 403,
+      status: 402,
       errorMessage: `You've used all of your total usage credits for Storage Pinning. Please add your payment method at https://thirdweb.com/dashboard/settings/billing.`,
       errorCode: "PAYMENT_METHOD_REQUIRED",
     });


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the status code returned when a payment method is required from `403` to `402` in the `service-utils` package, indicating that payment is necessary.

### Detailed summary
- Updated status code from `403` to `402` in:
  - `packages/service-utils/src/core/usageLimit/usageLimit.test.ts`
  - `packages/service-utils/src/core/usageLimit/index.ts`
- Adjusted error messages to reflect the change in status code.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->