### PR TITLE
Remove "push" script and task

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "release": "node ./scripts/pre-release.mjs && turbo run update-version && pnpm build:release && changeset publish",
     "version-packages:nightly": "node scripts/pre-nightly.mjs && changeset version --snapshot nightly",
     "release:nightly": "node ./scripts/pre-release.mjs && turbo run update-version && pnpm build && changeset publish --tag nightly",
-    "push": "turbo run push --filter=./packages/*",
     "hotlink-init": "node ./scripts/hotlink/hotlink-init.mjs",
     "hotlink-revert": "node ./scripts/hotlink/hotlink-revert.mjs"
   },

--- a/turbo.json
+++ b/turbo.json
@@ -84,10 +84,6 @@
     },
     "clean": {
       "cache": false
-    },
-    "push": {
-      "cache": false,
-      "dependsOn": ["build"]
     }
   }
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on modifying the `turbo.json` and `package.json` configuration files by removing the `push` configuration from `turbo.json` and updating the `package.json` scripts related to nightly releases.

### Detailed summary
- Removed the `push` configuration from `turbo.json`, including its `cache` option and `dependsOn` array.
- Updated the `package.json` by removing the `push` script that triggered `turbo run push --filter=./packages/*`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->