### PR TITLE
fix fee sharing percentage

### DIFF
--- a/apps/dashboard/src/components/pay/PayConfig.tsx
+++ b/apps/dashboard/src/components/pay/PayConfig.tsx
@@ -119,7 +119,7 @@ export const PayConfig: React.FC<PayConfigProps> = ({ apiKey }) => {
             </h3>
             <p className="mt-1.5 mb-4 text-foreground text-sm">
               thirdweb collects a 1% fee per end user transaction through{" "}
-              <strong>Buy With Crypto</strong>. We share 30% of this fee with
+              <strong>Buy With Crypto</strong>. We share 70% of this fee with
               you.{" "}
               <Link
                 href="https://portal.thirdweb.com/connect/pay/fee-sharing"


### PR DESCRIPTION
fixes DASH-476

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the fee-sharing information in the `PayConfig.tsx` component, increasing the percentage shared with users from 30% to 70%.

### Detailed summary
- Changed the text from "We share 30% of this fee with you." to "We share 70% of this fee with you." in the paragraph.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->