### PR TITLE
[SDK] Feature: Include chain ID in analytics events

### DIFF
--- a/.changeset/slimy-pots-camp.md
+++ b/.changeset/slimy-pots-camp.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Adds chain ID to tracked analytics

--- a/packages/thirdweb/src/analytics/track/connect.ts
+++ b/packages/thirdweb/src/analytics/track/connect.ts
@@ -10,8 +10,9 @@ export async function trackConnect(args: {
   ecosystem?: Ecosystem;
   walletType: string;
   walletAddress: string;
+  chainId?: number;
 }) {
-  const { client, ecosystem, walletType, walletAddress } = args;
+  const { client, ecosystem, walletType, walletAddress, chainId } = args;
   return track({
     client,
     ecosystem,
@@ -20,6 +21,7 @@ export async function trackConnect(args: {
       action: "connect",
       walletType,
       walletAddress,
+      chainId,
     },
   });
 }

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/ConfirmationScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/ConfirmationScreen.tsx
@@ -279,7 +279,7 @@ export function SwapConfirmationScreen(props: {
                   fromAmount: props.quote.swapDetails.fromAmountWei,
                   toToken: props.quote.swapDetails.toToken.tokenAddress,
                   toAmount: props.quote.swapDetails.toAmountWei,
-                  chainId: props.quote.swapDetails.toToken.chainId,
+                  chainId: props.quote.swapDetails.fromToken.chainId,
                   dstChainId: props.quote.swapDetails.toToken.chainId,
                 });
 

--- a/packages/thirdweb/src/react/web/ui/TransactionButton/TransactionModal.tsx
+++ b/packages/thirdweb/src/react/web/ui/TransactionButton/TransactionModal.tsx
@@ -42,6 +42,7 @@ export function TransactionModal(props: ModalProps) {
         client: props.client,
         walletAddress: account.address,
         walletType: wallet.id,
+        dstChainId: props.tx.chain.id,
         event: "open_pay_transaction_modal",
       });
     },

--- a/packages/thirdweb/src/wallets/coinbase/coinbase-wallet.ts
+++ b/packages/thirdweb/src/wallets/coinbase/coinbase-wallet.ts
@@ -81,6 +81,7 @@ export function coinbaseWalletSDK(args: {
         client: options.client,
         walletType: COINBASE,
         walletAddress: account.address,
+        chainId: chain.id,
       });
       // return account
       return account;
@@ -100,6 +101,7 @@ export function coinbaseWalletSDK(args: {
         client: options.client,
         walletType: COINBASE,
         walletAddress: account.address,
+        chainId: chain.id,
       });
       // return account
       return account;

--- a/packages/thirdweb/src/wallets/create-wallet.ts
+++ b/packages/thirdweb/src/wallets/create-wallet.ts
@@ -250,6 +250,7 @@ export function createWallet<const ID extends WalletId>(
               client: options.client,
               walletType: id,
               walletAddress: account.address,
+              chainId: chain.id,
             });
             // return account
             return account;
@@ -281,6 +282,7 @@ export function createWallet<const ID extends WalletId>(
               client: options.client,
               walletType: id,
               walletAddress: account.address,
+              chainId: chain.id,
             });
             // return account
             return account;
@@ -314,6 +316,7 @@ export function createWallet<const ID extends WalletId>(
               client: wcOptions.client,
               walletType: id,
               walletAddress: account.address,
+              chainId: chain.id,
             });
             return account;
           }
@@ -359,6 +362,7 @@ export function createWallet<const ID extends WalletId>(
               client: options.client,
               walletType: id,
               walletAddress: account.address,
+              chainId: chain.id,
             });
             // return account
             return account;

--- a/packages/thirdweb/src/wallets/in-app/core/wallet/in-app-core.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/wallet/in-app-core.ts
@@ -106,6 +106,7 @@ export function createInAppWallet(args: {
         ecosystem,
         walletType: walletId,
         walletAddress: account.address,
+        chainId: chain.id,
       });
       // return only the account
       return account;
@@ -153,6 +154,7 @@ export function createInAppWallet(args: {
         ecosystem,
         walletType: walletId,
         walletAddress: account.address,
+        chainId: chain.id,
       });
       // return only the account
       return account;

--- a/packages/thirdweb/src/wallets/native/create-wallet.ts
+++ b/packages/thirdweb/src/wallets/native/create-wallet.ts
@@ -169,6 +169,7 @@ export function createWallet<const ID extends WalletId>(
               client: options.client,
               walletType: id,
               walletAddress: account.address,
+              chainId: chain.id,
             });
             // return account
             return account;
@@ -202,6 +203,7 @@ export function createWallet<const ID extends WalletId>(
               client: wcOptions.client,
               walletType: id,
               walletAddress: account.address,
+              chainId: chain.id,
             });
             return account;
           }

--- a/packages/thirdweb/src/wallets/smart/smart-wallet.ts
+++ b/packages/thirdweb/src/wallets/smart/smart-wallet.ts
@@ -167,6 +167,7 @@ export function smartWallet(
         client: options.client,
         walletType: "smart",
         walletAddress: account.address,
+        chainId: chain.id,
       });
       // return account
       return account;
@@ -187,6 +188,7 @@ export function smartWallet(
         client: options.client,
         walletType: "smart",
         walletAddress: account.address,
+        chainId: chain.id,
       });
       // return account
       emitter.emit("accountChanged", account);


### PR DESCRIPTION
CNCT-2138

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding the `chainId` to various components in the `thirdweb` package to enhance the tracking of analytics and wallet connections.

### Detailed summary
- Added `chainId` to `TransactionModal.tsx` for transaction tracking.
- Updated `ConfirmationScreen.tsx` to use `fromToken.chainId`.
- Introduced `chainId` in multiple wallet creation functions across various wallet files.
- Modified analytics tracking to include `chainId`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->