### PR TITLE
[Global] Chore: Automate stale issues and PRs (30 days to stale, then 5 days till closing)

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,15 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: 'This issue has been inactive for 30 days. It is now marked as stale and will be closed in 5 days if no further activity occurs.'
+          stale-pr-message: 'This PR has been inactive for 30 days. It is now marked as stale and will be closed in 5 days if no further activity occurs.'
+          days-before-stale: 30
+          days-before-close: 5


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a GitHub Actions workflow to manage stale issues and pull requests by automatically marking them as stale after 30 days of inactivity and closing them after an additional 5 days if no activity occurs.

### Detailed summary
- Created a new workflow file: `.github/workflows/stale.yml`
- Defined the workflow name as 'Close stale issues and PRs'
- Set the workflow to trigger on a scheduled cron job
- Configured a job named `stale` to run on `ubuntu-latest`
- Used `actions/stale@v9` to manage stale issues and PRs
- Specified messages for stale issues and PRs
- Set `days-before-stale` to 30
- Set `days-before-close` to 5

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->