### PR TITLE
fix: make encryption key optional for custom auth wallets

### DIFF
--- a/.changeset/rich-kangaroos-sip.md
+++ b/.changeset/rich-kangaroos-sip.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Make encryption key optional for in-app and ecosystem wallets custom auth

--- a/apps/portal/src/app/connect/in-app-wallet/custom-auth/configuration/page.mdx
+++ b/apps/portal/src/app/connect/in-app-wallet/custom-auth/configuration/page.mdx
@@ -67,7 +67,6 @@ const handlePostLogin = async (jwt: string) => {
 			client,
 			strategy: "jwt",
 			jwt,
-			encryptionKey: "your-encryption-key",
 		});
 		return wallet;
 	});
@@ -87,7 +86,6 @@ const account = await wallet.connect({
 	client,
 	strategy: "jwt",
 	jwt,
-	encryptionKey: "your-encryption-key",
 });
 
 // use the account to send transactions
@@ -95,10 +93,6 @@ const account = await wallet.connect({
 
 </TabsContent>
 </Tabs>
-
-You can set your `encryptionKey` in either a secret env variable or ask the user to enter a password for it.
-
-** Do not hardcode the `encryptionKey` in your code. **
 
 ## Generic auth
 
@@ -159,7 +153,6 @@ const handlePostLogin = async (jwt: string) => {
 			strategy: "auth_endpoint",
 			// This is the payload that is sent to the auth endpoint
 			payload,
-			encryptionKey: "your-encryption-key",
 		});
 		return wallet;
 	});
@@ -182,7 +175,6 @@ const account = await wallet.connect({
 	strategy: "auth_endpoint",
 	// This is the payload that is sent to the auth endpoint
 	payload,
-	encryptionKey: "your-encryption-key",
 });
 
 // use the account to send transactions
@@ -190,7 +182,3 @@ const account = await wallet.connect({
 
 </TabsContent>
 </Tabs>
-
-You can set your `encryptionKey` in either a secret env variable or ask the user to enter a password for it.
-
-**Do not hardcode the `encryptionKey` in your code. Use environment variables, server returned keys or user derived keys.**

--- a/apps/portal/src/app/connect/in-app-wallet/custom-auth/custom-auth-server/page.mdx
+++ b/apps/portal/src/app/connect/in-app-wallet/custom-auth/custom-auth-server/page.mdx
@@ -107,7 +107,6 @@ const handlePostLogin = async (jwt: string) => {
 			client,
 			strategy: "auth_endpoint",
 			payload: JSON.stringify({ userId: "ANY_RANDOM_ID_HERE" }),
-			encryptionKey: "your-encryption-key",
 		});
 		return wallet;
 	});
@@ -127,7 +126,6 @@ const account = await wallet.connect({
 	client,
 	strategy: "auth_endpoint",
 	payload: JSON.stringify({ userId: "ANY_RANDOM_ID_HERE" }),
-	encryptionKey: "your-encryption-key",
 });
 
 // use the account to send transactions
@@ -135,10 +133,6 @@ const account = await wallet.connect({
 
 </TabsContent>
 </Tabs>
-
-You can set your encryptionKey in either a secret env variable or ask the user to enter a password for it.
-
-** Do not hardcode the encryptionKey in your code. **
 
 A persistent, cross-platform wallet is now created for your user!
 

--- a/apps/portal/src/app/connect/in-app-wallet/custom-auth/firebase-auth/page.mdx
+++ b/apps/portal/src/app/connect/in-app-wallet/custom-auth/firebase-auth/page.mdx
@@ -153,16 +153,11 @@ const connectInApp = async (jwt: string) => {
 			client,
 			strategy: "jwt",
 			jwt: await getFirebaseJWT(),
-			encryptionKey: "your-encryption-key",
 		});
 		return wallet;
 	});
 };
 ```
-
-You can set your `encryptionKey` in either a secret env variable or ask the user to enter a password for it.
-
-** Do not hardcode the `encryptionKey` in your code. **
 
 After the connectInApp function returns, the ThirdwebProvider will have connected a wallet thereby granting access to all hooks and functionalities.
 

--- a/apps/portal/src/app/dotnet/wallets/providers/in-app-wallet/page.mdx
+++ b/apps/portal/src/app/dotnet/wallets/providers/in-app-wallet/page.mdx
@@ -64,10 +64,10 @@ var address = await wallet.LoginWithOauth(
 var address = await siweWallet.LoginWithSiwe(chainId: 1);
 
 // Custom Auth (JWT)
-var address = await wallet.LoginWithCustomAuth(jwt: "myjwt", encryptionkey: "myencryptionkey");
+var address = await wallet.LoginWithCustomAuth(jwt: "myjwt");
 
 // Custom Auth (AuthEndpoint)
-var address = await wallet.LoginWithAuthEndpoint(payload: "mypayload", encryptionkey: "myencryptionkey");
+var address = await wallet.LoginWithAuthEndpoint(payload: "mypayload");
 
 // Guest Login (Easy onboarding)
 var address = await wallet.LoginWithGuest();

--- a/packages/thirdweb/src/wallets/in-app/core/authentication/types.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/authentication/types.ts
@@ -34,8 +34,8 @@ export type SocialAuthArgsType = {
 
 export type SingleStepAuthArgsType =
   | SocialAuthArgsType
-  | { strategy: "jwt"; jwt: string; encryptionKey: string }
-  | { strategy: "auth_endpoint"; payload: string; encryptionKey: string }
+  | { strategy: "jwt"; jwt: string; encryptionKey?: string }
+  | { strategy: "auth_endpoint"; payload: string; encryptionKey?: string }
   | {
       /**
        * @deprecated


### PR DESCRIPTION
## Problem solved

fixes CNCT-2269

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on making the `encryptionKey` optional in the custom authentication methods for in-app and ecosystem wallets, enhancing security practices by discouraging hardcoding sensitive data.

### Detailed summary
- Updated `SingleStepAuthArgsType` to make `encryptionKey` optional for both `jwt` and `auth_endpoint` strategies.
- Removed hardcoded `encryptionKey` from various examples and documentation.
- Emphasized using environment variables or user input for `encryptionKey`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->