### PR TITLE
Update Banner copy

### DIFF
--- a/apps/dashboard/src/components/notices/AnnouncementBanner.tsx
+++ b/apps/dashboard/src/components/notices/AnnouncementBanner.tsx
@@ -54,7 +54,7 @@ export function UnlimitedWalletsBanner() {
   return (
     <AnnouncementBanner
       href="/dashboard/settings/billing?coupon=FREEWALLETS"
-      label='Get 12 months of unlimited in-app wallets by applying the "FREEWALLETS" coupon in the billing dashboard'
+      label='Claim 12 months of free in-app wallets. Use code "FREEWALLETS". Redeem offer by October 31st!'
       trackingLabel="unlimited-wallets"
     />
   );


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `label` prop of the `AnnouncementBanner` component to provide a clearer and more engaging message about the offer related to in-app wallets.

### Detailed summary
- Updated the `label` prop in the `AnnouncementBanner`:
  - Changed from: 'Get 12 months of unlimited in-app wallets by applying the "FREEWALLETS" coupon in the billing dashboard'
  - To: 'Claim 12 months of free in-app wallets. Use code "FREEWALLETS". Redeem offer by October 31st!'

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->