### PR TITLE
[Dashboard] Fix falsy logic when updating Royalties and PlatformFees

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/settings/components/platform-fees.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/settings/components/platform-fees.tsx
@@ -10,8 +10,7 @@ import { SolidityInput } from "contract-ui/components/solidity-inputs";
 import { useTrack } from "hooks/analytics/useTrack";
 import { useTxNotifications } from "hooks/useTxNotifications";
 import { useForm } from "react-hook-form";
-import { toast } from "sonner";
-import { type ThirdwebContract, ZERO_ADDRESS } from "thirdweb";
+import type { ThirdwebContract } from "thirdweb";
 import {
   getPlatformFeeInfo,
   setPlatformFeeInfo,
@@ -36,11 +35,11 @@ const CommonPlatformFeeSchema = z.object({
   /**
    * platform fee basis points
    */
-  platform_fee_basis_points: BasisPointsSchema.default(0),
+  platform_fee_basis_points: BasisPointsSchema,
   /**
    * platform fee recipient address
    */
-  platform_fee_recipient: AddressOrEnsSchema.default(ZERO_ADDRESS),
+  platform_fee_recipient: AddressOrEnsSchema,
 });
 
 export const SettingsPlatformFees = ({
@@ -84,14 +83,6 @@ export const SettingsPlatformFees = ({
             action: "set-platform-fees",
             label: "attempt",
           });
-          // In the v4 hook we defaulted recipient to address_zero and bps to `0`
-          // but let's actually throw an error here for better transparency
-          if (!data.platform_fee_basis_points) {
-            return toast.error("Please enter valid basis points.");
-          }
-          if (!data.platform_fee_recipient) {
-            return toast.error("Please enter a valid platform fee recipient.");
-          }
           const transaction = setPlatformFeeInfo({
             contract,
             platformFeeRecipient: data.platform_fee_recipient,

--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/settings/components/royalties.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/settings/components/royalties.tsx
@@ -10,8 +10,7 @@ import { SolidityInput } from "contract-ui/components/solidity-inputs";
 import { useTrack } from "hooks/analytics/useTrack";
 import { useTxNotifications } from "hooks/useTxNotifications";
 import { useForm } from "react-hook-form";
-import { toast } from "sonner";
-import { type ThirdwebContract, ZERO_ADDRESS } from "thirdweb";
+import type { ThirdwebContract } from "thirdweb";
 import {
   getDefaultRoyaltyInfo,
   setDefaultRoyaltyInfo,
@@ -46,7 +45,7 @@ const CommonRoyaltySchema = z.object({
    * @internal
    * @remarks used by OpenSea "seller_fee_basis_points"
    */
-  seller_fee_basis_points: BasisPointsSchema.default(0),
+  seller_fee_basis_points: BasisPointsSchema,
 
   /**
    * The address of the royalty recipient. All royalties will be sent
@@ -54,7 +53,7 @@ const CommonRoyaltySchema = z.object({
    * @internal
    * @remarks used by OpenSea "fee_recipient"
    */
-  fee_recipient: AddressOrEnsSchema.default(ZERO_ADDRESS),
+  fee_recipient: AddressOrEnsSchema,
 });
 
 export const SettingsRoyalties = ({
@@ -97,14 +96,6 @@ export const SettingsRoyalties = ({
             action: "set-royalty",
             label: "attempt",
           });
-          // In the v4 hook we defaulted recipient to address_zero and bps to `0`
-          // but let's actually throw an error here for better transparency
-          if (!d.seller_fee_basis_points) {
-            return toast.error("Please enter valid basis points.");
-          }
-          if (!d.fee_recipient) {
-            return toast.error("Please enter a valid royalty fee recipient.");
-          }
           const transaction = setDefaultRoyaltyInfo({
             contract,
             royaltyRecipient: d.fee_recipient,


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refining the validation logic for platform fees and royalties by removing default values and error handling related to `platform_fee_basis_points` and `platform_fee_recipient` in `platform-fees.tsx` and `royalties.tsx`.

### Detailed summary
- Removed default values for `platform_fee_basis_points` and `platform_fee_recipient` in `platform-fees.tsx`.
- Removed error handling for invalid `platform_fee_basis_points` and `platform_fee_recipient` in `platform-fees.tsx`.
- Removed default values for `seller_fee_basis_points` and `fee_recipient` in `royalties.tsx`.
- Removed error handling for invalid `seller_fee_basis_points` and `fee_recipient` in `royalties.tsx`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->