### PR TITLE
[Dashboard] Refactor: Remove chakra components (2)

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/nfts/components/nft-property.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/nfts/components/nft-property.tsx
@@ -1,4 +1,4 @@
-import { Card, Text } from "tw-components";
+import { Card } from "@/components/ui/card";
 
 interface NftPropertyProps {
   // biome-ignore lint/suspicious/noExplicitAny: FIXME
@@ -7,22 +7,17 @@ interface NftPropertyProps {
 
 export const NftProperty: React.FC<NftPropertyProps> = ({ property }) => {
   return (
-    <Card className="flex flex-col gap-2">
+    <Card className="flex flex-col gap-2 p-3">
       {property?.trait_type && (
-        <Text
-          size="label.sm"
-          color="primary.500"
-          textAlign="center"
-          lineHeight={1.2}
-        >
+        <p className="text-center text-link-foreground text-sm leading-[1.2]">
           {property?.trait_type}
-        </Text>
+        </p>
       )}
-      <Text size="label.md" textAlign="center">
+      <p className="text-center text-muted-foreground text-sm">
         {typeof property?.value === "object"
           ? JSON.stringify(property?.value || {})
           : property?.value}
-      </Text>
+      </p>
     </Card>
   );
 };

--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/nfts/components/supply-cards.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/nfts/components/supply-cards.tsx
@@ -1,6 +1,4 @@
 "use client";
-
-import { Skeleton, Stat, StatLabel, StatNumber } from "@chakra-ui/react";
 import { useMemo } from "react";
 import type { ThirdwebContract } from "thirdweb";
 import {
@@ -9,7 +7,7 @@ import {
   totalSupply,
 } from "thirdweb/extensions/erc721";
 import { useReadContract } from "thirdweb/react";
-import { Card } from "tw-components";
+import { StatCard } from "../../overview/components/stat-card";
 
 interface SupplyCardsProps {
   contract: ThirdwebContract;
@@ -37,27 +35,22 @@ export const SupplyCards: React.FC<SupplyCardsProps> = ({ contract }) => {
   );
 
   return (
-    <div className="flex flex-col gap-3 md:flex-row md:gap-6">
-      <Card as={Stat}>
-        <StatLabel mb={{ base: 1, md: 0 }}>Total Supply</StatLabel>
-        <Skeleton isLoaded={nextTokenIdQuery.isSuccess}>
-          <StatNumber>{realTotalSupply.toString()}</StatNumber>
-        </Skeleton>
-      </Card>
-      <Card as={Stat}>
-        <StatLabel mb={{ base: 1, md: 0 }}>Claimed Supply</StatLabel>
-        <Skeleton isLoaded={totalSupplyQuery.isSuccess}>
-          <StatNumber>{totalSupplyQuery?.data?.toString()}</StatNumber>
-        </Skeleton>
-      </Card>
-      <Card as={Stat}>
-        <StatLabel mb={{ base: 1, md: 0 }}>Unclaimed Supply</StatLabel>
-        <Skeleton
-          isLoaded={totalSupplyQuery.isSuccess && nextTokenIdQuery.isSuccess}
-        >
-          <StatNumber>{unclaimedSupply}</StatNumber>
-        </Skeleton>
-      </Card>
+    <div className="flex flex-row gap-3 md:gap-6 [&>*]:grow">
+      <StatCard
+        value={realTotalSupply.toString()}
+        label="Total Supply"
+        isPending={nextTokenIdQuery.isPending}
+      />
+      <StatCard
+        value={totalSupplyQuery?.data?.toString() || "N/A"}
+        label="Claimed Supply"
+        isPending={totalSupplyQuery.isPending}
+      />
+      <StatCard
+        value={unclaimedSupply}
+        label="Unclaimed Supply"
+        isPending={totalSupplyQuery.isPending || nextTokenIdQuery.isPending}
+      />
     </div>
   );
 };

--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/nfts/components/table.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/nfts/components/table.tsx
@@ -41,7 +41,6 @@ import type { NFT, ThirdwebContract } from "thirdweb";
 import * as ERC721Ext from "thirdweb/extensions/erc721";
 import * as ERC1155Ext from "thirdweb/extensions/erc1155";
 import { useReadContract } from "thirdweb/react";
-import { Heading, Text } from "tw-components";
 
 interface ContractOverviewNFTGetAllProps {
   contract: ThirdwebContract;
@@ -61,11 +60,7 @@ export const NFTGetAllTable: React.FC<ContractOverviewNFTGetAllProps> = ({
       {
         Header: "Token Id",
         accessor: (row) => row.id?.toString(),
-        Cell: (cell: CellProps<NFT, string>) => (
-          <Text size="body.md" fontFamily="mono">
-            {cell.value}
-          </Text>
-        ),
+        Cell: (cell: CellProps<NFT, string>) => <p>{cell.value}</p>,
       },
       {
         Header: "Media",
@@ -140,9 +135,9 @@ export const NFTGetAllTable: React.FC<ContractOverviewNFTGetAllProps> = ({
         Cell: (cell: CellProps<NFT, number>) => {
           if (cell.row.original.type === "ERC1155") {
             return (
-              <Text noOfLines={4} size="body.md" fontFamily="mono">
+              <p className="line-clamp-4 font-mono text-base">
                 {cell.row.original.supply.toString()}
-              </Text>
+              </p>
             );
           }
         },
@@ -267,9 +262,9 @@ export const NFTGetAllTable: React.FC<ContractOverviewNFTGetAllProps> = ({
                     // biome-ignore lint/suspicious/noArrayIndexKey: FIXME
                     key={columnIndex}
                   >
-                    <Text as="label" size="label.sm" color="faded">
+                    <p className="text-muted-foreground">
                       {column.render("Header")}
-                    </Text>
+                    </p>
                   </Th>
                 ))}
                 {/* Need to add an empty header for the drawer button */}
@@ -352,7 +347,7 @@ export const NFTGetAllTable: React.FC<ContractOverviewNFTGetAllProps> = ({
               >
                 <Flex align="center" gap={4}>
                   <Spinner size="sm" />
-                  <Heading size="label.lg">Fetching new page</Heading>
+                  <p className="text-lg">Fetching new page</p>
                 </Flex>
               </Flex>
             )}
@@ -373,12 +368,12 @@ export const NFTGetAllTable: React.FC<ContractOverviewNFTGetAllProps> = ({
             icon={<ChevronLeftIcon className="size-4" />}
             onClick={() => previousPage()}
           />
-          <Text whiteSpace="nowrap">
+          <p className="whitespace-nowrap">
             Page <strong>{pageIndex + 1}</strong> of{" "}
             <Skeleton as="span" display="inline" isLoaded={querySuccess}>
               <strong>{pageCount}</strong>
             </Skeleton>
-          </Text>
+          </p>
           <IconButton
             isDisabled={!canNextPage || queryLoading}
             aria-label="next page"

--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/overview/components/listing-stats.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/overview/components/listing-stats.tsx
@@ -1,8 +1,8 @@
-import { SkeletonContainer } from "@/components/ui/skeleton";
 import { useMemo } from "react";
 import type { ThirdwebContract } from "thirdweb";
 import { totalAuctions, totalListings } from "thirdweb/extensions/marketplace";
 import { useReadContract } from "thirdweb/react";
+import { StatCard } from "./stat-card";
 
 const TotalListingsStat: React.FC<{ contract: ThirdwebContract }> = ({
   contract,
@@ -82,20 +82,3 @@ export const ListingStatsV3: React.FC<ListingStatsV3Props> = ({
     </div>
   );
 };
-
-function StatCard(props: {
-  value: string;
-  isPending: boolean;
-  label: string;
-}) {
-  return (
-    <dl className="block rounded-lg border border-border bg-muted/50 p-4">
-      <dt className="mb-1.5 text-sm md:text-base">{props.label}</dt>
-      <SkeletonContainer
-        loadedData={props.isPending ? undefined : props.value}
-        skeletonData={"0000"}
-        render={(v) => <dd className="truncate font-semibold text-xl">{v}</dd>}
-      />
-    </dl>
-  );
-}

--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/overview/components/stat-card.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/overview/components/stat-card.tsx
@@ -1,0 +1,18 @@
+import { SkeletonContainer } from "@/components/ui/skeleton";
+
+export function StatCard(props: {
+  value: string;
+  isPending: boolean;
+  label: string;
+}) {
+  return (
+    <dl className="block rounded-lg border border-border bg-muted/50 p-4">
+      <dt className="mb-1.5 text-sm md:text-base">{props.label}</dt>
+      <SkeletonContainer
+        loadedData={props.isPending ? undefined : props.value}
+        skeletonData={"0000"}
+        render={(v) => <dd className="truncate font-semibold text-xl">{v}</dd>}
+      />
+    </dl>
+  );
+}

--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/permissions/components/contract-permission.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/permissions/components/contract-permission.tsx
@@ -1,9 +1,9 @@
+import { Card } from "@/components/ui/card";
 import { useIsAdmin } from "@3rdweb-sdk/react/hooks/useContractRoles";
 import { Flex, Select, Spinner } from "@chakra-ui/react";
 import { InfoIcon } from "lucide-react";
 import { useFormContext } from "react-hook-form";
 import { type ThirdwebContract, ZERO_ADDRESS } from "thirdweb";
-import { Card, Heading, Text } from "tw-components";
 import { PermissionEditor } from "./permissions-editor";
 
 interface ContractPermissionProps {
@@ -17,7 +17,6 @@ export const ContractPermission: React.FC<ContractPermissionProps> = ({
   role,
   description,
   isPending,
-
   contract,
 }) => {
   const {
@@ -33,15 +32,15 @@ export const ContractPermission: React.FC<ContractPermissionProps> = ({
   const isAdmin = useIsAdmin(contract);
 
   return (
-    <Card position="relative">
+    <Card className="relative p-4">
       <Flex direction="column" gap={3}>
         <div className="mb-3 flex flex-col gap-2">
           <div className="flex flex-row">
             <div className="flex grow flex-col gap-1">
-              <Heading size="subtitle.sm" textTransform="capitalize">
+              <p className="font-semibold text-base capitalize">
                 {role === "minter" ? "Minter / Creator" : role}
-              </Heading>
-              <Text>{description}</Text>
+              </p>
+              <p className="text-muted-foreground">{description}</p>
             </div>
 
             {role === "transfer" && (
@@ -49,7 +48,7 @@ export const ContractPermission: React.FC<ContractPermissionProps> = ({
                 {isPending || isSubmitting ? (
                   <Flex align="center" gap={2} px={2}>
                     <Spinner size="sm" />
-                    <Text>{isPending ? "Loading ..." : "Updating ..."}</Text>
+                    <p>{isPending ? "Loading ..." : "Updating ..."}</p>
                   </Flex>
                 ) : (
                   <Select
@@ -84,7 +83,7 @@ export const ContractPermission: React.FC<ContractPermissionProps> = ({
                 {isPending || isSubmitting ? (
                   <Flex align="center" gap={2} px={2}>
                     <Spinner size="sm" />
-                    <Text>{isPending ? "Loading ..." : "Updating ..."}</Text>
+                    <p>{isPending ? "Loading ..." : "Updating ..."}</p>
                   </Flex>
                 ) : (
                   <Select
@@ -119,7 +118,7 @@ export const ContractPermission: React.FC<ContractPermissionProps> = ({
                 {isPending || isSubmitting ? (
                   <Flex align="center" gap={2} px={2}>
                     <Spinner size="sm" />
-                    <Text>{isPending ? "Loading ..." : "Updating ..."}</Text>
+                    <p>{isPending ? "Loading ..." : "Updating ..."}</p>
                   </Flex>
                 ) : (
                   <Select
@@ -165,8 +164,8 @@ export const ContractPermission: React.FC<ContractPermissionProps> = ({
               padding="10px"
               gap={3}
             >
-              <InfoIcon className="size-6 text-primary-foreground hover:opacity-10" />
-              <Text color="primary.800" _dark={{ color: "primary.100" }}>
+              <InfoIcon className="size-6 text-primary hover:opacity-10 dark:text-primary-foreground" />
+              <p className="text-primary dark:text-primary-foreground">
                 {isRestricted ? (
                   <>
                     The tokens in this contract are currently{" "}
@@ -181,7 +180,7 @@ export const ContractPermission: React.FC<ContractPermissionProps> = ({
                     transfer their tokens.
                   </>
                 )}
-              </Text>
+              </p>
             </Flex>
           )}
 
@@ -200,8 +199,8 @@ export const ContractPermission: React.FC<ContractPermissionProps> = ({
               padding="10px"
               gap={3}
             >
-              <InfoIcon className="size-6 text-primary-foreground hover:opacity-10" />
-              <Text color="primary.800" _dark={{ color: "primary.100" }}>
+              <InfoIcon className="size-6 text-primary hover:opacity-10 dark:text-primary-foreground" />
+              <p className="text-primary dark:text-primary-foreground">
                 {isRestricted ? (
                   <>
                     Currently, only addresses specified below will be able to
@@ -210,7 +209,7 @@ export const ContractPermission: React.FC<ContractPermissionProps> = ({
                 ) : (
                   <>This marketplace is open for anyone to create listings.</>
                 )}
-              </Text>
+              </p>
             </Flex>
           )}
 
@@ -229,8 +228,8 @@ export const ContractPermission: React.FC<ContractPermissionProps> = ({
               padding="10px"
               gap={3}
             >
-              <InfoIcon className="size-6 text-primary-foreground hover:opacity-10" />
-              <Text color="primary.800" _dark={{ color: "primary.100" }}>
+              <InfoIcon className="size-6 text-primary hover:opacity-10 dark:text-primary-foreground" />
+              <p className="text-primary dark:text-primary-foreground">
                 {isRestricted ? (
                   <>
                     Currently, only assets from the contracts specified below
@@ -242,7 +241,7 @@ export const ContractPermission: React.FC<ContractPermissionProps> = ({
                     contract.
                   </>
                 )}
-              </Text>
+              </p>
             </Flex>
           )}
 


### PR DESCRIPTION
188 imports

part of DASH-388

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `StatCard` component for displaying statistics with a skeleton loader and updates various components to use this new card for better UI consistency. Additionally, it refines the presentation of text elements across components.

### Detailed summary
- Added a new `StatCard` component in `stat-card.tsx`.
- Updated `SupplyCards` to utilize `StatCard` for total, claimed, and unclaimed supply stats.
- Refined text presentation in `nft-property.tsx` and `contract-permission.tsx` by replacing `Text` components with `<p>` tags for consistency.
- Removed the old `StatCard` implementation from `listing-stats.tsx`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->