### PR TITLE
redirect /team/~/... to /team/<first-team-slug>/...

### DIFF
--- a/apps/dashboard/src/middleware.ts
+++ b/apps/dashboard/src/middleware.ts
@@ -1,3 +1,4 @@
+import { getTeams } from "@/api/team";
 import { isLoginRequired } from "@/constants/auth";
 import { COOKIE_ACTIVE_ACCOUNT, COOKIE_PREFIX_TOKEN } from "@/constants/cookie";
 import { type NextRequest, NextResponse } from "next/server";
@@ -91,6 +92,18 @@ export async function middleware(request: NextRequest) {
     // if we have more than 1 path part, we're in the <address>/<slug> case -> publish page
     if (paths.length > 1) {
       return rewrite(request, `/published-contract${pathname}`);
+    }
+  }
+
+  // redirect /team/~/... to /team/<first_team_slug>/...
+  if (paths[0] === "team" && paths[1] === "~") {
+    // TODO - need an API to get the first team to avoid fetching all teams
+    const teams = await getTeams();
+    const firstTeam = teams[0];
+    if (firstTeam) {
+      const modifiedPaths = [...paths];
+      modifiedPaths[1] = firstTeam.slug;
+      return redirect(request, `/${modifiedPaths.join("/")}`);
     }
   }
   // END /<address>/... case


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new redirect functionality in the `middleware` for handling requests to `/team/~/...`, redirecting them to the first team's slug.

### Detailed summary
- Added a check for the path starting with `team` and `~`.
- Implemented a call to `getTeams()` to retrieve the list of teams.
- Redirects to the first team's slug if available.
- Maintains existing functionality for other paths.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->