### PR TITLE
[Dashboard] Remove react-icons (2)

### DIFF
--- a/apps/dashboard/src/components/dashboard/RelevantDataSection.tsx
+++ b/apps/dashboard/src/components/dashboard/RelevantDataSection.tsx
@@ -1,6 +1,6 @@
 import { Flex } from "@chakra-ui/react";
+import { MoveRightIcon } from "lucide-react";
 import { useState } from "react";
-import { BsArrowRight } from "react-icons/bs";
 import { Heading, Text, TrackedLink } from "tw-components";
 
 interface RelevantDataSectionProps {
@@ -56,7 +56,7 @@ export const RelevantDataSection: React.FC<RelevantDataSectionProps> = ({
             alignItems="center"
             gap="0.5em"
           >
-            View more <BsArrowRight />
+            View more <MoveRightIcon className="size-4" />
           </Text>
         ) : null}
       </Flex>

--- a/apps/dashboard/src/components/engine/configuration/engine-wallet-config.tsx
+++ b/apps/dashboard/src/components/engine/configuration/engine-wallet-config.tsx
@@ -13,7 +13,6 @@ import {
 import { CircleAlertIcon } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
-import {} from "react-icons/md";
 import { Heading } from "tw-components";
 import { KmsAwsConfig } from "./kms-aws-config";
 import { KmsGcpConfig } from "./kms-gcp-config";

--- a/apps/dashboard/src/components/engine/configuration/webhooks-table.tsx
+++ b/apps/dashboard/src/components/engine/configuration/webhooks-table.tsx
@@ -20,8 +20,8 @@ import { TWTable } from "components/shared/TWTable";
 import { format, formatDistanceToNowStrict } from "date-fns";
 import { useTrack } from "hooks/analytics/useTrack";
 import { useTxNotifications } from "hooks/useTxNotifications";
+import { Trash2Icon } from "lucide-react";
 import { useState } from "react";
-import { FiTrash } from "react-icons/fi";
 import { Button, Card, FormLabel, Text } from "tw-components";
 import { AddressCopyButton } from "tw-components/AddressCopyButton";
 
@@ -212,7 +212,7 @@ export const WebhooksTable: React.FC<WebhooksTableProps> = ({
         isFetched={isFetched}
         onMenuClick={[
           {
-            icon: FiTrash,
+            icon: <Trash2Icon className="size-4" />,
             text: "Delete",
             onClick: onDelete,
             isDestructive: true,

--- a/apps/dashboard/src/components/engine/contract-subscription/contract-subscriptions-table.tsx
+++ b/apps/dashboard/src/components/engine/contract-subscription/contract-subscriptions-table.tsx
@@ -29,8 +29,9 @@ import { useTrack } from "hooks/analytics/useTrack";
 import { useAllChainsData } from "hooks/chains/allChains";
 import { useTxNotifications } from "hooks/useTxNotifications";
 import { useV5DashboardChain } from "lib/v5-adapter";
+import { Trash2Icon } from "lucide-react";
 import { useState } from "react";
-import { FiInfo, FiTrash } from "react-icons/fi";
+import { FiInfo } from "react-icons/fi";
 import { eth_getBlockByNumber, getRpcClient } from "thirdweb";
 import { shortenAddress as shortenAddresThrows } from "thirdweb/utils";
 import { Button, Card, FormLabel, LinkButton, Text } from "tw-components";
@@ -221,7 +222,7 @@ export const ContractSubscriptionTable: React.FC<
         isFetched={isFetched}
         onMenuClick={[
           {
-            icon: FiTrash,
+            icon: <Trash2Icon className="size-4" />,
             text: "Remove",
             onClick: (contractSub) => {
               setSelectedContractSub(contractSub);

--- a/apps/dashboard/src/components/engine/engine-instances-table.tsx
+++ b/apps/dashboard/src/components/engine/engine-instances-table.tsx
@@ -28,6 +28,7 @@ import { TWTable } from "components/shared/TWTable";
 import { useTrack } from "hooks/analytics/useTrack";
 import {
   CircleAlertIcon,
+  PencilIcon,
   SendIcon,
   Trash2Icon,
   TriangleAlertIcon,
@@ -35,8 +36,6 @@ import {
 import Link from "next/link";
 import { type ReactNode, useState } from "react";
 import { useForm } from "react-hook-form";
-import { BiPencil } from "react-icons/bi";
-import { FiTrash } from "react-icons/fi";
 import { toast } from "sonner";
 import { FormLabel } from "tw-components";
 
@@ -140,7 +139,7 @@ export const EngineInstancesTable: React.FC<EngineInstancesTableProps> = ({
         isPending={isPending}
         onMenuClick={[
           {
-            icon: BiPencil,
+            icon: <PencilIcon className="size-4" />,
             text: "Edit",
             onClick: (instance) => {
               trackEvent({
@@ -153,7 +152,7 @@ export const EngineInstancesTable: React.FC<EngineInstancesTableProps> = ({
             },
           },
           {
-            icon: FiTrash,
+            icon: <Trash2Icon className="size-4" />,
             text: "Remove",
             onClick: (instance) => {
               trackEvent({

--- a/apps/dashboard/src/components/engine/overview/backend-wallets-table.tsx
+++ b/apps/dashboard/src/components/engine/overview/backend-wallets-table.tsx
@@ -31,10 +31,10 @@ import { TWTable } from "components/shared/TWTable";
 import { useTrack } from "hooks/analytics/useTrack";
 import { useTxNotifications } from "hooks/useTxNotifications";
 import { useActiveChainAsDashboardChain } from "lib/v5-adapter";
+import { DownloadIcon, Trash2Icon, UploadIcon } from "lucide-react";
 import QRCode from "qrcode";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
-import { BiExport, BiImport, BiPencil } from "react-icons/bi";
 import { getAddress } from "thirdweb";
 import { shortenAddress } from "thirdweb/utils";
 import {
@@ -164,7 +164,7 @@ export const BackendWalletsTable: React.FC<BackendWalletsTableProps> = ({
         isFetched={isFetched}
         onMenuClick={[
           {
-            icon: BiPencil,
+            icon: <Trash2Icon className="size-4" />,
             text: "Edit",
             onClick: (wallet) => {
               setSelectedBackendWallet(wallet);
@@ -172,7 +172,7 @@ export const BackendWalletsTable: React.FC<BackendWalletsTableProps> = ({
             },
           },
           {
-            icon: BiImport,
+            icon: <DownloadIcon className="size-4" />,
             text: "Receive funds",
             onClick: (wallet) => {
               setSelectedBackendWallet(wallet);
@@ -180,7 +180,7 @@ export const BackendWalletsTable: React.FC<BackendWalletsTableProps> = ({
             },
           },
           {
-            icon: BiExport,
+            icon: <UploadIcon className="size-4" />,
             text: "Send funds",
             onClick: (wallet) => {
               setSelectedBackendWallet(wallet);

--- a/apps/dashboard/src/components/engine/permissions/access-tokens-table.tsx
+++ b/apps/dashboard/src/components/engine/permissions/access-tokens-table.tsx
@@ -22,9 +22,8 @@ import { createColumnHelper } from "@tanstack/react-table";
 import { TWTable } from "components/shared/TWTable";
 import { useTrack } from "hooks/analytics/useTrack";
 import { useTxNotifications } from "hooks/useTxNotifications";
+import { PencilIcon, Trash2Icon } from "lucide-react";
 import { useState } from "react";
-import { BiPencil } from "react-icons/bi";
-import { FiTrash } from "react-icons/fi";
 import { Button, FormLabel, Text } from "tw-components";
 import { toDateTimeLocal } from "utils/date-utils";
 
@@ -96,7 +95,7 @@ export const AccessTokensTable: React.FC<AccessTokensTableProps> = ({
         isFetched={isFetched}
         onMenuClick={[
           {
-            icon: BiPencil,
+            icon: <PencilIcon className="size-4" />,
             text: "Edit",
             onClick: (accessToken) => {
               setSelectedAccessToken(accessToken);
@@ -104,7 +103,7 @@ export const AccessTokensTable: React.FC<AccessTokensTableProps> = ({
             },
           },
           {
-            icon: FiTrash,
+            icon: <Trash2Icon className="size-4" />,
             text: "Delete",
             onClick: (accessToken) => {
               setSelectedAccessToken(accessToken);

--- a/apps/dashboard/src/components/engine/permissions/admins-table.tsx
+++ b/apps/dashboard/src/components/engine/permissions/admins-table.tsx
@@ -23,9 +23,8 @@ import { createColumnHelper } from "@tanstack/react-table";
 import { TWTable } from "components/shared/TWTable";
 import { useTrack } from "hooks/analytics/useTrack";
 import { useTxNotifications } from "hooks/useTxNotifications";
+import { PencilIcon, Trash2Icon } from "lucide-react";
 import { useState } from "react";
-import { BiPencil } from "react-icons/bi";
-import { FiTrash } from "react-icons/fi";
 import { Button, FormLabel, Text } from "tw-components";
 
 interface AdminsTableProps {
@@ -83,7 +82,7 @@ export const AdminsTable: React.FC<AdminsTableProps> = ({
         isFetched={isFetched}
         onMenuClick={[
           {
-            icon: BiPencil,
+            icon: <PencilIcon className="size-4" />,
             text: "Edit",
             onClick: (admin) => {
               setSelectedAdmin(admin);
@@ -91,7 +90,7 @@ export const AdminsTable: React.FC<AdminsTableProps> = ({
             },
           },
           {
-            icon: FiTrash,
+            icon: <Trash2Icon className="size-4" />,
             text: "Remove",
             onClick: (admin) => {
               setSelectedAdmin(admin);

--- a/apps/dashboard/src/components/engine/permissions/keypairs-table.tsx
+++ b/apps/dashboard/src/components/engine/permissions/keypairs-table.tsx
@@ -20,8 +20,8 @@ import { createColumnHelper } from "@tanstack/react-table";
 import { TWTable } from "components/shared/TWTable";
 import { useTrack } from "hooks/analytics/useTrack";
 import { useTxNotifications } from "hooks/useTxNotifications";
+import { Trash2Icon } from "lucide-react";
 import { useState } from "react";
-import { FiTrash } from "react-icons/fi";
 import { Button, CodeBlock, FormLabel, Text } from "tw-components";
 import { toDateTimeLocal } from "utils/date-utils";
 
@@ -88,7 +88,7 @@ export const KeypairsTable: React.FC<KeypairsTableProps> = ({
         isFetched={isFetched}
         onMenuClick={[
           {
-            icon: FiTrash,
+            icon: <Trash2Icon className="size-4" />,
             text: "Remove",
             onClick: (keypair) => {
               setSelectedKeypair(keypair);

--- a/apps/dashboard/src/components/engine/relayer/relayers-table.tsx
+++ b/apps/dashboard/src/components/engine/relayer/relayers-table.tsx
@@ -28,10 +28,9 @@ import { TWTable } from "components/shared/TWTable";
 import { useTrack } from "hooks/analytics/useTrack";
 import { useAllChainsData } from "hooks/chains/allChains";
 import { useTxNotifications } from "hooks/useTxNotifications";
+import { PencilIcon, Trash2Icon } from "lucide-react";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
-import { BiPencil } from "react-icons/bi";
-import { FiTrash } from "react-icons/fi";
 import { shortenAddress } from "thirdweb/utils";
 import {
   Button,
@@ -159,7 +158,7 @@ export const RelayersTable: React.FC<RelayersTableProps> = ({
         isFetched={isFetched}
         onMenuClick={[
           {
-            icon: BiPencil,
+            icon: <PencilIcon className="size-4" />,
             text: "Edit",
             onClick: (relayer) => {
               setSelectedRelayer(relayer);
@@ -167,7 +166,7 @@ export const RelayersTable: React.FC<RelayersTableProps> = ({
             },
           },
           {
-            icon: FiTrash,
+            icon: <Trash2Icon className="size-4" />,
             text: "Remove",
             onClick: (relayer) => {
               setSelectedRelayer(relayer);

--- a/apps/dashboard/src/components/shared/TWTable.tsx
+++ b/apps/dashboard/src/components/shared/TWTable.tsx
@@ -29,11 +29,10 @@ import {
 } from "@tanstack/react-table";
 import { EllipsisVerticalIcon, MoveRightIcon } from "lucide-react";
 import pluralize from "pluralize";
-import { type SetStateAction, useMemo, useState } from "react";
-import type { IconType } from "react-icons/lib";
+import { type ReactNode, type SetStateAction, useMemo, useState } from "react";
 
 type CtaMenuItem<TRowData> = {
-  icon?: IconType;
+  icon?: ReactNode;
   text: string;
   onClick: (row: TRowData) => void;
   isDestructive?: boolean;
@@ -216,7 +215,7 @@ export function TWTable<TRowData>(tableProps: TWTableProps<TRowData>) {
                                   isDestructive && "!text-destructive-text",
                                 )}
                               >
-                                {icon?.({ className: "size-4" })}
+                                {icon}
                                 {text}
                               </DropdownMenuItem>
                             );


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on updating icon imports and usages throughout various components in the dashboard application, replacing older icon libraries with `lucide-react` icons for consistency and improved visuals.

### Detailed summary
- Replaced `react-icons` icons with `lucide-react` icons in multiple components.
- Updated the `RelevantDataSection` to use `MoveRightIcon`.
- Updated `KeypairsTable`, `WebhooksTable`, `ContractSubscriptionTable`, `AdminsTable`, `EngineInstancesTable`, `RelayersTable`, `AccessTokensTable`, and `BackendWalletsTable` to use `Trash2Icon` and `PencilIcon`.
- Removed unused imports of `react-icons`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->