### PR TITLE
Fix ColorInput label click not triggering correct input in playground

### DIFF
--- a/apps/playground-web/src/app/connect/sign-in/components/ColorFormGroup.tsx
+++ b/apps/playground-web/src/app/connect/sign-in/components/ColorFormGroup.tsx
@@ -64,14 +64,13 @@ export function ColorFormGroup(props: {
                 <div className="flex flex-col gap-2 pb-4">
                   {colorSection.colors.map((color) => {
                     return (
+                      // biome-ignore lint/a11y/noLabelWithoutControl: input is inside the label, so no need to add id
                       <label
                         className="flex cursor-pointer items-center gap-3 rounded-lg p-2 transition-colors hover:bg-secondary"
                         key={color.colorId}
-                        htmlFor="color-input"
                       >
                         <div className="rounded-full border">
                           <ColorInput
-                            id="color-input"
                             className="size-10"
                             value={themeObj.colors[color.colorId]}
                             onChange={(value) => {

--- a/apps/playground-web/src/app/connect/sign-in/components/ColorInput/index.tsx
+++ b/apps/playground-web/src/app/connect/sign-in/components/ColorInput/index.tsx
@@ -7,7 +7,6 @@ export function ColorInput(props: {
   onChange: (value: string) => void;
   onClick?: () => void;
   className?: string;
-  id?: string;
 }) {
   const debouncedOnChange = useDebouncedCallback((value) => {
     props.onChange(value);
@@ -15,7 +14,6 @@ export function ColorInput(props: {
 
   return (
     <input
-      id={props.id}
       onChange={(e) => {
         debouncedOnChange(e.target.value);
       }}


### PR DESCRIPTION
Fixes: DASH-315

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the accessibility and functionality of the `ColorInput` component within the `ColorFormGroup` by removing the `id` prop from the `ColorInput` and addressing a linting issue regarding label controls.

### Detailed summary
- Removed the `id` prop from the `ColorInput` component.
- Added a comment to ignore a linting rule regarding the `label` element's control association for accessibility.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->