### PR TITLE
feat: switch to v2 bundler for all user operations

### DIFF
--- a/.changeset/dry-toes-clean.md
+++ b/.changeset/dry-toes-clean.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Switch to v2 bundler for all user operations for better performance

--- a/packages/thirdweb/src/wallets/smart/lib/bundler.ts
+++ b/packages/thirdweb/src/wallets/smart/lib/bundler.ts
@@ -21,7 +21,6 @@ import {
   ENTRYPOINT_ADDRESS_v0_6,
   MANAGED_ACCOUNT_GAS_BUFFER,
   getDefaultBundlerUrl,
-  getEntryPointVersion,
 } from "./constants.js";
 import { hexlifyUserOp } from "./utils.js";
 
@@ -269,12 +268,7 @@ async function sendBundlerRequest(args: {
     console.debug(`>>> sending ${operation} with payload:`, params);
   }
 
-  const entryPointVersion = getEntryPointVersion(
-    options.entrypointAddress || ENTRYPOINT_ADDRESS_v0_6,
-  );
-  const bundlerVersion = entryPointVersion === "v0.6" ? "v1" : "v2";
-  const bundlerUrl =
-    options.bundlerUrl ?? getDefaultBundlerUrl(options.chain, bundlerVersion);
+  const bundlerUrl = options.bundlerUrl ?? getDefaultBundlerUrl(options.chain);
   const fetchWithHeaders = getClientFetch(options.client);
   const response = await fetchWithHeaders(bundlerUrl, {
     method: "POST",

--- a/packages/thirdweb/src/wallets/smart/lib/constants.ts
+++ b/packages/thirdweb/src/wallets/smart/lib/constants.ts
@@ -36,12 +36,12 @@ export const getDefaultAccountFactory = (entryPointAddress?: string) => {
 /**
  * @internal
  */
-export const getDefaultBundlerUrl = (chain: Chain, version: "v1" | "v2") => {
+export const getDefaultBundlerUrl = (chain: Chain) => {
   const domain = getThirdwebDomains().bundler;
   if (domain.startsWith("localhost:")) {
-    return `http://${domain}/${version ?? "v1"}?chain=${chain.id}`;
+    return `http://${domain}/v2?chain=${chain.id}`;
   }
-  return `https://${chain.id}.${domain}/${version ?? "v1"}`;
+  return `https://${chain.id}.${domain}/v2`;
 };
 
 export const getEntryPointVersion = (address: string): "v0.6" | "v0.7" => {

--- a/packages/thirdweb/src/wallets/smart/lib/paymaster.ts
+++ b/packages/thirdweb/src/wallets/smart/lib/paymaster.ts
@@ -11,7 +11,6 @@ import {
   DEBUG,
   ENTRYPOINT_ADDRESS_v0_6,
   getDefaultBundlerUrl,
-  getEntryPointVersion,
 } from "./constants.js";
 import { hexlifyUserOp } from "./utils.js";
 
@@ -53,9 +52,7 @@ export async function getPaymasterAndData(args: {
   };
 
   const entrypoint = entrypointAddress ?? ENTRYPOINT_ADDRESS_v0_6;
-  const entrypointVersion = getEntryPointVersion(entrypoint);
-  const paymasterVersion = entrypointVersion === "v0.6" ? "v1" : "v2";
-  const paymasterUrl = getDefaultBundlerUrl(chain, paymasterVersion);
+  const paymasterUrl = getDefaultBundlerUrl(chain);
 
   // Ask the paymaster to sign the transaction and return a valid paymasterAndData value.
   const fetchWithHeaders = getClientFetch(client);

--- a/packages/thirdweb/src/wallets/smart/lib/userop.ts
+++ b/packages/thirdweb/src/wallets/smart/lib/userop.ts
@@ -218,12 +218,7 @@ async function getGasFees(args: {
   const { executeTx, bundlerOptions, chain, client } = args;
   let { maxFeePerGas, maxPriorityFeePerGas } = executeTx;
 
-  const entrypointVersion = getEntryPointVersion(
-    bundlerOptions.entrypointAddress || ENTRYPOINT_ADDRESS_v0_6,
-  );
-  const bundlerVersion = entrypointVersion === "v0.6" ? "v1" : "v2";
-  const bundlerUrl =
-    bundlerOptions?.bundlerUrl ?? getDefaultBundlerUrl(chain, bundlerVersion);
+  const bundlerUrl = bundlerOptions?.bundlerUrl ?? getDefaultBundlerUrl(chain);
 
   if (isThirdwebUrl(bundlerUrl)) {
     // get gas prices from bundler


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added



<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on switching to the v2 bundler for improved performance across user operations in the `thirdweb` package.

### Detailed summary
- Updated `getDefaultBundlerUrl` to use v2 directly, removing version parameter.
- Simplified bundler URL logic in `userop.ts`, `paymaster.ts`, and `bundler.ts`.
- Removed conditional logic for determining bundler and paymaster versions based on entry point version.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->