### PR TITLE
[SDK] Update docs for claimTo extensions

### DIFF
--- a/packages/thirdweb/src/extensions/erc1155/drops/write/claimTo.ts
+++ b/packages/thirdweb/src/extensions/erc1155/drops/write/claimTo.ts
@@ -19,6 +19,7 @@ export type ClaimToParams = {
  * @param options - The options for the transaction
  * @extension ERC1155
  * @example
+ * ### Basic usage
  * ```ts
  * import { claimTo } from "thirdweb/extensions/erc1155";
  * import { sendTransaction } from "thirdweb";
@@ -31,6 +32,18 @@ export type ClaimToParams = {
  * });
  *
  * await sendTransaction({ transaction, account });
+ * ```
+ *
+ * ### For Drops with allowlists
+ * You need to specify the claimer address as the `from` param to avoid any issue with the allowlist
+ * ```ts
+ * const transaction = claimTo({
+ *   contract,
+ *   to: "0x...",
+ *   tokenId: 0n,
+ *   quantity: 1n,
+ *   from: "0x...", // address of the one claiming
+ * });
  * ```
  * @throws If no claim condition is set
  * @returns The prepared transaction

--- a/packages/thirdweb/src/extensions/erc20/drops/write/claimTo.ts
+++ b/packages/thirdweb/src/extensions/erc20/drops/write/claimTo.ts
@@ -20,6 +20,8 @@ export type ClaimToParams = {
  * @param options - The options for the transaction
  * @extension ERC20
  * @example
+ *
+ * ### Basic usage
  * ```ts
  * import { claimTo } from "thirdweb/extensions/erc20";
  * import { sendTransaction } from "thirdweb";
@@ -31,6 +33,17 @@ export type ClaimToParams = {
  * });
  *
  * await sendTransaction({ transaction, account });
+ * ```
+ *
+ * ### For Drops with allowlists
+ * You need to specify the claimer address as the `from` param to avoid any issue with the allowlist
+ * ```ts
+ * const transaction = claimTo({
+ *   contract,
+ *   to: "0x...",
+ *   quantity: 100n,
+ *   from: "0x...", // address of the one claiming
+ * });
  * ```
  * @throws If no claim condition is set
  * @returns A promise that resolves with the submitted transaction hash.

--- a/packages/thirdweb/src/extensions/erc721/drops/write/claimTo.ts
+++ b/packages/thirdweb/src/extensions/erc721/drops/write/claimTo.ts
@@ -23,6 +23,8 @@ export type ClaimToParams = {
  * @param options - The options for the transaction
  * @extension ERC721
  * @example
+ *
+ * ### Basic usage
  * ```ts
  * import { claimTo } from "thirdweb/extensions/erc721";
  * import { sendTransaction } from "thirdweb";
@@ -34,6 +36,17 @@ export type ClaimToParams = {
  * });
  *
  * await sendTransaction({ transaction, account });
+ * ```
+ *
+ * ### For Drops with allowlists
+ * You need to specify the claimer address as the `from` param to avoid any issue with the allowlist
+ * ```ts
+ * const transaction = claimTo({
+ *   contract,
+ *   to: "0x...",
+ *   quantity: 1n,
+ *   from: "0x...", // address of the one claiming
+ * });
  * ```
  * @throws If no claim condition is set
  * @returns A promise that resolves with the submitted transaction hash.


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the documentation for the `claimTo` function across three extensions: `ERC1155`, `ERC20`, and `ERC721`. It adds examples for basic usage and includes specific guidance for handling drops with allowlists.

### Detailed summary
- Added a "Basic usage" section with example code for `claimTo` in `ERC1155`, `ERC20`, and `ERC721`.
- Included a section for drops with allowlists, explaining the need for the `from` parameter.
- Provided example code for the `claimTo` function with the `from` parameter in all three extensions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->