### PR TITLE
fix postbuild cache

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -8,13 +8,12 @@
     "dev": "next dev --turbopack",
     "prebuild": "pnpm run create-index",
     "build": "next build",
-    "postbuild": "pnpm run extract-search-data",
+    "postbuild": "pnpm run extract-search-data && pnpm next-sitemap",
     "start": "next start",
     "lint": "biome check ./src && eslint ./src",
     "fix": "biome check ./src --fix && eslint ./src --fix",
     "create-index": "pnpm tsx scripts/createEmptySearchIndex.ts",
-    "extract-search-data": "pnpm tsx scripts/extractSearchData.ts",
-    "postextract-search-data": "next-sitemap"
+    "extract-search-data": "pnpm tsx scripts/extractSearchData.ts"
   },
   "dependencies": {
     "@dirtycajunrice/klee": "^1.0.1",

--- a/turbo.json
+++ b/turbo.json
@@ -6,6 +6,16 @@
       "outputs": ["dist/**"],
       "dependsOn": ["^build"]
     },
+    "postbuild": {
+      "dependsOn": ["^postbuild"],
+      "outputs": [
+        "dist/**",
+        ".next/**",
+        "public/robots.txt",
+        "public/sitemap*.xml",
+        "searchIndex.json"
+      ]
+    },
     "bench": {
       "cache": false,
       "dependsOn": []


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the build process in the `turbo.json` and `package.json` files. It adds a new `postbuild` step that includes additional outputs and modifies the existing `postbuild` command to run `next-sitemap` after extracting search data.

### Detailed summary
- Added a new `postbuild` section in `turbo.json` with dependencies and outputs.
- Updated the `postbuild` command in `apps/portal/package.json` to run `next-sitemap` after `extract-search-data`.
- Maintained the `extract-search-data` command without changes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->