### PR TITLE
[Service Utils] Feature: add ecosystem headers to extractAuthorizationData

### DIFF
--- a/.changeset/tame-tips-type.md
+++ b/.changeset/tame-tips-type.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+Adds ecosystem headers to extractAuthorizationData result

--- a/packages/service-utils/src/cf-worker/index.ts
+++ b/packages/service-utils/src/cf-worker/index.ts
@@ -105,6 +105,16 @@ export async function extractAuthorizationData(
     bundleId = requestUrl.searchParams.get("bundleId");
   }
 
+  let ecosystemId = headers.get("x-ecosystem-id");
+  if (!ecosystemId) {
+    ecosystemId = requestUrl.searchParams.get("ecosystemId");
+  }
+
+  let ecosystemPartnerId = headers.get("x-ecosystem-partner-id");
+  if (!ecosystemPartnerId) {
+    ecosystemPartnerId = requestUrl.searchParams.get("ecosystemPartnerId");
+  }
+
   let origin = headers.get("origin");
   // if origin header is not available we'll fall back to referrer;
   if (!origin) {
@@ -150,6 +160,8 @@ export async function extractAuthorizationData(
     hashedJWT: jwt ? await hashSecretKey(jwt) : null,
     secretKey,
     clientId,
+    ecosystemId,
+    ecosystemPartnerId,
     origin,
     bundleId,
     secretKeyHash,

--- a/packages/service-utils/src/core/authorize/index.ts
+++ b/packages/service-utils/src/core/authorize/index.ts
@@ -12,6 +12,8 @@ import type { AuthorizationResult } from "./types.js";
 export type AuthorizationInput = {
   secretKey: string | null;
   clientId: string | null;
+  ecosystemId: string | null;
+  ecosystemPartnerId: string | null;
   origin: string | null;
   bundleId: string | null;
   secretKeyHash: string | null;

--- a/packages/service-utils/src/node/index.ts
+++ b/packages/service-utils/src/node/index.ts
@@ -107,12 +107,23 @@ export function extractAuthorizationData(
   if (!clientId) {
     clientId = requestUrl.searchParams.get("clientId");
   }
+
   // bundle id from header is first preference
   let bundleId = getHeader(headers, "x-bundle-id");
 
   // next preference is search param
   if (!bundleId) {
     bundleId = requestUrl.searchParams.get("bundleId");
+  }
+
+  let ecosystemId = getHeader(headers, "x-ecosystem-id");
+  if (!ecosystemId) {
+    ecosystemId = requestUrl.searchParams.get("ecosystemId");
+  }
+
+  let ecosystemPartnerId = getHeader(headers, "x-ecosystem-partner-id");
+  if (!ecosystemPartnerId) {
+    ecosystemPartnerId = requestUrl.searchParams.get("ecosystemPartnerId");
   }
 
   let origin = getHeader(headers, "origin");
@@ -166,6 +177,8 @@ export function extractAuthorizationData(
     secretKeyHash,
     secretKey,
     clientId,
+    ecosystemId,
+    ecosystemPartnerId,
     origin,
     bundleId,
     targetAddress: authInput.targetAddress,


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces additional ecosystem-related headers to the `extractAuthorizationData` function, enhancing the authorization data extraction process by including `ecosystemId` and `ecosystemPartnerId`.

### Detailed summary
- Added `ecosystemId` and `ecosystemPartnerId` properties to the authorization data structure.
- Updated the `extractAuthorizationData` function in multiple files to retrieve `ecosystemId` and `ecosystemPartnerId` from headers and search parameters.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->