### PR TITLE
Fix Cronos zkevm deployments

### DIFF
--- a/.changeset/cold-dolphins-know.md
+++ b/.changeset/cold-dolphins-know.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Add cronos zkevm to isZkSyncChain check

--- a/packages/thirdweb/src/utils/any-evm/zksync/isZkSyncChain.ts
+++ b/packages/thirdweb/src/utils/any-evm/zksync/isZkSyncChain.ts
@@ -5,6 +5,8 @@ export function isZkSyncChain(chain: Chain) {
     chain.id === 324 ||
     chain.id === 300 ||
     chain.id === 302 ||
-    chain.id === 11124
+    chain.id === 11124 ||
+    chain.id === 282 || // cronos zkevm testnet
+    chain.id === 388 // cronos zkevm mainnet
   );
 }


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `isZkSyncChain` check to include support for the `cronos zkevm` chains, enhancing the functionality of the `thirdweb` package.

### Detailed summary
- Modified the `isZkSyncChain` function in `packages/thirdweb/src/utils/any-evm/zksync/isZkSyncChain.ts`.
- Added checks for `chain.id` values `282` (cronos zkevm testnet) and `388` (cronos zkevm mainnet).

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->