### PR TITLE
Add providerOverride as an option for fiat payments

### DIFF
--- a/.changeset/calm-actors-rest.md
+++ b/.changeset/calm-actors-rest.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Allow choosing a specific fiat provider

--- a/packages/thirdweb/src/pay/buyWithFiat/getQuote.ts
+++ b/packages/thirdweb/src/pay/buyWithFiat/getQuote.ts
@@ -91,6 +91,14 @@ export type GetBuyWithFiatQuoteParams = {
    * By default, we choose a recommended provider based on the location of the user, KYC status, and currency.
    */
   preferredProvider?: FiatProvider;
+
+    /**
+   * Optional parameter to specify an overriding onramp provider.
+   *
+   * By default, we choose a recommended provider based on the location of the user, KYC status, and currency.
+   * If this is set, we will always choose this specific onramp provider, or error if this provider cannot support the user.
+   */
+  providerOverride?: FiatProvider;
 };
 
 /**
@@ -313,6 +321,7 @@ export async function getBuyWithFiatQuote(
         fromAddress: params.fromAddress,
         toGasAmountWei: params.toGasAmountWei,
         preferredProvider: params.preferredProvider,
+        providerOverride: params.providerOverride,
       }),
     });
 

--- a/packages/thirdweb/src/react/core/hooks/connection/ConnectButtonProps.ts
+++ b/packages/thirdweb/src/react/core/hooks/connection/ConnectButtonProps.ts
@@ -91,6 +91,7 @@ export type PayUIOptions = Prettify<
             currency?: "USD" | "CAD" | "GBP" | "EUR" | "JPY";
           };
           preferredProvider?: FiatProvider;
+          providerOverride?: FiatProvider;
         }
       | false;
 

--- a/packages/thirdweb/src/react/core/hooks/transaction/useSendTransaction.ts
+++ b/packages/thirdweb/src/react/core/hooks/transaction/useSendTransaction.ts
@@ -61,6 +61,7 @@ export type SendTransactionPayModalConfig =
             };
             testMode?: boolean;
             preferredProvider?: FiatProvider;
+            providerOverride?: FiatProvider;
           };
       purchaseData?: object;
       /**

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx
@@ -1247,6 +1247,7 @@ function FiatScreenContent(props: {
           purchaseData: props.payOptions.purchaseData,
           fromAddress: payer.account.address,
           preferredProvider: buyWithFiatOptions?.preferredProvider,
+          providerOverride: buyWithFiatOptions?.providerOverride,
         }
       : undefined,
   );


### PR DESCRIPTION
## Problem solved

Allow customers to override the fiat provider routing and specify the provider they want.

Fixes https://linear.app/thirdweb/issue/CNCT-2227/pro-only-keep-stripe-as-a-provider-for-pay

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the ability to specify a custom fiat provider through a new `providerOverride` parameter across several components, enhancing flexibility in fiat transactions.

### Detailed summary
- Added `providerOverride` parameter to `ConnectButtonProps.ts`.
- Updated `useSendTransaction.ts` to include `providerOverride`.
- Modified `BuyScreen.tsx` to pass `providerOverride` from `buyWithFiatOptions`.
- Enhanced `getQuote.ts` with documentation for `providerOverride`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->