### PR TITLE
feat: add Soneium Minato chain definition

### DIFF
--- a/.changeset/tasty-worms-mate.md
+++ b/.changeset/tasty-worms-mate.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Add soneiumMinato chain definition

--- a/apps/playground-web/src/components/in-app-wallet/profile-sections.tsx
+++ b/apps/playground-web/src/components/in-app-wallet/profile-sections.tsx
@@ -55,19 +55,34 @@ export function Profiles() {
   
           function App() {
             const { mutate: linkProfile, isPending, error } = useLinkProfile();
+
+            const linkMetamask = () => {
+              // link any external wallet
+              linkProfile({
+                client: THIRDWEB_CLIENT,
+                strategy: "wallet",
+                wallet: createWallet("io.metamask"), // or any other wallet
+                chain: baseSepolia,
+              });
+            };
+
+            const linkPasskey = () => {
+              // link any web2 identity provider
+              linkProfile({
+                client: THIRDWEB_CLIENT,
+                strategy: "passkey", // or "email", "phone", etc.
+                type: "sign-up",
+              });
+            };
   
             return (
   <div>
-    <button
-      onClick={() => linkProfile({
-        client: THIRDWEB_CLIENT,
-        strategy: "wallet",
-        wallet: createWallet("com.coinbase.wallet"),
-        chain: baseSepolia,
-      })}
-      >
-      Link Coinbase Wallet
-    </button>
+      <button onClick={linkMetamask}>
+        Link Metamask
+      </button>
+      <button onClick={linkPasskey}>
+        Link Passkey
+      </button>
   </div>
   );
   };`}

--- a/packages/thirdweb/src/chains/chain-definitions/soneium-minato.ts
+++ b/packages/thirdweb/src/chains/chain-definitions/soneium-minato.ts
@@ -1,0 +1,17 @@
+import { defineChain } from "../utils.js";
+
+/**
+ * @chain
+ */
+export const soneiumMinato = /* @__PURE__ */ defineChain({
+  id: 1946,
+  name: "Soneium Minato",
+  nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
+  blockExplorers: [
+    {
+      name: "Minato Explorer",
+      url: "https://explorer-testnet.soneium.org/",
+    },
+  ],
+  testnet: true,
+});

--- a/packages/thirdweb/src/exports/chains.ts
+++ b/packages/thirdweb/src/exports/chains.ts
@@ -77,3 +77,4 @@ export { celoAlfajoresTestnet } from "../chains/chain-definitions/celo-alfajores
 export { fraxtalTestnet } from "../chains/chain-definitions/fraxtal-testnet.js";
 export { metalL2Testnet } from "../chains/chain-definitions/metal-l2-testnet.js";
 export { modeTestnet } from "../chains/chain-definitions/mode-testnet.js";
+export { soneiumMinato } from "../chains/chain-definitions/soneium-minato.js";


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new blockchain chain definition for `soneiumMinato` and modifies the wallet linking functionality in the `App` component to support linking to `Metamask` and `Passkey` instead of `Coinbase Wallet`.

### Detailed summary
- Added `soneiumMinato` chain definition in `packages/thirdweb/src/chains/chain-definitions/soneium-minato.ts`.
- Exported `soneiumMinato` in `packages/thirdweb/src/exports/chains.ts`.
- Updated the `App` component in `apps/playground-web/src/components/in-app-wallet/profile-sections.tsx` to:
  - Implement `linkMetamask` function for linking to `Metamask`.
  - Implement `linkPasskey` function for linking to `Passkey`.
  - Replace the `Link Coinbase Wallet` button with buttons for `Link Metamask` and `Link Passkey`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->