### PR TITLE
feat: set default domain for thirdweb auth

### DIFF
--- a/apps/playground-web/src/app/connect/auth/server/actions/auth.ts
+++ b/apps/playground-web/src/app/connect/auth/server/actions/auth.ts
@@ -8,7 +8,7 @@ import { generateAccount, privateKeyToAccount } from "thirdweb/wallets";
 const privateKey = process.env.THIRDWEB_ADMIN_PRIVATE_KEY;
 
 const thirdwebAuth = createAuth({
-  domain: process.env.NEXT_PUBLIC_THIRDWEB_AUTH_DOMAIN || "",
+  domain: process.env.NEXT_PUBLIC_THIRDWEB_AUTH_DOMAIN || "thirdweb.com",
   client: THIRDWEB_CLIENT,
   adminAccount: privateKey
     ? privateKeyToAccount({ client: THIRDWEB_CLIENT, privateKey })


### PR DESCRIPTION
## Problem solved

Addresses CNCT-2132

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `domain` configuration in the `thirdwebAuth` object to use a default value of `"thirdweb.com"` if the environment variable `NEXT_PUBLIC_THIRDWEB_AUTH_DOMAIN` is not set.

### Detailed summary
- Changed the `domain` property in the `thirdwebAuth` configuration from an empty string to `"thirdweb.com"` as the default value.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->