### PR TITLE
Remove isValidContract check for localhost chain on contract page

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/layout.tsx
@@ -4,6 +4,7 @@ import { ContractMetadata } from "components/custom-contract/contract-header/con
 import { DeprecatedAlert } from "components/shared/DeprecatedAlert";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import { localhost } from "thirdweb/chains";
 import { getContractMetadata } from "thirdweb/extensions/common";
 import { isAddress, isContractDeployed } from "thirdweb/utils";
 import { resolveFunctionSelectors } from "../../../../../lib/selectors";
@@ -38,11 +39,15 @@ export default async function Layout(props: {
     notFound();
   }
 
-  // check if the contract exists
-  const isValidContract = await isContractDeployed(contract).catch(() => false);
-  if (!isValidContract) {
-    // TODO - replace 404 with a better page to upsale deploy or other thirdweb products
-    notFound();
+  if (contract.chain.id !== localhost.id) {
+    // check if the contract exists
+    const isValidContract = await isContractDeployed(contract).catch(
+      () => false,
+    );
+    if (!isValidContract) {
+      // TODO - replace 404 with a better page to upsale deploy or other thirdweb products
+      notFound();
+    }
   }
 
   const contractPageMetadata = await getContractPageMetadata(contract);


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added



<!-- start pr-codex -->

---

## PR-Codex overview
This PR modifies the `layout.tsx` file to enhance the contract validation logic by including a check for the `localhost` chain ID before verifying if a contract is deployed. This helps prevent unnecessary contract checks for local development environments.

### Detailed summary
- Added an import for `localhost` from `thirdweb/chains`.
- Wrapped the contract existence check in a condition to only execute if the `contract.chain.id` is not `localhost.id`.
- Maintained the existing logic for handling invalid contracts and the `notFound` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->