### PR TITLE
fix: respect custom paymaster callback

### DIFF
--- a/.changeset/smart-donkeys-jam.md
+++ b/.changeset/smart-donkeys-jam.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix custom paymaster callback not being respected

--- a/packages/thirdweb/src/wallets/smart/index.ts
+++ b/packages/thirdweb/src/wallets/smart/index.ts
@@ -225,6 +225,8 @@ async function createSmartAccount(
           };
         };
         paymasterOverride = options.overrides?.paymaster || paymasterCallback;
+      } else {
+        paymasterOverride = options.overrides?.paymaster;
       }
       const executeTx = prepareExecute({
         accountContract,


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added



<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the custom paymaster callback handling in the `thirdweb` package and adding a test to ensure the new behavior works as expected.

### Detailed summary
- Updated `paymasterOverride` logic in `packages/thirdweb/src/wallets/smart/index.ts` to respect the custom paymaster callback.
- Added a new test case in `packages/thirdweb/src/wallets/smart/smart-wallet-integration.test.ts` to validate the use of a different paymaster.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->