### PR TITLE
Show last 50 changelogs in portal instead of last 100

### DIFF
--- a/apps/portal/src/app/changelog/ghost.ts
+++ b/apps/portal/src/app/changelog/ghost.ts
@@ -8,7 +8,7 @@ export async function fetchChangeLogs() {
     key: GHOST_THIRDWEB_BLOG_KEY,
     fields: ["title", "slug", "published_at"].join(","),
     filter: "tag:changelog",
-    limit: "100",
+    limit: "50",
     order: "published_at DESC",
     include: ["authors", "tags"].join(","),
   })


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying the parameters for fetching changelog entries in the `ghost.ts` file, specifically adjusting the limit of entries retrieved.

### Detailed summary
- Changed the `-limit` parameter from `100` to `50` in the fetch request for changelog entries.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->