### PR TITLE
feat: expose auth options on useConnectModal

### DIFF
--- a/.changeset/blue-seahorses-compare.md
+++ b/.changeset/blue-seahorses-compare.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Expose auth options on `useConnectModal`

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/useConnectModal.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/useConnectModal.tsx
@@ -5,6 +5,7 @@ import type { Wallet } from "../../../../wallets/interfaces/wallet.js";
 import type { SmartWalletOptions } from "../../../../wallets/smart/types.js";
 import type { AppMetadata } from "../../../../wallets/types.js";
 import type { Theme } from "../../../core/design-system/index.js";
+import type { SiweAuthOptions } from "../../../core/hooks/auth/useSiweAuth.js";
 import { SetRootElementContext } from "../../../core/providers/RootElementContext.js";
 import { WalletUIStatesProvider } from "../../providers/wallet-ui-states-provider.js";
 import { canFitWideModal } from "../../utils/canFitWideModal.js";
@@ -432,4 +433,14 @@ export type UseConnectModalOptions = {
    * If you want to hide the branding, set this prop to `false`
    */
   showThirdwebBranding?: boolean;
+
+  /**
+   * Enable SIWE (Sign in with Ethererum) by passing an object of type `SiweAuthOptions` to
+   * enforce the users to sign a message after connecting their wallet to authenticate themselves.
+   *
+   * Refer to the [`SiweAuthOptions`](https://portal.thirdweb.com/references/typescript/v5/SiweAuthOptions) for more details
+   */
+  auth?: SiweAuthOptions;
 };
+
+// TODO: consilidate Button/Embed/Modal props into one type with extras


### PR DESCRIPTION
## Problem solved

Fixes CNCT-2068


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces an enhancement to the `useConnectModal` by exposing authentication options that allow users to utilize Sign in with Ethereum (SIWE) for added security during wallet connections.

### Detailed summary
- Added `auth` property to `UseConnectModalOptions` type.
- `auth` accepts an object of type `SiweAuthOptions` for user authentication.
- Updated documentation to reference `SiweAuthOptions` with a link for further details.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->