### PR TITLE
Fix Portal > Contracts overview page links

### DIFF
--- a/apps/dashboard/src/pages/sdk.tsx
+++ b/apps/dashboard/src/pages/sdk.tsx
@@ -61,7 +61,7 @@ const Web3SDK: ThirdwebNextPage = () => {
         title="Powerful SDKs for every stack"
         description="Build web3 applications that can interact with your smart contracts using our powerful SDKs and CLI."
         buttonText="Get started"
-        buttonLink="https://portal.thirdweb.com/contracts/interact/overview"
+        buttonLink="https://portal.thirdweb.com/contracts"
         image={require("../../public/assets/product-pages/sdk/hero.png")}
         gradient="linear-gradient(147.15deg, #410AB6 30.17%, #5BFF40 100.01%)"
       >

--- a/apps/portal/redirects.mjs
+++ b/apps/portal/redirects.mjs
@@ -798,9 +798,9 @@ const contractRedirects = {
   "/publish/getting-started": "/contracts/publish/publish-contract",
   "/publish/deployment-options": "/contracts/publish/publish-options",
   "/publish/get-featured-on-explore": "/contracts/publish/overview",
-  "/sdk": "/contracts/interact/overview",
-  "/sdk/how-it-works": "/contracts/interact/overview",
-  "/sdk/getting-started": "/contracts/interact/overview",
+  "/sdk": "/contracts",
+  "/sdk/how-it-works": "/contracts",
+  "/sdk/getting-started": "/contracts",
   //design documentation
   "/contracts/design/Drop": "/contracts/design-docs/drop",
   "/contracts/design/Marketplace": "/contracts/design-docs/marketplace",
@@ -808,6 +808,7 @@ const contractRedirects = {
   "/contracts/design/Multiwrap": "/contracts/design-docs/multiwrap",
   "/contracts/design/Pack": "/contracts/design-docs/pack",
   "/contracts/design/SignatureDrop": "/contracts",
+  "/interact": "/contracts",
 };
 
 const infrastructureRedirects = {

--- a/apps/portal/src/app/connect/in-app-wallet/guides/interact-blockchain/page.mdx
+++ b/apps/portal/src/app/connect/in-app-wallet/guides/interact-blockchain/page.mdx
@@ -22,7 +22,7 @@ export const metadata = createMetadata({
 
 # Interact with the blockchain
 
-One connected, in-app wallets can be used alongside the [Contract SDK](/contracts/interact/overview) to interact with the blockchain.
+Once connected, in-app wallets can be used alongside the [Contract SDK](/contracts) to interact with the blockchain.
 
 ## Initialize the SDK With Your Wallet
 

--- a/apps/portal/src/app/contracts/explore/pre-built-contracts/nft-drop/page.mdx
+++ b/apps/portal/src/app/contracts/explore/pre-built-contracts/nft-drop/page.mdx
@@ -198,4 +198,4 @@ const sdk = useSDK(
 
 ## Interact with your contract
 
-For easy-to-use code snippets for your contract, view the Code Snippets on your contract's dashboard or visit the [SDK documentation](/contracts/interact/overview).
+For easy-to-use code snippets for your contract, view the Code Snippets on your contract's dashboard or visit the [SDK documentation](/contracts).

--- a/apps/portal/src/app/contracts/page.mdx
+++ b/apps/portal/src/app/contracts/page.mdx
@@ -20,7 +20,7 @@ Trusted, modular smart contracts that can be deployed securely on any EVM chain.
 - [Build:](/contracts/build/overview) Write your own smart contracts
 - [Deploy:](/contracts/deploy/overview) Contract deployment built for any use-case
 - [Publish:](/contracts/publish/overview) Publish your contracts onchain
-- [Interact:](/contracts/interact/overview) Integrate smart contract interactions directly into your app
+- [Interact:](/contracts) Integrate smart contract interactions directly into your app
 
 ### Templates
 

--- a/apps/portal/src/app/glossary/gas/page.mdx
+++ b/apps/portal/src/app/glossary/gas/page.mdx
@@ -7,7 +7,7 @@ Gas fees are typically paid in the currency that is native to the blockchain you
 
 While using thirdweb is free, you will need to cover the cost of performing actions that update the blockchain's state.
 
-This includes actions performed via the thirdweb [dashboard](https://thirdweb.com/team), our [SDKs](/contracts/interact/overview), or any of our other products, including:
+This includes actions performed via the thirdweb [dashboard](https://thirdweb.com/team), our [SDKs](/contracts), or any of our other products, including:
 
 - Deploying smart contracts
 - [Lazy-minting](/glossary/lazy-minting) the metadata of your NFTs

--- a/apps/portal/src/app/glossary/ipfs/page.mdx
+++ b/apps/portal/src/app/glossary/ipfs/page.mdx
@@ -9,6 +9,6 @@ To secure content on IPFS forever, a node must [pin](https://docs.ipfs.tech/conc
 [Learn more about how IPFS works](https://ipfs.tech/#how).
 
 To read data from IPFS, an [IPFS Gateway](https://docs.ipfs.tech/concepts/ipfs-gateway/) is required. This allows you to access data from the IPFS protocol on browsers and other HTTP clients, such
-as when building an application using our [SDK](/contracts/interact/overview).
+as when building an application using our [SDK](/contracts).
 
 Out of the box, all of our tools use [Storage](/storage) to store, pin, and retrieve data from IPFS via a gateway, currently powered by [Pinata](https://pinata.cloud/) under the hood.

--- a/apps/portal/src/app/page.tsx
+++ b/apps/portal/src/app/page.tsx
@@ -318,7 +318,7 @@ function ContractsSection() {
           title="Interact"
           description="Add smart contract interactions in your app"
           icon={ContractInteractIcon}
-          href="/contracts/interact/overview"
+          href="/contracts"
         />
         <ArticleCardIndex
           title="Explore"

--- a/apps/portal/src/app/react/v5/in-app-wallet/how-to/interact-blockchain/page.mdx
+++ b/apps/portal/src/app/react/v5/in-app-wallet/how-to/interact-blockchain/page.mdx
@@ -22,7 +22,7 @@ export const metadata = createMetadata({
 
 # Interact with the blockchain
 
-One connected, in-app wallets can be used alongside the [Contract SDK](/contracts/interact/overview) to interact with the blockchain.
+Once connected, in-app wallets can be used alongside the [Contract SDK](/contracts) to interact with the blockchain.
 
 ## Initialize the SDK With Your Wallet
 


### PR DESCRIPTION
Fixes: DASH-487

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating references related to smart contract interactions throughout the application, specifically changing URLs from `/contracts/interact/overview` to `/contracts` for improved navigation and clarity.

### Detailed summary
- Updated `href` in `apps/portal/src/app/page.tsx` from `/contracts/interact/overview` to `/contracts`.
- Modified references in `apps/portal/src/app/connect/in-app-wallet/guides/interact-blockchain/page.mdx` to use `/contracts`.
- Changed links in `apps/portal/src/app/contracts/page.mdx` to point to `/contracts`.
- Adjusted `apps/portal/src/app/react/v5/in-app-wallet/how-to/interact-blockchain/page.mdx` links to `/contracts`.
- Updated documentation in `apps/portal/src/app/contracts/explore/pre-built-contracts/nft-drop/page.mdx` to refer to `/contracts`.
- Changed `buttonLink` in `apps/dashboard/src/pages/sdk.tsx` from `https://portal.thirdweb.com/contracts/interact/overview` to `https://portal.thirdweb.com/contracts`.
- Updated IPFS documentation in `apps/portal/src/app/glossary/ipfs/page.mdx` to link to `/contracts`.
- Changed references in `apps/portal/src/app/glossary/gas/page.mdx` from `/contracts/interact/overview` to `/contracts`.
- Updated redirects in `apps/portal/redirects.mjs` to point `/sdk`, `/sdk/how-it-works`, and `/sdk/getting-started` to `/contracts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->