### PR TITLE
fix: ensure valid block explorer URL for address links

### DIFF
--- a/apps/dashboard/src/components/custom-contract/contract-header/metadata-header.tsx
+++ b/apps/dashboard/src/components/custom-contract/contract-header/metadata-header.tsx
@@ -117,7 +117,7 @@ export const MetadataHeader: React.FC<MetadataHeaderProps> = ({
             <BadgeLink
               key={validBlockExplorer.url}
               name={validBlockExplorer.name}
-              href={`${validBlockExplorer.url}/address/${address}`}
+              href={`${validBlockExplorer.url.endsWith("/") ? validBlockExplorer.url : `${validBlockExplorer.url}/`}address/${address}`}
             />
           ))}
 


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the URL construction for the `href` attribute in the `metadata-header.tsx` component by ensuring that a trailing slash is included when necessary.

### Detailed summary
- Updated the `href` construction for `validBlockExplorer.url` to check if it ends with a `/`.
- If it does not end with a `/`, it appends one before adding the `address/${address}` segment.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->