### PR TITLE
[SDK] Avoid IPFS uploads in tests whenever possible

### DIFF
--- a/packages/thirdweb/src/extensions/erc1155/drop1155.test.ts
+++ b/packages/thirdweb/src/extensions/erc1155/drop1155.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, describe, expect, it } from "vitest";
+import { TEST_CONTRACT_URI } from "~test/ipfs-uris.js";
 import { VITALIK_WALLET } from "../../../test/src/addresses.js";
 import { ANVIL_CHAIN } from "../../../test/src/chains.js";
 import { TEST_CLIENT } from "../../../test/src/test-clients.js";
@@ -11,7 +12,6 @@ import { type ThirdwebContract, getContract } from "../../contract/contract.js";
 import { sendAndConfirmTransaction } from "../../transaction/actions/send-and-confirm-transaction.js";
 import { resolvePromisedValue } from "../../utils/promise/resolve-promised-value.js";
 import { toEther } from "../../utils/units.js";
-import { getContractMetadata } from "../common/read/getContractMetadata.js";
 import { deployERC1155Contract } from "../prebuilts/deploy-erc1155.js";
 import { balanceOf } from "./__generated__/IERC1155/read/balanceOf.js";
 import { nextTokenIdToMint } from "./__generated__/IERC1155Enumerable/read/nextTokenIdToMint.js";
@@ -37,6 +37,7 @@ describe.runIf(process.env.TW_SECRET_KEY)(
         client: TEST_CLIENT,
         params: {
           name: "Test DropERC1155",
+          contractURI: TEST_CONTRACT_URI,
         },
         type: "DropERC1155",
       });
@@ -48,16 +49,6 @@ describe.runIf(process.env.TW_SECRET_KEY)(
       });
       // this deploys a contract, it may take some time
     }, 60_000);
-
-    describe("Deployment", () => {
-      it("should deploy", async () => {
-        expect(contract).toBeDefined();
-      });
-      it("should have the correct name", async () => {
-        const metadata = await getContractMetadata({ contract });
-        expect(metadata.name).toBe("Test DropERC1155");
-      });
-    });
 
     it("should allow for lazy minting tokens", async () => {
       const mintTx = lazyMint({

--- a/packages/thirdweb/src/extensions/erc1155/token1155.test.ts
+++ b/packages/thirdweb/src/extensions/erc1155/token1155.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, describe, expect, it } from "vitest";
+import { TEST_CONTRACT_URI } from "~test/ipfs-uris.js";
 import { ANVIL_CHAIN } from "../../../test/src/chains.js";
 import { TEST_CLIENT } from "../../../test/src/test-clients.js";
 import {
@@ -7,7 +8,6 @@ import {
 } from "../../../test/src/test-wallets.js";
 import { type ThirdwebContract, getContract } from "../../contract/contract.js";
 import { sendAndConfirmTransaction } from "../../transaction/actions/send-and-confirm-transaction.js";
-import { getContractMetadata } from "../common/read/getContractMetadata.js";
 import { deployERC1155Contract } from "../prebuilts/deploy-erc1155.js";
 import { balanceOf } from "./__generated__/IERC1155/read/balanceOf.js";
 import { totalSupply } from "./__generated__/IERC1155/read/totalSupply.js";
@@ -27,6 +27,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("TokenERC1155", () => {
       client: TEST_CLIENT,
       params: {
         name: "Test TokenERC1155",
+        contractURI: TEST_CONTRACT_URI,
       },
       type: "TokenERC1155",
     });
@@ -38,16 +39,6 @@ describe.runIf(process.env.TW_SECRET_KEY)("TokenERC1155", () => {
     });
     // this deploys a contract, it may take some time
   }, 60_000);
-
-  describe("Deployment", () => {
-    it("should deploy", async () => {
-      expect(contract).toBeDefined();
-    });
-    it("should have the correct name", async () => {
-      const metadata = await getContractMetadata({ contract });
-      expect(metadata.name).toBe("Test TokenERC1155");
-    });
-  });
 
   it("should allow for minting tokens", async () => {
     // initially no tokens minted

--- a/packages/thirdweb/src/extensions/erc20/drop20.test.ts
+++ b/packages/thirdweb/src/extensions/erc20/drop20.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, describe, expect, it } from "vitest";
+import { TEST_CONTRACT_URI } from "~test/ipfs-uris.js";
 import { VITALIK_WALLET } from "../../../test/src/addresses.js";
 import { ANVIL_CHAIN } from "../../../test/src/chains.js";
 import { TEST_CLIENT } from "../../../test/src/test-clients.js";
@@ -12,7 +13,6 @@ import { type ThirdwebContract, getContract } from "../../contract/contract.js";
 import { sendAndConfirmTransaction } from "../../transaction/actions/send-and-confirm-transaction.js";
 import { resolvePromisedValue } from "../../utils/promise/resolve-promised-value.js";
 import { toEther } from "../../utils/units.js";
-import { getContractMetadata } from "../common/read/getContractMetadata.js";
 import { deployERC20Contract } from "../prebuilts/deploy-erc20.js";
 import { getClaimConditions } from "./drops/read/getClaimConditions.js";
 import { claimTo } from "./drops/write/claimTo.js";
@@ -35,6 +35,7 @@ describe.runIf(process.env.TW_SECRET_KEY)(
         client: TEST_CLIENT,
         params: {
           name: "Test DropERC20",
+          contractURI: TEST_CONTRACT_URI,
         },
         type: "DropERC20",
       });
@@ -46,16 +47,6 @@ describe.runIf(process.env.TW_SECRET_KEY)(
       });
       // this deploys a contract, it may take some time
     }, 60_000);
-
-    describe("Deployment", () => {
-      it("should deploy", async () => {
-        expect(contract).toBeDefined();
-      });
-      it("should have the correct name", async () => {
-        const metadata = await getContractMetadata({ contract });
-        expect(metadata.name).toBe("Test DropERC20");
-      });
-    });
 
     it("should allow to claim tokens", async () => {
       await expect(

--- a/packages/thirdweb/src/extensions/erc721/drop721.test.ts
+++ b/packages/thirdweb/src/extensions/erc721/drop721.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, describe, expect, it } from "vitest";
+import { TEST_CONTRACT_URI } from "~test/ipfs-uris.js";
 import { VITALIK_WALLET } from "../../../test/src/addresses.js";
 import { ANVIL_CHAIN } from "../../../test/src/chains.js";
 import { TEST_CLIENT } from "../../../test/src/test-clients.js";
@@ -12,7 +13,6 @@ import { type ThirdwebContract, getContract } from "../../contract/contract.js";
 import { sendAndConfirmTransaction } from "../../transaction/actions/send-and-confirm-transaction.js";
 import { resolvePromisedValue } from "../../utils/promise/resolve-promised-value.js";
 import { toEther } from "../../utils/units.js";
-import { getContractMetadata } from "../common/read/getContractMetadata.js";
 import { deployERC20Contract } from "../prebuilts/deploy-erc20.js";
 import { deployERC721Contract } from "../prebuilts/deploy-erc721.js";
 import { balanceOf } from "./__generated__/IERC721A/read/balanceOf.js";
@@ -40,6 +40,7 @@ describe.runIf(process.env.TW_SECRET_KEY)(
         client: TEST_CLIENT,
         params: {
           name: "Test DropERC721",
+          contractURI: TEST_CONTRACT_URI,
         },
         type: "DropERC721",
       });
@@ -50,6 +51,7 @@ describe.runIf(process.env.TW_SECRET_KEY)(
         client: TEST_CLIENT,
         params: {
           name: "Test ERC20",
+          contractURI: TEST_CONTRACT_URI,
         },
         type: "TokenERC20",
       });
@@ -67,16 +69,6 @@ describe.runIf(process.env.TW_SECRET_KEY)(
       });
       // this deploys a contract, it may take some time
     }, 120_000);
-
-    describe("Deployment", () => {
-      it("should deploy", async () => {
-        expect(contract).toBeDefined();
-      });
-      it("should have the correct name", async () => {
-        const metadata = await getContractMetadata({ contract });
-        expect(metadata.name).toBe("Test DropERC721");
-      });
-    });
 
     it("should allow for lazy minting tokens", async () => {
       const mintTx = lazyMint({

--- a/packages/thirdweb/src/extensions/erc721/lazyMinting/write/createAndReveal.test.ts
+++ b/packages/thirdweb/src/extensions/erc721/lazyMinting/write/createAndReveal.test.ts
@@ -1,5 +1,6 @@
 import { beforeAll, describe, it } from "vitest";
 import { expect } from "vitest";
+import { TEST_CONTRACT_URI } from "~test/ipfs-uris.js";
 import { ANVIL_CHAIN } from "../../../../../test/src/chains.js";
 import { TEST_CLIENT } from "../../../../../test/src/test-clients.js";
 import { TEST_ACCOUNT_A } from "../../../../../test/src/test-wallets.js";
@@ -39,8 +40,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("createAndReveal", () => {
       type: "DropERC721",
       params: {
         name: "Test NFT",
-        description: "Test NFT Description",
-        contractURI: "",
+        contractURI: TEST_CONTRACT_URI,
       },
     });
     contract = getContract({

--- a/packages/thirdweb/src/extensions/erc721/write/mintTo.test.ts
+++ b/packages/thirdweb/src/extensions/erc721/write/mintTo.test.ts
@@ -3,6 +3,7 @@ import { ANVIL_CHAIN } from "~test/chains.js";
 import { TEST_CLIENT } from "~test/test-clients.js";
 import { TEST_ACCOUNT_A } from "~test/test-wallets.js";
 
+import { TEST_CONTRACT_URI } from "~test/ipfs-uris.js";
 import {
   type ThirdwebContract,
   getContract,
@@ -27,6 +28,7 @@ describe.runIf(!!process.env.TW_SECRET_KEY)("erc721 mintTo extension", () => {
       type: "TokenERC721",
       params: {
         name: "NFTDrop",
+        contractURI: TEST_CONTRACT_URI,
       },
     });
     contract = getContract({

--- a/packages/thirdweb/src/extensions/marketplace/english-auctions/english-auctions.test.ts
+++ b/packages/thirdweb/src/extensions/marketplace/english-auctions/english-auctions.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, describe, expect, it } from "vitest";
+import { TEST_CONTRACT_URI } from "~test/ipfs-uris.js";
 import { ANVIL_CHAIN } from "../../../../test/src/chains.js";
 import { TEST_CLIENT } from "../../../../test/src/test-clients.js";
 import {
@@ -37,6 +38,7 @@ describe.skip("Marketplace: English Auctions", () => {
       client: TEST_CLIENT,
       params: {
         name: "TestMarketPlace",
+        contractURI: TEST_CONTRACT_URI,
       },
     });
     marketplaceContract = getContract({
@@ -53,6 +55,7 @@ describe.skip("Marketplace: English Auctions", () => {
       client: TEST_CLIENT,
       params: {
         name: "TestERC721",
+        contractURI: TEST_CONTRACT_URI,
       },
     });
 

--- a/packages/thirdweb/src/extensions/marketplace/offers/offers.test.ts
+++ b/packages/thirdweb/src/extensions/marketplace/offers/offers.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, describe, expect, it } from "vitest";
+import { TEST_CONTRACT_URI } from "~test/ipfs-uris.js";
 import { ANVIL_CHAIN } from "../../../../test/src/chains.js";
 import { TEST_CLIENT } from "../../../../test/src/test-clients.js";
 import {
@@ -43,6 +44,7 @@ describe.skip("Marketplace: Offers", () => {
       client: TEST_CLIENT,
       params: {
         name: "TestMarketPlace",
+        contractURI: TEST_CONTRACT_URI,
       },
     });
     marketplaceContract = getContract({
@@ -59,6 +61,7 @@ describe.skip("Marketplace: Offers", () => {
       client: TEST_CLIENT,
       params: {
         name: "TestERC721",
+        contractURI: TEST_CONTRACT_URI,
       },
     });
 

--- a/packages/thirdweb/src/extensions/modules/ClaimableERC1155/claimableERC1155.test.ts
+++ b/packages/thirdweb/src/extensions/modules/ClaimableERC1155/claimableERC1155.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, describe, expect, it } from "vitest";
+import { TEST_CONTRACT_URI } from "~test/ipfs-uris.js";
 import { ANVIL_CHAIN } from "../../../../test/src/chains.js";
 import { TEST_CLIENT } from "../../../../test/src/test-clients.js";
 import {
@@ -29,7 +30,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("ModularClaimableERC1155", () => {
       core: "ERC1155",
       params: {
         name: "TestDropERC1155",
-        symbol: "TT",
+        contractURI: TEST_CONTRACT_URI,
       },
       modules: [
         ClaimableERC1155.module({

--- a/packages/thirdweb/src/extensions/modules/ClaimableERC20/claimableERC20.test.ts
+++ b/packages/thirdweb/src/extensions/modules/ClaimableERC20/claimableERC20.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, describe, expect, it } from "vitest";
+import { TEST_CONTRACT_URI } from "~test/ipfs-uris.js";
 import { ANVIL_CHAIN } from "../../../../test/src/chains.js";
 import { TEST_CLIENT } from "../../../../test/src/test-clients.js";
 import {
@@ -26,7 +27,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("ModularDropERC20", () => {
       core: "ERC20",
       params: {
         name: "TestDropERC20",
-        symbol: "TT",
+        contractURI: TEST_CONTRACT_URI,
       },
       modules: [
         ClaimableERC20.module({

--- a/packages/thirdweb/src/extensions/modules/ClaimableERC721/claimableERC721.test.ts
+++ b/packages/thirdweb/src/extensions/modules/ClaimableERC721/claimableERC721.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, describe, expect, it } from "vitest";
+import { TEST_CONTRACT_URI } from "~test/ipfs-uris.js";
 import { ANVIL_CHAIN } from "../../../../test/src/chains.js";
 import { TEST_CLIENT } from "../../../../test/src/test-clients.js";
 import {
@@ -27,7 +28,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("ModularClaimableERC721", () => {
       core: "ERC721",
       params: {
         name: "TestDropERC721",
-        symbol: "TT",
+        contractURI: TEST_CONTRACT_URI,
       },
       modules: [
         ClaimableERC721.module({

--- a/packages/thirdweb/src/extensions/modules/MintableERC1155/mintableERC1155.test.ts
+++ b/packages/thirdweb/src/extensions/modules/MintableERC1155/mintableERC1155.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, describe, expect, it } from "vitest";
+import { TEST_CONTRACT_URI } from "~test/ipfs-uris.js";
 import { ANVIL_CHAIN } from "../../../../test/src/chains.js";
 import { TEST_CLIENT } from "../../../../test/src/test-clients.js";
 import {
@@ -32,6 +33,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("ModularTokenERC1155", () => {
       params: {
         name: "TestTokenERC1155",
         symbol: "TT",
+        contractURI: TEST_CONTRACT_URI,
       },
       modules: [
         MintableERC1155.module({

--- a/packages/thirdweb/src/extensions/modules/MintableERC20/mintableERC20.test.ts
+++ b/packages/thirdweb/src/extensions/modules/MintableERC20/mintableERC20.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, describe, expect, it } from "vitest";
+import { TEST_CONTRACT_URI } from "~test/ipfs-uris.js";
 import { ANVIL_CHAIN } from "../../../../test/src/chains.js";
 import { TEST_CLIENT } from "../../../../test/src/test-clients.js";
 import {
@@ -27,6 +28,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("ModularTokenERC20", () => {
       params: {
         name: "TestTokenERC20",
         symbol: "TT",
+        contractURI: TEST_CONTRACT_URI,
       },
       modules: [
         MintableERC20.module({

--- a/packages/thirdweb/src/extensions/modules/MintableERC721/mintableERC721.test.ts
+++ b/packages/thirdweb/src/extensions/modules/MintableERC721/mintableERC721.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, describe, expect, it } from "vitest";
+import { TEST_CONTRACT_URI } from "~test/ipfs-uris.js";
 import { ANVIL_CHAIN } from "../../../../test/src/chains.js";
 import { TEST_CLIENT } from "../../../../test/src/test-clients.js";
 import {
@@ -31,6 +32,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("ModularTokenERC721", () => {
       params: {
         name: "TestTokenERC721",
         symbol: "TT",
+        contractURI: TEST_CONTRACT_URI,
       },
       modules: [
         MintableERC721.module({

--- a/packages/thirdweb/src/extensions/modules/OpenEditionMetadataERC721/openEditionERC721.test.ts
+++ b/packages/thirdweb/src/extensions/modules/OpenEditionMetadataERC721/openEditionERC721.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, describe, expect, it } from "vitest";
+import { TEST_CONTRACT_URI } from "~test/ipfs-uris.js";
 import { ANVIL_CHAIN } from "../../../../test/src/chains.js";
 import { TEST_CLIENT } from "../../../../test/src/test-clients.js";
 import {
@@ -30,6 +31,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("ModularOpenEditionERC721", () => {
       params: {
         name: "TestDropERC721",
         symbol: "TT",
+        contractURI: TEST_CONTRACT_URI,
       },
       modules: [
         ClaimableERC721.module({

--- a/packages/thirdweb/src/extensions/permissions/permissions.test.ts
+++ b/packages/thirdweb/src/extensions/permissions/permissions.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, describe, expect, it } from "vitest";
+import { TEST_CONTRACT_URI } from "~test/ipfs-uris.js";
 import { ANVIL_CHAIN } from "../../../test/src/chains.js";
 import { TEST_CLIENT } from "../../../test/src/test-clients.js";
 import {
@@ -22,6 +23,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("Permissions", () => {
       client: TEST_CLIENT,
       params: {
         name: "PermissionsErc20",
+        contractURI: TEST_CONTRACT_URI,
       },
       type: "TokenERC20",
     });
@@ -196,6 +198,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("PermissionsEnumerable", () => {
       client: TEST_CLIENT,
       params: {
         name: "PermissionsErc20",
+        contractURI: TEST_CONTRACT_URI,
       },
       type: "TokenERC20",
     });


### PR DESCRIPTION
For contract-deployment tests we don't touch them.
For other tests that use the contract-deployment methods, we specify the `contractURI` to skip the IPFS contractURI upload.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the use of `TEST_CONTRACT_URI` in various test files related to ERC721, ERC20, and ERC1155 contracts, ensuring that all relevant tests now reference a standardized contract URI.

### Detailed summary
- Added `TEST_CONTRACT_URI` import to multiple test files.
- Updated `params` to include `contractURI: TEST_CONTRACT_URI` in:
  - `mintTo.test.ts`
  - `mintableERC20.test.ts`
  - `mintableERC721.test.ts`
  - `mintableERC1155.test.ts`
  - `claimableERC20.test.ts`
  - `openEditionERC721.test.ts`
  - `claimableERC721.test.ts`
  - `claimableERC1155.test.ts`
  - `offers.test.ts`
  - `createAndReveal.test.ts`
  - `english-auctions.test.ts`
  - `permissions.test.ts`
  - `token1155.test.ts`
  - `drop20.test.ts`
  - `drop1155.test.ts`
  - `drop721.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->