### PR TITLE
chore: Add promptTokens and completionTokens fields

### DIFF
--- a/.changeset/tall-donuts-divide.md
+++ b/.changeset/tall-donuts-divide.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+feat: add promptTokens and completionTokens fields to usage

--- a/packages/service-utils/src/core/usage.ts
+++ b/packages/service-utils/src/core/usage.ts
@@ -76,5 +76,7 @@ export const usageEventSchema = z.object({
   onRampId: z.string().optional(),
   evmRequestParams: z.string().optional(),
   providerIp: z.string().optional(),
+  promptTokens: z.number().int().nonnegative().optional(),
+  completionTokens: z.number().int().nonnegative().optional(),
 });
 export type UsageEvent = z.infer<typeof usageEventSchema>;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces new fields to track token usage in the `usageEventSchema` of the `@thirdweb-dev/service-utils` package.

### Detailed summary
- Added `promptTokens` field as an optional integer, non-negative number.
- Added `completionTokens` field as an optional integer, non-negative number.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->