### PR TITLE
Update condition for showing verify email button in faucet claim section

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/(chainPage)/components/client/FaucetButton.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/(chainPage)/components/client/FaucetButton.tsx
@@ -202,7 +202,10 @@ export function FaucetButton({
   }
 
   // Email verification is required to claim from the faucet
-  if (accountQuery.data.status === "noCustomer") {
+  if (
+    !accountQuery.data.emailConfirmedAt &&
+    !accountQuery.data.unconfirmedEmail
+  ) {
     return (
       <>
         <Button


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the condition for allowing users to claim from the faucet by incorporating email verification checks.

### Detailed summary
- Changed the condition from checking if the `accountQuery.data.status` is `"noCustomer"` to checking if both `accountQuery.data.emailConfirmedAt` is falsy and `accountQuery.data.unconfirmedEmail` is falsy.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->