### PR TITLE
updated to use contractInfo name

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/modules/components/BatchMetadata.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/modules/components/BatchMetadata.tsx
@@ -66,8 +66,6 @@ export type UploadMetadataFormValues = z.infer<typeof uploadMetadataFormSchema>;
 function BatchMetadataModule(props: ModuleInstanceProps) {
   const { contract, ownerAccount } = props;
 
-  const isErc721 = props.contractInfo.name === "BatchMetadataERC721";
-
   const uploadMetadata = useCallback(
     async (values: UploadMetadataFormValues) => {
       if (!ownerAccount) {
@@ -75,9 +73,10 @@ function BatchMetadataModule(props: ModuleInstanceProps) {
       }
 
       const nft = parseAttributes(values);
-      const uploadMetadata = isErc721
-        ? BatchMetadataERC721.uploadMetadata
-        : BatchMetadataERC1155.uploadMetadata;
+      const uploadMetadata =
+        props.contractInfo.name === "BatchMetadataERC721"
+          ? BatchMetadataERC721.uploadMetadata
+          : BatchMetadataERC1155.uploadMetadata;
       const uploadMetadataTx = uploadMetadata({
         contract,
         metadatas: [nft],
@@ -88,7 +87,7 @@ function BatchMetadataModule(props: ModuleInstanceProps) {
         transaction: uploadMetadataTx,
       });
     },
-    [contract, ownerAccount, isErc721],
+    [contract, ownerAccount, props.contractInfo.name],
   );
 
   return (

--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/modules/components/claimable.stories.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/modules/components/claimable.stories.tsx
@@ -1,5 +1,12 @@
 import { ChakraProviderSetup } from "@/components/ChakraProviderSetup";
 import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import type { Meta, StoryObj } from "@storybook/react";
 import { useMutation } from "@tanstack/react-query";
 import { subDays } from "date-fns";
@@ -60,8 +67,7 @@ const claimCondition = {
 
 function Component() {
   const [isOwner, setIsOwner] = useState(true);
-  const [isErc721, setIsErc721] = useState(false);
-  const [isErc20, setIsErc20] = useState(false);
+  const [name, setName] = useState("ClaimableERC721");
   const [isClaimConditionLoading, setIsClaimConditionLoading] = useState(false);
   const [isPrimarySaleRecipientLoading, setIsPrimarySaleRecipientLoading] =
     useState(false);
@@ -119,19 +125,16 @@ function Component() {
               label="Is Owner"
             />
 
-            <CheckboxWithLabel
-              value={isErc721}
-              onChange={setIsErc721}
-              id="isErc721"
-              label="isErc721"
-            />
-
-            <CheckboxWithLabel
-              value={isErc20}
-              onChange={setIsErc20}
-              id="isErc20"
-              label="isErc20"
-            />
+            <Select value={name} onValueChange={(v) => setName(v)}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="MintableERC721">MintableERC721</SelectItem>
+                <SelectItem value="MintableERC1155">MintableERC1155</SelectItem>
+                <SelectItem value="MintableERC20">MintableERC20</SelectItem>
+              </SelectContent>
+            </Select>
 
             <CheckboxWithLabel
               value={isClaimConditionLoading}
@@ -168,10 +171,12 @@ function Component() {
             }}
             claimConditionSection={{
               data:
-                isClaimConditionLoading || (!isErc721 && !tokenId)
+                isClaimConditionLoading ||
+                (name === "MintableERC1155" && !tokenId)
                   ? undefined
                   : {
                       claimCondition,
+                      currencyDecimals: 18,
                       tokenDecimals: 18,
                     },
               isLoading: false,
@@ -186,8 +191,7 @@ function Component() {
               isPending: removeMutation.isPending,
             }}
             isOwnerAccount={isOwner}
-            isErc721={isErc721}
-            isErc20={isErc20}
+            name={name}
             contractChainId={1}
             setTokenId={setTokenId}
             isValidTokenId={true}

--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/modules/components/mintable.stories.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/modules/components/mintable.stories.tsx
@@ -1,5 +1,14 @@
+"use client";
+
 import { ChakraProviderSetup } from "@/components/ChakraProviderSetup";
 import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import type { Meta, StoryObj } from "@storybook/react";
 import { useMutation } from "@tanstack/react-query";
 import { useState } from "react";
@@ -42,7 +51,7 @@ const testAddress1 = "0x1F846F6DAE38E1C88D71EAA191760B15f38B7A37";
 
 function Component() {
   const [isOwner, setIsOwner] = useState(true);
-  const [isErc721, setIsErc721] = useState(false);
+  const [name, setName] = useState("MintableERC721");
   const [isBatchMetadataInstalled, setIsBatchMetadataInstalled] =
     useState(false);
   async function updatePrimaryRecipientStub(values: UpdateFormValues) {
@@ -91,18 +100,22 @@ function Component() {
             />
 
             <CheckboxWithLabel
-              value={isErc721}
-              onChange={setIsErc721}
-              id="isErc721"
-              label="isErc721"
-            />
-
-            <CheckboxWithLabel
               value={isBatchMetadataInstalled}
               onChange={setIsBatchMetadataInstalled}
               id="isBatchMetadataInstalled"
               label="isBatchMetadataInstalled"
             />
+
+            <Select value={name} onValueChange={(v) => setName(v)}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="MintableERC721">MintableERC721</SelectItem>
+                <SelectItem value="MintableERC1155">MintableERC1155</SelectItem>
+                <SelectItem value="MintableERC20">MintableERC20</SelectItem>
+              </SelectContent>
+            </Select>
           </div>
 
           <BadgeContainer label="Empty Primary Sale Recipient">
@@ -118,7 +131,7 @@ function Component() {
                 isPending: removeMutation.isPending,
               }}
               isOwnerAccount={isOwner}
-              isErc721={isErc721}
+              name={name}
               isBatchMetadataInstalled={isBatchMetadataInstalled}
               contractChainId={1}
             />
@@ -137,7 +150,7 @@ function Component() {
                 isPending: removeMutation.isPending,
               }}
               isOwnerAccount={isOwner}
-              isErc721={isErc721}
+              name={name}
               isBatchMetadataInstalled={isBatchMetadataInstalled}
               contractChainId={1}
             />
@@ -156,7 +169,7 @@ function Component() {
                 isPending: removeMutation.isPending,
               }}
               isOwnerAccount={isOwner}
-              isErc721={isErc721}
+              name={name}
               isBatchMetadataInstalled={isBatchMetadataInstalled}
               contractChainId={1}
             />


### PR DESCRIPTION
https://linear.app/thirdweb/issue/DASH-489/modules-ui-bug-with-erc20-modules-showing-tokenid

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the handling of ERC token types across various components to improve clarity and maintainability. It replaces boolean flags for token types with string identifiers, streamlining the logic for determining contract behavior based on the token type.

### Detailed summary
- Replaced boolean flags for token types with string comparisons in various components.
- Updated `uploadMetadata`, `transferable`, and `mintable` logic to use `props.contractInfo.name`.
- Changed UI components to utilize `Select` for token type selection instead of checkboxes.
- Modified contract interaction methods to accommodate new token type handling.
- Enhanced readability and maintainability of the codebase.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->