### PR TITLE
fix: small typo in the getting started docs

### DIFF
--- a/apps/portal/src/app/contracts/modular-contracts/get-started/create-module-contract/page.mdx
+++ b/apps/portal/src/app/contracts/modular-contracts/get-started/create-module-contract/page.mdx
@@ -363,8 +363,8 @@ export const metadata = createMetadata({
            override
            returns (ModuleConfig memory config)
        {
-           config.callbackFunctions = new CallbackFunction ;
-           config.fallbackFunctions = new FallbackFunction ;
+           config.callbackFunctions = new CallbackFunction[](1);
+           config.fallbackFunctions = new FallbackFunction[](2);
 
            config.callbackFunctions[0] = CallbackFunction(
                this.beforeIncrement.selector


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the initialization of `callbackFunctions` and `fallbackFunctions` in the `create-module-contract` page to use array types instead of single instances.

### Detailed summary
- Changed `config.callbackFunctions` initialization from `new CallbackFunction` to `new CallbackFunction[](1)`.
- Changed `config.fallbackFunctions` initialization from `new FallbackFunction` to `new FallbackFunction[](2)`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->