### PR TITLE
Add /unlimited-wallets framer path in rewrites, format js files with biome

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,5 +21,8 @@
   },
   "[markdown]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "biomejs.biome"
   }
 }

--- a/apps/dashboard/next-sitemap.config.js
+++ b/apps/dashboard/next-sitemap.config.js
@@ -3,7 +3,7 @@
  *
  */
 async function fetchChainsFromApi() {
-  const res = await fetch(`https://api.thirdweb.com/v1/chains`, {
+  const res = await fetch("https://api.thirdweb.com/v1/chains", {
     headers: {
       "Content-Type": "application/json",
     },
@@ -55,7 +55,9 @@ module.exports = {
     ],
   },
   exclude: ["/chain/validate"],
-  transform: async (config, path) => {
+  transform: async (config, _path) => {
+    let path = _path;
+
     // ignore og image paths
     if (path.includes("_og")) {
       return null;

--- a/apps/dashboard/next.config.js
+++ b/apps/dashboard/next.config.js
@@ -40,7 +40,11 @@ const securityHeaders = [
 const redirects = require("./redirects");
 
 // add framer paths here
-const FRAMER_PATHS = ["/connect/sign-in", "/contracts/modular-contracts"];
+const FRAMER_PATHS = [
+  "/connect/sign-in",
+  "/contracts/modular-contracts",
+  "/unlimited-wallets",
+];
 
 /**
  * @returns {import('next').RemotePattern[]}


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating configuration settings and modifying paths in the `next.config.js` and `next-sitemap.config.js` files, as well as adding a new formatter for JavaScript in the `.vscode/settings.json` file.

### Detailed summary
- Added a default formatter for `javascript` in `.vscode/settings.json`.
- Expanded the `FRAMER_PATHS` array in `apps/dashboard/next.config.js` to include `"/unlimited-wallets"`.
- Changed the `fetch` URL string format in `apps/dashboard/next-sitemap.config.js` to use double quotes.
- Renamed the parameter `_path` to `path` in the `transform` function in `next-sitemap.config.js`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->