### PR TITLE
fix: use maxFeePerGas for Pay gas estimations

### DIFF
--- a/.changeset/hot-bees-turn.md
+++ b/.changeset/hot-bees-turn.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Use maxFeePerGas for Pay gas cost estimations in transaction flow

--- a/apps/playground-web/src/components/pay/transaction-button.tsx
+++ b/apps/playground-web/src/components/pay/transaction-button.tsx
@@ -2,7 +2,7 @@
 
 import { useTheme } from "next-themes";
 import { getContract } from "thirdweb";
-import { polygon, sepolia } from "thirdweb/chains";
+import { base, sepolia } from "thirdweb/chains";
 import { transfer } from "thirdweb/extensions/erc20";
 import { claimTo, getNFT } from "thirdweb/extensions/erc1155";
 import {
@@ -16,8 +16,8 @@ import { THIRDWEB_CLIENT } from "../../lib/client";
 import { StyledConnectButton } from "../styled-connect-button";
 
 const nftContract = getContract({
-  address: "0x827c1c3889923015C1FC31BF677D00FbE6F01D52",
-  chain: polygon,
+  address: "0xf0d0CBf84005Dd4eC81364D1f5D7d896Bd53D1B8",
+  chain: base,
   client: THIRDWEB_CLIENT,
 });
 
@@ -35,7 +35,7 @@ export function PayTransactionPreview() {
   const { theme } = useTheme();
   const { data: nft } = useReadContract(getNFT, {
     contract: nftContract,
-    tokenId: 0n,
+    tokenId: 1n,
   });
 
   return (
@@ -51,7 +51,7 @@ export function PayTransactionPreview() {
             transaction: claimTo({
               contract: nftContract,
               quantity: 1n,
-              tokenId: 0n,
+              tokenId: 1n,
               to: account?.address || "",
             }),
             metadata: nft?.metadata,

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/Details.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/Details.tsx
@@ -363,7 +363,7 @@ function DetailsModal(props: {
           {chainNameQuery.name || `Unknown chain #${walletChain?.id}`}
           <Text color="secondaryText" size="xs">
             {balanceQuery.data ? (
-              formatNumber(Number(balanceQuery.data.displayValue), 5)
+              formatNumber(Number(balanceQuery.data.displayValue), 9)
             ) : (
               <Skeleton height="1em" width="100px" />
             )}{" "}

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/TransactionModeScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/TransactionModeScreen.tsx
@@ -125,7 +125,7 @@ export function TransactionModeScreen(props: {
               {balanceQuery.data ? (
                 <Container flex="row" gap="3xs" center="y">
                   <Text size="xs" color="secondaryText" weight={500}>
-                    {formatTokenBalance(balanceQuery.data, false, 3)}
+                    {formatTokenBalance(balanceQuery.data, false)}
                   </Text>
                   <TokenSymbol
                     token={transactionCostAndData.token}

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/WalletSelectorButton.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/WalletSelectorButton.tsx
@@ -115,7 +115,7 @@ function TokenBalanceRow(props: {
       <div style={{ flex: 1 }} />
       <Container flex="row" center="y" gap="3xs">
         <Text size="xs" color="secondaryText">
-          {formatTokenBalance(tokenBalance.balance, true, 3)}
+          {formatTokenBalance(tokenBalance.balance, true)}
         </Text>
       </Container>
     </StyledButton>

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/PayWithCrypto.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/PayWithCrypto.tsx
@@ -74,7 +74,7 @@ export function PayWithCryptoQuoteInfo(props: {
         {balanceQuery.data ? (
           <Container flex="row" gap="3xs" center="y">
             <Text size="xs" color="secondaryText" weight={500}>
-              {formatTokenBalance(balanceQuery.data, false, 3)}
+              {formatTokenBalance(balanceQuery.data, false)}
             </Text>
             <TokenSymbol
               token={props.token}

--- a/packages/thirdweb/src/transaction/actions/estimate-gas-cost.test.ts
+++ b/packages/thirdweb/src/transaction/actions/estimate-gas-cost.test.ts
@@ -22,11 +22,11 @@ describe.runIf(process.env.TW_SECRET_KEY)("estimateGasCost", () => {
         transaction: tx,
       });
       expect(result).toMatchInlineSnapshot(`
-          {
-            "ether": "0.001196638702568277",
-            "wei": 1196638702568277n,
-          }
-        `);
+        {
+          "ether": "0.002468675264234022",
+          "wei": 2468675264234022n,
+        }
+      `);
     });
 
     it("should estimateGasCost native token", async () => {
@@ -41,8 +41,8 @@ describe.runIf(process.env.TW_SECRET_KEY)("estimateGasCost", () => {
       });
       expect(result).toMatchInlineSnapshot(`
         {
-          "ether": "0.00052179661420146",
-          "wei": 521796614201460n,
+          "ether": "0.00107647061028156",
+          "wei": 1076470610281560n,
         }
       `);
     });
@@ -61,8 +61,8 @@ describe.runIf(process.env.TW_SECRET_KEY)("estimateGasCost", () => {
       });
       expect(result).toMatchInlineSnapshot(`
         {
-          "ether": "0.000021198198952138",
-          "wei": 21198198952138n,
+          "ether": "0.000023420415571618",
+          "wei": 23420415571618n,
         }
       `);
     });


### PR DESCRIPTION
## Problem solved

Fixes CNCT-2287

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving gas cost estimations and enhancing token balance formatting in the `thirdweb` package. It updates the way gas fees are calculated and modifies the display of token balances in various components.

### Detailed summary
- Updated gas cost estimation to use `maxFeePerGas`.
- Increased decimal precision for displayed token balances in:
  - `Details.tsx` (from 5 to 9 decimals)
  - `WalletSelectorButton.tsx` (default precision)
  - `PayWithCrypto.tsx` (default precision)
  - `TransactionModeScreen.tsx` (default precision)
- Modified inline snapshots in tests for gas cost estimates.
- Changed gas price retrieval to use `getDefaultGasOverrides`.
- Updated the NFT contract address and chain in `transaction-button.tsx`.
- Adjusted the token ID from `0n` to `1n` in `PayTransactionPreview`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->