### PR TITLE
[Dashboard] Remove react-children-utilities

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -79,7 +79,6 @@
     "prismjs": "^1.29.0",
     "qrcode": "^1.5.3",
     "react": "18.3.1",
-    "react-children-utilities": "^2.10.0",
     "react-day-picker": "^8.10.1",
     "react-dom": "18.3.1",
     "react-dropzone": "^14.2.9",

--- a/apps/dashboard/src/components/contract-components/published-contract/markdown-renderer.tsx
+++ b/apps/dashboard/src/components/contract-components/published-contract/markdown-renderer.tsx
@@ -13,10 +13,53 @@ import {
   UnorderedList,
   chakra,
 } from "@chakra-ui/react";
-import { onlyText } from "react-children-utilities";
+import { Children, type ReactNode, isValidElement } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { CodeBlock, Heading, Text } from "tw-components";
+
+// From https://github.com/fernandopasik/react-children-utilities
+const onlyText = (children: ReactNode | ReactNode[]): string => {
+  if (!Array.isArray(children) && !isValidElement(children)) {
+    return childToString(children);
+  }
+
+  return Children.toArray(children).reduce(
+    (text: string, child: ReactNode): string => {
+      let newText = "";
+
+      if (
+        isValidElement<{ children?: ReactNode[] }>(child) &&
+        Boolean(child.props.children)
+      ) {
+        newText = onlyText(child.props.children);
+      } else if (isValidElement(child)) {
+        newText = "";
+      } else {
+        newText = childToString(child);
+      }
+
+      return text.concat(newText);
+    },
+    "",
+  );
+};
+
+const childToString = (child?: ReactNode): string => {
+  if (
+    typeof child === "undefined" ||
+    child === null ||
+    typeof child === "boolean"
+  ) {
+    return "";
+  }
+
+  if (JSON.stringify(child) === "{}") {
+    return "";
+  }
+
+  return (child as number | string).toString();
+};
 
 const ChakraReactMarkdown = chakra(ReactMarkdown);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,9 +232,6 @@ importers:
       react:
         specifier: 18.3.1
         version: 18.3.1
-      react-children-utilities:
-        specifier: ^2.10.0
-        version: 2.10.0(react@18.3.1)
       react-day-picker:
         specifier: ^8.10.1
         version: 8.10.1(date-fns@4.1.0)(react@18.3.1)
@@ -11815,11 +11812,6 @@ packages:
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
-
-  react-children-utilities@2.10.0:
-    resolution: {integrity: sha512-9naSkrOHACjoDsHDtAQR5mGMp3ffv1DkUSQPDa8iJFP0+lXloS4fw44hMHaWeNF3qL4B3GPiJ9032Oo309oa9g==}
-    peerDependencies:
-      react: '>=15'
 
   react-clientside-effect@1.2.6:
     resolution: {integrity: sha512-XGGGRQAKY+q25Lz9a/4EPqom7WRjz3z9R2k4jhVKA/puQFH/5Nt27vFZYql4m4NVNdUvX8PS3O7r/Zzm7cjUlg==}
@@ -28751,10 +28743,6 @@ snapshots:
       ini: 1.3.8
       minimist: 1.2.8
       strip-json-comments: 2.0.1
-
-  react-children-utilities@2.10.0(react@18.3.1):
-    dependencies:
-      react: 18.3.1
 
   react-clientside-effect@1.2.6(react@18.3.1):
     dependencies:


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `package.json` and `pnpm-lock.yaml` files by removing the `react-children-utilities` dependency and replacing its functionality with custom utility functions in the `markdown-renderer.tsx` file.

### Detailed summary
- Removed `react-children-utilities` dependency from `package.json` and `pnpm-lock.yaml`.
- Added custom `onlyText` and `childToString` utility functions in `markdown-renderer.tsx` to handle child elements.
- Updated imports in `markdown-renderer.tsx` to use React's `Children` and `isValidElement`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->