### PR TITLE
Check for linear in PR description

### DIFF
--- a/.github/workflows/linear.yml
+++ b/.github/workflows/linear.yml
@@ -1,0 +1,26 @@
+name: Check for "linear" in pull request body
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+
+jobs:
+  check_linear_in_pr_body:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for linked issue in pull request body
+        run: |
+          pr_body=$(curl -s \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.number }} | jq -r .body)
+
+          echo "Pull Request Body: $pr_body"
+
+          if echo "$pr_body" | grep -iE "CNCT|DASH"; then
+            echo "Linked issue found in the pull request body."
+          else
+            echo "No linked issue found in the pull request body."
+            exit 1
+          fi


### PR DESCRIPTION
## Problem solved


Fixes https://linear.app/thirdweb/issue/ENG-2/better-enforce-linear-use

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a GitHub Actions workflow that checks for specific keywords in the pull request body to ensure linked issues are mentioned.

### Detailed summary
- Added a new workflow file: `.github/workflows/linear.yml`.
- Defined a workflow named `Check for "linear" in pull request body`.
- Triggered on pull request events (opened and edited).
- Created a job `check_linear_in_pr_body` to verify the presence of keywords "CNCT" or "DASH" in the PR body.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->