### PR TITLE
Add bottom padding to Sidebar

### DIFF
--- a/apps/dashboard/src/@/components/blocks/Sidebar.tsx
+++ b/apps/dashboard/src/@/components/blocks/Sidebar.tsx
@@ -35,7 +35,7 @@ export function Sidebar(props: SidebarContentProps) {
         props.className,
       )}
     >
-      <div className="pt-7">
+      <div className="py-7">
         {props.header}
         <div className="flex flex-col gap-1">
           <RenderSidebarLinks links={props.links} />


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on a minor style adjustment in the `Sidebar.tsx` component, specifically changing a class name for padding.

### Detailed summary
- Changed the class name from `pt-7` to `py-7` in the `<div>` element, which alters the vertical padding applied to the sidebar.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->