### PR TITLE
feat: add custom auth demo in playground

### DIFF
--- a/apps/playground-web/src/app/connect/in-app-wallet/page.tsx
+++ b/apps/playground-web/src/app/connect/in-app-wallet/page.tsx
@@ -1,4 +1,5 @@
 import { CodeExample } from "@/components/code/code-example";
+import { CustomLoginForm } from "@/components/in-app-wallet/custom-login-form";
 import { InAppConnectEmbed } from "../../../components/in-app-wallet/connect-button";
 import { Profiles } from "../../../components/in-app-wallet/profile-sections";
 import ThirdwebProvider from "../../../components/thirdweb-provider";
@@ -30,12 +31,15 @@ function AnyAuth() {
           base.
         </p>
       </div>
-
-      <CodeExample
-        preview={<InAppConnectEmbed />}
-        code={`import { inAppWallet } from "thirdweb/wallets";
+      <div className="space-y-2">
+        <h3 className="mb-3 font-medium text-lg">Prebuilt UI</h3>
+        <p className="max-w-[600px]">
+          Instant out of the box authentication with a prebuilt UI.
+        </p>
+        <CodeExample
+          preview={<InAppConnectEmbed />}
+          code={`import { inAppWallet } from "thirdweb/wallets";
         import { ConnectEmbed } from "thirdweb/react";
-
 
         const wallets = [
           inAppWallet(
@@ -66,8 +70,83 @@ function AnyAuth() {
           return (
 <ConnectEmbed client={client} wallets={wallets} />);
 };`}
-        lang="tsx"
-      />
+          lang="tsx"
+        />
+      </div>
+      <div className="space-y-2">
+        <h3 className="mb-3 font-medium text-lg">Custom Auth and UI</h3>
+        <p className="max-w-[600px]">
+          Customize the login UI and integrate with your existing user base. No
+          limits on customizations and auth methods.
+        </p>
+        <CodeExample
+          preview={
+            <div className="w-1/2">
+              <CustomLoginForm />
+            </div>
+          }
+          code={`import { useMutation } from "@tanstack/react-query";
+import { useState } from "react";
+import { useConnect } from "thirdweb/react";
+import { inAppWallet } from "thirdweb/wallets";
+
+export function CustomLoginForm() {
+  const [email, setEmail] = useState("");
+  const { connect, isConnecting, error } = useConnect();
+
+  const { mutate: loginWithCustomAuth } = useMutation({
+    mutationFn: async (email: string) => {
+      const wallet = await connect(async () => {
+        const wallet = inAppWallet();
+        await wallet.connect({
+          strategy: "auth_endpoint",
+          client,
+          // your own custom auth payload here
+          payload: JSON.stringify({
+            userId: email,
+            email,
+          }),
+        });
+        return wallet;
+      });
+      return wallet;
+    }
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    loginWithCustomAuth(email);
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div>
+        <label htmlFor="email">
+          Email Address
+        </label>
+        <input
+          type="email"
+          id="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="Enter your email"
+          required
+        />
+        <button
+          type="submit"
+          disabled={isConnecting || !email}
+        >
+          {isConnecting ? "Submitting..." : "Submit"}
+        </button>
+        {error && <p>{error.message}</p>}
+      </div>
+    </form>
+  );
+}
+`}
+          lang="tsx"
+        />
+      </div>
     </>
   );
 }

--- a/apps/playground-web/src/components/in-app-wallet/custom-login-form.tsx
+++ b/apps/playground-web/src/components/in-app-wallet/custom-login-form.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { THIRDWEB_CLIENT } from "@/lib/client";
+import { useMutation } from "@tanstack/react-query";
+import { useState } from "react";
+import { useActiveAccount, useConnect } from "thirdweb/react";
+import { inAppWallet } from "thirdweb/wallets";
+import { InAppConnectEmbed } from "./connect-button";
+
+export function CustomLoginForm() {
+  const [email, setEmail] = useState("");
+  const { connect, isConnecting, error } = useConnect();
+  const account = useActiveAccount();
+
+  const { mutate: loginWithCustomAuthEndpoint } = useMutation({
+    mutationFn: async (email: string) => {
+      const wallet = await connect(async () => {
+        const wallet = inAppWallet();
+        await wallet.connect({
+          strategy: "auth_endpoint",
+          client: THIRDWEB_CLIENT,
+          payload: JSON.stringify({
+            userId: email,
+            email,
+          }),
+        });
+        return wallet;
+      });
+      return wallet;
+    },
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    loginWithCustomAuthEndpoint(email);
+  };
+  if (account) {
+    return <InAppConnectEmbed />;
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="mt-4">
+      <div className="flex flex-col space-y-2">
+        <label htmlFor="email" className="font-medium text-sm">
+          Email Address
+        </label>
+        <input
+          type="email"
+          id="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="rounded-lg border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          placeholder="Enter your email"
+          required
+        />
+        <button
+          type="submit"
+          className="rounded-lg bg-blue-500 px-4 py-2 text-white transition-colors enabled:hover:bg-blue-600"
+          disabled={isConnecting || !email}
+        >
+          {isConnecting ? "Submitting..." : "Submit"}
+        </button>
+        {error && <p className="max-w-[300px] text-red-500">{error.message}</p>}
+      </div>
+    </form>
+  );
+}


### PR DESCRIPTION
https://linear.app/thirdweb/issue/CNCT-2364/custom-auth-demo-in-playground

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `CustomLoginForm` component for user authentication using an email address. It integrates a custom authentication strategy with the `inAppWallet`, enhancing the user experience by allowing seamless login and error handling.

### Detailed summary
- Added `CustomLoginForm` component in `custom-login-form.tsx`.
- Implemented email input and submission handling with `useState` and `useMutation`.
- Integrated `inAppWallet` for custom authentication.
- Updated `page.tsx` to include `CustomLoginForm` in the UI with a new section for custom auth and UI.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->