### PR TITLE
feat: add 'from' parameter to estimateGas example

### DIFF
--- a/packages/thirdweb/src/transaction/actions/estimate-gas.ts
+++ b/packages/thirdweb/src/transaction/actions/estimate-gas.ts
@@ -49,6 +49,7 @@ const cache = new WeakMap<
  * import { estimateGas } from "thirdweb";
  * const gas = await estimateGas({
  *  transaction,
+ *  from: "0x...",
  * });
  * ```
  */


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added



<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `estimateGas` function call in the `packages/thirdweb/src/transaction/actions/estimate-gas.ts` file to include a `from` parameter with a placeholder address.

### Detailed summary
- Added `from: "0x..."` to the `estimateGas` function call.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->