### PR TITLE
Show 404 on deprecated chain contract page

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/layout.tsx
@@ -28,14 +28,19 @@ export default async function Layout(props: {
     return <ConfigureCustomChain chainSlug={props.params.chain_id} />;
   }
 
+  const { contract, chainMetadata } = info;
+
+  if (chainMetadata.status === "deprecated") {
+    notFound();
+  }
+
   // check if the contract exists
-  const isValidContract = await isContractDeployed(info.contract);
+  const isValidContract = await isContractDeployed(contract);
   if (!isValidContract) {
     // TODO - replace 404 with a better page to upsale deploy or other thirdweb products
     notFound();
   }
 
-  const { contract, chainMetadata } = info;
   const contractPageMetadata = await getContractPageMetadata(contract);
   const sidebarLinks = getContractPageSidebarLinks({
     chainSlug: chainMetadata.slug,


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `layout.tsx` file to improve the handling of contract information and metadata, particularly addressing deprecated chain statuses and modifying the contract validation logic.

### Detailed summary
- Added a check for `chainMetadata.status` to call `notFound()` if the status is "deprecated".
- Changed the variable used in `isContractDeployed` from `info.contract` to `contract`.
- Adjusted the order of variable declarations for `contract` and `chainMetadata`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->