### PR TITLE
add nebula service definition

### DIFF
--- a/.changeset/eight-poems-end.md
+++ b/.changeset/eight-poems-end.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+Added nebula service scope

--- a/.github/workflows/linear.yml
+++ b/.github/workflows/linear.yml
@@ -18,7 +18,7 @@ jobs:
 
           echo "Pull Request Body: $pr_body"
 
-          if echo "$pr_body" | grep -iE "CNCT|DASH"; then
+          if echo "$pr_body" | grep -iE "CNCT|DASH|BLOCK"; then
             echo "Linked issue found in the pull request body."
           else
             echo "No linked issue found in the pull request body."

--- a/apps/dashboard/src/components/settings/ApiKeys/validations.ts
+++ b/apps/dashboard/src/components/settings/ApiKeys/validations.ts
@@ -149,4 +149,4 @@ export type ApiKeyPayConfigValidationSchema = z.infer<
 >;
 
 // FIXME: Remove
-export const HIDDEN_SERVICES = ["relayer", "chainsaw"];
+export const HIDDEN_SERVICES = ["relayer", "chainsaw", "nebula"];

--- a/packages/service-utils/src/core/services.ts
+++ b/packages/service-utils/src/core/services.ts
@@ -65,6 +65,13 @@ export const SERVICE_DEFINITIONS = {
     // all actions allowed
     actions: [],
   },
+  nebula: {
+    name: "nebula",
+    title: "Nebula",
+    description: "Nebula services",
+    // all actions allowed
+    actions: [],
+  },
 } as const;
 
 export const SERVICE_NAMES = Object.keys(


### PR DESCRIPTION
## Problem solved

https://linear.app/thirdweb/issue/BLOCK-412/add-api-key-scope

Added Nebula service scope to the service definitions and included it in the hidden services list.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the `nebula` service scope to the project and updates related configurations and validations, enhancing the API key settings and workflow checks.

### Detailed summary
- Added `nebula` service scope in `packages/service-utils/src/core/services.ts`.
- Updated `HIDDEN_SERVICES` in `apps/dashboard/src/components/settings/ApiKeys/validations.ts` to include `nebula`.
- Modified the condition in `.github/workflows/linear.yml` to check for the `BLOCK` keyword in pull request bodies.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->