### PR TITLE
[SDK] Chore: Increase chains size

### DIFF
--- a/packages/thirdweb/.size-limit.json
+++ b/packages/thirdweb/.size-limit.json
@@ -19,7 +19,7 @@
   {
     "name": "thirdweb/chains (tree-shaking)",
     "path": "./dist/esm/exports/chains.js",
-    "limit": "500 B",
+    "limit": "600 B",
     "import": "{ ethereum }"
   },
   {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the size limit for the `thirdweb/chains (tree-shaking)` package.

### Detailed summary
- Updated the `limit` for `thirdweb/chains (tree-shaking)` from `500 B` to `600 B` in the `.size-limit.json` configuration file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->