### PR TITLE
Team Member Settings Page updates

### DIFF
--- a/apps/dashboard/src/@/api/team-members.ts
+++ b/apps/dashboard/src/@/api/team-members.ts
@@ -1,7 +1,6 @@
 import "server-only";
-import { COOKIE_ACTIVE_ACCOUNT, COOKIE_PREFIX_TOKEN } from "@/constants/cookie";
 import { API_SERVER_URL } from "@/constants/env";
-import { cookies } from "next/headers";
+import { getAuthToken } from "../../app/api/lib/getAuthToken";
 
 const TeamAccountRole = {
   OWNER: "OWNER",
@@ -26,14 +25,10 @@ export type TeamMember = {
 };
 
 export async function getMembers(teamSlug: string) {
-  const cookiesManager = cookies();
-  const activeAccount = cookiesManager.get(COOKIE_ACTIVE_ACCOUNT)?.value;
-  const token = activeAccount
-    ? cookiesManager.get(COOKIE_PREFIX_TOKEN + activeAccount)?.value
-    : null;
+  const token = getAuthToken();
 
   if (!token) {
-    return [];
+    return undefined;
   }
 
   const teamsRes = await fetch(
@@ -44,8 +39,10 @@ export async function getMembers(teamSlug: string) {
       },
     },
   );
+
   if (teamsRes.ok) {
     return (await teamsRes.json())?.result as TeamMember[];
   }
-  return [];
+
+  return undefined;
 }

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/settings/members/InviteSection.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/settings/members/InviteSection.tsx
@@ -25,19 +25,19 @@ export function InviteSection(props: {
 }) {
   const teamPlan = getValidTeamPlan(props.team);
   let bottomSection: React.ReactNode = null;
-  const inviteEnabled = teamPlan === "pro" && props.userHasEditPermission;
+  const inviteEnabled = teamPlan !== "free" && props.userHasEditPermission;
 
-  if (teamPlan !== "pro") {
+  if (teamPlan === "free") {
     bottomSection = (
       <div className="lg:px6 flex items-center justify-between gap-4 border-border border-t px-4 py-4">
         <p className="text-muted-foreground text-sm">
-          This feature is only available on the{" "}
+          This feature is not available on the Free Plan.{" "}
           <Link
             href="https://thirdweb.com/pricing"
             target="_blank"
             className="text-link-foreground hover:text-foreground"
           >
-            Pro plan <ExternalLinkIcon className="inline size-3" />
+            View plans <ExternalLinkIcon className="inline size-3" />
           </Link>
         </p>
 

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/settings/members/TeamMembersSettingsPage.stories.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/settings/members/TeamMembersSettingsPage.stories.tsx
@@ -1,7 +1,7 @@
-import type { Team } from "@/api/team";
 import type { TeamAccountRole, TeamMember } from "@/api/team-members";
 import { Toaster } from "@/components/ui/sonner";
 import type { Meta, StoryObj } from "@storybook/react";
+import { teamStub } from "../../../../../../../stories/stubs";
 import {
   BadgeContainer,
   mobileViewport,
@@ -34,37 +34,22 @@ export const Mobile: Story = {
   },
 };
 
-const freeTeam: Team = {
-  id: "team-id-foo-bar",
-  name: "Team XYZ",
-  slug: "team-slug-foo-bar",
-  createdAt: "2023-07-07T19:21:33.604Z",
-  updatedAt: "2024-07-11T00:01:02.241Z",
-  billingStatus: "validPayment",
-  billingPlan: "free",
-  billingEmail: "foo@example.com",
-};
+const freeTeam = teamStub("foo", "free");
+const proTeam = teamStub("bar", "pro");
+const growthTeam = teamStub("bazz", "growth");
 
-const proTeam: Team = {
-  id: "team-id-foo-bar",
-  name: "Team XYZ",
-  slug: "team-slug-foo-bar",
-  createdAt: "2023-07-07T19:21:33.604Z",
-  updatedAt: "2024-07-11T00:01:02.241Z",
-  billingStatus: "validPayment",
-  billingPlan: "pro",
-  billingEmail: "foo@example.com",
-};
-
-function createMemberStub(id: string, role: TeamAccountRole): TeamMember {
+function createMemberStub(
+  id: string,
+  role: TeamAccountRole,
+  createdHours: number,
+): TeamMember {
   const date = new Date();
-  // add random time to the date
-  date.setHours(Math.floor(Math.random() * 24));
+  date.setHours(createdHours);
 
   const member: TeamMember = {
     account: {
       email: `user-${id}@foo.com`,
-      name: `username-${id}`,
+      name: id,
     },
     accountId: `account-id-${id}`,
     createdAt: date,
@@ -78,9 +63,9 @@ function createMemberStub(id: string, role: TeamAccountRole): TeamMember {
 }
 
 const membersStub: TeamMember[] = [
-  createMemberStub("1", "OWNER"),
-  createMemberStub("2", "MEMBER"),
-  createMemberStub("3", "OWNER"),
+  createMemberStub("first-member", "OWNER", 1),
+  createMemberStub("third-member", "MEMBER", 3),
+  createMemberStub("second-member", "OWNER", 2),
 ];
 
 function Story() {
@@ -107,7 +92,7 @@ function CompVariants() {
 
         {/* Invite */}
         <div className="flex flex-col gap-10">
-          <BadgeContainer label="Not a Pro Team">
+          <BadgeContainer label="Free Team">
             <InviteSection team={freeTeam} userHasEditPermission={false} />
           </BadgeContainer>
 
@@ -118,31 +103,28 @@ function CompVariants() {
           <BadgeContainer label="Pro, User has permission">
             <InviteSection team={proTeam} userHasEditPermission={true} />
           </BadgeContainer>
+
+          <BadgeContainer label="Growth, User has permission">
+            <InviteSection team={growthTeam} userHasEditPermission={true} />
+          </BadgeContainer>
         </div>
 
         <div className="my-10" />
 
-        {/* Invite */}
+        <h2 className="py-4 font-semibold text-3xl">Team Members Variants</h2>
+
         <div className="flex flex-col gap-10">
-          <BadgeContainer label="Pro Team, has permission">
+          <BadgeContainer label="Has permission">
             <ManageMembersSection
-              team={proTeam}
+              team={freeTeam}
               userHasEditPermission={true}
               members={membersStub}
             />
           </BadgeContainer>
 
-          <BadgeContainer label="Not a Pro Team, No permission">
+          <BadgeContainer label="No permission">
             <ManageMembersSection
               team={freeTeam}
-              userHasEditPermission={false}
-              members={membersStub}
-            />
-          </BadgeContainer>
-
-          <BadgeContainer label="Pro Team, No permission">
-            <ManageMembersSection
-              team={proTeam}
               userHasEditPermission={false}
               members={membersStub}
             />

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/settings/members/TeamMembersSettingsPage.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/settings/members/TeamMembersSettingsPage.tsx
@@ -1,5 +1,7 @@
 import type { Team } from "@/api/team";
 import type { TeamMember } from "@/api/team-members";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { AlertCircleIcon } from "lucide-react";
 import { InviteSection } from "./InviteSection";
 import { ManageMembersSection } from "./ManageMembersSection";
 
@@ -10,6 +12,17 @@ export function TeamMembersSettingsPage(props: {
 }) {
   return (
     <div>
+      <Alert variant="info">
+        <AlertCircleIcon className="size-5 text-red-400" />
+        <AlertTitle>
+          Inviting and Managing Team Members is not available yet
+        </AlertTitle>
+        <AlertDescription>
+          This feature will be available in Q4 2024
+        </AlertDescription>
+      </Alert>
+      <div className="h-10" />
+
       <InviteSection
         team={props.team}
         userHasEditPermission={props.userHasEditPermission}

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/settings/members/page.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/settings/members/page.tsx
@@ -1,6 +1,7 @@
 import { getTeamBySlug } from "@/api/team";
 import { getMembers } from "@/api/team-members";
 import { notFound } from "next/navigation";
+import { getAccount } from "../../../../../../account/settings/getAccount";
 import { TeamMembersSettingsPage } from "./TeamMembersSettingsPage";
 
 export default async function Page(props: {
@@ -8,12 +9,19 @@ export default async function Page(props: {
     team_slug: string;
   };
 }) {
-  const [team, members] = await Promise.all([
+  const [account, team, members] = await Promise.all([
+    getAccount(),
     getTeamBySlug(props.params.team_slug),
     getMembers(props.params.team_slug),
   ]);
 
-  if (!team) {
+  if (!team || !account || !members) {
+    notFound();
+  }
+
+  const accountMemberInfo = members.find((m) => m.accountId === account.id);
+
+  if (!accountMemberInfo) {
     notFound();
   }
 
@@ -21,8 +29,7 @@ export default async function Page(props: {
     <TeamMembersSettingsPage
       team={team}
       members={members}
-      // TODO
-      userHasEditPermission={true}
+      userHasEditPermission={accountMemberInfo.role === "OWNER"}
     />
   );
 }


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `TeamMembersSettingsPage` and related components by introducing alerts for unavailable features, refining member management logic, and improving filtering and sorting capabilities for team members.

### Detailed summary
- Added an `Alert` to `TeamMembersSettingsPage` indicating feature unavailability.
- Modified `inviteEnabled` logic in `InviteSection` to exclude the "free" plan.
- Updated error handling in `getMembers` to return `undefined` instead of an empty array.
- Enhanced `Page` component to check for `account` and `members`.
- Adjusted `ManageMembersSection` to filter and sort members based on selected role.
- Changed member stubs to use a `teamStub` function for consistency.
- Improved UI labels and messages for better clarity.
- Refactored filtering logic in `ManageMembersSection` to use `useMemo` for performance.
- Added props for role and sort management in `FiltersSection` and `RoleSelector`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->