### PR TITLE
feat(storage): add JSON object upload example and documentation

### DIFF
--- a/apps/portal/src/app/typescript/v5/storage/page.mdx
+++ b/apps/portal/src/app/typescript/v5/storage/page.mdx
@@ -2,7 +2,7 @@
 
 The thirdweb SDK comes built-in with an IPFS uploader and downloader.
 
-### Download from IPFS
+## Download from IPFS
 
 ```ts
 import { download } from "thirdweb/storage";
@@ -15,7 +15,27 @@ const file = await download({
 
 You can view all of the configuration options in the [full reference](/references/typescript/v5/download).
 
-### Upload to IPFS
+## Upload to IPFS
+
+### Uploading JSON objects
+
+```ts
+import { upload } from "thirdweb/storage";
+
+const uris = await upload({
+	client,
+	files: [
+		{
+			name: "something",
+			data: {
+				hello: "world",
+			},
+		},
+	],
+});
+```
+
+### Uploading files
 
 ```ts
 import { upload } from "thirdweb/storage";

--- a/packages/thirdweb/src/storage/upload.ts
+++ b/packages/thirdweb/src/storage/upload.ts
@@ -33,6 +33,25 @@ type UploadReturnType<TFiles extends UploadableFile[]> = TFiles extends {
  * @returns A promise that resolves to the uploaded file URI or URIs (when passing multiple files).
  * @throws An error if the upload fails.
  * @example
+ *
+ * ### Uploading JSON objects
+ *
+ * ```ts
+ * import { upload } from "thirdweb/storage";
+ * const uri = await upload({
+ *  client,
+ *  files: [
+ *    {
+ *      name: "something",
+ *      data: {
+ *        hello: "world",
+ *      },
+ *    },
+ *  ],
+ * });
+ *
+ * ### Uploading files
+ *
  * ```ts
  * import { upload } from "thirdweb/storage";
  * const uri = await upload({


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added



<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the documentation for the `upload` and `download` functions in the `thirdweb/storage` module by adding examples for uploading JSON objects and restructuring section headers for clarity.

### Detailed summary
- Added an example for uploading JSON objects in `packages/thirdweb/src/storage/upload.ts`.
- Changed section header from "### Download from IPFS" to "## Download from IPFS" in `apps/portal/src/app/typescript/v5/storage/page.mdx`.
- Changed section header from "### Upload to IPFS" to "## Upload to IPFS" in `apps/portal/src/app/typescript/v5/storage/page.mdx`.
- Included an example for uploading JSON objects in `apps/portal/src/app/typescript/v5/storage/page.mdx`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->