### PR TITLE
[Dashboard] Update simplehash supported networks

### DIFF
--- a/apps/dashboard/src/lib/wallet/nfts/types.ts
+++ b/apps/dashboard/src/lib/wallet/nfts/types.ts
@@ -136,6 +136,10 @@ export const simpleHashSupportedChainIdsMap: Record<number, string> = {
   [zkSync.id]: "zksync-era",
   [zora.id]: "zora",
   [zoraSepolia.id]: "zora-sepolia",
+  [1329]: "sei",
+  [1328]: "sei-atlantic-2",
+  [360]: "shape",
+  [33139]: "apechain",
 };
 
 export type AlchemySupportedChainId = keyof typeof alchemySupportedChainIdsMap;


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds new supported NFT chains to the `alchemySupportedChainIdsMap` in the `apps/dashboard/src/lib/wallet/nfts/types.ts` file.

### Detailed summary
- Added new chain IDs:
  - `sei`
  - `sei-atlantic-2`
  - `shape`
  - `apechain`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->