### PR TITLE
[Portal] Fix useChain in migrate docs

### DIFF
--- a/apps/portal/src/app/react/v5/migrate/cheatsheet/page.mdx
+++ b/apps/portal/src/app/react/v5/migrate/cheatsheet/page.mdx
@@ -14,7 +14,7 @@
 | Connect              | `ConnectWallet`                                       | [`ConnectButton`](/react/v5/ConnectButton)                                     |
 | Connection Status    | `useConnectionStatus()`                               | [`useActiveWalletConnectionStatus()`](/references/typescript/v5/useActiveWalletConnectionStatus)                 |
 | Switch Chain         | `useSwitchChain()`                                    | [`useSwitchActiveWalletChain()`](/references/typescript/v5/useSwitchActiveWalletChain)                      |
-| Get Connected Chain  | `useChain()`                                          | [`useSwitchActiveWalletChain()`](/references/typescript/v5/useSwitchActiveWalletChain)                  |
+| Get Connected Chain  | `useChain()`                                          | [`useActiveWalletChain()`](/references/typescript/v5/useActiveWalletChain)                  |
 
 
 ### TypeScript Cheatsheet

--- a/apps/portal/src/app/typescript/v5/migrate/page.mdx
+++ b/apps/portal/src/app/typescript/v5/migrate/page.mdx
@@ -2,7 +2,7 @@ import {
   ArticleIconCard,
 } from "@doc";
 import {
-	ReactIcon,
+  ReactIcon,
 } from "@/icons";
 
 # Migration from TypeScript SDK v4
@@ -178,4 +178,4 @@ const onClick = async () => {
 | Connect              | `ConnectWallet`                                       | [`ConnectButton`](/react/v5/ConnectButton)                                     |
 | Connection Status    | `useConnectionStatus()`                               | [`useActiveWalletConnectionStatus()`](/references/typescript/v5/useActiveWalletConnectionStatus)                 |
 | Switch Chain         | `useSwitchChain()`                                    | [`useSwitchActiveWalletChain()`](/references/typescript/v5/useSwitchActiveWalletChain)                      |
-| Get Connected Chain  | `useChain()`                                          | [`useSwitchActiveWalletChain()`](/references/typescript/v5/useSwitchActiveWalletChain)                  |
+| Get Connected Chain  | `useChain()`                                          | [`useActiveWalletChain()`](/references/typescript/v5/useActiveWalletChain)                  |


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the TypeScript SDK migration documentation to reflect changes in the function references for managing wallet connections and chains.

### Detailed summary
- Updated the reference for `Get Connected Chain` from `useSwitchActiveWalletChain()` to `useActiveWalletChain()` in both `apps/portal/src/app/react/v5/migrate/cheatsheet/page.mdx` and `apps/portal/src/app/typescript/v5/migrate/page.mdx`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->