### PR TITLE
[SDK] get ERC20Value for claimToBatch

### DIFF
--- a/packages/thirdweb/src/transaction/prepare-transaction.ts
+++ b/packages/thirdweb/src/transaction/prepare-transaction.ts
@@ -25,10 +25,20 @@ export type StaticPrepareTransactionOptions = {
   client: ThirdwebClient;
   // extras
   extraCallData?: Hex;
-  erc20Value?: {
-    amountWei: bigint;
-    tokenAddress: Address;
-  };
+  erc20Value?:
+    | {
+        amountWei: bigint;
+        tokenAddress: Address;
+      }
+    | Promise<
+        Readonly<
+          | {
+              amountWei: bigint;
+              tokenAddress: Address;
+            }
+          | undefined
+        >
+      >;
 };
 
 export type EIP712TransactionOptions = {


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `erc20Value` type in `prepare-transaction.ts` and adding a new `getERC20Value` function in `claimToBatch.ts` to handle promise resolutions for ERC20 values in batch claims.

### Detailed summary
- Updated `erc20Value` type to allow a promise or undefined in `prepare-transaction.ts`.
- Modified `claimToBatch` function to include `erc20Value` in the overrides.
- Added `getERC20Value` function to resolve and aggregate ERC20 values from claims.
- Implemented filtering and summation logic in `getERC20Value`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->