### PR TITLE
[SDK] Fix: Adds overrides to createNewPack

### DIFF
--- a/.changeset/tame-walls-live.md
+++ b/.changeset/tame-walls-live.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Adds the ability to override transaction values in createNewPack

--- a/packages/thirdweb/src/extensions/pack/createNewPack.ts
+++ b/packages/thirdweb/src/extensions/pack/createNewPack.ts
@@ -1,7 +1,10 @@
 import type { ThirdwebClient } from "../../client/client.js";
 import { type ThirdwebContract, getContract } from "../../contract/contract.js";
 import { upload } from "../../storage/upload.js";
-import type { BaseTransactionOptions } from "../../transaction/types.js";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../transaction/types.js";
 import type { NFTInput } from "../../utils/nft/parseNft.js";
 import { toUnits } from "../../utils/units.js";
 import type { AddPackContentsParams } from "./__generated__/IPack/write/addPackContents.js";
@@ -114,7 +117,7 @@ export type CreateNewPackParams = {
  * ```
  */
 export function createNewPack(
-  options: BaseTransactionOptions<CreateNewPackParams>,
+  options: WithOverrides<BaseTransactionOptions<CreateNewPackParams>>,
 ) {
   return createPack({
     contract: options.contract,
@@ -126,7 +129,7 @@ export function createNewPack(
  * @internal
  */
 async function getCreatePackParams(
-  options: BaseTransactionOptions<CreateNewPackParams>,
+  options: WithOverrides<BaseTransactionOptions<CreateNewPackParams>>,
 ): Promise<CreatePackParams> {
   const {
     contract,
@@ -138,6 +141,7 @@ async function getCreatePackParams(
     erc721Rewards,
     erc1155Rewards,
     tokenOwner,
+    overrides,
   } = options;
   const [erc20Content, erc721Content, erc1155Content, packUri] =
     await Promise.all([
@@ -179,6 +183,7 @@ async function getCreatePackParams(
     // openStartTimestamp should be in seconds and not millisecond
     openStartTimestamp: BigInt(Math.ceil(openStartTimestamp.getTime() / 1000)),
     amountDistributedPerOpen,
+    overrides,
   };
 }
 


### PR DESCRIPTION
CNCT-2230

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the ability to override transaction values in the `createNewPack` function within the `thirdweb` package.

### Detailed summary
- Added `WithOverrides` type to the `options` parameter in `createNewPack`.
- Updated `getCreatePackParams` function to accept `WithOverrides<BaseTransactionOptions<CreateNewPackParams>>`.
- Included `overrides` in the parameters returned by `getCreatePackParams`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->