### PR TITLE
[SDK] Fix UI issue when assetTabs is set to an empty array

### DIFF
--- a/.changeset/pink-ducks-flash.md
+++ b/.changeset/pink-ducks-flash.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix UI issue when assetTabs is set to an empty array

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/Details.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/Details.tsx
@@ -660,7 +660,7 @@ function DetailsModal(props: {
 
           {/* View Funds */}
           {/* Hide the View Funds button if the assetTabs props is set to an empty array */}
-          {(props.assetTabs === undefined || props.assetTabs.length) && (
+          {(props.assetTabs === undefined || props.assetTabs.length > 0) && (
             <MenuButton
               onClick={() => {
                 setScreen("view-assets");


### PR DESCRIPTION
CNCT-2476

<!-- start pr-codex -->

---

## PR-Codex overview
This PR addresses a UI issue in the `ConnectWallet` component of the `thirdweb` package, specifically related to the visibility of the "View Funds" button when the `assetTabs` prop is an empty array.

### Detailed summary
- Updated the condition for rendering the "View Funds" button in `Details.tsx`.
- Changed the condition from checking if `props.assetTabs.length` exists to checking if `props.assetTabs.length > 0`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->