### PR TITLE
feat: add account factory 0.7 to explore

### DIFF
--- a/apps/dashboard/src/data/explore.ts
+++ b/apps/dashboard/src/data/explore.ts
@@ -272,6 +272,8 @@ const SMART_WALLET = {
   contracts: [
     "thirdweb.eth/AccountFactory",
     "thirdweb.eth/ManagedAccountFactory",
+    "thirdweb.eth/AccountFactory_0_7",
+    "thirdweb.eth/ManagedAccountFactory_0_7",
   ],
   showInExplore: true,
 } satisfies ExploreCategory;

--- a/apps/portal/src/app/connect/account-abstraction/factories/page.mdx
+++ b/apps/portal/src/app/connect/account-abstraction/factories/page.mdx
@@ -20,7 +20,10 @@ export const metadata = createMetadata({
 
 # Account Factories
 
-By default, the SDK uses a global account factory deployed on most chains at address [`0x85e23b94e7F5E9cC1fF78BCe78cfb15B81f0DF00`](https://thirdweb.com/1/0x85e23b94e7F5E9cC1fF78BCe78cfb15B81f0DF00).
+By default, the SDK uses a global account factory deployed on most chains:
+
+- [`AccountFactory`](https://thirdweb.com/thirdweb.eth/AccountFactory) at address [`0x85e23b94e7F5E9cC1fF78BCe78cfb15B81f0DF00`](https://thirdweb.com/1/0x85e23b94e7F5E9cC1fF78BCe78cfb15B81f0DF00) for Entrypoint v0.6.
+- [`AccountFactory_0_7`](https://thirdweb.com/thirdweb.eth/AccountFactory_0_7) at address [`0x4be0ddfebca9a5a4a617dee4dece99e7c862dceb`](https://thirdweb.com/1/0x4be0ddfebca9a5a4a617dee4dece99e7c862dceb) for Entrypoint v0.7.
 
 The default account factory deploys standard, immutable accounts with the features listed below. However, you can customize the behavior of your apps smart accounts by deploying your own account factory contracts.
 
@@ -32,13 +35,23 @@ thirdweb offers different kinds of prebuilt account factories:
 
 <Grid>
 	<ArticleIconCard
-		title="Account Factory"
+		title="Account Factory for Entrypoint v0.6"
 		href="https://thirdweb.com/thirdweb.eth/AccountFactory"
 		icon={WalletsSmartIcon}
 	/>
 	<ArticleIconCard
-		title="Managed Account Factory"
+		title="Managed Account Factory for Entrypoint v0.6"
 		href="https://thirdweb.com/thirdweb.eth/ManagedAccountFactory"
+		icon={WalletsSmartIcon}
+	/>
+	<ArticleIconCard
+		title="Account Factory for Entrypoint v0.7"
+		href="https://thirdweb.com/thirdweb.eth/AccountFactory_0_7"
+		icon={WalletsSmartIcon}
+	/>
+	<ArticleIconCard
+		title="Managed Account Factory for Entrypoint v0.7"
+		href="https://thirdweb.com/thirdweb.eth/ManagedAccountFactory_0_7"
 		icon={WalletsSmartIcon}
 	/>
 </Grid>

--- a/packages/thirdweb/src/wallets/smart/smart-wallet.ts
+++ b/packages/thirdweb/src/wallets/smart/smart-wallet.ts
@@ -69,6 +69,40 @@ import { getDefaultAccountFactory } from "./lib/constants.js";
  * });
  * ```
  *
+ * ## Using a custom account factory
+ *
+ * You can pass a custom account factory to the `smartWallet` function to use a your own account factory.
+ *
+ * ```ts
+ * import { smartWallet } from "thirdweb/wallets";
+ * import { sepolia } from "thirdweb/chains";
+ *
+ * const wallet = smartWallet({
+ *  chain: sepolia,
+ *  sponsorGas: true, // enable sponsored transactions
+ *  factoryAddress: "0x...", // custom factory address
+ * });
+ *
+ * ## Using v0.7 Entrypoint
+ *
+ * Both v0.6 (default) and v0.7 ERC4337 Entrypoints are supported. To use the v0.7 Entrypoint, you can pass the `entrypointAddress` option to the `smartWallet` function, as well as a compatible account factory.
+ *
+ * You can use the predeployed `DEFAULT_ACCOUNT_FACTORY_V0_7` or deploy your own [AccountFactory  v0.7](https://thirdweb.com/thirdweb.eth/AccountFactory_0_7).
+ *
+ * ```ts
+ * import { smartWallet, DEFAULT_ACCOUNT_FACTORY_V0_7, ENTRYPOINT_ADDRESS_v0_7 } from "thirdweb/wallets/smart";
+ * import { sepolia } from "thirdweb/chains";
+ *
+ * const wallet = smartWallet({
+ *  chain: sepolia,
+ *  sponsorGas: true, // enable sponsored transactions
+ *  factoryAddress: DEFAULT_ACCOUNT_FACTORY_V0_7,
+ *  overrides: {
+ *    entrypointAddress: ENTRYPOINT_ADDRESS_v0_7
+ *  }
+ * });
+ * ```
+ *
  * ## Configuring the smart wallet
  *
  * You can pass options to the `smartWallet` function to configure the smart wallet.


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces support for new account factories in the SDK, specifically for Entrypoint v0.7, and updates documentation to reflect these changes. It enhances the `smartWallet` function with options for custom factories and provides detailed usage examples.

### Detailed summary
- Added support for `thirdweb.eth/AccountFactory_0_7` and `thirdweb.eth/ManagedAccountFactory_0_7`.
- Updated documentation to include usage of custom account factories in the `smartWallet` function.
- Provided examples for using both v0.6 and v0.7 Entrypoint options.
- Enhanced account factory descriptions and links in the documentation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->