### PR TITLE
Fix: Pass iframe data on every call

### DIFF
--- a/.changeset/tricky-lamps-cheer.md
+++ b/.changeset/tricky-lamps-cheer.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix flaky auth state in PWAs

--- a/packages/thirdweb/src/wallets/in-app/web/utils/iFrameCommunication/InAppWalletIframeCommunicator.ts
+++ b/packages/thirdweb/src/wallets/in-app/web/utils/iFrameCommunication/InAppWalletIframeCommunicator.ts
@@ -11,8 +11,6 @@ export class InAppWalletIframeCommunicator<
   // biome-ignore lint/suspicious/noExplicitAny: TODO: fix any
   T extends { [key: string]: any },
 > extends IframeCommunicator<T> {
-  clientId: string;
-  ecosystem?: Ecosystem;
   /**
    * @internal
    */
@@ -35,29 +33,16 @@ export class InAppWalletIframeCommunicator<
       }).href,
       baseUrl,
       container: document.body,
+      localStorage: new ClientScopedStorage({
+        storage: webLocalStorage,
+        clientId,
+        ecosystem,
+      }),
+      clientId,
+      ecosystem,
     });
     this.clientId = clientId;
     this.ecosystem = ecosystem;
-  }
-
-  /**
-   * @internal
-   */
-  override async onIframeLoadedInitVariables() {
-    const localStorage = new ClientScopedStorage({
-      storage: webLocalStorage,
-      clientId: this.clientId,
-      ecosystem: this.ecosystem,
-    });
-
-    return {
-      authCookie: await localStorage.getAuthCookie(),
-      deviceShareStored: await localStorage.getDeviceShare(),
-      walletUserId: await localStorage.getWalletUserId(),
-      clientId: this.clientId,
-      partnerId: this.ecosystem?.partnerId,
-      ecosystemId: this.ecosystem?.id,
-    };
   }
 }
 


### PR DESCRIPTION
## Problem solved

This removes any assumptions of the iframe's local storage persistence.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing flaky authentication state in Progressive Web Apps (PWAs) by improving the handling of local storage and client identifiers in the `InAppWalletIframeCommunicator` and `IframeCommunicator` classes.

### Detailed summary
- Removed redundant `clientId` and `ecosystem` properties from `InAppWalletIframeCommunicator`.
- Integrated `localStorage` into both `InAppWalletIframeCommunicator` and `IframeCommunicator` constructors.
- Updated `onIframeLoadedInitVariables` to fetch authentication data from `localStorage`.
- Changed message structure in `postMessage` calls to include initialization data.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->