### PR TITLE
Make reason form field optional in delete engine form

### DIFF
--- a/apps/dashboard/src/components/engine/engine-instances-table.tsx
+++ b/apps/dashboard/src/components/engine/engine-instances-table.tsx
@@ -430,34 +430,22 @@ function DeleteSubscriptionModalContent(props: {
 
       <form onSubmit={form.handleSubmit(onSubmit)}>
         {/* Reason */}
-        <FormControl isRequired>
+        <FormControl>
           <FormLabel className="!text-base">
             Please share your feedback to help us improve Engine.
           </FormLabel>
           <RadioGroup>
             <div className="flex flex-col gap-2">
-              <Radio
-                value="USING_SELF_HOSTED"
-                {...form.register("reason", { required: true })}
-              >
+              <Radio value="USING_SELF_HOSTED" {...form.register("reason")}>
                 <span className="text-sm"> Migrating to self-hosted </span>
               </Radio>
-              <Radio
-                value="TOO_EXPENSIVE"
-                {...form.register("reason", { required: true })}
-              >
+              <Radio value="TOO_EXPENSIVE" {...form.register("reason")}>
                 <span className="text-sm"> Too expensive </span>
               </Radio>
-              <Radio
-                value="MISSING_FEATURES"
-                {...form.register("reason", { required: true })}
-              >
+              <Radio value="MISSING_FEATURES" {...form.register("reason")}>
                 <span className="text-sm"> Missing features </span>
               </Radio>
-              <Radio
-                value="OTHER"
-                {...form.register("reason", { required: true })}
-              >
+              <Radio value="OTHER" {...form.register("reason")}>
                 <span className="text-sm"> Other </span>
               </Radio>
             </div>


### PR DESCRIPTION
Fixes: DASH-381

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying the `engine-instances-table.tsx` component to simplify the form validation by removing the `required` attribute from the `Radio` components, while maintaining their functionality.

### Detailed summary
- Removed `isRequired` from the `<FormControl>` component.
- Removed `required: true` from the `form.register("reason")` calls in all `<Radio>` components.
- Kept the `value` and inner `<span>` text for each `Radio` component intact.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->