### PR TITLE
Show Payment Modal when applying a coupon if account has no validPayment method setup

### DIFF
--- a/apps/dashboard/src/components/settings/Account/Billing/ApplyCouponCard.stories.tsx
+++ b/apps/dashboard/src/components/settings/Account/Billing/ApplyCouponCard.stories.tsx
@@ -59,6 +59,19 @@ function Story() {
           submit={statusStub(200)}
           onCouponApplied={undefined}
           prefillPromoCode="XYZ"
+          isPaymentSetup={true}
+          onAddPayment={() => {}}
+        />
+      </BadgeContainer>
+
+      <BadgeContainer label="No Valid Payment setup">
+        <ApplyCouponCardUI
+          submit={statusStub(200)}
+          onCouponApplied={undefined}
+          isPaymentSetup={false}
+          onAddPayment={() => {
+            console.log("show payment modal");
+          }}
         />
       </BadgeContainer>
 
@@ -66,6 +79,8 @@ function Story() {
         <ApplyCouponCardUI
           submit={statusStub(200)}
           onCouponApplied={undefined}
+          isPaymentSetup={true}
+          onAddPayment={() => {}}
         />
       </BadgeContainer>
 
@@ -73,6 +88,8 @@ function Story() {
         <ApplyCouponCardUI
           submit={statusStub(400)}
           onCouponApplied={undefined}
+          isPaymentSetup={true}
+          onAddPayment={() => {}}
         />
       </BadgeContainer>
 
@@ -80,6 +97,8 @@ function Story() {
         <ApplyCouponCardUI
           submit={statusStub(401)}
           onCouponApplied={undefined}
+          isPaymentSetup={true}
+          onAddPayment={() => {}}
         />
       </BadgeContainer>
 
@@ -87,6 +106,8 @@ function Story() {
         <ApplyCouponCardUI
           submit={statusStub(409)}
           onCouponApplied={undefined}
+          isPaymentSetup={true}
+          onAddPayment={() => {}}
         />
       </BadgeContainer>
 
@@ -94,6 +115,8 @@ function Story() {
         <ApplyCouponCardUI
           submit={statusStub(429)}
           onCouponApplied={undefined}
+          isPaymentSetup={true}
+          onAddPayment={() => {}}
         />
       </BadgeContainer>
 
@@ -101,6 +124,8 @@ function Story() {
         <ApplyCouponCardUI
           submit={statusStub(500)}
           onCouponApplied={undefined}
+          isPaymentSetup={true}
+          onAddPayment={() => {}}
         />
       </BadgeContainer>
       <Toaster richColors />


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the handling of payment setup in the `ApplyCouponCard` and `CouponSection` components. It adds functionality to prompt users to add a payment method when applying a coupon if no valid payment is set up.

### Detailed summary
- Added `isPaymentSetup` and `onAddPayment` props to `ApplyCouponCard` and `ApplyCouponCardUI`.
- Updated `CouponSection` to include `isPaymentSetup` and `onAddPayment` props.
- Modified `onSubmit` in `ApplyCouponCardUI` to call `onAddPayment` if no payment is set up.
- Changed `bottomText` in `ApplyCouponCardUI` based on payment setup status.
- Updated modal handling in `Billing` component to manage payment modal visibility.
- Updated `CouponSection` rendering to trigger payment modal when no valid payment is set.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->