### PR TITLE
fix: createAndSignUserOp with multiple transactions

### DIFF
--- a/.changeset/clean-icons-guess.md
+++ b/.changeset/clean-icons-guess.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix createAndSignUserOp with multiple transactions

--- a/packages/thirdweb/src/wallets/smart/lib/userop.ts
+++ b/packages/thirdweb/src/wallets/smart/lib/userop.ts
@@ -683,6 +683,7 @@ export async function createAndSignUserOp(options: {
     const tx = options.transactions[0] as PreparedTransaction;
     const serializedTx = await toSerializableTransaction({
       transaction: tx,
+      from: accountAddress,
     });
     executeTx = prepareExecute({
       accountContract,
@@ -694,6 +695,7 @@ export async function createAndSignUserOp(options: {
       options.transactions.map((tx) =>
         toSerializableTransaction({
           transaction: tx,
+          from: accountAddress,
         }),
       ),
     );


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the `createAndSignUserOp` function to handle multiple transactions by adding the `from` property to the serialized transaction.

### Detailed summary
- Updated `createAndSignUserOp` in `packages/thirdweb/src/wallets/smart/lib/userop.ts` to include `from: accountAddress` in the `toSerializableTransaction` calls for each transaction.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->