### PR TITLE
Fix Get started with deploying contracts card buttons layout

### DIFF
--- a/apps/dashboard/src/app/team/[team_slug]/[project_slug]/contracts/_components/GetStartedWithContractsDeploy.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/[project_slug]/contracts/_components/GetStartedWithContractsDeploy.tsx
@@ -108,7 +108,7 @@ const DeployOptions = () => {
       />
 
       <button
-        className="mt-3 flex cursor-pointer items-center gap-2 rounded-lg border border-border bg-muted/50 p-4 hover:bg-muted"
+        className="mt-3 flex w-full cursor-pointer items-center gap-2 rounded-lg border border-border bg-muted/50 p-4 hover:bg-muted"
         type="button"
         onClick={() => {
           activeTabContent.onClick?.();
@@ -136,7 +136,9 @@ const DeployOptions = () => {
           }`}
         />
         <div>
-          <h4 className="font-semibold text-lg">{activeTabContent.title}</h4>
+          <h4 className="text-start font-semibold text-lg">
+            {activeTabContent.title}
+          </h4>
           <p className="text-muted-foreground text-sm">
             {activeTabContent.description}
           </p>


### PR DESCRIPTION
Current: 

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/yNOf1svJ8o3zjO7zQouZ/41286158-0065-465b-80a5-f61dd62af7b7.png)



Fixed: 

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/yNOf1svJ8o3zjO7zQouZ/be5b23ed-8159-421d-beb0-ca4dfc2f8c12.png)



<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the layout and styling of the `GetStartedWithContractsDeploy` component by adjusting button width and modifying the heading alignment.

### Detailed summary
- Changed the `className` of the `<button>` to set its width to full (`w-full`).
- Modified the `<h4>` tag's `className` to align text to the start (`text-start`), enhancing readability.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->