### PR TITLE
feat: auto-resolve entrypoint address from factory

### DIFF
--- a/.changeset/late-bats-cry.md
+++ b/.changeset/late-bats-cry.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Auto resolve entrypoint address from factory when available

--- a/packages/thirdweb/src/wallets/smart/smart-wallet-integration-v07.test.ts
+++ b/packages/thirdweb/src/wallets/smart/smart-wallet-integration-v07.test.ts
@@ -23,7 +23,7 @@ import { isContractDeployed } from "../../utils/bytecode/is-contract-deployed.js
 import { sleep } from "../../utils/sleep.js";
 import type { Account, Wallet } from "../interfaces/wallet.js";
 import { generateAccount } from "../utils/generateAccount.js";
-import { ENTRYPOINT_ADDRESS_v0_7 } from "./lib/constants.js";
+import { DEFAULT_ACCOUNT_FACTORY_V0_7 } from "./lib/constants.js";
 import { smartWallet } from "./smart-wallet.js";
 
 let wallet: Wallet;
@@ -54,9 +54,7 @@ describe.runIf(process.env.TW_SECRET_KEY).sequential(
       wallet = smartWallet({
         chain,
         gasless: true,
-        overrides: {
-          entrypointAddress: ENTRYPOINT_ADDRESS_v0_7,
-        },
+        factoryAddress: DEFAULT_ACCOUNT_FACTORY_V0_7,
       });
       smartAccount = await wallet.connect({
         client: TEST_CLIENT,

--- a/packages/thirdweb/src/wallets/smart/smart-wallet.ts
+++ b/packages/thirdweb/src/wallets/smart/smart-wallet.ts
@@ -85,21 +85,18 @@ import { getDefaultAccountFactory } from "./lib/constants.js";
  *
  * ## Using v0.7 Entrypoint
  *
- * Both v0.6 (default) and v0.7 ERC4337 Entrypoints are supported. To use the v0.7 Entrypoint, you can pass the `entrypointAddress` option to the `smartWallet` function, as well as a compatible account factory.
+ * Both v0.6 (default) and v0.7 ERC4337 Entrypoints are supported. To use the v0.7 Entrypoint, simply pass in a compatible account factory.
  *
  * You can use the predeployed `DEFAULT_ACCOUNT_FACTORY_V0_7` or deploy your own [AccountFactory  v0.7](https://thirdweb.com/thirdweb.eth/AccountFactory_0_7).
  *
  * ```ts
- * import { smartWallet, DEFAULT_ACCOUNT_FACTORY_V0_7, ENTRYPOINT_ADDRESS_v0_7 } from "thirdweb/wallets/smart";
+ * import { smartWallet, DEFAULT_ACCOUNT_FACTORY_V0_7 } from "thirdweb/wallets/smart";
  * import { sepolia } from "thirdweb/chains";
  *
  * const wallet = smartWallet({
  *  chain: sepolia,
  *  sponsorGas: true, // enable sponsored transactions
- *  factoryAddress: DEFAULT_ACCOUNT_FACTORY_V0_7,
- *  overrides: {
- *    entrypointAddress: ENTRYPOINT_ADDRESS_v0_7
- *  }
+ *  factoryAddress: DEFAULT_ACCOUNT_FACTORY_V0_7, // 0.7 factory address
  * });
  * ```
  *


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `smartWallet` integration by automatically resolving the entrypoint address from the factory when it's available, simplifying the wallet setup process.

### Detailed summary
- Replaced the `entrypointAddress` override with `factoryAddress` in `smart-wallet-integration-v07.test.ts`.
- Updated documentation to reflect the removal of the `entrypointAddress` option.
- Added logic to automatically resolve the entrypoint address from the factory in `connectSmartWallet`.
- Introduced a new function `getEntrypointFromFactory` to fetch the entrypoint address from the specified factory contract.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->