### PR TITLE
ignore invalid module search param in deploy page

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/published-contract/[publisher]/[contract_id]/[version]/deploy/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/published-contract/[publisher]/[contract_id]/[version]/deploy/page.tsx
@@ -8,13 +8,18 @@ export default async function PublishedContractVersionDeployPage(props: {
     version: string;
   }>;
   searchParams: Promise<{
-    module?: string[];
+    module?: string[] | string;
   }>;
 }) {
   const searchParams = await props.searchParams;
   const params = await props.params;
-  const modules = searchParams.module
-    ?.map((m) => moduleFromBase64(m))
-    .filter((m) => m !== null);
+  const moduleParam =
+    typeof searchParams.module === "string"
+      ? [searchParams.module]
+      : searchParams.module;
+
+  const modules =
+    moduleParam?.map((m) => moduleFromBase64(m)).filter((m) => m !== null) ||
+    [];
   return <DeployFormForPublishInfo {...params} modules={modules} />;
 }

--- a/apps/dashboard/src/app/(dashboard)/published-contract/[publisher]/[contract_id]/deploy/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/published-contract/[publisher]/[contract_id]/deploy/page.tsx
@@ -7,15 +7,21 @@ type Props = {
     contract_id: string;
   }>;
   searchParams: Promise<{
-    module?: string[];
+    module?: string[] | string;
   }>;
 };
 
 export default async function PublishedContractDeployPage(props: Props) {
   const searchParams = await props.searchParams;
   const params = await props.params;
-  const modules = searchParams.module
-    ?.map((m) => moduleFromBase64(m))
-    .filter((m) => m !== null);
+  const moduleParam =
+    typeof searchParams.module === "string"
+      ? [searchParams.module]
+      : searchParams.module;
+
+  const modules =
+    moduleParam?.map((m) => moduleFromBase64(m)).filter((m) => m !== null) ||
+    [];
+
   return <DeployFormForPublishInfo {...params} modules={modules} />;
 }


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the handling of the `module` search parameter in two components, allowing it to accept either an array or a single string. This change simplifies the logic for processing the `module` parameter and ensures consistent behavior.

### Detailed summary
- Updated the type of `module` in `searchParams` to accept `string[] | string`.
- Changed the logic to handle `searchParams.module`:
  - If it's a string, wrap it in an array.
  - If it's an array, use it directly.
- Ensured `modules` is initialized to an empty array if no valid modules are found.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->