### PR TITLE
[Dashboard] Parse ENS value to evm address on uploading snapshots

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/_components/claim-conditions/snapshot-upload.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/_components/claim-conditions/snapshot-upload.tsx
@@ -68,7 +68,16 @@ export const SnapshotUpload: React.FC<SnapshotUploadProps> = ({
   const paginationPortalRef = useRef<HTMLDivElement>(null);
 
   const onSave = () => {
-    setSnapshot(normalizeQuery.data.result);
+    // Make sure we are not passing ENS values to the claim-condition extension
+    // we should use the `resolvedAddress` value instead
+    setSnapshot(
+      normalizeQuery.data.result.map((o) => ({
+        address: o.resolvedAddress,
+        maxClaimable: o.maxClaimable,
+        price: o.price,
+        currencyAddress: o.currencyAddress,
+      })),
+    );
     setOpenSnapshotIndex(-1);
   };
 

--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/tokens/components/airdrop-upload.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/tokens/components/airdrop-upload.tsx
@@ -45,7 +45,12 @@ export const AirdropUpload: React.FC<AirdropUploadProps> = ({
   } = useCsvUpload<AirdropAddressInput>({ csvParser });
   const paginationPortalRef = useRef<HTMLDivElement>(null);
   const onSave = () => {
-    setAirdrop(normalizeQuery.data.result);
+    setAirdrop(
+      normalizeQuery.data.result.map((o) => ({
+        address: o.resolvedAddress,
+        quantity: o.quantity,
+      })),
+    );
     onClose();
   };
 


### PR DESCRIPTION
dash-472

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the saving functionality in two components, `airdrop-upload.tsx` and `snapshot-upload.tsx`, to ensure that the data being set uses the `resolvedAddress` instead of potentially incorrect values, and to structure the data appropriately.

### Detailed summary
- In `airdrop-upload.tsx`:
  - Updated `setAirdrop` to map over `normalizeQuery.data.result` and set `address` and `quantity`.
  
- In `snapshot-upload.tsx`:
  - Added comments to clarify that `resolvedAddress` should be used instead of ENS values.
  - Updated `setSnapshot` to map over `normalizeQuery.data.result` and set `address`, `maxClaimable`, `price`, and `currencyAddress`.
  - Reset `openSnapshotIndex` to `-1`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->