### PR TITLE
[Portal] Docs: adds SiteEmbed and SiteLink to docs

### DIFF
--- a/apps/portal/src/app/react/v5/sidebar.tsx
+++ b/apps/portal/src/app/react/v5/sidebar.tsx
@@ -392,6 +392,21 @@ export const sidebar: SideBar = {
     },
     { separator: true },
     {
+      name: "Advanced",
+      isCollapsible: false,
+      links: [
+        {
+          name: "UI Components",
+          links: ["SiteEmbed", "SiteLink"].map((name) => ({
+            name,
+            href: `${slug}/${name}`,
+            icon: <CodeIcon />,
+          })),
+        },
+      ],
+    },
+    { separator: true },
+    {
       name: "Migrate from v4",
       href: `${slug}/migrate`,
       links: [


### PR DESCRIPTION
CNCT-2266

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new section titled "Advanced" to the sidebar in the application, which includes links to "UI Components" with individual links for `SiteEmbed` and `SiteLink`.

### Detailed summary
- Added a new sidebar section with the name "Advanced".
- Set `isCollapsible` to `false` for the "Advanced" section.
- Created a `links` array under "Advanced" containing a link for `UI Components`.
- Mapped `SiteEmbed` and `SiteLink` to generate link objects with `name`, `href`, and `icon`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->