### PR TITLE
[Dashboard] Fix: Handle null publisher profile

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/profile/[addressOrEns]/ProfileUI.tsx
+++ b/apps/dashboard/src/app/(dashboard)/profile/[addressOrEns]/ProfileUI.tsx
@@ -13,7 +13,7 @@ import { PublishedContracts } from "./components/published-contracts";
 export function ProfileUI(props: {
   profileAddress: string;
   ensName: string | undefined;
-  publisherProfile: ProfileMetadata;
+  publisherProfile: ProfileMetadata | null;
   showEditProfile: boolean;
 }) {
   const { profileAddress, ensName, publisherProfile, showEditProfile } = props;
@@ -34,21 +34,25 @@ export function ProfileUI(props: {
               {displayName}
             </h1>
 
-            {publisherProfile.bio && (
+            {publisherProfile?.bio && (
               <p className="line-clamp-2 text-muted-foreground">
                 {publisherProfile.bio}
               </p>
             )}
 
             <div className="-translate-x-2 mt-1">
-              <PublisherSocials publisherProfile={publisherProfile} />
+              {publisherProfile && (
+                <PublisherSocials publisherProfile={publisherProfile} />
+              )}
             </div>
           </div>
         </div>
 
         {showEditProfile && (
           <div className="shrink-0">
-            <EditProfile publisherProfile={publisherProfile} />
+            {publisherProfile && (
+              <EditProfile publisherProfile={publisherProfile} />
+            )}
           </div>
         )}
       </div>

--- a/apps/dashboard/src/app/(dashboard)/profile/[addressOrEns]/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/profile/[addressOrEns]/page.tsx
@@ -26,10 +26,6 @@ export default async function Page(props: PageProps) {
     resolvedInfo.address,
   ).catch(() => null);
 
-  if (!publisherProfile) {
-    return notFound();
-  }
-
   return (
     <ProfileUI
       ensName={resolvedInfo.ensName}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on handling the case where `publisherProfile` can be `null`, ensuring that the UI components render correctly without errors when `publisherProfile` is not available.

### Detailed summary
- Updated `publisherProfile` type from `ProfileMetadata` to `ProfileMetadata | null`.
- Added optional chaining (`?.`) to safely access `bio` property.
- Wrapped `PublisherSocials` and `EditProfile` components with conditional rendering to check for `publisherProfile`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->