### PR TITLE
Fix unhandled server error on certain deprecated chain slugs

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/(chain)/utils.ts
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/utils.ts
@@ -86,7 +86,7 @@ export async function getChain(
     ).then((res) => res.json()) as Promise<{ data: ChainServices }>,
   ]);
 
-  if (!chain.data) {
+  if (!chain.data || !chainServices.data) {
     notFound();
   }
   return {


### PR DESCRIPTION
Fixes: DASH-311

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the conditional check for the existence of `chain.data` in the `utils.ts` file, ensuring that both `chain.data` and `chainServices.data` are verified before proceeding to call `notFound()`.

### Detailed summary
- Modified the conditional statement to check for both `chain.data` and `chainServices.data`:
  - Changed from `if (!chain.data)` to `if (!chain.data || !chainServices.data)`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->