### PR TITLE
Improve storage upload error handling

### DIFF
--- a/.changeset/thick-gifts-push.md
+++ b/.changeset/thick-gifts-push.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+improve error handling for 402 and 403 error codes in storage upload

--- a/packages/thirdweb/src/storage/upload/web-node.ts
+++ b/packages/thirdweb/src/storage/upload/web-node.ts
@@ -30,6 +30,16 @@ export async function uploadBatch<const TFiles extends UploadableFile[]>(
         "Unauthorized - You don't have permission to use this service.",
       );
     }
+    if (res.status === 402) {
+      throw new Error(
+        "You have reached your storage limit. Please add a valid payment method to continue using the service.",
+      );
+    }
+    if (res.status === 403) {
+      throw new Error(
+        "Forbidden - You don't have permission to use this service.",
+      );
+    }
     throw new Error(
       `Failed to upload files to IPFS - ${res.status} - ${res.statusText}`,
     );


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on improving error handling in the `thirdweb` package by adding specific error messages for HTTP status codes 402 (Payment Required) and 403 (Forbidden) during storage uploads.

### Detailed summary
- Added error handling for HTTP status `402`: Throws an error indicating the storage limit has been reached and prompts to add a payment method.
- Added error handling for HTTP status `403`: Throws an error indicating lack of permission to use the service.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->