### PR TITLE
[Dashboard | SDK] Feature: Ref values for address params in publish

### DIFF
--- a/apps/dashboard/src/@/components/blocks/FormFieldSetup.tsx
+++ b/apps/dashboard/src/@/components/blocks/FormFieldSetup.tsx
@@ -3,16 +3,17 @@ import { ToolTipLabel } from "@/components/ui/tooltip";
 import { AsteriskIcon, InfoIcon } from "lucide-react";
 
 export function FormFieldSetup(props: {
-  htmlFor: string;
+  htmlFor?: string;
   label: string;
   errorMessage: React.ReactNode | undefined;
   children: React.ReactNode;
   tooltip?: React.ReactNode;
   isRequired: boolean;
   helperText?: React.ReactNode;
+  className?: string;
 }) {
   return (
-    <div>
+    <div className={props.className}>
       <div className="mb-2 inline-flex items-center gap-1">
         <Label htmlFor={props.htmlFor}>{props.label}</Label>
 

--- a/apps/dashboard/src/app/(dashboard)/contracts/publish/[publish_uri]/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/contracts/publish/[publish_uri]/page.tsx
@@ -73,7 +73,7 @@ export default async function PublishContractPage(
   }
 
   return (
-    <div className="container flex flex-col gap-8 py-8">
+    <div className="container flex max-w-[1130px] flex-col gap-8 py-8">
       <ChakraProviderSetup>
         <ContractPublishForm
           jwt={token}

--- a/apps/dashboard/src/components/contract-components/contract-deploy-form/trusted-forwarders-fieldset.tsx
+++ b/apps/dashboard/src/components/contract-components/contract-deploy-form/trusted-forwarders-fieldset.tsx
@@ -2,7 +2,10 @@ import { Flex, FormControl, InputGroup } from "@chakra-ui/react";
 import { SolidityInput } from "contract-ui/components/solidity-inputs";
 import { FormErrorMessage, FormHelperText, FormLabel } from "tw-components";
 import { Fieldset } from "./common";
-import type { CustomContractDeploymentForm } from "./custom-contract";
+import type {
+  CustomContractDeploymentForm,
+  DynamicValue,
+} from "./custom-contract";
 
 interface TrustedForwardersFieldsetProps {
   form: CustomContractDeploymentForm;
@@ -11,56 +14,65 @@ interface TrustedForwardersFieldsetProps {
 export const TrustedForwardersFieldset: React.FC<
   TrustedForwardersFieldsetProps
 > = ({ form }) => {
+  const isDynamicValue = (val: string | DynamicValue): val is DynamicValue => {
+    return typeof val === "object" && val !== null && "dynamicValue" in val;
+  };
+
+  const value = form.watch("deployParams._trustedForwarders");
   return (
-    <Fieldset legend="Gasless">
-      <FormControl
-        isRequired
-        isInvalid={
-          !!form.getFieldState(
-            "deployParams._trustedForwarders",
-            form.formState,
-          ).error
-        }
-      >
-        <div className="flex items-center justify-between gap-6">
-          {/* left */}
-          <div>
-            <FormLabel>Trusted Forwarders</FormLabel>
-
-            <FormHelperText className="!text-sm text-muted-foreground">
-              <span className="mb-1 block text-muted-foreground text-sm">
-                Trusted forwarder addresses to enable ERC-2771 transactions
-                (i.e. gasless).
-              </span>
-
-              <span className="block text-muted-foreground text-sm">
-                You can provide your own forwarder.
-              </span>
-            </FormHelperText>
-          </div>
-        </div>
-
-        <div className="fade-in-0 block animate-in pt-3 duration-400">
-          <InputGroup size="md">
-            <Flex flexDir="column" w="full">
-              <SolidityInput
-                value={form.watch("deployParams._trustedForwarders")}
-                solidityType="address[]"
-                {...form.register("deployParams._trustedForwarders")}
-              />
-            </Flex>
-          </InputGroup>
-
-          <FormErrorMessage>
-            {
-              form.getFieldState(
+    <>
+      {!isDynamicValue(value) && (
+        <Fieldset legend="Gasless">
+          <FormControl
+            isRequired
+            isInvalid={
+              !!form.getFieldState(
                 "deployParams._trustedForwarders",
                 form.formState,
-              ).error?.message
+              ).error
             }
-          </FormErrorMessage>
-        </div>
-      </FormControl>
-    </Fieldset>
+          >
+            <div className="flex items-center justify-between gap-6">
+              {/* left */}
+              <div>
+                <FormLabel>Trusted Forwarders</FormLabel>
+
+                <FormHelperText className="!text-sm text-muted-foreground">
+                  <span className="mb-1 block text-muted-foreground text-sm">
+                    Trusted forwarder addresses to enable ERC-2771 transactions
+                    (i.e. gasless).
+                  </span>
+
+                  <span className="block text-muted-foreground text-sm">
+                    You can provide your own forwarder.
+                  </span>
+                </FormHelperText>
+              </div>
+            </div>
+
+            <div className="fade-in-0 block animate-in pt-3 duration-400">
+              <InputGroup size="md">
+                <Flex flexDir="column" w="full">
+                  <SolidityInput
+                    value={value}
+                    solidityType="address[]"
+                    {...form.register("deployParams._trustedForwarders")}
+                  />
+                </Flex>
+              </InputGroup>
+
+              <FormErrorMessage>
+                {
+                  form.getFieldState(
+                    "deployParams._trustedForwarders",
+                    form.formState,
+                  ).error?.message
+                }
+              </FormErrorMessage>
+            </div>
+          </FormControl>
+        </Fieldset>
+      )}
+    </>
   );
 };

--- a/apps/dashboard/src/components/contract-components/contract-publish-form/contract-params-fieldset.tsx
+++ b/apps/dashboard/src/components/contract-components/contract-publish-form/contract-params-fieldset.tsx
@@ -1,29 +1,19 @@
-import {
-  Divider,
-  Flex,
-  FormControl,
-  Input,
-  InputGroup,
-  InputRightElement,
-  Textarea,
-  Tooltip,
-  useBreakpointValue,
-} from "@chakra-ui/react";
+import { FormFieldSetup } from "@/components/blocks/FormFieldSetup";
+import { Checkbox, CheckboxWithLabel } from "@/components/ui/checkbox";
+import { InlineCode } from "@/components/ui/inline-code";
+import { Input } from "@/components/ui/input";
+import { Separator } from "@/components/ui/separator";
+import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
+import { FormControl, useBreakpointValue } from "@chakra-ui/react";
 import type { AbiParameter } from "abitype";
 import { SolidityInput } from "contract-ui/components/solidity-inputs";
 import { camelToTitle } from "contract-ui/components/solidity-inputs/helpers";
 import { getTemplateValuesForType } from "lib/deployment/template-values";
+import { useState } from "react";
 import { useFormContext } from "react-hook-form";
-import {
-  Button,
-  Card,
-  Checkbox,
-  FormErrorMessage,
-  FormHelperText,
-  FormLabel,
-  Heading,
-  Text,
-} from "tw-components";
+import { DecodedInputArrayFieldset } from "./decoded-bytes-input/decoded-input-array-fieldset";
+import { RefInputFieldset } from "./ref-contract-input/ref-input-fieldset";
 
 interface ContractParamsFieldsetProps {
   deployParams: readonly AbiParameter[];
@@ -32,243 +22,288 @@ export const ContractParamsFieldset: React.FC<ContractParamsFieldsetProps> = ({
   deployParams,
 }) => {
   const form = useFormContext();
-
   const isMobile = useBreakpointValue({ base: true, md: false });
 
+  const [isCustomInputEnabledArray, setIsCustomInputEnabledArray] = useState(
+    Array(deployParams.length).fill(false),
+  );
+
+  const handleCustomInputEnabledArrayChange = (
+    index: number,
+    newValue: boolean,
+  ) => {
+    const newIsCustomInputEnabledArray = [...isCustomInputEnabledArray];
+    newIsCustomInputEnabledArray[index] = newValue;
+    setIsCustomInputEnabledArray(newIsCustomInputEnabledArray);
+
+    if (newValue) {
+      form.setValue(
+        `constructorParams.${deployParams[index]?.name || "*"}.defaultValue`,
+        "",
+        {
+          shouldDirty: true,
+        },
+      );
+
+      form.setValue(
+        `constructorParams.${deployParams[index]?.name || "*"}.dynamicValue.type`,
+        deployParams[index]?.type,
+      );
+    } else {
+      form.setValue(
+        `constructorParams.${deployParams[index]?.name || "*"}.dynamicValue.type`,
+        "",
+      );
+      form.setValue(
+        `constructorParams.${deployParams[index]?.name || "*"}.dynamicValue`,
+        "",
+        {
+          shouldDirty: true,
+        },
+      );
+    }
+  };
+
   return (
-    <Flex gap={16} direction="column" as="fieldset">
-      <Flex gap={2} direction="column">
-        <Heading size="title.lg">Contract Parameters</Heading>
-        <Text fontStyle="normal">
-          These are the parameters users will need to fill in when deploying
-          this contract.
-        </Text>
-      </Flex>
-      <Flex flexDir="column" gap={10}>
+    <fieldset>
+      <h2 className="font-semibold text-3xl tracking-tight">
+        Contract Parameters
+      </h2>
+      <p className="text-muted-foreground">
+        These are the parameters users will need to fill in when deploying this
+        contract.
+      </p>
+
+      <div className="h-6" />
+
+      <div className="flex flex-col gap-8">
         {deployParams.map((param, idx) => {
           const paramTemplateValues = getTemplateValuesForType(param.type);
           return (
-            <Flex flexDir="column" gap={6} key={`implementation_${param.name}`}>
-              <Flex justify="space-between" align="center">
-                {param.name ? (
-                  <Heading size="title.sm">{param.name}</Heading>
-                ) : (
-                  <Heading size="title.sm" fontStyle="italic">
-                    Unnamed param (will not be used)
-                  </Heading>
-                )}
-                <Text size="body.sm">{param.type}</Text>
-              </Flex>
-              <Flex gap={6} flexDir="column">
-                <Flex gap={4} flexDir={{ base: "column", md: "row" }}>
-                  <FormControl
-                    isInvalid={
-                      !!form.getFieldState(
-                        `constructorParams.${
-                          param.name ? param.name : "*"
-                        }.displayName`,
-                        form.formState,
-                      ).error
-                    }
-                  >
-                    <FormLabel flex="1" as={Text}>
-                      Display Name
-                    </FormLabel>
-                    <Input
-                      value={form.watch(
-                        `constructorParams.${
-                          param.name ? param.name : "*"
-                        }.displayName`,
-                      )}
-                      onChange={(e) =>
-                        form.setValue(
-                          `constructorParams.${
-                            param.name ? param.name : "*"
-                          }.displayName`,
-                          e.target.value,
-                        )
+            <div
+              key={`implementation_${param.name}`}
+              className="rounded-lg border border-border bg-muted/50 p-6"
+            >
+              {/* Title + Type */}
+              <div className="flex items-center gap-3">
+                <h3 className="font-semibold text-xl tracking-tight">
+                  {param.name ? (
+                    param.name
+                  ) : (
+                    <span className="italic">
+                      Unnamed param (will not be used)
+                    </span>
+                  )}
+                </h3>
+                <InlineCode
+                  className="px-2 text-base text-muted-foreground"
+                  code={param.type}
+                />
+              </div>
+
+              <div className="h-5" />
+
+              {/* Display Name */}
+              <FormFieldSetup
+                htmlFor="display-name"
+                isRequired={false}
+                label="Display Name"
+                errorMessage={
+                  form.getFieldState(
+                    `constructorParams.${
+                      param.name ? param.name : "*"
+                    }.displayName`,
+                    form.formState,
+                  ).error?.message
+                }
+              >
+                <Input
+                  id="display-name"
+                  value={form.watch(
+                    `constructorParams.${
+                      param.name ? param.name : "*"
+                    }.displayName`,
+                  )}
+                  onChange={(e) =>
+                    form.setValue(
+                      `constructorParams.${
+                        param.name ? param.name : "*"
+                      }.displayName`,
+                      e.target.value,
+                    )
+                  }
+                  placeholder={camelToTitle(param.name ? param.name : "*")}
+                />
+              </FormFieldSetup>
+
+              <div className="h-5" />
+
+              {/* Description */}
+              <FormFieldSetup
+                isRequired={false}
+                label="Description"
+                errorMessage={
+                  form.getFieldState(
+                    `constructorParams.${
+                      param.name ? param.name : "*"
+                    }.description`,
+                    form.formState,
+                  ).error?.message
+                }
+                htmlFor="description"
+                helperText={
+                  <>
+                    {form.watch(
+                      `constructorParams.${
+                        param.name ? param.name : "*"
+                      }.description`,
+                    )?.length ?? 0}
+                    /400 characters
+                  </>
+                }
+              >
+                <Textarea
+                  id="description"
+                  value={form.watch(
+                    `constructorParams.${
+                      param.name ? param.name : "*"
+                    }.description`,
+                  )}
+                  onChange={(e) =>
+                    form.setValue(
+                      `constructorParams.${
+                        param.name ? param.name : "*"
+                      }.description`,
+                      e.target.value,
+                    )
+                  }
+                  className="h-full"
+                  maxLength={400}
+                  placeholder="Enter a description for this parameter."
+                />
+              </FormFieldSetup>
+
+              <Separator className="my-6" />
+
+              {/* Default Value */}
+              <div className="flex flex-col gap-5">
+                {/* Title + Description + Switch */}
+                <div className="flex flex-col justify-between gap-6 md:flex-row md:items-start">
+                  <div>
+                    <h4 className="font-medium text-base"> Default Value </h4>
+                    <p className="text-muted-foreground text-sm">
+                      Value prefilled in deployment form
+                    </p>
+                  </div>
+                  {(param.type === "address" ||
+                    param.type === "address[]" ||
+                    param.type === "bytes" ||
+                    param.type === "bytes[]") && (
+                    <div className="flex items-center gap-3 text-sm">
+                      Dynamic Input
+                      <Switch
+                        checked={isCustomInputEnabledArray[idx]}
+                        onCheckedChange={(v) =>
+                          handleCustomInputEnabledArrayChange(idx, v)
+                        }
+                      />
+                    </div>
+                  )}
+                </div>
+
+                {/* Inputs */}
+                {!isCustomInputEnabledArray[idx] ? (
+                  <FormControl>
+                    <SolidityInput
+                      className="!bg-background !text-sm placeholder:!text-sm"
+                      solidityType={param.type}
+                      placeholder={
+                        isMobile ||
+                        paramTemplateValues?.[0]?.value ===
+                          "{{trusted_forwarders}}"
+                          ? "Pre-filled value."
+                          : "This value will be pre-filled in the deploy form."
                       }
-                      placeholder={camelToTitle(param.name ? param.name : "*")}
-                    />
-                    <FormErrorMessage>
-                      {
-                        form.getFieldState(
-                          `constructorParams.${
-                            param.name ? param.name : "*"
-                          }.displayName`,
-                          form.formState,
-                        ).error?.message
-                      }
-                    </FormErrorMessage>
-                  </FormControl>
-                  <FormControl
-                    isInvalid={
-                      !!form.getFieldState(
+                      {...form.register(
                         `constructorParams.${
                           param.name ? param.name : "*"
                         }.defaultValue`,
-                        form.formState,
-                      ).error
-                    }
-                  >
-                    <FormLabel as={Text}>Default Value</FormLabel>
-                    <InputGroup size="md">
-                      <Flex flexDir="column" w="full">
-                        <SolidityInput
-                          solidityType={
-                            param.type === "address" ? "string" : param.type
-                          }
-                          placeholder={
-                            isMobile ||
-                            paramTemplateValues?.[0]?.value ===
-                              "{{trusted_forwarders}}"
-                              ? "Pre-filled value."
-                              : "This value will be pre-filled in the deploy form."
-                          }
-                          {...form.register(
+                      )}
+                    />
+                  </FormControl>
+                ) : param.type === "address" || param.type === "address[]" ? (
+                  <RefInputFieldset param={param} />
+                ) : (
+                  <DecodedInputArrayFieldset param={param} />
+                )}
+
+                {/* Checkboxes */}
+                {paramTemplateValues.length > 0 &&
+                  !isCustomInputEnabledArray[idx] &&
+                  paramTemplateValues[0]?.helperText && (
+                    <CheckboxWithLabel className="text-foreground">
+                      <Checkbox
+                        checked={
+                          form.watch(
                             `constructorParams.${
                               param.name ? param.name : "*"
                             }.defaultValue`,
-                          )}
-                        />
-                      </Flex>
-                      {paramTemplateValues.length > 0 && (
-                        <InputRightElement width="10.5rem">
-                          <Tooltip
-                            bg="transparent"
-                            boxShadow="none"
-                            shouldWrapChildren
-                            label={
-                              <Card
-                                as={Flex}
-                                flexDir="column"
-                                gap={2}
-                                bgColor="backgroundHighlight"
-                              >
-                                <Text>
-                                  {paramTemplateValues[0]?.helperText} Click to
-                                  apply.
-                                </Text>
-                              </Card>
-                            }
-                          >
-                            <Button
-                              size="xs"
-                              padding="3"
-                              paddingY="3.5"
-                              onClick={() => {
-                                form.setValue(
-                                  `constructorParams.${
-                                    param.name ? param.name : "*"
-                                  }.defaultValue`,
-                                  paramTemplateValues[0]?.value,
-                                  {
-                                    shouldDirty: true,
-                                  },
-                                );
-                              }}
-                            >
-                              {paramTemplateValues[0]?.value}
-                            </Button>
-                          </Tooltip>
-                        </InputRightElement>
-                      )}
-                    </InputGroup>
-                    <FormErrorMessage>
-                      {
-                        form.getFieldState(
-                          `constructorParams.${
-                            param.name ? param.name : "*"
-                          }.defaultValue`,
-                          form.formState,
-                        ).error?.message
-                      }
-                    </FormErrorMessage>
-                  </FormControl>
-                </Flex>
-                <Flex flexDir="column" w="full">
-                  <FormControl
-                    isInvalid={
-                      !!form.getFieldState(
-                        `constructorParams.${
-                          param.name ? param.name : "*"
-                        }.description`,
-                        form.formState,
-                      ).error
-                    }
-                  >
-                    <FormLabel as={Text}>Description</FormLabel>
-                    <Textarea
-                      value={form.watch(
-                        `constructorParams.${
-                          param.name ? param.name : "*"
-                        }.description`,
-                      )}
-                      onChange={(e) =>
-                        form.setValue(
-                          `constructorParams.${
-                            param.name ? param.name : "*"
-                          }.description`,
-                          e.target.value,
-                        )
-                      }
-                      h="full"
-                      maxLength={400}
-                      placeholder="Enter a description for this parameter."
-                    />
-                    <FormHelperText>
-                      {form.watch(
-                        `constructorParams.${
-                          param.name ? param.name : "*"
-                        }.description`,
-                      )?.length ?? 0}
-                      /400 characters
-                    </FormHelperText>
-                  </FormControl>
-                </Flex>
+                          ) === paramTemplateValues[0]?.value
+                        }
+                        onCheckedChange={(v) => {
+                          form.setValue(
+                            `constructorParams.${
+                              param.name ? param.name : "*"
+                            }.defaultValue`,
+                            v ? paramTemplateValues[0]?.value : "",
+                            {
+                              shouldDirty: true,
+                            },
+                          );
+                        }}
+                      />
+                      {paramTemplateValues[0]?.helperText}
+                    </CheckboxWithLabel>
+                  )}
+
                 {form.watch(
                   `constructorParams.${
                     param.name ? param.name : "*"
                   }.defaultValue`,
                 ) && (
-                  <Flex flexDir="column" w="full">
-                    <FormControl
-                      isInvalid={
-                        !!form.getFieldState(
-                          `constructorParams.${
-                            param.name ? param.name : "*"
-                          }.description`,
-                          form.formState,
-                        ).error
-                      }
-                    >
-                      <Checkbox
-                        placeSelf="start"
-                        {...form.register(
+                  <CheckboxWithLabel>
+                    <Checkbox
+                      {...form.register(
+                        `constructorParams.${
+                          param.name ? param.name : "*"
+                        }.hidden`,
+                      )}
+                      onCheckedChange={(v) => {
+                        form.setValue(
                           `constructorParams.${
                             param.name ? param.name : "*"
                           }.hidden`,
-                        )}
-                      >
-                        <Flex flexDir="column">
-                          <FormLabel as={Text} m={0}>
-                            Advanced Parameter
-                          </FormLabel>
-                          <Text>
-                            This parameter will be in the collapsed advanced
-                            section.
-                          </Text>
-                        </Flex>
-                      </Checkbox>
-                    </FormControl>
-                  </Flex>
+                          !!v,
+                        );
+                      }}
+                    />
+
+                    <div className="flex flex-col">
+                      <span className="font-medium text-foreground">
+                        Advanced Parameter
+                      </span>
+                      <span>
+                        This parameter will be in the collapsed advanced
+                        section.
+                      </span>
+                    </div>
+                  </CheckboxWithLabel>
                 )}
-              </Flex>
-              {idx !== deployParams.length - 1 ? <Divider mt={8} /> : null}
-            </Flex>
+              </div>
+            </div>
           );
         })}
-      </Flex>
-    </Flex>
+      </div>
+    </fieldset>
   );
 };

--- a/apps/dashboard/src/components/contract-components/contract-publish-form/decoded-bytes-input/decoded-input-array-fieldset.tsx
+++ b/apps/dashboard/src/components/contract-components/contract-publish-form/decoded-bytes-input/decoded-input-array-fieldset.tsx
@@ -1,0 +1,88 @@
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { Button } from "@/components/ui/button";
+import { ToolTipLabel } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import type { AbiParameter } from "abitype";
+import { PlusIcon, TrashIcon } from "lucide-react";
+import { useFieldArray, useFormContext } from "react-hook-form";
+import { DecodedInputSet } from "./decoded-input-set";
+
+interface DecodedInputArrayFieldsetProps {
+  param: AbiParameter;
+}
+
+export const DecodedInputArrayFieldset: React.FC<
+  DecodedInputArrayFieldsetProps
+> = ({ param }) => {
+  const form = useFormContext();
+
+  const { fields, append, remove } = useFieldArray({
+    name: `constructorParams.${param.name ? param.name : "*"}.dynamicValue.paramsToEncode`,
+    control: form.control,
+  });
+
+  return (
+    <fieldset>
+      <div className={cn(fields.length > 0 && "border-border border-b")}>
+        {fields.map((item, index) => (
+          <Accordion type="single" collapsible className="-mx-1" key={item.id}>
+            <AccordionItem value="metadata" className="border-none">
+              <AccordionTrigger className="gap-3 border-border border-t px-1">
+                <div className="flex grow items-center justify-between gap-4">
+                  Parameter set {index + 1}
+                  <ToolTipLabel label="Remove parameter set">
+                    <Button
+                      asChild
+                      size="sm"
+                      className="!text-destructive-text h-auto w-auto p-2"
+                      variant="ghost"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        remove(index);
+                      }}
+                    >
+                      <div role="button" tabIndex={0}>
+                        <TrashIcon className="size-4" />
+                      </div>
+                    </Button>
+                  </ToolTipLabel>
+                </div>
+              </AccordionTrigger>
+              <AccordionContent className="px-1 pb-6">
+                <div className="rounded-lg border border-border px-6 pt-1 pb-6">
+                  <DecodedInputSet setIndex={index} param={param} />
+                </div>
+              </AccordionContent>
+            </AccordionItem>
+          </Accordion>
+        ))}
+      </div>
+
+      <div className="mt-6 flex justify-start">
+        <Button
+          type="button"
+          size="sm"
+          className="gap-2 bg-background"
+          variant="outline"
+          disabled={param.type === "bytes" && fields.length >= 1}
+          onClick={() =>
+            append({
+              contractId: "",
+              version: "",
+              publisherAddress: "",
+            })
+          }
+        >
+          <PlusIcon className="size-4" />
+          Add parameter set
+        </Button>
+      </div>
+    </fieldset>
+  );
+};

--- a/apps/dashboard/src/components/contract-components/contract-publish-form/decoded-bytes-input/decoded-input-set.tsx
+++ b/apps/dashboard/src/components/contract-components/contract-publish-form/decoded-bytes-input/decoded-input-set.tsx
@@ -1,0 +1,91 @@
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { Button } from "@/components/ui/button";
+import { ToolTipLabel } from "@/components/ui/tooltip";
+import type { AbiParameter } from "abitype";
+import { PlusIcon, TrashIcon } from "lucide-react";
+import { useFieldArray, useFormContext } from "react-hook-form";
+import { DecodedInput } from "./decoded-input";
+
+interface DecodedInputSetProps {
+  param: AbiParameter;
+  setIndex: number;
+}
+
+export const DecodedInputSet: React.FC<DecodedInputSetProps> = ({
+  param,
+  setIndex,
+}) => {
+  const form = useFormContext();
+
+  const { fields, append, remove } = useFieldArray({
+    name: `constructorParams.${param.name ? param.name : "*"}.dynamicValue.paramsToEncode.${setIndex}`,
+    control: form.control,
+  });
+
+  return (
+    <fieldset>
+      {fields.map((item, index) => (
+        <Accordion type="single" collapsible className="-mx-1" key={item.id}>
+          <AccordionItem value="metadata" className="border-border border-b">
+            <AccordionTrigger className="gap-3 border-0 px-1 ">
+              <div className="flex grow items-center justify-between gap-4">
+                <span className="font-medium text-sm">
+                  Parameter {index + 1}
+                </span>
+                <ToolTipLabel label="Remove Parameter">
+                  <Button
+                    asChild
+                    size="sm"
+                    className="!text-destructive-text h-auto w-auto p-2"
+                    variant="ghost"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      remove(index);
+                    }}
+                  >
+                    <div role="button" tabIndex={0}>
+                      <TrashIcon className="size-4" />
+                    </div>
+                  </Button>
+                </ToolTipLabel>
+              </div>
+            </AccordionTrigger>
+            <AccordionContent className="px-1 pb-6">
+              <DecodedInput
+                key={item.id}
+                paramIndex={index}
+                setIndex={setIndex}
+                param={param}
+              />
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
+      ))}
+
+      <div className="mt-6 flex justify-start">
+        <Button
+          type="button"
+          size="sm"
+          className="gap-2"
+          variant="outline"
+          disabled={param.type === "bytes" && fields.length >= 1}
+          onClick={() =>
+            append({
+              type: "",
+              defaultValue: "",
+            })
+          }
+        >
+          <PlusIcon className="size-4" />
+          Add Parameter
+        </Button>
+      </div>
+    </fieldset>
+  );
+};

--- a/apps/dashboard/src/components/contract-components/contract-publish-form/decoded-bytes-input/decoded-input.tsx
+++ b/apps/dashboard/src/components/contract-components/contract-publish-form/decoded-bytes-input/decoded-input.tsx
@@ -1,0 +1,127 @@
+import { FormFieldSetup } from "@/components/blocks/FormFieldSetup";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import type { AbiParameter } from "abitype";
+import { useState } from "react";
+import { useFormContext } from "react-hook-form";
+import { RefBytesInputFieldset } from "./ref-bytes-input-fieldset";
+
+interface DecodedInputProps {
+  param: AbiParameter;
+  paramIndex: number;
+  setIndex: number;
+  className?: string;
+}
+
+export const DecodedInput: React.FC<DecodedInputProps> = ({
+  param,
+  paramIndex,
+  setIndex,
+  className,
+}) => {
+  const form = useFormContext();
+  const [isCustomAddress, setIsCustomAddress] = useState(false);
+  const selectedType = form.watch(
+    `constructorParams.${param.name ? param.name : "*"}.dynamicValue.paramsToEncode.${setIndex}.${paramIndex}.type`,
+  );
+
+  // Toggle function to handle custom input visibility and reset fields
+  const handleToggleCustomInput = (newVal: boolean) => {
+    setIsCustomAddress(newVal);
+    const path =
+      `constructorParams.${param.name ? param.name : "*"}.dynamicValue.paramsToEncode.${setIndex}.${paramIndex}` as const;
+
+    if (newVal) {
+      form.setValue(`${path}.dynamicValue.type`, selectedType);
+      form.resetField(`${path}.defaultValue`);
+    } else {
+      form.setValue(`${path}.dynamicValue.type`, "");
+      form.resetField(`${path}.dynamicValue`);
+    }
+  };
+
+  const showDynamicInputToggle =
+    selectedType === "address" || selectedType === "address[]";
+
+  return (
+    <div className={className}>
+      {/* Type */}
+      <FormFieldSetup
+        isRequired={true}
+        label="Parameter Type"
+        errorMessage={
+          form.getFieldState(
+            `constructorParams.${param.name ? param.name : "*"}.dynamicValue.paramsToEncode.${setIndex}.${paramIndex}.type`,
+            form.formState,
+          ).error?.message
+        }
+      >
+        <Select
+          {...form.register(
+            `constructorParams.${param.name ? param.name : "*"}.dynamicValue.paramsToEncode.${setIndex}.${paramIndex}.type`,
+          )}
+          onValueChange={(v) => {
+            form.setValue(
+              `constructorParams.${param.name ? param.name : "*"}.dynamicValue.paramsToEncode.${setIndex}.${paramIndex}.type`,
+              v,
+            );
+          }}
+        >
+          <SelectTrigger className="w-full">
+            <SelectValue placeholder="Select type" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="address">address</SelectItem>
+            <SelectItem value="bool">bool</SelectItem>
+            <SelectItem value="bytes32">bytes32</SelectItem>
+            <SelectItem value="string">string</SelectItem>
+            <SelectItem value="uint256"> uint256 </SelectItem>
+          </SelectContent>
+        </Select>
+      </FormFieldSetup>
+
+      <div className="h-5" />
+
+      {/* Value */}
+      <div className="flex justify-between gap-4">
+        <h5>Parameter Value</h5>
+        {showDynamicInputToggle && (
+          <div className="flex items-center gap-3 text-sm">
+            Dynamic Input
+            <Switch
+              checked={isCustomAddress}
+              onCheckedChange={(v) => handleToggleCustomInput(!!v)}
+            />
+          </div>
+        )}
+      </div>
+
+      <div className="h-2" />
+
+      <div>
+        {isCustomAddress ? (
+          <RefBytesInputFieldset
+            param={param}
+            setIndex={setIndex}
+            paramIndex={paramIndex}
+          />
+        ) : (
+          <Input
+            placeholder="Enter value"
+            {...form.register(
+              `constructorParams.${param.name ? param.name : "*"}.dynamicValue.paramsToEncode.${setIndex}.${paramIndex}.defaultValue`,
+            )}
+            disabled={selectedType === "address" && isCustomAddress}
+          />
+        )}
+      </div>
+    </div>
+  );
+};

--- a/apps/dashboard/src/components/contract-components/contract-publish-form/decoded-bytes-input/ref-bytes-input-fieldset.tsx
+++ b/apps/dashboard/src/components/contract-components/contract-publish-form/decoded-bytes-input/ref-bytes-input-fieldset.tsx
@@ -1,0 +1,63 @@
+import { Button } from "@/components/ui/button";
+import type { AbiParameter } from "abitype";
+import { PlusIcon } from "lucide-react";
+import { useFieldArray, useFormContext } from "react-hook-form";
+import { RefBytesContractInput } from "./ref-bytes-input";
+
+interface RefBytesInputFieldsetProps {
+  param: AbiParameter;
+  paramIndex: number;
+  setIndex: number;
+}
+
+export const RefBytesInputFieldset: React.FC<RefBytesInputFieldsetProps> = ({
+  param,
+  setIndex,
+  paramIndex,
+}) => {
+  const form = useFormContext();
+
+  const { fields, append, remove } = useFieldArray({
+    name: `constructorParams.${param.name ? param.name : "*"}.dynamicValue.paramsToEncode.${setIndex}.${paramIndex}.dynamicValue.refContracts`,
+    control: form.control,
+  });
+
+  return (
+    <div className="flex flex-col gap-5">
+      {fields.map((item, index) => (
+        <RefBytesContractInput
+          key={item.id}
+          remove={remove}
+          index={index}
+          param={param}
+          paramIndex={paramIndex}
+          setIndex={setIndex}
+          className="border-border border-b pb-6"
+        />
+      ))}
+
+      <div>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          className="gap-2"
+          onClick={() =>
+            append({
+              contractId: "",
+              version: "",
+              publisherAddress: "",
+              salt: "",
+            })
+          }
+        >
+          <PlusIcon className="size-4" />
+          Add Reference
+        </Button>
+        <p className="mt-2 text-muted-foreground text-sm">
+          Add reference contracts for this parameter
+        </p>
+      </div>
+    </div>
+  );
+};

--- a/apps/dashboard/src/components/contract-components/contract-publish-form/decoded-bytes-input/ref-bytes-input.tsx
+++ b/apps/dashboard/src/components/contract-components/contract-publish-form/decoded-bytes-input/ref-bytes-input.tsx
@@ -1,0 +1,204 @@
+import { FormFieldSetup } from "@/components/blocks/FormFieldSetup";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { SkeletonContainer } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+import type { AbiParameter } from "abitype";
+import { TrashIcon } from "lucide-react";
+import { useFormContext } from "react-hook-form";
+import { useAllVersions, usePublishedContractsQuery } from "../../hooks";
+
+interface RefBytesContractInputProps {
+  param: AbiParameter;
+  index: number;
+  paramIndex: number;
+  setIndex: number;
+  remove: (index: number) => void;
+  className?: string;
+}
+
+export const RefBytesContractInput: React.FC<RefBytesContractInputProps> = ({
+  param,
+  index,
+  paramIndex,
+  setIndex,
+  remove,
+  className,
+}) => {
+  const form = useFormContext();
+
+  const publishedContractsQuery = usePublishedContractsQuery(
+    form.watch(
+      `constructorParams.${param.name ? param.name : "*"}.dynamicValue.paramsToEncode.${setIndex}.${paramIndex}.dynamicValue.refContracts.${index}.publisherAddress`,
+    ),
+  );
+
+  const allVersions = useAllVersions(
+    form.watch(
+      `constructorParams.${param.name ? param.name : "*"}.dynamicValue.paramsToEncode.${setIndex}.${paramIndex}.dynamicValue.refContracts.${index}.publisherAddress`,
+    ),
+    form.watch(
+      `constructorParams.${param.name ? param.name : "*"}.dynamicValue.paramsToEncode.${setIndex}.${paramIndex}.dynamicValue.refContracts.${index}.contractId`,
+    ),
+  );
+
+  return (
+    <div className={cn("flex flex-col items-end gap-4 lg:flex-row", className)}>
+      <div className="grid grow grid-cols-1 gap-4 lg:grid-cols-4">
+        <FormFieldSetup
+          label="Publisher"
+          isRequired={true}
+          errorMessage={
+            form.getFieldState(
+              `constructorParams.${param.name ? param.name : "*"}.dynamicValue.paramsToEncode.${setIndex}.${paramIndex}.dynamicValue.refContracts.${index}.publisherAddress`,
+              form.formState,
+            ).error?.message
+          }
+        >
+          <Input
+            placeholder="Address or ENS"
+            className="truncate"
+            {...form.register(
+              `constructorParams.${param.name ? param.name : "*"}.dynamicValue.paramsToEncode.${setIndex}.${paramIndex}.dynamicValue.refContracts.${index}.publisherAddress`,
+            )}
+          />
+        </FormFieldSetup>
+
+        <FormFieldSetup
+          label="Contract Name"
+          isRequired={true}
+          errorMessage={
+            form.getFieldState(
+              `constructorParams.${param.name ? param.name : "*"}.dynamicValue.refContracts.${index}.contractId`,
+              form.formState,
+            ).error?.message
+          }
+        >
+          <SkeletonContainer
+            className="block"
+            loadedData={!publishedContractsQuery.isFetching ? true : undefined}
+            skeletonData={false}
+            render={() => {
+              return (
+                <Select
+                  disabled={(publishedContractsQuery?.data || []).length === 0}
+                  {...form.register(
+                    `constructorParams.${param.name ? param.name : "*"}.dynamicValue.paramsToEncode.${setIndex}.${paramIndex}.dynamicValue.refContracts.${index}.contractId`,
+                  )}
+                  onValueChange={(v) => {
+                    form.setValue(
+                      `constructorParams.${param.name ? param.name : "*"}.dynamicValue.paramsToEncode.${setIndex}.${paramIndex}.dynamicValue.refContracts.${index}.contractId`,
+                      v,
+                    );
+                  }}
+                >
+                  <SelectTrigger className="min-w-[180px]">
+                    <SelectValue
+                      placeholder={
+                        publishedContractsQuery.isFetched &&
+                        (publishedContractsQuery?.data || []).length === 0
+                          ? "No contracts found"
+                          : "Select contract"
+                      }
+                    />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {publishedContractsQuery?.data?.map(({ contractId }) => (
+                      <SelectItem key={contractId} value={contractId}>
+                        {contractId}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              );
+            }}
+          />
+        </FormFieldSetup>
+
+        <FormFieldSetup
+          label="Contract Version"
+          isRequired={false}
+          errorMessage={
+            form.getFieldState(
+              `constructorParams.${param.name ? param.name : "*"}.dynamicValue.refContracts.${index}.version`,
+              form.formState,
+            ).error?.message
+          }
+        >
+          <SkeletonContainer
+            className="block"
+            loadedData={!allVersions.isFetching ? true : undefined}
+            skeletonData={false}
+            render={() => {
+              return (
+                <Select
+                  disabled={!allVersions.data}
+                  {...form.register(
+                    `constructorParams.${param.name ? param.name : "*"}.dynamicValue.paramsToEncode.${setIndex}.${paramIndex}.dynamicValue.refContracts.${index}.version`,
+                  )}
+                  onValueChange={(v) => {
+                    form.setValue(
+                      `constructorParams.${param.name ? param.name : "*"}.dynamicValue.paramsToEncode.${setIndex}.${paramIndex}.dynamicValue.refContracts.${index}.version`,
+                      v === "latest" ? "" : v,
+                    );
+                  }}
+                >
+                  <SelectTrigger className="min-w-[180px]">
+                    <SelectValue placeholder="Latest Version" />
+                  </SelectTrigger>
+
+                  <SelectContent>
+                    <SelectItem value="latest">Latest Version</SelectItem>
+                    {allVersions?.data?.map(({ version }) => {
+                      if (!version) return null;
+                      return (
+                        <SelectItem key={version} value={version}>
+                          {version}
+                        </SelectItem>
+                      );
+                    })}
+                  </SelectContent>
+                </Select>
+              );
+            }}
+          />
+        </FormFieldSetup>
+
+        <FormFieldSetup
+          isRequired={false}
+          label="Salt"
+          errorMessage={
+            form.getFieldState(
+              `constructorParams.${param.name ? param.name : "*"}.dynamicValue.paramsToEncode.${setIndex}.${paramIndex}.dynamicValue.refContracts.${index}.salt`,
+              form.formState,
+            ).error?.message
+          }
+        >
+          <Input
+            className="truncate"
+            placeholder="Salt (optional)"
+            {...form.register(
+              `constructorParams.${param.name ? param.name : "*"}.dynamicValue.paramsToEncode.${setIndex}.${paramIndex}.dynamicValue.refContracts.${index}.salt`,
+            )}
+          />
+        </FormFieldSetup>
+      </div>
+
+      <Button
+        aria-label="Remove"
+        onClick={() => remove(index)}
+        variant="outline"
+        className="self-end text-destructive-text"
+      >
+        <TrashIcon className="size-4" />
+      </Button>
+    </div>
+  );
+};

--- a/apps/dashboard/src/components/contract-components/contract-publish-form/impl-params-fieldset.tsx
+++ b/apps/dashboard/src/components/contract-components/contract-publish-form/impl-params-fieldset.tsx
@@ -1,0 +1,176 @@
+import { Checkbox, CheckboxWithLabel } from "@/components/ui/checkbox";
+import { InlineCode } from "@/components/ui/inline-code";
+import { Switch } from "@/components/ui/switch";
+import { FormControl, useBreakpointValue } from "@chakra-ui/react";
+import type { AbiParameter } from "abitype";
+import { SolidityInput } from "contract-ui/components/solidity-inputs";
+import { getTemplateValuesForType } from "lib/deployment/template-values";
+import { useState } from "react";
+import { useFormContext } from "react-hook-form";
+import { RefInputImplFieldset } from "./ref-contract-impl-input/ref-input-impl-fieldset";
+
+interface ImplementationParamsFieldsetProps {
+  implParams: readonly AbiParameter[];
+}
+export const ImplementationParamsFieldset: React.FC<
+  ImplementationParamsFieldsetProps
+> = ({ implParams }) => {
+  const form = useFormContext();
+
+  const isMobile = useBreakpointValue({ base: true, md: false });
+
+  const [isCustomInputEnabled, setIsCustomInputEnabled] = useState(
+    Array(implParams.length).fill(false),
+  );
+
+  const handleToggleCustomInput = (index: number, newValue: boolean) => {
+    const newIsCustomInputEnabled = [...isCustomInputEnabled];
+    newIsCustomInputEnabled[index] = newValue;
+    setIsCustomInputEnabled(newIsCustomInputEnabled);
+
+    // Clear or set values accordingly when toggling between input types
+    if (newValue) {
+      form.setValue(
+        `implConstructorParams.${implParams[index]?.name || "*"}.dynamicValue.type`,
+        implParams[index]?.type,
+      );
+      form.setValue(
+        `implConstructorParams.${implParams[index]?.name || "*"}.defaultValue`,
+        "",
+        {
+          shouldDirty: true,
+        },
+      );
+    } else {
+      form.setValue(
+        `implConstructorParams.${implParams[index]?.name || "*"}.dynamicValue.type`,
+        "",
+      );
+      form.setValue(
+        `implConstructorParams.${implParams[index]?.name || "*"}.dynamicValue`,
+        "",
+        {
+          shouldDirty: true,
+        },
+      );
+    }
+  };
+
+  return (
+    <fieldset>
+      <h2 className="font-semibold text-3xl tracking-tight">
+        Implementation Contract Constructor Parameters
+      </h2>
+      <p className="text-muted-foreground">
+        These are the parameters users will need to fill in when deploying this
+        contract.
+      </p>
+
+      <div className="h-6" />
+
+      <div className="flex flex-col gap-8">
+        {implParams.map((param, idx) => {
+          const paramTemplateValues = getTemplateValuesForType(param.type);
+          return (
+            <div
+              key={`implementation_${param.name}`}
+              className="rounded-lg border border-border bg-muted/50 p-6"
+            >
+              {/* Title + Type */}
+              <div className="flex items-center gap-3">
+                <h3 className="font-semibold text-xl tracking-tight">
+                  {param.name ? (
+                    param.name
+                  ) : (
+                    <span className="italic">
+                      Unnamed param (will not be used)
+                    </span>
+                  )}
+                </h3>
+                <InlineCode
+                  className="px-2 text-base text-muted-foreground"
+                  code={param.type}
+                />
+              </div>
+              <div className="h-5" />
+              <div className="flex flex-col gap-5">
+                {/* Title + Description + Switch */}
+                <div className="flex flex-col justify-between gap-6 md:flex-row md:items-start">
+                  <div>
+                    <h4 className="font-medium text-base"> Default Value </h4>
+                    <p className="text-muted-foreground text-sm">
+                      Value prefilled in deployment form
+                    </p>
+                  </div>
+                  {(param.type === "address" ||
+                    param.type === "address[]" ||
+                    param.type === "bytes" ||
+                    param.type === "bytes[]") && (
+                    <div className="flex items-center gap-3 text-sm">
+                      Dynamic Input
+                      <Switch
+                        checked={isCustomInputEnabled[idx]}
+                        onCheckedChange={(v) => handleToggleCustomInput(idx, v)}
+                      />
+                    </div>
+                  )}
+                </div>
+
+                {!isCustomInputEnabled[idx] ? (
+                  <FormControl>
+                    <SolidityInput
+                      className="!bg-background !text-sm placeholder:!text-sm"
+                      solidityType={param.type}
+                      placeholder={
+                        isMobile ||
+                        paramTemplateValues?.[0]?.value ===
+                          "{{trusted_forwarders}}"
+                          ? "Pre-filled value."
+                          : "This value will be pre-filled in the deploy form."
+                      }
+                      {...form.register(
+                        `implConstructorParams.${
+                          param.name ? param.name : "*"
+                        }.defaultValue`,
+                      )}
+                    />
+                  </FormControl>
+                ) : (
+                  <RefInputImplFieldset param={param} />
+                )}
+
+                {paramTemplateValues.length > 0 &&
+                  !isCustomInputEnabled[idx] &&
+                  paramTemplateValues[0]?.helperText && (
+                    <CheckboxWithLabel className="text-foreground">
+                      <Checkbox
+                        checked={
+                          form.watch(
+                            `implConstructorParams.${
+                              param.name ? param.name : "*"
+                            }.defaultValue`,
+                          ) === paramTemplateValues[0]?.value
+                        }
+                        onCheckedChange={(v) => {
+                          form.setValue(
+                            `implConstructorParams.${
+                              param.name ? param.name : "*"
+                            }.defaultValue`,
+                            v ? paramTemplateValues[0]?.value : "",
+                            {
+                              shouldDirty: true,
+                            },
+                          );
+                        }}
+                      />
+                      {paramTemplateValues[0]?.helperText}
+                    </CheckboxWithLabel>
+                  )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </fieldset>
+  );
+};

--- a/apps/dashboard/src/components/contract-components/contract-publish-form/ref-contract-impl-input/ref-input-impl-fieldset.tsx
+++ b/apps/dashboard/src/components/contract-components/contract-publish-form/ref-contract-impl-input/ref-input-impl-fieldset.tsx
@@ -1,0 +1,62 @@
+import { cn } from "@/lib/utils";
+import type { AbiParameter } from "abitype";
+import { PlusIcon } from "lucide-react";
+import { useFieldArray, useFormContext } from "react-hook-form";
+import { Button } from "tw-components";
+import { RefContractImplInput } from "./ref-input-impl";
+
+interface RefInputImplFieldsetProps {
+  param: AbiParameter;
+}
+
+export const RefInputImplFieldset: React.FC<RefInputImplFieldsetProps> = ({
+  param,
+}) => {
+  const form = useFormContext();
+
+  const { fields, append, remove } = useFieldArray({
+    name: `implConstructorParams.${param.name ? param.name : "*"}.dynamicValue.refContracts`,
+    control: form.control,
+  });
+
+  const hideAddButton = param.type === "address" && fields.length >= 1;
+
+  return (
+    <div className="flex flex-col gap-5">
+      {fields.map((item, index) => (
+        <RefContractImplInput
+          key={item.id}
+          remove={remove}
+          index={index}
+          param={param}
+          className={cn(!hideAddButton && "border-border border-b pb-5")}
+        />
+      ))}
+
+      {!hideAddButton && (
+        <div>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className="gap-2"
+            onClick={() =>
+              append({
+                contractId: "",
+                version: "",
+                publisherAddress: "",
+                salt: "",
+              })
+            }
+          >
+            <PlusIcon className="size-4" />
+            Add Reference
+          </Button>
+          <p className="mt-2 text-muted-foreground text-sm">
+            Set Reference contract for this parameter
+          </p>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/apps/dashboard/src/components/contract-components/contract-publish-form/ref-contract-impl-input/ref-input-impl.tsx
+++ b/apps/dashboard/src/components/contract-components/contract-publish-form/ref-contract-impl-input/ref-input-impl.tsx
@@ -1,0 +1,201 @@
+import { FormFieldSetup } from "@/components/blocks/FormFieldSetup";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { SkeletonContainer } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+import type { AbiParameter } from "abitype";
+import { TrashIcon } from "lucide-react";
+import { useFormContext } from "react-hook-form";
+import { useAllVersions, usePublishedContractsQuery } from "../../hooks";
+
+interface RefContractImplInputProps {
+  param: AbiParameter;
+  index: number;
+  remove: (index: number) => void;
+  className?: string;
+}
+
+export const RefContractImplInput: React.FC<RefContractImplInputProps> = ({
+  param,
+  index,
+  remove,
+  className,
+}) => {
+  const form = useFormContext();
+
+  const publishedContractsQuery = usePublishedContractsQuery(
+    form.watch(
+      `implConstructorParams.${param.name ? param.name : "*"}.dynamicValue.refContracts.${index}.publisherAddress`,
+    ),
+  );
+
+  const allVersions = useAllVersions(
+    form.watch(
+      `implConstructorParams.${param.name ? param.name : "*"}.dynamicValue.refContracts.${index}.publisherAddress`,
+    ),
+    form.watch(
+      `implConstructorParams.${param.name ? param.name : "*"}.dynamicValue.refContracts.${index}.contractId`,
+    ),
+  );
+
+  return (
+    <div className={cn("flex flex-col gap-4 lg:flex-row", className)}>
+      <div className="grid grow grid-cols-1 gap-4 lg:grid-cols-4">
+        <FormFieldSetup
+          isRequired={true}
+          label="Publisher"
+          errorMessage={
+            form.getFieldState(
+              `implConstructorParams.${param.name ? param.name : "*"}.dynamicValue.refContracts.${index}.publisherAddress`,
+              form.formState,
+            ).error?.message
+          }
+        >
+          <Input
+            className="truncate"
+            placeholder="Address or ENS"
+            {...form.register(
+              `implConstructorParams.${param.name ? param.name : "*"}.dynamicValue.refContracts.${index}.publisherAddress`,
+            )}
+          />
+        </FormFieldSetup>
+
+        <FormFieldSetup
+          label="Contract Name"
+          isRequired={true}
+          errorMessage={
+            form.getFieldState(
+              `implConstructorParams.${param.name ? param.name : "*"}.dynamicValue.refContracts.${index}.contractId`,
+              form.formState,
+            ).error?.message
+          }
+        >
+          <SkeletonContainer
+            className="block"
+            loadedData={!publishedContractsQuery.isFetching ? true : undefined}
+            skeletonData={false}
+            render={() => {
+              return (
+                <Select
+                  disabled={(publishedContractsQuery?.data || []).length === 0}
+                  {...form.register(
+                    `implConstructorParams.${param.name ? param.name : "*"}.dynamicValue.refContracts.${index}.contractId`,
+                  )}
+                  onValueChange={(v) => {
+                    form.setValue(
+                      `implConstructorParams.${param.name ? param.name : "*"}.dynamicValue.refContracts.${index}.contractId`,
+                      v,
+                    );
+                  }}
+                >
+                  <SelectTrigger className="min-w-[180px]">
+                    <SelectValue
+                      placeholder={
+                        publishedContractsQuery.isFetched &&
+                        (publishedContractsQuery?.data || []).length === 0
+                          ? "No contracts found"
+                          : "Select contract"
+                      }
+                    />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {publishedContractsQuery?.data?.map(({ contractId }) => (
+                      <SelectItem key={contractId} value={contractId}>
+                        {" "}
+                        {contractId}{" "}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              );
+            }}
+          />
+        </FormFieldSetup>
+
+        <FormFieldSetup
+          label="Contract Version"
+          isRequired={false}
+          errorMessage={
+            form.getFieldState(
+              `implConstructorParams.${param.name ? param.name : "*"}.dynamicValue.refContracts.${index}.version`,
+              form.formState,
+            ).error?.message
+          }
+        >
+          <SkeletonContainer
+            className="block"
+            loadedData={!allVersions.isFetching ? true : undefined}
+            skeletonData={false}
+            render={() => {
+              return (
+                <Select
+                  disabled={!allVersions.data}
+                  {...form.register(
+                    `implConstructorParams.${param.name ? param.name : "*"}.dynamicValue.refContracts.${index}.version`,
+                  )}
+                  onValueChange={(v) => {
+                    form.setValue(
+                      `implConstructorParams.${param.name ? param.name : "*"}.dynamicValue.refContracts.${index}.version`,
+                      v === "latest" ? "" : v,
+                    );
+                  }}
+                >
+                  <SelectTrigger className="min-w-[180px]">
+                    <SelectValue placeholder="Latest Version" />
+                  </SelectTrigger>
+
+                  <SelectContent>
+                    <SelectItem value="latest">Latest Version</SelectItem>
+                    {allVersions?.data?.map(({ version }) => {
+                      if (!version) return null;
+                      return (
+                        <SelectItem key={version} value={version}>
+                          {version}
+                        </SelectItem>
+                      );
+                    })}
+                  </SelectContent>
+                </Select>
+              );
+            }}
+          />
+        </FormFieldSetup>
+
+        <FormFieldSetup
+          isRequired={false}
+          label="Salt"
+          errorMessage={
+            form.getFieldState(
+              `implConstructorParams.${param.name ? param.name : "*"}.dynamicValue.refContracts.${index}.salt`,
+              form.formState,
+            ).error?.message
+          }
+        >
+          <Input
+            className="truncate"
+            placeholder="Salt (optional)"
+            {...form.register(
+              `implConstructorParams.${param.name ? param.name : "*"}.dynamicValue.refContracts.${index}.salt`,
+            )}
+          />
+        </FormFieldSetup>
+      </div>
+
+      <Button
+        aria-label="Remove"
+        onClick={() => remove(index)}
+        variant="outline"
+        className="self-end text-destructive-text"
+      >
+        <TrashIcon className="size-4" />
+      </Button>
+    </div>
+  );
+};

--- a/apps/dashboard/src/components/contract-components/contract-publish-form/ref-contract-input/ref-input-fieldset.tsx
+++ b/apps/dashboard/src/components/contract-components/contract-publish-form/ref-contract-input/ref-input-fieldset.tsx
@@ -1,0 +1,61 @@
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import type { AbiParameter } from "abitype";
+import { PlusIcon } from "lucide-react";
+import { useFieldArray, useFormContext } from "react-hook-form";
+import { RefContractInput } from "./ref-input";
+
+interface RefInputFieldsetProps {
+  param: AbiParameter;
+}
+
+export const RefInputFieldset: React.FC<RefInputFieldsetProps> = ({
+  param,
+}) => {
+  const form = useFormContext();
+
+  const { fields, append, remove } = useFieldArray({
+    name: `constructorParams.${param.name ? param.name : "*"}.dynamicValue.refContracts`,
+    control: form.control,
+  });
+  const hideAddButton = param.type === "address" && fields.length >= 1;
+
+  return (
+    <div className="flex flex-col gap-5">
+      {fields.map((item, index) => (
+        <RefContractInput
+          key={item.id}
+          remove={remove}
+          index={index}
+          param={param}
+          className={cn(!hideAddButton && "border-border border-b pb-5")}
+        />
+      ))}
+
+      {!hideAddButton && (
+        <div>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className="gap-2"
+            onClick={() =>
+              append({
+                contractId: "",
+                version: "",
+                publisherAddress: "",
+                salt: "",
+              })
+            }
+          >
+            <PlusIcon className="size-4" />
+            Add Reference
+          </Button>
+          <p className="mt-2 text-muted-foreground text-sm">
+            Set Reference contract for this parameter
+          </p>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/apps/dashboard/src/components/contract-components/contract-publish-form/ref-contract-input/ref-input.tsx
+++ b/apps/dashboard/src/components/contract-components/contract-publish-form/ref-contract-input/ref-input.tsx
@@ -1,0 +1,201 @@
+import { FormFieldSetup } from "@/components/blocks/FormFieldSetup";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { SkeletonContainer } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+import type { AbiParameter } from "abitype";
+import { TrashIcon } from "lucide-react";
+import { useFormContext } from "react-hook-form";
+import { useAllVersions, usePublishedContractsQuery } from "../../hooks";
+
+interface RefContractInputProps {
+  param: AbiParameter;
+  index: number;
+  remove: (index: number) => void;
+  className?: string;
+}
+
+export const RefContractInput: React.FC<RefContractInputProps> = ({
+  param,
+  index,
+  remove,
+  className,
+}) => {
+  const form = useFormContext();
+
+  const publishedContractsQuery = usePublishedContractsQuery(
+    form.watch(
+      `constructorParams.${param.name ? param.name : "*"}.dynamicValue.refContracts.${index}.publisherAddress`,
+    ),
+  );
+
+  const allVersions = useAllVersions(
+    form.watch(
+      `constructorParams.${param.name ? param.name : "*"}.dynamicValue.refContracts.${index}.publisherAddress`,
+    ),
+    form.watch(
+      `constructorParams.${param.name ? param.name : "*"}.dynamicValue.refContracts.${index}.contractId`,
+    ),
+  );
+
+  return (
+    <div className={cn("flex flex-col gap-4 lg:flex-row", className)}>
+      <div className="grid grow grid-cols-1 gap-4 lg:grid-cols-4">
+        <FormFieldSetup
+          isRequired={true}
+          label="Publisher"
+          errorMessage={
+            form.getFieldState(
+              `constructorParams.${param.name ? param.name : "*"}.dynamicValue.refContracts.${index}.publisherAddress`,
+              form.formState,
+            ).error?.message
+          }
+        >
+          <Input
+            className="truncate"
+            placeholder="Address or ENS"
+            {...form.register(
+              `constructorParams.${param.name ? param.name : "*"}.dynamicValue.refContracts.${index}.publisherAddress`,
+            )}
+          />
+        </FormFieldSetup>
+
+        <FormFieldSetup
+          label="Contract Name"
+          isRequired={true}
+          errorMessage={
+            form.getFieldState(
+              `constructorParams.${param.name ? param.name : "*"}.dynamicValue.refContracts.${index}.contractId`,
+              form.formState,
+            ).error?.message
+          }
+        >
+          <SkeletonContainer
+            className="block"
+            loadedData={!publishedContractsQuery.isFetching ? true : undefined}
+            skeletonData={false}
+            render={() => {
+              return (
+                <Select
+                  disabled={(publishedContractsQuery?.data || []).length === 0}
+                  {...form.register(
+                    `constructorParams.${param.name ? param.name : "*"}.dynamicValue.refContracts.${index}.contractId`,
+                  )}
+                  onValueChange={(v) => {
+                    form.setValue(
+                      `constructorParams.${param.name ? param.name : "*"}.dynamicValue.refContracts.${index}.contractId`,
+                      v,
+                    );
+                  }}
+                >
+                  <SelectTrigger className="min-w-[180px]">
+                    <SelectValue
+                      placeholder={
+                        publishedContractsQuery.isFetched &&
+                        (publishedContractsQuery?.data || []).length === 0
+                          ? "No contracts found"
+                          : "Select contract"
+                      }
+                    />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {publishedContractsQuery?.data?.map(({ contractId }) => (
+                      <SelectItem key={contractId} value={contractId}>
+                        {" "}
+                        {contractId}{" "}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              );
+            }}
+          />
+        </FormFieldSetup>
+
+        <FormFieldSetup
+          label="Contract Version"
+          isRequired={false}
+          errorMessage={
+            form.getFieldState(
+              `constructorParams.${param.name ? param.name : "*"}.dynamicValue.refContracts.${index}.version`,
+              form.formState,
+            ).error?.message
+          }
+        >
+          <SkeletonContainer
+            className="block"
+            loadedData={!allVersions.isFetching ? true : undefined}
+            skeletonData={false}
+            render={() => {
+              return (
+                <Select
+                  disabled={!allVersions.data}
+                  {...form.register(
+                    `constructorParams.${param.name ? param.name : "*"}.dynamicValue.refContracts.${index}.version`,
+                  )}
+                  onValueChange={(v) => {
+                    form.setValue(
+                      `constructorParams.${param.name ? param.name : "*"}.dynamicValue.refContracts.${index}.version`,
+                      v === "latest" ? "" : v,
+                    );
+                  }}
+                >
+                  <SelectTrigger className="min-w-[180px]">
+                    <SelectValue placeholder="Latest Version" />
+                  </SelectTrigger>
+
+                  <SelectContent>
+                    <SelectItem value="latest">Latest Version</SelectItem>
+                    {allVersions?.data?.map(({ version }) => {
+                      if (!version) return null;
+                      return (
+                        <SelectItem key={version} value={version}>
+                          {version}
+                        </SelectItem>
+                      );
+                    })}
+                  </SelectContent>
+                </Select>
+              );
+            }}
+          />
+        </FormFieldSetup>
+
+        <FormFieldSetup
+          isRequired={false}
+          label="Salt"
+          errorMessage={
+            form.getFieldState(
+              `constructorParams.${param.name ? param.name : "*"}.dynamicValue.refContracts.${index}.salt`,
+              form.formState,
+            ).error?.message
+          }
+        >
+          <Input
+            className="truncate"
+            placeholder="Salt (optional)"
+            {...form.register(
+              `constructorParams.${param.name ? param.name : "*"}.dynamicValue.refContracts.${index}.salt`,
+            )}
+          />
+        </FormFieldSetup>
+      </div>
+
+      <Button
+        aria-label="Remove"
+        onClick={() => remove(index)}
+        variant="outline"
+        className="self-end text-destructive-text"
+      >
+        <TrashIcon className="size-4" />
+      </Button>
+    </div>
+  );
+};

--- a/apps/dashboard/src/contract-ui/components/solidity-inputs/raw-input.tsx
+++ b/apps/dashboard/src/contract-ui/components/solidity-inputs/raw-input.tsx
@@ -1,5 +1,4 @@
-import { Flex, Textarea, type TextareaProps } from "@chakra-ui/react";
-import { FormHelperText } from "tw-components";
+import { Textarea, type TextareaProps } from "@chakra-ui/react";
 import type { SolidityInputWithTypeProps } from ".";
 import { formatHint, validateSolidityInput } from "./helpers";
 
@@ -48,7 +47,7 @@ export const SolidityRawInput: React.FC<SolidityInputWithTypeProps> = ({
   };
 
   return (
-    <Flex flexDir="column">
+    <div className="flex flex-col">
       <Textarea
         fontFamily="mono"
         placeholder={solidityType}
@@ -56,10 +55,10 @@ export const SolidityRawInput: React.FC<SolidityInputWithTypeProps> = ({
         value={form.watch(inputName)}
         onChange={handleChange}
       />
-      <FormHelperText>
+      <div className="mt-2 text-muted-foreground text-sm">
         Input should be passed in JSON format - Ex:{" "}
         {formatHint(solidityType, solidityComponents)}
-      </FormHelperText>
-    </Flex>
+      </div>
+    </div>
   );
 };

--- a/apps/dashboard/src/contract-ui/components/solidity-inputs/string-input.tsx
+++ b/apps/dashboard/src/contract-ui/components/solidity-inputs/string-input.tsx
@@ -9,6 +9,8 @@ export const SolidityStringInput: React.FC<SolidityInputWithTypeProps> = ({
   formContext: form,
   solidityName,
   functionName,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  solidityType,
   ...inputProps
 }) => {
   const storageUpload = useDashboardStorageUpload();

--- a/packages/thirdweb/src/contract/deployment/deploy-with-abi.ts
+++ b/packages/thirdweb/src/contract/deployment/deploy-with-abi.ts
@@ -152,7 +152,7 @@ export async function deployContract(
       }),
     );
     if (isDeployed) {
-      throw new Error(`Contract already deployed at address: ${address}`);
+      return address;
     }
     await sendAndConfirmTransaction({
       account: options.account,

--- a/packages/thirdweb/src/extensions/prebuilts/deploy-published.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/deploy-published.ts
@@ -19,6 +19,10 @@ import type { FetchDeployMetadataResult } from "../../utils/any-evm/deploy-metad
 import type { Hex } from "../../utils/encoding/hex.js";
 import type { Account } from "../../wallets/interfaces/wallet.js";
 import { getAllDefaultConstructorParamsForImplementation } from "./get-required-transactions.js";
+import {
+  type ImplementationConstructorParam,
+  processRefDeployments,
+} from "./process-ref-deployments.js";
 
 /**
  * @extension DEPLOY
@@ -105,8 +109,9 @@ export async function deployPublishedContract(
     chain,
     deployMetadata,
     client,
-    initializeParams: contractParams,
-    implementationConstructorParams,
+    initializeParams: contractParams || deployMetadata.constructorParams,
+    implementationConstructorParams:
+      implementationConstructorParams || deployMetadata.implConstructorParams,
     salt,
   });
 }
@@ -144,6 +149,31 @@ export async function deployContractfromDeployMetadata(
     modules,
     salt,
   } = options;
+
+  const processedImplParams: Record<string, string | string[]> = {};
+  for (const key in implementationConstructorParams) {
+    processedImplParams[key] = await processRefDeployments({
+      client,
+      account,
+      chain,
+      paramValue: implementationConstructorParams[key] as
+        | string
+        | ImplementationConstructorParam,
+    });
+  }
+
+  const processedInitializeParams: Record<string, string | string[]> = {};
+  for (const key in initializeParams) {
+    processedInitializeParams[key] = await processRefDeployments({
+      client,
+      account,
+      chain,
+      paramValue: initializeParams[key] as
+        | string
+        | ImplementationConstructorParam,
+    });
+  }
+
   switch (deployMetadata?.deployType) {
     case "standard": {
       return directDeploy({
@@ -151,7 +181,7 @@ export async function deployContractfromDeployMetadata(
         client,
         chain,
         compilerMetadata: deployMetadata,
-        contractParams: initializeParams,
+        contractParams: processedInitializeParams,
         salt,
       });
     }
@@ -170,7 +200,7 @@ export async function deployContractfromDeployMetadata(
           account,
           contractId: deployMetadata.name,
           constructorParams:
-            implementationConstructorParams ||
+            processedImplParams ||
             (await getAllDefaultConstructorParamsForImplementation({
               chain,
               client,
@@ -183,7 +213,7 @@ export async function deployContractfromDeployMetadata(
         chain,
         deployMetadata: deployMetadata,
         implementationContract,
-        initializeParams,
+        initializeParams: processedInitializeParams,
         account,
         modules,
       });
@@ -239,7 +269,7 @@ export async function deployContractfromDeployMetadata(
         client,
         chain,
         compilerMetadata: deployMetadata,
-        contractParams: initializeParams,
+        contractParams: processedInitializeParams,
         salt,
       });
     }

--- a/packages/thirdweb/src/extensions/prebuilts/process-ref-deployments.test.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/process-ref-deployments.test.ts
@@ -1,0 +1,196 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { ANVIL_CHAIN } from "../../../test/src/chains.js";
+import { TEST_CLIENT } from "../../../test/src/test-clients.js";
+import { TEST_ACCOUNT_A } from "../../../test/src/test-wallets.js";
+import { getContract } from "../../contract/contract.js";
+import { readContract } from "../../transaction/read-contract.js";
+import { getInstalledModules } from "../modules/__generated__/IModularCore/read/getInstalledModules.js";
+import { deployPublishedContract } from "./deploy-published.js";
+
+describe.runIf(process.env.TW_SECRET_KEY)(
+  "deployref",
+  {
+    timeout: 120000,
+  },
+  () => {
+    let multisigAddress: string;
+    let dummyContractAddress: string;
+    let mintfeeManagerModuleAddress: string;
+    let mintfeeManagerCoreAddress: string;
+    let claimableModuleAddress: string;
+    let wethAddress: string;
+    let forwarderAddress: string;
+    let multiwrapAddress: string;
+
+    beforeAll(async () => {
+      multisigAddress = await deployPublishedContract({
+        client: TEST_CLIENT,
+        chain: ANVIL_CHAIN,
+        account: TEST_ACCOUNT_A,
+        contractId: "MultiSig",
+        version: "0.0.4",
+        salt: "tw",
+        publisher: "0x6453a486d52e0EB6E79Ec4491038E2522a926936",
+      });
+      dummyContractAddress = await deployPublishedContract({
+        client: TEST_CLIENT,
+        chain: ANVIL_CHAIN,
+        account: TEST_ACCOUNT_A,
+        contractId: "ContractWithBytes",
+        version: "0.0.1",
+        salt: "tw",
+        publisher: "0x6453a486d52e0EB6E79Ec4491038E2522a926936",
+      });
+      mintfeeManagerModuleAddress = await deployPublishedContract({
+        client: TEST_CLIENT,
+        chain: ANVIL_CHAIN,
+        account: TEST_ACCOUNT_A,
+        contractId: "MintFeeManagerModule",
+        version: "0.0.1",
+        salt: "tw",
+        publisher: "0x6453a486d52e0EB6E79Ec4491038E2522a926936",
+      });
+      mintfeeManagerCoreAddress = await deployPublishedContract({
+        client: TEST_CLIENT,
+        chain: ANVIL_CHAIN,
+        account: TEST_ACCOUNT_A,
+        contractId: "MintFeeManagerCore",
+        version: "0.0.25",
+        salt: "tw",
+        publisher: "0x6453a486d52e0EB6E79Ec4491038E2522a926936",
+      });
+      claimableModuleAddress = await deployPublishedContract({
+        client: TEST_CLIENT,
+        chain: ANVIL_CHAIN,
+        account: TEST_ACCOUNT_A,
+        contractId: "ClaimableERC721",
+        version: "0.0.13",
+        salt: "tw",
+        publisher: "0x6453a486d52e0EB6E79Ec4491038E2522a926936",
+      });
+
+      wethAddress = await deployPublishedContract({
+        client: TEST_CLIENT,
+        chain: ANVIL_CHAIN,
+        account: TEST_ACCOUNT_A,
+        contractId: "WETH9",
+        version: "0.0.1",
+        salt: "thirdweb",
+        publisher: "0x6453a486d52e0EB6E79Ec4491038E2522a926936",
+      });
+      forwarderAddress = await deployPublishedContract({
+        client: TEST_CLIENT,
+        chain: ANVIL_CHAIN,
+        account: TEST_ACCOUNT_A,
+        contractId: "Forwarder",
+        version: "0.0.1",
+        salt: "thirdweb",
+        publisher: "0x6453a486d52e0EB6E79Ec4491038E2522a926936",
+      });
+      multiwrapAddress = await deployPublishedContract({
+        client: TEST_CLIENT,
+        chain: ANVIL_CHAIN,
+        account: TEST_ACCOUNT_A,
+        contractId: "Multiwrap",
+        version: "0.0.4",
+        publisher: "0x6453a486d52e0EB6E79Ec4491038E2522a926936",
+        contractParams: {
+          _defaultAdmin: TEST_ACCOUNT_A.address,
+          _name: "test",
+          _symbol: "test",
+          _contractURI: "",
+          _trustedForwarders: {
+            defaultValue: "",
+            dynamicValue: {
+              type: "address[]",
+              refContracts: [
+                {
+                  contractId: "Forwarder",
+                  version: "0.0.1",
+                  publisherAddress:
+                    "0x6453a486d52e0EB6E79Ec4491038E2522a926936",
+                  salt: "",
+                },
+              ],
+            },
+          },
+          _royaltyRecipient: TEST_ACCOUNT_A.address,
+          _royaltyBps: 500n,
+        },
+      });
+    }, 120000);
+
+    it("should set ref contract dependencies for direct deploy contracts", async () => {
+      const claimableModule = getContract({
+        client: TEST_CLIENT,
+        chain: ANVIL_CHAIN,
+        address: claimableModuleAddress,
+      });
+      const fetchedMintFeeManagerAddress = await readContract({
+        contract: claimableModule,
+        method: "function mintFeeManager() returns (address)",
+      });
+      expect(fetchedMintFeeManagerAddress.toLowerCase()).to.eq(
+        mintfeeManagerCoreAddress,
+      );
+
+      const mintFeeManager = getContract({
+        client: TEST_CLIENT,
+        chain: ANVIL_CHAIN,
+        address: mintfeeManagerCoreAddress,
+      });
+      const owner = await readContract({
+        contract: mintFeeManager,
+        method: "function owner() returns (address)",
+      });
+      const modules = await getInstalledModules({
+        contract: mintFeeManager,
+      });
+      const feeRecipient = await readContract({
+        contract: mintFeeManager,
+        method: "function getfeeRecipient() returns (address)",
+      });
+      const fee = await readContract({
+        contract: mintFeeManager,
+        method: "function getDefaultMintFee() returns (uint256)",
+      });
+      expect(owner.toLowerCase()).to.eq(multisigAddress);
+      expect(modules.length).to.eq(1);
+      expect(modules[0]?.implementation.toLowerCase()).to.eq(
+        mintfeeManagerModuleAddress,
+      );
+      expect(feeRecipient.toLowerCase()).to.eq(multisigAddress);
+      expect(fee).to.eq(5n);
+
+      const dummyContract = getContract({
+        client: TEST_CLIENT,
+        chain: ANVIL_CHAIN,
+        address: dummyContractAddress,
+      });
+      const dummyContractOwner = await readContract({
+        contract: dummyContract,
+        method: "function owner() returns (address)",
+      });
+      expect(dummyContractOwner.toLowerCase()).to.eq(multisigAddress);
+    });
+
+    it("should set ref contract dependencies for auto factory contracts", async () => {
+      const multiwrap = getContract({
+        client: TEST_CLIENT,
+        chain: ANVIL_CHAIN,
+        address: multiwrapAddress,
+      });
+      const fetchedWethAddress = await readContract({
+        contract: multiwrap,
+        method: "function nativeTokenWrapper() returns (address)",
+      });
+      const isTrustedForwarder = await readContract({
+        contract: multiwrap,
+        method: "function isTrustedForwarder(address forwarder) returns (bool)",
+        params: [forwarderAddress],
+      });
+      expect(fetchedWethAddress.toLowerCase()).to.eq(wethAddress);
+      expect(isTrustedForwarder).to.be.true;
+    });
+  },
+);

--- a/packages/thirdweb/src/extensions/prebuilts/process-ref-deployments.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/process-ref-deployments.ts
@@ -1,0 +1,167 @@
+import type { Chain } from "../../chains/types.js";
+import type { ThirdwebClient } from "../../client/client.js";
+import { encodeAbiParameters } from "../../utils/abi/encodeAbiParameters.js";
+import type { DynamicParams } from "../../utils/any-evm/deploy-metadata.js";
+import type { Account } from "../../wallets/interfaces/wallet.js";
+import { deployPublishedContract } from "./deploy-published.js";
+
+export type ImplementationConstructorParam = {
+  defaultValue?: string;
+  dynamicValue?: DynamicParams;
+};
+
+type ProcessRefDeploymentsOptions = {
+  client: ThirdwebClient;
+  chain: Chain;
+  account: Account;
+  paramValue: string | ImplementationConstructorParam;
+};
+
+export async function processRefDeployments(
+  options: ProcessRefDeploymentsOptions,
+): Promise<string | string[]> {
+  const { client, account, chain, paramValue } = options;
+
+  if (typeof paramValue === "object") {
+    if (
+      "defaultValue" in paramValue &&
+      paramValue.defaultValue &&
+      paramValue.defaultValue.length > 0
+    ) {
+      return paramValue.defaultValue;
+    }
+
+    if ("dynamicValue" in paramValue && paramValue.dynamicValue) {
+      const dynamicValue = paramValue.dynamicValue;
+      const contracts = dynamicValue.refContracts;
+
+      if (dynamicValue.type === "address") {
+        if (!contracts || contracts.length === 0 || !contracts[0]?.contractId) {
+          throw new Error("Invalid or empty param value");
+        }
+        const salt =
+          contracts[0]?.salt && contracts[0]?.salt.length > 0
+            ? contracts[0]?.salt
+            : "thirdweb";
+
+        const addr = await deployPublishedContract({
+          client,
+          chain,
+          account,
+          contractId: contracts[0]?.contractId,
+          publisher: contracts[0]?.publisherAddress,
+          version: contracts[0]?.version,
+          salt,
+        });
+
+        return addr;
+      }
+
+      if (dynamicValue.type === "address[]") {
+        if (!contracts || contracts.length === 0) {
+          throw new Error("Invalid or empty param value");
+        }
+        const addressArray = [];
+
+        for (const c of contracts) {
+          const salt = c?.salt && c?.salt.length > 0 ? c?.salt : "thirdweb";
+
+          addressArray.push(
+            await deployPublishedContract({
+              client,
+              chain,
+              account,
+              contractId: c.contractId,
+              publisher: c.publisherAddress,
+              version: c.version,
+              salt,
+            }),
+          );
+        }
+
+        return addressArray;
+      }
+
+      if (dynamicValue.type === "bytes") {
+        if (!dynamicValue.paramsToEncode) {
+          throw new Error("Invalid or empty param value");
+        }
+        const paramsToEncode = dynamicValue.paramsToEncode[0];
+
+        if (paramsToEncode) {
+          const types = [];
+          const values = [];
+          for (const v of paramsToEncode) {
+            types.push(v.type);
+
+            if (v.defaultValue) {
+              values.push(v.defaultValue);
+            } else if (v.dynamicValue) {
+              values.push(
+                await processRefDeployments({
+                  client,
+                  account,
+                  chain,
+                  paramValue: v,
+                }),
+              );
+            }
+          }
+
+          return encodeAbiParameters(
+            types.map((t) => {
+              return { type: t };
+            }),
+            values,
+          );
+        }
+      }
+
+      if (dynamicValue.type === "bytes[]") {
+        if (!dynamicValue.paramsToEncode) {
+          throw new Error("Invalid or empty param value");
+        }
+        const bytesArray = [];
+        const paramArray = dynamicValue.paramsToEncode;
+
+        for (const a of paramArray) {
+          const paramsToEncode = a;
+
+          if (paramsToEncode) {
+            const types = [];
+            const values = [];
+            for (const v of paramsToEncode) {
+              types.push(v.type);
+
+              if (v.defaultValue) {
+                values.push(v.defaultValue);
+              } else if (v.dynamicValue) {
+                values.push(
+                  await processRefDeployments({
+                    client,
+                    account,
+                    chain,
+                    paramValue: v,
+                  }),
+                );
+              }
+            }
+
+            bytesArray.push(
+              encodeAbiParameters(
+                types.map((t) => {
+                  return { type: t };
+                }),
+                values,
+              ),
+            );
+          }
+        }
+
+        return bytesArray;
+      }
+    }
+  }
+
+  return paramValue as string;
+}

--- a/packages/thirdweb/src/extensions/thirdweb/write/publish.ts
+++ b/packages/thirdweb/src/extensions/thirdweb/write/publish.ts
@@ -78,6 +78,7 @@ export function publishContract(
         changelog: options.metadata.changelog,
         compositeAbi: options.metadata.compositeAbi,
         constructorParams: options.metadata.constructorParams,
+        implConstructorParams: options.metadata.implConstructorParams,
         defaultExtensions: options.metadata.defaultExtensions,
         defaultModules: options.metadata.defaultModules,
         deployType: options.metadata.deployType,

--- a/packages/thirdweb/src/utils/any-evm/deploy-metadata.ts
+++ b/packages/thirdweb/src/utils/any-evm/deploy-metadata.ts
@@ -159,6 +159,27 @@ type ParsedCompilerMetadata = {
   zk_version?: string;
 };
 
+export type DynamicParams = {
+  type: "address" | "address[]" | "bytes" | "bytes[]";
+
+  // use for address types
+  refContracts?: Array<{
+    contractId: string;
+    publisherAddress: string;
+    version: string;
+    salt?: string;
+  }>;
+
+  // use for bytes
+  paramsToEncode?: Array<
+    Array<{
+      type: string;
+      defaultValue?: string;
+      dynamicValue?: DynamicParams; // can have address type which may need ref
+    }>
+  >;
+};
+
 export type CompilerMetadata = Prettify<
   RawCompilerMetadata & ParsedCompilerMetadata
 >;
@@ -220,6 +241,14 @@ export type ExtendedMetadata = {
       description?: string;
       defaultValue?: string;
       hidden?: boolean;
+      dynamicValue?: DynamicParams;
+    }
+  >;
+  implConstructorParams?: Record<
+    string,
+    {
+      defaultValue?: string;
+      dynamicValue?: DynamicParams;
     }
   >;
   compositeAbi?: Abi;


### PR DESCRIPTION
PROT-932
PROT-864

## Problem solved

https://linear.app/thirdweb/project/[contract-tooling]-deployment-publish-flow-revamp-0194e04e2a84/overview

Handle contract refs in publish form -- Resolve / deploy all linked contracts in publish metadata, and pass the addresses as constructor args for corresponding params. 

It recursively deploys all referenced contracts through the ref chain, before deploying the main contract.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the deployment and management of smart contracts by introducing dynamic parameters and improving UI components for contract publishing, including better handling of reference contracts and constructor parameters.

### Detailed summary
- Changed error handling in `deploy-with-abi.ts` to return address instead of throwing an error.
- Updated UI layout in `string-input.tsx` for improved responsiveness.
- Added `dynamicValue` support in various components for constructor parameters.
- Enhanced `FormFieldSetup` to accept optional `className`.
- Introduced new `DynamicParams` type for flexible contract deployment.
- Implemented dynamic input handling for reference contracts in multiple components.
- Added handling for `implConstructorParams` in contract deployment logic.
- Improved component structure for better readability and maintainability.

> The following files were skipped due to too many changes: `apps/dashboard/src/components/contract-components/contract-publish-form/contract-params-fieldset.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->