### PR TITLE
Fix line break in engine Allowlisted Domains textarea placeholder

### DIFF
--- a/apps/dashboard/src/components/engine/configuration/cors.tsx
+++ b/apps/dashboard/src/components/engine/configuration/cors.tsx
@@ -63,7 +63,7 @@ export const EngineCorsConfig: React.FC<EngineCorsConfigProps> = ({
       </Flex>
 
       <Textarea
-        placeholder="https://example.com\nhttp://localhost:3000"
+        placeholder={"https://example.com\nhttp://localhost:3000"}
         rows={4}
         {...form.register("raw")}
       />


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `placeholder` attribute of the `Textarea` component in the `cors.tsx` file to use curly braces for string interpolation.

### Detailed summary
- Changed the `placeholder` prop from `placeholder="https://example.com\nhttp://localhost:3000"` to `placeholder={"https://example.com\nhttp://localhost:3000"}` in the `Textarea` component.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->