### PR TITLE
Update service-utils event publishing to accept any source

### DIFF
--- a/packages/service-utils/src/core/usage.ts
+++ b/packages/service-utils/src/core/usage.ts
@@ -1,20 +1,7 @@
 import { z } from "zod";
 
 export const usageEventSchema = z.object({
-  source: z.enum([
-    "ecosystemWallets",
-    "embeddedWallets",
-    "rpc",
-    "storage",
-    "bundler",
-    "paymaster",
-    "relayer",
-    "connectWallet",
-    "checkout",
-    "engine",
-    "pay",
-    "rpcV2",
-  ]),
+  source: z.string(),
   action: z.string(),
 
   /**


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `usageEventSchema` in `packages/service-utils/src/core/usage.ts` by changing the type of the `source` field from an enumeration to a string, allowing for more flexibility in the values that can be assigned to `source`.

### Detailed summary
- Changed the type of `source` from `z.enum([...])` to `z.string()`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->