### PR TITLE
fix typedoc setup

### DIFF
--- a/packages/thirdweb/scripts/typedoc.mjs
+++ b/packages/thirdweb/scripts/typedoc.mjs
@@ -1,29 +1,9 @@
 // @ts-check
 import TypeDoc from "typedoc";
 
-/**
- *
- * Generate a documentation JSON file for a project
- * @param {{ entryPoints: string[]; exclude: string[]; }} options
- */
-async function typedoc(options) {
-  const jsonOut = "typedoc/documentation.json";
+const jsonOut = "typedoc/documentation.json";
 
-  const app = await TypeDoc.Application.bootstrapWithPlugins({
-    entryPoints: options.entryPoints,
-    excludeInternal: true,
-    exclude: options.exclude,
-  });
-
-  const project = await app.convert();
-  if (!project) {
-    throw new Error("Failed to create project");
-  }
-
-  await app.generateJson(project, jsonOut);
-}
-
-typedoc({
+const app = await TypeDoc.Application.bootstrapWithPlugins({
   entryPoints: ["src/exports/**/*.ts", "src/extensions/modules/**/index.ts"],
   exclude: [
     "src/exports/*.native.ts",
@@ -33,4 +13,13 @@ typedoc({
     "src/**/*.test.tsx",
     "src/**/*.bench.ts",
   ],
+  excludeInternal: true,
+  tsconfig: "tsconfig.typedoc.json",
 });
+
+const project = await app.convert();
+if (!project) {
+  throw new Error("Failed to create project");
+}
+
+await app.generateJson(project, jsonOut);

--- a/packages/thirdweb/tsconfig.typedoc.json
+++ b/packages/thirdweb/tsconfig.typedoc.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.base.json",
+  "include": ["src"],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.test-d.ts",
+    "src/**/*.bench.ts",
+    "src/**/*.macro.ts"
+  ],
+  "compilerOptions": {
+    "moduleResolution": "NodeNext",
+    "sourceMap": true,
+    "rootDir": "./src"
+  }
+}


### PR DESCRIPTION
### TL;DR

Refactored TypeDoc script and added a dedicated TypeScript configuration for documentation generation.

### What changed?

- Simplified the `typedoc.mjs` script by removing the `typedoc` function and directly executing the TypeDoc application.
- Added a new `tsconfig.typedoc.json` file specifically for TypeDoc configuration.
- Updated the TypeDoc application configuration to use the new TypeScript config file.

### How to test?

1. Run the TypeDoc script to generate documentation.
2. Verify that the `typedoc/documentation.json` file is created successfully.
3. Check that the generated documentation includes the correct files and excludes the specified ones.

### Why make this change?

This change improves the documentation generation process by:
1. Simplifying the TypeDoc script for better maintainability.
2. Providing a dedicated TypeScript configuration for documentation, ensuring more accurate type information.
3. Enhancing consistency in the documentation output by using a specific tsconfig file.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on configuring TypeDoc for generating documentation for the `thirdweb` package, including a new `tsconfig.typedoc.json` file and adjustments to the `typedoc.mjs` script.

### Detailed summary
- Added `tsconfig.typedoc.json` with configuration options for TypeDoc.
- Updated `typedoc.mjs` to use new entry points and exclude patterns.
- Set `tsconfig` option to reference the new `tsconfig.typedoc.json`.
- Removed the previous function definition for `typedoc`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->