### PR TITLE
fix: handle 0n as from/to blocks in getContractEvents

### DIFF
--- a/.changeset/heavy-camels-help.md
+++ b/.changeset/heavy-camels-help.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix passing 0n as from/to blocks in getContractEvents

--- a/packages/thirdweb/src/event/actions/get-events.ts
+++ b/packages/thirdweb/src/event/actions/get-events.ts
@@ -124,8 +124,8 @@ export async function getContractEvents<
 
     // Make sure the inputs were properly defined
     if (
-      fromBlock &&
-      toBlock &&
+      fromBlock !== undefined &&
+      toBlock !== undefined &&
       BigInt(toBlock) - BigInt(fromBlock) !== BigInt(blockRange)
     ) {
       throw new Error(
@@ -133,9 +133,9 @@ export async function getContractEvents<
       );
     }
 
-    if (fromBlock) {
+    if (fromBlock !== undefined) {
       restParams.toBlock = BigInt(fromBlock) + BigInt(blockRange) - 1n; // Subtract one because toBlock is inclusive
-    } else if (toBlock) {
+    } else if (toBlock !== undefined) {
       restParams.fromBlock = BigInt(toBlock) - BigInt(blockRange) + 1n; // Add one because fromBlock is inclusive
     } else {
       // If no from or to block specified, use the latest block as the to block


### PR DESCRIPTION
Fixes CNCT-1987

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the validation of `fromBlock` and `toBlock` inputs in the `getContractEvents` function to ensure they are properly defined. It fixes the handling of cases where these values might be `0n`.

### Detailed summary
- Updated condition checks for `fromBlock` and `toBlock` to ensure they are not `undefined`.
- Modified error handling to check for valid block ranges.
- Adjusted logic for setting `restParams.toBlock` and `restParams.fromBlock` to account for inclusive ranges.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->