### PR TITLE
[SDK] Expose stuff for UD extensions, improve test

### DIFF
--- a/.changeset/big-fans-reflect.md
+++ b/.changeset/big-fans-reflect.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Expose UnstoppableDomains extensions: namehash and reverseNameOf

--- a/packages/thirdweb/scripts/generate/abis/unstoppable-domains/UnstoppableDomains.json
+++ b/packages/thirdweb/scripts/generate/abis/unstoppable-domains/UnstoppableDomains.json
@@ -1,5 +1,6 @@
 [
   "function reverseNameOf(address addr) view returns (string reverseUri)",
   "function getMany(string[] keys, uint256 tokenId) view returns (string[] values)",
-  "function namehash(string[] labels) pure returns (uint256 hash)"
+  "function namehash(string[] labels) pure returns (uint256 hash)",
+  "function exists(uint256 tokenId) view returns (bool)"
 ]

--- a/packages/thirdweb/src/exports/extensions/unstoppable-domains.ts
+++ b/packages/thirdweb/src/exports/extensions/unstoppable-domains.ts
@@ -7,3 +7,12 @@ export {
   type ResolveAddressOptions,
   resolveAddress,
 } from "../../extensions/unstoppable-domains/read/resolveAddress.js";
+export {
+  // Need this to resolve the tokenId, so that Social SDK can fetch the owner's Avatar from it
+  namehash,
+  type NamehashParams,
+} from "../../extensions/unstoppable-domains/__generated__/UnstoppableDomains/read/namehash.js";
+export {
+  reverseNameOf,
+  type ReverseNameOfParams,
+} from "../../extensions/unstoppable-domains/__generated__/UnstoppableDomains/read/reverseNameOf.js";

--- a/packages/thirdweb/src/extensions/unstoppable-domains/__generated__/UnstoppableDomains/read/exists.ts
+++ b/packages/thirdweb/src/extensions/unstoppable-domains/__generated__/UnstoppableDomains/read/exists.ts
@@ -1,0 +1,121 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { readContract } from "../../../../../transaction/read-contract.js";
+import type { BaseTransactionOptions } from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { decodeAbiParameters } from "viem";
+import type { Hex } from "../../../../../utils/encoding/hex.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+
+/**
+ * Represents the parameters for the "exists" function.
+ */
+export type ExistsParams = {
+  tokenId: AbiParameterToPrimitiveType<{ type: "uint256"; name: "tokenId" }>;
+};
+
+export const FN_SELECTOR = "0x4f558e79" as const;
+const FN_INPUTS = [
+  {
+    type: "uint256",
+    name: "tokenId",
+  },
+] as const;
+const FN_OUTPUTS = [
+  {
+    type: "bool",
+  },
+] as const;
+
+/**
+ * Checks if the `exists` method is supported by the given contract.
+ * @param availableSelectors An array of 4byte function selectors of the contract. You can get this in various ways, such as using "whatsabi" or if you have the ABI of the contract available you can use it to generate the selectors.
+ * @returns A boolean indicating if the `exists` method is supported.
+ * @extension UNSTOPPABLE-DOMAINS
+ * @example
+ * ```ts
+ * import { isExistsSupported } from "thirdweb/extensions/unstoppable-domains";
+ * const supported = isExistsSupported(["0x..."]);
+ * ```
+ */
+export function isExistsSupported(availableSelectors: string[]) {
+  return detectMethod({
+    availableSelectors,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "exists" function.
+ * @param options - The options for the exists function.
+ * @returns The encoded ABI parameters.
+ * @extension UNSTOPPABLE-DOMAINS
+ * @example
+ * ```ts
+ * import { encodeExistsParams } from "thirdweb/extensions/unstoppable-domains";
+ * const result = encodeExistsParams({
+ *  tokenId: ...,
+ * });
+ * ```
+ */
+export function encodeExistsParams(options: ExistsParams) {
+  return encodeAbiParameters(FN_INPUTS, [options.tokenId]);
+}
+
+/**
+ * Encodes the "exists" function into a Hex string with its parameters.
+ * @param options - The options for the exists function.
+ * @returns The encoded hexadecimal string.
+ * @extension UNSTOPPABLE-DOMAINS
+ * @example
+ * ```ts
+ * import { encodeExists } from "thirdweb/extensions/unstoppable-domains";
+ * const result = encodeExists({
+ *  tokenId: ...,
+ * });
+ * ```
+ */
+export function encodeExists(options: ExistsParams) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeExistsParams(options).slice(2)) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Decodes the result of the exists function call.
+ * @param result - The hexadecimal result to decode.
+ * @returns The decoded result as per the FN_OUTPUTS definition.
+ * @extension UNSTOPPABLE-DOMAINS
+ * @example
+ * ```ts
+ * import { decodeExistsResult } from "thirdweb/extensions/unstoppable-domains";
+ * const result = decodeExistsResultResult("...");
+ * ```
+ */
+export function decodeExistsResult(result: Hex) {
+  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+}
+
+/**
+ * Calls the "exists" function on the contract.
+ * @param options - The options for the exists function.
+ * @returns The parsed result of the function call.
+ * @extension UNSTOPPABLE-DOMAINS
+ * @example
+ * ```ts
+ * import { exists } from "thirdweb/extensions/unstoppable-domains";
+ *
+ * const result = await exists({
+ *  contract,
+ *  tokenId: ...,
+ * });
+ *
+ * ```
+ */
+export async function exists(options: BaseTransactionOptions<ExistsParams>) {
+  return readContract({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: [options.tokenId],
+  });
+}

--- a/packages/thirdweb/src/extensions/unstoppable-domains/read/resolveAddress.test.ts
+++ b/packages/thirdweb/src/extensions/unstoppable-domains/read/resolveAddress.test.ts
@@ -15,4 +15,15 @@ describe("Unstoppable Domain: resolve address", () => {
       ).toLowerCase(),
     ).toBe("0x12345674b599ce99958242b3D3741e7b01841DF3".toLowerCase());
   });
+
+  it("should throw an error with a non-existent domain name", async () => {
+    await expect(() =>
+      resolveAddress({
+        name: "thirdwebsdk.thissuredoesnotexist",
+        client: TEST_CLIENT,
+      }),
+    ).rejects.toThrowError(
+      "Could not resolve a valid tokenId from the domain: thirdwebsdk.thissuredoesnotexist. Make sure it exists.",
+    );
+  });
 });

--- a/packages/thirdweb/src/extensions/unstoppable-domains/read/resolveAddress.ts
+++ b/packages/thirdweb/src/extensions/unstoppable-domains/read/resolveAddress.ts
@@ -4,6 +4,7 @@ import type { ThirdwebClient } from "../../../client/client.js";
 import { getContract } from "../../../contract/contract.js";
 import { getAddress, isAddress } from "../../../utils/address.js";
 import { withCache } from "../../../utils/promise/withCache.js";
+import { exists } from "../__generated__/UnstoppableDomains/read/exists.js";
 import { getMany } from "../__generated__/UnstoppableDomains/read/getMany.js";
 import { namehash } from "../__generated__/UnstoppableDomains/read/namehash.js";
 import { UD_POLYGON_MAINNET } from "../consts.js";
@@ -70,6 +71,14 @@ export async function resolveAddress(
         contract,
         labels: name.split("."),
       });
+
+      // `namehash` always return a value, we should use `exists` to make sure it's valid
+      const _exists = await exists({ contract, tokenId: possibleTokenId });
+      if (!_exists) {
+        throw new Error(
+          `Could not resolve a valid tokenId from the domain: ${name}. Make sure it exists.`,
+        );
+      }
 
       // Resolve ETH address from the tokenId
       const resolved = await getMany({


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `thirdweb` package by exposing new functionalities related to `UnstoppableDomains`, specifically adding the `exists`, `namehash`, and `reverseNameOf` methods, along with error handling for domain resolution.

### Detailed summary
- Added `exists` method to check if a token ID is valid.
- Exposed `namehash` and `reverseNameOf` functions in `unstoppable-domains`.
- Updated `resolveAddress` to utilize `exists` for validating token IDs.
- Added test case for error handling when resolving non-existent domain names.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->