### PR TITLE
[SDK] Feature: Adds prepare functions for zksync deploys

### DIFF
--- a/packages/thirdweb/src/contract/deployment/zksync/zkDeployCreate2Factory.ts
+++ b/packages/thirdweb/src/contract/deployment/zksync/zkDeployCreate2Factory.ts
@@ -17,7 +17,7 @@ import { prepareZkDeployContractTransaction } from "./zkDeployContract.js";
 /**
  * @internal
  */
-export async function prepareZkDeployCreate2FactoryTransaction(
+async function prepareZkDeployCreate2FactoryTransaction(
   options: ClientAndChainAndAccount,
 ) {
   const create2Signer = privateKeyToAccount({

--- a/packages/thirdweb/src/contract/deployment/zksync/zkDeployProxy.ts
+++ b/packages/thirdweb/src/contract/deployment/zksync/zkDeployProxy.ts
@@ -9,51 +9,7 @@ import { resolvePromisedValue } from "../../../utils/promise/resolve-promised-va
 import { randomBytesHex } from "../../../utils/random.js";
 import type { ClientAndChainAndAccount } from "../../../utils/types.js";
 import type { ThirdwebContract } from "../../contract.js";
-import {
-  prepareZkDeployContractDeterministicTransaction,
-  zkDeployContractDeterministic,
-} from "./zkDeployDeterministic.js";
-
-/**
- * @internal
- */
-export async function prepareZkDeployProxyTransaction(
-  options: ClientAndChainAndAccount & {
-    cloneFactoryContract: ThirdwebContract;
-    initializeTransaction: PreparedTransaction;
-    salt?: string;
-  },
-) {
-  const implementationAddress = await resolvePromisedValue(
-    options.initializeTransaction.to,
-  );
-  if (!implementationAddress) {
-    throw new Error("initializeTransaction must have a 'to' field set");
-  }
-  const deployed = await isContractDeployed({
-    address: implementationAddress,
-    chain: options.chain,
-    client: options.client,
-  });
-  if (!deployed) {
-    throw new Error(
-      `Implementation contract at ${implementationAddress} is not deployed`,
-    );
-  }
-  // deploy tw proxy of the implementation
-  return prepareZkDeployContractDeterministicTransaction({
-    client: options.client,
-    chain: options.chain,
-    account: options.account,
-    abi: twProxyAbi,
-    bytecode: twProxyBytecode,
-    params: {
-      _logic: implementationAddress,
-      _data: await encode(options.initializeTransaction),
-    },
-    salt: options.salt || randomBytesHex(32),
-  });
-}
+import { zkDeployContractDeterministic } from "./zkDeployDeterministic.js";
 
 /**
  * @internal

--- a/packages/thirdweb/src/contract/deployment/zksync/zkDeployProxy.ts
+++ b/packages/thirdweb/src/contract/deployment/zksync/zkDeployProxy.ts
@@ -9,7 +9,51 @@ import { resolvePromisedValue } from "../../../utils/promise/resolve-promised-va
 import { randomBytesHex } from "../../../utils/random.js";
 import type { ClientAndChainAndAccount } from "../../../utils/types.js";
 import type { ThirdwebContract } from "../../contract.js";
-import { zkDeployContractDeterministic } from "./zkDeployDeterministic.js";
+import {
+  prepareZkDeployContractDeterministicTransaction,
+  zkDeployContractDeterministic,
+} from "./zkDeployDeterministic.js";
+
+/**
+ * @internal
+ */
+export async function prepareZkDeployProxyTransaction(
+  options: ClientAndChainAndAccount & {
+    cloneFactoryContract: ThirdwebContract;
+    initializeTransaction: PreparedTransaction;
+    salt?: string;
+  },
+) {
+  const implementationAddress = await resolvePromisedValue(
+    options.initializeTransaction.to,
+  );
+  if (!implementationAddress) {
+    throw new Error("initializeTransaction must have a 'to' field set");
+  }
+  const deployed = await isContractDeployed({
+    address: implementationAddress,
+    chain: options.chain,
+    client: options.client,
+  });
+  if (!deployed) {
+    throw new Error(
+      `Implementation contract at ${implementationAddress} is not deployed`,
+    );
+  }
+  // deploy tw proxy of the implementation
+  return prepareZkDeployContractDeterministicTransaction({
+    client: options.client,
+    chain: options.chain,
+    account: options.account,
+    abi: twProxyAbi,
+    bytecode: twProxyBytecode,
+    params: {
+      _logic: implementationAddress,
+      _data: await encode(options.initializeTransaction),
+    },
+    salt: options.salt || randomBytesHex(32),
+  });
+}
 
 /**
  * @internal


### PR DESCRIPTION
This PR starts the work necessary for CNCT-2398. Further work will be needed to determine how to prepare a deployment transaction that generalizes across all deploy types without access to an account.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR refactors the contract deployment functions in the `thirdweb` package to improve clarity and modularity. It introduces new transaction preparation functions and modifies existing ones to streamline the deployment process for both standard and deterministic contracts.

### Detailed summary
- Renamed `zkDeployContract` to `prepareZkDeployContractTransaction`.
- Introduced `prepareZkDeployContractDeterministicTransaction` for deterministic deployment.
- Updated `zkDeployCreate2Factory` to use the new transaction preparation functions.
- Removed direct calls to `zkDeployContract` in favor of new preparation functions.
- Added handling for optional `salt` and `deploymentType` parameters in deployment functions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->