### PR TITLE
feat: export additional types from service-utils

### DIFF
--- a/.changeset/strong-laws-fail.md
+++ b/.changeset/strong-laws-fail.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+Export types

--- a/packages/service-utils/src/index.ts
+++ b/packages/service-utils/src/index.ts
@@ -1,5 +1,14 @@
 // Exports the public service definitions.
 export * from "./core/services.js";
+export type {
+  ApiKeyMetadata,
+  AccountMetadata,
+  ApiAccountResponse,
+  ApiResponse,
+  CoreServiceConfig,
+  PolicyResult,
+  UserOpData,
+} from "./core/api.js";
 
 export {
   authorizeBundleId,


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added



<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `@thirdweb-dev/service-utils` package by exporting additional types from the `core/api.js` file, enhancing type definitions for better type safety and usability.

### Detailed summary
- Updated `@thirdweb-dev/service-utils` to a patch version.
- Exported types from `./core/api.js`:
  - `ApiKeyMetadata`
  - `AccountMetadata`
  - `ApiAccountResponse`
  - `ApiResponse`
  - `CoreServiceConfig`
  - `PolicyResult`
  - `UserOpData`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->