### PR TITLE
[SDK] Fix: ConnectEmbed SIWE Revalidation

### DIFF
--- a/.changeset/tall-melons-sneeze.md
+++ b/.changeset/tall-melons-sneeze.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix revalidation with siwe auth in ConnectEmbed

--- a/packages/thirdweb/src/react/core/hooks/auth/useSiweAuth.ts
+++ b/packages/thirdweb/src/react/core/hooks/auth/useSiweAuth.ts
@@ -66,12 +66,13 @@ export function useSiweAuth(
       }
       return authOptions.isLoggedIn(activeAccount.address);
     },
+    gcTime: 0,
     placeholderData: false,
     refetchOnWindowFocus: false,
   });
 
   const loginMutation = useMutation({
-    mutationKey: ["siwe_auth", "login"],
+    mutationKey: ["siwe_auth", "login", activeAccount?.address],
     mutationFn: async () => {
       if (!authOptions) {
         throw new Error("No auth options provided");
@@ -117,7 +118,7 @@ export function useSiweAuth(
   });
 
   const logoutMutation = useMutation({
-    mutationKey: ["siwe_auth", "logout"],
+    mutationKey: ["siwe_auth", "logout", activeAccount?.address],
     mutationFn: async () => {
       if (!authOptions) {
         throw new Error("No auth options provided");


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing revalidation issues with `siwe` authentication in the `ConnectEmbed` component by updating the mutation keys to include the `activeAccount` address.

### Detailed summary
- Updated `mutationKey` for `login` to include `activeAccount?.address`.
- Updated `mutationKey` for `logout` to include `activeAccount?.address`.
- Added `gcTime`, `placeholderData`, and `refetchOnWindowFocus` options in the hook configuration.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->