### PR TITLE
change text for trusted forwarder form

### DIFF
--- a/apps/dashboard/src/components/contract-components/contract-deploy-form/trusted-forwarders-fieldset.tsx
+++ b/apps/dashboard/src/components/contract-components/contract-deploy-form/trusted-forwarders-fieldset.tsx
@@ -34,9 +34,7 @@ export const TrustedForwardersFieldset: React.FC<
               </span>
 
               <span className="block text-muted-foreground text-sm">
-                You can provide your own forwarder, or click the button below to
-                use default forwarders provided by thirdweb. Leave empty if not
-                needed.
+                You can provide your own forwarder.
               </span>
             </FormHelperText>
           </div>


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added



<!-- start pr-codex -->

---

## PR-Codex overview
This PR simplifies the text displayed in the `trusted-forwarders-fieldset.tsx` component by removing the option for users to click a button for default forwarders provided by thirdweb. It now only mentions the ability to provide a custom forwarder.

### Detailed summary
- The text within the `<span>` element was changed to remove the option for default forwarders.
- The updated text now states: "You can provide your own forwarder."

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->