### PR TITLE
Winston/don't use iframe for jwt or custom auth endpoint validation

### DIFF
--- a/.changeset/three-dancers-hear.md
+++ b/.changeset/three-dancers-hear.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Consolidate custom jwt and custom auth endpoint through common endpoint

--- a/packages/thirdweb/src/wallets/in-app/core/authentication/guest.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/authentication/guest.ts
@@ -29,25 +29,22 @@ export async function guestAuthenticate(args: {
   }
 
   const clientFetch = getClientFetch(args.client, args.ecosystem);
-  const authResult = await (async () => {
-    const path = getLoginCallbackUrl({
-      authOption: "guest",
-      client: args.client,
-      ecosystem: args.ecosystem,
-    });
-    const res = await clientFetch(`${path}`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        sessionId,
-      }),
-    });
+  const path = getLoginCallbackUrl({
+    authOption: "guest",
+    client: args.client,
+    ecosystem: args.ecosystem,
+  });
+  const res = await clientFetch(`${path}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      sessionId,
+    }),
+  });
 
-    if (!res.ok) throw new Error("Failed to generate guest account");
+  if (!res.ok) throw new Error("Failed to generate guest account");
 
-    return (await res.json()) satisfies AuthStoredTokenWithCookieReturnType;
-  })();
-  return authResult;
+  return (await res.json()) satisfies AuthStoredTokenWithCookieReturnType;
 }

--- a/packages/thirdweb/src/wallets/in-app/core/authentication/jwt.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/authentication/jwt.ts
@@ -1,19 +1,21 @@
 import type { ThirdwebClient } from "../../../../client/client.js";
-import { getSessionHeaders } from "../../native/helpers/api/fetchers.js";
+import { getClientFetch } from "../../../../utils/fetch.js";
 import { ROUTE_AUTH_JWT_CALLBACK } from "../../native/helpers/constants.js";
 import { createErrorMessage } from "../../native/helpers/errors.js";
-import type { ClientScopedStorage } from "./client-scoped-storage.js";
+import type { Ecosystem } from "../wallet/types.js";
 import type { AuthStoredTokenWithCookieReturnType } from "./types.js";
 
 export async function customJwt(args: {
   jwt: string;
   client: ThirdwebClient;
-  storage: ClientScopedStorage;
+  ecosystem?: Ecosystem;
 }): Promise<AuthStoredTokenWithCookieReturnType> {
-  const resp = await fetch(ROUTE_AUTH_JWT_CALLBACK, {
+  const clientFetch = getClientFetch(args.client, args.ecosystem);
+
+  const res = await clientFetch(ROUTE_AUTH_JWT_CALLBACK, {
     method: "POST",
     headers: {
-      ...getSessionHeaders(),
+      "Content-Type": "application/json",
     },
     body: JSON.stringify({
       jwt: args.jwt,
@@ -21,13 +23,14 @@ export async function customJwt(args: {
     }),
   });
 
-  if (!resp.ok) {
-    const error = await resp.json();
+  if (!res.ok) {
+    const error = await res.json();
     throw new Error(`JWT authentication error: ${error.message}`);
   }
 
   try {
-    const { verifiedToken } = await resp.json();
+    const { verifiedToken } = await res.json();
+
     return { storedToken: verifiedToken };
   } catch (e) {
     throw new Error(

--- a/packages/thirdweb/src/wallets/in-app/native/helpers/api/fetchers.ts
+++ b/packages/thirdweb/src/wallets/in-app/native/helpers/api/fetchers.ts
@@ -19,7 +19,7 @@ const ECOSYSTEM_PARTNER_ID_HEADER = "x-ecosystem-partner-id";
 
 let sessionNonce: Hex | undefined = undefined;
 
-export function getSessionHeaders() {
+function getSessionHeaders() {
   if (!sessionNonce) {
     sessionNonce = randomBytesHex(16);
   }

--- a/packages/thirdweb/src/wallets/in-app/native/native-connector.ts
+++ b/packages/thirdweb/src/wallets/in-app/native/native-connector.ts
@@ -199,13 +199,13 @@ export class InAppNativeConnector implements InAppConnector {
         return customJwt({
           jwt: params.jwt,
           client: this.client,
-          storage: this.storage,
+          ecosystem: this.ecosystem,
         });
       case "auth_endpoint":
         return authEndpoint({
           payload: params.payload,
           client: this.client,
-          storage: this.storage,
+          ecosystem: this.ecosystem,
         });
       default:
         throw new Error(`Unsupported authentication type: ${strategy}`);


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR consolidates the custom JWT and custom authentication endpoint into a common endpoint, streamlining the authentication process in the `thirdweb` package.

### Detailed summary
- Removed `getSessionHeaders` function export in `fetchers.ts`.
- Updated `native-connector.ts` to include `ecosystem` in authentication payloads.
- Refactored guest authentication in `guest.ts` for clarity.
- Replaced direct fetch calls with `getClientFetch` in `jwt.ts` and `authEndpoint.ts`.
- Added `ecosystem` parameter to `customJwt` and `authEndpoint` functions.
- Updated `InAppWebConnector` to handle `recoveryCode` in `loginWithAuthToken`.
- Refactored authentication strategy handling to use consolidated endpoints.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->