### PR TITLE
Update chain stack type check

### DIFF
--- a/apps/dashboard/src/components/configure-networks/ConfigureNetworkForm.tsx
+++ b/apps/dashboard/src/components/configure-networks/ConfigureNetworkForm.tsx
@@ -28,6 +28,7 @@ export type NetworkConfigFormData = {
   type: "testnet" | "mainnet";
   icon: string;
   slug: string;
+  stackType?: string;
 };
 
 // lowercase it, replace all spaces with hyphens, and then strip all non-alphanumeric characters
@@ -71,6 +72,7 @@ export const ConfigureNetworkForm: React.FC<NetworkConfigFormProps> = ({
       type: editingChain?.testnet ? "testnet" : "mainnet",
       icon: editingChain?.icon?.url || "",
       slug: prefillSlug || editingChain?.slug || "",
+      stackType: "",
     },
     mode: "onChange",
   });
@@ -146,6 +148,7 @@ export const ConfigureNetworkForm: React.FC<NetworkConfigFormProps> = ({
               format: "",
             },
         testnet: data.type === "testnet",
+        stackType: data.stackType || "",
       };
     } else {
       configuredNetwork = {
@@ -170,6 +173,7 @@ export const ConfigureNetworkForm: React.FC<NetworkConfigFormProps> = ({
               format: "",
             }
           : undefined,
+        stackType: data.stackType || "",
       };
     }
 

--- a/apps/dashboard/src/contract-ui/tabs/embed/components/embed-setup.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/embed/components/embed-setup.tsx
@@ -243,6 +243,7 @@ export const EmbedSetup: React.FC<EmbedSetupProps> = ({
     shortName: "unknown",
     slug: "unknown",
     testnet: false,
+    stackType: "",
   };
 
   const { register, watch } = useForm<{

--- a/packages/thirdweb/src/chains/types.ts
+++ b/packages/thirdweb/src/chains/types.ts
@@ -82,6 +82,7 @@ export type ChainMetadata = {
     type: string;
     bridges?: Readonly<Array<{ url: string }>>;
   };
+  stackType: string;
 };
 
 /**

--- a/packages/thirdweb/src/chains/utils.ts
+++ b/packages/thirdweb/src/chains/utils.ts
@@ -365,5 +365,6 @@ function createChainMetadata(
         url: e.url,
         standard: "EIP3091",
       })) || data?.explorers,
+    stackType: data?.stackType || "",
   };
 }


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the `stackType` property across various files to enhance the handling of blockchain network configurations and improve the detection of ZkSync chains.

### Detailed summary
- Added `stackType` property to `chains/types.ts` and `chains/utils.ts`.
- Included `stackType` in the `embed-setup.tsx` component.
- Updated `ConfigureNetworkForm.tsx` to handle `stackType`.
- Modified `isZkSyncChain.ts` to use `getChainMetadata` and check `stackType` for ZkSync chains.
- Removed the `getChainStack` function, consolidating stack fetching logic.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->