### PR TITLE
Add reason string on abort() method in fetch util

### DIFF
--- a/.changeset/serious-masks-serve.md
+++ b/.changeset/serious-masks-serve.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Add reason string on abort controller's `abort` method to avoid `AbortError: signal is aborted without reason` errors

--- a/packages/thirdweb/src/storage/download.test.ts
+++ b/packages/thirdweb/src/storage/download.test.ts
@@ -106,7 +106,7 @@ describe("download", () => {
         uri: "ipfs://QmTest1234567890TestHash/file.txt",
         requestTimeoutMs: 500,
       }),
-    ).rejects.toThrow("This operation was aborted");
+    ).rejects.toThrow("timeout");
   });
 
   it("should respect custom client timeout", async () => {
@@ -125,6 +125,6 @@ describe("download", () => {
         },
         uri: "ipfs://QmTest1234567890TestHash/file.txt",
       }),
-    ).rejects.toThrow("This operation was aborted");
+    ).rejects.toThrow("timeout");
   });
 });

--- a/packages/thirdweb/src/utils/fetch.ts
+++ b/packages/thirdweb/src/utils/fetch.ts
@@ -72,7 +72,7 @@ export function getClientFetch(client: ThirdwebClient, ecosystem?: Ecosystem) {
     if (requestTimeoutMs) {
       controller = new AbortController();
       abortTimeout = setTimeout(() => {
-        controller?.abort();
+        controller?.abort("timeout");
       }, requestTimeoutMs);
     }
 


### PR DESCRIPTION
Fixes: DASH-323

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving error handling in the `abort` method of the `AbortController` by adding a reason string to avoid generic abort errors. It also updates tests to reflect this change.

### Detailed summary
- Added a reason string `"timeout"` to the `abort` method in `fetch.ts`.
- Updated tests in `download.test.ts` to expect the error message `"timeout"` instead of `"This operation was aborted"`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->