### PR TITLE
[SDK] Fix: pass gasPrice to injected provider

### DIFF
--- a/packages/thirdweb/src/wallets/injected/index.ts
+++ b/packages/thirdweb/src/wallets/injected/index.ts
@@ -120,6 +120,7 @@ function createAccount(provider: Ethereum, _address: string) {
             accessList: tx.accessList,
             value: tx.value ? numberToHex(tx.value) : undefined,
             gas: tx.gas ? numberToHex(tx.gas) : undefined,
+            gasPrice: tx.gasPrice ? numberToHex(tx.gasPrice) : undefined,
             from: this.address,
             to: tx.to as Address,
             data: tx.data,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds support for `gasPrice` in the transaction object handling within the `injected` wallet module.

### Detailed summary
- Added a new line to include `gasPrice` in the transaction object.
- The `gasPrice` is conditionally set using `numberToHex(tx.gasPrice)` if `tx.gasPrice` exists.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->