### PR TITLE
Shorten publisher address in OG image on published contract page

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/published-contract/[publisher]/[contract_id]/utils/publishedContractOGImageTemplate.tsx
+++ b/apps/dashboard/src/app/(dashboard)/published-contract/[publisher]/[contract_id]/utils/publishedContractOGImageTemplate.tsx
@@ -1,7 +1,9 @@
 /* eslint-disable @next/next/no-img-element */
 import { getThirdwebClient } from "@/constants/thirdweb.server";
 import { ImageResponse } from "next/og";
+import { isAddress } from "thirdweb";
 import { download } from "thirdweb/storage";
+import { shortenAddress } from "thirdweb/utils";
 
 const OgBrandIcon: React.FC = () => (
   // biome-ignore lint/a11y/noSvgWithoutTitle: not needed
@@ -255,7 +257,9 @@ export async function publishedContractOGImageTemplate(params: {
             )}
 
             <h2 tw="text-2xl text-white font-medium max-w-full">
-              {params.publisher}
+              {isAddress(params.publisher)
+                ? shortenAddress(params.publisher)
+                : params.publisher}
             </h2>
           </div>
         </div>


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `publishedContractOGImageTemplate` function by adding address validation and shortening for the publisher's address in the Open Graph image template.

### Detailed summary
- Imported `isAddress` and `shortenAddress` from `thirdweb`.
- Updated the rendering of `params.publisher` to check if it is a valid address.
- If valid, the publisher's address is shortened; otherwise, the original publisher name is displayed.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->