### PR TITLE
feat: export fetchKeyMetadataFromApi and remove checkPolicy options

### DIFF
--- a/.changeset/wet-spiders-punch.md
+++ b/.changeset/wet-spiders-punch.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+Export fetchKeyMetadataFromApi, remove checkPolicy options

--- a/packages/service-utils/src/core/api.ts
+++ b/packages/service-utils/src/core/api.ts
@@ -20,11 +20,6 @@ export type CoreServiceConfig = {
   serviceApiKey: string;
   serviceAction?: string;
   useWalletAuth?: boolean;
-  checkPolicy?: boolean;
-  policyMetadata?: {
-    chainId: number;
-    userOp: UserOpData;
-  };
 };
 
 type Usage = {
@@ -90,15 +85,8 @@ export async function fetchKeyMetadataFromApi(
   clientId: string,
   config: CoreServiceConfig,
 ): Promise<ApiResponse> {
-  const { apiUrl, serviceScope, serviceApiKey, checkPolicy, policyMetadata } =
-    config;
-  const policyQuery =
-    checkPolicy && policyMetadata
-      ? `&checkPolicy=true&policyMetadata=${encodeURIComponent(
-          JSON.stringify(policyMetadata),
-        )}`
-      : "";
-  const url = `${apiUrl}/v1/keys/use?clientId=${clientId}&scope=${serviceScope}&includeUsage=true${policyQuery}`;
+  const { apiUrl, serviceScope, serviceApiKey } = config;
+  const url = `${apiUrl}/v1/keys/use?clientId=${clientId}&scope=${serviceScope}&includeUsage=true`;
   const response = await fetch(url, {
     method: "GET",
     headers: {

--- a/packages/service-utils/src/index.ts
+++ b/packages/service-utils/src/index.ts
@@ -8,6 +8,7 @@ export type {
   CoreServiceConfig,
   PolicyResult,
   UserOpData,
+  fetchKeyMetadataFromApi,
 } from "./core/api.js";
 
 export {


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on exporting the `fetchKeyMetadataFromApi` function and removing the `checkPolicy` options from the service configuration in the `service-utils` package.

### Detailed summary
- Exported `fetchKeyMetadataFromApi` from `./core/api.js`.
- Removed the `checkPolicy` option from the configuration.
- Eliminated the `policyMetadata` parameter from the function signature.
- Updated the URL construction to no longer include policy-related query parameters.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->