### PR TITLE
fix: ensure smart accounts are deployed before validating signatures

### DIFF
--- a/.changeset/smooth-walls-glow.md
+++ b/.changeset/smooth-walls-glow.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Ensure smart accounts are deployed before validating signatures

--- a/packages/thirdweb/src/wallets/smart/smart-wallet-dev.test.ts
+++ b/packages/thirdweb/src/wallets/smart/smart-wallet-dev.test.ts
@@ -2,7 +2,6 @@ import { beforeAll, describe, expect, it } from "vitest";
 import { TEST_CLIENT } from "../../../test/src/test-clients.js";
 import { arbitrumSepolia } from "../../chains/chain-definitions/arbitrum-sepolia.js";
 import { type ThirdwebContract, getContract } from "../../contract/contract.js";
-
 import { balanceOf } from "../../extensions/erc1155/__generated__/IERC1155/read/balanceOf.js";
 import { claimTo } from "../../extensions/erc1155/drops/write/claimTo.js";
 import { sendAndConfirmTransaction } from "../../transaction/actions/send-and-confirm-transaction.js";
@@ -60,6 +59,12 @@ describe.runIf(process.env.TW_SECRET_KEY).skip.sequential(
 
     it("can connect", async () => {
       expect(smartWalletAddress).toHaveLength(42);
+    });
+
+    it("can sign a msg", async () => {
+      await smartAccount.signMessage({ message: "hello world" });
+      const isDeployed = await isContractDeployed(accountContract);
+      expect(isDeployed).toEqual(true);
     });
 
     it("can execute a tx", async () => {


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on ensuring that smart accounts are deployed before validating signatures in the `thirdweb` package. It introduces a new function to confirm contract deployment and updates tests to validate the deployment process.

### Detailed summary
- Added a test case in `smart-wallet-dev.test.ts` to check if a smart account can sign a message after deployment.
- Introduced `confirmContractDeployment` function to verify that the smart account contract is deployed before proceeding.
- Included comments to handle synchronization issues between the bundler and RPC during contract deployment.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->