### PR TITLE
[SDK] Add tests for chain utils

### DIFF
--- a/packages/thirdweb/src/chains/utils.ts
+++ b/packages/thirdweb/src/chains/utils.ts
@@ -10,7 +10,10 @@ import type {
   LegacyChain,
 } from "./types.js";
 
-const CUSTOM_CHAIN_MAP = new Map<number, Chain>();
+/**
+ * @internal Exported for tests
+ */
+export const CUSTOM_CHAIN_MAP = new Map<number, Chain>();
 
 /**
  * Defines a chain with the given options.
@@ -98,7 +101,10 @@ function isLegacyChain(
   return "rpc" in chain && Array.isArray(chain.rpc) && "slug" in chain;
 }
 
-function convertLegacyChain(legacyChain: LegacyChain): Chain {
+/**
+ * @internal
+ */
+export function convertLegacyChain(legacyChain: LegacyChain): Chain {
   const RPC_URL = getThirdwebDomains().rpc;
   return {
     id: legacyChain.chainId,


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `CUSTOM_CHAIN_MAP` and `convertLegacyChain` functionalities, making them exportable for testing. It also adds new test cases to validate chain properties and conversions.

### Detailed summary
- Changed `CUSTOM_CHAIN_MAP` to be exported for testing.
- Exported `convertLegacyChain` function for internal use.
- Added a `legacyChain` object representing Ethereum Mainnet.
- Introduced multiple test cases for chain properties and conversions.
- Verified caching of chains using `CUSTOM_CHAIN_MAP`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->