### PR TITLE
chore: New Engine Docs link, add some AA issues to troubleshooting guide

### DIFF
--- a/apps/portal/src/app/engine/faq/page.mdx
+++ b/apps/portal/src/app/engine/faq/page.mdx
@@ -109,7 +109,7 @@ Here's an example of a 2-hour timeout:
 
 ### How do I customize my RPC?
 
-Use [Update Chain Configuration](https://redocly.github.io/redoc/?url=https://demo.web3api.thirdweb.com/json#tag/Configuration/operation/updateChainsConfiguration) to override a chain's settings.
+Use [Update Chain Configuration](https://thirdweb-engine.apidocumentation.com/reference#tag/configuration/POST/configuration/chains) to override a chain's settings.
 
 **Example**
 

--- a/apps/portal/src/app/engine/features/cancelling-transactions/page.mdx
+++ b/apps/portal/src/app/engine/features/cancelling-transactions/page.mdx
@@ -24,8 +24,6 @@ When Engine receives a cancellation request:
 
 **When canceled, the transaction will not be re-attempted.** Your backend may safely re-attempt this transaction.
 
-_Note: Use [Retry Transaction](https://redocly.github.io/redoc/?url=https://demo.web3api.thirdweb.com/json#tag/Transaction/operation/retry) instead to increase the gas settings for a queued transaction._
-
 ## Cancel a transaction from the API
 
 ```typescript
@@ -44,7 +42,7 @@ if (resp.status === 200) {
 }
 ```
 
-Reference: [`Cancel Transaction`](https://redocly.github.io/redoc/?url=https://demo.web3api.thirdweb.com/json#tag/Transaction/operation/cancel)
+Reference: [`Cancel Transaction`](https://thirdweb-engine.apidocumentation.com/reference#tag/transaction/POST/transaction/cancel)
 
 ## Cancel a transaction from the dashboard
 

--- a/apps/portal/src/app/engine/features/contract-subscriptions/page.mdx
+++ b/apps/portal/src/app/engine/features/contract-subscriptions/page.mdx
@@ -38,7 +38,7 @@ Your app may trigger an action when an onchain event occurs, such as:
 1. Select **Add Contract Subscription**.
 1. Provide a webhook URL.
 
-API reference: [`POST /contract-subscriptions/add`](https://redocly.github.io/redoc/?url=https://demo.web3api.thirdweb.com/json#tag/Contract-Subscriptions/operation/addContractSubscription)
+API reference: [`POST /contract-subscriptions/add`](https://thirdweb-engine.apidocumentation.com/reference#tag/contract-subscriptions/POST/contract-subscriptions/add)
 
 #### Remove a Contract Subscription
 
@@ -46,7 +46,7 @@ API reference: [`POST /contract-subscriptions/add`](https://redocly.github.io/re
 1. Select **Contract Subscriptions**.
 1. Select **... > Remove** next to an existing subscription.
 
-API reference: [`POST /contract-subscriptions/remove`](https://redocly.github.io/redoc/?url=https://demo.web3api.thirdweb.com/json#tag/Contract-Subscriptions/operation/removeContractSubscription)
+API reference: [`POST /contract-subscriptions/remove`](https://thirdweb-engine.apidocumentation.com/reference#tag/contract-subscriptions/POST/contract-subscriptions/remove)
 
 ## Handling webhooks
 

--- a/apps/portal/src/app/engine/features/contracts/page.mdx
+++ b/apps/portal/src/app/engine/features/contracts/page.mdx
@@ -67,7 +67,7 @@ This is the request body to call the second function:
 
 </Details>
 
-[See API reference](https://redocly.github.io/redoc/?url=https://demo.web3api.thirdweb.com/json#tag/Contract/operation/write)
+[See API reference](https://thirdweb-engine.apidocumentation.com/reference#tag/contract/POST/contract/{chain}/{contractAddress}/write)
 
 ### Call a payable method
 

--- a/apps/portal/src/app/engine/sidebar.tsx
+++ b/apps/portal/src/app/engine/sidebar.tsx
@@ -87,7 +87,7 @@ export const sidebar: SideBar = {
     },
     {
       name: "API Reference",
-      href: "https://redocly.github.io/redoc/?url=https://demo.web3api.thirdweb.com/json",
+      href: "https://thirdweb-engine.apidocumentation.com/",
     },
     {
       name: "Typescript SDK",

--- a/apps/portal/src/app/engine/troubleshooting/page.mdx
+++ b/apps/portal/src/app/engine/troubleshooting/page.mdx
@@ -60,9 +60,9 @@ Engine automatically manages nonces so this error typically should not occur.
 
 It's possible the transactions are not being accepted by the mempool. To remediate this issue, you can retry a transaction, cancel it, or reset all backend wallet nonces.
 
-To retry a transaction, use [`POST /transaction/sync-retry`](https://redocly.github.io/redoc/?url=https://demo.web3api.thirdweb.com/json#tag/Transaction/operation/syncRetry) and provide the `queueId`. You may also provide a higher gas value to increase the likelihood of the transaction being mined.
+To retry a transaction, use [`POST /transaction/sync-retry`](https://thirdweb-engine.apidocumentation.com/reference#tag/transaction/POST/transaction/sync-retry) and provide the `queueId`. You may also provide a higher gas value to increase the likelihood of the transaction being mined.
 
-To cancel a transaction, use [`POST /transaction/cancel`](https://redocly.github.io/redoc/?url=https://demo.web3api.thirdweb.com/json#tag/Transaction/operation/cancel) and provide the `queueId`.
+To cancel a transaction, use [`POST /transaction/cancel`](https://thirdweb-engine.apidocumentation.com/reference#tag/transaction/POST/transaction/cancel) and provide the `queueId`.
 
 
 <Callout
@@ -72,7 +72,7 @@ To cancel a transaction, use [`POST /transaction/cancel`](https://redocly.github
     Transactions that were sent but not yet mined may fail because new transactions will use the same nonce values as previously sent transactions.
 </Callout>
 
-To reset the nonce, use [`POST /backend-wallet/reset-nonce`](https://redocly.github.io/redoc/?url=https://demo.web3api.thirdweb.com/json#tag/Backend-Wallet/operation/resetNonces) to sync the Engine nonce with the onchain value. This step resets all nonce values tracked in Engine, and the next sent transaction will use the next available onchain nonce.
+To reset the nonce for all backend wallets, use [`POST /backend-wallet/reset-nonce`](https://thirdweb-engine.apidocumentation.com/reference#tag/backend-wallet/POST/backend-wallet/reset-nonces) to force-sync the Engine nonces with the onchain values.
 
 ### Received "Insufficient funds for gas * price + value" error
 
@@ -94,3 +94,30 @@ Even though the transaction is expected to consume less gas, the transaction wil
 **How to resolve**
 
 Add more funds to your backend wallet. Or wait until the gas fees on the chain are lower and try again.
+
+## Sending UserOps
+
+UserOps are **User Op**erations sent by a backend wallet on behalf of smart accounts, used in the Account Abstraction pattern.
+
+### Received "Invalid UserOperation signature or paymaster signature" error
+
+*Also known as: code -32507*
+
+**What it means**
+
+The backend wallet you are sending the transaction with does not have sufficient permissions to send a userOp for this account address.
+
+**How to resolve**
+
+Confirm if the backend wallet is a valid admin for this account.
+If you are using Session Keys, confirm they are not close to or already expired.
+
+### Received "AA21 didn’t pay prefund" error
+
+**What it means**
+
+Your thirdweb API key used by Engine is not properly configured to use Account Abstraction, or you have a [sponsorship rule](https://portal.thirdweb.com/connect/account-abstraction/sponsorship-rules) that has been exceeded. 
+
+**How to resolve**
+
+Confirm if the API key is tied to an account with valid payment. Also confirm if there are any sponsorship rule for the Engine API key.


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates various documentation links throughout the application to point to the new API documentation site, replacing the old `redocly` URLs with the new `thirdweb-engine.apidocumentation.com` URLs. 

### Detailed summary
- Updated `API Reference` link in `sidebar.tsx`.
- Changed API reference links in `page.mdx` files to new URLs.
- Updated links for `Update Chain Configuration`, `Cancel Transaction`, and `Contract Subscriptions` operations.
- Added new sections for `UserOps` and related error handling in `troubleshooting/page.mdx`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->