### PR TITLE
[SDK] Fix useSetActiveWallet code example in JSDoc

### DIFF
--- a/packages/thirdweb/src/react/core/hooks/wallets/useSetActiveWallet.ts
+++ b/packages/thirdweb/src/react/core/hooks/wallets/useSetActiveWallet.ts
@@ -9,10 +9,10 @@ import { useConnectionManagerCtx } from "../../providers/connection-manager.js";
  * ```jsx
  * import { useSetActiveWallet } from "thirdweb/react";
  *
- * const setActiveAccount = useSetActiveWallet();
+ * const setActiveWallet = useSetActiveWallet();
  *
  * // later in your code
- * await setActiveAccount(account);
+ * await setActiveWallet(wallet);
  * ```
  * @walletConnection
  */


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on renaming the variable used to set the active wallet in the `useSetActiveWallet` hook for clarity and consistency.

### Detailed summary
- Changed the variable name from `setActiveAccount` to `setActiveWallet` for better clarity.
- Updated the usage of the variable in the code from `await setActiveAccount(account);` to `await setActiveWallet(wallet);`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->