### PR TITLE
Add turbo defaults to inputs in turbo config

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -78,30 +78,30 @@
       "dependsOn": ["^build"]
     },
     "thirdweb#update-version": {
-      "inputs": ["package.json"],
+      "inputs": ["$TURBO_DEFAULT$", "package.json"],
       "outputs": ["src/version.ts"]
     },
     "test": {
       "outputs": ["coverage/**"],
-      "inputs": ["src/**", "test/**"],
+      "inputs": ["$TURBO_DEFAULT$", "src/**", "test/**"],
       "dependsOn": ["^build"]
     },
     "storybook": {
-      "inputs": ["src/**"]
+      "inputs": ["$TURBO_DEFAULT$", "src/**"]
     },
     "test:legacy": {
       "outputs": ["coverage/**"],
-      "inputs": ["src/**", "test/**"],
+      "inputs": ["$TURBO_DEFAULT$", "src/**", "test/**"],
       "dependsOn": ["^build"]
     },
     "e2e": {
       "outputs": [],
-      "inputs": ["src/**", "fixtures/**"],
+      "inputs": ["$TURBO_DEFAULT$", "src/**", "fixtures/**"],
       "dependsOn": ["^build"]
     },
     "e2e:legacy": {
       "outputs": [],
-      "inputs": ["src/**", "fixtures/**"],
+      "inputs": ["$TURBO_DEFAULT$", "src/**", "fixtures/**"],
       "dependsOn": ["^build"]
     },
     "lint": {


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `turbo.json` configuration to include a placeholder, `$TURBO_DEFAULT$`, in the `inputs` for several tasks, enhancing flexibility in input management.

### Detailed summary
- Added `$TURBO_DEFAULT$` to `inputs` for:
  - `thirdweb#update-version`
  - `test`
  - `storybook`
  - `test:legacy`
  - `e2e`
  - `e2e:legacy`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->