### PR TITLE
Add Billing alerts on /connect layout in app router

### DIFF
--- a/apps/dashboard/src/@3rdweb-sdk/react/hooks/useLoggedInUser.ts
+++ b/apps/dashboard/src/@3rdweb-sdk/react/hooks/useLoggedInUser.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { isLoginRequired } from "@/constants/auth";
 import { useDashboardRouter } from "@/lib/DashboardRouter";
 import { useQuery } from "@tanstack/react-query";

--- a/apps/dashboard/src/app/(dashboard)/dashboard/connect/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/dashboard/connect/layout.tsx
@@ -1,7 +1,13 @@
+import { BillingAlerts } from "../../../../components/settings/Account/Billing/alerts/Alert";
 import { ConnectSidebarLayout } from "./DashboardConnectLayout";
 
 export default function Layout(props: {
   children: React.ReactNode;
 }) {
-  return <ConnectSidebarLayout>{props.children}</ConnectSidebarLayout>;
+  return (
+    <ConnectSidebarLayout>
+      <BillingAlerts className="pb-6" />
+      {props.children}
+    </ConnectSidebarLayout>
+  );
 }

--- a/apps/dashboard/src/components/layout/app-shell/index.tsx
+++ b/apps/dashboard/src/components/layout/app-shell/index.tsx
@@ -26,7 +26,7 @@ export const AppShell: ComponentWithChildren<AppShellProps> = ({
         className={cn("min-h-screen py-6 md:pt-10 md:pb-20", mainClassName)}
       >
         <Container maxW="container.page">
-          <BillingAlerts />
+          <BillingAlerts className="py-6" />
         </Container>
 
         {layout === "custom-contract" ? (

--- a/apps/dashboard/src/components/settings/Account/Billing/alerts/Alert.tsx
+++ b/apps/dashboard/src/components/settings/Account/Billing/alerts/Alert.tsx
@@ -3,6 +3,7 @@
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { TrackedLinkTW } from "@/components/ui/tracked-link";
+import { cn } from "@/lib/utils";
 import {
   type Account,
   AccountStatus,
@@ -36,7 +37,9 @@ type AlertConditionType = {
     | "usage";
 };
 
-export const BillingAlerts = () => {
+export const BillingAlerts = (props: {
+  className?: string;
+}) => {
   const pathname = usePathname();
   const { isLoggedIn } = useLoggedInUser();
   const usageQuery = useAccountUsage();
@@ -64,6 +67,7 @@ export const BillingAlerts = () => {
     <BillingAlertsUI
       usageData={usageQuery.data}
       dashboardAccount={meQuery.data}
+      className={props.className}
     />
   );
 };
@@ -71,6 +75,7 @@ export const BillingAlerts = () => {
 export function BillingAlertsUI(props: {
   usageData: UsageBillableByService;
   dashboardAccount: Account;
+  className?: string;
 }) {
   const { usageData, dashboardAccount } = props;
   const trackEvent = useTrack();
@@ -295,7 +300,9 @@ export function BillingAlertsUI(props: {
     return null;
   }
 
-  return <div className="flex flex-col gap-4 py-6">{alerts}</div>;
+  return (
+    <div className={cn("flex flex-col gap-4", props.className)}>{alerts}</div>
+  );
 }
 
 type AddPaymentNotificationProps = {


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `className` prop for the `BillingAlerts` component, allowing for customized styling. It also integrates the `BillingAlerts` component into the `Layout` and modifies its rendering to accommodate the new prop.

### Detailed summary
- Added `className` prop to `BillingAlerts` component.
- Updated `BillingAlerts` usage in `apps/dashboard/src/components/layout/app-shell/index.tsx` to include `className="py-6"`.
- Integrated `BillingAlerts` in `apps/dashboard/src/app/(dashboard)/dashboard/connect/layout.tsx` with `className="pb-6"`.
- Modified `BillingAlertsUI` to accept and apply `className` prop for styling.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->