### PR TITLE
[Portal] Docs: Fix detectMethod example

### DIFF
--- a/packages/thirdweb/src/utils/bytecode/detectExtension.ts
+++ b/packages/thirdweb/src/utils/bytecode/detectExtension.ts
@@ -15,8 +15,8 @@ type DetectExtensionOptions = {
  * ```ts
  * import { detectMethod } from "thirdweb/utils/extensions/detect.js";
  * const hasDecimals = await detectMethod({
- *  contract,
  *  method: "function decimals() view returns (uint8)",
+ *  availableSelectors: ["0x313ce567"],
  * });
  * ```
  * @contract


### PR DESCRIPTION
CNCT-2479

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `detectMethod` function call in the `detectExtension.ts` file to use `availableSelectors` instead of specifying the method directly.

### Detailed summary
- Changed the `detectMethod` call to use `availableSelectors` with the value `["0x313ce567"]`.
- Removed the previous method specification: `method: "function decimals() view returns (uint8)"`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->