### PR TITLE
[Dashboard] Fix: Exclude testnet $ from total sponsored

### DIFF
--- a/apps/dashboard/src/@3rdweb-sdk/react/hooks/useApi.ts
+++ b/apps/dashboard/src/@3rdweb-sdk/react/hooks/useApi.ts
@@ -5,6 +5,7 @@ import {
   useQueryClient,
 } from "@tanstack/react-query";
 import { THIRDWEB_ANALYTICS_API_HOST, THIRDWEB_API_HOST } from "constants/urls";
+import { useAllChainsData } from "hooks/chains/allChains";
 import invariant from "tiny-invariant";
 import { accountKeys, apiKeys, authorizedWallets } from "../cache-keys";
 import { useLoggedInUser } from "./useLoggedInUser";
@@ -442,6 +443,7 @@ export function useUserOpUsageAggregate(args: {
 }) {
   const { clientId, from, to } = args;
   const { user, isLoggedIn } = useLoggedInUser();
+  const chainStore = useAllChainsData();
 
   return useQuery<UserOpStats>({
     queryKey: accountKeys.userOpStats(
@@ -452,16 +454,25 @@ export function useUserOpUsageAggregate(args: {
       "all",
     ),
     queryFn: async () => {
-      const userOpStats: UserOpStats[] = await getUserOpUsage({
-        clientId,
-        from,
-        to,
-        period: "all",
-      });
+      const userOpStats: (UserOpStats & { chainId?: string })[] =
+        await getUserOpUsage({
+          clientId,
+          from,
+          to,
+          period: "all",
+        });
 
       // Aggregate stats across wallet types
       return userOpStats.reduce(
         (acc, curr) => {
+          // Skip testnets from the aggregated stats
+          if (curr.chainId) {
+            const chain = chainStore.idToChain.get(Number(curr.chainId));
+            if (chain?.testnet) {
+              return acc;
+            }
+          }
+
           acc.successful += curr.successful;
           acc.failed += curr.failed;
           acc.sponsoredUsd += curr.sponsoredUsd;

--- a/apps/dashboard/src/components/analytics/stat.tsx
+++ b/apps/dashboard/src/components/analytics/stat.tsx
@@ -8,7 +8,9 @@ export const Stat: React.FC<{
     <dl className="flex items-center justify-between gap-4 rounded-lg border border-border bg-muted/50 p-4 lg:p-6">
       <div>
         <dd className="font-semibold text-3xl tracking-tight lg:text-5xl">
-          {value && formatter ? formatter(value) : value?.toLocaleString()}
+          {value !== undefined && formatter
+            ? formatter(value)
+            : value?.toLocaleString()}
         </dd>
         <dt className="font-medium text-muted-foreground text-sm tracking-tight lg:text-lg">
           {label}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the `useUserOpUsageAggregate` hook in the `useApi.ts` file by incorporating chain data and refining the aggregation logic to exclude testnets. Additionally, it updates the rendering logic in `stat.tsx` for better handling of `value` and `formatter`.

### Detailed summary
- Updated rendering logic in `stat.tsx` to check for `value` using `!== undefined`.
- Added `useAllChainsData` import in `useApi.ts`.
- Introduced `chainStore` to access chain data in `useUserOpUsageAggregate`.
- Modified `userOpStats` type to include optional `chainId`.
- Implemented logic to skip testnets in aggregated stats.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->