### PR TITLE
[SDK] Fix: Hedera toWei Conversion

### DIFF
--- a/.changeset/bright-mayflies-think.md
+++ b/.changeset/bright-mayflies-think.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Account for Hedera wei decimals difference

--- a/packages/thirdweb/src/contract/deployment/zksync/zkDeployCreate2Factory.ts
+++ b/packages/thirdweb/src/contract/deployment/zksync/zkDeployCreate2Factory.ts
@@ -41,7 +41,7 @@ export async function zkDeployCreate2Factory(
     privateKey: PUBLISHED_PRIVATE_KEY,
   });
 
-  const valueToSend = toWei("0.01");
+  const valueToSend = toWei("0.01", options.chain);
   const balance = await getWalletBalance({
     address: create2Signer.address,
     chain: options.chain,

--- a/packages/thirdweb/src/extensions/erc20/write/deposit.ts
+++ b/packages/thirdweb/src/extensions/erc20/write/deposit.ts
@@ -29,7 +29,9 @@ export type DepositParams =
  */
 export function deposit(options: BaseTransactionOptions<DepositParams>) {
   const value =
-    "amountWei" in options ? options.amountWei : toWei(options.amount);
+    "amountWei" in options
+      ? options.amountWei
+      : toWei(options.amount, options.contract.chain);
   return prepareContractCall({
     contract: options.contract,
     method: [FN_SELECTOR, [], []] as const,

--- a/packages/thirdweb/src/react/core/hooks/wallets/useSendToken.ts
+++ b/packages/thirdweb/src/react/core/hooks/wallets/useSendToken.ts
@@ -79,7 +79,7 @@ export function useSendToken(client: ThirdwebClient) {
           chain: activeChain,
           client,
           to,
-          value: toWei(amount),
+          value: toWei(amount, activeChain),
         });
 
         await sendTransaction({

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/TransferConfirmationScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/TransferConfirmationScreen.tsx
@@ -217,7 +217,7 @@ export function TransferConfirmationScreen(
                       client,
                       chain,
                       to: receiverAddress,
-                      value: toWei(tokenAmount),
+                      value: toWei(tokenAmount, chain),
                     })
                   : transfer({
                       contract: getContract({

--- a/packages/thirdweb/src/utils/units.ts
+++ b/packages/thirdweb/src/utils/units.ts
@@ -1,3 +1,5 @@
+import type { Chain } from "../chains/types.js";
+
 /**
  * Converts a given number of units to a string representation with a specified number of decimal places.
  * @param units - The number of units to convert.
@@ -125,10 +127,22 @@ export function toUnits(tokens: string, decimals: number): bigint {
  * toWei('1')
  * // 1000000000000000000n
  * ```
+ *
+ * For chains with varying decimals, you can provide the chain.
+ * ```ts
+ * import { toWei } from "thirdweb/utils";
+ * toWei('1', defineChain(295))
+ * // 10000000n
+ * ```
  * @utils
  */
-export function toWei(tokens: string) {
-  return toUnits(tokens, 18);
+export function toWei(tokens: string, chain?: Chain) {
+  switch (chain?.id) {
+    case 295:
+      return toUnits(tokens, 8);
+    default:
+      return toUnits(tokens, 18);
+  }
 }
 
 /**


### PR DESCRIPTION
[Relevant Slack discussion](https://thirdwebdev.slack.com/archives/C04P6J3K0ES/p1731616237108399?thread_ts=1730826933.868789&cid=C04P6J3K0ES)

CNCT-2368

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adjusting the `toWei` function to account for different decimal configurations across chains, specifically for Hedera and zkSync, enhancing token handling in various components.

### Detailed summary
- Updated `toWei` function to accept a `chain` parameter for variable decimals.
- Modified `useSendToken.ts` to use `toWei(amount, activeChain)`.
- Changed `TransferConfirmationScreen.tsx` to use `toWei(tokenAmount, chain)`.
- Adjusted `zkDeployCreate2Factory.ts` to use `toWei("0.01", options.chain)`.
- Altered `deposit.ts` to handle `options.amount` with respect to `options.contract.chain`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->