### PR TITLE
fix: use stringify helper for bigint serialization

### DIFF
--- a/.changeset/dull-mails-sleep.md
+++ b/.changeset/dull-mails-sleep.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Use stringify instead of JSON.stringify in most places to handle bigint serialization

--- a/packages/thirdweb/src/auth/core/verify-jwt.ts
+++ b/packages/thirdweb/src/auth/core/verify-jwt.ts
@@ -1,3 +1,4 @@
+import { stringify } from "../../utils/json.js";
 import { decodeJWT } from "../../utils/jwt/decode-jwt.js";
 import type { JWTPayload } from "../../utils/jwt/types.js";
 import { verifyEOASignature } from "../verify-signature.js";
@@ -82,7 +83,7 @@ export function verifyJWT(options: AuthOptions) {
     }
 
     const verified = await verifyEOASignature({
-      message: JSON.stringify(payload),
+      message: stringify(payload),
       signature,
       address: issuerAddress,
     });

--- a/packages/thirdweb/src/pay/buyWithCrypto/getQuote.ts
+++ b/packages/thirdweb/src/pay/buyWithCrypto/getQuote.ts
@@ -5,6 +5,7 @@ import { getContract } from "../../contract/contract.js";
 import { approve } from "../../extensions/erc20/write/approve.js";
 import type { PrepareTransactionOptions } from "../../transaction/prepare-transaction.js";
 import { getClientFetch } from "../../utils/fetch.js";
+import { stringify } from "../../utils/json.js";
 import { getPayBuyWithCryptoQuoteEndpoint } from "../utils/definitions.js";
 import type {
   QuoteApprovalInfo,
@@ -223,7 +224,7 @@ export async function getBuyWithCryptoQuote(
         Accept: "application/json",
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({
+      body: stringify({
         fromAddress: params.fromAddress,
         toAddress: params.toAddress,
         fromChainId: params.fromChainId.toString(),

--- a/packages/thirdweb/src/pay/buyWithCrypto/getTransfer.ts
+++ b/packages/thirdweb/src/pay/buyWithCrypto/getTransfer.ts
@@ -6,6 +6,7 @@ import { approve } from "../../extensions/erc20/write/approve.js";
 import type { PrepareTransactionOptions } from "../../transaction/prepare-transaction.js";
 import type { Address } from "../../utils/address.js";
 import { getClientFetch } from "../../utils/fetch.js";
+import { stringify } from "../../utils/json.js";
 import { getPayBuyWithCryptoTransferEndpoint } from "../utils/definitions.js";
 import type {
   QuoteApprovalInfo,
@@ -129,7 +130,7 @@ export async function getBuyWithCryptoTransfer(
         Accept: "application/json",
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({
+      body: stringify({
         fromAddress: params.fromAddress,
         toAddress: params.toAddress,
         chainId: params.chainId,

--- a/packages/thirdweb/src/pay/buyWithFiat/getQuote.ts
+++ b/packages/thirdweb/src/pay/buyWithFiat/getQuote.ts
@@ -1,5 +1,6 @@
 import type { ThirdwebClient } from "../../client/client.js";
 import { getClientFetch } from "../../utils/fetch.js";
+import { stringify } from "../../utils/json.js";
 import type { FiatProvider } from "../utils/commonTypes.js";
 import { getPayBuyWithFiatQuoteEndpoint } from "../utils/definitions.js";
 
@@ -299,7 +300,7 @@ export async function getBuyWithFiatQuote(
         Accept: "application/json",
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({
+      body: stringify({
         toAddress: params.toAddress,
         fromCurrencySymbol: params.fromCurrencySymbol,
         toChainId: params.toChainId.toString(),

--- a/packages/thirdweb/src/rpc/rpc.ts
+++ b/packages/thirdweb/src/rpc/rpc.ts
@@ -3,6 +3,7 @@ import type { ThirdwebClient } from "../client/client.js";
 
 import type { Chain } from "../chains/types.js";
 import { getRpcUrlForChain } from "../chains/utils.js";
+import { stringify } from "../utils/json.js";
 import { type RpcRequest, fetchRpc, fetchSingleRpc } from "./fetch-rpc.js";
 
 const RPC_CLIENT_MAP = new WeakMap();
@@ -23,7 +24,7 @@ function getRpcClientMap(client: ThirdwebClient) {
  * @internal
  */
 function rpcRequestKey(request: RpcRequest): string {
-  return `${request.method}:${JSON.stringify(request.params)}`;
+  return `${request.method}:${stringify(request.params)}`;
 }
 
 const DEFAULT_MAX_BATCH_SIZE = 100;

--- a/packages/thirdweb/src/utils/extensions/airdrop/process-snapshot-erc1155.ts
+++ b/packages/thirdweb/src/utils/extensions/airdrop/process-snapshot-erc1155.ts
@@ -2,6 +2,7 @@ import type { ThirdwebClient } from "../../../client/client.js";
 import { MerkleTree } from "../../../merkletree/MerkleTree.js";
 import { upload } from "../../../storage/upload.js";
 import type { Hex } from "../../encoding/hex.js";
+import { stringify } from "../../json.js";
 import { hashEntryERC1155 } from "./hash-entry-erc1155.js";
 import type {
   ShardDataERC1155,
@@ -54,7 +55,7 @@ export async function processSnapshotERC1155(options: {
       entries,
     };
     shardsToUpload.push({
-      data: JSON.stringify(data),
+      data: stringify(data),
       name: `${shardId}.json`,
     });
   }
@@ -74,7 +75,7 @@ export async function processSnapshotERC1155(options: {
   // 6. Also upload the original entries for retrieving all entries
   const originalEntriesUri = await upload({
     client: options.client,
-    files: [JSON.stringify(options.snapshot)],
+    files: [stringify(options.snapshot)],
   });
   // 7. assmeble the final sharded merkle tree info
   const shardedMerkleInfo: ShardedMerkleTreeInfo = {

--- a/packages/thirdweb/src/utils/extensions/airdrop/process-snapshot-erc20.ts
+++ b/packages/thirdweb/src/utils/extensions/airdrop/process-snapshot-erc20.ts
@@ -2,6 +2,7 @@ import type { ThirdwebClient } from "../../../client/client.js";
 import { MerkleTree } from "../../../merkletree/MerkleTree.js";
 import { upload } from "../../../storage/upload.js";
 import type { Hex } from "../../encoding/hex.js";
+import { stringify } from "../../json.js";
 import { hashEntryERC20 } from "./hash-entry-erc20.js";
 import type {
   ShardDataERC20,
@@ -56,7 +57,7 @@ export async function processSnapshotERC20(options: {
       entries,
     };
     shardsToUpload.push({
-      data: JSON.stringify(data),
+      data: stringify(data),
       name: `${shardId}.json`,
     });
   }
@@ -76,7 +77,7 @@ export async function processSnapshotERC20(options: {
   // 6. Also upload the original entries for retrieving all entries
   const originalEntriesUri = await upload({
     client: options.client,
-    files: [JSON.stringify(options.snapshot)],
+    files: [stringify(options.snapshot)],
   });
   // 7. assmeble the final sharded merkle tree info
   const shardedMerkleInfo: ShardedMerkleTreeInfo = {

--- a/packages/thirdweb/src/utils/extensions/airdrop/process-snapshot-erc721.ts
+++ b/packages/thirdweb/src/utils/extensions/airdrop/process-snapshot-erc721.ts
@@ -2,6 +2,7 @@ import type { ThirdwebClient } from "../../../client/client.js";
 import { MerkleTree } from "../../../merkletree/MerkleTree.js";
 import { upload } from "../../../storage/upload.js";
 import type { Hex } from "../../encoding/hex.js";
+import { stringify } from "../../json.js";
 import { hashEntryERC721 } from "./hash-entry-erc721.js";
 import type {
   ShardDataERC721,
@@ -54,7 +55,7 @@ export async function processSnapshotERC721(options: {
       entries,
     };
     shardsToUpload.push({
-      data: JSON.stringify(data),
+      data: stringify(data),
       name: `${shardId}.json`,
     });
   }
@@ -74,7 +75,7 @@ export async function processSnapshotERC721(options: {
   // 6. Also upload the original entries for retrieving all entries
   const originalEntriesUri = await upload({
     client: options.client,
-    files: [JSON.stringify(options.snapshot)],
+    files: [stringify(options.snapshot)],
   });
   // 7. assmeble the final sharded merkle tree info
   const shardedMerkleInfo: ShardedMerkleTreeInfo = {

--- a/packages/thirdweb/src/utils/extensions/drops/process-override-list.ts
+++ b/packages/thirdweb/src/utils/extensions/drops/process-override-list.ts
@@ -3,6 +3,7 @@ import type { ThirdwebClient } from "../../../client/client.js";
 import { MerkleTree } from "../../../merkletree/MerkleTree.js";
 import { upload } from "../../../storage/upload.js";
 import type { Hex } from "../../encoding/hex.js";
+import { stringify } from "../../json.js";
 import { hashEntry } from "./hash-entry.js";
 import type {
   OverrideEntry,
@@ -67,7 +68,7 @@ export async function processOverrideList(options: {
       entries,
     };
     shardsToUpload.push({
-      data: JSON.stringify(data),
+      data: stringify(data),
       name: `${shardId}.json`,
     });
   }
@@ -87,7 +88,7 @@ export async function processOverrideList(options: {
   // 6. Also upload the original entries for retrieving all entries
   const originalEntriesUri = await upload({
     client: options.client,
-    files: [JSON.stringify(options.overrides)],
+    files: [stringify(options.overrides)],
   });
   // 7. assmeble the final sharded merkle tree info
   const shardedMerkleInfo: ShardedMerkleTreeInfo = {

--- a/packages/thirdweb/src/utils/jwt/encode-jwt.ts
+++ b/packages/thirdweb/src/utils/jwt/encode-jwt.ts
@@ -1,5 +1,6 @@
 import type { Account } from "../../wallets/interfaces/wallet.js";
 import { stringToBytes } from "../encoding/to-bytes.js";
+import { stringify } from "../json.js";
 import { randomBytesHex } from "../random.js";
 import { uint8ArrayToBase64 } from "../uint8-array.js";
 import { PRECOMPILED_B64_ENCODED_JWT_HEADER } from "./jwt-header.js";
@@ -47,14 +48,13 @@ type EncodeJWTParams = { payload: JWTPayloadInput; account: Account };
  */
 export async function encodeJWT(options: EncodeJWTParams) {
   const payload = await ensureJWTPayload(options.payload);
-  const message = JSON.stringify(payload);
+  const message = stringify(payload);
 
   const signature = await options.account.signMessage({ message });
 
-  const encodedData = uint8ArrayToBase64(
-    stringToBytes(JSON.stringify(payload)),
-    { urlSafe: true },
-  );
+  const encodedData = uint8ArrayToBase64(stringToBytes(message), {
+    urlSafe: true,
+  });
 
   const encodedSignature = uint8ArrayToBase64(stringToBytes(signature), {
     urlSafe: true,

--- a/packages/thirdweb/src/utils/nft/fetch-token-metadata.test.ts
+++ b/packages/thirdweb/src/utils/nft/fetch-token-metadata.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { TEST_CLIENT } from "~test/test-clients.js";
+import { stringify } from "../json.js";
 import {
   type FetchTokenMetadataOptions,
   fetchTokenMetadata,
@@ -9,7 +10,7 @@ describe("fetchTokenMetadata", () => {
   it("should return a json object from a valid base64 encoded json", async () => {
     const validJson = { foo: "bar" };
     const validBase64Json = `data:application/json;base64,${btoa(
-      JSON.stringify(validJson),
+      stringify(validJson),
     )}`;
 
     const options: FetchTokenMetadataOptions = {

--- a/packages/thirdweb/src/utils/storage/walletStorage.ts
+++ b/packages/thirdweb/src/utils/storage/walletStorage.ts
@@ -1,3 +1,4 @@
+import { stringify } from "../json.js";
 import type { AsyncStorage } from "./AsyncStorage.js";
 
 const CONNECT_PARAMS_MAP_KEY = "tw:connected-wallet-params";
@@ -39,7 +40,7 @@ export async function saveConnectParamsToStorage<T extends object>(
     };
   }
 
-  storage.setItem(CONNECT_PARAMS_MAP_KEY, JSON.stringify(value));
+  storage.setItem(CONNECT_PARAMS_MAP_KEY, stringify(value));
 }
 
 /**
@@ -67,7 +68,7 @@ export async function deleteConnectParamsFromStorage(
     }
 
     delete value[walletId];
-    storage.setItem(CONNECT_PARAMS_MAP_KEY, JSON.stringify(value));
+    storage.setItem(CONNECT_PARAMS_MAP_KEY, stringify(value));
   }
 }
 
@@ -100,7 +101,7 @@ export async function getSavedConnectParamsFromStorage<T extends object>(
 
 function isStringifiable(value: unknown): boolean {
   try {
-    JSON.stringify(value);
+    stringify(value);
     return true;
   } catch {
     return false;

--- a/packages/thirdweb/src/wallets/in-app/core/authentication/authEndpoint.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/authentication/authEndpoint.ts
@@ -1,5 +1,6 @@
 import type { ThirdwebClient } from "../../../../client/client.js";
 import { getClientFetch } from "../../../../utils/fetch.js";
+import { stringify } from "../../../../utils/json.js";
 import { ROUTE_AUTH_ENDPOINT_CALLBACK } from "../../native/helpers/constants.js";
 import { createErrorMessage } from "../../native/helpers/errors.js";
 import type { Ecosystem } from "../wallet/types.js";
@@ -17,7 +18,7 @@ export async function authEndpoint(args: {
     headers: {
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({
+    body: stringify({
       payload: args.payload,
       developerClientId: args.client.clientId,
     }),

--- a/packages/thirdweb/src/wallets/in-app/core/authentication/guest.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/authentication/guest.ts
@@ -1,5 +1,6 @@
 import type { ThirdwebClient } from "../../../../client/client.js";
 import { getClientFetch } from "../../../../utils/fetch.js";
+import { stringify } from "../../../../utils/json.js";
 import { randomBytesHex } from "../../../../utils/random.js";
 import type { AsyncStorage } from "../../../../utils/storage/AsyncStorage.js";
 import type { Ecosystem } from "../wallet/types.js";
@@ -39,7 +40,7 @@ export async function guestAuthenticate(args: {
     headers: {
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({
+    body: stringify({
       sessionId,
     }),
   });

--- a/packages/thirdweb/src/wallets/in-app/core/authentication/jwt.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/authentication/jwt.ts
@@ -1,5 +1,6 @@
 import type { ThirdwebClient } from "../../../../client/client.js";
 import { getClientFetch } from "../../../../utils/fetch.js";
+import { stringify } from "../../../../utils/json.js";
 import { ROUTE_AUTH_JWT_CALLBACK } from "../../native/helpers/constants.js";
 import { createErrorMessage } from "../../native/helpers/errors.js";
 import type { Ecosystem } from "../wallet/types.js";
@@ -17,7 +18,7 @@ export async function customJwt(args: {
     headers: {
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({
+    body: stringify({
       jwt: args.jwt,
       developerClientId: args.client.clientId,
     }),

--- a/packages/thirdweb/src/wallets/in-app/core/authentication/linkAccount.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/authentication/linkAccount.ts
@@ -1,6 +1,7 @@
 import type { ThirdwebClient } from "../../../../client/client.js";
 import { getThirdwebBaseUrl } from "../../../../utils/domains.js";
 import { getClientFetch } from "../../../../utils/fetch.js";
+import { stringify } from "../../../../utils/json.js";
 import type { Ecosystem } from "../wallet/types.js";
 import type { ClientScopedStorage } from "./client-scoped-storage.js";
 import type { Profile } from "./types.js";
@@ -40,7 +41,7 @@ export async function linkAccount({
     {
       method: "POST",
       headers,
-      body: JSON.stringify({
+      body: stringify({
         accountAuthTokenToConnect: tokenToLink,
       }),
     },

--- a/packages/thirdweb/src/wallets/in-app/core/authentication/passkeys.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/authentication/passkeys.ts
@@ -1,6 +1,7 @@
 import type { ThirdwebClient } from "../../../../client/client.js";
 import { getThirdwebBaseUrl } from "../../../../utils/domains.js";
 import { getClientFetch } from "../../../../utils/fetch.js";
+import { stringify } from "../../../../utils/json.js";
 import type { Ecosystem } from "../wallet/types.js";
 import type { ClientScopedStorage } from "./client-scoped-storage.js";
 import type { AuthStoredTokenWithCookieReturnType } from "./types.js";
@@ -96,7 +97,7 @@ export async function registerPasskey(options: {
       "Content-Type": "application/json",
       ...customHeaders,
     },
-    body: JSON.stringify({
+    body: stringify({
       type: "sign-up",
       authenticatorData: registration.authenticatorData,
       credentialId: registration.credentialId,
@@ -166,7 +167,7 @@ export async function loginWithPasskey(options: {
       "Content-Type": "application/json",
       ...customHeaders,
     },
-    body: JSON.stringify({
+    body: stringify({
       type: "sign-in",
       authenticatorData: authentication.authenticatorData,
       credentialId: authentication.credentialId,

--- a/packages/thirdweb/src/wallets/in-app/core/authentication/siwe.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/authentication/siwe.ts
@@ -3,6 +3,7 @@ import type { LoginPayload } from "../../../../auth/core/types.js";
 import type { Chain } from "../../../../chains/types.js";
 import type { ThirdwebClient } from "../../../../client/client.js";
 import { getClientFetch } from "../../../../utils/fetch.js";
+import { stringify } from "../../../../utils/json.js";
 import type { Wallet } from "../../../interfaces/wallet.js";
 import type { Ecosystem } from "../wallet/types.js";
 import { getLoginCallbackUrl, getLoginUrl } from "./getLoginPath.js";
@@ -50,7 +51,7 @@ export async function siweAuthenticate(args: {
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({
+        body: stringify({
           signature,
           payload,
         }),

--- a/packages/thirdweb/src/wallets/in-app/core/wallet/in-app-core.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/wallet/in-app-core.ts
@@ -2,6 +2,7 @@ import { trackConnect } from "../../../../analytics/track/connect.js";
 import type { Chain } from "../../../../chains/types.js";
 import { getCachedChainIfExists } from "../../../../chains/utils.js";
 import type { ThirdwebClient } from "../../../../client/client.js";
+import { stringify } from "../../../../utils/json.js";
 import { getEcosystemInfo } from "../../../ecosystem/get-ecosystem-wallet-auth-options.js";
 import type { Account, Wallet } from "../../../interfaces/wallet.js";
 import { createWalletEmitter } from "../../../wallet-emitter.js";
@@ -22,7 +23,7 @@ export async function getOrCreateInAppWalletConnector(
   connectorFactory: (client: ThirdwebClient) => Promise<InAppConnector>,
   ecosystem?: Ecosystem,
 ) {
-  const key = JSON.stringify({ clientId: client.clientId, ecosystem });
+  const key = stringify({ clientId: client.clientId, ecosystem });
   if (connectorCache.has(key)) {
     return connectorCache.get(key) as InAppConnector;
   }

--- a/packages/thirdweb/src/wallets/in-app/native/helpers/api/fetchers.ts
+++ b/packages/thirdweb/src/wallets/in-app/native/helpers/api/fetchers.ts
@@ -1,6 +1,7 @@
 import type { ThirdwebClient } from "../../../../../client/client.js";
 import type { Hex } from "../../../../../utils/encoding/hex.js";
 import { getClientFetch } from "../../../../../utils/fetch.js";
+import { stringify } from "../../../../../utils/json.js";
 import { randomBytesHex } from "../../../../../utils/random.js";
 import type { ClientScopedStorage } from "../../../core/authentication/client-scoped-storage.js";
 import type { UserDetailsApiType } from "../../../core/authentication/types.js";
@@ -35,7 +36,7 @@ export const verifyClientId = async (client: ThirdwebClient) => {
     headers: {
       ...getSessionHeaders(),
     },
-    body: JSON.stringify({ clientId: client.clientId, parentDomain: "" }),
+    body: stringify({ clientId: client.clientId, parentDomain: "" }),
   });
   if (!resp.ok) {
     const error = await resp.json();
@@ -155,7 +156,7 @@ export async function storeUserShares({
     props: {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
+      body: stringify({
         walletAddress,
         maybeEncryptedRecoveryShares,
         authShare,
@@ -168,7 +169,7 @@ export async function storeUserShares({
     const error = await resp.json();
 
     throw new Error(
-      `Something went wrong storing user wallet shares: ${JSON.stringify(
+      `Something went wrong storing user wallet shares: ${stringify(
         error.message,
         null,
         2,
@@ -193,7 +194,7 @@ export async function getUserShares(args: {
   if (!resp.ok) {
     const error = await resp.json();
     throw new Error(
-      `Something went wrong getting user's wallet: ${JSON.stringify(
+      `Something went wrong getting user's wallet: ${stringify(
         error.message,
         null,
         2,

--- a/packages/thirdweb/src/wallets/in-app/native/helpers/errors.ts
+++ b/packages/thirdweb/src/wallets/in-app/native/helpers/errors.ts
@@ -1,3 +1,5 @@
+import { stringify } from "../../../../utils/json.js";
+
 export const ErrorMessages = {
   invalidOtp:
     "Your OTP code is invalid or expired. Please request a new code or try again.",
@@ -8,5 +10,5 @@ export const createErrorMessage = (message: string, error: unknown): string => {
   if (error instanceof Error) {
     return `${message}: ${error.message}`;
   }
-  return `${message}: ${JSON.stringify(error)}`;
+  return `${message}: ${stringify(error)}`;
 };

--- a/packages/thirdweb/src/wallets/in-app/native/helpers/storage/local.ts
+++ b/packages/thirdweb/src/wallets/in-app/native/helpers/storage/local.ts
@@ -1,4 +1,5 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import { stringify } from "../../../../../utils/json.js";
 import {
   DEVICE_SHARE_LOCAL_STORAGE_NAME,
   WALLET_USER_DETAILS_LOCAL_STORAGE_NAME,
@@ -65,7 +66,7 @@ export async function setWallerUserDetails({
   await setItemInAsyncStorage(
     // ! Keep this in sync with getWalletUserDetails function below
     name,
-    JSON.stringify({ userId, email: newEmail }),
+    stringify({ userId, email: newEmail }),
   );
 }
 

--- a/packages/thirdweb/src/wallets/in-app/native/helpers/wallet/migration.ts
+++ b/packages/thirdweb/src/wallets/in-app/native/helpers/wallet/migration.ts
@@ -4,6 +4,7 @@ import QuickCrypto from "react-native-quick-crypto";
 import type { ThirdwebClient } from "../../../../../client/client.js";
 import { getThirdwebBaseUrl } from "../../../../../utils/domains.js";
 import { stringToBytes } from "../../../../../utils/encoding/to-bytes.js";
+import { stringify } from "../../../../../utils/json.js";
 import { randomBytesBuffer } from "../../../../../utils/random.js";
 import {
   concatUint8Arrays,
@@ -72,7 +73,7 @@ export async function migrateToEnclaveWallet(args: {
   });
   if (!idTokenResponse.ok) {
     throw new Error(
-      `Failed to fetch id token from Cognito: ${JSON.stringify(
+      `Failed to fetch id token from Cognito: ${stringify(
         await idTokenResponse.json(),
         null,
         2,
@@ -164,7 +165,7 @@ async function executeMigration(args: {
     url: `${getThirdwebBaseUrl("inAppWallet")}/api/v1/enclave-wallet/migrate`,
     props: {
       method: "POST",
-      body: JSON.stringify({
+      body: stringify({
         address: args.address,
         kmsCiphertextB64: args.kmsCiphertextB64,
         encryptedPrivateKeyB64: args.encryptedPrivateKeyB64,
@@ -175,7 +176,7 @@ async function executeMigration(args: {
   });
   if (!migrationResponse.ok) {
     throw new Error(
-      `Failed to migrate to enclave wallet: ${JSON.stringify(
+      `Failed to migrate to enclave wallet: ${stringify(
         await migrationResponse.json(),
       )}`,
     );

--- a/packages/thirdweb/src/wallets/in-app/native/helpers/wallet/recoveryCode.ts
+++ b/packages/thirdweb/src/wallets/in-app/native/helpers/wallet/recoveryCode.ts
@@ -5,6 +5,7 @@ import {
 } from "@aws-sdk/credential-providers";
 import type { ThirdwebClient } from "../../../../../client/client.js";
 import { stringToBytes } from "../../../../../utils/encoding/to-bytes.js";
+import { stringify } from "../../../../../utils/json.js";
 import type { ClientScopedStorage } from "../../../core/authentication/client-scoped-storage.js";
 import { authFetchEmbeddedWalletUser } from "../api/fetchers.js";
 import {
@@ -31,7 +32,7 @@ export async function getCognitoRecoveryPasswordV1(args: {
   });
   if (!idTokenResponse.ok) {
     throw new Error(
-      `Failed to fetch id token from Cognito: ${JSON.stringify(
+      `Failed to fetch id token from Cognito: ${stringify(
         await idTokenResponse.json(),
         null,
         2,
@@ -61,7 +62,7 @@ export async function getCognitoRecoveryPasswordV1(args: {
   const params = {
     FunctionName: GENERATE_RECOVERY_PASSWORD_LAMBDA_FUNCTION_V1,
     Payload: stringToBytes(
-      JSON.stringify({
+      stringify({
         accessToken,
         idToken,
       }),
@@ -92,7 +93,7 @@ export async function getCognitoRecoveryPasswordV2(args: {
   });
   if (!idTokenResponse.ok) {
     throw new Error(
-      `Failed to fetch id token from Cognito: ${JSON.stringify(
+      `Failed to fetch id token from Cognito: ${stringify(
         await idTokenResponse.json(),
         null,
         2,
@@ -121,7 +122,7 @@ export async function getCognitoRecoveryPasswordV2(args: {
   const params = {
     FunctionName: GENERATE_RECOVERY_PASSWORD_LAMBDA_FUNCTION_V2,
     Payload: stringToBytes(
-      JSON.stringify({
+      stringify({
         token: lambdaToken,
       }),
     ),

--- a/packages/thirdweb/src/wallets/in-app/web/lib/auth/otp.ts
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/auth/otp.ts
@@ -1,4 +1,5 @@
 import type { ThirdwebClient } from "../../../../../client/client.js";
+import { stringify } from "../../../../../utils/json.js";
 import {
   getLoginCallbackUrl,
   getLoginUrl,
@@ -46,7 +47,7 @@ export const sendOtp = async (args: PreAuthArgsType): Promise<void> => {
   const response = await fetch(url, {
     method: "POST",
     headers,
-    body: JSON.stringify(body),
+    body: stringify(body),
   });
 
   if (!response.ok) {
@@ -103,7 +104,7 @@ export const verifyOtp = async (
   const response = await fetch(url, {
     method: "POST",
     headers,
-    body: JSON.stringify(body),
+    body: stringify(body),
   });
 
   if (!response.ok) {

--- a/packages/thirdweb/src/wallets/manager/index.ts
+++ b/packages/thirdweb/src/wallets/manager/index.ts
@@ -5,6 +5,7 @@ import { hasSmartAccount } from "../../react/core/utils/isSmartWallet.js";
 import { computedStore } from "../../reactive/computedStore.js";
 import { effect } from "../../reactive/effect.js";
 import { createStore } from "../../reactive/store.js";
+import { stringify } from "../../utils/json.js";
 import type { AsyncStorage } from "../../utils/storage/AsyncStorage.js";
 import { deleteConnectParamsFromStorage } from "../../utils/storage/walletStorage.js";
 import type { Account, Wallet } from "../interfaces/wallet.js";
@@ -216,7 +217,7 @@ export function createConnectionManager(storage: AsyncStorage) {
     () => {
       const _chain = activeWalletChainStore.getValue();
       if (_chain) {
-        storage.setItem(LAST_ACTIVE_CHAIN, JSON.stringify(_chain));
+        storage.setItem(LAST_ACTIVE_CHAIN, stringify(_chain));
       } else {
         storage.removeItem(LAST_ACTIVE_CHAIN);
       }
@@ -231,7 +232,7 @@ export function createConnectionManager(storage: AsyncStorage) {
       const accounts = connectedWallets.getValue();
       const ids = accounts.map((acc) => acc?.id).filter((c) => !!c) as string[];
 
-      storage.setItem(CONNECTED_WALLET_IDS, JSON.stringify(ids));
+      storage.setItem(CONNECTED_WALLET_IDS, stringify(ids));
     },
     [connectedWallets],
     false,
@@ -276,7 +277,7 @@ export function createConnectionManager(storage: AsyncStorage) {
     const allChainsSame = chains.every((c) => {
       const definedChain = currentMapVal.get(c.id);
       // basically a deep equal check
-      return JSON.stringify(definedChain) === JSON.stringify(c);
+      return stringify(definedChain) === stringify(c);
     });
 
     if (allChainsSame) {

--- a/packages/thirdweb/src/wallets/smart/lib/bundler.ts
+++ b/packages/thirdweb/src/wallets/smart/lib/bundler.ts
@@ -290,7 +290,7 @@ async function sendBundlerRequest(args: {
   if (!response.ok || res.error) {
     let error = res.error || response.statusText;
     if (typeof error === "object") {
-      error = JSON.stringify(error);
+      error = stringify(error);
     }
     const code = res.code || "UNKNOWN";
 

--- a/packages/thirdweb/src/wallets/smart/lib/paymaster.ts
+++ b/packages/thirdweb/src/wallets/smart/lib/paymaster.ts
@@ -2,6 +2,7 @@ import type { Chain } from "../../../chains/types.js";
 import type { ThirdwebClient } from "../../../client/client.js";
 import { hexToBigInt } from "../../../utils/encoding/hex.js";
 import { getClientFetch } from "../../../utils/fetch.js";
+import { stringify } from "../../../utils/json.js";
 import type {
   PaymasterResult,
   UserOperationV06,
@@ -59,7 +60,7 @@ export async function getPaymasterAndData(args: {
   const response = await fetchWithHeaders(paymasterUrl, {
     method: "POST",
     headers,
-    body: JSON.stringify({
+    body: stringify({
       jsonrpc: "2.0",
       id: 1,
       method: "pm_sponsorUserOperation",

--- a/packages/thirdweb/src/wallets/wallet-connect/controller.ts
+++ b/packages/thirdweb/src/wallets/wallet-connect/controller.ts
@@ -24,6 +24,7 @@ import {
   stringToHex,
   uint8ArrayToHex,
 } from "../../utils/encoding/hex.js";
+import { stringify } from "../../utils/json.js";
 import { parseTypedData } from "../../utils/signatures/helpers/parseTypedData.js";
 import type { AsyncStorage } from "../../utils/storage/AsyncStorage.js";
 import {
@@ -536,7 +537,7 @@ function setRequestedChainsIds(
   chains: number[] | undefined,
   storage: AsyncStorage,
 ) {
-  storage?.setItem(storageKeys.requestedChains, JSON.stringify(chains));
+  storage?.setItem(storageKeys.requestedChains, stringify(chains));
 }
 
 /**

--- a/packages/thirdweb/src/wallets/wallet-connect/receiver/session-store.ts
+++ b/packages/thirdweb/src/wallets/wallet-connect/receiver/session-store.ts
@@ -1,3 +1,4 @@
+import { stringify } from "../../../utils/json.js";
 import { ClientScopedStorage } from "../../in-app/core/authentication/client-scoped-storage.js";
 import type { WalletConnectSession } from "./types.js";
 
@@ -45,9 +46,7 @@ export async function saveSession(
     await walletConnectSessions.getWalletConnectSessions();
   const sessions = JSON.parse(stringifiedSessions ?? "[]");
   sessions.push(session);
-  await walletConnectSessions.saveWalletConnectSessions(
-    JSON.stringify(sessions),
-  );
+  await walletConnectSessions.saveWalletConnectSessions(stringify(sessions));
 }
 
 /**
@@ -65,9 +64,7 @@ export async function removeSession(
   const newSessions = sessions.filter(
     (s: WalletConnectSession) => s.topic !== session.topic,
   );
-  await walletConnectSessions.saveWalletConnectSessions(
-    JSON.stringify(newSessions),
-  );
+  await walletConnectSessions.saveWalletConnectSessions(stringify(newSessions));
 }
 
 /**

--- a/packages/thirdweb/test/src/utils.ts
+++ b/packages/thirdweb/test/src/utils.ts
@@ -1,4 +1,5 @@
 import { getRpcClient } from "../../src/rpc/rpc.js";
+import { stringify } from "../../src/utils/json.js";
 import { wait } from "../../src/utils/promise/wait.js";
 import { FORKED_ETHEREUM_CHAIN } from "./chains.js";
 import { TEST_CLIENT } from "./test-clients.js";
@@ -17,5 +18,5 @@ export async function mineBlock(chain = FORKED_ETHEREUM_CHAIN) {
 }
 
 export function cloneObject<T>(obj: T): T {
-  return JSON.parse(JSON.stringify(obj));
+  return JSON.parse(stringify(obj));
 }


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on replacing `JSON.stringify` with `stringify` in various parts of the codebase to improve bigint serialization handling.

### Detailed summary
- Updated error handling in `bundler.ts` to use `stringify`.
- Modified `verify-jwt.ts` to use `stringify` for payload serialization.
- Changed error message creation in `errors.ts` to use `stringify`.
- Altered object cloning in `utils.ts` to use `stringify`.
- Updated local storage interactions in `local.ts` to use `stringify`.
- Replaced `JSON.stringify` with `stringify` in multiple request bodies across several files, including `paymaster.ts`, `authEndpoint.ts`, and others.
- Adjusted JWT encoding in `encode-jwt.ts` to utilize `stringify`.
- Enhanced session storage methods to use `stringify` in `session-store.ts`.
- Updated error handling in various parts of the codebase to improve error message formatting using `stringify`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->