### PR TITLE
chore: Allow optional includeUsage (default: true)

### DIFF
--- a/.changeset/gold-pumpkins-poke.md
+++ b/.changeset/gold-pumpkins-poke.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+chore: Allow optional includeUsage (default: true)

--- a/packages/service-utils/src/core/api.ts
+++ b/packages/service-utils/src/core/api.ts
@@ -20,6 +20,7 @@ export type CoreServiceConfig = {
   serviceApiKey: string;
   serviceAction?: string;
   useWalletAuth?: boolean;
+  includeUsage?: boolean;
 };
 
 type Usage = {
@@ -85,8 +86,8 @@ export async function fetchKeyMetadataFromApi(
   clientId: string,
   config: CoreServiceConfig,
 ): Promise<ApiResponse> {
-  const { apiUrl, serviceScope, serviceApiKey } = config;
-  const url = `${apiUrl}/v1/keys/use?clientId=${clientId}&scope=${serviceScope}&includeUsage=true`;
+  const { apiUrl, serviceScope, serviceApiKey, includeUsage = true } = config;
+  const url = `${apiUrl}/v1/keys/use?clientId=${clientId}&scope=${serviceScope}&includeUsage=${includeUsage}`;
   const response = await fetch(url, {
     method: "GET",
     headers: {
@@ -111,10 +112,10 @@ export async function fetchAccountFromApi(
   config: CoreServiceConfig,
   useWalletAuth: boolean,
 ): Promise<ApiAccountResponse> {
-  const { apiUrl, serviceApiKey } = config;
+  const { apiUrl, serviceApiKey, includeUsage = true } = config;
   const url = useWalletAuth
-    ? `${apiUrl}/v1/wallet/me?includeUsage=true`
-    : `${apiUrl}/v1/account/me?includeUsage=true`;
+    ? `${apiUrl}/v1/wallet/me?includeUsage=${includeUsage}`
+    : `${apiUrl}/v1/account/me?includeUsage=${includeUsage}`;
   const response = await fetch(url, {
     method: "GET",
     headers: {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces an optional `includeUsage` parameter to the configuration of API calls in the `service-utils` package, defaulting to `true`. This change allows for more flexible API requests regarding usage data.

### Detailed summary
- Added optional `includeUsage` parameter to `CoreServiceConfig`.
- Updated `fetchKeyMetadataFromApi` to use `includeUsage` in the API URL.
- Updated `fetchAccountFromApi` to use `includeUsage` in the API URL for both wallet and account requests.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->