### PR TITLE
[SDK] Chore: Sets coverage thresholds

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -87,7 +87,7 @@ jobs:
 
       - run: pnpm test
 
-      - name: Upload coverage reports to Codecov
+      - name: Code Coverage
         uses: codecov/codecov-action@v5
         with:
           directory: packages/

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,7 +5,7 @@ coverage:
         target: auto
     patch:
       packages:
-        target: auto
+        target: 80%
         flags:
           - packages
       


### PR DESCRIPTION
CNCT-2485

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving code coverage requirements and updating the CI workflow for better clarity and functionality.

### Detailed summary
- Updated `codecov.yml` to set the coverage `target` to `80%`.
- Renamed the CI workflow step from `Upload coverage reports to Codecov` to `Code Coverage`.
- Adjusted the `uses` directive for the Codecov action to `codecov/codecov-action@v5`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->