### PR TITLE
Fix API key creation on embed page

### DIFF
--- a/apps/dashboard/src/components/settings/ApiKeys/Create/CreateApiKeyModal.stories.tsx
+++ b/apps/dashboard/src/components/settings/ApiKeys/Create/CreateApiKeyModal.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { useMutation } from "@tanstack/react-query";
 import { useState } from "react";
 import { Toaster } from "sonner";
-import { CreateAPIKeyDialogUI } from ".";
+import { CreateAPIKeyDialogUI, type CreateAPIKeyPrefillOptions } from ".";
 import { createApiKeyStub } from "../../../../stories/stubs";
 import { mobileViewport } from "../../../../stories/utils";
 
@@ -51,8 +51,19 @@ export const MobileAPIKeyWording: Story = {
   },
 };
 
+export const DesktopAPIKeyWordingWithPrefill: Story = {
+  args: {
+    wording: "api-key",
+    prefill: {
+      name: "Foo",
+      domains: "foo.bar",
+    },
+  },
+};
+
 function Story(props: {
   wording: "project" | "api-key";
+  prefill?: CreateAPIKeyPrefillOptions;
 }) {
   const [isOpen, setIsOpen] = useState(true);
   const mutation = useMutation({
@@ -72,6 +83,7 @@ function Story(props: {
         open={isOpen}
         onOpenChange={setIsOpen}
         createKeyMutation={mutation}
+        prefill={props.prefill}
       />
 
       <Button

--- a/apps/dashboard/src/components/settings/ApiKeys/Create/index.tsx
+++ b/apps/dashboard/src/components/settings/ApiKeys/Create/index.tsx
@@ -43,11 +43,17 @@ import {
   apiKeyCreateValidationSchema,
 } from "../validations";
 
+export type CreateAPIKeyPrefillOptions = {
+  name?: string;
+  domains?: string;
+};
+
 export type CreateAPIKeyDialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   wording: "project" | "api-key";
   onCreateAndComplete?: () => void;
+  prefill?: CreateAPIKeyPrefillOptions;
 };
 
 const CreateAPIKeyDialog = (props: CreateAPIKeyDialogProps) => {
@@ -71,6 +77,7 @@ export const CreateAPIKeyDialogUI = (props: {
     CreateKeyInput,
     unknown
   >;
+  prefill?: CreateAPIKeyPrefillOptions;
 }) => {
   const [screen, setScreen] = useState<
     { id: "create" } | { id: "api-details"; key: ApiKey }
@@ -102,6 +109,7 @@ export const CreateAPIKeyDialogUI = (props: {
               onAPIKeyCreated={(key) => {
                 setScreen({ id: "api-details", key });
               }}
+              prefill={props.prefill}
             />
           )}
 
@@ -131,6 +139,7 @@ function CreateAPIKeyForm(props: {
     unknown
   >;
   onAPIKeyCreated: (key: ApiKey) => void;
+  prefill?: CreateAPIKeyPrefillOptions;
 }) {
   const { wording } = props;
   const [showAlert, setShowAlert] = useState<"no-domain" | "any-domain">();
@@ -141,8 +150,8 @@ function CreateAPIKeyForm(props: {
   const form = useForm<ApiKeyCreateValidationSchema>({
     resolver: zodResolver(apiKeyCreateValidationSchema),
     defaultValues: {
-      name: "",
-      domains: "",
+      name: props.prefill?.name || "",
+      domains: props.prefill?.domains || "",
     },
   });
 


### PR DESCRIPTION
Fixes: DASH-340

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new feature for pre-filling API key creation forms and enhances the `CreateAPIKeyDialog` component. It also updates the `EmbedSetup` component to include a modal for creating API keys and adjusts the handling of user interactions based on account status.

### Detailed summary
- Added `CreateAPIKeyPrefillOptions` type for pre-filling API key forms.
- Introduced `DesktopAPIKeyWordingWithPrefill` story for testing.
- Modified `CreateAPIKeyDialogProps` and `CreateAPIKeyDialogUI` to accept `prefill` prop.
- Updated `CreateAPIKeyForm` to utilize pre-fill values.
- Implemented `LazyCreateAPIKeyDialog` in `EmbedSetup` for API key creation.
- Adjusted button behavior in `EmbedSetup` to show modal based on user account status.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->