### PR TITLE
Fix missing description meta tag, add og:site_name in portal

### DIFF
--- a/apps/portal/src/components/Document/metadata.ts
+++ b/apps/portal/src/components/Document/metadata.ts
@@ -32,6 +32,7 @@ export function createMetadata(obj: {
 }): Metadata {
   return {
     title: obj.title,
+    description: obj.description,
     metadataBase: new URL("https://portal.thirdweb.com"),
     twitter: {
       title: obj.title,
@@ -45,6 +46,7 @@ export function createMetadata(obj: {
       description: obj.description,
       locale: "en_US",
       type: "website",
+      siteName: "thirdweb docs",
       images: obj.image
         ? [
             {


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the metadata returned by the `createMetadata` function in the `metadata.ts` file by adding a `description` and a `siteName` field.

### Detailed summary
- Added `description: obj.description` to the returned object.
- Added `siteName: "thirdweb docs"` to the returned object.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->