### PR TITLE
Winston/cnct 2311 pro cannot sign transaction with in app wallet

### DIFF
--- a/.changeset/serious-plants-play.md
+++ b/.changeset/serious-plants-play.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+fix enclave transaction signing for transactions with 0 maxPriorityFeePerGas

--- a/packages/thirdweb/src/wallets/in-app/core/wallet/enclave-wallet.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/wallet/enclave-wallet.ts
@@ -141,34 +141,39 @@ export class EnclaveWallet implements IWebWallet {
       const transaction: Record<string, Hex | number | undefined> = {
         to: tx.to ? getAddress(tx.to) : undefined,
         data: tx.data,
-        value: tx.value ? toHex(tx.value) : undefined,
-        gas: tx.gas ? toHex(tx.gas + tx.gas / BigInt(10)) : undefined, // Add a 10% buffer to gas
-        nonce: tx.nonce
-          ? toHex(tx.nonce)
-          : toHex(
-              await import(
-                "../../../../rpc/actions/eth_getTransactionCount.js"
-              ).then(({ eth_getTransactionCount }) =>
-                eth_getTransactionCount(rpcRequest, {
-                  address: this.address,
-                  blockTag: "pending",
-                }),
+        value: typeof tx.value === "bigint" ? toHex(tx.value) : undefined,
+        gas:
+          typeof tx.gas === "bigint"
+            ? toHex(tx.gas + tx.gas / BigInt(10))
+            : undefined, // Add a 10% buffer to gas
+        nonce:
+          typeof tx.nonce === "number"
+            ? toHex(tx.nonce)
+            : toHex(
+                await import(
+                  "../../../../rpc/actions/eth_getTransactionCount.js"
+                ).then(({ eth_getTransactionCount }) =>
+                  eth_getTransactionCount(rpcRequest, {
+                    address: this.address,
+                    blockTag: "pending",
+                  }),
+                ),
               ),
-            ),
         chainId: toHex(tx.chainId),
       };
 
       if (tx.maxFeePerGas) {
         transaction.maxFeePerGas = toHex(tx.maxFeePerGas);
-        transaction.maxPriorityFeePerGas = tx.maxPriorityFeePerGas
-          ? toHex(tx.maxPriorityFeePerGas)
-          : undefined;
+        transaction.maxPriorityFeePerGas =
+          typeof tx.maxPriorityFeePerGas === "bigint"
+            ? toHex(tx.maxPriorityFeePerGas)
+            : undefined;
         transaction.type = 2;
       } else {
-        transaction.gasPrice = tx.gasPrice ? toHex(tx.gasPrice) : undefined;
+        transaction.gasPrice =
+          typeof tx.gasPrice === "bigint" ? toHex(tx.gasPrice) : undefined;
         transaction.type = 0;
       }
-
       return signEnclaveTransaction({
         client,
         storage,


### PR DESCRIPTION
## Problem solved

https://linear.app/thirdweb/issue/CNCT-2311/pro-cannot-sign-transaction-with-in-app-wallet

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the transaction signing process in the `thirdweb` wallet by ensuring that the types of transaction parameters are properly checked before processing them.

### Detailed summary
- Updated handling of `tx.value`, `tx.gas`, `tx.nonce`, `tx.maxPriorityFeePerGas`, and `tx.gasPrice` to check their types before conversion to hex.
- Ensured `tx.maxFeePerGas` and `tx.gasPrice` are set based on type checks.
- Maintained logic for adding a 10% buffer to `tx.gas`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->