### PR TITLE
fix postbuild step

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -7,14 +7,14 @@
       "dependsOn": ["^build"]
     },
     "postbuild": {
-      "dependsOn": ["^postbuild"],
       "outputs": [
         "dist/**",
         ".next/**",
         "public/robots.txt",
         "public/sitemap*.xml",
         "searchIndex.json"
-      ]
+      ],
+      "inputs": ["$TURBO_DEFAULT$", ".next/**"]
     },
     "bench": {
       "cache": false,


### PR DESCRIPTION
fixes DASH-478

<!-- start pr-codex -->

---

## PR-Codex overview
This PR modifies the `postbuild` configuration in the `turbo.json` file, changing the dependencies and output specifications while adding input definitions.

### Detailed summary
- Removed the `dependsOn` entry in the `postbuild` section.
- Updated the `outputs` array to maintain the same values.
- Added an `inputs` array with `"$TURBO_DEFAULT$"` and `".next/**"` in the `postbuild` section.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->