### PR TITLE
test: add environment check for ERC1155 mintToBatch tests

### DIFF
--- a/packages/thirdweb/src/extensions/erc1155/write/mintToBatch.test.ts
+++ b/packages/thirdweb/src/extensions/erc1155/write/mintToBatch.test.ts
@@ -13,62 +13,65 @@ const chain = ANVIL_CHAIN;
 const client = TEST_CLIENT;
 const account = TEST_ACCOUNT_C;
 
-describe("ERC1155 Edition: mintToBatch", () => {
-  it("should mint multiple tokens in one tx", async () => {
-    const contract = getContract({
-      chain,
-      client,
-      address: await deployERC1155Contract({
+describe.runIf(process.env.TW_SECRET_KEY)(
+  "ERC1155 Edition: mintToBatch",
+  () => {
+    it("should mint multiple tokens in one tx", async () => {
+      const contract = getContract({
         chain,
         client,
+        address: await deployERC1155Contract({
+          chain,
+          client,
+          account,
+          type: "TokenERC1155",
+          params: {
+            name: "edition",
+            contractURI: TEST_CONTRACT_URI,
+          },
+        }),
+      });
+
+      await sendAndConfirmTransaction({
         account,
-        type: "TokenERC1155",
-        params: {
-          name: "edition",
-          contractURI: TEST_CONTRACT_URI,
+        transaction: mintToBatch({
+          contract,
+          to: account.address,
+          nfts: [
+            { metadata: { name: "token 0" }, supply: 1n },
+            { metadata: { name: "token 1" }, supply: 2n },
+            { metadata: { name: "token 2" }, supply: 3n },
+          ],
+        }),
+      });
+
+      const nfts = await getNFTs({ contract });
+      expect(nfts).toStrictEqual([
+        {
+          metadata: { name: "token 0" },
+          owner: null,
+          id: 0n,
+          tokenURI: "ipfs://QmPZ6LpGqMuFbHKTXrNW1NRNLHf1nrxS4dtoFqdZZTKvPX/0",
+          type: "ERC1155",
+          supply: 1n,
         },
-      }),
+        {
+          metadata: { name: "token 1" },
+          owner: null,
+          id: 1n,
+          tokenURI: "ipfs://QmRFPyc3yEYxR4pQxwyTQWTine51TxWCoD6nzJWR3eX45b/0",
+          type: "ERC1155",
+          supply: 2n,
+        },
+        {
+          metadata: { name: "token 2" },
+          owner: null,
+          id: 2n,
+          tokenURI: "ipfs://QmesQiRLHCgqWZM2GFCs7Nb7rr2S72hU1BVQc7xiTyKZtT/0",
+          type: "ERC1155",
+          supply: 3n,
+        },
+      ]);
     });
-
-    await sendAndConfirmTransaction({
-      account,
-      transaction: mintToBatch({
-        contract,
-        to: account.address,
-        nfts: [
-          { metadata: { name: "token 0" }, supply: 1n },
-          { metadata: { name: "token 1" }, supply: 2n },
-          { metadata: { name: "token 2" }, supply: 3n },
-        ],
-      }),
-    });
-
-    const nfts = await getNFTs({ contract });
-    expect(nfts).toStrictEqual([
-      {
-        metadata: { name: "token 0" },
-        owner: null,
-        id: 0n,
-        tokenURI: "ipfs://QmPZ6LpGqMuFbHKTXrNW1NRNLHf1nrxS4dtoFqdZZTKvPX/0",
-        type: "ERC1155",
-        supply: 1n,
-      },
-      {
-        metadata: { name: "token 1" },
-        owner: null,
-        id: 1n,
-        tokenURI: "ipfs://QmRFPyc3yEYxR4pQxwyTQWTine51TxWCoD6nzJWR3eX45b/0",
-        type: "ERC1155",
-        supply: 2n,
-      },
-      {
-        metadata: { name: "token 2" },
-        owner: null,
-        id: 2n,
-        tokenURI: "ipfs://QmesQiRLHCgqWZM2GFCs7Nb7rr2S72hU1BVQc7xiTyKZtT/0",
-        type: "ERC1155",
-        supply: 3n,
-      },
-    ]);
-  });
-});
+  },
+);


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR refactors the test for the `mintToBatch` function in the `ERC1155 Edition` module, enhancing its structure and clarity. It modifies the test to run conditionally based on the presence of a secret key and organizes the minting logic more effectively.

### Detailed summary
- Changed `describe` to run conditionally with `process.env.TW_SECRET_KEY`.
- Improved organization of the test case for `mintToBatch`.
- Added `account` to the contract deployment parameters.
- Consolidated the minting transaction logic.
- Retained the NFT expectation check after minting.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->