### PR TITLE
[Dashboard] Improve team overview page load perf + UI adjustments

### DIFF
--- a/apps/dashboard/src/app/team/components/Analytics/AnalyticsHeader.tsx
+++ b/apps/dashboard/src/app/team/components/Analytics/AnalyticsHeader.tsx
@@ -9,9 +9,11 @@ export function AnalyticsHeader(props: {
   const { title, interval, range } = props;
 
   return (
-    <div className="container flex flex-col items-start gap-6 px-2 py-6 md:h-[120px] md:flex-row md:items-center md:p-6 md:py-0">
+    <div className="container flex flex-col items-start gap-3 py-10 md:flex-row md:items-center">
       <div className="flex-1">
-        <h1 className="font-semibold text-3xl text-foreground">{title}</h1>
+        <h1 className="font-semibold text-2xl tracking-tight md:text-3xl">
+          {title}
+        </h1>
       </div>
       <RangeSelector interval={interval} range={range} />
     </div>

--- a/apps/dashboard/src/app/team/components/Analytics/EmptyState.tsx
+++ b/apps/dashboard/src/app/team/components/Analytics/EmptyState.tsx
@@ -17,7 +17,7 @@ import walletsIcon from "../../../../../public/assets/tw-icons/wallets.svg";
 
 export function EmptyState() {
   return (
-    <section className="flex items-start justify-center md:min-h-[500px]">
+    <section className="flex w-full items-start justify-center md:min-h-[500px]">
       <div className="group container flex flex-col items-center justify-center gap-8 rounded-lg border bg-card p-6 py-24">
         <div className="flex max-w-[500px] flex-col items-center justify-center gap-6">
           <AnimatedIcons />

--- a/apps/dashboard/src/components/analytics/range-selector.tsx
+++ b/apps/dashboard/src/components/analytics/range-selector.tsx
@@ -73,7 +73,7 @@ export function RangeSelector({
   });
 
   return (
-    <div className="flex flex-col justify-end gap-3 sm:flex-row">
+    <div className="flex justify-end gap-4">
       <DateRangeSelector
         range={localRange}
         setRange={(newRange) => {


### PR DESCRIPTION
Move the chart data fetching inside suspense boundary with loading fallback to speed up page load

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the layout and structure of various components in the dashboard, enhancing the user interface and experience. It also introduces a loading state and refines the handling of search parameters in the `TeamOverviewPage`.

### Detailed summary
- Updated the `range-selector` layout for better spacing.
- Expanded the `EmptyState` section to use full width.
- Adjusted `AnalyticsHeader` styles and title size.
- Introduced `GenericLoadingPage` for loading states.
- Enhanced `TeamOverviewPage` to handle search parameters as promises.
- Refactored content layout in `TeamOverviewPage` for better organization and readability.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->