### PR TITLE
Catch fetchDeployMetadata error and redirect to 404

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/contracts/deploy/[compiler_uri]/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/contracts/deploy/[compiler_uri]/page.tsx
@@ -1,4 +1,5 @@
 import { getThirdwebClient } from "@/constants/thirdweb.server";
+import { notFound } from "next/navigation";
 import { fetchDeployMetadata } from "thirdweb/contract";
 import { DeployContractInfo } from "../../../published-contract/components/contract-info";
 import { DeployFormForUri } from "../../../published-contract/components/uri-based-deploy";
@@ -16,7 +17,12 @@ export default async function DirectDeployPage(props: DirectDeployPageProps) {
     client: getThirdwebClient(),
     // force `ipfs://` prefix
     uri: parsedUri.startsWith("ipfs://") ? parsedUri : `ipfs://${parsedUri}`,
-  });
+  }).catch(() => null);
+
+  if (!metadata) {
+    notFound();
+  }
+
   return (
     <div className="container flex flex-col gap-4 py-8">
       <DeployContractInfo

--- a/apps/dashboard/src/app/(dashboard)/contracts/publish/[publish_uri]/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/contracts/publish/[publish_uri]/page.tsx
@@ -25,7 +25,11 @@ export default async function PublishContractPage(
   const publishMetadataFromUri = await fetchDeployMetadata({
     uri: publishUri,
     client: getThirdwebClient(),
-  });
+  }).catch(() => null);
+
+  if (!publishMetadataFromUri) {
+    notFound();
+  }
 
   let publishMetadata = publishMetadataFromUri;
 


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving error handling in two pages of the dashboard by adding checks for missing metadata, leading to a `notFound` response when necessary.

### Detailed summary
- In `page.tsx` of the `publish` directory, added a check for `publishMetadataFromUri`. If not found, it calls `notFound()`.
- In `page.tsx` of the `deploy` directory, added a check for `metadata`. If not found, it calls `notFound()`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->