### PR TITLE
Add extra info on page crashing errors to identify them in Sentry dashboard

### DIFF
--- a/apps/dashboard/src/app/global-error.tsx
+++ b/apps/dashboard/src/app/global-error.tsx
@@ -13,7 +13,17 @@ export default function GlobalError({
   // legitimate usecase
   // eslint-disable-next-line no-restricted-syntax
   useEffect(() => {
-    Sentry.captureException(error);
+    Sentry.withScope((scope) => {
+      scope.setTag("page-crashed", "true");
+      scope.setLevel("fatal");
+      Sentry.captureException(error, {
+        extra: {
+          crashedPage: true,
+          boundary: "global",
+          router: "app",
+        },
+      });
+    });
   }, [error]);
 
   return (

--- a/apps/dashboard/src/pages/_error.tsx
+++ b/apps/dashboard/src/pages/_error.tsx
@@ -23,6 +23,20 @@ CustomErrorComponent.getInitialProps = async (contextData) => {
   // time to send the error before the lambda exits
   await Sentry.captureUnderscoreErrorException(contextData);
 
+  if (contextData.err instanceof Error) {
+    Sentry.withScope((scope) => {
+      scope.setTag("page-crashed", "true");
+      scope.setLevel("fatal");
+      Sentry.captureException(contextData.err, {
+        extra: {
+          crashedPage: true,
+          boundary: "global",
+          router: "pages",
+        },
+      });
+    });
+  }
+
   // This will contain the status code of the response
   return NextErrorComponent.getInitialProps(contextData);
 };


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances error handling in the application by implementing `Sentry`'s `withScope` method for capturing exceptions, allowing for more detailed context about the errors, such as tags and extra information regarding the page and router.

### Detailed summary
- In `global-error.tsx`, replaced direct `Sentry.captureException` call with `Sentry.withScope` to set tags and levels before capturing the exception.
- Added extra data to the captured exception, including `crashedPage`, `boundary`, and `router`.
- In `_error.tsx`, added a similar `Sentry.withScope` implementation for handling errors in `contextData`.
- Enhanced captured exceptions in `_error.tsx` with context-specific extra data.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->