### PR TITLE
fix: resolve ecosystem image URL using thirdweb storage

### DIFF
--- a/apps/wallet-ui/src/app/[ecosystem]/(authed)/layout.tsx
+++ b/apps/wallet-ui/src/app/[ecosystem]/(authed)/layout.tsx
@@ -1,6 +1,8 @@
 import ConnectButton from "@/components/ConnectButton";
 import { authedOnly } from "@/lib/auth";
 import { getEcosystemInfo } from "@/lib/ecosystems";
+import { resolveScheme } from "thirdweb/storage";
+import { client } from "../../../lib/client";
 
 export default async function Layout({
   children,
@@ -18,7 +20,7 @@ export default async function Layout({
           <div className="flex items-center gap-2">
             <img
               className="h-8 w-8"
-              src={ecosystem.imageUrl}
+              src={resolveScheme({ uri: ecosystem.imageUrl, client })}
               alt={ecosystem.name}
               width={100}
               height={100}


### PR DESCRIPTION
## Problem solved

Fixes CNCT-2087

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `Layout` component in the `wallet-ui` application by improving how the ecosystem image is resolved, leveraging the `resolveScheme` function from the `thirdweb/storage` library.

### Detailed summary
- Added import for `resolveScheme` from `thirdweb/storage`.
- Added import for `client` from `../../../lib/client`.
- Updated the `src` attribute of the `img` tag to use `resolveScheme({ uri: ecosystem.imageUrl, client })` instead of directly using `ecosystem.imageUrl`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->