### PR TITLE
Fix op estimation edge case

### DIFF
--- a/packages/thirdweb/src/wallets/smart/lib/bundler.ts
+++ b/packages/thirdweb/src/wallets/smart/lib/bundler.ts
@@ -149,7 +149,7 @@ export async function getUserOpGasFees(args: {
 export async function getUserOpReceipt(
   args: BundlerOptions & {
     userOpHash: Hex;
-  }
+  },
 ): Promise<TransactionReceipt | undefined> {
   const res = await getUserOpReceiptRaw(args);
 
@@ -166,7 +166,7 @@ export async function getUserOpReceipt(
     const revertReason = logs[0]?.args?.revertReason;
     if (!revertReason) {
       throw new Error(
-        `UserOp failed at txHash: ${res.receipt.transactionHash}`
+        `UserOp failed at txHash: ${res.receipt.transactionHash}`,
       );
     }
     const revertMsg = decodeErrorResult({
@@ -175,7 +175,7 @@ export async function getUserOpReceipt(
     throw new Error(
       `UserOp failed with reason: '${revertMsg.args.join(",")}' at txHash: ${
         res.receipt.transactionHash
-      }`
+      }`,
     );
   }
   return res.receipt;
@@ -200,7 +200,7 @@ export async function getUserOpReceipt(
 export async function getUserOpReceiptRaw(
   args: BundlerOptions & {
     userOpHash: Hex;
-  }
+  },
 ): Promise<UserOperationReceipt | undefined> {
   const res = await sendBundlerRequest({
     options: args,
@@ -297,7 +297,7 @@ async function sendBundlerRequest(args: {
     throw new Error(
       `${operation} error: ${error}
 Status: ${response.status}
-Code: ${code}`
+Code: ${code}`,
     );
   }
 

--- a/packages/thirdweb/src/wallets/smart/lib/bundler.ts
+++ b/packages/thirdweb/src/wallets/smart/lib/bundler.ts
@@ -84,7 +84,10 @@ export async function estimateUserOpGas(args: {
   // add gas buffer for managed account factory delegate calls
   return {
     preVerificationGas: hexToBigInt(res.preVerificationGas),
-    verificationGas: hexToBigInt(res.verificationGas),
+    verificationGas:
+      res.verificationGas !== undefined
+        ? hexToBigInt(res.verificationGas)
+        : undefined,
     verificationGasLimit: hexToBigInt(res.verificationGasLimit),
     callGasLimit: hexToBigInt(res.callGasLimit) + MANAGED_ACCOUNT_GAS_BUFFER,
     paymasterVerificationGasLimit:
@@ -146,7 +149,7 @@ export async function getUserOpGasFees(args: {
 export async function getUserOpReceipt(
   args: BundlerOptions & {
     userOpHash: Hex;
-  },
+  }
 ): Promise<TransactionReceipt | undefined> {
   const res = await getUserOpReceiptRaw(args);
 
@@ -163,7 +166,7 @@ export async function getUserOpReceipt(
     const revertReason = logs[0]?.args?.revertReason;
     if (!revertReason) {
       throw new Error(
-        `UserOp failed at txHash: ${res.receipt.transactionHash}`,
+        `UserOp failed at txHash: ${res.receipt.transactionHash}`
       );
     }
     const revertMsg = decodeErrorResult({
@@ -172,7 +175,7 @@ export async function getUserOpReceipt(
     throw new Error(
       `UserOp failed with reason: '${revertMsg.args.join(",")}' at txHash: ${
         res.receipt.transactionHash
-      }`,
+      }`
     );
   }
   return res.receipt;
@@ -197,7 +200,7 @@ export async function getUserOpReceipt(
 export async function getUserOpReceiptRaw(
   args: BundlerOptions & {
     userOpHash: Hex;
-  },
+  }
 ): Promise<UserOperationReceipt | undefined> {
   const res = await sendBundlerRequest({
     options: args,
@@ -294,7 +297,7 @@ async function sendBundlerRequest(args: {
     throw new Error(
       `${operation} error: ${error}
 Status: ${response.status}
-Code: ${code}`,
+Code: ${code}`
     );
   }
 

--- a/packages/thirdweb/src/wallets/smart/types.ts
+++ b/packages/thirdweb/src/wallets/smart/types.ts
@@ -172,7 +172,7 @@ export type PaymasterResult = {
 
 export type EstimationResult = {
   preVerificationGas: bigint;
-  verificationGas: bigint;
+  verificationGas?: bigint;
   verificationGasLimit: bigint;
   callGasLimit: bigint;
   // v0.7 types


### PR DESCRIPTION
## Problem solved

Generally verificationGas is not a thing, but just in case it is with some bundlers, making it optional so it doesn't throw "Cannot convert undefined to a BigInt"

<!-- start pr-codex -->

---

## PR-Codex overview
This PR modifies the `EstimationResult` type and its usage in the `bundler.ts` file to make the `verificationGas` property optional. This change allows for better handling of cases where `verificationGas` may not be present.

### Detailed summary
- In `types.ts`, changed `verificationGas` from a required property to an optional property (`verificationGas?: bigint`).
- In `bundler.ts`, updated the return statement to check if `res.verificationGas` is defined before converting it with `hexToBigInt`, returning `undefined` if not present.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->