### PR TITLE
[SDK] Fix: Only request specified wallet connect chains

### DIFF
--- a/.changeset/chilly-colts-beam.md
+++ b/.changeset/chilly-colts-beam.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fixes WC connections with wallets that have limited chain support

--- a/packages/thirdweb/src/wallets/wallet-connect/controller.ts
+++ b/packages/thirdweb/src/wallets/wallet-connect/controller.ts
@@ -131,11 +131,7 @@ export async function connectWC(
         ? { pairingTopic: wcOptions?.pairingTopic }
         : {}),
       optionalChains: chainsToRequest,
-      chains: chainToRequest
-        ? [chainToRequest.id]
-        : chainsToRequest.length > 0
-          ? [chainsToRequest[0]]
-          : [1],
+      chains: chainToRequest ? [chainToRequest.id] : undefined,
       rpcMap: rpcMap,
     });
   }
@@ -265,12 +261,8 @@ async function initProvider(
     projectId: wcOptions?.projectId || DEFAULT_PROJECT_ID,
     optionalMethods: OPTIONAL_METHODS,
     optionalEvents: OPTIONAL_EVENTS,
-    optionalChains: chainsToRequest,
-    chains: chainToRequest
-      ? [chainToRequest.id]
-      : chainsToRequest.length > 0
-        ? [chainsToRequest[0]]
-        : [1],
+    optionalChains: chainsToRequest || [1],
+    chains: chainToRequest ? [chainToRequest.id] : undefined,
     metadata: {
       name: wcOptions?.appMetadata?.name || getDefaultAppMetadata().name,
       description:
@@ -509,7 +501,10 @@ async function switchChainWC(
  * Set the requested chains to the storage.
  * @internal
  */
-function setRequestedChainsIds(chains: number[], storage: AsyncStorage) {
+function setRequestedChainsIds(
+  chains: number[] | undefined,
+  storage: AsyncStorage,
+) {
   storage?.setItem(storageKeys.requestedChains, JSON.stringify(chains));
 }
 
@@ -550,13 +545,9 @@ function getChainsToRequest(options: {
     });
   }
 
-  const optionalChainIds = optionalChains.map((c) => c.id) || [];
-
-  const chainsToRequest: ArrayOneOrMore<number> = options.chain
-    ? [options.chain.id, ...optionalChainIds]
-    : optionalChainIds.length > 0
-      ? (optionalChainIds as ArrayOneOrMore<number>)
-      : [1];
+  const chainsToRequest: ArrayOneOrMore<number> | undefined = options.chain
+    ? [options.chain.id]
+    : undefined;
 
   if (!options.chain && optionalChains.length === 0) {
     rpcMap[1] = getCachedChain(1).rpc;


### PR DESCRIPTION
Falls in line with the WC spec and appeases some picky wallets

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing wallet connection issues in `thirdweb` related to limited chain support by refining how chains are handled in the wallet connection logic.

### Detailed summary
- Updated the handling of `optionalChains` and `chains` in the `initProvider` function.
- Changed `setRequestedChainsIds` to accept `chains` as `number[] | undefined`.
- Simplified the creation of `chainsToRequest` to handle undefined cases.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->