### PR TITLE
Remove scrollIntoView for activeTab

### DIFF
--- a/apps/dashboard/src/@/components/ui/tabs.tsx
+++ b/apps/dashboard/src/@/components/ui/tabs.tsx
@@ -159,12 +159,6 @@ function useUnderline<El extends HTMLElement>() {
         setTimeout(() => {
           lineEl.style.transition = "transform 0.3s, width 0.3s";
         }, 0);
-
-        activeTabEl.scrollIntoView({
-          behavior: "smooth",
-          block: "nearest",
-          inline: "center",
-        });
       } else if (lineRef.current) {
         lineRef.current.style.width = "0px";
       }


### PR DESCRIPTION
Its creating issues with scrolling on iOS

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying the transition effects for a tab component in the `tabs.tsx` file, specifically enhancing the visual behavior when a tab is activated.

### Detailed summary
- Added a transition effect to `lineEl` for `transform` and `width` over `0.3s`.
- Removed the `scrollIntoView` method call with smooth behavior for the active tab element.
- Set the width of `lineRef.current` to `0px` when no active tab is present.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->