### PR TITLE
unhide insight service

### DIFF
--- a/apps/dashboard/src/components/settings/ApiKeys/validations.ts
+++ b/apps/dashboard/src/components/settings/ApiKeys/validations.ts
@@ -149,4 +149,4 @@ export type ApiKeyPayConfigValidationSchema = z.infer<
 >;
 
 // FIXME: Remove
-export const HIDDEN_SERVICES = ["relayer", "chainsaw", "insight"];
+export const HIDDEN_SERVICES = ["relayer", "chainsaw"];


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying the `HIDDEN_SERVICES` constant in the `validations.ts` file by removing the `"insight"` service from the list of hidden services.

### Detailed summary
- Updated the `HIDDEN_SERVICES` constant in `apps/dashboard/src/components/settings/ApiKeys/validations.ts` 
- Removed `"insight"` from the array, leaving only `"relayer"` and `"chainsaw"` as hidden services.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->