### PR TITLE
[Dashboard] Remove <Drawer /> from SetSharedMetadata form

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/nfts/components/shared-metadata-button.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/nfts/components/shared-metadata-button.tsx
@@ -1,10 +1,16 @@
 "use client";
-
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
 import { MinterOnly } from "@3rdweb-sdk/react/components/roles/minter-only";
-import { useDisclosure } from "@chakra-ui/react";
 import { PlusIcon } from "lucide-react";
+import { useState } from "react";
 import type { ThirdwebContract } from "thirdweb";
-import { Button, Drawer } from "tw-components";
+import { Button } from "tw-components";
 import { SharedMetadataForm } from "./shared-metadata-form";
 
 interface NFTSharedMetadataButtonProps {
@@ -14,26 +20,26 @@ interface NFTSharedMetadataButtonProps {
 export const NFTSharedMetadataButton: React.FC<
   NFTSharedMetadataButtonProps
 > = ({ contract, ...restButtonProps }) => {
-  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [open, setOpen] = useState(false);
   return (
     <MinterOnly contract={contract}>
-      <Drawer
-        allowPinchZoom
-        preserveScrollBarGap
-        size="lg"
-        onClose={onClose}
-        isOpen={isOpen}
-      >
-        <SharedMetadataForm contract={contract} />
-      </Drawer>
-      <Button
-        colorScheme="primary"
-        leftIcon={<PlusIcon className="size-5" />}
-        {...restButtonProps}
-        onClick={onOpen}
-      >
-        Set NFT Metadata
-      </Button>
+      <Sheet open={open} onOpenChange={setOpen}>
+        <SheetTrigger asChild>
+          <Button
+            colorScheme="primary"
+            leftIcon={<PlusIcon className="size-5" />}
+            {...restButtonProps}
+          >
+            Set NFT Metadata
+          </Button>
+        </SheetTrigger>
+        <SheetContent className="w-full overflow-y-auto sm:min-w-[540px] lg:min-w-[700px]">
+          <SheetHeader>
+            <SheetTitle className="text-left">Set NFT Metadata</SheetTitle>
+          </SheetHeader>
+          <SharedMetadataForm contract={contract} setOpen={setOpen} />
+        </SheetContent>
+      </Sheet>
     </MinterOnly>
   );
 };


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the `NFTSharedMetadataButton` and `SharedMetadataForm` components to replace the `Drawer` UI component with a new `Sheet` component, enhancing the user interface for setting NFT metadata.

### Detailed summary
- Replaced `Drawer` with `Sheet` in `NFTSharedMetadataButton`.
- Updated state management from `useDisclosure` to `useState`.
- Modified props in `SharedMetadataForm` to accept `setOpen`.
- Integrated `toast` for success/error messages instead of modal context notifications.
- Adjusted button functionalities and styles for consistency with the new `Sheet` component.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->