### PR TITLE
[Dashboard] Update support email to include wallet address (DASH-75)

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/support/components/create-ticket.action.ts
+++ b/apps/dashboard/src/app/(dashboard)/support/components/create-ticket.action.ts
@@ -36,13 +36,16 @@ function prepareEmailTitle(
   return title;
 }
 
-function prepareEmailBody(
-  product: string,
-  markdownInput: string,
-  email: string,
-  address: string,
-  extraInfoInput: Record<string, string>,
-) {
+function prepareEmailBody(props: {
+  product: string;
+  markdownInput: string;
+  email: string;
+  name: string;
+  extraInfoInput: Record<string, string>;
+  walletAddress: string;
+}) {
+  const { extraInfoInput, email, walletAddress, product, name, markdownInput } =
+    props;
   // Update `markdown` to include the infos from the form
   const extraInfo = Object.keys(extraInfoInput)
     .filter((key) => key.startsWith("extraInfo_"))
@@ -54,7 +57,8 @@ function prepareEmailBody(
     })
     .join("");
   const markdown = `# Email: ${email}
-  # Address: ${address}
+  # Name: ${name}
+  # Wallet address: ${walletAddress}
   # Product: ${product}
   ${extraInfo}
   # Message:
@@ -110,13 +114,14 @@ export async function createTicketAction(
     keyVal[key] = formData.get(key)?.toString() || "";
   }
 
-  const markdown = prepareEmailBody(
+  const markdown = prepareEmailBody({
     product,
-    keyVal.markdown,
-    account.data.email,
-    account.data.name,
-    keyVal,
-  );
+    markdownInput: keyVal.markdown,
+    email: account.data.email,
+    name: account.data.name,
+    extraInfoInput: keyVal,
+    walletAddress: activeAccount,
+  });
 
   const content = {
     type: "email",


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR refactors the `prepareEmailBody` function to use a single `props` object for parameters, enhancing readability and maintainability. It also updates the parameters to include `name` and `walletAddress`, while modifying how the markdown content is generated.

### Detailed summary
- Changed `prepareEmailBody` function to accept a single `props` object.
- Added new parameters: `name` and `walletAddress`.
- Updated destructuring of `props` for better clarity.
- Modified markdown template to include `name` and `walletAddress` instead of `address`.
- Updated the call to `prepareEmailBody` to match the new structure.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->