### PR TITLE
Fix error thrown from PublishedBy card on localhost chain

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/overview/contract-overview-page.client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/overview/contract-overview-page.client.tsx
@@ -1,17 +1,9 @@
 "use client";
-
-import { useThirdwebClient } from "@/constants/thirdweb.client";
-import { useQuery } from "@tanstack/react-query";
 import type { ThirdwebContract } from "thirdweb";
 import type { ChainMetadata } from "thirdweb/chains";
-import { useActiveAccount } from "thirdweb/react";
 import { ErrorPage, LoadingPage } from "../_components/page-skeletons";
 import { useContractPageMetadata } from "../_hooks/useContractPageMetadata";
 import { ContractOverviewPage } from "./ContractOverviewPage";
-import {
-  PublishedByUI,
-  getPublishedByCardProps,
-} from "./components/published-by-ui";
 
 export function ContractOverviewPageClient(props: {
   contract: ThirdwebContract;
@@ -44,30 +36,8 @@ export function ContractOverviewPageClient(props: {
       chainSlug={chainMetadata.slug}
       isAnalyticsSupported={contractPageMetadata.isAnalyticsSupported}
       functionSelectors={contractPageMetadata.functionSelectors}
-      // TODO
-      publishedBy={<PublishedByClient contract={props.contract} />}
+      // TODO - create a fully client rendered version of publishedBy and ContractCard and plug it here
+      publishedBy={undefined}
     />
   );
-}
-
-function PublishedByClient(props: {
-  contract: ThirdwebContract;
-}) {
-  const client = useThirdwebClient();
-  const address = useActiveAccount()?.address;
-  const propsQuery = useQuery({
-    queryKey: ["getPublishedByCardProps", props],
-    queryFn: () =>
-      getPublishedByCardProps({
-        address: address || null,
-        client: client,
-        contract: props.contract,
-      }),
-  });
-
-  if (!propsQuery.data) {
-    return null;
-  }
-
-  return <PublishedByUI {...propsQuery.data} />;
 }


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the `ContractOverviewPageClient` component by removing the `PublishedByClient` function and its related imports, while also updating the `publishedBy` prop to be `undefined`. This is part of a larger effort to create a fully client-rendered version of certain components.

### Detailed summary
- Removed unused imports related to `useThirdwebClient`, `useQuery`, and `useActiveAccount`.
- Eliminated the `PublishedByClient` function, which fetched and displayed published by card props.
- Updated the `publishedBy` prop in `ContractOverviewPageClient` to be `undefined` instead of using `PublishedByClient`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->