### PR TITLE
Fix View all analytics link in contract overview page

### DIFF
--- a/apps/dashboard/src/contract-ui/tabs/overview/components/Analytics.tsx
+++ b/apps/dashboard/src/contract-ui/tabs/overview/components/Analytics.tsx
@@ -50,7 +50,7 @@ export const AnalyticsOverview: React.FC<AnalyticsOverviewProps> = ({
             });
           }}
         >
-          <Link href={`${chainSlug}/${contractAddress}/analytics`}>
+          <Link href={`/${chainSlug}/${contractAddress}/analytics`}>
             <span>View All</span>
             <ArrowRightIcon className="size-4" />
           </Link>


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the URL structure for the `Link` component in the `Analytics.tsx` file to ensure it starts with a leading slash.

### Detailed summary
- Changed the `href` attribute in the `Link` component from `${chainSlug}/${contractAddress}/analytics` to `/${chainSlug}/${contractAddress}/analytics`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->