### PR TITLE
feat: use paymaster for all zk testnet chains

### DIFF
--- a/apps/dashboard/src/@/constants/thirdweb.server.ts
+++ b/apps/dashboard/src/@/constants/thirdweb.server.ts
@@ -54,16 +54,25 @@ export function getThirdwebClient(jwt?: string) {
               chain: transaction.chain,
             },
             transaction: serializedTx,
+          }).catch((e) => {
+            console.warn(
+              "No zk paymaster data available on chain ",
+              transaction.chain.id,
+              e,
+            );
+            return undefined;
           });
           return {
             account,
             transaction: {
               ...transaction,
-              eip712: {
-                ...transaction.eip712,
-                paymaster: pmData.paymaster,
-                paymasterInput: pmData.paymasterInput,
-              },
+              eip712: pmData
+                ? {
+                    ...transaction.eip712,
+                    paymaster: pmData.paymaster,
+                    paymasterInput: pmData.paymasterInput,
+                  }
+                : transaction.eip712,
             },
           };
         }

--- a/packages/thirdweb/src/utils/any-evm/zksync/isZkSyncChain.ts
+++ b/packages/thirdweb/src/utils/any-evm/zksync/isZkSyncChain.ts
@@ -18,7 +18,8 @@ export async function isZkSyncChain(chain: Chain) {
     chain.id === 37111 ||
     chain.id === 978658 ||
     chain.id === 531050104 ||
-    chain.id === 4457845
+    chain.id === 4457845 ||
+    chain.id === 2741
   ) {
     return true;
   }


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the handling of zkSync chains by incorporating testnet checks and improving transaction management with paymaster data.

### Detailed summary
- In `isZkSyncChain.ts`, added support for chain ID `2741`.
- In `thirdweb.server.ts`:
  - Imported `getChainMetadata`.
  - Added logic to check if a chain is a testnet.
  - Integrated `isZkSyncChain` to conditionally use paymaster data for zkSync testnets.
  - Removed the previous specific handling for the `531050104` chain.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->