### PR TITLE
fix: force wallet chain switch in Pay UI

### DIFF
--- a/.changeset/fuzzy-lobsters-deliver.md
+++ b/.changeset/fuzzy-lobsters-deliver.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix Pay UI not force switching connected wallet chain

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx
@@ -984,7 +984,8 @@ function SwapScreenContent(props: {
 
   const disableContinue =
     (swapRequired && !quoteQuery.data) || isNotEnoughBalance;
-  const switchChainRequired = props.payer.chain.id !== fromChain.id;
+  const switchChainRequired =
+    props.payer.wallet.getChain()?.id !== fromChain.id;
 
   // biome-ignore lint/suspicious/noExplicitAny: <explanation>
   function getErrorMessage(err: any) {


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added



<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the Pay UI to ensure it correctly switches the connected wallet's chain when necessary.

### Detailed summary
- Updated the condition for `switchChainRequired` in `BuyScreen.tsx` to check if the wallet's chain ID matches the `fromChain.id` using `props.payer.wallet.getChain()?.id` instead of `props.payer.chain.id`.
- Added a patch entry for `thirdweb` in the changelog.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->