### PR TITLE
remove nebula from service list

### DIFF
--- a/.changeset/green-bottles-approve.md
+++ b/.changeset/green-bottles-approve.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+remove nebula scope

--- a/packages/service-utils/src/core/services.ts
+++ b/packages/service-utils/src/core/services.ts
@@ -65,13 +65,6 @@ export const SERVICE_DEFINITIONS = {
     // all actions allowed
     actions: [],
   },
-  nebula: {
-    name: "nebula",
-    title: "Nebula",
-    description: "Nebula services",
-    // all actions allowed
-    actions: [],
-  },
 } as const;
 
 export const SERVICE_NAMES = Object.keys(


### PR DESCRIPTION
## Problem solved

https://linear.app/thirdweb/issue/BLOCK-412/add-api-key-scope

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on removing the `nebula` service from the `service-utils` package, simplifying the service structure.

### Detailed summary
- Removed the `nebula` service definition from the `services.ts` file, including its `name`, `title`, `description`, and `actions`. 
- Adjusted the structure to reflect the removal of the `nebula` service.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->