### PR TITLE
chore: Update version flow updates deployment

### DIFF
--- a/apps/dashboard/src/@3rdweb-sdk/react/hooks/useEngine.ts
+++ b/apps/dashboard/src/@3rdweb-sdk/react/hooks/useEngine.ts
@@ -18,7 +18,6 @@ export type EngineInstance = {
   name: string;
   url: string;
   lastAccessedAt: string;
-  cloudDeployedAt?: string;
   status:
     | "active"
     | "pending"
@@ -26,6 +25,7 @@ export type EngineInstance = {
     | "deploying"
     | "paymentFailed"
     | "deploymentFailed";
+  deploymentId?: string;
 };
 
 // Not checking for null token because the token is required the tanstack useQuery hook
@@ -189,23 +189,26 @@ export function useEngineLatestVersion() {
 
 interface UpdateVersionInput {
   engineId: string;
+  serverVersion: string;
 }
 
-export function useEngineUpdateVersion() {
+export function useEngineUpdateServerVersion() {
   return useMutation({
     mutationFn: async (input: UpdateVersionInput) => {
       invariant(input.engineId, "engineId is required");
 
-      const res = await fetch(`${THIRDWEB_API_HOST}/v1/engine/update-version`, {
-        method: "POST",
-
-        headers: {
-          "Content-Type": "application/json",
+      const res = await fetch(
+        `${THIRDWEB_API_HOST}/v2/engine/${input.engineId}/infrastructure`,
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            serverVersion: input.serverVersion,
+          }),
         },
-        body: JSON.stringify({
-          engineId: input.engineId,
-        }),
-      });
+      );
       // we never use the response body
       res.body?.cancel();
       if (!res.ok) {

--- a/apps/dashboard/src/components/engine/configuration/ip-allowlist.tsx
+++ b/apps/dashboard/src/components/engine/configuration/ip-allowlist.tsx
@@ -87,7 +87,7 @@ export const EngineIpAllowlistConfig: React.FC<
       </Flex>
 
       <Textarea
-        placeholder="8.8.8.8\nff06:0:0:0:0:0:0:c3"
+        placeholder={"8.8.8.8\nff06:0:0:0:0:0:0:c3"}
         rows={4}
         {...form.register("raw")}
       />

--- a/apps/dashboard/src/components/engine/create/CreateEnginePage.tsx
+++ b/apps/dashboard/src/components/engine/create/CreateEnginePage.tsx
@@ -112,7 +112,7 @@ export const CreateEnginePage = () => {
       </h1>
 
       <p className="mb-7 text-muted-foreground">
-        Host Engine on thirdweb with no setup or maintenance required
+        Host Engine on thirdweb with no setup or maintenance required.
       </p>
 
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">

--- a/apps/dashboard/src/components/engine/engine-instances-table.tsx
+++ b/apps/dashboard/src/components/engine/engine-instances-table.tsx
@@ -266,11 +266,7 @@ const EditModal = (props: {
               className="gap-2"
               disabled={!form.formState.isDirty}
             >
-              {editInstance.isPending ? (
-                <Spinner className="size-4" />
-              ) : (
-                <SendIcon className="size-4" />
-              )}
+              {editInstance.isPending && <Spinner className="size-4" />}
               Update
             </Button>
           </DialogFooter>
@@ -292,7 +288,7 @@ const RemoveModal = (props: {
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="z-[10001]" dialogOverlayClassName="z-[10000]">
         {instance.status === "paymentFailed" ||
-        (instance.status === "active" && !instance.cloudDeployedAt) ? (
+        (instance.status === "active" && !instance.deploymentId) ? (
           <RemoveFromDashboardModalContent
             refetch={refetch}
             instance={instance}

--- a/apps/dashboard/src/components/engine/import/EngineImportPage.tsx
+++ b/apps/dashboard/src/components/engine/import/EngineImportPage.tsx
@@ -114,7 +114,7 @@ export const EngineImportPage = () => {
             <div className="mt-2 flex items-center gap-2">
               <CircleAlertIcon className="!static size-3 text-warning-foreground" />
               <p className="text-muted-foreground text-sm">
-                Do not import a URL you do not recognize
+                Do not import a URL you do not recognize.
               </p>
             </div>
           </FormControl>


### PR DESCRIPTION
## Problem solved

Changes the "update Engine version" flow to query the infra backend to perform the version upgrade.

Previously this would ping Slack for a thirdweb staff to update.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on improving the code quality and user interface of the dashboard components by updating placeholders, fixing text formatting, and refactoring function names for clarity. It also enhances the update functionality for the Engine version.

### Detailed summary
- Updated `placeholder` in `ip-allowlist.tsx` for consistency.
- Added periods to sentences in `EngineImportPage.tsx` and `CreateEnginePage.tsx`.
- Simplified conditional rendering in `engine-instances-table.tsx`.
- Changed `cloudDeployedAt` to `deploymentId` for clarity in `useEngine.ts`.
- Renamed `useEngineUpdateVersion` to `useEngineUpdateServerVersion`.
- Modified API endpoint and method in `useEngineUpdateServerVersion`.
- Updated variable names for better readability in `EngineVersionBadge`.
- Refactored `UpdateVersionModal` to use `latestVersion` instead of `latest`.
- Improved user feedback messages during engine updates.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->