### PR TITLE
feat: Support ERC-6492 signature verification on zksync chains

### DIFF
--- a/.changeset/gentle-kids-serve.md
+++ b/.changeset/gentle-kids-serve.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Support erc6492 signature verification on zksync

--- a/packages/thirdweb/src/auth/verify-signature.ts
+++ b/packages/thirdweb/src/auth/verify-signature.ts
@@ -152,7 +152,8 @@ export async function verifySignature(options: VerifySignatureParams) {
   if (isVerifyContractWalletSignatureParams(options)) {
     try {
       return await verifyContractWalletSignature(options);
-    } catch {
+    } catch (err) {
+      console.error("Error verifying smart contract wallet signature", err);
       // no-op we skip to return false
     }
   } else if (!warningTriggered) {


### PR DESCRIPTION
## Problem solved

Fixes CNCT-2383

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing signature verification for ERC-6492 on the zksync blockchain, improving error handling, and adjusting the verification logic to accommodate zksync-specific requirements.

### Detailed summary
- Added support for ERC-6492 signature verification on zksync.
- Improved error handling in `verify-signature.ts` and `verify-hash.ts`.
- Introduced `ZKSYNC_VALIDATOR_ADDRESS` constant.
- Modified the `verificationData` logic to handle zksync chains.
- Updated the return value handling in `verifyHash` to use `hexToBool`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->