### PR TITLE
[SDK] Improve ERC1155 test coverage

### DIFF
--- a/packages/thirdweb/src/extensions/erc1155/read/getNFTs.test.ts
+++ b/packages/thirdweb/src/extensions/erc1155/read/getNFTs.test.ts
@@ -1,0 +1,44 @@
+import { type Abi, toFunctionSelector } from "viem";
+import { describe, expect, it } from "vitest";
+import { ANVIL_CHAIN } from "~test/chains.js";
+import { TEST_CONTRACT_URI } from "~test/ipfs-uris.js";
+import { TEST_CLIENT } from "~test/test-clients.js";
+import { DROP1155_CONTRACT } from "~test/test-contracts.js";
+import { TEST_ACCOUNT_C } from "~test/test-wallets.js";
+import { resolveContractAbi } from "../../../contract/actions/resolve-abi.js";
+import { getContract } from "../../../contract/contract.js";
+import { deployERC1155Contract } from "../../../extensions/prebuilts/deploy-erc1155.js";
+import { isGetNFTsSupported } from "./getNFTs.js";
+
+describe.runIf(process.env.TW_SECRET_KEY)("ERC1155 getNFTs", () => {
+  it("isGetNFTsSupported should work with our Edition Drop contracts", async () => {
+    const abi = await resolveContractAbi<Abi>(DROP1155_CONTRACT);
+    const selectors = abi
+      .filter((f) => f.type === "function")
+      .map((f) => toFunctionSelector(f));
+    expect(isGetNFTsSupported(selectors)).toBe(true);
+  });
+
+  it("isGetNFTsSupported should work with our Edition contracts", async () => {
+    const contract = getContract({
+      address: await deployERC1155Contract({
+        chain: ANVIL_CHAIN,
+        client: TEST_CLIENT,
+        params: {
+          name: "",
+          contractURI: TEST_CONTRACT_URI,
+        },
+        type: "TokenERC1155",
+        account: TEST_ACCOUNT_C,
+      }),
+      chain: ANVIL_CHAIN,
+      client: TEST_CLIENT,
+    });
+
+    const abi = await resolveContractAbi<Abi>(contract);
+    const selectors = abi
+      .filter((f) => f.type === "function")
+      .map((f) => toFunctionSelector(f));
+    expect(isGetNFTsSupported(selectors)).toBe(true);
+  });
+});

--- a/packages/thirdweb/src/extensions/erc1155/write/lazyMint.test.ts
+++ b/packages/thirdweb/src/extensions/erc1155/write/lazyMint.test.ts
@@ -1,0 +1,35 @@
+import { type Abi, toFunctionSelector } from "viem";
+import { describe, expect, it } from "vitest";
+import { ANVIL_CHAIN } from "~test/chains.js";
+import { TEST_CONTRACT_URI } from "~test/ipfs-uris.js";
+import { TEST_CLIENT } from "~test/test-clients.js";
+import { TEST_ACCOUNT_C } from "~test/test-wallets.js";
+import { resolveContractAbi } from "../../../contract/actions/resolve-abi.js";
+import { getContract } from "../../../contract/contract.js";
+import { deployERC1155Contract } from "../../../extensions/prebuilts/deploy-erc1155.js";
+import { isLazyMintSupported } from "./lazyMint.js";
+
+describe.runIf(process.env.TW_SECRET_KEY)("erc1155: lazyMint", () => {
+  it("`isLazyMintSupported` should work with our Edition Drop contracts", async () => {
+    const contract = getContract({
+      address: await deployERC1155Contract({
+        chain: ANVIL_CHAIN,
+        client: TEST_CLIENT,
+        params: {
+          name: "",
+          contractURI: TEST_CONTRACT_URI,
+        },
+        type: "DropERC1155",
+        account: TEST_ACCOUNT_C,
+      }),
+      chain: ANVIL_CHAIN,
+      client: TEST_CLIENT,
+    });
+
+    const abi = await resolveContractAbi<Abi>(contract);
+    const selectors = abi
+      .filter((f) => f.type === "function")
+      .map((f) => toFunctionSelector(f));
+    expect(isLazyMintSupported(selectors)).toBe(true);
+  });
+});

--- a/packages/thirdweb/src/extensions/erc1155/write/mintAdditionalSupplyTo.test.ts
+++ b/packages/thirdweb/src/extensions/erc1155/write/mintAdditionalSupplyTo.test.ts
@@ -1,0 +1,38 @@
+import { type Abi, toFunctionSelector } from "viem";
+import { describe, expect, it } from "vitest";
+import { ANVIL_CHAIN } from "~test/chains.js";
+import { TEST_CONTRACT_URI } from "~test/ipfs-uris.js";
+import { TEST_CLIENT } from "~test/test-clients.js";
+import { TEST_ACCOUNT_C } from "~test/test-wallets.js";
+import { resolveContractAbi } from "../../../contract/actions/resolve-abi.js";
+import { getContract } from "../../../contract/contract.js";
+import { deployERC1155Contract } from "../../../extensions/prebuilts/deploy-erc1155.js";
+import { isMintAdditionalSupplyToSupported } from "./mintAdditionalSupplyTo.js";
+
+describe.runIf(process.env.TW_SECRET_KEY)(
+  "erc1155: mintAdditionalSupplyTo",
+  () => {
+    it("`isMintAdditionalSupplyToSupported` should work with our Edition contracts", async () => {
+      const contract = getContract({
+        address: await deployERC1155Contract({
+          chain: ANVIL_CHAIN,
+          client: TEST_CLIENT,
+          params: {
+            name: "",
+            contractURI: TEST_CONTRACT_URI,
+          },
+          type: "TokenERC1155",
+          account: TEST_ACCOUNT_C,
+        }),
+        chain: ANVIL_CHAIN,
+        client: TEST_CLIENT,
+      });
+
+      const abi = await resolveContractAbi<Abi>(contract);
+      const selectors = abi
+        .filter((f) => f.type === "function")
+        .map((f) => toFunctionSelector(f));
+      expect(isMintAdditionalSupplyToSupported(selectors)).toBe(true);
+    });
+  },
+);

--- a/packages/thirdweb/src/extensions/erc1155/write/mintTo.test.ts
+++ b/packages/thirdweb/src/extensions/erc1155/write/mintTo.test.ts
@@ -1,0 +1,43 @@
+import {} from "viem";
+import { describe, expect, it } from "vitest";
+import { ANVIL_CHAIN } from "~test/chains.js";
+import { TEST_CONTRACT_URI } from "~test/ipfs-uris.js";
+import { TEST_CLIENT } from "~test/test-clients.js";
+import { TEST_ACCOUNT_C } from "~test/test-wallets.js";
+import { getContract } from "../../../contract/contract.js";
+import { deployERC1155Contract } from "../../../extensions/prebuilts/deploy-erc1155.js";
+import { sendAndConfirmTransaction } from "../../../transaction/actions/send-and-confirm-transaction.js";
+import { uri } from "../__generated__/IERC1155/read/uri.js";
+import { mintTo } from "./mintTo.js";
+
+describe.runIf(process.env.TW_SECRET_KEY)("erc1155: mintTo", () => {
+  it("should mint with `nft` being declared as a string", async () => {
+    const contract = getContract({
+      address: await deployERC1155Contract({
+        chain: ANVIL_CHAIN,
+        client: TEST_CLIENT,
+        params: {
+          name: "",
+          contractURI: TEST_CONTRACT_URI,
+        },
+        type: "TokenERC1155",
+        account: TEST_ACCOUNT_C,
+      }),
+      chain: ANVIL_CHAIN,
+      client: TEST_CLIENT,
+    });
+
+    await sendAndConfirmTransaction({
+      transaction: mintTo({
+        contract,
+        nft: TEST_CONTRACT_URI,
+        to: TEST_ACCOUNT_C.address,
+        supply: 1n,
+      }),
+      account: TEST_ACCOUNT_C,
+    });
+
+    const tokenUri = await uri({ contract, tokenId: 0n });
+    expect(tokenUri).toBe(TEST_CONTRACT_URI);
+  });
+});

--- a/packages/thirdweb/src/extensions/erc20/read/isERC20.test.ts
+++ b/packages/thirdweb/src/extensions/erc20/read/isERC20.test.ts
@@ -8,7 +8,7 @@ import {
 import { resolveContractAbi } from "../../../contract/actions/resolve-abi.js";
 import { isERC20 } from "./isERC20.js";
 
-describe("isERC20", () => {
+describe.runIf(process.env.TW_SECRET_KEY)("isERC20", () => {
   it("should detect USDT as a valid erc20 contract", async () => {
     const abi = await resolveContractAbi<Abi>(USDT_CONTRACT);
     const selectors = abi

--- a/packages/thirdweb/src/extensions/erc20/write/transferBatch.test.ts
+++ b/packages/thirdweb/src/extensions/erc20/write/transferBatch.test.ts
@@ -19,7 +19,7 @@ const chain = ANVIL_CHAIN;
 const client = TEST_CLIENT;
 const account = TEST_ACCOUNT_A;
 
-describe("erc20: transferBatch", () => {
+describe.runIf(process.env.TW_SECRET_KEY)("erc20: transferBatch", () => {
   it("should transfer tokens to multiple recipients", async () => {
     const address = await deployERC20Contract({
       type: "TokenERC20",


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing test cases for various ERC20 and ERC1155 functionalities by conditionally running tests based on the presence of a `TW_SECRET_KEY`. It also introduces new tests for lazy minting and additional supply minting capabilities.

### Detailed summary
- Updated `describe` blocks to conditionally run tests using `describe.runIf(process.env.TW_SECRET_KEY)`.
- Added tests for `isLazyMintSupported` in `erc1155: lazyMint`.
- Added tests for `isMintAdditionalSupplyToSupported` in `erc1155: mintAdditionalSupplyTo`.
- Added tests for minting functionality in `erc1155: mintTo`.
- Added tests for `isGetNFTsSupported` in `ERC1155 getNFTs`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->