### PR TITLE
fix: add missing partner id for ecosystem wallet

### DIFF
--- a/.changeset/famous-spies-grab.md
+++ b/.changeset/famous-spies-grab.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+fix missing partner id when creating ecosystem wallet

--- a/packages/thirdweb/src/wallets/in-app/native/ecosystem.ts
+++ b/packages/thirdweb/src/wallets/in-app/native/ecosystem.ts
@@ -76,6 +76,7 @@ export function ecosystemWallet(
         ...createOptions?.auth,
         options: [], // controlled by ecosystem
       },
+      partnerId: createOptions?.partnerId,
     },
     connectorFactory: async (client: ThirdwebClient) => {
       const { InAppNativeConnector } = await import("./native-connector.js");

--- a/packages/thirdweb/src/wallets/in-app/web/ecosystem.ts
+++ b/packages/thirdweb/src/wallets/in-app/web/ecosystem.ts
@@ -76,6 +76,7 @@ export function ecosystemWallet(
         ...createOptions?.auth,
         options: [], // controlled by ecosystem
       },
+      partnerId: ecosystem.partnerId,
     },
     connectorFactory: async (client: ThirdwebClient) => {
       const { InAppWebConnector } = await import("./lib/web-connector.js");


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the issue of missing `partnerId` when creating an ecosystem wallet in the `thirdweb` package.

### Detailed summary
- Added `partnerId: ecosystem.partnerId` in `packages/thirdweb/src/wallets/in-app/web/ecosystem.ts`.
- Added `partnerId: createOptions?.partnerId` in `packages/thirdweb/src/wallets/in-app/native/ecosystem.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->