### PR TITLE
[Dashboard] Feature: Updated Claimable

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/modules/components/CurrencySelector.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/modules/components/CurrencySelector.tsx
@@ -166,7 +166,8 @@ export function CurrencySelector<
             ))}
           {isCustomCurrency &&
             !isPaymentsSelector &&
-            initialValue !== NATIVE_TOKEN_ADDRESS.toLowerCase() && (
+            initialValue.toLowerCase() !==
+              NATIVE_TOKEN_ADDRESS.toLowerCase() && (
               <SelectItem key={initialValue} value={initialValue}>
                 {initialValue}
               </SelectItem>

--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/modules/components/claimable.stories.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/modules/components/claimable.stories.tsx
@@ -48,7 +48,7 @@ const testAddress1 = "0x1F846F6DAE38E1C88D71EAA191760B15f38B7A37";
 const claimCondition = {
   availableSupply: BigInt(100),
   maxMintPerWallet: BigInt(10),
-  pricePerUnit: 10n,
+  pricePerUnit: 10000000000000000000n,
   // we get checksummed NATIVE_TOKEN_ADDRESS from claim condition query for native token
   currency: checksumAddress(NATIVE_TOKEN_ADDRESS),
   // last week
@@ -64,6 +64,8 @@ function Component() {
   const [isClaimConditionLoading, setIsClaimConditionLoading] = useState(false);
   const [isPrimarySaleRecipientLoading, setIsPrimarySaleRecipientLoading] =
     useState(false);
+  const [tokenId, setTokenId] = useState("");
+  const [noClaimConditionSet, setNoClaimConditionSet] = useState(false);
 
   async function updatePrimarySaleRecipientStub(
     values: PrimarySaleRecipientFormValues,
@@ -80,12 +82,6 @@ function Component() {
   async function mintStub(values: MintFormValues) {
     console.log("submitting", values);
     await new Promise((resolve) => setTimeout(resolve, 1000));
-  }
-
-  async function getClaimConditionErc1155Stub() {
-    console.log("claim condition in stub: ", claimCondition);
-    await new Promise((resolve) => setTimeout(resolve, 1500));
-    return claimCondition;
   }
 
   const removeMutation = useMutation({
@@ -142,6 +138,13 @@ function Component() {
               id="isPrimarySaleRecipientLoading"
               label="Primary Sale Recipient Section Loading"
             />
+
+            <CheckboxWithLabel
+              value={noClaimConditionSet}
+              onChange={setNoClaimConditionSet}
+              id="noClaimConditionSet"
+              label="No Claim Condition Set"
+            />
           </div>
 
           <ClaimableModuleUI
@@ -156,14 +159,16 @@ function Component() {
               setPrimarySaleRecipient: updatePrimarySaleRecipientStub,
             }}
             claimConditionSection={{
-              data: isClaimConditionLoading
-                ? undefined
-                : {
-                    claimCondition,
-                    tokenDecimals: 18,
-                  },
+              data:
+                isClaimConditionLoading || (!isErc721 && !tokenId)
+                  ? undefined
+                  : {
+                      claimCondition,
+                      tokenDecimals: 18,
+                    },
+              isLoading: false,
               setClaimCondition: updateClaimConditionStub,
-              getClaimConditionErc1155: getClaimConditionErc1155Stub,
+              tokenId,
             }}
             mintSection={{
               mint: mintStub,
@@ -175,6 +180,9 @@ function Component() {
             isOwnerAccount={isOwner}
             isErc721={isErc721}
             contractChainId={1}
+            setTokenId={setTokenId}
+            isValidTokenId={true}
+            noClaimConditionSet={noClaimConditionSet}
           />
 
           <Toaster richColors />

--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/modules/components/module-instance.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/modules/components/module-instance.tsx
@@ -39,7 +39,7 @@ export function ModuleInstance(props: ModuleInstanceProps) {
     return <RoyaltyModule {...props} />;
   }
 
-  if (props.contractInfo.name.includes("Claimable-ignore")) {
+  if (props.contractInfo.name.includes("Claimable")) {
     return <ClaimableModule {...props} />;
   }
 


### PR DESCRIPTION
- tokenId and setToken introduced at the parent level ClaimableModule
- Claim Conditions are fetched at the parent level

https://linear.app/thirdweb/issue/DES-251/claimable-erc721-erc1155-erc20

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily modifies the `Claimable` module and related components to enhance functionality and improve user experience by adding token ID management and updating claim conditions.

### Detailed summary
- Changed condition for rendering `ClaimableModule` to check for "Claimable" instead of "Claimable-ignore".
- Updated logic in `CurrencySelector` for checking `initialValue`.
- Added `tokenId` and `noClaimConditionSet` state management in `claimable.stories.tsx`.
- Removed unused `getClaimConditionErc1155Stub` function.
- Introduced a checkbox for `noClaimConditionSet` in the UI.
- Adjusted claim condition logic to include `tokenId` validation.
- Enhanced `ClaimableModule` with new state and props for token ID management.
- Updated `ClaimableModuleUI` to handle token ID input and validation.
- Refactored `ClaimConditionSection` to check for claim conditions and manage form state.
- Added warning alert for cases with no claim conditions set.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->