### PR TITLE
thirdweb should be lowercase

### DIFF
--- a/apps/portal/src/app/connect/pay/guides/accept-direct-payments/page.mdx
+++ b/apps/portal/src/app/connect/pay/guides/accept-direct-payments/page.mdx
@@ -38,7 +38,7 @@ Before jumping in, it's important to understand the full system, from initial pu
 Now, let's get started.
 
 <Steps>
-	<Step title="Set Up Thirdweb Engine">
+	<Step title="Set Up thirdweb Engine">
 
     	1. If you haven't already, log in and [deploy an Engine
     	instance](https://thirdweb.com/team/~/~/engine)


### PR DESCRIPTION
## Problem solved

Never forget, always fight for it.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting the capitalization of the word `thirdweb` in the title of a `Step` component within the `page.mdx` file.

### Detailed summary
- Changed the title in the `Step` component from "Set Up Thirdweb Engine" to "Set Up thirdweb Engine".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->