### PR TITLE
[Dashboard] Fix: MAU date range

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/dashboard/connect/in-app-wallets/[clientId]/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/dashboard/connect/in-app-wallets/[clientId]/layout.tsx
@@ -1,5 +1,6 @@
 import { InAppWalletsSummary } from "components/embedded-wallets/Analytics/Summary";
 import { getInAppWalletUsage } from "data/analytics/wallets/in-app";
+import { subDays } from "date-fns";
 import { redirect } from "next/navigation";
 import { getAuthToken } from "../../../../../api/lib/getAuthToken";
 import { InAppWaletFooterSection } from "../../../../../team/[team_slug]/[project_slug]/connect/in-app-wallets/_components/footer";
@@ -42,7 +43,7 @@ export default async function Page(props: {
 
   const monthlyStatsPromise = getInAppWalletUsage({
     clientId,
-    from: new Date(new Date().getFullYear(), new Date().getMonth(), 1),
+    from: subDays(new Date(), 30),
     to: new Date(),
     period: "month",
   });

--- a/apps/dashboard/src/app/team/[team_slug]/[project_slug]/connect/in-app-wallets/_components/header.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/[project_slug]/connect/in-app-wallets/_components/header.tsx
@@ -1,6 +1,7 @@
 import { TrackedLinkTW } from "@/components/ui/tracked-link";
 import { InAppWalletsSummary } from "components/embedded-wallets/Analytics/Summary";
 import { getInAppWalletUsage } from "data/analytics/wallets/in-app";
+import { subDays } from "date-fns";
 import { TRACKING_CATEGORY } from "../_constants";
 
 export async function InAppWalletsHeader({ clientId }: { clientId: string }) {
@@ -13,7 +14,7 @@ export async function InAppWalletsHeader({ clientId }: { clientId: string }) {
 
   const monthlyStatsPromise = getInAppWalletUsage({
     clientId,
-    from: new Date(new Date().getFullYear(), new Date().getMonth(), 1),
+    from: subDays(new Date(), 30),
     to: new Date(),
     period: "month",
   });


### PR DESCRIPTION
Fixes CNCT-2185

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `from` date parameter in the `getInAppWalletUsage` function calls to retrieve data from the last 30 days instead of the first day of the current month.

### Detailed summary
- In `layout.tsx`, changed `from` date in `getInAppWalletUsage` from the first day of the current month to 30 days ago using `subDays`.
- In `header.tsx`, similarly updated `from` date in `getInAppWalletUsage` to 30 days ago using `subDays`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->