### PR TITLE
feat: enable smart account chain switching between zk/non-zk

### DIFF
--- a/.changeset/new-rules-buy.md
+++ b/.changeset/new-rules-buy.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Allow smart accounts to switch chains between zk and non zk chains

--- a/packages/thirdweb/src/utils/any-evm/zksync/isZkSyncChain.ts
+++ b/packages/thirdweb/src/utils/any-evm/zksync/isZkSyncChain.ts
@@ -1,5 +1,4 @@
 import type { Chain } from "../../../chains/types.js";
-import { getChainMetadata } from "../../../chains/utils.js";
 
 export async function isZkSyncChain(chain: Chain) {
   if (chain.id === 1337 || chain.id === 31337) {
@@ -22,12 +21,5 @@ export async function isZkSyncChain(chain: Chain) {
     return true;
   }
 
-  // fallback to checking the stack on rpc
-  try {
-    const chainMetadata = await getChainMetadata(chain);
-    return chainMetadata.stackType === "zksync_stack";
-  } catch {
-    // If the network check fails, assume it's not a ZkSync chain
-    return false;
-  }
+  return false;
 }


### PR DESCRIPTION
## Problem solved

Fixes CNCT-2148
Fixes #5224



<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a patch for `thirdweb` to enhance smart accounts by allowing them to switch between zk and non-zk chains. It modifies the `isZkSyncChain` function and updates the `smartWallet` function to incorporate this new chain-switching capability.

### Detailed summary
- Added a patch note for `thirdweb` to allow chain switching.
- Modified the `isZkSyncChain` function to remove the fallback to RPC checks.
- Updated the `smartWallet` function to first check if the new chain is a zkSync chain before checking if the factory contract is deployed.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->