### PR TITLE
Fix Contract Type shown in Contracts Table, Fix PublishedBy not showing latest version

### DIFF
--- a/apps/dashboard/src/components/contract-components/shared/published-by.tsx
+++ b/apps/dashboard/src/components/contract-components/shared/published-by.tsx
@@ -28,7 +28,7 @@ export const PublishedBy: React.FC<PublishedByProps> = ({ contract }) => {
   const publishedContractToShow = useMemo(() => {
     const reversedPublishedContractsFromDeploy = [
       ...(publishedContractsFromDeploy.data || []),
-    ];
+    ].reverse();
 
     return (
       reversedPublishedContractsFromDeploy.find(

--- a/apps/dashboard/src/components/contract-components/tables/cells.tsx
+++ b/apps/dashboard/src/components/contract-components/tables/cells.tsx
@@ -11,6 +11,7 @@ import Link from "next/link";
 import { memo } from "react";
 import { getContract } from "thirdweb";
 import { shortenIfAddress } from "utils/usedapp-external";
+import { THIRDWEB_DEPLOYER_ADDRESS } from "../../../constants/addresses";
 import { usePublishedContractsFromDeploy } from "../hooks";
 
 interface AsyncContractNameCellProps {
@@ -75,11 +76,32 @@ export const AsyncContractTypeCell = memo(
     const publishedContractsFromDeployQuery =
       usePublishedContractsFromDeploy(contract);
 
+    const publishedContractsFromDeployOriginal =
+      publishedContractsFromDeployQuery.data || [];
+
+    const publishedContractsFromDeploySorted = [
+      ...publishedContractsFromDeployOriginal,
+    ]
+      // latest first
+      .reverse()
+      // prioritize showing the publisher === thirdweb
+      .sort((a, b) => {
+        const aIsTWPublisher = a.publisher === THIRDWEB_DEPLOYER_ADDRESS;
+        const bIsTWPublisher = b.publisher === THIRDWEB_DEPLOYER_ADDRESS;
+        if (aIsTWPublisher && !bIsTWPublisher) {
+          return -1;
+        }
+        if (!aIsTWPublisher && bIsTWPublisher) {
+          return 1;
+        }
+        return 0;
+      });
+
     const contractMetadata = useDashboardContractMetadata(contract);
 
     const contractType =
-      publishedContractsFromDeployQuery.data?.[0]?.displayName ||
-      publishedContractsFromDeployQuery.data?.[0]?.name;
+      publishedContractsFromDeploySorted[0]?.displayName ||
+      publishedContractsFromDeploySorted[0]?.name;
 
     return (
       <SkeletonContainer


### PR DESCRIPTION
Fixes DASH-274

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the handling of published contracts in the dashboard by reversing and sorting the list of contracts based on the publisher's address, ensuring that the latest contracts are prioritized, especially those from the `THIRDWEB_DEPLOYER_ADDRESS`.

### Detailed summary
- In `published-by.tsx`, reversed the order of `reversedPublishedContractsFromDeploy`.
- In `cells.tsx`, introduced `publishedContractsFromDeployOriginal` to hold the original data.
- Created `publishedContractsFromDeploySorted` to reverse and sort the contracts prioritizing those from `THIRDWEB_DEPLOYER_ADDRESS`.
- Updated the contract type retrieval to use `publishedContractsFromDeploySorted`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->