### PR TITLE
[SDK] Fix: ensure optional chains are passed to wc

### DIFF
--- a/.changeset/red-donkeys-teach.md
+++ b/.changeset/red-donkeys-teach.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Ensure optional chains are passed to wallet connect request


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on improving the handling of optional chains in the `wallet-connect` functionality, ensuring that required and optional chains are correctly processed during wallet connection requests.

### Detailed summary
- Updated `getChainsToRequest` to return `requiredChain` and `optionalChains` instead of just `chainsToRequest`.
- Modified `connectWC` and `initProvider` functions to use `requiredChain` for the `chains` parameter.
- Ensured `optionalChains` are passed correctly in wallet connect requests.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->