### PR TITLE
Try very high staticPageGenerationTimeout value

### DIFF
--- a/apps/dashboard/next.config.js
+++ b/apps/dashboard/next.config.js
@@ -164,6 +164,7 @@ const moduleExports = {
     emotion: true,
   },
   productionBrowserSourceMaps: false,
+  staticPageGenerationTimeout: 500,
 };
 
 const { withSentryConfig } = require("@sentry/nextjs");

--- a/apps/dashboard/src/app/(dashboard)/explore/[category]/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/explore/[category]/page.tsx
@@ -144,6 +144,3 @@ export async function generateStaticParams() {
     params: { category },
   }));
 }
-
-// TODO - figure out why this page is not building if we let it be static
-export const dynamic = "force-dynamic";

--- a/apps/dashboard/src/app/(dashboard)/explore/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/explore/page.tsx
@@ -57,6 +57,3 @@ export default async function ExplorePage() {
     </div>
   );
 }
-
-// TODO - figure out why this page is not building if we let it be static
-export const dynamic = "force-dynamic";


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the configuration for static page generation in a Next.js application and addressing issues related to dynamic page rendering.

### Detailed summary
- In `next.config.js`, added `staticPageGenerationTimeout` set to `500`.
- Removed comments and the `dynamic` export set to `"force-dynamic"` in `apps/dashboard/src/app/(dashboard)/explore/page.tsx`.
- Removed comments and the `dynamic` export set to `"force-dynamic"` in `apps/dashboard/src/app/(dashboard)/explore/[category]/page.tsx`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->