### PR TITLE
chore: update chains

### DIFF
--- a/.changeset/real-insects-fix.md
+++ b/.changeset/real-insects-fix.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Update default zk chains

--- a/apps/playground-web/src/components/account-abstraction/sponsored-tx-zksync.tsx
+++ b/apps/playground-web/src/components/account-abstraction/sponsored-tx-zksync.tsx
@@ -67,7 +67,7 @@ export function SponsoredTxZksyncPreview() {
           {smartAccount ? (
             <div className="flex flex-col justify-center p-2">
               <p className="mb-2 text-center font-semibold">
-                You own {ownedNfts?.[0]?.quantityOwned.toString() || "0"}
+                You own {ownedNfts?.[0]?.quantityOwned.toString() || "0"}{" "}
                 Kittens
               </p>
               <TransactionButton

--- a/apps/playground-web/src/components/account-abstraction/sponsored-tx.tsx
+++ b/apps/playground-web/src/components/account-abstraction/sponsored-tx.tsx
@@ -69,7 +69,7 @@ export function SponsoredTxPreview() {
           {smartAccount ? (
             <div className="flex flex-col justify-center p-2">
               <p className="mb-2 text-center font-semibold">
-                You own {ownedNfts?.[0]?.quantityOwned.toString() || "0"}
+                You own {ownedNfts?.[0]?.quantityOwned.toString() || "0"}{" "}
                 Kittens
               </p>
               <TransactionButton

--- a/apps/portal/src/app/typescript/v5/sidebar.tsx
+++ b/apps/portal/src/app/typescript/v5/sidebar.tsx
@@ -139,9 +139,15 @@ export const sidebar: SideBar = {
             },
             ...[
               "smartWallet",
+              "predictAddress",
+              "createAndSignUserOp",
+              "createUnsignedUserOp",
               "signUserOp",
               "bundleUserOp",
+              "getUserOpReceipt",
               "waitForUserOpReceipt",
+              "getUserOpGasFees",
+              "estimateUserOpGas",
             ].map((name) => ({
               name,
               href: `${slug}/${name}`,
@@ -155,7 +161,6 @@ export const sidebar: SideBar = {
               "getAccountsOfSigner",
               "getAllActiveSigners",
               "getPermissionsForSigner",
-              "createUnsignedUserOp",
             ].map((name) => ({
               name,
               href: `${slug}/erc4337/${name}`,

--- a/packages/thirdweb/src/transaction/actions/zksync/send-eip712-transaction.ts
+++ b/packages/thirdweb/src/transaction/actions/zksync/send-eip712-transaction.ts
@@ -133,6 +133,10 @@ export async function populateEip712Transaction(
     maxFeePerGas = baseFee * 2n; // bumping the base fee per gas to ensure fast inclusion
     maxPriorityFeePerGas = toBigInt(result.max_priority_fee_per_gas) || 1n;
     gasPerPubdata = toBigInt(result.gas_per_pubdata_limit) * 2n; // doubling for fast inclusion;
+    if (gasPerPubdata < 50000n) {
+      // enforce a minimum gas per pubdata limit
+      gasPerPubdata = 50000n;
+    }
   }
 
   // serialize the transaction (with fees, gas, nonce)

--- a/packages/thirdweb/src/utils/any-evm/zksync/isZkSyncChain.ts
+++ b/packages/thirdweb/src/utils/any-evm/zksync/isZkSyncChain.ts
@@ -16,7 +16,8 @@ export async function isZkSyncChain(chain: Chain) {
     chain.id === 388 ||
     chain.id === 4654 ||
     chain.id === 333271 ||
-    chain.id === 37111
+    chain.id === 37111 ||
+    chain.id === 978658
   ) {
     return true;
   }

--- a/packages/thirdweb/src/wallets/smart/smart-wallet-zksync.test.ts
+++ b/packages/thirdweb/src/wallets/smart/smart-wallet-zksync.test.ts
@@ -148,5 +148,28 @@ describe.runIf(process.env.TW_SECRET_KEY).todo(
       console.log(tx.transactionHash);
       expect(tx.transactionHash.length).toBe(66);
     });
+
+    it("should send a transaction on Treasure Topaz Testnet", async () => {
+      const sw = smartWallet({
+        chain: defineChain(978658),
+        sponsorGas: true,
+      });
+      const account = await sw.connect({
+        client: TEST_CLIENT,
+        personalAccount,
+      });
+      const tx = await sendTransaction({
+        transaction: prepareTransaction({
+          chain: defineChain(978658),
+          client: TEST_CLIENT,
+          to: account.address,
+          value: BigInt(0),
+          data: "0x",
+        }),
+        account: account,
+      });
+      console.log(tx.transactionHash);
+      expect(tx.transactionHash.length).toBe(66);
+    });
   },
 );


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the handling of zkSync chains, enhancing user messaging in the UI, enforcing a minimum gas limit for transactions, and adding tests for interactions with the Treasure Topaz Testnet.

### Detailed summary
- Updated `isZkSyncChain.ts` to include `chain.id` 978658.
- Modified UI text in `sponsored-tx.tsx` and `sponsored-tx-zksync.tsx` to append "Kittens" to the NFT ownership message.
- Enforced a minimum gas limit of 50000n in `send-eip712-transaction.ts`.
- Added a test case for sending transactions on the Treasure Topaz Testnet in `smart-wallet-zksync.test.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->