### PR TITLE
Update pregen docs

### DIFF
--- a/apps/portal/src/app/connect/ecosystems/pregenerate-wallets/page.mdx
+++ b/apps/portal/src/app/connect/ecosystems/pregenerate-wallets/page.mdx
@@ -41,6 +41,7 @@ Use this when [bringing your own authentication method](/connect/in-app-wallet/c
 You need to include the following headers:
 
 - `x-ecosystem-id`: Your ecosystem ID
+- `x-ecosystem-partner-id`: Your ecosystem partner ID
 - `x-secret-key`: Your secret key for authentication
 - `Content-Type`: Must be set to `application/json`
 
@@ -51,6 +52,7 @@ Here's an example curl command to pregenerate an embedded wallet:
 ```bash
 curl -X POST 'https://embedded-wallet.thirdweb.com/api/v1/pregenerate' \
   -H 'x-ecosystem-id: ecosystem.example-eco-123' \
+  -H 'x-ecosystem-partner-id: 1415d24e-c7b0-4fce-846e-740841ef2c32' \
   -H 'x-secret-key: 9f8e7d6c5b4a3f2e1d0c9b8a7ffge434b2a1f0e9d8c7b6a5f4e3d2c1b0a9f8e7' \
   -H 'Content-Type: application/json' \
   -d '{


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added



<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the API documentation for pregenerating wallets in the `page.mdx` file by modifying the header parameters used in the curl command.

### Detailed summary
- Changed the header from `x-ecosystem-id` to `x-ecosystem-partner-id` with a new example value.
- Retained the `x-secret-key` and `Content-Type` headers without changes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->