### PR TITLE
Fix /dashboards path redirecting to /login

### DIFF
--- a/apps/dashboard/src/@/constants/auth.ts
+++ b/apps/dashboard/src/@/constants/auth.ts
@@ -1,14 +1,16 @@
-const LOGGED_IN_ONLY_PATHS = [
-  // anything that _starts_ with /dashboard is logged in only
-  "/dashboard",
-  // team pages are logged in only
-  "/team",
-  // anything that _starts_ with /cli is logged in only
-  "/cli",
-  // publish page
-  "/contracts/publish",
-];
-
 export function isLoginRequired(pathname: string) {
-  return LOGGED_IN_ONLY_PATHS.some((path) => pathname.startsWith(path));
+  // remove '/' in front and then split by '/'
+  const paths = pathname.slice(1).split("/");
+
+  // /dashboard, /team, /cli
+  if (paths[0] === "dashboard" || paths[0] === "team" || paths[0] === "cli") {
+    return true;
+  }
+
+  // /contracts/publish
+  if (paths[0] === "contracts" && paths[1] === "publish") {
+    return true;
+  }
+
+  return false;
 }


### PR DESCRIPTION
Fixes: DASH-395

<!-- start pr-codex -->

---

## PR-Codex overview
This PR modifies the `isLoginRequired` function in the `auth.ts` file to change how it determines if a login is required for certain paths. It replaces the previous array-based check with a more explicit conditional check based on the first segments of the path.

### Detailed summary
- Removed the `LOGGED_IN_ONLY_PATHS` array and its contents.
- Introduced a new method to check the path by splitting the `pathname`.
- Added conditions to check if the first segment is `dashboard`, `team`, or `cli`.
- Added a condition to check if the path is `/contracts/publish`.
- Simplified the return logic to return `true` or `false` based on the checks.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->