### PR TITLE
Add a case study to project showcase

### DIFF
--- a/apps/dashboard/src/lib/project-showcase-constants.ts
+++ b/apps/dashboard/src/lib/project-showcase-constants.ts
@@ -455,6 +455,18 @@ export const PROJECT_SHOWCASE_DATA = [
     industries: ["Decentralized Finance", "Games", "Tools"],
     link: "https://xaigames.io",
   },
+  {
+    id: 42,
+    title: "Zeeverse",
+    slug: "zeeverse",
+    description:
+      "Zeeverse is a free-to-play monster-tamer RPG set in an indigenous fantasy world.",
+    image: "ipfs://QmU9MTJk4ESbJ7XGYUQzZqXxHWFUAx7SZNmeYDfLZHExtd",
+    industries: ["Game"],
+    link: "https://zee-verse.com/?ref=blog.thirdweb.com",
+    case_study:
+      "https://blog.thirdweb.com/case-studies/how-zeeverse-built-a-monster-tamer-rpg-with-seamless-web3-onboarding/",
+  },
 ];
 
 export const PROJECT_SHOWCASE_INDUSTRIES = [


### PR DESCRIPTION
Last PR related to this, guaranteed


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new project entry to the `PROJECT_SHOWCASE_INDUSTRIES` in the `project-showcase-constants.ts` file, detailing a game called "Zeeverse."

### Detailed summary
- Added a new project with `id: 42`.
- Set `title` to "Zeeverse".
- Assigned `slug` as "zeeverse".
- Provided a description of "Zeeverse" as a free-to-play monster-tamer RPG.
- Included an `image` link for the project.
- Categorized under `industries` as ["Game"].
- Added a `link` to the project website.
- Included a `case_study` URL for further information.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->