### PR TITLE
fix: Handle zero maxPriorityFeePerGas in 712 transactions

### DIFF
--- a/.changeset/wild-games-vanish.md
+++ b/.changeset/wild-games-vanish.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Handle 0 value for maxPriorityFeePerGas in 712 transactions

--- a/packages/thirdweb/src/transaction/actions/zksync/send-eip712-transaction.ts
+++ b/packages/thirdweb/src/transaction/actions/zksync/send-eip712-transaction.ts
@@ -173,7 +173,11 @@ export async function getZkGasFees(args: {
     resolvePromisedValue(transaction.eip712),
   ]);
   let gasPerPubdata = eip712?.gasPerPubdata;
-  if (!gas || !maxFeePerGas || !maxPriorityFeePerGas) {
+  if (
+    gas === undefined ||
+    maxFeePerGas === undefined ||
+    maxPriorityFeePerGas === undefined
+  ) {
     const rpc = getRpcClient(transaction);
     const params = await formatTransaction({ transaction, from });
     const result = (await rpc({


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added



<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on handling scenarios where `maxPriorityFeePerGas` can be zero in EIP-712 transactions within the `thirdweb` package.

### Detailed summary
- Updated the condition to check for `undefined` values for `gas`, `maxFeePerGas`, and `maxPriorityFeePerGas` in `send-eip712-transaction.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->