### PR TITLE
fix: throw if no token is found in local storage

### DIFF
--- a/.changeset/long-rocks-tan.md
+++ b/.changeset/long-rocks-tan.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Throw an error if an expected auth token is missing

--- a/packages/thirdweb/src/wallets/in-app/web/lib/actions/get-enclave-user-status.ts
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/actions/get-enclave-user-status.ts
@@ -32,13 +32,11 @@ export async function getUserStatus({
   );
 
   if (!response.ok) {
-    console.log("response", response.status);
     if (response.status === 401) {
       // 401 response indicates there is no user logged in, so we return undefined
       return undefined;
     }
     const result = await response.json();
-    console.log("result", result);
     throw new Error(`Failed to get user status: ${result.error}`);
   }
 

--- a/packages/thirdweb/src/wallets/in-app/web/lib/actions/sign-message.enclave.ts
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/actions/sign-message.enclave.ts
@@ -22,6 +22,10 @@ export async function signMessage({
   const clientFetch = getClientFetch(client, ecosystem);
   const authToken = await storage.getAuthCookie();
 
+  if (!authToken) {
+    throw new Error("No auth token found when signing message");
+  }
+
   const response = await clientFetch(
     `${getThirdwebBaseUrl("inAppWallet")}/api/v1/enclave-wallet/sign-message`,
     {

--- a/packages/thirdweb/src/wallets/in-app/web/lib/actions/sign-transaction.enclave.ts
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/actions/sign-transaction.enclave.ts
@@ -17,9 +17,12 @@ export async function signTransaction({
   payload: Record<string, Hex | number | undefined>;
   storage: ClientScopedStorage;
 }) {
-  console.log("payload", payload);
   const clientFetch = getClientFetch(client, ecosystem);
   const authToken = await storage.getAuthCookie();
+
+  if (!authToken) {
+    throw new Error("No auth token found when signing transaction");
+  }
 
   const response = await clientFetch(
     `${getThirdwebBaseUrl("inAppWallet")}/api/v1/enclave-wallet/sign-transaction`,

--- a/packages/thirdweb/src/wallets/in-app/web/lib/actions/sign-typed-data.enclave.ts
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/actions/sign-typed-data.enclave.ts
@@ -24,6 +24,10 @@ export async function signTypedData<
   const clientFetch = getClientFetch(client, ecosystem);
   const authToken = await storage.getAuthCookie();
 
+  if (!authToken) {
+    throw new Error("No auth token found when signing typed data");
+  }
+
   const response = await clientFetch(
     `${getThirdwebBaseUrl("inAppWallet")}/api/v1/enclave-wallet/sign-typed-data`,
     {


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing error handling in the `thirdweb` package by ensuring that an error is thrown when an expected authentication token is missing during various signing operations.

### Detailed summary
- Added error handling for missing `authToken` in:
  - `sign-message.enclave.ts`: Throws error when signing a message.
  - `sign-typed-data.enclave.ts`: Throws error when signing typed data.
  - `sign-transaction.enclave.ts`: Throws error when signing a transaction.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->