### PR TITLE
feat: always add URI to SIWE payload

### DIFF
--- a/.changeset/soft-weeks-know.md
+++ b/.changeset/soft-weeks-know.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Always add URI to SIWE payload

--- a/packages/thirdweb/src/auth/core/generate-login-payload.test.ts
+++ b/packages/thirdweb/src/auth/core/generate-login-payload.test.ts
@@ -89,7 +89,7 @@ describe("generateLoginPayload", () => {
         "issued_at": "1970-01-01T00:00:00.000Z",
         "resources": undefined,
         "statement": "Please ensure that the domain above matches the URL of the current website.",
-        "uri": undefined,
+        "uri": "example.com",
         "version": "1",
       }
     `);

--- a/packages/thirdweb/src/auth/core/generate-login-payload.ts
+++ b/packages/thirdweb/src/auth/core/generate-login-payload.ts
@@ -46,7 +46,7 @@ export function generateLoginPayload(options: AuthOptions) {
       statement: options.login?.statement || DEFAULT_LOGIN_STATEMENT,
       version: options.login?.version || DEFAULT_LOGIN_VERSION,
       resources: options.login?.resources,
-      uri: options.login?.uri,
+      uri: options.login?.uri || options.domain,
     };
   };
 }


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on ensuring that the `uri` is always included in the SIWE payload by providing a default value based on the `domain` if it is not specified.

### Detailed summary
- Updated `generate-login-payload.ts` to set `uri` to `options.login?.uri || options.domain`.
- Modified the test in `generate-login-payload.test.ts` to expect `uri` to be "example.com" instead of `undefined`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->