### PR TITLE
[SDK] Feature: Configure analytics URL

### DIFF
--- a/.changeset/red-garlics-play.md
+++ b/.changeset/red-garlics-play.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Enable configuring the analytics endpoint

--- a/apps/playground-web/src/lib/client.ts
+++ b/apps/playground-web/src/lib/client.ts
@@ -8,6 +8,7 @@ setThirdwebDomains({
   storage: process.env.NEXT_PUBLIC_STORAGE_URL,
   bundler: process.env.NEXT_PUBLIC_BUNDLER_URL,
   pay: process.env.NEXT_PUBLIC_PAY_URL,
+  analytics: process.env.NEXT_PUBLIC_ANALYTICS_URL,
 });
 
 const isDev =

--- a/packages/thirdweb/src/analytics/track/index.ts
+++ b/packages/thirdweb/src/analytics/track/index.ts
@@ -1,9 +1,8 @@
 import type { ThirdwebClient } from "../../client/client.js";
+import { getThirdwebBaseUrl } from "../../utils/domains.js";
 import { getClientFetch } from "../../utils/fetch.js";
 import { stringify } from "../../utils/json.js";
 import type { Ecosystem } from "../../wallets/in-app/core/wallet/types.js";
-
-const ANALYTICS_ENDPOINT = "https://c.thirdweb.com/event";
 
 /**
  * @internal
@@ -23,7 +22,7 @@ export async function track({
     ...data,
   };
 
-  return fetch(ANALYTICS_ENDPOINT, {
+  return fetch(`${getThirdwebBaseUrl("analytics")}/event`, {
     method: "POST",
     body: stringify(event),
   }).catch(() => {});

--- a/packages/thirdweb/src/utils/domains.ts
+++ b/packages/thirdweb/src/utils/domains.ts
@@ -29,6 +29,11 @@ type DomainOverrides = {
    * @default "bundler.thirdweb.com"
    */
   bundler?: string;
+  /**
+   * The base URL for the analytics server.
+   * @default "c.thirdweb.com"
+   */
+  analytics?: string;
 };
 
 export const DEFAULT_RPC_URL = "rpc.thirdweb.com";
@@ -37,6 +42,7 @@ const DEFAULT_IN_APP_WALLET_URL = "embedded-wallet.thirdweb.com";
 const DEFAULT_PAY_URL = "pay.thirdweb.com";
 const DEFAULT_STORAGE_URL = "storage.thirdweb.com";
 const DEFAULT_BUNDLER_URL = "bundler.thirdweb.com";
+const DEFAULT_ANALYTICS_URL = "c.thirdweb.com";
 
 let domains: { [k in keyof DomainOverrides]-?: string } = {
   rpc: DEFAULT_RPC_URL,
@@ -45,6 +51,7 @@ let domains: { [k in keyof DomainOverrides]-?: string } = {
   pay: DEFAULT_PAY_URL,
   storage: DEFAULT_STORAGE_URL,
   bundler: DEFAULT_BUNDLER_URL,
+  analytics: DEFAULT_ANALYTICS_URL,
 };
 
 /**
@@ -58,6 +65,7 @@ export const setThirdwebDomains = (DomainOverrides: DomainOverrides) => {
     pay: DomainOverrides.pay ?? DEFAULT_PAY_URL,
     storage: DomainOverrides.storage ?? DEFAULT_STORAGE_URL,
     bundler: DomainOverrides.bundler ?? DEFAULT_BUNDLER_URL,
+    analytics: DomainOverrides.analytics ?? DEFAULT_ANALYTICS_URL,
   };
 };
 


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enabling the configuration of the analytics endpoint in the `thirdweb` package, allowing users to customize where analytics data is sent.

### Detailed summary
- Added `analytics` configuration option in `apps/playground-web/src/lib/client.ts`.
- Replaced hardcoded `ANALYTICS_ENDPOINT` with a dynamic URL in `packages/thirdweb/src/analytics/track/index.ts`.
- Introduced `DEFAULT_ANALYTICS_URL` in `packages/thirdweb/src/utils/domains.ts`.
- Updated `domains` object to include `analytics` with a default value.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->