### PR TITLE
Remove accidentally added file path in Pay UI

### DIFF
--- a/.changeset/hip-camels-cheat.md
+++ b/.changeset/hip-camels-cheat.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Remove extra text shown in Error Message in Pay UI

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx
@@ -1483,10 +1483,7 @@ function FiatScreenContent(props: {
         <div>
           {errorMsg.minAmount && (
             <Text color="danger" size="sm" center multiline>
-              Minimum amount is {errorMsg.minAmount}
-              {
-                " packages/thirdweb/src/react/web/ui/ConnectWallet/TransactionsScreen.tsx"
-              }
+              Minimum amount is {errorMsg.minAmount}{" "}
               <TokenSymbol
                 token={toToken}
                 chain={toChain}


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the user experience in the Pay UI by removing unnecessary text from the error message displayed when the minimum amount is not met.

### Detailed summary
- Updated the error message in `BuyScreen.tsx` to remove extra text.
- Simplified the message to only display "Minimum amount is {errorMsg.minAmount}."

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->