### PR TITLE
feat: set initial balance for Anvil proxy in tests

### DIFF
--- a/packages/thirdweb/src/wallets/smart/smart-wallet-integration.test.ts
+++ b/packages/thirdweb/src/wallets/smart/smart-wallet-integration.test.ts
@@ -20,6 +20,7 @@ import { sendAndConfirmTransaction } from "../../transaction/actions/send-and-co
 import { sendBatchTransaction } from "../../transaction/actions/send-batch-transaction.js";
 import { waitForReceipt } from "../../transaction/actions/wait-for-tx-receipt.js";
 import { isContractDeployed } from "../../utils/bytecode/is-contract-deployed.js";
+import { sleep } from "../../utils/sleep.js";
 import type { Account, Wallet } from "../interfaces/wallet.js";
 import { generateAccount } from "../utils/generateAccount.js";
 import { smartWallet } from "./smart-wallet.js";
@@ -332,15 +333,17 @@ describe.runIf(process.env.TW_SECRET_KEY).sequential(
           }),
           account: newSmartAccount,
         }),
-        sendAndConfirmTransaction({
-          transaction: claimTo({
-            contract,
-            quantity: 1n,
-            to: newSmartAccount.address,
-            tokenId: 0n,
+        sleep(1000).then(() =>
+          sendAndConfirmTransaction({
+            transaction: claimTo({
+              contract,
+              quantity: 1n,
+              to: newSmartAccount.address,
+              tokenId: 0n,
+            }),
+            account: newSmartAccount,
           }),
-          account: newSmartAccount,
-        }),
+        ),
       ]);
       expect(txs.length).toEqual(2);
       expect(txs.every((t) => t.transactionHash.length === 66)).toBe(true);

--- a/packages/thirdweb/test/globalSetup.ts
+++ b/packages/thirdweb/test/globalSetup.ts
@@ -62,6 +62,9 @@ export default async function globalSetup() {
 
   const shutdownAnvil = await startProxy({
     port: 8648,
+    options: {
+      balance: 1000000000n,
+    },
   });
 
   // TODO re-enable thirdweb RPC for this fork


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the testing functionality for the `smart-wallet` integration by adding a delay before sending a transaction and introducing a new option for the `startProxy` function.

### Detailed summary
- Added an `options` parameter with a `balance` of `1000000000n` to the `startProxy` function in `globalSetup.ts`.
- Imported the `sleep` function in `smart-wallet-integration.test.ts`.
- Implemented a delay of 1000 milliseconds before calling `sendAndConfirmTransaction` in the test for the `smart-wallet`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->