### PR TITLE
fix: Engine deletion endpoint requires engineId

### DIFF
--- a/apps/dashboard/src/@3rdweb-sdk/react/hooks/useEngine.ts
+++ b/apps/dashboard/src/@3rdweb-sdk/react/hooks/useEngine.ts
@@ -262,6 +262,7 @@ export function useEngineRemoveFromDashboard() {
 }
 
 export interface DeleteCloudHostedInput {
+  engineId: string;
   deploymentId: string;
   reason: "USING_SELF_HOSTED" | "TOO_EXPENSIVE" | "MISSING_FEATURES" | "OTHER";
   feedback: string;
@@ -273,12 +274,13 @@ export function useEngineDeleteCloudHosted() {
 
   return useMutation({
     mutationFn: async ({
+      engineId,
       deploymentId,
       reason,
       feedback,
     }: DeleteCloudHostedInput) => {
       const res = await fetch(
-        `${THIRDWEB_API_HOST}/v2/engine/deployments/${deploymentId}/infrastructure/delete`,
+        `${THIRDWEB_API_HOST}/v2/engine/deployments/${deploymentId}/infrastructure/delete?engineId=${engineId}`,
         {
           method: "POST",
           headers: {

--- a/apps/dashboard/src/components/engine/engine-instances-table.tsx
+++ b/apps/dashboard/src/components/engine/engine-instances-table.tsx
@@ -387,6 +387,7 @@ function DeleteSubscriptionModalContent(props: {
   const [ackDeletion, setAckDeletion] = useState(false);
   const form = useForm<DeleteCloudHostedInput>({
     defaultValues: {
+      engineId: instance.id,
       deploymentId: instance.deploymentId,
     },
     reValidateMode: "onChange",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the `DeleteCloudHostedInput` interface and the `useForm` initialization to include `engineId`, allowing for more specific deletion requests in the engine instances table.

### Detailed summary
- Added `engineId` to the `DeleteCloudHostedInput` interface.
- Updated the `useForm` hook in `engine-instances-table.tsx` to set `engineId` from `instance.id`.
- Modified the mutation function to include `engineId` in the fetch URL for deletion requests.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->