### PR TITLE
fix: overestimate zksync gas limit for paymaster extra gas

### DIFF
--- a/.changeset/nasty-experts-whisper.md
+++ b/.changeset/nasty-experts-whisper.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Overestimate zksync gas limit to account for paymaster extra gas

--- a/packages/thirdweb/src/transaction/actions/zksync/send-eip712-transaction.ts
+++ b/packages/thirdweb/src/transaction/actions/zksync/send-eip712-transaction.ts
@@ -128,7 +128,7 @@ export async function populateEip712Transaction(
       max_priority_fee_per_gas: string;
       gas_per_pubdata_limit: string;
     };
-    gas = toBigInt(result.gas_limit);
+    gas = toBigInt(result.gas_limit) * 2n; // overestimating to avoid issues when not accounting for paymaster extra gas ( we should really pass the paymaster input above for better accuracy )
     const baseFee = toBigInt(result.max_fee_per_gas);
     maxFeePerGas = baseFee * 2n; // bumping the base fee per gas to ensure fast inclusion
     maxPriorityFeePerGas = toBigInt(result.max_priority_fee_per_gas) || 1n;

--- a/packages/thirdweb/src/wallets/smart/smart-wallet-zksync.test.ts
+++ b/packages/thirdweb/src/wallets/smart/smart-wallet-zksync.test.ts
@@ -64,6 +64,18 @@ describe.runIf(process.env.TW_SECRET_KEY).todo(
       expect(tx.transactionHash.length).toBe(66);
     });
 
+    it("should send dummy a transactions", async () => {
+      const tx = await sendAndConfirmTransaction({
+        transaction: prepareTransaction({
+          chain,
+          client,
+          to: "0x611e71B12a2B1C0c884574042414Fe360aF0C5A7",
+        }),
+        account: smartAccount,
+      });
+      expect(tx.transactionHash.length).toBe(66);
+    });
+
     it.skip("should send a transaction on zkcandy", async () => {
       const zkCandy = defineChain(302);
       const zkCandySmartWallet = smartWallet({


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added



<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the gas estimation for `zksync` transactions by overestimating the gas limit to accommodate extra gas required for paymaster operations, and it adds a test case for sending transactions.

### Detailed summary
- Added a patch for `thirdweb` to overestimate `zksync` gas limit.
- Introduced a new test case in `packages/thirdweb/src/wallets/smart/smart-wallet-zksync.test.ts` for sending dummy transactions.
- Updated gas calculation in `packages/thirdweb/src/transaction/actions/zksync/send-eip712-transaction.ts` to double the gas limit and base fee for better transaction inclusion.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->