### PR TITLE
api server url env cleanup

### DIFF
--- a/apps/dashboard/src/@/api/projects.ts
+++ b/apps/dashboard/src/@/api/projects.ts
@@ -1,9 +1,7 @@
 import "server-only";
 import { COOKIE_ACTIVE_ACCOUNT, COOKIE_PREFIX_TOKEN } from "@/constants/cookie";
+import { API_SERVER_URL } from "@/constants/env";
 import { cookies } from "next/headers";
-
-const THIRDWEB_API_HOST =
-  process.env.NEXT_PUBLIC_THIRDWEB_API_HOST || "https://api.thirdweb.com";
 
 export type Project = {
   id: string;
@@ -34,7 +32,7 @@ export async function getProjects(teamSlug: string) {
   }
 
   const teamsRes = await fetch(
-    `${THIRDWEB_API_HOST}/v1/teams/${teamSlug}/projects`,
+    `${API_SERVER_URL}/v1/teams/${teamSlug}/projects`,
     {
       headers: {
         Authorization: `Bearer ${token}`,
@@ -59,7 +57,7 @@ export async function getProject(teamSlug: string, projectSlug: string) {
   }
 
   const teamsRes = await fetch(
-    `${THIRDWEB_API_HOST}/v1/teams/${teamSlug}/projects/${projectSlug}`,
+    `${API_SERVER_URL}/v1/teams/${teamSlug}/projects/${projectSlug}`,
     {
       headers: {
         Authorization: `Bearer ${token}`,

--- a/apps/dashboard/src/@/api/team-members.ts
+++ b/apps/dashboard/src/@/api/team-members.ts
@@ -1,9 +1,7 @@
 import "server-only";
 import { COOKIE_ACTIVE_ACCOUNT, COOKIE_PREFIX_TOKEN } from "@/constants/cookie";
+import { API_SERVER_URL } from "@/constants/env";
 import { cookies } from "next/headers";
-
-const THIRDWEB_API_HOST =
-  process.env.NEXT_PUBLIC_THIRDWEB_API_HOST || "https://api.thirdweb.com";
 
 const TeamAccountRole = {
   OWNER: "OWNER",
@@ -39,7 +37,7 @@ export async function getMembers(teamSlug: string) {
   }
 
   const teamsRes = await fetch(
-    `${THIRDWEB_API_HOST}/v1/teams/${teamSlug}/members`,
+    `${API_SERVER_URL}/v1/teams/${teamSlug}/members`,
     {
       headers: {
         Authorization: `Bearer ${token}`,

--- a/apps/dashboard/src/@/api/team.ts
+++ b/apps/dashboard/src/@/api/team.ts
@@ -1,9 +1,7 @@
 import "server-only";
 import { COOKIE_ACTIVE_ACCOUNT, COOKIE_PREFIX_TOKEN } from "@/constants/cookie";
+import { API_SERVER_URL } from "@/constants/env";
 import { cookies } from "next/headers";
-
-const THIRDWEB_API_HOST =
-  process.env.NEXT_PUBLIC_THIRDWEB_API_HOST || "https://api.thirdweb.com";
 
 export type Team = {
   id: string;
@@ -35,7 +33,7 @@ export async function getTeamBySlug(slug: string) {
     return null;
   }
 
-  const teamRes = await fetch(`${THIRDWEB_API_HOST}/v1/teams/${slug}`, {
+  const teamRes = await fetch(`${API_SERVER_URL}/v1/teams/${slug}`, {
     headers: {
       Authorization: `Bearer ${token}`,
     },
@@ -57,7 +55,7 @@ export async function getTeams() {
     return [];
   }
 
-  const teamsRes = await fetch(`${THIRDWEB_API_HOST}/v1/teams`, {
+  const teamsRes = await fetch(`${API_SERVER_URL}/v1/teams`, {
     headers: {
       Authorization: `Bearer ${token}`,
     },

--- a/apps/dashboard/src/@/constants/env.ts
+++ b/apps/dashboard/src/@/constants/env.ts
@@ -20,3 +20,6 @@ export const PROD_OR_DEV_URL = isProd ? "thirdweb.com" : "thirdweb-dev.com";
 export const DASHBOARD_STORAGE_URL =
   process.env.NEXT_PUBLIC_DASHBOARD_UPLOAD_SERVER ||
   "https://storage.thirdweb.com";
+
+export const API_SERVER_URL =
+  process.env.NEXT_PUBLIC_THIRDWEB_API_HOST || "https://api.thirdweb.com";

--- a/apps/dashboard/src/app/(dashboard)/(chain)/utils.ts
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/utils.ts
@@ -37,6 +37,7 @@ import zytronCTA from "./temp-assets/zytronCTA.jpg";
 
 // END TEMPORARY
 
+import { API_SERVER_URL } from "@/constants/env";
 import type { ChainMetadata } from "thirdweb/chains";
 import type {
   ChainMetadataWithServices,
@@ -44,18 +45,15 @@ import type {
   ChainServices,
 } from "./types/chain";
 
-const THIRDWEB_API_HOST =
-  process.env.NEXT_PUBLIC_THIRDWEB_API_HOST || "https://api.thirdweb.com";
-
 export async function getChains() {
   const [chains, chainServices] = await Promise.all([
     fetch(
-      `${THIRDWEB_API_HOST}/v1/chains`,
+      `${API_SERVER_URL}/v1/chains`,
       // revalidate every 60 minutes
       { next: { revalidate: 60 * 60 } },
     ).then((res) => res.json()) as Promise<{ data: ChainMetadata[] }>,
     fetch(
-      `${THIRDWEB_API_HOST}/v1/chains/services`,
+      `${API_SERVER_URL}/v1/chains/services`,
       // revalidate every 60 minutes
       { next: { revalidate: 60 * 60 } },
     ).then((res) => res.json()) as Promise<{
@@ -77,12 +75,12 @@ export async function getChain(
 ): Promise<ChainMetadataWithServices> {
   const [chain, chainServices] = await Promise.all([
     fetch(
-      `${THIRDWEB_API_HOST}/v1/chains/${chainIdOrSlug}`,
+      `${API_SERVER_URL}/v1/chains/${chainIdOrSlug}`,
       // revalidate every 15 minutes
       { next: { revalidate: 15 * 60 } },
     ).then((res) => res.json()) as Promise<{ data: ChainMetadata }>,
     fetch(
-      `${THIRDWEB_API_HOST}/v1/chains/${chainIdOrSlug}/services`,
+      `${API_SERVER_URL}/v1/chains/${chainIdOrSlug}/services`,
       // revalidate every 15 minutes
       { next: { revalidate: 15 * 60 } },
     ).then((res) => res.json()) as Promise<{ data: ChainServices }>,

--- a/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/utils/fetchEcosystem.ts
+++ b/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/utils/fetchEcosystem.ts
@@ -1,14 +1,12 @@
+import { API_SERVER_URL } from "@/constants/env";
 import type { Ecosystem } from "../types";
 
 export async function fetchEcosystem(slug: string, authToken: string) {
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_THIRDWEB_API_HOST || "https://api.thirdweb.com"}/v1/ecosystem-wallet/${slug}`,
-    {
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-      },
+  const res = await fetch(`${API_SERVER_URL}/v1/ecosystem-wallet/${slug}`, {
+    headers: {
+      Authorization: `Bearer ${authToken}`,
     },
-  );
+  });
   if (!res.ok) {
     const data = await res.json();
     console.error(data);

--- a/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/utils/fetchEcosystemList.ts
+++ b/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/utils/fetchEcosystemList.ts
@@ -1,14 +1,12 @@
+import { API_SERVER_URL } from "@/constants/env";
 import type { Ecosystem } from "../types";
 
 export async function fetchEcosystemList(authToken: string) {
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_THIRDWEB_API_HOST || "https://api.thirdweb.com"}/v1/ecosystem-wallet/list`,
-    {
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-      },
+  const res = await fetch(`${API_SERVER_URL}/v1/ecosystem-wallet/list`, {
+    headers: {
+      Authorization: `Bearer ${authToken}`,
     },
-  );
+  });
 
   if (!res.ok) {
     const data = await res.json();

--- a/apps/dashboard/src/app/(dashboard)/support/components/create-ticket.action.ts
+++ b/apps/dashboard/src/app/(dashboard)/support/components/create-ticket.action.ts
@@ -2,6 +2,7 @@
 import "server-only";
 
 import { COOKIE_ACTIVE_ACCOUNT, COOKIE_PREFIX_TOKEN } from "@/constants/cookie";
+import { API_SERVER_URL } from "@/constants/env";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 
@@ -11,8 +12,6 @@ type State = {
 };
 
 const UNTHREAD_API_KEY = process.env.UNTHREAD_API_KEY || "";
-const THIRDWEB_API_HOST =
-  process.env.NEXT_PUBLIC_THIRDWEB_API_HOST || "https://api.thirdweb.com";
 
 const planToCustomerId = {
   free: process.env.UNTHREAD_FREE_TIER_ID as string,
@@ -77,7 +76,7 @@ export async function createTicketAction(
     // user is not logged in, make them log in
     redirect(`/login?next=${encodeURIComponent("/support")}`);
   }
-  const accountRes = await fetch(`${THIRDWEB_API_HOST}/v1/account/me`, {
+  const accountRes = await fetch(`${API_SERVER_URL}/v1/account/me`, {
     method: "GET",
     headers: {
       Authorization: `Bearer ${token}`,

--- a/apps/dashboard/src/app/account/settings/getAccount.ts
+++ b/apps/dashboard/src/app/account/settings/getAccount.ts
@@ -1,11 +1,10 @@
+import { API_SERVER_URL } from "@/constants/env";
 import type { Account } from "@3rdweb-sdk/react/hooks/useApi";
 import { getAuthToken } from "../../api/lib/getAuthToken";
 
 export async function getAccount() {
   const authToken = getAuthToken();
-  const apiServerURL = new URL(
-    process.env.NEXT_PUBLIC_THIRDWEB_API_HOST || "https://api.thirdweb.com",
-  );
+  const apiServerURL = new URL(API_SERVER_URL);
 
   apiServerURL.pathname = "/v1/account/me";
 

--- a/apps/dashboard/src/app/api/auth/ensure-login/route.ts
+++ b/apps/dashboard/src/app/api/auth/ensure-login/route.ts
@@ -1,10 +1,8 @@
 import { COOKIE_ACTIVE_ACCOUNT, COOKIE_PREFIX_TOKEN } from "@/constants/cookie";
+import { API_SERVER_URL } from "@/constants/env";
 import { cookies } from "next/headers";
 import { type NextRequest, NextResponse } from "next/server";
 import { getAddress } from "thirdweb/utils";
-
-const THIRDWEB_API_HOST =
-  process.env.NEXT_PUBLIC_THIRDWEB_API_HOST || "https://api.thirdweb.com";
 
 export type EnsureLoginPayload = {
   pathname: string;
@@ -56,7 +54,7 @@ export const GET = async (req: NextRequest) => {
   }
 
   // check that the token is valid by checking for the user account
-  const accountRes = await fetch(`${THIRDWEB_API_HOST}/v1/account/me`, {
+  const accountRes = await fetch(`${API_SERVER_URL}/v1/account/me`, {
     method: "GET",
     headers: {
       Authorization: `Bearer ${token}`,

--- a/apps/dashboard/src/app/api/auth/get-auth-token/route.ts
+++ b/apps/dashboard/src/app/api/auth/get-auth-token/route.ts
@@ -1,10 +1,8 @@
 import { COOKIE_PREFIX_TOKEN } from "@/constants/cookie";
+import { API_SERVER_URL } from "@/constants/env";
 import { cookies } from "next/headers";
 import { type NextRequest, NextResponse } from "next/server";
 import { getAddress } from "thirdweb/utils";
-
-const THIRDWEB_API_HOST =
-  process.env.NEXT_PUBLIC_THIRDWEB_API_HOST || "https://api.thirdweb.com";
 
 export type GetAuthTokenResponse = {
   jwt: string | null;
@@ -43,7 +41,7 @@ export const GET = async (req: NextRequest) => {
   }
 
   // check token validity
-  const accountRes = await fetch(`${THIRDWEB_API_HOST}/v1/account/me`, {
+  const accountRes = await fetch(`${API_SERVER_URL}/v1/account/me`, {
     method: "GET",
     headers: {
       Authorization: `Bearer ${token}`,

--- a/apps/dashboard/src/app/api/lib/getAPIKeys.ts
+++ b/apps/dashboard/src/app/api/lib/getAPIKeys.ts
@@ -1,3 +1,4 @@
+import { API_SERVER_URL } from "@/constants/env";
 import type { ApiKey } from "@3rdweb-sdk/react/hooks/useApi";
 import { getAuthToken } from "./getAuthToken";
 
@@ -36,17 +37,14 @@ export async function getAPIKey(apiKeyId: string) {
 
 export async function getApiKeys() {
   const authToken = getAuthToken();
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_THIRDWEB_API_HOST || "https://api.thirdweb.com"}/v1/keys`,
-    {
-      method: "GET",
+  const res = await fetch(`${API_SERVER_URL}/v1/keys`, {
+    method: "GET",
 
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${authToken}`,
-      },
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${authToken}`,
     },
-  );
+  });
   const json = await res.json();
 
   if (json.error) {

--- a/apps/dashboard/src/app/login/auth-actions.ts
+++ b/apps/dashboard/src/app/login/auth-actions.ts
@@ -2,6 +2,7 @@
 import "server-only";
 
 import { COOKIE_ACTIVE_ACCOUNT, COOKIE_PREFIX_TOKEN } from "@/constants/cookie";
+import { API_SERVER_URL } from "@/constants/env";
 import { cookies } from "next/headers";
 import { getAddress } from "thirdweb";
 import type {
@@ -9,9 +10,6 @@ import type {
   LoginPayload,
   VerifyLoginPayloadParams,
 } from "thirdweb/auth";
-
-const THIRDWEB_API_HOST =
-  process.env.NEXT_PUBLIC_THIRDWEB_API_HOST || "https://api.thirdweb.com";
 
 const THIRDWEB_API_SECRET = process.env.API_SERVER_SECRET || "";
 
@@ -21,7 +19,7 @@ export async function getLoginPayload(
   if (!THIRDWEB_API_SECRET) {
     throw new Error("API_SERVER_SECRET is not set");
   }
-  const res = await fetch(`${THIRDWEB_API_HOST}/v2/siwe/payload`, {
+  const res = await fetch(`${API_SERVER_URL}/v2/siwe/payload`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -48,7 +46,7 @@ export async function doLogin(payload: VerifyLoginPayloadParams) {
   const cookieStore = cookies();
 
   // forward the request to the API server
-  const res = await fetch(`${THIRDWEB_API_HOST}/v2/siwe/login`, {
+  const res = await fetch(`${API_SERVER_URL}/v2/siwe/login`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -144,7 +142,7 @@ export async function isLoggedIn(address: string) {
     return false;
   }
 
-  const res = await fetch(`${THIRDWEB_API_HOST}/v1/account/me`, {
+  const res = await fetch(`${API_SERVER_URL}/v1/account/me`, {
     method: "GET",
     headers: {
       "Content-Type": "application/json",

--- a/apps/dashboard/src/pages/api/server-proxy/api/[...paths].tsx
+++ b/apps/dashboard/src/pages/api/server-proxy/api/[...paths].tsx
@@ -1,4 +1,5 @@
 import { COOKIE_ACTIVE_ACCOUNT, COOKIE_PREFIX_TOKEN } from "@/constants/cookie";
+import { API_SERVER_URL } from "@/constants/env";
 import type { NextRequest } from "next/server";
 import { getAddress } from "thirdweb";
 
@@ -21,15 +22,13 @@ const handler = async (req: NextRequest) => {
   searchParams.delete("paths");
 
   // create a new URL object for the API server
-  const API_SERVER_URL = new URL(
-    process.env.NEXT_PUBLIC_THIRDWEB_API_HOST || "https://api.thirdweb.com",
-  );
-  API_SERVER_URL.pathname = pathname;
+  const url = new URL(API_SERVER_URL);
+  url.pathname = pathname;
   searchParams.forEach((value, key) => {
-    API_SERVER_URL.searchParams.append(key, value);
+    url.searchParams.append(key, value);
   });
 
-  return fetch(API_SERVER_URL, {
+  return fetch(url, {
     method: req.method,
     headers: {
       "content-type": "application/json",


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the API server URL usage across multiple files in the `dashboard` application. It introduces a new constant, `API_SERVER_URL`, to centralize the management of the API endpoint, replacing direct references to the environment variable.

### Detailed summary
- Added `API_SERVER_URL` constant in `env.ts`.
- Replaced direct environment variable references with `API_SERVER_URL` in:
  - `getAccount.ts`
  - `fetchEcosystemList.ts`
  - `fetchEcosystem.ts`
  - `team-members.ts`
  - `get-auth-token/route.ts`
  - `getAPIKeys.ts`
  - `ensure-login/route.ts`
  - `server-proxy/api/[...paths].tsx`
  - `team.ts`
  - `projects.ts`
  - `create-ticket.action.ts`
  - `auth-actions.ts`
  - `utils.ts`
- Updated fetch requests to use `API_SERVER_URL` for consistency and maintainability.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->