### PR TITLE
Add insight service and expose cacheOptions for node auth

### DIFF
--- a/.changeset/popular-dragons-sin.md
+++ b/.changeset/popular-dragons-sin.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+Adds insight scope to api key and exposes cacheOptions for node auth

--- a/apps/dashboard/src/components/settings/ApiKeys/validations.ts
+++ b/apps/dashboard/src/components/settings/ApiKeys/validations.ts
@@ -149,4 +149,4 @@ export type ApiKeyPayConfigValidationSchema = z.infer<
 >;
 
 // FIXME: Remove
-export const HIDDEN_SERVICES = ["relayer", "chainsaw"];
+export const HIDDEN_SERVICES = ["relayer", "chainsaw", "insight"];

--- a/packages/service-utils/src/core/authorize/index.ts
+++ b/packages/service-utils/src/core/authorize/index.ts
@@ -22,7 +22,7 @@ export type AuthorizationInput = {
   useWalletAuth?: string | null;
 };
 
-type CacheOptions = {
+export type CacheOptions = {
   get: (clientId: string) => Promise<string | null>;
   put: (
     clientId: string,

--- a/packages/service-utils/src/core/services.ts
+++ b/packages/service-utils/src/core/services.ts
@@ -58,6 +58,13 @@ export const SERVICE_DEFINITIONS = {
     // all actions allowed
     actions: [],
   },
+  insight: {
+    name: "insight",
+    title: "Insight",
+    description: "Insight services",
+    // all actions allowed
+    actions: [],
+  },
 } as const;
 
 export const SERVICE_NAMES = Object.keys(

--- a/packages/service-utils/src/node/index.ts
+++ b/packages/service-utils/src/node/index.ts
@@ -6,7 +6,10 @@ import type {
 } from "node:http";
 import type { CoreServiceConfig } from "../core/api.js";
 import { authorize } from "../core/authorize/index.js";
-import type { AuthorizationInput } from "../core/authorize/index.js";
+import type {
+  AuthorizationInput,
+  CacheOptions,
+} from "../core/authorize/index.js";
 import type { AuthorizationResult } from "../core/authorize/types.js";
 import type { CoreAuthInput } from "../core/types.js";
 export * from "../core/usage.js";
@@ -39,6 +42,7 @@ export type AuthInput = CoreAuthInput & {
 export async function authorizeNode(
   authInput: AuthInput,
   serviceConfig: NodeServiceConfig,
+  cacheOptions?: CacheOptions,
 ): Promise<AuthorizationResult> {
   let authData: AuthorizationInput;
   try {
@@ -60,7 +64,7 @@ export async function authorizeNode(
     };
   }
 
-  return await authorize(authData, serviceConfig);
+  return await authorize(authData, serviceConfig, cacheOptions);
 }
 
 function getHeader(


### PR DESCRIPTION
## Problem solved

This update adds the "insight" scope to API keys and exposes cacheOptions for node authentication. It also includes the "insight" service in the SERVICE_DEFINITIONS object and adds it to the HIDDEN_SERVICES array. The authorizeNode function now accepts an optional cacheOptions parameter, allowing for more flexible caching strategies in node authentication.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces enhancements to the `service-utils` package by adding an `insight` service and expanding the `authorizeNode` function to accept `cacheOptions`. It also updates the `CacheOptions` type and modifies the `HIDDEN_SERVICES` array.

### Detailed summary
- Added `insight` service with name, title, and description in `services.ts`.
- Exported the `CacheOptions` type in `index.ts`.
- Modified `authorizeNode` function to accept `cacheOptions`.
- Updated `HIDDEN_SERVICES` to include `insight`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->