### PR TITLE
[Dashboard]: fix client ID not being passed correctly to in app wallet user content

### DIFF
--- a/apps/dashboard/src/app/team/[team_slug]/[project_slug]/connect/in-app-wallets/users/page.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/[project_slug]/connect/in-app-wallets/users/page.tsx
@@ -1,14 +1,21 @@
+import { getProject } from "@/api/projects";
 import { InAppWalletUsersPageContent } from "components/embedded-wallets/Users";
+import { notFound } from "next/navigation";
 import { TRACKING_CATEGORY } from "../_constants";
 
 export default async function Page(props: {
   params: Promise<{ team_slug: string; project_slug: string }>;
 }) {
   const params = await props.params;
+  const project = await getProject(params.team_slug, params.project_slug);
+  if (!project) {
+    notFound();
+  }
+
   return (
     <>
       <InAppWalletUsersPageContent
-        clientId={params.project_slug}
+        clientId={project.publishableKey}
         trackingCategory={TRACKING_CATEGORY}
       />
     </>


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `Page` component in `apps/dashboard/src/app/team/[team_slug]/[project_slug]/connect/in-app-wallets/users/page.tsx` by adding project validation and updating the client ID used in the `InAppWalletUsersPageContent` component.

### Detailed summary
- Added import of `notFound` from `next/navigation`.
- Fetched the `project` using `getProject` based on `team_slug` and `project_slug`.
- Implemented a check for the existence of `project`; if not found, triggers `notFound()`.
- Updated `clientId` prop in `InAppWalletUsersPageContent` to use `project.publishableKey`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->