### PR TITLE
fix: update timeline for GDPR compliance

### DIFF
--- a/apps/portal/src/app/connect/in-app-wallet/security/page.mdx
+++ b/apps/portal/src/app/connect/in-app-wallet/security/page.mdx
@@ -70,7 +70,7 @@ Using threshold secret sharing, thirdweb cannot reconstruct a user's private key
 
 #### GDPR & CCPA
 
-In-app wallets are compliant with GDPR and CCPA within 90 days.
+thirdweb complies to GDPR and CCPA compliance frameworks and deletes customer data per request within the required timeframe of each standard (30 days for GDPR and 45 for CCPA).
 
 #### Audit and Bounty Program
 


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the information regarding compliance with GDPR and CCPA in the `page.mdx` file, providing more detailed and accurate descriptions of the standards and the timeframe for data deletion.

### Detailed summary
- Modified the compliance statement for GDPR and CCPA.
- Changed the text from "In-app wallets are compliant with GDPR and CCPA within 90 days" to a more detailed explanation of `thirdweb`'s compliance and data deletion timelines (30 days for GDPR and 45 for CCPA).

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->