### PR TITLE
fix: pass empty array for missing block explorers in wallet_addEthereumChain

### DIFF
--- a/.changeset/poor-trainers-clean.md
+++ b/.changeset/poor-trainers-clean.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Pass empty array to wallet_addEthereumChain if no block explorers found

--- a/packages/thirdweb/src/wallets/injected/index.ts
+++ b/packages/thirdweb/src/wallets/injected/index.ts
@@ -271,7 +271,8 @@ async function switchChain(provider: Ethereum, chain: Chain) {
             chainName: apiChain.name,
             nativeCurrency: apiChain.nativeCurrency,
             rpcUrls: getValidPublicRPCUrl(apiChain), // no client id on purpose here
-            blockExplorerUrls: apiChain.explorers?.map((x) => x.url),
+            // @ts-expect-error - fixes firefox, needs to be null not undefined
+            blockExplorerUrls: apiChain.explorers?.map((x) => x.url) ?? null,
           },
         ],
       });


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the handling of block explorer URLs in the `thirdweb` wallet integration, specifically addressing compatibility issues with Firefox by ensuring that an empty array is passed when no explorers are found.

### Detailed summary
- Updated the `blockExplorerUrls` assignment in `packages/thirdweb/src/wallets/injected/index.ts` to use `?? null` instead of potentially undefined.
- Added a comment indicating the reason for the change, specifically to fix an issue in Firefox.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->