### PR TITLE
chore: don't override auth token / client id when hitting in app wall…

### DIFF
--- a/.changeset/nervous-tips-pay.md
+++ b/.changeset/nervous-tips-pay.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+fix: allow account linking on thirdweb dashboard

--- a/packages/thirdweb/src/utils/fetch.ts
+++ b/packages/thirdweb/src/utils/fetch.ts
@@ -47,7 +47,7 @@ export function getClientFetch(client: ThirdwebClient, ecosystem?: Ecosystem) {
 
       // if we have an auth token set, use that (thirdweb.com/dashboard sets this for the user)
       // pay urls should never send the auth token, because we always want the "developer" to be the one making the request, not the "end user"
-      if (authToken && !isPayUrl(url)) {
+      if (authToken && !isPayUrl(url) && !isInAppWalletUrl(url)) {
         headers.set("authorization", `Bearer ${authToken}`);
       } else if (secretKey) {
         headers.set("x-secret-key", secretKey);
@@ -135,6 +135,19 @@ function isPayUrl(url: string): boolean {
     const { hostname } = new URL(url);
     // pay service hostname always starts with "pay."
     return hostname.startsWith("pay.");
+  } catch {
+    return false;
+  }
+}
+
+function isInAppWalletUrl(url: string): boolean {
+  try {
+    const { hostname } = new URL(url);
+    // in app wallet service hostname always starts with "in-app-wallet." or "embedded-wallet."
+    return (
+      hostname.startsWith("in-app-wallet.") ||
+      hostname.startsWith("embedded-wallet.")
+    );
   } catch {
     return false;
   }


### PR DESCRIPTION
…et url

## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the authentication logic in the `thirdweb` dashboard by allowing account linking and preventing the use of auth tokens in specific URLs.

### Detailed summary
- Updated the condition for using the `authToken` in `fetch.ts` to include a check for `isInAppWalletUrl`.
- Introduced a new function `isInAppWalletUrl` to identify URLs related to in-app wallets based on their hostname.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->