### PR TITLE
[SDK] Fix: PayEmbed Error State

### DIFF
--- a/.changeset/plenty-dragons-carry.md
+++ b/.changeset/plenty-dragons-carry.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fixes PayEmbed error state appearing on certain errors

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx
@@ -24,6 +24,7 @@ import { useBuyWithFiatQuote } from "../../../../../core/hooks/pay/useBuyWithFia
 import { useActiveAccount } from "../../../../../core/hooks/wallets/useActiveAccount.js";
 import { invalidateWalletBalance } from "../../../../../core/providers/invalidateWalletBalance.js";
 import type { SupportedTokens } from "../../../../../core/utils/defaultTokens.js";
+import { ErrorState } from "../../../../wallets/shared/ErrorState.js";
 import { LoadingScreen } from "../../../../wallets/shared/LoadingScreen.js";
 import type { PayEmbedConnectOptions } from "../../../PayEmbed.js";
 import { ChainName } from "../../../components/ChainName.js";
@@ -105,6 +106,24 @@ export default function BuyScreen(props: BuyScreenProps) {
     isTestMode,
   );
 
+  if (supportedDestinationsQuery.isError) {
+    return (
+      <Container
+        style={{
+          minHeight: "350px",
+        }}
+        fullHeight
+        flex="row"
+        center="both"
+      >
+        <ErrorState
+          title="Something went wrong"
+          onTryAgain={supportedDestinationsQuery.refetch}
+        />
+      </Container>
+    );
+  }
+
   if (!supportedDestinationsQuery.data) {
     return <LoadingScreen />;
   }
@@ -137,9 +156,11 @@ type BuyScreenContentProps = {
  */
 function BuyScreenContent(props: BuyScreenContentProps) {
   const { client, supportedDestinations, connectLocale, payOptions } = props;
+  console.log("BuyScreenContent");
 
   const activeAccount = useActiveAccount();
   const { payer, setPayer } = usePayerSetup();
+  console.log("payer", payer);
 
   const [screen, setScreen] = useState<SelectedScreen>({
     id: "main",
@@ -476,6 +497,8 @@ function BuyScreenContent(props: BuyScreenContentProps) {
       />
     );
   }
+
+  console.log("SCREEN", screen.id);
 
   return (
     <Container animate="fadein">

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/main/useBuyTxStates.ts
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/main/useBuyTxStates.ts
@@ -58,7 +58,7 @@ export function useTransactionCostAndData(args: {
     ],
     queryFn: async () => {
       if (!account) {
-        throw new Error("No account");
+        throw new Error("No payer account found");
       }
 
       const erc20Value = await resolvePromisedValue(transaction.erc20Value);
@@ -112,7 +112,6 @@ export function useTransactionCostAndData(args: {
           getChainMetadata(transaction.chain),
           getTransactionGasCost(transaction, account?.address),
         ]);
-
       const walletBalance = nativeWalletBalance;
       const transactionValueWei =
         (await resolvePromisedValue(transaction.value)) || 0n;
@@ -129,7 +128,7 @@ export function useTransactionCostAndData(args: {
         transactionValueWei,
       } satisfies TransactionCostAndData;
     },
-    enabled: !!transaction && !!account && !!txQueryKey,
+    enabled: !!transaction && !!txQueryKey,
     refetchInterval: () => {
       if (transaction.erc20Value) {
         // if erc20 value is set, we don't need to poll


### PR DESCRIPTION
CNCT-2385

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing error handling in the `Buy` and `TransactionModeScreen` components of the `thirdweb` package. It improves user experience by providing clearer error messages and loading states.

### Detailed summary
- Updated error message from `"No account"` to `"No payer account found"` in `useBuyTxStates.ts`.
- Added error handling for `supportedDestinationsQuery` in `BuyScreen.tsx`.
- Introduced loading and error states for `TransactionModeScreen` with appropriate user feedback.
- Enhanced logging for debugging in `BuyScreenContent`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->