### PR TITLE
[Dashboard] Feature: RPC Chart

### DIFF
--- a/apps/dashboard/src/@3rdweb-sdk/react/hooks/useApi.ts
+++ b/apps/dashboard/src/@3rdweb-sdk/react/hooks/useApi.ts
@@ -1,4 +1,3 @@
-import type { UserOpStats } from "@/api/analytics";
 import type { Team } from "@/api/team";
 import {
   type Query,
@@ -9,6 +8,7 @@ import {
 import { THIRDWEB_ANALYTICS_API_HOST, THIRDWEB_API_HOST } from "constants/urls";
 import { useAllChainsData } from "hooks/chains/allChains";
 import invariant from "tiny-invariant";
+import type { UserOpStats } from "types/analytics";
 import { accountKeys, apiKeys, authorizedWallets } from "../cache-keys";
 import { useLoggedInUser } from "./useLoggedInUser";
 

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/_components/TotalSponsoredCard.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/_components/TotalSponsoredCard.tsx
@@ -1,7 +1,7 @@
-import type { UserOpStats } from "@/api/analytics";
 import { cn } from "@/lib/utils";
 import { defineChain } from "thirdweb";
 import { type ChainMetadata, getChainMetadata } from "thirdweb/chains";
+import type { UserOpStats } from "types/analytics";
 import { EmptyAccountAbstractionChartContent } from "../../../../../components/smart-wallets/AccountAbstractionAnalytics/SponsoredTransactionsChartCard";
 import { BarChart } from "../../../components/Analytics/BarChart";
 import { CombinedBarChartCard } from "../../../components/Analytics/CombinedBarChartCard";

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/page.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/page.tsx
@@ -10,7 +10,7 @@ import type {
   InAppWalletStats,
   WalletStats,
   WalletUserStats,
-} from "@/api/analytics";
+} from "types/analytics";
 
 import {
   type DurationId,

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/analytics/components/EcosystemWalletUsersChartCard.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/analytics/components/EcosystemWalletUsersChartCard.tsx
@@ -1,5 +1,4 @@
 "use client";
-import type { EcosystemWalletStats } from "@/api/analytics";
 import { ExportToCSVButton } from "@/components/blocks/ExportToCSVButton";
 import {
   type ChartConfig,
@@ -21,6 +20,7 @@ import { format } from "date-fns";
 import { formatTickerNumber } from "lib/format-utils";
 import { useMemo } from "react";
 import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
+import type { EcosystemWalletStats } from "types/analytics";
 
 type ChartData = Record<string, number> & {
   time: string; // human readable date

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/analytics/components/Summary.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/analytics/components/Summary.tsx
@@ -1,6 +1,6 @@
-import type { EcosystemWalletStats } from "@/api/analytics";
 import { Stat } from "components/analytics/stat";
 import { ActivityIcon, UserIcon } from "lucide-react";
+import type { EcosystemWalletStats } from "types/analytics";
 
 export function EcosystemWalletsSummary(props: {
   allTimeStats: EcosystemWalletStats[] | undefined;

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/components/ecosystem-header.client.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/components/ecosystem-header.client.tsx
@@ -1,5 +1,4 @@
 "use client";
-import type { EcosystemWalletStats } from "@/api/analytics";
 import { CopyButton } from "@/components/ui/CopyButton";
 import { Spinner } from "@/components/ui/Spinner/Spinner";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -24,6 +23,7 @@ import {
 } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
+import type { EcosystemWalletStats } from "types/analytics";
 import { useEcosystemList } from "../../../hooks/use-ecosystem-list";
 import type { Ecosystem } from "../../../types";
 import { EcosystemWalletsSummary } from "../analytics/components/Summary";

--- a/apps/dashboard/src/app/team/[team_slug]/[project_slug]/components/RpcMethodBarChartCard/RpcMethodBarChartCard.stories.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/[project_slug]/components/RpcMethodBarChartCard/RpcMethodBarChartCard.stories.tsx
@@ -1,0 +1,86 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { BadgeContainer, mobileViewport } from "stories/utils";
+import type { RpcMethodStats } from "types/analytics";
+import { RpcMethodBarChartCardUI } from "./RpcMethodBarChartCardUI";
+
+const meta = {
+  title: "Analytics/RpcMethodBarChartCard",
+  component: Component,
+  parameters: {
+    layout: "centered",
+  },
+} satisfies Meta<typeof Component>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Desktop: Story = {
+  parameters: {
+    viewport: { defaultViewport: "desktop" },
+  },
+};
+
+export const Mobile: Story = {
+  parameters: {
+    viewport: mobileViewport("iphone14"),
+  },
+};
+
+const generateTimeSeriesData = (
+  days: number,
+  methods: string[],
+  emptyData = false,
+) => {
+  const data: RpcMethodStats[] = [];
+  const today = new Date();
+
+  for (let i = days - 1; i >= 0; i--) {
+    const date = new Date(today);
+    date.setDate(date.getDate() - i);
+
+    for (const method of methods) {
+      data.push({
+        date: date.toISOString(),
+        evmMethod: method,
+        count: emptyData ? 0 : Math.floor(Math.random() * 1000) + 100,
+      });
+    }
+  }
+
+  return data;
+};
+
+const commonMethods = [
+  "eth_call",
+  "eth_getBalance",
+  "eth_getTransactionReceipt",
+  "eth_blockNumber",
+];
+
+function Component() {
+  return (
+    <div className="container space-y-8 py-8">
+      <BadgeContainer label="Normal Usage">
+        <RpcMethodBarChartCardUI
+          rawData={generateTimeSeriesData(30, commonMethods)}
+        />
+      </BadgeContainer>
+
+      <BadgeContainer label="Empty Data">
+        <RpcMethodBarChartCardUI rawData={[]} />
+      </BadgeContainer>
+
+      <BadgeContainer label="Zero Values">
+        <RpcMethodBarChartCardUI
+          rawData={generateTimeSeriesData(30, commonMethods, true)}
+        />
+      </BadgeContainer>
+
+      <BadgeContainer label="Single Method">
+        <RpcMethodBarChartCardUI
+          rawData={generateTimeSeriesData(30, ["eth_call"])}
+        />
+      </BadgeContainer>
+    </div>
+  );
+}

--- a/apps/dashboard/src/app/team/[team_slug]/[project_slug]/components/RpcMethodBarChartCard/RpcMethodBarChartCardUI.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/[project_slug]/components/RpcMethodBarChartCard/RpcMethodBarChartCardUI.tsx
@@ -1,0 +1,163 @@
+"use client";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+import { formatTickerNumber } from "lib/format-utils";
+import { useMemo } from "react";
+import {
+  Bar,
+  CartesianGrid,
+  BarChart as RechartsBarChart,
+  XAxis,
+  YAxis,
+} from "recharts";
+import type { RpcMethodStats } from "types/analytics";
+import { EmptyStateCard } from "../../../../components/Analytics/EmptyStateCard";
+
+export function RpcMethodBarChartCardUI({
+  rawData,
+}: { rawData: RpcMethodStats[] }) {
+  const uniqueMethods = useMemo(
+    () => Array.from(new Set(rawData.map((d) => d.evmMethod))),
+    [rawData],
+  );
+  const uniqueDates = useMemo(
+    () => Array.from(new Set(rawData.map((d) => d.date))),
+    [rawData],
+  );
+
+  const data = useMemo(() => {
+    return uniqueDates.map((date) => {
+      const dateData: { [key: string]: string | number } = { date };
+      for (const method of uniqueMethods) {
+        const methodData = rawData.find(
+          (d) => d.date === date && d.evmMethod === method,
+        );
+        dateData[method] = methodData?.count ?? 0;
+      }
+
+      // If we have too many methods to display well, add "other" and group the lowest keys for each time period
+      if (uniqueMethods.length > 5) {
+        // If we haven't added "other" as a key yet, add it
+        if (!uniqueMethods.includes("Other")) {
+          uniqueMethods.push("Other");
+        }
+
+        // Sort the methods by their count for the time period
+        const sortedMethods = uniqueMethods
+          .filter((m) => m !== "Other")
+          .sort(
+            (a, b) =>
+              ((dateData[b] as number) ?? 0) - ((dateData[a] as number) ?? 0),
+          );
+
+        dateData.Other = 0;
+        for (const method of sortedMethods.slice(5, sortedMethods.length)) {
+          dateData.Other += (dateData[method] as number) ?? 0;
+          delete dateData[method];
+        }
+      }
+      return dateData;
+    });
+  }, [uniqueDates, uniqueMethods, rawData]);
+
+  const config: ChartConfig = useMemo(() => {
+    const config: ChartConfig = {};
+    for (const method of uniqueMethods) {
+      config[method] = {
+        label: method,
+      };
+    }
+    return config;
+  }, [uniqueMethods]);
+
+  if (
+    data.length === 0 ||
+    data.every((date) =>
+      Object.keys(date).every((k) => k === "date" || date[k] === 0),
+    )
+  ) {
+    return <EmptyStateCard metric="RPC" link="https://portal.thirdweb.com/" />;
+  }
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-col items-stretch space-y-0 border-b p-0">
+        <div className="flex flex-1 flex-col justify-center gap-1 p-6">
+          <CardTitle className="font-semibold text-lg">RPC Methods</CardTitle>
+        </div>
+      </CardHeader>
+      <CardContent className="px-2 sm:p-6 sm:pl-0">
+        <ChartContainer
+          config={config}
+          className="aspect-auto h-[250px] w-full pt-6"
+        >
+          <RechartsBarChart
+            accessibilityLayer
+            data={data}
+            margin={{
+              left: 12,
+              right: 12,
+            }}
+          >
+            <CartesianGrid vertical={false} />
+            <XAxis
+              dataKey="date"
+              tickLine={false}
+              axisLine={false}
+              tickMargin={8}
+              minTickGap={32}
+              tickFormatter={(value: string) => {
+                const date = new Date(value);
+                return date.toLocaleDateString("en-US", {
+                  month: "short",
+                  day: "numeric",
+                });
+              }}
+            />
+            <YAxis
+              width={48}
+              tickLine={false}
+              axisLine={false}
+              tickFormatter={(value: number) => formatTickerNumber(value)}
+            />
+            <ChartTooltip
+              content={
+                <ChartTooltipContent
+                  labelFormatter={(value) => {
+                    return new Date(value).toLocaleDateString("en-US", {
+                      month: "short",
+                      day: "numeric",
+                      year: "numeric",
+                    });
+                  }}
+                  valueFormatter={(v: unknown) =>
+                    formatTickerNumber(v as number)
+                  }
+                />
+              }
+            />
+            {uniqueMethods.map((method, idx) => (
+              <Bar
+                key={method}
+                stackId="a"
+                dataKey={method}
+                radius={[
+                  idx === uniqueMethods.length - 1 ? 4 : 0,
+                  idx === uniqueMethods.length - 1 ? 4 : 0,
+                  idx === 0 ? 4 : 0,
+                  idx === 0 ? 4 : 0,
+                ]}
+                fill={`hsl(var(--chart-${idx + 1}))`}
+              />
+            ))}
+          </RechartsBarChart>
+        </ChartContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/dashboard/src/app/team/[team_slug]/[project_slug]/components/RpcMethodBarChartCard/index.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/[project_slug]/components/RpcMethodBarChartCard/index.tsx
@@ -1,0 +1,26 @@
+import { getRpcMethodUsage } from "@/api/analytics";
+import { LoadingChartState } from "components/analytics/empty-chart-state";
+import { Suspense } from "react";
+import type { AnalyticsQueryParams } from "types/analytics";
+import { RpcMethodBarChartCardUI } from "./RpcMethodBarChartCardUI";
+
+export function RpcMethodBarChartCard(props: AnalyticsQueryParams) {
+  return (
+    // TODO: Add better LoadingChartState
+    <Suspense
+      fallback={
+        <div className="h-[400px]">
+          <LoadingChartState />
+        </div>
+      }
+    >
+      <RpcMethodBarChartCardAsync {...props} />
+    </Suspense>
+  );
+}
+
+async function RpcMethodBarChartCardAsync(props: AnalyticsQueryParams) {
+  const rawData = await getRpcMethodUsage(props);
+
+  return <RpcMethodBarChartCardUI rawData={rawData} />;
+}

--- a/apps/dashboard/src/app/team/[team_slug]/[project_slug]/connect/analytics/ConnectAnalyticsDashboardUI.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/[project_slug]/connect/analytics/ConnectAnalyticsDashboardUI.tsx
@@ -1,8 +1,3 @@
-import type {
-  InAppWalletStats,
-  UserOpStats,
-  WalletStats,
-} from "@/api/analytics";
 import { Button } from "@/components/ui/button";
 import type { Range } from "components/analytics/date-range-selector";
 import { Stat } from "components/analytics/stat";
@@ -12,6 +7,11 @@ import { differenceInDays } from "date-fns";
 import { ArrowRightIcon, CableIcon, WalletCardsIcon } from "lucide-react";
 import Link from "next/link";
 import { useMemo } from "react";
+import type {
+  InAppWalletStats,
+  UserOpStats,
+  WalletStats,
+} from "types/analytics";
 import { DateRangeSelector } from "../../../../../../components/analytics/date-range-selector";
 import { IntervalSelector } from "../../../../../../components/analytics/interval-selector";
 import { DailyConnectionsChartCard } from "./_components/DailyConnectionsChartCard";

--- a/apps/dashboard/src/app/team/[team_slug]/[project_slug]/connect/analytics/_components/DailyConnectionsChartCard.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/[project_slug]/connect/analytics/_components/DailyConnectionsChartCard.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import type { WalletStats } from "@/api/analytics";
 import { ExportToCSVButton } from "@/components/blocks/ExportToCSVButton";
 import {
   type ChartConfig,
@@ -35,6 +34,7 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
+import type { WalletStats } from "types/analytics";
 import { formatTickerNumber } from "../../../../../../../lib/format-utils";
 
 type ChartToShow = "uniqueWallets" | "totalWallets";

--- a/apps/dashboard/src/app/team/[team_slug]/[project_slug]/connect/analytics/_components/WalletConnectorsChartCard.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/[project_slug]/connect/analytics/_components/WalletConnectorsChartCard.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import type { WalletStats } from "@/api/analytics";
 import { ExportToCSVButton } from "@/components/blocks/ExportToCSVButton";
 import {
   type ChartConfig,
@@ -27,6 +26,7 @@ import { DocLink } from "components/shared/DocLink";
 import { format } from "date-fns";
 import { useMemo, useState } from "react";
 import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
+import type { WalletStats } from "types/analytics";
 import {
   formatTickerNumber,
   formatWalletType,

--- a/apps/dashboard/src/app/team/[team_slug]/[project_slug]/connect/analytics/_components/WalletDistributionChartCard.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/[project_slug]/connect/analytics/_components/WalletDistributionChartCard.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import type { WalletStats } from "@/api/analytics";
 import { ExportToCSVButton } from "@/components/blocks/ExportToCSVButton";
 import {
   type ChartConfig,
@@ -26,6 +25,7 @@ import { TypeScriptIcon } from "components/icons/brand-icons/TypeScriptIcon";
 import { DocLink } from "components/shared/DocLink";
 import { useMemo, useState } from "react";
 import { Pie, PieChart } from "recharts";
+import type { WalletStats } from "types/analytics";
 import {
   formatTickerNumber,
   formatWalletType,

--- a/apps/dashboard/src/app/team/[team_slug]/[project_slug]/connect/analytics/_components/storyUtils.ts
+++ b/apps/dashboard/src/app/team/[team_slug]/[project_slug]/connect/analytics/_components/storyUtils.ts
@@ -1,5 +1,5 @@
-import type { WalletStats } from "@/api/analytics";
 import type { WalletId } from "thirdweb/wallets";
+import type { WalletStats } from "types/analytics";
 
 const walletsToPickFrom: WalletId[] = [
   "io.metamask",

--- a/apps/dashboard/src/components/embedded-wallets/Analytics/InAppWalletUsersChartCard.stories.tsx
+++ b/apps/dashboard/src/components/embedded-wallets/Analytics/InAppWalletUsersChartCard.stories.tsx
@@ -1,6 +1,6 @@
-import type { InAppWalletStats } from "@/api/analytics";
 import type { Meta, StoryObj } from "@storybook/react";
 import type { InAppWalletAuth } from "thirdweb/wallets";
+import type { InAppWalletStats } from "types/analytics";
 import { BadgeContainer, mobileViewport } from "../../../stories/utils";
 import { InAppWalletUsersChartCardUI } from "./InAppWalletUsersChartCard";
 

--- a/apps/dashboard/src/components/embedded-wallets/Analytics/InAppWalletUsersChartCard.tsx
+++ b/apps/dashboard/src/components/embedded-wallets/Analytics/InAppWalletUsersChartCard.tsx
@@ -1,5 +1,4 @@
 "use client";
-import type { InAppWalletStats } from "@/api/analytics";
 import { ExportToCSVButton } from "@/components/blocks/ExportToCSVButton";
 import {
   type ChartConfig,
@@ -21,6 +20,7 @@ import { DocLink } from "components/shared/DocLink";
 import { format } from "date-fns";
 import { useMemo } from "react";
 import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
+import type { InAppWalletStats } from "types/analytics";
 import { formatTickerNumber } from "../../../lib/format-utils";
 
 type ChartData = Record<string, number> & {

--- a/apps/dashboard/src/components/embedded-wallets/Analytics/Summary.tsx
+++ b/apps/dashboard/src/components/embedded-wallets/Analytics/Summary.tsx
@@ -1,6 +1,6 @@
-import type { InAppWalletStats } from "@/api/analytics";
 import { Stat } from "components/analytics/stat";
 import { ActivityIcon, UserIcon } from "lucide-react";
+import type { InAppWalletStats } from "types/analytics";
 
 export function InAppWalletsSummary(props: {
   allTimeStats: InAppWalletStats[] | undefined;

--- a/apps/dashboard/src/components/smart-wallets/AccountAbstractionAnalytics/AccountAbstractionSummary.tsx
+++ b/apps/dashboard/src/components/smart-wallets/AccountAbstractionAnalytics/AccountAbstractionSummary.tsx
@@ -1,6 +1,6 @@
-import type { UserOpStats } from "@/api/analytics";
 import { Stat } from "components/analytics/stat";
 import { ActivityIcon, CoinsIcon } from "lucide-react";
+import type { UserOpStats } from "types/analytics";
 
 export function AccountAbstractionSummary(props: {
   aggregateUserOpUsageQuery?: UserOpStats;

--- a/apps/dashboard/src/components/smart-wallets/AccountAbstractionAnalytics/SponsoredTransactionsChartCard.tsx
+++ b/apps/dashboard/src/components/smart-wallets/AccountAbstractionAnalytics/SponsoredTransactionsChartCard.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import type { UserOpStats } from "@/api/analytics";
 import { ExportToCSVButton } from "@/components/blocks/ExportToCSVButton";
 import {
   type ChartConfig,
@@ -24,6 +23,7 @@ import { format } from "date-fns";
 import { useAllChainsData } from "hooks/chains/allChains";
 import { useMemo } from "react";
 import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
+import type { UserOpStats } from "types/analytics";
 import { formatTickerNumber } from "../../../lib/format-utils";
 
 type ChartData = Record<string, number> & {

--- a/apps/dashboard/src/components/smart-wallets/AccountAbstractionAnalytics/TotalSponsoredChartCard.tsx
+++ b/apps/dashboard/src/components/smart-wallets/AccountAbstractionAnalytics/TotalSponsoredChartCard.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import type { UserOpStats } from "@/api/analytics";
 import { ExportToCSVButton } from "@/components/blocks/ExportToCSVButton";
 import {
   type ChartConfig,
@@ -23,6 +22,7 @@ import { DocLink } from "components/shared/DocLink";
 import { format } from "date-fns";
 import { useMemo } from "react";
 import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
+import type { UserOpStats } from "types/analytics";
 import { useAllChainsData } from "../../../hooks/chains/allChains";
 import { formatTickerNumber } from "../../../lib/format-utils";
 

--- a/apps/dashboard/src/components/smart-wallets/AccountAbstractionAnalytics/storyUtils.ts
+++ b/apps/dashboard/src/components/smart-wallets/AccountAbstractionAnalytics/storyUtils.ts
@@ -1,4 +1,4 @@
-import type { UserOpStats } from "@/api/analytics";
+import type { UserOpStats } from "types/analytics";
 
 export function createUserOpStatsStub(days: number): UserOpStats[] {
   const stubbedData: UserOpStats[] = [];

--- a/apps/dashboard/src/data/analytics/wallets/ecosystem.ts
+++ b/apps/dashboard/src/data/analytics/wallets/ecosystem.ts
@@ -1,4 +1,4 @@
-import type { EcosystemWalletStats } from "@/api/analytics";
+import type { EcosystemWalletStats } from "types/analytics";
 import { fetchAnalytics } from "../fetch-analytics";
 
 export async function getEcosystemWalletUsage(args: {

--- a/apps/dashboard/src/data/analytics/wallets/in-app.ts
+++ b/apps/dashboard/src/data/analytics/wallets/in-app.ts
@@ -1,4 +1,4 @@
-import type { InAppWalletStats } from "@/api/analytics";
+import type { InAppWalletStats } from "types/analytics";
 import { fetchAnalytics } from "../fetch-analytics";
 
 export async function getInAppWalletUsage(args: {

--- a/apps/dashboard/src/types/analytics.ts
+++ b/apps/dashboard/src/types/analytics.ts
@@ -1,0 +1,43 @@
+export interface WalletStats {
+  date: string;
+  uniqueWalletsConnected: number;
+  totalConnections: number;
+  walletType: string;
+}
+
+export interface WalletUserStats {
+  date: string;
+  newUsers: number;
+  returningUsers: number;
+  totalUsers: number;
+}
+
+export interface InAppWalletStats {
+  date: string;
+  authenticationMethod: string;
+  uniqueWalletsConnected: number;
+}
+
+export interface EcosystemWalletStats extends InAppWalletStats {}
+
+export interface UserOpStats {
+  date: string;
+  successful: number;
+  failed: number;
+  sponsoredUsd: number;
+  chainId?: string;
+}
+
+export interface RpcMethodStats {
+  date: string;
+  evmMethod: string;
+  count: number;
+}
+
+export interface AnalyticsQueryParams {
+  clientId?: string;
+  accountId?: string;
+  from?: Date;
+  to?: Date;
+  period?: "day" | "week" | "month" | "year" | "all";
+}


### PR DESCRIPTION
CNCT-2395


<img width="1161" alt="Screenshot 2024-11-22 at 9 52 09 PM" src="https://github.com/user-attachments/assets/e46f1645-11bb-42d5-abcf-147852a3e8ce">

<!-- start pr-codex -->

---

## PR-Codex overview
This PR refactors the analytics-related imports and types, moving them from `@/api/analytics` to a new `types/analytics` module. It enhances type safety and organization by centralizing analytics type definitions.

### Detailed summary
- Changed import paths for analytics types from `@/api/analytics` to `types/analytics`.
- Introduced new types in `types/analytics.ts`: `WalletStats`, `WalletUserStats`, `InAppWalletStats`, `EcosystemWalletStats`, `UserOpStats`, `RpcMethodStats`, and `AnalyticsQueryParams`.
- Updated various components and functions to use the new types.
- Added `getRpcMethodUsage` and `isProjectActive` functions in `@/api/analytics`.
- Modified components to include new charts and analytics features, such as `RpcMethodBarChartCard`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->