### PR TITLE
[SDK] Fix: adds ERC20 transfer overrides param

### DIFF
--- a/packages/thirdweb/src/extensions/erc20/write/transfer.ts
+++ b/packages/thirdweb/src/extensions/erc20/write/transfer.ts
@@ -1,4 +1,7 @@
-import type { BaseTransactionOptions } from "../../../transaction/types.js";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../transaction/types.js";
 import type { Prettify } from "../../../utils/type-utils.js";
 import { toUnits } from "../../../utils/units.js";
 import { transfer as generatedTransfer } from "../__generated__/IERC20/write/transfer.js";
@@ -8,14 +11,16 @@ import { transfer as generatedTransfer } from "../__generated__/IERC20/write/tra
  * @extension ERC20
  */
 export type TransferParams = Prettify<
-  { to: string } & (
-    | {
-        amount: number | string;
-      }
-    | {
-        amountWei: bigint;
-      }
-  )
+  WithOverrides<
+    { to: string } & (
+      | {
+          amount: number | string;
+        }
+      | {
+          amountWei: bigint;
+        }
+    )
+  >
 >;
 
 /**
@@ -60,6 +65,7 @@ export function transfer(options: BaseTransactionOptions<TransferParams>) {
             amountWei: amount,
             tokenAddress: options.contract.address,
           },
+          ...options.overrides,
         },
       } as const;
     },

--- a/packages/thirdweb/src/extensions/erc20/write/transferFrom.ts
+++ b/packages/thirdweb/src/extensions/erc20/write/transferFrom.ts
@@ -1,5 +1,8 @@
 import type { Address } from "abitype";
-import type { BaseTransactionOptions } from "../../../transaction/types.js";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../transaction/types.js";
 import { toUnits } from "../../../utils/units.js";
 
 import type { Prettify } from "../../../utils/type-utils.js";
@@ -10,14 +13,16 @@ import { transferFrom as generatedTransferFrom } from "../__generated__/IERC20/w
  * @extension ERC20
  */
 export type TransferFromParams = Prettify<
-  { to: Address; from: Address } & (
-    | {
-        amount: number | string;
-      }
-    | {
-        amountWei: bigint;
-      }
-  )
+  WithOverrides<
+    { to: Address; from: Address } & (
+      | {
+          amount: number | string;
+        }
+      | {
+          amountWei: bigint;
+        }
+    )
+  >
 >;
 
 /**
@@ -66,6 +71,7 @@ export function transferFrom(
             amountWei: amount,
             tokenAddress: options.contract.address,
           },
+          ...options.overrides,
         },
       } as const;
     },


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `transferFrom` and `transfer` functions in the `erc20` extension by adding `WithOverrides` to the transaction parameters, enabling the passing of additional options during token transfers.

### Detailed summary
- Added `WithOverrides` to `TransferFromParams` and `TransferParams` types.
- Updated the `transferFrom` function to accept `options.overrides`.
- Updated the `transfer` function to accept `options.overrides`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->