### PR TITLE
[SDK] Fix upload reveal batch

### DIFF
--- a/.changeset/sweet-pears-change.md
+++ b/.changeset/sweet-pears-change.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix upload logic for delayed reveal batch


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the upload logic in the `createDelayedRevealBatch` function for handling delayed reveal batches in the `thirdweb` library. It enhances the functionality by ensuring proper file naming and integrates the retrieval of the next token ID.

### Detailed summary
- Updated `createDelayedRevealBatch` to use `Promise.all` for concurrent uploads and token ID retrieval.
- Introduced `startFileNumber` to correctly calculate file names for batch uploads.
- Removed mock implementations in tests, replacing them with direct function calls.
- Improved test coverage for delayed reveal functionality, ensuring proper metadata handling.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->