### PR TITLE
[SDK] Avoid out-of-fund in tests

### DIFF
--- a/packages/thirdweb/src/extensions/erc1155/drops/read/getActiveClaimCondition.test.ts
+++ b/packages/thirdweb/src/extensions/erc1155/drops/read/getActiveClaimCondition.test.ts
@@ -4,7 +4,7 @@ import { ANVIL_CHAIN } from "~test/chains.js";
 import { TEST_CONTRACT_URI } from "~test/ipfs-uris.js";
 import { TEST_CLIENT } from "~test/test-clients.js";
 import { MAX_UINT256 } from "~test/test-consts.js";
-import { TEST_ACCOUNT_A } from "~test/test-wallets.js";
+import { TEST_ACCOUNT_B } from "~test/test-wallets.js";
 import { DROP1155_CONTRACT } from "../../../../../test/src/test-contracts.js";
 import { NATIVE_TOKEN_ADDRESS } from "../../../../constants/addresses.js";
 import { getContract } from "../../../../contract/contract.js";
@@ -14,6 +14,8 @@ import { sendAndConfirmTransaction } from "../../../../transaction/actions/send-
 import { lazyMint } from "../../write/lazyMint.js";
 import { setClaimConditions } from "../write/setClaimConditions.js";
 import { getActiveClaimCondition } from "./getActiveClaimCondition.js";
+
+const account = TEST_ACCOUNT_B;
 
 describe.runIf(process.env.TW_SECRET_KEY)("erc1155.getClaimConditions", () => {
   it("should return the correct claim conditions", async () => {
@@ -39,7 +41,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("erc1155.getClaimConditions", () => {
     const address = await deployERC1155Contract({
       client: TEST_CLIENT,
       chain: ANVIL_CHAIN,
-      account: TEST_ACCOUNT_A,
+      account,
       type: "DropERC1155",
       params: {
         name: "EditionDrop",
@@ -56,7 +58,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("erc1155.getClaimConditions", () => {
     const lzMint = lazyMint({ contract, nfts: [{ name: "token #0" }] });
     await sendAndConfirmTransaction({
       transaction: lzMint,
-      account: TEST_ACCOUNT_A,
+      account,
     });
 
     // Create a public allowlist claim phase
@@ -97,7 +99,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("erc1155.getClaimConditions", () => {
 
     await sendAndConfirmTransaction({
       transaction: setCC,
-      account: TEST_ACCOUNT_A,
+      account,
     });
 
     const activeCC = await getActiveClaimCondition({ contract, tokenId: 0n });

--- a/packages/thirdweb/src/extensions/erc721/drops/write/updateMetadata.test.ts
+++ b/packages/thirdweb/src/extensions/erc721/drops/write/updateMetadata.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { ANVIL_CHAIN } from "~test/chains.js";
 import { TEST_CLIENT } from "~test/test-clients.js";
-import { TEST_ACCOUNT_A } from "~test/test-wallets.js";
+import { TEST_ACCOUNT_C } from "~test/test-wallets.js";
 
 import { TEST_CONTRACT_URI } from "~test/ipfs-uris.js";
 import { getContract } from "../../../../contract/contract.js";
@@ -11,7 +11,7 @@ import { getNFTs } from "../../read/getNFTs.js";
 import { lazyMint } from "../../write/lazyMint.js";
 import { updateMetadata } from "./updateMetadata.js";
 
-const account = TEST_ACCOUNT_A;
+const account = TEST_ACCOUNT_C;
 const client = TEST_CLIENT;
 const chain = ANVIL_CHAIN;
 

--- a/packages/thirdweb/src/extensions/erc721/read/getTotalClaimedSupply.test.ts
+++ b/packages/thirdweb/src/extensions/erc721/read/getTotalClaimedSupply.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { ANVIL_CHAIN } from "~test/chains.js";
 import { TEST_CONTRACT_URI } from "~test/ipfs-uris.js";
 import { TEST_CLIENT } from "~test/test-clients.js";
-import { TEST_ACCOUNT_A } from "~test/test-wallets.js";
+import { TEST_ACCOUNT_B } from "~test/test-wallets.js";
 import { NATIVE_TOKEN_ADDRESS } from "../../../constants/addresses.js";
 import {
   type ThirdwebContract,
@@ -15,7 +15,7 @@ import { setClaimConditions } from "../drops/write/setClaimConditions.js";
 import { lazyMint } from "../write/lazyMint.js";
 import { getTotalClaimedSupply } from "./getTotalClaimedSupply.js";
 
-const account = TEST_ACCOUNT_A;
+const account = TEST_ACCOUNT_B;
 let contract: ThirdwebContract;
 
 describe.runIf(process.env.TW_SECRET_KEY)(

--- a/packages/thirdweb/src/extensions/erc721/read/getTotalUnclaimedSupply.test.ts
+++ b/packages/thirdweb/src/extensions/erc721/read/getTotalUnclaimedSupply.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { ANVIL_CHAIN } from "~test/chains.js";
 import { TEST_CONTRACT_URI } from "~test/ipfs-uris.js";
 import { TEST_CLIENT } from "~test/test-clients.js";
-import { TEST_ACCOUNT_A } from "~test/test-wallets.js";
+import { TEST_ACCOUNT_D } from "~test/test-wallets.js";
 import { NATIVE_TOKEN_ADDRESS } from "../../../constants/addresses.js";
 import {
   type ThirdwebContract,
@@ -15,7 +15,7 @@ import { setClaimConditions } from "../drops/write/setClaimConditions.js";
 import { lazyMint } from "../write/lazyMint.js";
 import { getTotalUnclaimedSupply } from "./getTotalUnclaimedSupply.js";
 
-const account = TEST_ACCOUNT_A;
+const account = TEST_ACCOUNT_D;
 let contract: ThirdwebContract;
 
 describe.runIf(process.env.TW_SECRET_KEY)(

--- a/packages/thirdweb/src/extensions/erc721/write/updateTokenURI.test.ts
+++ b/packages/thirdweb/src/extensions/erc721/write/updateTokenURI.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { ANVIL_CHAIN } from "~test/chains.js";
 import { TEST_CONTRACT_URI } from "~test/ipfs-uris.js";
 import { TEST_CLIENT } from "~test/test-clients.js";
-import { TEST_ACCOUNT_A } from "~test/test-wallets.js";
+import { TEST_ACCOUNT_C } from "~test/test-wallets.js";
 import { getContract } from "../../../contract/contract.js";
 import { deployERC721Contract } from "../../../extensions/prebuilts/deploy-erc721.js";
 import { sendAndConfirmTransaction } from "../../../transaction/actions/send-and-confirm-transaction.js";
@@ -12,7 +12,7 @@ import { updateTokenURI } from "./updateTokenURI.js";
 
 const client = TEST_CLIENT;
 const chain = ANVIL_CHAIN;
-const account = TEST_ACCOUNT_A;
+const account = TEST_ACCOUNT_C;
 
 describe.runIf(process.env.TW_SECRET_KEY)(
   "NFTCollection: Update token uri",

--- a/packages/thirdweb/src/extensions/prebuilts/deploy-erc20.test.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/deploy-erc20.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { ANVIL_CHAIN } from "../../../test/src/chains.js";
 import { TEST_CLIENT } from "../../../test/src/test-clients.js";
-import { TEST_ACCOUNT_A } from "../../../test/src/test-wallets.js";
+import { TEST_ACCOUNT_D } from "../../../test/src/test-wallets.js";
 import { getContract } from "../../contract/contract.js";
 import { name } from "../common/read/name.js";
 import { deployERC20Contract } from "./deploy-erc20.js";
+
+const account = TEST_ACCOUNT_D;
 
 // skip this test suite if there is no secret key available to test with
 // TODO: remove reliance on secret key during unit tests entirely
@@ -13,7 +15,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("deployERC20", () => {
     const address = await deployERC20Contract({
       client: TEST_CLIENT,
       chain: ANVIL_CHAIN,
-      account: TEST_ACCOUNT_A,
+      account,
       type: "DropERC20",
       params: {
         name: "TokenDrop",
@@ -35,7 +37,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("deployERC20", () => {
     const address = await deployERC20Contract({
       client: TEST_CLIENT,
       chain: ANVIL_CHAIN,
-      account: TEST_ACCOUNT_A,
+      account,
       type: "TokenERC20",
       params: {
         name: "Token",

--- a/packages/thirdweb/src/extensions/prebuilts/deploy-erc721.test.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/deploy-erc721.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { ANVIL_CHAIN } from "../../../test/src/chains.js";
 import { TEST_CLIENT } from "../../../test/src/test-clients.js";
-import { TEST_ACCOUNT_A } from "../../../test/src/test-wallets.js";
+import { TEST_ACCOUNT_B } from "../../../test/src/test-wallets.js";
 import { getContract } from "../../contract/contract.js";
 import { name } from "../common/read/name.js";
 import { deployERC721Contract } from "./deploy-erc721.js";
+
+const account = TEST_ACCOUNT_B;
 
 // skip this test suite if there is no secret key available to test with
 // TODO: remove reliance on secret key during unit tests entirely
@@ -13,7 +15,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("deployERC721", () => {
     const address = await deployERC721Contract({
       client: TEST_CLIENT,
       chain: ANVIL_CHAIN,
-      account: TEST_ACCOUNT_A,
+      account,
       type: "DropERC721",
       params: {
         name: "NFTDrop",
@@ -34,7 +36,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("deployERC721", () => {
     const address = await deployERC721Contract({
       client: TEST_CLIENT,
       chain: ANVIL_CHAIN,
-      account: TEST_ACCOUNT_A,
+      account,
       type: "TokenERC721",
       params: {
         name: "NFTCollection",
@@ -55,7 +57,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("deployERC721", () => {
     const address = await deployERC721Contract({
       client: TEST_CLIENT,
       chain: ANVIL_CHAIN,
-      account: TEST_ACCOUNT_A,
+      account,
       type: "OpenEditionERC721",
       params: {
         name: "OE",

--- a/packages/thirdweb/src/extensions/prebuilts/deploy-split.test.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/deploy-split.test.ts
@@ -1,14 +1,14 @@
 import { describe, expect, it } from "vitest";
 import { ANVIL_CHAIN } from "~test/chains.js";
 import { TEST_CLIENT } from "~test/test-clients.js";
-import { TEST_ACCOUNT_A } from "~test/test-wallets.js";
+import { TEST_ACCOUNT_D } from "~test/test-wallets.js";
 import { isAddress } from "../../utils/address.js";
 import { deploySplitContract } from "./deploy-split.js";
 
 describe.runIf(process.env.TW_SECRET_KEY)("deploy-split contract", () => {
   it("should deploy Split contract", async () => {
     const address = await deploySplitContract({
-      account: TEST_ACCOUNT_A,
+      account: TEST_ACCOUNT_D,
       client: TEST_CLIENT,
       chain: ANVIL_CHAIN,
       params: {

--- a/packages/thirdweb/src/extensions/prebuilts/deploy-vote.test.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/deploy-vote.test.ts
@@ -2,17 +2,19 @@ import { describe, expect, it } from "vitest";
 import { ANVIL_CHAIN } from "~test/chains.js";
 import { TEST_CONTRACT_URI } from "~test/ipfs-uris.js";
 import { TEST_CLIENT } from "~test/test-clients.js";
-import { TEST_ACCOUNT_A } from "~test/test-wallets.js";
+import { TEST_ACCOUNT_B } from "~test/test-wallets.js";
 import { isAddress } from "../../utils/address.js";
 import { deployERC20Contract } from "./deploy-erc20.js";
 import { deployVoteContract } from "./deploy-vote.js";
+
+const account = TEST_ACCOUNT_B;
 
 describe.runIf(process.env.TW_SECRET_KEY)("deploy-voteERC20 contract", () => {
   it("should deploy Vote contract", async () => {
     const tokenAddress = await deployERC20Contract({
       client: TEST_CLIENT,
       chain: ANVIL_CHAIN,
-      account: TEST_ACCOUNT_A,
+      account,
       type: "TokenERC20",
       params: {
         name: "Token",
@@ -20,7 +22,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("deploy-voteERC20 contract", () => {
       },
     });
     const address = await deployVoteContract({
-      account: TEST_ACCOUNT_A,
+      account,
       client: TEST_CLIENT,
       chain: ANVIL_CHAIN,
       params: {
@@ -45,7 +47,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("deploy-voteERC20 contract", () => {
     const tokenAddress = await deployERC20Contract({
       client: TEST_CLIENT,
       chain: ANVIL_CHAIN,
-      account: TEST_ACCOUNT_A,
+      account,
       type: "TokenERC20",
       params: {
         name: "Token",
@@ -54,7 +56,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("deploy-voteERC20 contract", () => {
     });
     await expect(() =>
       deployVoteContract({
-        account: TEST_ACCOUNT_A,
+        account,
         client: TEST_CLIENT,
         chain: ANVIL_CHAIN,
         params: {

--- a/packages/thirdweb/src/extensions/split/read/getAllRecipientsAddresses.test.ts
+++ b/packages/thirdweb/src/extensions/split/read/getAllRecipientsAddresses.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { ANVIL_CHAIN } from "~test/chains.js";
 import { TEST_CONTRACT_URI } from "~test/ipfs-uris.js";
 import { TEST_CLIENT } from "~test/test-clients.js";
-import { TEST_ACCOUNT_A } from "~test/test-wallets.js";
+import { TEST_ACCOUNT_C } from "~test/test-wallets.js";
 import { getContract } from "../../../contract/contract.js";
 import { deploySplitContract } from "../../../extensions/prebuilts/deploy-split.js";
 import { getAllRecipientsAddresses } from "./getAllRecipientsAddresses.js";
@@ -17,7 +17,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("getAllRecipientsAddresses", () => {
       "0xA6f11e47dE28B3dB934e945daeb6F538E9019694",
     ];
     const address = await deploySplitContract({
-      account: TEST_ACCOUNT_A,
+      account: TEST_ACCOUNT_C,
       client: TEST_CLIENT,
       chain: ANVIL_CHAIN,
       params: {

--- a/packages/thirdweb/src/extensions/split/read/getAllRecipientsPercentages.test.ts
+++ b/packages/thirdweb/src/extensions/split/read/getAllRecipientsPercentages.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { ANVIL_CHAIN } from "~test/chains.js";
 import { TEST_CONTRACT_URI } from "~test/ipfs-uris.js";
 import { TEST_CLIENT } from "~test/test-clients.js";
-import { TEST_ACCOUNT_A } from "~test/test-wallets.js";
+import { TEST_ACCOUNT_C } from "~test/test-wallets.js";
 import { getContract } from "../../../contract/contract.js";
 import { deploySplitContract } from "../../../extensions/prebuilts/deploy-split.js";
 import { getAllRecipientsPercentages } from "./getAllRecipientsPercentages.js";
@@ -17,7 +17,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("getAllRecipientsPercentages", () => {
       "0xA6f11e47dE28B3dB934e945daeb6F538E9019694",
     ];
     const address = await deploySplitContract({
-      account: TEST_ACCOUNT_A,
+      account: TEST_ACCOUNT_C,
       client: TEST_CLIENT,
       chain: ANVIL_CHAIN,
       params: {

--- a/packages/thirdweb/src/extensions/vote/read/proposalExists.test.ts
+++ b/packages/thirdweb/src/extensions/vote/read/proposalExists.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { ANVIL_CHAIN } from "~test/chains.js";
 import { TEST_CONTRACT_URI } from "~test/ipfs-uris.js";
 import { TEST_CLIENT } from "~test/test-clients.js";
-import { TEST_ACCOUNT_A } from "~test/test-wallets.js";
+import { TEST_ACCOUNT_C } from "~test/test-wallets.js";
 import { getContract } from "../../../contract/contract.js";
 import { delegate } from "../../../extensions/erc20/__generated__/IVotes/write/delegate.js";
 import { mintTo } from "../../../extensions/erc20/write/mintTo.js";
@@ -13,7 +13,7 @@ import { propose } from "../__generated__/Vote/write/propose.js";
 import { getAll } from "./getAll.js";
 import { proposalExists } from "./proposalExists.js";
 
-const account = TEST_ACCOUNT_A;
+const account = TEST_ACCOUNT_C;
 const client = TEST_CLIENT;
 const chain = ANVIL_CHAIN;
 
@@ -22,7 +22,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("proposal exists", () => {
     const tokenAddress = await deployERC20Contract({
       client: TEST_CLIENT,
       chain: ANVIL_CHAIN,
-      account: TEST_ACCOUNT_A,
+      account,
       type: "TokenERC20",
       params: {
         name: "Token",
@@ -30,7 +30,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("proposal exists", () => {
       },
     });
     const address = await deployVoteContract({
-      account: TEST_ACCOUNT_A,
+      account,
       client: TEST_CLIENT,
       chain: ANVIL_CHAIN,
       params: {
@@ -57,7 +57,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("proposal exists", () => {
     const tokenAddress = await deployERC20Contract({
       client: TEST_CLIENT,
       chain: ANVIL_CHAIN,
-      account: TEST_ACCOUNT_A,
+      account,
       type: "TokenERC20",
       params: {
         name: "Token",
@@ -65,7 +65,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("proposal exists", () => {
       },
     });
     const address = await deployVoteContract({
-      account: TEST_ACCOUNT_A,
+      account,
       client: TEST_CLIENT,
       chain: ANVIL_CHAIN,
       params: {

--- a/packages/thirdweb/src/wallets/utils/getTokenBalance.test.ts
+++ b/packages/thirdweb/src/wallets/utils/getTokenBalance.test.ts
@@ -2,17 +2,19 @@ import { describe, expect, it } from "vitest";
 import { ANVIL_CHAIN, FORKED_ETHEREUM_CHAIN } from "~test/chains.js";
 import { TEST_CONTRACT_URI } from "~test/ipfs-uris.js";
 import { TEST_CLIENT } from "~test/test-clients.js";
-import { TEST_ACCOUNT_A } from "~test/test-wallets.js";
+import { TEST_ACCOUNT_D } from "~test/test-wallets.js";
 import { getContract } from "../../contract/contract.js";
 import { mintTo } from "../../extensions/erc20/write/mintTo.js";
 import { deployERC20Contract } from "../../extensions/prebuilts/deploy-erc20.js";
 import { sendAndConfirmTransaction } from "../../transaction/actions/send-and-confirm-transaction.js";
 import { getTokenBalance } from "./getTokenBalance.js";
 
+const account = TEST_ACCOUNT_D;
+
 describe.runIf(process.env.TW_SECRET_KEY)("getTokenBalance", () => {
   it("should work for native token", async () => {
     const result = await getTokenBalance({
-      account: TEST_ACCOUNT_A,
+      account,
       client: TEST_CLIENT,
       chain: FORKED_ETHEREUM_CHAIN,
     });
@@ -30,7 +32,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("getTokenBalance", () => {
     const erc20Address = await deployERC20Contract({
       client: TEST_CLIENT,
       chain: ANVIL_CHAIN,
-      account: TEST_ACCOUNT_A,
+      account,
       type: "TokenERC20",
       params: {
         name: "",
@@ -48,18 +50,18 @@ describe.runIf(process.env.TW_SECRET_KEY)("getTokenBalance", () => {
     // Mint some tokens
     const tx = mintTo({
       contract: erc20Contract,
-      to: TEST_ACCOUNT_A.address,
+      to: account.address,
       amount,
     });
 
     await sendAndConfirmTransaction({
       transaction: tx,
-      account: TEST_ACCOUNT_A,
+      account,
     });
 
     const result = await getTokenBalance({
       client: TEST_CLIENT,
-      account: TEST_ACCOUNT_A,
+      account,
       tokenAddress: erc20Address,
       chain: ANVIL_CHAIN,
     });


### PR DESCRIPTION
We are mostly using `TEST_ACCOUNT_A` in our tests, at some point the account runs out of funds.
Theoretically if we share some loads to account B, C and D, things will be improved?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on updating the test files in the `thirdweb` package to replace instances of `TEST_ACCOUNT_A` with other test accounts (`TEST_ACCOUNT_B`, `TEST_ACCOUNT_C`, and `TEST_ACCOUNT_D`). This helps ensure diverse testing scenarios.

### Detailed summary
- Replaced `TEST_ACCOUNT_A` with `TEST_ACCOUNT_D` in `deploy-split.test.ts`.
- Replaced `TEST_ACCOUNT_A` with `TEST_ACCOUNT_C` in multiple test files, including `updateMetadata.test.ts`, `getAllRecipientsAddresses.test.ts`, `updateTokenURI.test.ts`, and others.
- Replaced `TEST_ACCOUNT_A` with `TEST_ACCOUNT_B` in `getTotalClaimedSupply.test.ts`, `getTotalUnclaimedSupply.test.ts`, and other files.
- Updated various test files to use the new account variables for deploying contracts and testing functionalities.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->