### PR TITLE
feat: support for enclave migration in React Native

### DIFF
--- a/.changeset/chilly-mangos-decide.md
+++ b/.changeset/chilly-mangos-decide.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/react-native-adapter": minor
+---
+
+Updated required dependencies

--- a/.changeset/soft-colts-eat.md
+++ b/.changeset/soft-colts-eat.md
@@ -1,0 +1,7 @@
+---
+"thirdweb": minor
+---
+
+Support for enclave wallet migration in React Native
+
+this change requires the latest version of the `@thirdweb-dev/react-native-adapter` package to be installed.

--- a/packages/react-native-adapter/package.json
+++ b/packages/react-native-adapter/package.json
@@ -23,11 +23,9 @@
     },
     "./package.json": "./package.json"
   },
-  "files": [
-    "dist/*",
-    "src/*"
-  ],
+  "files": ["dist/*", "src/*"],
   "dependencies": {
+    "@aws-sdk/client-kms": "3.670.0",
     "@aws-sdk/client-lambda": "3.670.0",
     "@aws-sdk/credential-providers": "3.670.0",
     "@mobile-wallet-protocol/client": "0.0.3",

--- a/packages/thirdweb/package.json
+++ b/packages/thirdweb/package.json
@@ -234,6 +234,9 @@
     "@aws-sdk/client-lambda": {
       "optional": true
     },
+    "@aws-sdk/client-kms": {
+      "optional": true
+    },
     "@aws-sdk/credential-providers": {
       "optional": true
     },
@@ -279,6 +282,7 @@
     "node": ">=18"
   },
   "devDependencies": {
+    "@aws-sdk/client-kms": "3.670.0",
     "@aws-sdk/client-lambda": "3.670.0",
     "@aws-sdk/credential-providers": "3.670.0",
     "@biomejs/biome": "1.9.3",

--- a/packages/thirdweb/src/react/native/ui/components/WalletImage.tsx
+++ b/packages/thirdweb/src/react/native/ui/components/WalletImage.tsx
@@ -1,4 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
+import type { ThirdwebClient } from "../../../../client/client.js";
+import { resolveScheme } from "../../../../utils/ipfs.js";
 import { nativeLocalStorage } from "../../../../utils/storage/nativeStorage.js";
 import { getWalletInfo } from "../../../../wallets/__generated__/getWalletInfo.js";
 import type { Wallet } from "../../../../wallets/interfaces/wallet.js";
@@ -25,10 +27,11 @@ import { RNImage } from "./RNImage.js";
 export const WalletImage = (props: {
   theme: Theme;
   wallet: Wallet;
+  client: ThirdwebClient;
   size: number;
   avatar?: string | null;
 }) => {
-  const { wallet, avatar, size } = props;
+  const { wallet, avatar, size, client } = props;
 
   const { data: imageData } = useQuery({
     queryKey: ["wallet-image", wallet.id, wallet.getAccount()?.address],
@@ -55,7 +58,7 @@ export const WalletImage = (props: {
       try {
         const externalWalletImage = await getWalletInfo(activeEOAId, true);
         if (externalWalletImage) {
-          return externalWalletImage;
+          return resolveScheme({ client, uri: externalWalletImage });
         }
       } catch {}
 

--- a/packages/thirdweb/src/react/native/ui/connect/ConnectModal.tsx
+++ b/packages/thirdweb/src/react/native/ui/connect/ConnectModal.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from "react";
 import { Platform, StyleSheet, View } from "react-native";
 import { SvgXml } from "react-native-svg";
 import type { Chain } from "../../../../chains/types.js";
+import type { ThirdwebClient } from "../../../../client/client.js";
 import type { MultiStepAuthProviderType } from "../../../../wallets/in-app/core/authentication/types.js";
 import type { InAppWalletAuth } from "../../../../wallets/in-app/core/wallet/types.js";
 import type { Wallet } from "../../../../wallets/interfaces/wallet.js";
@@ -269,6 +270,7 @@ export function ConnectModal(
           <WalletLoadingView
             theme={theme}
             wallet={modalState.wallet}
+            client={client}
             authProvider={modalState.authMethod}
           />
           {containerType === "modal" ? (
@@ -328,6 +330,7 @@ export function ConnectModal(
           )}
           <SignInView
             theme={theme}
+            client={client}
             siweAuth={siweAuth}
             onSignIn={() => props.onClose?.()}
             onError={(error) => setModalState({ screen: "error", error })}
@@ -462,10 +465,12 @@ export function ConnectModal(
 function WalletLoadingView({
   theme,
   wallet,
+  client,
   authProvider,
 }: {
   theme: Theme;
   wallet: Wallet;
+  client: ThirdwebClient;
   authProvider?: InAppWalletAuth;
 }) {
   const walletInfo = useWalletInfo(wallet.id);
@@ -500,7 +505,12 @@ function WalletLoadingView({
             />
           </View>
         ) : (
-          <WalletImage theme={theme} size={90} wallet={wallet} />
+          <WalletImage
+            theme={theme}
+            size={90}
+            wallet={wallet}
+            client={client}
+          />
         )}
       </WalletLoadingThumbnail>
       <Spacer size="xl" />
@@ -522,12 +532,14 @@ function WalletLoadingView({
 function SignInView({
   theme,
   siweAuth,
+  client,
   onSignIn,
   onError,
   onDisconnect,
 }: {
   theme: Theme;
   siweAuth: ReturnType<typeof useSiweAuth>;
+  client: ThirdwebClient;
   onSignIn: () => void;
   onError: (error: string) => void;
   onDisconnect: () => void;
@@ -552,7 +564,12 @@ function SignInView({
           imageSize={100}
           animate={isSigningIn}
         >
-          <WalletImage theme={theme} size={90} wallet={wallet} />
+          <WalletImage
+            theme={theme}
+            size={90}
+            wallet={wallet}
+            client={client}
+          />
         </WalletLoadingThumbnail>
         <Spacer size="xl" />
         <ThemedText theme={theme} type="subtitle">

--- a/packages/thirdweb/src/react/native/ui/connect/ConnectedButton.tsx
+++ b/packages/thirdweb/src/react/native/ui/connect/ConnectedButton.tsx
@@ -20,7 +20,7 @@ export function ConnectedButton(
   },
 ) {
   const theme = parseTheme(props.theme);
-  const { account, wallet } = props;
+  const { account, wallet, client } = props;
   const walletChain = useActiveWalletChain();
   const { pfp, name, balanceQuery } = useConnectedWalletDetails(
     props.client,
@@ -40,7 +40,13 @@ export function ConnectedButton(
       }}
     >
       <View style={styles.row}>
-        <WalletImage theme={theme} size={40} wallet={wallet} avatar={pfp} />
+        <WalletImage
+          theme={theme}
+          size={40}
+          wallet={wallet}
+          avatar={pfp}
+          client={client}
+        />
         <View style={styles.col}>
           <ThemedText
             theme={theme}

--- a/packages/thirdweb/src/react/native/ui/connect/ConnectedModal.tsx
+++ b/packages/thirdweb/src/react/native/ui/connect/ConnectedModal.tsx
@@ -85,6 +85,7 @@ export function ConnectedModal(props: ConnectedModalProps) {
         <ReceiveScreen
           account={props.account}
           wallet={props.wallet}
+          client={props.client}
           theme={theme}
           containerType={props.containerType}
           onBack={() => setModalState({ screen: "account" })}
@@ -161,7 +162,7 @@ export function ConnectedModal(props: ConnectedModalProps) {
 }
 
 const AccountHeader = (props: ConnectedModalProps) => {
-  const { account, wallet, theme } = props;
+  const { account, wallet, theme, client } = props;
   const walletChain = useActiveWalletChain();
   const { pfp, name, balanceQuery } = useConnectedWalletDetails(
     props.client,
@@ -171,7 +172,13 @@ const AccountHeader = (props: ConnectedModalProps) => {
   );
   return (
     <View style={styles.accountHeaderContainer}>
-      <WalletImage theme={theme} size={70} wallet={wallet} avatar={pfp} />
+      <WalletImage
+        theme={theme}
+        size={70}
+        wallet={wallet}
+        avatar={pfp}
+        client={client}
+      />
       <SmartAccountBadge client={props.client} theme={theme} />
       <Spacer size="smd" />
       <Address account={account} theme={theme} addressOrENS={name} />

--- a/packages/thirdweb/src/react/native/ui/connect/ReceiveScreen.tsx
+++ b/packages/thirdweb/src/react/native/ui/connect/ReceiveScreen.tsx
@@ -1,4 +1,5 @@
 import { StyleSheet, View } from "react-native";
+import type { ThirdwebClient } from "../../../../client/client.js";
 import { shortenAddress } from "../../../../utils/address.js";
 import type { Account, Wallet } from "../../../../wallets/interfaces/wallet.js";
 import type { Theme } from "../../../core/design-system/index.js";
@@ -16,10 +17,12 @@ type ReceiveScreenProps = {
   onClose?: () => void;
   onBack?: () => void;
   containerType: ContainerType;
+  client: ThirdwebClient;
 };
 
 export const ReceiveScreen = (props: ReceiveScreenProps) => {
-  const { wallet, account, theme, onClose, onBack, containerType } = props;
+  const { wallet, account, theme, onClose, onBack, containerType, client } =
+    props;
 
   return (
     <>
@@ -32,7 +35,7 @@ export const ReceiveScreen = (props: ReceiveScreenProps) => {
       />
       <View style={styles.container}>
         {/* TODO (rn) QR code scanning */}
-        <WalletImage theme={theme} wallet={wallet} size={80} />
+        <WalletImage theme={theme} wallet={wallet} size={80} client={client} />
         <Spacer size="lg" />
         <View
           style={[

--- a/packages/thirdweb/src/wallets/in-app/core/actions/generate-wallet.enclave.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/actions/generate-wallet.enclave.ts
@@ -1,7 +1,8 @@
-import type { ThirdwebClient } from "../../../../../client/client.js";
-import { getThirdwebBaseUrl } from "../../../../../utils/domains.js";
-import { getClientFetch } from "../../../../../utils/fetch.js";
-import type { Ecosystem } from "../../../core/wallet/types.js";
+import type { ThirdwebClient } from "../../../../client/client.js";
+import { getThirdwebBaseUrl } from "../../../../utils/domains.js";
+import { getClientFetch } from "../../../../utils/fetch.js";
+import type { UserWallet } from "../wallet/enclave-wallet.js";
+import type { Ecosystem } from "../wallet/types.js";
 
 /**
  * Generate a new enclave wallet using an auth token
@@ -34,10 +35,7 @@ export async function generateWallet({
   }
 
   const { wallet } = (await response.json()) as {
-    wallet: {
-      address: string;
-      type: "enclave";
-    };
+    wallet: UserWallet;
   };
 
   return wallet;

--- a/packages/thirdweb/src/wallets/in-app/core/actions/get-enclave-user-status.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/actions/get-enclave-user-status.ts
@@ -1,8 +1,8 @@
-import type { ThirdwebClient } from "../../../../../client/client.js";
-import { getThirdwebBaseUrl } from "../../../../../utils/domains.js";
-import { getClientFetch } from "../../../../../utils/fetch.js";
-import type { UserStatus } from "../../../core/wallet/enclave-wallet.js";
-import type { Ecosystem } from "../../../core/wallet/types.js";
+import type { ThirdwebClient } from "../../../../client/client.js";
+import { getThirdwebBaseUrl } from "../../../../utils/domains.js";
+import { getClientFetch } from "../../../../utils/fetch.js";
+import type { UserStatus } from "../wallet/enclave-wallet.js";
+import type { Ecosystem } from "../wallet/types.js";
 
 /**
  * Gets the user's status from the backend.

--- a/packages/thirdweb/src/wallets/in-app/core/actions/sign-message.enclave.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/actions/sign-message.enclave.ts
@@ -1,26 +1,24 @@
-import type { ThirdwebClient } from "../../../../../client/client.js";
-import { getThirdwebBaseUrl } from "../../../../../utils/domains.js";
-import { getClientFetch } from "../../../../../utils/fetch.js";
-import { stringify } from "../../../../../utils/json.js";
-import type { ClientScopedStorage } from "../../../core/authentication/client-scoped-storage.js";
-import type { Ecosystem } from "../../../core/wallet/types.js";
+import type { ThirdwebClient } from "../../../../client/client.js";
+import { getThirdwebBaseUrl } from "../../../../utils/domains.js";
+import { getClientFetch } from "../../../../utils/fetch.js";
+import { stringify } from "../../../../utils/json.js";
+import type { ClientScopedStorage } from "../authentication/client-scoped-storage.js";
 
 export async function signMessage({
   client,
-  ecosystem,
   payload: { message, isRaw },
   storage,
 }: {
   client: ThirdwebClient;
-  ecosystem?: Ecosystem;
   payload: {
     message: string;
     isRaw: boolean;
   };
   storage: ClientScopedStorage;
 }) {
-  const clientFetch = getClientFetch(client, ecosystem);
   const authToken = await storage.getAuthCookie();
+  const ecosystem = storage.ecosystem;
+  const clientFetch = getClientFetch(client, ecosystem);
 
   if (!authToken) {
     throw new Error("No auth token found when signing message");

--- a/packages/thirdweb/src/wallets/in-app/core/actions/sign-transaction.enclave.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/actions/sign-transaction.enclave.ts
@@ -1,24 +1,22 @@
-import type { ThirdwebClient } from "../../../../../client/client.js";
-import { getThirdwebBaseUrl } from "../../../../../utils/domains.js";
-import type { Hex } from "../../../../../utils/encoding/hex.js";
-import { getClientFetch } from "../../../../../utils/fetch.js";
-import { stringify } from "../../../../../utils/json.js";
-import type { ClientScopedStorage } from "../../../core/authentication/client-scoped-storage.js";
-import type { Ecosystem } from "../../../core/wallet/types.js";
+import type { ThirdwebClient } from "../../../../client/client.js";
+import { getThirdwebBaseUrl } from "../../../../utils/domains.js";
+import type { Hex } from "../../../../utils/encoding/hex.js";
+import { getClientFetch } from "../../../../utils/fetch.js";
+import { stringify } from "../../../../utils/json.js";
+import type { ClientScopedStorage } from "../authentication/client-scoped-storage.js";
 
 export async function signTransaction({
   client,
-  ecosystem,
   payload,
   storage,
 }: {
   client: ThirdwebClient;
-  ecosystem?: Ecosystem;
   payload: Record<string, Hex | number | undefined>;
   storage: ClientScopedStorage;
 }) {
-  const clientFetch = getClientFetch(client, ecosystem);
   const authToken = await storage.getAuthCookie();
+  const ecosystem = storage.ecosystem;
+  const clientFetch = getClientFetch(client, ecosystem);
 
   if (!authToken) {
     throw new Error("No auth token found when signing transaction");

--- a/packages/thirdweb/src/wallets/in-app/core/actions/sign-typed-data.enclave.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/actions/sign-typed-data.enclave.ts
@@ -1,28 +1,26 @@
 import type { TypedData } from "abitype";
 import type { TypedDataDefinition } from "viem";
-import type { ThirdwebClient } from "../../../../../client/client.js";
-import { getThirdwebBaseUrl } from "../../../../../utils/domains.js";
-import { getClientFetch } from "../../../../../utils/fetch.js";
-import { stringify } from "../../../../../utils/json.js";
-import type { ClientScopedStorage } from "../../../core/authentication/client-scoped-storage.js";
-import type { Ecosystem } from "../../../core/wallet/types.js";
+import type { ThirdwebClient } from "../../../../client/client.js";
+import { getThirdwebBaseUrl } from "../../../../utils/domains.js";
+import { getClientFetch } from "../../../../utils/fetch.js";
+import { stringify } from "../../../../utils/json.js";
+import type { ClientScopedStorage } from "../authentication/client-scoped-storage.js";
 
 export async function signTypedData<
   const typedData extends TypedData | Record<string, unknown>,
   primaryType extends keyof typedData | "EIP712Domain" = keyof typedData,
 >({
   client,
-  ecosystem,
   payload,
   storage,
 }: {
   client: ThirdwebClient;
-  ecosystem?: Ecosystem;
   payload: TypedDataDefinition<typedData, primaryType>;
   storage: ClientScopedStorage;
 }) {
-  const clientFetch = getClientFetch(client, ecosystem);
   const authToken = await storage.getAuthCookie();
+  const ecosystem = storage.ecosystem;
+  const clientFetch = getClientFetch(client, ecosystem);
 
   if (!authToken) {
     throw new Error("No auth token found when signing typed data");

--- a/packages/thirdweb/src/wallets/in-app/core/authentication/client-scoped-storage.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/authentication/client-scoped-storage.ts
@@ -1,5 +1,4 @@
 import type { AsyncStorage } from "../../../../utils/storage/AsyncStorage.js";
-import type { EcosystemWalletId } from "../../../wallet-types.js";
 import {
   AUTH_TOKEN_LOCAL_STORAGE_NAME,
   DEVICE_SHARE_LOCAL_STORAGE_NAME,
@@ -8,6 +7,7 @@ import {
   WALLET_CONNECT_SESSIONS_LOCAL_STORAGE_NAME,
   WALLET_USER_ID_LOCAL_STORAGE_NAME,
 } from "../constants/settings.js";
+import type { Ecosystem } from "../wallet/types.js";
 
 const data = new Map<string, string>();
 
@@ -17,20 +17,22 @@ const data = new Map<string, string>();
 export class ClientScopedStorage {
   protected key: string;
   protected storage: AsyncStorage | null;
+  public ecosystem?: Ecosystem;
   /**
    * @internal
    */
   constructor({
     storage,
     clientId,
-    ecosystemId,
+    ecosystem,
   }: {
     storage: AsyncStorage | null;
     clientId: string;
-    ecosystemId?: EcosystemWalletId;
+    ecosystem?: Ecosystem;
   }) {
     this.storage = storage;
-    this.key = getLocalStorageKey(clientId, ecosystemId);
+    this.key = getLocalStorageKey(clientId, ecosystem?.id);
+    this.ecosystem = ecosystem;
   }
 
   protected async getItem(key: string): Promise<string | null> {

--- a/packages/thirdweb/src/wallets/in-app/core/authentication/guest.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/authentication/guest.ts
@@ -19,7 +19,7 @@ export async function guestAuthenticate(args: {
   const storage = new ClientScopedStorage({
     storage: args.storage,
     clientId: args.client.clientId,
-    ecosystemId: args.ecosystem?.id,
+    ecosystem: args.ecosystem,
   });
 
   let sessionId = await storage.getGuestSessionId();

--- a/packages/thirdweb/src/wallets/in-app/core/wallet/enclave-wallet.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/wallet/enclave-wallet.ts
@@ -11,10 +11,10 @@ import type {
   Account,
   SendTransactionOption,
 } from "../../../interfaces/wallet.js";
-import { getUserStatus } from "../../web/lib/actions/get-enclave-user-status.js";
-import { signMessage as signEnclaveMessage } from "../../web/lib/actions/sign-message.enclave.js";
-import { signTransaction as signEnclaveTransaction } from "../../web/lib/actions/sign-transaction.enclave.js";
-import { signTypedData as signEnclaveTypedData } from "../../web/lib/actions/sign-typed-data.enclave.js";
+import { getUserStatus } from "../actions/get-enclave-user-status.js";
+import { signMessage as signEnclaveMessage } from "../actions/sign-message.enclave.js";
+import { signTransaction as signEnclaveTransaction } from "../actions/sign-transaction.enclave.js";
+import { signTypedData as signEnclaveTypedData } from "../actions/sign-typed-data.enclave.js";
 import type { ClientScopedStorage } from "../authentication/client-scoped-storage.js";
 import type {
   AuthDetails,
@@ -33,16 +33,14 @@ export type UserStatus = {
       | { address: string; [key: string]: string }
       | { id: string; [key: string]: string };
   }[];
-  wallets:
-    | [
-        {
-          address: string;
-          createdAt: string;
-          type: "sharded" | "enclave";
-        },
-      ]
-    | [];
+  wallets: UserWallet[];
   id: string;
+};
+
+export type UserWallet = {
+  address: string;
+  createdAt: string;
+  type: "sharded" | "enclave";
 };
 
 export class EnclaveWallet implements IWebWallet {
@@ -130,7 +128,6 @@ export class EnclaveWallet implements IWebWallet {
    */
   async getAccount(): Promise<Account> {
     const client = this.client;
-    const ecosystem = this.ecosystem;
     const storage = this.localStorage;
 
     const _signTransaction = async (tx: SendTransactionOption) => {
@@ -171,7 +168,6 @@ export class EnclaveWallet implements IWebWallet {
 
       return signEnclaveTransaction({
         client,
-        ecosystem,
         storage,
         payload: transaction,
       });
@@ -218,7 +214,6 @@ export class EnclaveWallet implements IWebWallet {
 
         const { signature } = await signEnclaveMessage({
           client,
-          ecosystem,
           payload: messagePayload,
           storage,
         });
@@ -228,7 +223,6 @@ export class EnclaveWallet implements IWebWallet {
         const parsedTypedData = parseTypedData(_typedData);
         const { signature } = await signEnclaveTypedData({
           client,
-          ecosystem,
           payload: parsedTypedData,
           storage,
         });

--- a/packages/thirdweb/src/wallets/in-app/native/auth/passkeys.ts
+++ b/packages/thirdweb/src/wallets/in-app/native/auth/passkeys.ts
@@ -125,7 +125,7 @@ export async function hasStoredPasskey(
   const storage = new ClientScopedStorage({
     storage: nativeLocalStorage,
     clientId: client.clientId,
-    ecosystemId: ecosystemId,
+    ecosystem: ecosystemId ? { id: ecosystemId } : undefined,
   });
   const credId = await storage.getPasskeyCredentialId();
   return !!credId;

--- a/packages/thirdweb/src/wallets/in-app/native/helpers/api/fetchers.ts
+++ b/packages/thirdweb/src/wallets/in-app/native/helpers/api/fetchers.ts
@@ -14,6 +14,8 @@ import { createErrorMessage } from "../errors.js";
 
 const EMBEDDED_WALLET_TOKEN_HEADER = "embedded-wallet-token";
 const PAPER_CLIENT_ID_HEADER = "x-thirdweb-client-id";
+const ECOSYSTEM_ID_HEADER = "x-ecosystem-id";
+const ECOSYSTEM_PARTNER_ID_HEADER = "x-ecosystem-partner-id";
 
 let sessionNonce: Hex | undefined = undefined;
 
@@ -63,6 +65,12 @@ export async function authFetchEmbeddedWalletUser(args: {
           authTokenClient || ""
         }`,
         [PAPER_CLIENT_ID_HEADER]: client.clientId,
+        ...(storage.ecosystem
+          ? {
+              [ECOSYSTEM_ID_HEADER]: storage.ecosystem.id,
+              [ECOSYSTEM_PARTNER_ID_HEADER]: storage.ecosystem?.partnerId,
+            }
+          : {}),
         ...getSessionHeaders(),
       }
     : {
@@ -70,6 +78,12 @@ export async function authFetchEmbeddedWalletUser(args: {
           authTokenClient || ""
         }`,
         [PAPER_CLIENT_ID_HEADER]: client.clientId,
+        ...(storage.ecosystem
+          ? {
+              [ECOSYSTEM_ID_HEADER]: storage.ecosystem.id,
+              [ECOSYSTEM_PARTNER_ID_HEADER]: storage.ecosystem?.partnerId,
+            }
+          : {}),
         ...getSessionHeaders(),
       };
 

--- a/packages/thirdweb/src/wallets/in-app/native/helpers/auth/middleware.ts
+++ b/packages/thirdweb/src/wallets/in-app/native/helpers/auth/middleware.ts
@@ -102,10 +102,11 @@ async function getRecoveryCode(args: {
     }
     try {
       return await getCognitoRecoveryPasswordV2({ client, storage });
-    } catch {
+    } catch (err) {
+      console.error("Error recovering wallet", err);
       return await getCognitoRecoveryPasswordV1({ client, storage }).catch(
         () => {
-          throw new Error("Something went wrong getting cognito recovery code");
+          throw new Error("Something went wrong while recovering wallet");
         },
       );
     }

--- a/packages/thirdweb/src/wallets/in-app/native/helpers/constants.ts
+++ b/packages/thirdweb/src/wallets/in-app/native/helpers/constants.ts
@@ -22,6 +22,8 @@ export const GENERATE_RECOVERY_PASSWORD_LAMBDA_FUNCTION_V1 =
   "arn:aws:lambda:us-west-2:324457261097:function:recovery-share-password-GenerateRecoverySharePassw-bbE5ZbVAToil";
 export const GENERATE_RECOVERY_PASSWORD_LAMBDA_FUNCTION_V2 =
   "arn:aws:lambda:us-west-2:324457261097:function:lambda-thirdweb-auth-enc-key-prod-ThirdwebAuthEncKeyFunction";
+export const ENCLAVE_KMS_KEY_ARN =
+  "arn:aws:kms:us-west-2:324457261097:key/8b2a8cd5-9b22-4ea0-a6bc-463824a78f20";
 
 // TODO allow overriding domain
 const DOMAIN_URL_2023 = getThirdwebBaseUrl("inAppWallet");

--- a/packages/thirdweb/src/wallets/in-app/native/helpers/wallet/migration.ts
+++ b/packages/thirdweb/src/wallets/in-app/native/helpers/wallet/migration.ts
@@ -1,0 +1,185 @@
+import { GenerateDataKeyCommand, KMSClient } from "@aws-sdk/client-kms";
+import { fromCognitoIdentity } from "@aws-sdk/credential-providers";
+import QuickCrypto from "react-native-quick-crypto";
+import type { ThirdwebClient } from "../../../../../client/client.js";
+import { getThirdwebBaseUrl } from "../../../../../utils/domains.js";
+import { stringToBytes } from "../../../../../utils/encoding/to-bytes.js";
+import { randomBytesBuffer } from "../../../../../utils/random.js";
+import {
+  concatUint8Arrays,
+  uint8ArrayToBase64,
+} from "../../../../../utils/uint8-array.js";
+import { privateKeyToAccount } from "../../../../private-key.js";
+import type { ClientScopedStorage } from "../../../core/authentication/client-scoped-storage.js";
+import type { AuthStoredTokenWithCookieReturnType } from "../../../core/authentication/types.js";
+import type { UserWallet } from "../../../core/wallet/enclave-wallet.js";
+import { authFetchEmbeddedWalletUser } from "../api/fetchers.js";
+import { postAuth } from "../auth/middleware.js";
+import {
+  AWS_REGION,
+  ENCLAVE_KMS_KEY_ARN,
+  ROUTE_AUTH_COGNITO_ID_TOKEN_V2,
+} from "../constants.js";
+import { getShares, getWalletPrivateKeyFromShares } from "./retrieval.js";
+
+/**
+ * Migrate a sharded wallet to an enclave wallet.
+ *
+ * @param args - The arguments for the migration process.
+ * @returns The migrated user wallet.
+ */
+export async function migrateToEnclaveWallet(args: {
+  client: ThirdwebClient;
+  storage: ClientScopedStorage;
+  storedToken: AuthStoredTokenWithCookieReturnType["storedToken"];
+  encryptionKey?: string;
+}): Promise<UserWallet> {
+  // setup sharded wallet first, so we have the shares available
+  await postAuth({
+    storedToken: args.storedToken,
+    client: args.client,
+    storage: args.storage,
+    encryptionKey: args.encryptionKey,
+  });
+
+  const { authShare, deviceShare } = await getShares({
+    client: args.client,
+    authShare: { toRetrieve: true },
+    deviceShare: { toRetrieve: true },
+    recoveryShare: { toRetrieve: false },
+    storage: args.storage,
+  });
+
+  // construct the sharded wallet
+  const privateKey = await getWalletPrivateKeyFromShares([
+    authShare,
+    deviceShare,
+  ]);
+  const account = privateKeyToAccount({
+    client: args.client,
+    privateKey,
+  });
+  const address = account.address;
+
+  // get cognito identity
+  const idTokenResponse = await authFetchEmbeddedWalletUser({
+    client: args.client,
+    url: ROUTE_AUTH_COGNITO_ID_TOKEN_V2,
+    props: {
+      method: "GET",
+    },
+    storage: args.storage,
+  });
+  if (!idTokenResponse.ok) {
+    throw new Error(
+      `Failed to fetch id token from Cognito: ${JSON.stringify(
+        await idTokenResponse.json(),
+        null,
+        2,
+      )}`,
+    );
+  }
+  const idTokenResult = await idTokenResponse.json();
+  const { token, identityId } = idTokenResult;
+
+  const cognitoIdentity = fromCognitoIdentity({
+    clientConfig: {
+      region: AWS_REGION,
+    },
+    identityId,
+    logins: {
+      "cognito-identity.amazonaws.com": token,
+    },
+  });
+
+  // get kms key
+  const kmsClient = new KMSClient({
+    region: AWS_REGION,
+    credentials: cognitoIdentity,
+  });
+  const generateDataKeyCommand = new GenerateDataKeyCommand({
+    KeyId: ENCLAVE_KMS_KEY_ARN,
+    KeySpec: "AES_256",
+  });
+  const encryptedKeyResult = await kmsClient.send(generateDataKeyCommand);
+  const plaintextKeyBlob = encryptedKeyResult.Plaintext;
+  const cipherTextBlob = encryptedKeyResult.CiphertextBlob;
+  if (!plaintextKeyBlob || !cipherTextBlob) {
+    throw new Error("No migration key found. Please try again.");
+  }
+
+  // encrypt private key
+  const iv = randomBytesBuffer(16);
+  // @ts-ignore - default import buils but ts doesn't like it
+  const key = await QuickCrypto.subtle.importKey(
+    "raw",
+    plaintextKeyBlob,
+    "AES-CBC",
+    false,
+    ["encrypt", "decrypt"],
+  );
+
+  // @ts-ignore - default import buils but ts doesn't like it
+  const encryptedPrivateKey = await QuickCrypto.subtle.encrypt(
+    {
+      name: "AES-CBC",
+      iv,
+    },
+    key,
+    stringToBytes(privateKey),
+  );
+
+  const encryptedData = concatUint8Arrays([
+    iv,
+    new Uint8Array(encryptedPrivateKey),
+  ]);
+
+  const ivB64 = uint8ArrayToBase64(iv);
+  const cipherTextB64 = uint8ArrayToBase64(cipherTextBlob);
+  const encryptedPrivateKeyB64 = uint8ArrayToBase64(encryptedData);
+
+  // execute migration
+  const result = await executeMigration({
+    client: args.client,
+    storage: args.storage,
+    address,
+    kmsCiphertextB64: cipherTextB64,
+    encryptedPrivateKeyB64: encryptedPrivateKeyB64,
+    ivB64,
+  });
+
+  return result;
+}
+
+async function executeMigration(args: {
+  client: ThirdwebClient;
+  storage: ClientScopedStorage;
+  address: string;
+  kmsCiphertextB64: string;
+  encryptedPrivateKeyB64: string;
+  ivB64: string;
+}): Promise<UserWallet> {
+  const migrationResponse = await authFetchEmbeddedWalletUser({
+    client: args.client,
+    url: `${getThirdwebBaseUrl("inAppWallet")}/api/v1/enclave-wallet/migrate`,
+    props: {
+      method: "POST",
+      body: JSON.stringify({
+        address: args.address,
+        kmsCiphertextB64: args.kmsCiphertextB64,
+        encryptedPrivateKeyB64: args.encryptedPrivateKeyB64,
+        ivB64: args.ivB64,
+      }),
+    },
+    storage: args.storage,
+  });
+  if (!migrationResponse.ok) {
+    throw new Error(
+      `Failed to migrate to enclave wallet: ${JSON.stringify(
+        await migrationResponse.json(),
+      )}`,
+    );
+  }
+  const migrationResult = (await migrationResponse.json()) as UserWallet;
+  return migrationResult;
+}

--- a/packages/thirdweb/src/wallets/in-app/native/helpers/wallet/retrieval.ts
+++ b/packages/thirdweb/src/wallets/in-app/native/helpers/wallet/retrieval.ts
@@ -40,7 +40,7 @@ export async function getExistingUserAccount(args: {
   });
 }
 
-async function getWalletPrivateKeyFromShares(shares: string[]) {
+export async function getWalletPrivateKeyFromShares(shares: string[]) {
   const { secrets } = await import("./sss.js");
   let privateKeyHex = secrets.combine(shares, 0);
   if (!isHex(privateKeyHex)) {
@@ -86,7 +86,7 @@ async function getAccountFromShares(args: {
  * @returns The requested shares
  * @throws if attempting to get deviceShare when it's not present
  */
-async function getShares<
+export async function getShares<
   A extends boolean,
   D extends boolean,
   R extends boolean,

--- a/packages/thirdweb/src/wallets/in-app/web/lib/auth/iframe-auth.ts
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/auth/iframe-auth.ts
@@ -1,4 +1,6 @@
 import type { ThirdwebClient } from "../../../../../client/client.js";
+import { generateWallet } from "../../../core/actions/generate-wallet.enclave.js";
+import { getUserStatus } from "../../../core/actions/get-enclave-user-status.js";
 import type { ClientScopedStorage } from "../../../core/authentication/client-scoped-storage.js";
 import type {
   AuthAndWalletRpcReturnType,
@@ -10,8 +12,6 @@ import type {
 import type { Ecosystem } from "../../../core/wallet/types.js";
 import type { ClientIdWithQuerierType } from "../../types.js";
 import type { InAppWalletIframeCommunicator } from "../../utils/iFrameCommunication/InAppWalletIframeCommunicator.js";
-import { generateWallet } from "../actions/generate-wallet.enclave.js";
-import { getUserStatus } from "../actions/get-enclave-user-status.js";
 import { BaseLogin } from "./base-login.js";
 
 export type AuthQuerierTypes = {

--- a/packages/thirdweb/src/wallets/in-app/web/lib/auth/passkeys.ts
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/auth/passkeys.ts
@@ -86,7 +86,7 @@ export async function hasStoredPasskey(
   const storage = new ClientScopedStorage({
     storage: webLocalStorage, // TODO (passkey) react native variant of this fn
     clientId: client.clientId,
-    ecosystemId: ecosystemId,
+    ecosystem: ecosystemId ? { id: ecosystemId } : undefined,
   });
   const credId = await storage.getPasskeyCredentialId();
   return !!credId;

--- a/packages/thirdweb/src/wallets/in-app/web/lib/web-connector.ts
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/web-connector.ts
@@ -3,6 +3,7 @@ import { getThirdwebBaseUrl } from "../../../../utils/domains.js";
 import { webLocalStorage } from "../../../../utils/storage/webStorage.js";
 import type { SocialAuthOption } from "../../../../wallets/types.js";
 import type { Account } from "../../../interfaces/wallet.js";
+import { getUserStatus } from "../../core/actions/get-enclave-user-status.js";
 import { ClientScopedStorage } from "../../core/authentication/client-scoped-storage.js";
 import { guestAuthenticate } from "../../core/authentication/guest.js";
 import {
@@ -28,7 +29,6 @@ import type { InAppConnector } from "../../core/interfaces/connector.js";
 import { EnclaveWallet } from "../../core/wallet/enclave-wallet.js";
 import type { Ecosystem } from "../../core/wallet/types.js";
 import type { IWebWallet } from "../../core/wallet/web-wallet.js";
-import { getUserStatus } from "../lib/actions/get-enclave-user-status.js";
 import type { InAppWalletConstructorType } from "../types.js";
 import { InAppWalletIframeCommunicator } from "../utils/iFrameCommunication/InAppWalletIframeCommunicator.js";
 import { Auth, type AuthQuerierTypes } from "./auth/iframe-auth.js";
@@ -43,7 +43,7 @@ export class InAppWebConnector implements InAppConnector {
   private client: ThirdwebClient;
   private ecosystem?: Ecosystem;
   private querier: InAppWalletIframeCommunicator<AuthQuerierTypes>;
-  private localStorage: ClientScopedStorage;
+  private storage: ClientScopedStorage;
 
   private wallet?: IWebWallet;
   /**
@@ -79,10 +79,10 @@ export class InAppWebConnector implements InAppConnector {
     this.client = client;
     this.ecosystem = ecosystem;
     this.passkeyDomain = passkeyDomain;
-    this.localStorage = new ClientScopedStorage({
+    this.storage = new ClientScopedStorage({
       storage: webLocalStorage,
       clientId: client.clientId,
-      ecosystemId: ecosystem?.id,
+      ecosystem: ecosystem,
     });
     this.querier = new InAppWalletIframeCommunicator({
       clientId: client.clientId,
@@ -94,7 +94,7 @@ export class InAppWebConnector implements InAppConnector {
       client,
       querier: this.querier,
       baseUrl,
-      localStorage: this.localStorage,
+      localStorage: this.storage,
       ecosystem,
       onAuthSuccess: async (authResult) => {
         onAuthSuccess?.(authResult);
@@ -162,7 +162,7 @@ export class InAppWebConnector implements InAppConnector {
   }
 
   async initializeWallet(authToken?: string) {
-    const storedAuthToken = await this.localStorage.getAuthCookie();
+    const storedAuthToken = await this.storage.getAuthCookie();
     if (!authToken && storedAuthToken === null) {
       throw new Error(
         "No auth token provided and no stored auth token found to initialize the wallet",
@@ -183,12 +183,12 @@ export class InAppWebConnector implements InAppConnector {
       );
     }
 
-    if (user.wallets[0].type === "enclave") {
+    if (user.wallets[0]?.type === "enclave") {
       this.wallet = new EnclaveWallet({
         client: this.client,
         ecosystem: this.ecosystem,
         address: user.wallets[0].address,
-        storage: this.localStorage,
+        storage: this.storage,
       });
       return;
     }
@@ -197,7 +197,7 @@ export class InAppWebConnector implements InAppConnector {
       client: this.client,
       ecosystem: this.ecosystem,
       querier: this.querier,
-      localStorage: this.localStorage,
+      localStorage: this.storage,
     });
   }
 
@@ -227,7 +227,7 @@ export class InAppWebConnector implements InAppConnector {
   async getUser(): Promise<GetUser> {
     // If we don't have a wallet yet we'll create one
     if (!this.wallet) {
-      const localAuthToken = await this.localStorage.getAuthCookie();
+      const localAuthToken = await this.storage.getAuthCookie();
       if (!localAuthToken) {
         return { status: "Logged Out" };
       }
@@ -413,7 +413,7 @@ export class InAppWebConnector implements InAppConnector {
     const { PasskeyWebClient } = await import("./auth/passkeys.js");
     const { passkeyName, storeLastUsedPasskey = true } = args;
     const passkeyClient = new PasskeyWebClient();
-    const storage = this.localStorage;
+    const storage = this.storage;
     if (args.type === "sign-up") {
       return registerPasskey({
         client: this.client,
@@ -444,7 +444,7 @@ export class InAppWebConnector implements InAppConnector {
     return await linkAccount({
       client: args.client,
       tokenToLink: storedToken.cookieString,
-      storage: this.localStorage,
+      storage: this.storage,
       ecosystem: args.ecosystem || this.ecosystem,
     });
   }
@@ -453,7 +453,7 @@ export class InAppWebConnector implements InAppConnector {
     return getLinkedProfilesInternal({
       client: this.client,
       ecosystem: this.ecosystem,
-      storage: this.localStorage,
+      storage: this.storage,
     });
   }
 }

--- a/packages/thirdweb/src/wallets/in-app/web/utils/iFrameCommunication/InAppWalletIframeCommunicator.ts
+++ b/packages/thirdweb/src/wallets/in-app/web/utils/iFrameCommunication/InAppWalletIframeCommunicator.ts
@@ -47,7 +47,7 @@ export class InAppWalletIframeCommunicator<
     const localStorage = new ClientScopedStorage({
       storage: webLocalStorage,
       clientId: this.clientId,
-      ecosystemId: this.ecosystem?.id,
+      ecosystem: this.ecosystem,
     });
 
     return {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,7 +134,7 @@ importers:
         version: 1.1.3(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@sentry/nextjs':
         specifier: 8.34.0
-        version: 8.34.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.26.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.53.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.26.0(@opentelemetry/api@1.9.0))(next@14.2.15(@babel/core@7.25.8)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1))
+        version: 8.34.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.26.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.53.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.26.0(@opentelemetry/api@1.9.0))(next@14.2.15(@babel/core@7.25.8)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.95.0(@swc/core@1.7.35)(esbuild@0.23.1))
       '@shazow/whatsabi':
         specifier: ^0.15.3
         version: 0.15.3(@noble/hashes@1.5.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
@@ -290,7 +290,7 @@ importers:
         version: 2.5.4
       tailwindcss-animate:
         specifier: ^1.0.7
-        version: 1.0.7(tailwindcss@3.4.13(ts-node@10.9.2(@swc/core@1.7.35(@swc/helpers@0.5.13))(@types/node@20.14.9)(typescript@5.6.3)))
+        version: 1.0.7(tailwindcss@3.4.13(ts-node@10.9.2(@types/node@20.14.9)(typescript@5.6.3)))
       thirdweb:
         specifier: workspace:*
         version: link:../../packages/thirdweb
@@ -339,7 +339,7 @@ importers:
         version: 8.3.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.5(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@storybook/nextjs':
         specifier: 8.3.5
-        version: 8.3.5(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1)(next@14.2.15(@babel/core@7.25.8)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.5(bufferutil@4.0.8)(utf-8-validate@5.0.10))(type-fest@4.26.1)(typescript@5.6.3)(webpack-hot-middleware@2.26.1)(webpack@5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1))
+        version: 8.3.5(@swc/core@1.7.35)(esbuild@0.23.1)(next@14.2.15(@babel/core@7.25.8)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.5(bufferutil@4.0.8)(utf-8-validate@5.0.10))(type-fest@4.26.1)(typescript@5.6.3)(webpack-hot-middleware@2.26.1)(webpack@5.95.0(@swc/core@1.7.35)(esbuild@0.23.1))
       '@storybook/react':
         specifier: 8.3.5
         version: 8.3.5(@storybook/test@8.3.5(storybook@8.3.5(bufferutil@4.0.8)(utf-8-validate@5.0.10)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.5(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@5.6.3)
@@ -387,7 +387,7 @@ importers:
         version: 10.4.20(postcss@8.4.47)
       checkly:
         specifier: ^4.8.1
-        version: 4.9.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(@types/node@20.14.9)(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)
+        version: 4.9.0(@swc/core@1.7.35)(@types/node@20.14.9)(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)
       eslint:
         specifier: 8.57.0
         version: 8.57.0
@@ -414,7 +414,7 @@ importers:
         version: 8.3.5(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       tailwindcss:
         specifier: 3.4.13
-        version: 3.4.13(ts-node@10.9.2(@swc/core@1.7.35(@swc/helpers@0.5.13))(@types/node@20.14.9)(typescript@5.6.3))
+        version: 3.4.13(ts-node@10.9.2(@types/node@20.14.9)(typescript@5.6.3))
       typescript:
         specifier: 5.6.3
         version: 5.6.3
@@ -526,10 +526,10 @@ importers:
         version: 8.4.47
       tailwindcss:
         specifier: 3.4.13
-        version: 3.4.13(ts-node@10.9.2(@swc/core@1.7.35(@swc/helpers@0.5.13))(@types/node@20.14.9)(typescript@5.6.3))
+        version: 3.4.13(ts-node@10.9.2(@types/node@20.14.9)(typescript@5.6.3))
       tailwindcss-animate:
         specifier: ^1.0.7
-        version: 1.0.7(tailwindcss@3.4.13(ts-node@10.9.2(@swc/core@1.7.35(@swc/helpers@0.5.13))(@types/node@20.14.9)(typescript@5.6.3)))
+        version: 1.0.7(tailwindcss@3.4.13(ts-node@10.9.2(@types/node@20.14.9)(typescript@5.6.3)))
       typescript:
         specifier: 5.6.3
         version: 5.6.3
@@ -541,13 +541,13 @@ importers:
         version: 1.0.1(react@18.3.1)
       '@mdx-js/loader':
         specifier: ^2.3.0
-        version: 2.3.0(webpack@5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13)))
+        version: 2.3.0(webpack@5.95.0)
       '@mdx-js/react':
         specifier: ^2.3.0
         version: 2.3.0(react@18.3.1)
       '@next/mdx':
         specifier: ^13.5.6
-        version: 13.5.7(@mdx-js/loader@2.3.0(webpack@5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))))(@mdx-js/react@2.3.0(react@18.3.1))
+        version: 13.5.7(@mdx-js/loader@2.3.0(webpack@5.95.0))(@mdx-js/react@2.3.0(react@18.3.1))
       '@radix-ui/react-dialog':
         specifier: 1.1.2
         version: 1.1.2(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -631,7 +631,7 @@ importers:
         version: 2.5.4
       tailwindcss-animate:
         specifier: ^1.0.7
-        version: 1.0.7(tailwindcss@3.4.13(ts-node@10.9.2(@swc/core@1.7.35(@swc/helpers@0.5.13))(@types/node@20.14.9)(typescript@5.6.3)))
+        version: 1.0.7(tailwindcss@3.4.13(ts-node@10.9.2(@types/node@20.14.9)(typescript@5.6.3)))
       thirdweb:
         specifier: workspace:*
         version: link:../../packages/thirdweb
@@ -689,7 +689,7 @@ importers:
         version: 1.2.4
       eslint-plugin-tailwindcss:
         specifier: ^3.17.5
-        version: 3.17.5(tailwindcss@3.4.13(ts-node@10.9.2(@swc/core@1.7.35(@swc/helpers@0.5.13))(@types/node@20.14.9)(typescript@5.6.3)))
+        version: 3.17.5(tailwindcss@3.4.13(ts-node@10.9.2(@types/node@20.14.9)(typescript@5.6.3)))
       next-sitemap:
         specifier: ^4.2.3
         version: 4.2.3(next@14.2.15(@opentelemetry/api@1.9.0)(@playwright/test@1.48.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
@@ -698,7 +698,7 @@ importers:
         version: 8.4.47
       tailwindcss:
         specifier: 3.4.13
-        version: 3.4.13(ts-node@10.9.2(@swc/core@1.7.35(@swc/helpers@0.5.13))(@types/node@20.14.9)(typescript@5.6.3))
+        version: 3.4.13(ts-node@10.9.2(@types/node@20.14.9)(typescript@5.6.3))
       tsx:
         specifier: ^4.19.1
         version: 4.19.1
@@ -767,7 +767,7 @@ importers:
         version: 2.5.4
       tailwindcss-animate:
         specifier: ^1.0.7
-        version: 1.0.7(tailwindcss@3.4.13(ts-node@10.9.2(@swc/core@1.7.35(@swc/helpers@0.5.13))(@types/node@20.14.9)(typescript@5.6.3)))
+        version: 1.0.7(tailwindcss@3.4.13(ts-node@10.9.2(@types/node@20.14.9)(typescript@5.6.3)))
       thirdweb:
         specifier: workspace:*
         version: link:../../packages/thirdweb
@@ -798,13 +798,16 @@ importers:
         version: 8.4.47
       tailwindcss:
         specifier: 3.4.13
-        version: 3.4.13(ts-node@10.9.2(@swc/core@1.7.35(@swc/helpers@0.5.13))(@types/node@20.14.9)(typescript@5.6.3))
+        version: 3.4.13(ts-node@10.9.2(@types/node@20.14.9)(typescript@5.6.3))
       typescript:
         specifier: 5.6.3
         version: 5.6.3
 
   packages/react-native-adapter:
     dependencies:
+      '@aws-sdk/client-kms':
+        specifier: 3.670.0
+        version: 3.670.0
       '@aws-sdk/client-lambda':
         specifier: 3.670.0
         version: 3.670.0
@@ -946,6 +949,9 @@ importers:
         specifier: 2.21.25
         version: 2.21.25(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.23.8)
     devDependencies:
+      '@aws-sdk/client-kms':
+        specifier: 3.670.0
+        version: 3.670.0
       '@aws-sdk/client-lambda':
         specifier: 3.670.0
         version: 3.670.0
@@ -1132,6 +1138,10 @@ packages:
 
   '@aws-sdk/client-cognito-identity@3.670.0':
     resolution: {integrity: sha512-4q/yYdtO/RisGdQ3a2E912YekIpQYvS4TYPYS/onCbTXW/7C8/Ha7yUEncE7Woou0MDXyoVh50UATcJEmUt0+Q==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-sdk/client-kms@3.670.0':
+    resolution: {integrity: sha512-cV7tcrBfK3J/GrIe77ATi7LabZxCRRssj5QlPDV2dn5KRuxHWl9jR3JyglmEowsXKFiKllvbRi0PE9MM/y9UOw==}
     engines: {node: '>=16.0.0'}
 
   '@aws-sdk/client-lambda@3.670.0':
@@ -6401,9 +6411,6 @@ packages:
 
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
-
-  '@swc/helpers@0.5.13':
-    resolution: {integrity: sha512-UoKGxQ3r5kYI9dALKJapMmuK+1zWM/H17Z1+iwnNmzcJRnfFuevZs375TA5rW31pu4BS4NoSy1fRsexDXfWn5w==}
 
   '@swc/helpers@0.5.5':
     resolution: {integrity: sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==}
@@ -15292,6 +15299,52 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/client-kms@3.670.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/client-sso-oidc': 3.670.0(@aws-sdk/client-sts@3.670.0)
+      '@aws-sdk/client-sts': 3.670.0
+      '@aws-sdk/core': 3.667.0
+      '@aws-sdk/credential-provider-node': 3.670.0(@aws-sdk/client-sso-oidc@3.670.0(@aws-sdk/client-sts@3.670.0))(@aws-sdk/client-sts@3.670.0)
+      '@aws-sdk/middleware-host-header': 3.667.0
+      '@aws-sdk/middleware-logger': 3.667.0
+      '@aws-sdk/middleware-recursion-detection': 3.667.0
+      '@aws-sdk/middleware-user-agent': 3.669.0
+      '@aws-sdk/region-config-resolver': 3.667.0
+      '@aws-sdk/types': 3.667.0
+      '@aws-sdk/util-endpoints': 3.667.0
+      '@aws-sdk/util-user-agent-browser': 3.670.0
+      '@aws-sdk/util-user-agent-node': 3.669.0
+      '@smithy/config-resolver': 3.0.9
+      '@smithy/core': 2.4.8
+      '@smithy/fetch-http-handler': 3.2.9
+      '@smithy/hash-node': 3.0.7
+      '@smithy/invalid-dependency': 3.0.7
+      '@smithy/middleware-content-length': 3.0.9
+      '@smithy/middleware-endpoint': 3.1.4
+      '@smithy/middleware-retry': 3.0.23
+      '@smithy/middleware-serde': 3.0.7
+      '@smithy/middleware-stack': 3.0.7
+      '@smithy/node-config-provider': 3.1.8
+      '@smithy/node-http-handler': 3.2.4
+      '@smithy/protocol-http': 4.1.4
+      '@smithy/smithy-client': 3.4.0
+      '@smithy/types': 3.5.0
+      '@smithy/url-parser': 3.0.7
+      '@smithy/util-base64': 3.0.0
+      '@smithy/util-body-length-browser': 3.0.0
+      '@smithy/util-body-length-node': 3.0.0
+      '@smithy/util-defaults-mode-browser': 3.0.23
+      '@smithy/util-defaults-mode-node': 3.0.23
+      '@smithy/util-endpoints': 2.1.3
+      '@smithy/util-middleware': 3.0.7
+      '@smithy/util-retry': 3.0.7
+      '@smithy/util-utf8': 3.0.0
+      tslib: 2.7.0
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/client-lambda@3.670.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
@@ -20191,11 +20244,11 @@ snapshots:
       jju: 1.4.0
       read-yaml-file: 1.1.0
 
-  '@mdx-js/loader@2.3.0(webpack@5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13)))':
+  '@mdx-js/loader@2.3.0(webpack@5.95.0)':
     dependencies:
       '@mdx-js/mdx': 2.3.0
       source-map: 0.7.4
-      webpack: 5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))
+      webpack: 5.95.0
     transitivePeerDependencies:
       - supports-color
 
@@ -20351,11 +20404,11 @@ snapshots:
     dependencies:
       glob: 10.3.10
 
-  '@next/mdx@13.5.7(@mdx-js/loader@2.3.0(webpack@5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))))(@mdx-js/react@2.3.0(react@18.3.1))':
+  '@next/mdx@13.5.7(@mdx-js/loader@2.3.0(webpack@5.95.0))(@mdx-js/react@2.3.0(react@18.3.1))':
     dependencies:
       source-map: 0.7.4
     optionalDependencies:
-      '@mdx-js/loader': 2.3.0(webpack@5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13)))
+      '@mdx-js/loader': 2.3.0(webpack@5.95.0)
       '@mdx-js/react': 2.3.0(react@18.3.1)
 
   '@next/swc-darwin-arm64@14.2.15':
@@ -20508,7 +20561,7 @@ snapshots:
       widest-line: 3.1.0
       wrap-ansi: 7.0.0
 
-  '@oclif/core@2.8.11(@swc/core@1.7.35(@swc/helpers@0.5.13))(@types/node@20.14.9)(typescript@5.6.3)':
+  '@oclif/core@2.8.11(@swc/core@1.7.35)(@types/node@20.14.9)(typescript@5.6.3)':
     dependencies:
       '@types/cli-progress': 3.11.5
       ansi-escapes: 4.3.2
@@ -20534,7 +20587,7 @@ snapshots:
       strip-ansi: 6.0.1
       supports-color: 8.1.1
       supports-hyperlinks: 2.3.0
-      ts-node: 10.9.2(@swc/core@1.7.35(@swc/helpers@0.5.13))(@types/node@20.14.9)(typescript@5.6.3)
+      ts-node: 10.9.2(@swc/core@1.7.35)(@types/node@20.14.9)(typescript@5.6.3)
       tslib: 2.7.0
       widest-line: 3.1.0
       wordwrap: 1.0.0
@@ -20571,10 +20624,10 @@ snapshots:
     dependencies:
       '@oclif/core': 1.26.2
 
-  '@oclif/plugin-not-found@2.3.23(@swc/core@1.7.35(@swc/helpers@0.5.13))(@types/node@20.14.9)(typescript@5.6.3)':
+  '@oclif/plugin-not-found@2.3.23(@swc/core@1.7.35)(@types/node@20.14.9)(typescript@5.6.3)':
     dependencies:
       '@oclif/color': 1.0.13
-      '@oclif/core': 2.8.11(@swc/core@1.7.35(@swc/helpers@0.5.13))(@types/node@20.14.9)(typescript@5.6.3)
+      '@oclif/core': 2.8.11(@swc/core@1.7.35)(@types/node@20.14.9)(typescript@5.6.3)
       fast-levenshtein: 3.0.0
       lodash: 4.17.21
     transitivePeerDependencies:
@@ -20599,9 +20652,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@oclif/plugin-warn-if-update-available@2.0.24(@swc/core@1.7.35(@swc/helpers@0.5.13))(@types/node@20.14.9)(typescript@5.6.3)':
+  '@oclif/plugin-warn-if-update-available@2.0.24(@swc/core@1.7.35)(@types/node@20.14.9)(typescript@5.6.3)':
     dependencies:
-      '@oclif/core': 2.8.11(@swc/core@1.7.35(@swc/helpers@0.5.13))(@types/node@20.14.9)(typescript@5.6.3)
+      '@oclif/core': 2.8.11(@swc/core@1.7.35)(@types/node@20.14.9)(typescript@5.6.3)
       chalk: 4.1.2
       debug: 4.3.7(supports-color@8.1.1)
       fs-extra: 9.1.0
@@ -20964,7 +21017,7 @@ snapshots:
       playwright: 1.48.0
     optional: true
 
-  '@pmmmwh/react-refresh-webpack-plugin@0.5.15(react-refresh@0.14.2)(type-fest@4.26.1)(webpack-hot-middleware@2.26.1)(webpack@5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1))':
+  '@pmmmwh/react-refresh-webpack-plugin@0.5.15(react-refresh@0.14.2)(type-fest@4.26.1)(webpack-hot-middleware@2.26.1)(webpack@5.95.0(@swc/core@1.7.35)(esbuild@0.23.1))':
     dependencies:
       ansi-html: 0.0.9
       core-js-pure: 3.38.1
@@ -20974,7 +21027,7 @@ snapshots:
       react-refresh: 0.14.2
       schema-utils: 4.2.0
       source-map: 0.7.4
-      webpack: 5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1)
+      webpack: 5.95.0(@swc/core@1.7.35)(esbuild@0.23.1)
     optionalDependencies:
       type-fest: 4.26.1
       webpack-hot-middleware: 2.26.1
@@ -22628,7 +22681,7 @@ snapshots:
       '@sentry/types': 8.34.0
       '@sentry/utils': 8.34.0
 
-  '@sentry/nextjs@8.34.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.26.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.53.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.26.0(@opentelemetry/api@1.9.0))(next@14.2.15(@babel/core@7.25.8)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1))':
+  '@sentry/nextjs@8.34.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.26.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.53.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.26.0(@opentelemetry/api@1.9.0))(next@14.2.15(@babel/core@7.25.8)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.95.0(@swc/core@1.7.35)(esbuild@0.23.1))':
     dependencies:
       '@opentelemetry/instrumentation-http': 0.53.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.27.0
@@ -22641,14 +22694,14 @@ snapshots:
       '@sentry/types': 8.34.0
       '@sentry/utils': 8.34.0
       '@sentry/vercel-edge': 8.34.0
-      '@sentry/webpack-plugin': 2.22.3(webpack@5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1))
+      '@sentry/webpack-plugin': 2.22.3(webpack@5.95.0(@swc/core@1.7.35)(esbuild@0.23.1))
       chalk: 3.0.0
       next: 14.2.15(@babel/core@7.25.8)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       resolve: 1.22.8
       rollup: 3.29.5
       stacktrace-parser: 0.1.10
     optionalDependencies:
-      webpack: 5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1)
+      webpack: 5.95.0(@swc/core@1.7.35)(esbuild@0.23.1)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/core'
@@ -22730,12 +22783,12 @@ snapshots:
       '@sentry/types': 8.34.0
       '@sentry/utils': 8.34.0
 
-  '@sentry/webpack-plugin@2.22.3(webpack@5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1))':
+  '@sentry/webpack-plugin@2.22.3(webpack@5.95.0(@swc/core@1.7.35)(esbuild@0.23.1))':
     dependencies:
       '@sentry/bundler-plugin-core': 2.22.3
       unplugin: 1.0.1
       uuid: 9.0.1
-      webpack: 5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1)
+      webpack: 5.95.0(@swc/core@1.7.35)(esbuild@0.23.1)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -23383,7 +23436,7 @@ snapshots:
       - supports-color
       - webpack-sources
 
-  '@storybook/builder-webpack5@8.3.5(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1)(storybook@8.3.5(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@5.6.3)':
+  '@storybook/builder-webpack5@8.3.5(@swc/core@1.7.35)(esbuild@0.23.1)(storybook@8.3.5(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@5.6.3)':
     dependencies:
       '@storybook/core-webpack': 8.3.5(storybook@8.3.5(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@types/node': 22.7.5
@@ -23392,25 +23445,25 @@ snapshots:
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.4.1
       constants-browserify: 1.0.0
-      css-loader: 6.11.0(webpack@5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1))
+      css-loader: 6.11.0(webpack@5.95.0(@swc/core@1.7.35)(esbuild@0.23.1))
       es-module-lexer: 1.5.4
       express: 4.21.1
-      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.6.3)(webpack@5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1))
+      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.6.3)(webpack@5.95.0(@swc/core@1.7.35)(esbuild@0.23.1))
       fs-extra: 11.2.0
-      html-webpack-plugin: 5.6.0(webpack@5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1))
+      html-webpack-plugin: 5.6.0(webpack@5.95.0(@swc/core@1.7.35)(esbuild@0.23.1))
       magic-string: 0.30.12
       path-browserify: 1.0.1
       process: 0.11.10
       semver: 7.6.3
       storybook: 8.3.5(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      style-loader: 3.3.4(webpack@5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1))
-      terser-webpack-plugin: 5.3.10(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1)(webpack@5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1))
+      style-loader: 3.3.4(webpack@5.95.0(@swc/core@1.7.35)(esbuild@0.23.1))
+      terser-webpack-plugin: 5.3.10(@swc/core@1.7.35)(esbuild@0.23.1)(webpack@5.95.0(@swc/core@1.7.35)(esbuild@0.23.1))
       ts-dedent: 2.2.0
       url: 0.11.4
       util: 0.12.5
       util-deprecate: 1.0.2
-      webpack: 5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1)
-      webpack-dev-middleware: 6.1.3(webpack@5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1))
+      webpack: 5.95.0(@swc/core@1.7.35)(esbuild@0.23.1)
+      webpack-dev-middleware: 6.1.3(webpack@5.95.0(@swc/core@1.7.35)(esbuild@0.23.1))
       webpack-hot-middleware: 2.26.1
       webpack-virtual-modules: 0.6.2
     optionalDependencies:
@@ -23486,7 +23539,7 @@ snapshots:
     dependencies:
       storybook: 8.3.5(bufferutil@4.0.8)(utf-8-validate@5.0.10)
 
-  '@storybook/nextjs@8.3.5(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1)(next@14.2.15(@babel/core@7.25.8)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.5(bufferutil@4.0.8)(utf-8-validate@5.0.10))(type-fest@4.26.1)(typescript@5.6.3)(webpack-hot-middleware@2.26.1)(webpack@5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1))':
+  '@storybook/nextjs@8.3.5(@swc/core@1.7.35)(esbuild@0.23.1)(next@14.2.15(@babel/core@7.25.8)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.5(bufferutil@4.0.8)(utf-8-validate@5.0.10))(type-fest@4.26.1)(typescript@5.6.3)(webpack-hot-middleware@2.26.1)(webpack@5.95.0(@swc/core@1.7.35)(esbuild@0.23.1))':
     dependencies:
       '@babel/core': 7.25.8
       '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.25.8)
@@ -23501,32 +23554,32 @@ snapshots:
       '@babel/preset-react': 7.25.7(@babel/core@7.25.8)
       '@babel/preset-typescript': 7.25.7(@babel/core@7.25.8)
       '@babel/runtime': 7.25.7
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(react-refresh@0.14.2)(type-fest@4.26.1)(webpack-hot-middleware@2.26.1)(webpack@5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1))
-      '@storybook/builder-webpack5': 8.3.5(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1)(storybook@8.3.5(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@5.6.3)
-      '@storybook/preset-react-webpack': 8.3.5(@storybook/test@8.3.5(storybook@8.3.5(bufferutil@4.0.8)(utf-8-validate@5.0.10)))(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.5(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@5.6.3)
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(react-refresh@0.14.2)(type-fest@4.26.1)(webpack-hot-middleware@2.26.1)(webpack@5.95.0(@swc/core@1.7.35)(esbuild@0.23.1))
+      '@storybook/builder-webpack5': 8.3.5(@swc/core@1.7.35)(esbuild@0.23.1)(storybook@8.3.5(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@5.6.3)
+      '@storybook/preset-react-webpack': 8.3.5(@storybook/test@8.3.5(storybook@8.3.5(bufferutil@4.0.8)(utf-8-validate@5.0.10)))(@swc/core@1.7.35)(esbuild@0.23.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.5(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@5.6.3)
       '@storybook/react': 8.3.5(@storybook/test@8.3.5(storybook@8.3.5(bufferutil@4.0.8)(utf-8-validate@5.0.10)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.5(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@5.6.3)
       '@storybook/test': 8.3.5(storybook@8.3.5(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@types/node': 22.7.5
       '@types/semver': 7.5.8
-      babel-loader: 9.2.1(@babel/core@7.25.8)(webpack@5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1))
-      css-loader: 6.11.0(webpack@5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1))
+      babel-loader: 9.2.1(@babel/core@7.25.8)(webpack@5.95.0(@swc/core@1.7.35)(esbuild@0.23.1))
+      css-loader: 6.11.0(webpack@5.95.0(@swc/core@1.7.35)(esbuild@0.23.1))
       find-up: 5.0.0
       fs-extra: 11.2.0
       image-size: 1.1.1
       loader-utils: 3.3.1
       next: 14.2.15(@babel/core@7.25.8)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      node-polyfill-webpack-plugin: 2.0.1(webpack@5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1))
+      node-polyfill-webpack-plugin: 2.0.1(webpack@5.95.0(@swc/core@1.7.35)(esbuild@0.23.1))
       pnp-webpack-plugin: 1.7.0(typescript@5.6.3)
       postcss: 8.4.47
-      postcss-loader: 8.1.1(postcss@8.4.47)(typescript@5.6.3)(webpack@5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1))
+      postcss-loader: 8.1.1(postcss@8.4.47)(typescript@5.6.3)(webpack@5.95.0(@swc/core@1.7.35)(esbuild@0.23.1))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-refresh: 0.14.2
       resolve-url-loader: 5.0.0
-      sass-loader: 13.3.3(webpack@5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1))
+      sass-loader: 13.3.3(webpack@5.95.0(@swc/core@1.7.35)(esbuild@0.23.1))
       semver: 7.6.3
       storybook: 8.3.5(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      style-loader: 3.3.4(webpack@5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1))
+      style-loader: 3.3.4(webpack@5.95.0(@swc/core@1.7.35)(esbuild@0.23.1))
       styled-jsx: 5.1.6(@babel/core@7.25.8)(react@18.3.1)
       ts-dedent: 2.2.0
       tsconfig-paths: 4.2.0
@@ -23534,7 +23587,7 @@ snapshots:
     optionalDependencies:
       sharp: 0.33.5
       typescript: 5.6.3
-      webpack: 5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1)
+      webpack: 5.95.0(@swc/core@1.7.35)(esbuild@0.23.1)
     transitivePeerDependencies:
       - '@rspack/core'
       - '@swc/core'
@@ -23554,11 +23607,11 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@storybook/preset-react-webpack@8.3.5(@storybook/test@8.3.5(storybook@8.3.5(bufferutil@4.0.8)(utf-8-validate@5.0.10)))(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.5(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@5.6.3)':
+  '@storybook/preset-react-webpack@8.3.5(@storybook/test@8.3.5(storybook@8.3.5(bufferutil@4.0.8)(utf-8-validate@5.0.10)))(@swc/core@1.7.35)(esbuild@0.23.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.5(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@5.6.3)':
     dependencies:
       '@storybook/core-webpack': 8.3.5(storybook@8.3.5(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@storybook/react': 8.3.5(@storybook/test@8.3.5(storybook@8.3.5(bufferutil@4.0.8)(utf-8-validate@5.0.10)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.5(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@5.6.3)
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.6.3)(webpack@5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1))
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.6.3)(webpack@5.95.0(@swc/core@1.7.35)(esbuild@0.23.1))
       '@types/node': 22.7.5
       '@types/semver': 7.5.8
       find-up: 5.0.0
@@ -23571,7 +23624,7 @@ snapshots:
       semver: 7.6.3
       storybook: 8.3.5(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       tsconfig-paths: 4.2.0
-      webpack: 5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1)
+      webpack: 5.95.0(@swc/core@1.7.35)(esbuild@0.23.1)
     optionalDependencies:
       typescript: 5.6.3
     transitivePeerDependencies:
@@ -23586,7 +23639,7 @@ snapshots:
     dependencies:
       storybook: 8.3.5(bufferutil@4.0.8)(utf-8-validate@5.0.10)
 
-  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.6.3)(webpack@5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1))':
+  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.6.3)(webpack@5.95.0(@swc/core@1.7.35)(esbuild@0.23.1))':
     dependencies:
       debug: 4.3.7(supports-color@8.1.1)
       endent: 2.1.0
@@ -23596,7 +23649,7 @@ snapshots:
       react-docgen-typescript: 2.2.2(typescript@5.6.3)
       tslib: 2.7.0
       typescript: 5.6.3
-      webpack: 5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1)
+      webpack: 5.95.0(@swc/core@1.7.35)(esbuild@0.23.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -24047,7 +24100,7 @@ snapshots:
   '@swc/core-win32-x64-msvc@1.7.35':
     optional: true
 
-  '@swc/core@1.7.35(@swc/helpers@0.5.13)':
+  '@swc/core@1.7.35':
     dependencies:
       '@swc/counter': 0.1.3
       '@swc/types': 0.1.13
@@ -24062,15 +24115,9 @@ snapshots:
       '@swc/core-win32-arm64-msvc': 1.7.35
       '@swc/core-win32-ia32-msvc': 1.7.35
       '@swc/core-win32-x64-msvc': 1.7.35
-      '@swc/helpers': 0.5.13
     optional: true
 
   '@swc/counter@0.1.3': {}
-
-  '@swc/helpers@0.5.13':
-    dependencies:
-      tslib: 2.7.0
-    optional: true
 
   '@swc/helpers@0.5.5':
     dependencies:
@@ -25626,12 +25673,12 @@ snapshots:
     dependencies:
       '@babel/core': 7.25.8
 
-  babel-loader@9.2.1(@babel/core@7.25.8)(webpack@5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1)):
+  babel-loader@9.2.1(@babel/core@7.25.8)(webpack@5.95.0(@swc/core@1.7.35)(esbuild@0.23.1)):
     dependencies:
       '@babel/core': 7.25.8
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
-      webpack: 5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1)
+      webpack: 5.95.0(@swc/core@1.7.35)(esbuild@0.23.1)
 
   babel-plugin-macros@3.1.0:
     dependencies:
@@ -26106,13 +26153,13 @@ snapshots:
 
   check-error@2.1.1: {}
 
-  checkly@4.9.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(@types/node@20.14.9)(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10):
+  checkly@4.9.0(@swc/core@1.7.35)(@types/node@20.14.9)(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10):
     dependencies:
-      '@oclif/core': 2.8.11(@swc/core@1.7.35(@swc/helpers@0.5.13))(@types/node@20.14.9)(typescript@5.6.3)
+      '@oclif/core': 2.8.11(@swc/core@1.7.35)(@types/node@20.14.9)(typescript@5.6.3)
       '@oclif/plugin-help': 5.1.20
-      '@oclif/plugin-not-found': 2.3.23(@swc/core@1.7.35(@swc/helpers@0.5.13))(@types/node@20.14.9)(typescript@5.6.3)
+      '@oclif/plugin-not-found': 2.3.23(@swc/core@1.7.35)(@types/node@20.14.9)(typescript@5.6.3)
       '@oclif/plugin-plugins': 5.4.4
-      '@oclif/plugin-warn-if-update-available': 2.0.24(@swc/core@1.7.35(@swc/helpers@0.5.13))(@types/node@20.14.9)(typescript@5.6.3)
+      '@oclif/plugin-warn-if-update-available': 2.0.24(@swc/core@1.7.35)(@types/node@20.14.9)(typescript@5.6.3)
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.6.3)
       acorn: 8.8.1
       acorn-walk: 8.2.0
@@ -26590,7 +26637,7 @@ snapshots:
 
   css-color-keywords@1.0.0: {}
 
-  css-loader@6.11.0(webpack@5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1)):
+  css-loader@6.11.0(webpack@5.95.0(@swc/core@1.7.35)(esbuild@0.23.1)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.47)
       postcss: 8.4.47
@@ -26601,7 +26648,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.6.3
     optionalDependencies:
-      webpack: 5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1)
+      webpack: 5.95.0(@swc/core@1.7.35)(esbuild@0.23.1)
 
   css-select@4.3.0:
     dependencies:
@@ -27301,7 +27348,7 @@ snapshots:
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.9.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.9.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.14.1(eslint@8.57.0)(typescript@5.6.3))(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.10.0(eslint@8.57.0)
       eslint-plugin-react: 7.37.1(eslint@8.57.0)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.0)
@@ -27332,7 +27379,7 @@ snapshots:
       is-bun-module: 1.2.1
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.9.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.14.1(eslint@8.57.0)(typescript@5.6.3))(eslint@8.57.0)
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
@@ -27360,6 +27407,16 @@ snapshots:
       - bluebird
       - supports-color
 
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.14.1(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 7.14.1(eslint@8.57.0)(typescript@5.6.3)
+      eslint: 8.57.0
+      eslint-import-resolver-node: 0.3.9
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-module-utils@2.12.0(@typescript-eslint/parser@8.9.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.9.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
@@ -27371,7 +27428,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.9.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.0):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.14.1(eslint@8.57.0)(typescript@5.6.3))(eslint@8.57.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -27382,7 +27439,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.9.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.9.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.14.1(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -27394,7 +27451,7 @@ snapshots:
       string.prototype.trimend: 1.0.8
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.9.0(eslint@8.57.0)(typescript@5.6.3)
+      '@typescript-eslint/parser': 7.14.1(eslint@8.57.0)(typescript@5.6.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -27493,11 +27550,11 @@ snapshots:
 
   eslint-plugin-svg-jsx@1.2.4: {}
 
-  eslint-plugin-tailwindcss@3.17.5(tailwindcss@3.4.13(ts-node@10.9.2(@swc/core@1.7.35(@swc/helpers@0.5.13))(@types/node@20.14.9)(typescript@5.6.3))):
+  eslint-plugin-tailwindcss@3.17.5(tailwindcss@3.4.13(ts-node@10.9.2(@types/node@20.14.9)(typescript@5.6.3))):
     dependencies:
       fast-glob: 3.3.2
       postcss: 8.4.47
-      tailwindcss: 3.4.13(ts-node@10.9.2(@swc/core@1.7.35(@swc/helpers@0.5.13))(@types/node@20.14.9)(typescript@5.6.3))
+      tailwindcss: 3.4.13(ts-node@10.9.2(@types/node@20.14.9)(typescript@5.6.3))
 
   eslint-scope@5.1.1:
     dependencies:
@@ -28193,7 +28250,7 @@ snapshots:
       cross-spawn: 7.0.3
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.6.3)(webpack@5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1)):
+  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.6.3)(webpack@5.95.0(@swc/core@1.7.35)(esbuild@0.23.1)):
     dependencies:
       '@babel/code-frame': 7.25.7
       chalk: 4.1.2
@@ -28208,7 +28265,7 @@ snapshots:
       semver: 7.6.3
       tapable: 2.2.1
       typescript: 5.6.3
-      webpack: 5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1)
+      webpack: 5.95.0(@swc/core@1.7.35)(esbuild@0.23.1)
 
   form-data-encoder@2.1.4: {}
 
@@ -28736,7 +28793,7 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  html-webpack-plugin@5.6.0(webpack@5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1)):
+  html-webpack-plugin@5.6.0(webpack@5.95.0(@swc/core@1.7.35)(esbuild@0.23.1)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -28744,7 +28801,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.2.1
     optionalDependencies:
-      webpack: 5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1)
+      webpack: 5.95.0(@swc/core@1.7.35)(esbuild@0.23.1)
 
   htmlparser2@3.10.1:
     dependencies:
@@ -31201,7 +31258,7 @@ snapshots:
       '@next/env': 13.5.6
       fast-glob: 3.3.2
       minimist: 1.2.8
-      next: 14.2.15(@opentelemetry/api@1.9.0)(@playwright/test@1.48.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 14.2.15(@babel/core@7.25.8)(@opentelemetry/api@1.9.0)(@playwright/test@1.48.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   next-themes@0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -31262,33 +31319,6 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@14.2.15(@opentelemetry/api@1.9.0)(@playwright/test@1.48.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      '@next/env': 14.2.15
-      '@swc/helpers': 0.5.5
-      busboy: 1.6.0
-      caniuse-lite: 1.0.30001668
-      graceful-fs: 4.2.11
-      postcss: 8.4.31
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      styled-jsx: 5.1.1(@babel/core@7.25.8)(react@18.3.1)
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 14.2.15
-      '@next/swc-darwin-x64': 14.2.15
-      '@next/swc-linux-arm64-gnu': 14.2.15
-      '@next/swc-linux-arm64-musl': 14.2.15
-      '@next/swc-linux-x64-gnu': 14.2.15
-      '@next/swc-linux-x64-musl': 14.2.15
-      '@next/swc-win32-arm64-msvc': 14.2.15
-      '@next/swc-win32-ia32-msvc': 14.2.15
-      '@next/swc-win32-x64-msvc': 14.2.15
-      '@opentelemetry/api': 1.9.0
-      '@playwright/test': 1.48.0
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
-
   nextjs-toploader@1.6.12(next@14.2.15(@babel/core@7.25.8)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       next: 14.2.15(@babel/core@7.25.8)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -31299,7 +31329,7 @@ snapshots:
 
   nextjs-toploader@1.6.12(next@14.2.15(@opentelemetry/api@1.9.0)(@playwright/test@1.48.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      next: 14.2.15(@opentelemetry/api@1.9.0)(@playwright/test@1.48.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 14.2.15(@babel/core@7.25.8)(@opentelemetry/api@1.9.0)(@playwright/test@1.48.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       nprogress: 0.2.0
       prop-types: 15.8.1
       react: 18.3.1
@@ -31351,7 +31381,7 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-polyfill-webpack-plugin@2.0.1(webpack@5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1)):
+  node-polyfill-webpack-plugin@2.0.1(webpack@5.95.0(@swc/core@1.7.35)(esbuild@0.23.1)):
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -31378,7 +31408,7 @@ snapshots:
       url: 0.11.4
       util: 0.12.5
       vm-browserify: 1.1.2
-      webpack: 5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1)
+      webpack: 5.95.0(@swc/core@1.7.35)(esbuild@0.23.1)
 
   node-releases@2.0.18: {}
 
@@ -31977,22 +32007,22 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.4.47
 
-  postcss-load-config@4.0.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.7.35(@swc/helpers@0.5.13))(@types/node@20.14.9)(typescript@5.6.3)):
+  postcss-load-config@4.0.2(postcss@8.4.47)(ts-node@10.9.2(@types/node@20.14.9)(typescript@5.6.3)):
     dependencies:
       lilconfig: 3.1.2
       yaml: 2.5.1
     optionalDependencies:
       postcss: 8.4.47
-      ts-node: 10.9.2(@swc/core@1.7.35(@swc/helpers@0.5.13))(@types/node@20.14.9)(typescript@5.6.3)
+      ts-node: 10.9.2(@swc/core@1.7.35)(@types/node@20.14.9)(typescript@5.6.3)
 
-  postcss-loader@8.1.1(postcss@8.4.47)(typescript@5.6.3)(webpack@5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1)):
+  postcss-loader@8.1.1(postcss@8.4.47)(typescript@5.6.3)(webpack@5.95.0(@swc/core@1.7.35)(esbuild@0.23.1)):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.6.3)
       jiti: 1.21.6
       postcss: 8.4.47
       semver: 7.6.3
     optionalDependencies:
-      webpack: 5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1)
+      webpack: 5.95.0(@swc/core@1.7.35)(esbuild@0.23.1)
     transitivePeerDependencies:
       - typescript
 
@@ -33273,10 +33303,10 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@13.3.3(webpack@5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1)):
+  sass-loader@13.3.3(webpack@5.95.0(@swc/core@1.7.35)(esbuild@0.23.1)):
     dependencies:
       neo-async: 2.6.2
-      webpack: 5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1)
+      webpack: 5.95.0(@swc/core@1.7.35)(esbuild@0.23.1)
 
   satori@0.10.9:
     dependencies:
@@ -33806,9 +33836,9 @@ snapshots:
 
   structured-headers@0.4.1: {}
 
-  style-loader@3.3.4(webpack@5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1)):
+  style-loader@3.3.4(webpack@5.95.0(@swc/core@1.7.35)(esbuild@0.23.1)):
     dependencies:
-      webpack: 5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1)
+      webpack: 5.95.0(@swc/core@1.7.35)(esbuild@0.23.1)
 
   style-to-object@0.4.4:
     dependencies:
@@ -33957,11 +33987,11 @@ snapshots:
 
   tailwind-merge@2.5.4: {}
 
-  tailwindcss-animate@1.0.7(tailwindcss@3.4.13(ts-node@10.9.2(@swc/core@1.7.35(@swc/helpers@0.5.13))(@types/node@20.14.9)(typescript@5.6.3))):
+  tailwindcss-animate@1.0.7(tailwindcss@3.4.13(ts-node@10.9.2(@types/node@20.14.9)(typescript@5.6.3))):
     dependencies:
-      tailwindcss: 3.4.13(ts-node@10.9.2(@swc/core@1.7.35(@swc/helpers@0.5.13))(@types/node@20.14.9)(typescript@5.6.3))
+      tailwindcss: 3.4.13(ts-node@10.9.2(@types/node@20.14.9)(typescript@5.6.3))
 
-  tailwindcss@3.4.13(ts-node@10.9.2(@swc/core@1.7.35(@swc/helpers@0.5.13))(@types/node@20.14.9)(typescript@5.6.3)):
+  tailwindcss@3.4.13(ts-node@10.9.2(@types/node@20.14.9)(typescript@5.6.3)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -33980,7 +34010,7 @@ snapshots:
       postcss: 8.4.47
       postcss-import: 15.1.0(postcss@8.4.47)
       postcss-js: 4.0.1(postcss@8.4.47)
-      postcss-load-config: 4.0.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.7.35(@swc/helpers@0.5.13))(@types/node@20.14.9)(typescript@5.6.3))
+      postcss-load-config: 4.0.2(postcss@8.4.47)(ts-node@10.9.2(@types/node@20.14.9)(typescript@5.6.3))
       postcss-nested: 6.2.0(postcss@8.4.47)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.8
@@ -34071,28 +34101,17 @@ snapshots:
       ansi-escapes: 4.3.2
       supports-hyperlinks: 2.3.0
 
-  terser-webpack-plugin@5.3.10(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1)(webpack@5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1)):
+  terser-webpack-plugin@5.3.10(@swc/core@1.7.35)(esbuild@0.23.1)(webpack@5.95.0(@swc/core@1.7.35)(esbuild@0.23.1)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
       terser: 5.34.1
-      webpack: 5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1)
+      webpack: 5.95.0(@swc/core@1.7.35)(esbuild@0.23.1)
     optionalDependencies:
-      '@swc/core': 1.7.35(@swc/helpers@0.5.13)
+      '@swc/core': 1.7.35
       esbuild: 0.23.1
-
-  terser-webpack-plugin@5.3.10(@swc/core@1.7.35(@swc/helpers@0.5.13))(webpack@5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.25
-      jest-worker: 27.5.1
-      schema-utils: 3.3.0
-      serialize-javascript: 6.0.2
-      terser: 5.34.1
-      webpack: 5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))
-    optionalDependencies:
-      '@swc/core': 1.7.35(@swc/helpers@0.5.13)
 
   terser-webpack-plugin@5.3.10(webpack@5.95.0):
     dependencies:
@@ -34247,7 +34266,7 @@ snapshots:
 
   ts-mixer@6.0.4: {}
 
-  ts-node@10.9.2(@swc/core@1.7.35(@swc/helpers@0.5.13))(@types/node@20.14.9)(typescript@5.6.3):
+  ts-node@10.9.2(@swc/core@1.7.35)(@types/node@20.14.9)(typescript@5.6.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -34265,7 +34284,7 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optionalDependencies:
-      '@swc/core': 1.7.35(@swc/helpers@0.5.13)
+      '@swc/core': 1.7.35
 
   ts-pnp@1.2.0(typescript@5.6.3):
     optionalDependencies:
@@ -35091,7 +35110,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  webpack-dev-middleware@6.1.3(webpack@5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1)):
+  webpack-dev-middleware@6.1.3(webpack@5.95.0(@swc/core@1.7.35)(esbuild@0.23.1)):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3
@@ -35099,7 +35118,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.2.0
     optionalDependencies:
-      webpack: 5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1)
+      webpack: 5.95.0(@swc/core@1.7.35)(esbuild@0.23.1)
 
   webpack-hot-middleware@2.26.1:
     dependencies:
@@ -35143,7 +35162,7 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpack@5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13)):
+  webpack@5.95.0(@swc/core@1.7.35)(esbuild@0.23.1):
     dependencies:
       '@types/estree': 1.0.6
       '@webassemblyjs/ast': 1.12.1
@@ -35165,37 +35184,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(@swc/core@1.7.35(@swc/helpers@0.5.13))(webpack@5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13)))
-      watchpack: 2.4.2
-      webpack-sources: 3.2.3
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-
-  webpack@5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1):
-    dependencies:
-      '@types/estree': 1.0.6
-      '@webassemblyjs/ast': 1.12.1
-      '@webassemblyjs/wasm-edit': 1.12.1
-      '@webassemblyjs/wasm-parser': 1.12.1
-      acorn: 8.12.1
-      acorn-import-attributes: 1.9.5(acorn@8.12.1)
-      browserslist: 4.24.0
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.17.1
-      es-module-lexer: 1.5.4
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.0
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 3.3.0
-      tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1)(webpack@5.95.0(@swc/core@1.7.35(@swc/helpers@0.5.13))(esbuild@0.23.1))
+      terser-webpack-plugin: 5.3.10(@swc/core@1.7.35)(esbuild@0.23.1)(webpack@5.95.0(@swc/core@1.7.35)(esbuild@0.23.1))
       watchpack: 2.4.2
       webpack-sources: 3.2.3
     transitivePeerDependencies:


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `thirdweb` library with support for enclave wallet migration in React Native, along with updates to dependencies and improvements in error handling and wallet management.

### Detailed summary
- Added support for enclave wallet migration in React Native.
- Updated dependency on `@thirdweb-dev/react-native-adapter`.
- Changed `ecosystemId` references to `ecosystem` in several files.
- Improved error handling in `guest.ts` and other authentication files.
- Updated `WalletImage` component to accept `client` prop.
- Introduced `migrateToEnclaveWallet` function for migration logic.
- Refactored wallet initialization logic to accommodate new ecosystem structure.

> The following files were skipped due to too many changes: `pnpm-lock.yaml`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->