### PR TITLE
Fix theming class hydration warning on html element

### DIFF
--- a/apps/dashboard/src/app/global-error.tsx
+++ b/apps/dashboard/src/app/global-error.tsx
@@ -27,7 +27,7 @@ export default function GlobalError({
   }, [error]);
 
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body>
         <h2>Something went wrong!</h2>
         <button type="button" onClick={() => reset()}>

--- a/apps/dashboard/src/app/layout.tsx
+++ b/apps/dashboard/src/app/layout.tsx
@@ -55,7 +55,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <head>
         <PlausibleProvider
           domain="thirdweb.com"

--- a/apps/playground-web/src/app/layout.tsx
+++ b/apps/playground-web/src/app/layout.tsx
@@ -32,7 +32,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <head>
         <Script
           src="https://thirdweb.com/js/pl.js"

--- a/apps/portal/src/app/layout.tsx
+++ b/apps/portal/src/app/layout.tsx
@@ -38,7 +38,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <head>
         <PosthogHeadSetup />
         <Script

--- a/apps/wallet-ui/src/app/layout.tsx
+++ b/apps/wallet-ui/src/app/layout.tsx
@@ -11,7 +11,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body
         className={cn(
           "flex min-h-screen w-full max-w-screen justify-center",


### PR DESCRIPTION
This is the correct way to fix this 
https://github.com/pacocoursey/next-themes?tab=readme-ov-file#with-app


` suppressHydrationWarning` property only applies one level deep, so it won't block hydration warnings on other child elements of `<html>`

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding the `suppressHydrationWarning` attribute to the `<html>` tag in multiple layout files to prevent hydration warnings in React applications.

### Detailed summary
- Added `suppressHydrationWarning` to `<html lang="en">` in:
  - `apps/portal/src/app/layout.tsx`
  - `apps/dashboard/src/app/layout.tsx`
  - `apps/playground-web/src/app/layout.tsx`
  - `apps/wallet-ui/src/app/layout.tsx`
  - `apps/dashboard/src/app/global-error.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->