### PR TITLE
Fix home link in dashboard footer

### DIFF
--- a/apps/dashboard/src/@/components/blocks/app-footer.tsx
+++ b/apps/dashboard/src/@/components/blocks/app-footer.tsx
@@ -80,7 +80,7 @@ export function AppFooter(props: AppFooterProps) {
         <div className="grid grid-flow-col grid-cols-2 grid-rows-5 gap-2 md:flex md:flex-row md:justify-between">
           <Link
             className="px-[10px] py-[6px] text-muted-foreground text-sm hover:underline"
-            href="/"
+            href="/home"
           >
             Home
           </Link>


### PR DESCRIPTION
DASH-475

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `href` attribute of a `Link` component in the `app-footer.tsx` file to change the destination from the root (`/`) to the `/home` route.

### Detailed summary
- Changed the `href` attribute of the `Link` component from `"/"` to `"/home"` in `apps/dashboard/src/@/components/blocks/app-footer.tsx`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->