### PR TITLE
fix: transferable module restriction

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/modules/components/Transferable.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/modules/components/Transferable.tsx
@@ -103,7 +103,7 @@ function TransferableModule(props: ModuleInstanceProps) {
     <TransferableModuleUI
       {...props}
       isPending={isTransferEnabledQuery.isPending}
-      isRestricted={!!isTransferEnabledQuery.data}
+      isRestricted={!isTransferEnabledQuery.data}
       adminAddress={props.ownerAccount?.address || ""}
       update={update}
       isOwnerAccount={!!props.ownerAccount}


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `isRestricted` prop in the `Transferable` component to invert its boolean logic based on the `isTransferEnabledQuery.data`.

### Detailed summary
- Changed the `isRestricted` prop from `isRestricted={!!isTransferEnabledQuery.data}` to `isRestricted={!isTransferEnabledQuery.data}`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->