### PR TITLE
feat: allow overriding callGasLimit for userops

### DIFF
--- a/.changeset/fast-weeks-appear.md
+++ b/.changeset/fast-weeks-appear.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Allow overriding callGasLimit for userops

--- a/packages/thirdweb/src/wallets/smart/lib/calls.ts
+++ b/packages/thirdweb/src/wallets/smart/lib/calls.ts
@@ -106,6 +106,10 @@ export function prepareExecute(args: {
       transaction.value || 0n,
       transaction.data || "0x",
     ],
+    // if gas is specified for the inner tx, use that and add 21k for the execute call on the account contract
+    // this avoids another estimateGas call when bundling the userOp
+    // and also allows for passing custom gas limits for the inner tx
+    gas: transaction.gas ? transaction.gas + 21000n : undefined,
   });
 }
 


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the ability to override the `callGasLimit` for user operations in the `thirdweb` wallet, enhancing gas management for transactions. It also adds a `waitForDeployment` option to control the deployment wait behavior.

### Detailed summary
- Added support for overriding `callGasLimit` in user operations.
- Introduced `waitForDeployment` option in `createUnsignedUserOp` and `createAndSignUserOp` functions.
- Updated logic to conditionally wait for account deployment based on `waitForDeployment`.
- Adjusted gas handling in `populateUserOp_v0_6` and `populateUserOp_v0_7` to use `callGasLimit`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->