### PR TITLE
[SDK] Improve general test cases

### DIFF
--- a/packages/thirdweb/src/extensions/unstoppable-domains/read/resolveName.test.ts
+++ b/packages/thirdweb/src/extensions/unstoppable-domains/read/resolveName.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { TEST_CLIENT } from "~test/test-clients.js";
+import { TEST_ACCOUNT_D } from "~test/test-wallets.js";
 import { resolveName } from "./resolveName.js";
 
 // Double check: https://unstoppabledomains.com/d/thirdwebsdk.unstoppable
@@ -12,5 +13,13 @@ describe("Unstoppable Domain: resolve name", () => {
         client: TEST_CLIENT,
       }),
     ).toBe("thirdwebsdk.unstoppable");
+  });
+
+  it("should throw error on addresses that dont own any UD", async () => {
+    await expect(() =>
+      resolveName({ client: TEST_CLIENT, address: TEST_ACCOUNT_D.address }),
+    ).rejects.toThrowError(
+      `Failed to retrieve domain for address: ${TEST_ACCOUNT_D.address}. Make sure you have set the Reverse Resolution address for your domain at https://unstoppabledomains.com/manage?page=reverseResolution&domain=your-domain`,
+    );
   });
 });


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new test case to the `resolveName` functionality, ensuring that an error is thrown when trying to resolve a name for an address that does not own any Unstoppable Domains (UD). 

### Detailed summary
- Added import for `TEST_ACCOUNT_D` from `~test/test-wallets.js`.
- Introduced a new test case to check error handling in `resolveName`.
- The test verifies that an appropriate error message is thrown for addresses without UD ownership.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->