### PR TITLE
[Dashboard] Fix ERC20 claim conditions

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/_components/claim-conditions/claim-conditions-form/Inputs/MaxClaimablePerWalletInput.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/_components/claim-conditions/claim-conditions-form/Inputs/MaxClaimablePerWalletInput.tsx
@@ -54,7 +54,9 @@ export const MaxClaimablePerWalletInput: React.FC = () => {
       <QuantityInputWithUnlimited
         isRequired
         decimals={tokenDecimals}
-        isDisabled={dropType === "specific" || formDisabled}
+        isDisabled={
+          dropType === "specific" || formDisabled || (isErc20 && !tokenDecimals)
+        }
         value={field?.maxClaimablePerWallet?.toString() || "0"}
         onChange={(value) =>
           form.setValue(

--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/_components/claim-conditions/claim-conditions-form/Inputs/MaxClaimableSupplyInput.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/_components/claim-conditions/claim-conditions-form/Inputs/MaxClaimableSupplyInput.tsx
@@ -35,7 +35,7 @@ export const MaxClaimableSupplyInput: React.FC = () => {
     >
       <QuantityInputWithUnlimited
         isRequired
-        isDisabled={formDisabled}
+        isDisabled={formDisabled || (isErc20 && !tokenDecimals)}
         decimals={tokenDecimals}
         value={field.maxClaimableSupply?.toString() || "0"}
         onChange={(value) =>

--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/_components/claim-conditions/quantity-input-with-unlimited.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/_components/claim-conditions/quantity-input-with-unlimited.tsx
@@ -53,7 +53,7 @@ export const QuantityInputWithUnlimited: React.FC<
     <InputGroup {...restInputProps}>
       <Input
         isRequired={isRequired}
-        isDisabled={decimals === undefined || isDisabled}
+        isDisabled={isDisabled}
         value={stringValue === "unlimited" ? "Unlimited" : stringValue}
         onChange={(e) => updateValue(e.currentTarget.value)}
         onBlur={() => {
@@ -69,7 +69,7 @@ export const QuantityInputWithUnlimited: React.FC<
       {hideMaxButton ? null : (
         <InputRightElement w="auto">
           <Button
-            isDisabled={decimals === undefined || isDisabled}
+            isDisabled={isDisabled}
             colorScheme="primary"
             variant="ghost"
             size="sm"


### PR DESCRIPTION
Fix various issues with ERC20 claim conditions since we up'd it to v5 on the dashboard

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the handling of `tokenDecimals` for ERC20 tokens in the `ClaimConditionsForm` and related components, ensuring proper validation and conversion of values based on token type.

### Detailed summary
- Modified `isDisabled` properties in `MaxClaimableSupplyInput` and `MaxClaimablePerWalletInput` to account for `tokenDecimals`.
- Updated `ClaimConditionsForm` to handle `tokenDecimals` as `number | undefined`.
- Added checks for loading and existence of `tokenDecimals`.
- Introduced conversion functions for ERC20 values to and from display format.
- Adjusted logic in `setClaimPhasesTx` and `getClaimPhasesInLegacyFormat` to use `tokenDecimals` for ERC20 claims.
- Improved error handling and user feedback when `tokenDecimals` cannot be fetched.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->