### PR TITLE
Remove calls to 0.rpc on deploy page

### DIFF
--- a/apps/dashboard/src/components/contract-components/contract-deploy-form/custom-contract.tsx
+++ b/apps/dashboard/src/components/contract-components/contract-deploy-form/custom-contract.tsx
@@ -145,7 +145,7 @@ export const CustomContractForm: React.FC<CustomContractFormProps> = ({
 
   const customFactoryAbi = useCustomFactoryAbi(
     customFactoryAddress,
-    Number(customFactoryNetwork),
+    customFactoryNetwork ? Number(customFactoryNetwork) : undefined,
   );
 
   const isTWPublisher = checkTwPublisher(metadata?.publisher);

--- a/apps/dashboard/src/components/contract-components/hooks.ts
+++ b/apps/dashboard/src/components/contract-components/hooks.ts
@@ -212,19 +212,32 @@ export function useContractEvents(abi: Abi) {
   return abi.filter((a) => a.type === "event");
 }
 
-export function useCustomFactoryAbi(contractAddress: string, chainId: number) {
+export function useCustomFactoryAbi(
+  contractAddress: string,
+  chainId: number | undefined,
+) {
   const chain = useV5DashboardChain(chainId);
   const client = useThirdwebClient();
   const contract = useMemo(() => {
+    if (!chain) {
+      return undefined;
+    }
+
     return getContract({
       client,
       address: contractAddress,
       chain,
     });
   }, [contractAddress, chain, client]);
+
   return useQuery({
     queryKey: ["custom-factory-abi", contract],
-    queryFn: () => resolveContractAbi<Abi>(contract),
+    queryFn: () => {
+      if (!contract) {
+        throw new Error("Contract not found");
+      }
+      return resolveContractAbi<Abi>(contract);
+    },
     enabled: !!contract,
   });
 }


### PR DESCRIPTION
Fixes: DASH-268

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/yNOf1svJ8o3zjO7zQouZ/4d64b356-b831-40e3-96a6-ed686b59a3e9.png)



<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the handling of the `chainId` parameter in the `useCustomFactoryAbi` function to allow it to be `undefined`. It enhances error handling when the contract is not found, ensuring better robustness in the code.

### Detailed summary
- Modified `useCustomFactoryAbi` to accept `chainId` as `number | undefined`.
- Added a check for `chain` to return `undefined` if not available.
- Enhanced error handling in the `queryFn` to throw an error if the `contract` is not found.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->