### PR TITLE
Fix Cannot read properties of undefined (reading 'message') in errorParser.tsx

### DIFF
--- a/apps/dashboard/src/utils/errorParser.tsx
+++ b/apps/dashboard/src/utils/errorParser.tsx
@@ -123,7 +123,7 @@ function parseErrorCode(
       }
 
       return (
-        error?.data.message ||
+        error?.data?.message ||
         error?.message ||
         "An internal error occurred with your transaction."
       );


### PR DESCRIPTION
Fixes: DASH-326

<!-- start pr-codex -->

---

## PR-Codex overview
This PR improves the error handling logic in the `errorParser.tsx` file by adding optional chaining to safely access the `message` property of `error.data`, preventing potential runtime errors if `data` is undefined.

### Detailed summary
- Changed `error?.data.message` to `error?.data?.message` to add optional chaining.
- This change ensures that if `data` is undefined, it won't throw an error when trying to access `message`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->