### PR TITLE
feat: add ecosystem URL display in header

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/[slug]/(active)/components/client/ecosystem-header.client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/dashboard/connect/ecosystem/[slug]/(active)/components/client/ecosystem-header.client.tsx
@@ -165,11 +165,23 @@ export function EcosystemHeader(props: {
               {!ecosystem.slug ? (
                 <Skeleton className="h-6 w-[300px]" />
               ) : (
-                <div className="flex items-center gap-1">
-                  <p className="text-muted-foreground">
-                    ecosystem.{ecosystem.slug}
-                  </p>
-                  <CopyButton text={`ecosystem.${ecosystem.slug}`} />
+                <div className="flex flex-col gap-1">
+                  <div className="flex items-center gap-1">
+                    <p className="text-muted-foreground">
+                      ecosystem.{ecosystem.slug}
+                    </p>
+                    <CopyButton text={`ecosystem.${ecosystem.slug}`} />
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <a
+                      href={`https://${ecosystem.slug}.ecosystem.thirdweb.com`}
+                      className="text-link-foreground"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      {`${ecosystem.slug}.ecosystem.thirdweb.com`}
+                    </a>
+                  </div>
                 </div>
               )}
             </div>


### PR DESCRIPTION
## Problem solved

Fixes CNCT-2149

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the layout of the `ecosystem-header.client.tsx` component by restructuring the HTML elements for better organization and adding a link to the ecosystem's site.

### Detailed summary
- Changed the outer `div` class from `flex items-center gap-1` to `flex flex-col gap-1`.
- Wrapped the existing content in a new inner `div` with the class `flex items-center gap-1`.
- Added a new `div` with a link to the ecosystem's site, using the `href` attribute to construct the URL dynamically.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->