### PR TITLE
[SDK] Improve test coverage for ERC721 extensions

### DIFF
--- a/packages/thirdweb/src/extensions/erc721/read/getNFT.test.ts
+++ b/packages/thirdweb/src/extensions/erc721/read/getNFT.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, it } from "vitest";
 
+import { ANVIL_CHAIN } from "~test/chains.js";
+import { TEST_CONTRACT_URI } from "~test/ipfs-uris.js";
+import { TEST_CLIENT } from "~test/test-clients.js";
 import { DOODLES_CONTRACT } from "~test/test-contracts.js";
+import { TEST_ACCOUNT_A } from "~test/test-wallets.js";
+import { getContract } from "../../../contract/contract.js";
+import { deployERC721Contract } from "../../../extensions/prebuilts/deploy-erc721.js";
+import { sendAndConfirmTransaction } from "../../../transaction/actions/send-and-confirm-transaction.js";
+import { parseNFT } from "../../../utils/nft/parseNft.js";
+import { setTokenURI } from "../__generated__/INFTMetadata/write/setTokenURI.js";
+import { mintTo } from "../write/mintTo.js";
 import { getNFT } from "./getNFT.js";
 
 describe.runIf(process.env.TW_SECRET_KEY)("erc721.getNFT", () => {
@@ -88,5 +98,61 @@ describe.runIf(process.env.TW_SECRET_KEY)("erc721.getNFT", () => {
         "type": "ERC721",
       }
     `);
+  });
+
+  it("should return a default value if the URI of the token doesn't exist", async () => {
+    /**
+     * To create this test scenario, we first deploy an NFTCollection/Edition contract,
+     * mint a token, then purposefully change that token's URI to an empty string, using setTokenURI
+     */
+    const contract = getContract({
+      address: await deployERC721Contract({
+        chain: ANVIL_CHAIN,
+        client: TEST_CLIENT,
+        account: TEST_ACCOUNT_A,
+        type: "TokenERC721",
+        params: {
+          name: "",
+          contractURI: TEST_CONTRACT_URI,
+        },
+      }),
+      chain: ANVIL_CHAIN,
+      client: TEST_CLIENT,
+    });
+
+    await sendAndConfirmTransaction({
+      transaction: mintTo({
+        contract,
+        nft: { name: "token 0" },
+        to: TEST_ACCOUNT_A.address,
+      }),
+      account: TEST_ACCOUNT_A,
+    });
+
+    await sendAndConfirmTransaction({
+      transaction: setTokenURI({
+        contract,
+        tokenId: 0n,
+        // Need to have some spaces because NFTMetadata.sol does not allow to update an empty valud
+        uri: "  ",
+      }),
+      account: TEST_ACCOUNT_A,
+    });
+
+    expect(await getNFT({ contract, tokenId: 0n })).toStrictEqual(
+      parseNFT(
+        {
+          id: 0n,
+          type: "ERC721",
+          uri: "",
+        },
+        {
+          tokenId: 0n,
+          tokenUri: "",
+          type: "ERC721",
+          owner: null,
+        },
+      ),
+    );
   });
 });

--- a/packages/thirdweb/src/extensions/erc721/read/getNFT.ts
+++ b/packages/thirdweb/src/extensions/erc721/read/getNFT.ts
@@ -48,7 +48,7 @@ export async function getNFT(
       : null,
   ]);
 
-  if (!uri) {
+  if (!uri?.trim()) {
     return parseNFT(
       {
         id: options.tokenId,

--- a/packages/thirdweb/src/extensions/erc721/read/getNFTs.test.ts
+++ b/packages/thirdweb/src/extensions/erc721/read/getNFTs.test.ts
@@ -1,6 +1,17 @@
+import { type Abi, toFunctionSelector } from "viem";
 import { describe, expect, it } from "vitest";
-
-import { DOODLES_CONTRACT } from "~test/test-contracts.js";
+import { ANVIL_CHAIN } from "~test/chains.js";
+import { TEST_CONTRACT_URI } from "~test/ipfs-uris.js";
+import { TEST_CLIENT } from "~test/test-clients.js";
+import {
+  DOODLES_CONTRACT,
+  UNISWAPV3_FACTORY_CONTRACT,
+} from "~test/test-contracts.js";
+import { TEST_ACCOUNT_B } from "~test/test-wallets.js";
+import { resolveContractAbi } from "../../../contract/actions/resolve-abi.js";
+import { getContract } from "../../../contract/contract.js";
+import { deployERC721Contract } from "../../../extensions/prebuilts/deploy-erc721.js";
+import { isGetNFTSupported } from "./getNFT.js";
 import { getNFTs } from "./getNFTs.js";
 
 describe.runIf(process.env.TW_SECRET_KEY)("erc721.getNFTs", () => {
@@ -184,5 +195,36 @@ describe.runIf(process.env.TW_SECRET_KEY)("erc721.getNFTs", () => {
 
   it.todo("works for a contract with `1` indexed NFTs", async () => {
     // TODO find a contract that we can use that has "1 indexed" NFTs, then re-enable this test
+  });
+
+  it("isGetNFTsSupported should work", async () => {
+    const contract = getContract({
+      address: await deployERC721Contract({
+        chain: ANVIL_CHAIN,
+        client: TEST_CLIENT,
+        type: "TokenERC721",
+        params: {
+          name: "",
+          contractURI: TEST_CONTRACT_URI,
+        },
+        account: TEST_ACCOUNT_B,
+      }),
+      chain: ANVIL_CHAIN,
+      client: TEST_CLIENT,
+    });
+
+    const abi = await resolveContractAbi<Abi>(contract);
+    const selectors = abi
+      .filter((f) => f.type === "function")
+      .map((f) => toFunctionSelector(f));
+    expect(isGetNFTSupported(selectors)).toBe(true);
+  });
+
+  it("should throw error if totalSupply and nextTokenIdToMint are not supported", async () => {
+    await expect(() =>
+      getNFTs({ contract: UNISWAPV3_FACTORY_CONTRACT }),
+    ).rejects.toThrowError(
+      "Contract requires either `nextTokenIdToMint` or `totalSupply` function available to determine the next token ID to mint",
+    );
   });
 });

--- a/packages/thirdweb/src/extensions/erc721/read/getOwnedTokenIds.test.ts
+++ b/packages/thirdweb/src/extensions/erc721/read/getOwnedTokenIds.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { DOODLES_CONTRACT } from "~test/test-contracts.js";
+import {
+  DOODLES_CONTRACT,
+  UNISWAPV3_FACTORY_CONTRACT,
+} from "~test/test-contracts.js";
+import { TEST_ACCOUNT_B } from "~test/test-wallets.js";
 import { getOwnedTokenIds } from "./getOwnedTokenIds.js";
 
 describe.runIf(process.env.TW_SECRET_KEY)("erc721.getOwnedTokenIds", () => {
@@ -13,5 +17,15 @@ describe.runIf(process.env.TW_SECRET_KEY)("erc721.getOwnedTokenIds", () => {
     // The following code is based on the state of the forked chain
     // so the data should not change
     expect(tokenIds.length).toBe(81);
+  });
+
+  it("should throw if tokenOfOwnerByIndex or tokensOfOwner not supported", async () => {
+    // We know current Lens contract on Polygon doesn't have this.
+    const contract = UNISWAPV3_FACTORY_CONTRACT;
+    await expect(() =>
+      getOwnedTokenIds({ contract, owner: TEST_ACCOUNT_B.address }),
+    ).rejects.toThrowError(
+      `The contract at ${contract.address} on chain ${contract.chain.id} does not support the tokenOfOwnerByIndex or tokensOfOwner interface`,
+    );
   });
 });


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on enhancing the error handling and testing capabilities for the `erc721` extension, particularly around NFT retrieval and ownership functions. It introduces new tests and improves existing logic to ensure better reliability and coverage.

### Detailed summary
- Updated the condition in `getNFT.ts` to check for trimmed `uri`.
- Added imports for `UNISWAPV3_FACTORY_CONTRACT` and `TEST_ACCOUNT_B` in `getOwnedTokenIds.test.ts`.
- Introduced a test to verify error handling when unsupported functions are called in `getOwnedTokenIds.test.ts`.
- Expanded imports in `getNFTs.test.ts` and added a test for `isGetNFTSupported`.
- Added checks for unsupported functions in `getNFTs.test.ts`.
- Enhanced `getNFT.test.ts` with a new test for default values when the token URI is empty.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->