### PR TITLE
[React] Fix: Balance label space

### DIFF
--- a/.changeset/stale-suns-check.md
+++ b/.changeset/stale-suns-check.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix spacing in native balance label on connect UI

--- a/packages/thirdweb/biome.json
+++ b/packages/thirdweb/biome.json
@@ -1,30 +1,33 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.2/schema.json",
-  "extends": ["../../biome.json"],
-  "linter": {
-    "rules": {
-      "nursery": {
-        "noProcessEnv": "warn"
-      }
-    }
-  },
-  "overrides": [{
-    "include": ["src/**/*.test.ts","src/**/*.test.tsx", "src/stories/**"],
-    "linter": {
-      "rules": {
-        "nursery": {
-          "noProcessEnv": "off"
-        }
-      }
-    }
-  }],
-  "files": {
-    "ignore": [
-      "src/crypto/aes/lib/md5.ts",
-      "src/utils/promise/p-limit.ts",
-      "src/utils/bytecode/cbor-decode.ts",
-      "src/wallets/in-app/native/helpers/wallet/sss.ts",
-      "src/**/__generated__/**"
-    ]
-  }
+	"$schema": "https://biomejs.dev/schemas/1.9.2/schema.json",
+	"extends": ["../../biome.json"],
+	"linter": {
+		"rules": {
+			"nursery": {
+				"noProcessEnv": "warn",
+				"useConsistentCurlyBraces": "off"
+			}
+		}
+	},
+	"overrides": [
+		{
+			"include": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/stories/**"],
+			"linter": {
+				"rules": {
+					"nursery": {
+						"noProcessEnv": "off"
+					}
+				}
+			}
+		}
+	],
+	"files": {
+		"ignore": [
+			"src/crypto/aes/lib/md5.ts",
+			"src/utils/promise/p-limit.ts",
+			"src/utils/bytecode/cbor-decode.ts",
+			"src/wallets/in-app/native/helpers/wallet/sss.ts",
+			"src/**/__generated__/**"
+		]
+	}
 }

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/Details.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/Details.tsx
@@ -260,7 +260,7 @@ export const ConnectedWalletDetails: React.FC<{
             color="secondaryText"
             weight={400}
           >
-            {formatBalanceOnButton(Number(balanceQuery.data.displayValue))}
+            {formatBalanceOnButton(Number(balanceQuery.data.displayValue))}{" "}
             {balanceQuery.data.symbol}
           </Text>
         ) : (
@@ -366,7 +366,7 @@ function DetailsModal(props: {
               formatNumber(Number(balanceQuery.data.displayValue), 5)
             ) : (
               <Skeleton height="1em" width="100px" />
-            )}
+            )}{" "}
             {balanceQuery.data?.symbol}
           </Text>
         </Text>


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the user interface of the connect wallet feature by fixing spacing issues in the native balance label and updating the `biome.json` configuration to include a new linter rule.

### Detailed summary
- Fixed spacing in the native balance label in `packages/thirdweb/src/react/web/ui/ConnectWallet/Details.tsx`.
- Updated `biome.json` to add `useConsistentCurlyBraces: "off"` under the `nursery` linter rules.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->