### PR TITLE
fix: export fetchKeyMetadataFromApi from service-utils

### DIFF
--- a/.changeset/red-students-run.md
+++ b/.changeset/red-students-run.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+Fix fetchMetadataFromApi export

--- a/packages/service-utils/src/index.ts
+++ b/packages/service-utils/src/index.ts
@@ -8,8 +8,9 @@ export type {
   CoreServiceConfig,
   PolicyResult,
   UserOpData,
-  fetchKeyMetadataFromApi,
 } from "./core/api.js";
+
+export { fetchKeyMetadataFromApi } from "./core/api.js";
 
 export {
   authorizeBundleId,


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added



<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the export of the `fetchKeyMetadataFromApi` function in the `@thirdweb-dev/service-utils` package.

### Detailed summary
- Updated the `fetchKeyMetadataFromApi` export in `packages/service-utils/src/index.ts`.
- Added a patch in the `@thirdweb-dev/service-utils` section of the changeset.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->