### PR TITLE
Update stripe redirect links to handle subdomains

### DIFF
--- a/apps/dashboard/src/@/actions/billing.ts
+++ b/apps/dashboard/src/@/actions/billing.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import "server-only";
-import { API_SERVER_URL, getAbsoluteUrlFromPath } from "@/constants/env";
+import { API_SERVER_URL } from "@/constants/env";
 import { redirect } from "next/navigation";
 import { getAuthToken } from "../../app/api/lib/getAuthToken";
 import type { ProductSKU } from "../lib/billing";
@@ -9,7 +9,7 @@ import type { ProductSKU } from "../lib/billing";
 export type RedirectCheckoutOptions = {
   teamSlug: string;
   sku: ProductSKU;
-  redirectPath?: string;
+  redirectUrl: string;
   metadata?: Record<string, string>;
 };
 export async function redirectToCheckout(
@@ -34,10 +34,7 @@ export async function redirectToCheckout(
       method: "POST",
       body: JSON.stringify({
         sku: options.sku,
-        redirectTo: getAbsoluteUrlFromPath(
-          options.redirectPath ||
-            `/team/${options.teamSlug}/~/settings/billing`,
-        ).toString(),
+        redirectTo: options.redirectUrl,
         metadata: options.metadata || {},
       }),
       headers: {
@@ -64,7 +61,7 @@ export async function redirectToCheckout(
 
 export type BillingPortalOptions = {
   teamSlug: string | undefined;
-  redirectPath?: string;
+  redirectUrl: string;
 };
 export async function redirectToBillingPortal(
   options: BillingPortalOptions,
@@ -86,10 +83,7 @@ export async function redirectToBillingPortal(
     {
       method: "POST",
       body: JSON.stringify({
-        redirectTo: getAbsoluteUrlFromPath(
-          options.redirectPath ||
-            `/team/${options.teamSlug}/~/settings/billing`,
-        ).toString(),
+        redirectTo: options.redirectUrl,
       }),
       headers: {
         "Content-Type": "application/json",

--- a/apps/dashboard/src/@/components/billing.tsx
+++ b/apps/dashboard/src/@/components/billing.tsx
@@ -8,7 +8,11 @@ import {
 } from "../actions/billing";
 import { Button, type ButtonProps } from "./ui/button";
 
-type CheckoutButtonProps = RedirectCheckoutOptions & ButtonProps;
+type CheckoutButtonProps = Omit<RedirectCheckoutOptions, "redirectUrl"> &
+  ButtonProps & {
+    redirectPath: string;
+  };
+
 export function CheckoutButton({
   onClick,
   teamSlug,
@@ -27,7 +31,7 @@ export function CheckoutButton({
           teamSlug,
           sku,
           metadata,
-          redirectPath,
+          redirectUrl: getRedirectUrl(redirectPath),
         });
       }}
     >
@@ -36,7 +40,10 @@ export function CheckoutButton({
   );
 }
 
-type BillingPortalButtonProps = BillingPortalOptions & ButtonProps;
+type BillingPortalButtonProps = Omit<BillingPortalOptions, "redirectUrl"> &
+  ButtonProps & {
+    redirectPath: string;
+  };
 export function BillingPortalButton({
   onClick,
   teamSlug,
@@ -51,11 +58,17 @@ export function BillingPortalButton({
         onClick?.(e);
         await redirectToBillingPortal({
           teamSlug,
-          redirectPath,
+          redirectUrl: getRedirectUrl(redirectPath),
         });
       }}
     >
       {children}
     </Button>
   );
+}
+
+function getRedirectUrl(path: string) {
+  const url = new URL(window.location.origin);
+  url.pathname = path;
+  return url.toString();
 }

--- a/apps/dashboard/src/@/constants/env.ts
+++ b/apps/dashboard/src/@/constants/env.ts
@@ -39,10 +39,3 @@ export const BASE_URL = isProd
   : (process.env.NEXT_PUBLIC_VERCEL_BRANCH_URL
       ? `https://${process.env.NEXT_PUBLIC_VERCEL_BRANCH_URL}`
       : "http://localhost:3000") || "https://thirdweb-dev.com";
-
-export function getAbsoluteUrlFromPath(path: string) {
-  const url = new URL(BASE_URL);
-
-  url.pathname = path;
-  return url;
-}

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/settings/billing/components/PlanInfoCard.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/settings/billing/components/PlanInfoCard.tsx
@@ -49,7 +49,11 @@ export function PlanInfoCard(props: {
 
         <div className="flex flex-row gap-2">
           {/* manage team billing */}
-          <BillingPortalButton teamSlug={team.slug} variant="outline">
+          <BillingPortalButton
+            teamSlug={team.slug}
+            variant="outline"
+            redirectPath={`/team/${team.slug}/~/settings/billing`}
+          >
             Manage Billing
           </BillingPortalButton>
 


### PR DESCRIPTION
Fixes: DASH-479

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the billing-related components and functions to streamline the handling of redirect URLs. It introduces a consistent approach for managing redirect paths and enhances the `BillingPortalButton` and `CheckoutButton` components.

### Detailed summary
- Removed the `getAbsoluteUrlFromPath` function from `env.ts`.
- Modified `BillingPortalButton` to accept `redirectPath` and use `getRedirectUrl`.
- Updated `CheckoutButton` to accept `redirectPath` and use `getRedirectUrl`.
- Introduced `getRedirectUrl` function to construct URLs.
- Changed `RedirectCheckoutOptions` and `BillingPortalOptions` to use `redirectUrl` instead of `redirectPath`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->