### PR TITLE
feat: respect paymaster override in userop.ts

### DIFF
--- a/packages/thirdweb/src/wallets/smart/lib/userop.ts
+++ b/packages/thirdweb/src/wallets/smart/lib/userop.ts
@@ -151,6 +151,7 @@ export async function createUnsignedUserOp(args: {
     chain,
     bundlerUrl: overrides?.bundlerUrl,
     entrypointAddress: overrides?.entrypointAddress,
+    paymaster: overrides?.paymaster,
   };
 
   const entrypointVersion = getEntryPointVersion(


### PR DESCRIPTION
In the populate userOp methods we have e.g. the following:

```
const paymasterResult = (await getPaymasterAndData({
      userOp: partialOp,
      chain,
      client,
      entrypointAddress: overrides?.entrypointAddress,
      paymasterOverride: overrides?.paymaster,
    })) as Extract<PaymasterResult, { paymaster: string }>;
```

But `createUnsignedUserOp` currently does not pass down `paymaster` argument as part of overrides


<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new property to the configuration object in the `userop.ts` file, enhancing the functionality related to user operations.

### Detailed summary
- Added the `paymaster` property to the configuration object, sourced from `overrides?.paymaster`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->