### PR TITLE
fix: unstoppable domains test

### DIFF
--- a/packages/thirdweb/src/extensions/unstoppable-domains/read/resolveAddress.test.ts
+++ b/packages/thirdweb/src/extensions/unstoppable-domains/read/resolveAddress.test.ts
@@ -4,26 +4,29 @@ import { resolveAddress } from "./resolveAddress.js";
 
 // Double check: https://unstoppabledomains.com/d/thirdwebsdk.unstoppable
 
-describe("Unstoppable Domain: resolve address", () => {
-  it("should resolve address", async () => {
-    expect(
-      (
-        await resolveAddress({
-          name: "thirdwebsdk.unstoppable",
-          client: TEST_CLIENT,
-        })
-      ).toLowerCase(),
-    ).toBe("0x12345674b599ce99958242b3D3741e7b01841DF3".toLowerCase());
-  });
+describe.runIf(process.env.TW_SECRET_KEY)(
+  "Unstoppable Domain: resolve address",
+  () => {
+    it("should resolve address", async () => {
+      expect(
+        (
+          await resolveAddress({
+            name: "thirdwebsdk.unstoppable",
+            client: TEST_CLIENT,
+          })
+        ).toLowerCase(),
+      ).toBe("0x12345674b599ce99958242b3D3741e7b01841DF3".toLowerCase());
+    });
 
-  it("should throw an error with a non-existent domain name", async () => {
-    await expect(() =>
-      resolveAddress({
-        name: "thirdwebsdk.thissuredoesnotexist",
-        client: TEST_CLIENT,
-      }),
-    ).rejects.toThrowError(
-      "Could not resolve a valid tokenId from the domain: thirdwebsdk.thissuredoesnotexist. Make sure it exists.",
-    );
-  });
-});
+    it("should throw an error with a non-existent domain name", async () => {
+      await expect(() =>
+        resolveAddress({
+          name: "thirdwebsdk.thissuredoesnotexist",
+          client: TEST_CLIENT,
+        }),
+      ).rejects.toThrowError(
+        "Could not resolve a valid tokenId from the domain: thirdwebsdk.thissuredoesnotexist. Make sure it exists.",
+      );
+    });
+  },
+);


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the test suite for resolving addresses using `Unstoppable Domains`. It modifies the test structure to conditionally run the tests based on the presence of `TW_SECRET_KEY`.

### Detailed summary
- Changed `describe` to `describe.runIf(process.env.TW_SECRET_KEY)` to conditionally run the tests.
- Maintained the existing test cases for resolving addresses and handling non-existent domain names.
- Reformatted the indentation and structure for better readability.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->