### PR TITLE
fix: respect bundlerUrl in waitForUserReceipt

### DIFF
--- a/.changeset/perfect-pandas-exercise.md
+++ b/.changeset/perfect-pandas-exercise.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Respect bundlerUrl in waitForUserReceipt

--- a/packages/thirdweb/.size-limit.json
+++ b/packages/thirdweb/.size-limit.json
@@ -19,7 +19,7 @@
   {
     "name": "thirdweb/chains (tree-shaking)",
     "path": "./dist/esm/exports/chains.js",
-    "limit": "500 B",
+    "limit": "600 B",
     "import": "{ ethereum }"
   },
   {

--- a/packages/thirdweb/src/utils/any-evm/zksync/isZkSyncChain.ts
+++ b/packages/thirdweb/src/utils/any-evm/zksync/isZkSyncChain.ts
@@ -16,10 +16,20 @@ export async function isZkSyncChain(chain: Chain) {
     chain.id === 4654 ||
     chain.id === 333271 ||
     chain.id === 37111 ||
-    chain.id === 978658
+    chain.id === 978658 ||
+    chain.id === 531050104 ||
+    chain.id === 4457845
   ) {
     return true;
   }
 
-  return false;
+  // fallback to checking the stack on rpc
+  try {
+    const { getChainMetadata } = await import("../../../chains/utils.js");
+    const chainMetadata = await getChainMetadata(chain);
+    return chainMetadata.stackType === "zksync_stack";
+  } catch {
+    // If the network check fails, assume it's not a ZkSync chain
+    return false;
+  }
 }

--- a/packages/thirdweb/src/wallets/smart/index.ts
+++ b/packages/thirdweb/src/wallets/smart/index.ts
@@ -624,7 +624,7 @@ async function _sendUserOp(args: {
   });
   // wait for tx receipt rather than return the userOp hash
   const receipt = await waitForUserOpReceipt({
-    ...options,
+    ...bundlerOptions,
     userOpHash,
   });
 

--- a/packages/thirdweb/src/wallets/utils/getWalletBalance.test.ts
+++ b/packages/thirdweb/src/wallets/utils/getWalletBalance.test.ts
@@ -3,7 +3,6 @@ import { ANVIL_CHAIN } from "~test/chains.js";
 import { TEST_CONTRACT_URI } from "~test/ipfs-uris.js";
 import { TEST_CLIENT } from "~test/test-clients.js";
 import { TEST_ACCOUNT_A } from "~test/test-wallets.js";
-import { defineChain } from "../../chains/utils.js";
 import { getContract } from "../../contract/contract.js";
 import { mintTo } from "../../extensions/erc20/write/mintTo.js";
 import { deployERC20Contract } from "../../extensions/prebuilts/deploy-erc20.js";
@@ -57,12 +56,11 @@ describe.runIf(process.env.TW_SECRET_KEY)("getWalletBalance", () => {
     expect(result.displayValue).toBe(amount.toString());
   });
 
-  it("should work for un-named token", async () => {
+  it("should work for native currency", async () => {
     const result = await getWalletBalance({
       address: TEST_ACCOUNT_A.address,
       client: TEST_CLIENT,
-      chain: defineChain(97),
-      tokenAddress: "0xd66c6B4F0be8CE5b39D52E0Fd1344c389929B378",
+      chain: ANVIL_CHAIN,
     });
     expect(result).toBeDefined();
     expect(result.decimals).toBe(18);


### PR DESCRIPTION
## Problem solved

Fixes CNCT-2217

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the `thirdweb` package by updating configurations, enhancing transaction receipt handling, and refining chain identification logic.

### Detailed summary
- Updated `limit` in `.size-limit.json` from `500 B` to `600 B`.
- Changed `options` to `bundlerOptions` in `waitForUserOpReceipt`.
- Added new chain IDs in `isZkSyncChain.ts` and implemented a fallback mechanism to check the stack type.
- Renamed a test from "un-named token" to "native currency" in `getWalletBalance.test.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->