### PR TITLE
[CI] Chore: Update PR stale time to 7 days

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,5 +11,5 @@ jobs:
         with:
           stale-issue-message: 'This issue has been inactive for 30 days. It is now marked as stale and will be closed in 5 days if no further activity occurs.'
           stale-pr-message: 'This PR has been inactive for 30 days. It is now marked as stale and will be closed in 5 days if no further activity occurs.'
-          days-before-stale: 30
-          days-before-close: 5
+          days-before-stale: 7
+          days-before-close: 2


### PR DESCRIPTION
CNCT-2336

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the configuration for stale issues and pull requests in the `.github/workflows/stale.yml` file, reducing the inactivity periods before marking them as stale and before closing them.

### Detailed summary
- Changed `days-before-stale` from 30 to 7 days.
- Changed `days-before-close` from 5 to 2 days.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->