### PR TITLE
chore: Fix readContract docs

### DIFF
--- a/packages/thirdweb/src/react/core/hooks/contract/useReadContract.ts
+++ b/packages/thirdweb/src/react/core/hooks/contract/useReadContract.ts
@@ -45,7 +45,7 @@ type PickedQueryOptions = {
  *
  * const { data, isLoading } = useReadContract({
  *   contract,
- *   method: "function tokenURI(uint256 tokenId) returns (string)"});
+ *   method: "function tokenURI(uint256 tokenId) returns (string)"
  *   params: [1n],
  * });
  * ```

--- a/packages/thirdweb/src/transaction/read-contract.ts
+++ b/packages/thirdweb/src/transaction/read-contract.ts
@@ -111,7 +111,7 @@ export type ReadContractOptions<
  *
  * const { data, isLoading } = useReadContract({
  *   contract,
- *   method: "function tokenURI(uint256 tokenId) returns (string)"}),
+ *   method: "function tokenURI(uint256 tokenId) returns (string)",
  *   params: [1n],
  * });
  * ```


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `useReadContract` function calls in two files to properly format the `method` string by adding a trailing comma. This change ensures consistency and correctness in the function's parameters.

### Detailed summary
- In `packages/thirdweb/src/transaction/read-contract.ts`:
  - Added a trailing comma to the `method` string in `useReadContract`.
  
- In `packages/thirdweb/src/react/core/hooks/contract/useReadContract.ts`:
  - Added a trailing comma to the `method` string in `useReadContract`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->