### PR TITLE
fix: update useProfiles when connecting to different account

### DIFF
--- a/.changeset/stale-fans-ring.md
+++ b/.changeset/stale-fans-ring.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix useProfiles not updating when connecting to a different account

--- a/packages/thirdweb/src/react/native/hooks/wallets/useProfiles.ts
+++ b/packages/thirdweb/src/react/native/hooks/wallets/useProfiles.ts
@@ -31,7 +31,7 @@ export function useProfiles(args: {
 }): UseQueryResult<Profile[]> {
   const wallet = useAdminWallet();
   return useQuery({
-    queryKey: ["profiles", wallet?.id],
+    queryKey: ["profiles", wallet?.id, wallet?.getAccount()?.address],
     enabled: !!wallet && (wallet.id === "inApp" || isEcosystemWallet(wallet)),
     queryFn: async () => {
       const ecosystem: Ecosystem | undefined =

--- a/packages/thirdweb/src/react/web/hooks/wallets/useProfiles.ts
+++ b/packages/thirdweb/src/react/web/hooks/wallets/useProfiles.ts
@@ -31,7 +31,7 @@ export function useProfiles(args: {
 }): UseQueryResult<Profile[]> {
   const wallet = useAdminWallet();
   return useQuery({
-    queryKey: ["profiles", wallet?.id],
+    queryKey: ["profiles", wallet?.id, wallet?.getAccount()?.address],
     enabled: !!wallet && (wallet.id === "inApp" || isEcosystemWallet(wallet)),
     queryFn: async () => {
       const ecosystem: Ecosystem | undefined =


### PR DESCRIPTION
## Problem solved

Fixes CNCT-2100



<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the `useProfiles` hook to ensure it updates correctly when connecting to a different account by including the wallet's account address in the query key.

### Detailed summary
- Updated the `queryKey` in `useProfiles` for both web and native hooks to include `wallet?.getAccount()?.address`.
- This change helps in properly identifying profiles when the user connects a different wallet account.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->