### PR TITLE
update typedoc

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -49,7 +49,7 @@
     "tailwindcss-animate": "^1.0.7",
     "thirdweb": "workspace:*",
     "tiny-invariant": "^1.3.3",
-    "typedoc-better-json": "^0.9.2"
+    "typedoc-better-json": "0.9.4"
   },
   "devDependencies": {
     "@types/flexsearch": "^0.7.6",

--- a/packages/thirdweb/package.json
+++ b/packages/thirdweb/package.json
@@ -127,60 +127,24 @@
   },
   "typesVersions": {
     "*": {
-      "adapters/*": [
-        "./dist/types/exports/adapters/*.d.ts"
-      ],
-      "auth": [
-        "./dist/types/exports/auth.d.ts"
-      ],
-      "chains": [
-        "./dist/types/exports/chains.d.ts"
-      ],
-      "contract": [
-        "./dist/types/exports/contract.d.ts"
-      ],
-      "deploys": [
-        "./dist/types/exports/deploys.d.ts"
-      ],
-      "event": [
-        "./dist/types/exports/event.d.ts"
-      ],
-      "extensions/*": [
-        "./dist/types/exports/extensions/*.d.ts"
-      ],
-      "pay": [
-        "./dist/types/exports/pay.d.ts"
-      ],
-      "react": [
-        "./dist/types/exports/react.d.ts"
-      ],
-      "react-native": [
-        "./dist/types/exports/react-native.d.ts"
-      ],
-      "rpc": [
-        "./dist/types/exports/rpc.d.ts"
-      ],
-      "storage": [
-        "./dist/types/exports/storage.d.ts"
-      ],
-      "transaction": [
-        "./dist/types/exports/transaction.d.ts"
-      ],
-      "utils": [
-        "./dist/types/exports/utils.d.ts"
-      ],
-      "wallets": [
-        "./dist/types/exports/wallets.d.ts"
-      ],
-      "wallets/*": [
-        "./dist/types/exports/wallets/*.d.ts"
-      ],
-      "modules": [
-        "./dist/types/exports/modules.d.ts"
-      ],
-      "social": [
-        "./dist/types/exports/social.d.ts"
-      ]
+      "adapters/*": ["./dist/types/exports/adapters/*.d.ts"],
+      "auth": ["./dist/types/exports/auth.d.ts"],
+      "chains": ["./dist/types/exports/chains.d.ts"],
+      "contract": ["./dist/types/exports/contract.d.ts"],
+      "deploys": ["./dist/types/exports/deploys.d.ts"],
+      "event": ["./dist/types/exports/event.d.ts"],
+      "extensions/*": ["./dist/types/exports/extensions/*.d.ts"],
+      "pay": ["./dist/types/exports/pay.d.ts"],
+      "react": ["./dist/types/exports/react.d.ts"],
+      "react-native": ["./dist/types/exports/react-native.d.ts"],
+      "rpc": ["./dist/types/exports/rpc.d.ts"],
+      "storage": ["./dist/types/exports/storage.d.ts"],
+      "transaction": ["./dist/types/exports/transaction.d.ts"],
+      "utils": ["./dist/types/exports/utils.d.ts"],
+      "wallets": ["./dist/types/exports/wallets.d.ts"],
+      "wallets/*": ["./dist/types/exports/wallets/*.d.ts"],
+      "modules": ["./dist/types/exports/modules.d.ts"],
+      "social": ["./dist/types/exports/social.d.ts"]
     }
   },
   "browser": {
@@ -366,7 +330,7 @@
     "sharp": "^0.33.5",
     "size-limit": "11.1.6",
     "storybook": "8.4.6",
-    "typedoc": "0.26.11",
+    "typedoc": "0.27.2",
     "typescript": "5.7.2",
     "vite": "6.0.2",
     "vitest": "2.1.8"

--- a/packages/thirdweb/scripts/typedoc.mjs
+++ b/packages/thirdweb/scripts/typedoc.mjs
@@ -1,14 +1,10 @@
 // @ts-check
-import TypeDoc from "typedoc";
+import { Application } from "typedoc";
 
 const jsonOut = "typedoc/documentation.json";
 
-const app = await TypeDoc.Application.bootstrapWithPlugins({
-  entryPoints: [
-    "src/exports/**/*.ts",
-    "src/extensions/modules/**/index.ts",
-    "src/react/web/ui/prebuilt/NFT/index.ts",
-  ],
+const app = await Application.bootstrapWithPlugins({
+  entryPoints: ["src/exports/**/*.ts", "src/extensions/modules/**/index.ts"],
   exclude: [
     "src/exports/*.native.ts",
     "src/exports/**/*.native.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -641,8 +641,8 @@ importers:
         specifier: ^1.3.3
         version: 1.3.3
       typedoc-better-json:
-        specifier: ^0.9.2
-        version: 0.9.2(typescript@5.7.2)
+        specifier: 0.9.4
+        version: 0.9.4(typescript@5.7.2)
     devDependencies:
       '@types/flexsearch':
         specifier: ^0.7.6
@@ -1114,8 +1114,8 @@ importers:
         specifier: 8.4.6
         version: 8.4.6(bufferutil@4.0.8)(prettier@3.3.3)(utf-8-validate@5.0.10)
       typedoc:
-        specifier: 0.26.11
-        version: 0.26.11(typescript@5.7.2)
+        specifier: 0.27.2
+        version: 0.27.2(typescript@5.7.2)
       typescript:
         specifier: 5.7.2
         version: 5.7.2
@@ -3060,6 +3060,9 @@ packages:
   '@floating-ui/utils@0.2.8':
     resolution: {integrity: sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==}
 
+  '@gerrit0/mini-shiki@1.24.1':
+    resolution: {integrity: sha512-PNP/Gjv3VqU7z7DjRgO3F9Ok5frTKqtpV+LJW1RzMcr2zpRk0ulhEWnbcNGXzPC7BZyWMIHrkfQX2GZRfxrn6Q==}
+
   '@google/model-viewer@2.1.1':
     resolution: {integrity: sha512-5umyLoD5vMxlSVQwtmUXeNCNWs9dzmWykGm1qrHe/pCYrj/1lyJIgJRw+IxoMNodGqtcHEtfDhdNjRDM9yo/TA==}
     engines: {node: '>=6.0.0'}
@@ -4829,8 +4832,14 @@ packages:
   '@shikijs/engine-oniguruma@1.22.2':
     resolution: {integrity: sha512-GIZPAGzQOy56mGvWMoZRPggn0dTlBf1gutV5TdceLCZlFNqWmuc7u+CzD0Gd9vQUTgLbrt0KLzz6FNprqYAxlA==}
 
+  '@shikijs/engine-oniguruma@1.24.0':
+    resolution: {integrity: sha512-Eua0qNOL73Y82lGA4GF5P+G2+VXX9XnuUxkiUuwcxQPH4wom+tE39kZpBFXfUuwNYxHSkrSxpB1p4kyRW0moSg==}
+
   '@shikijs/types@1.22.2':
     resolution: {integrity: sha512-NCWDa6LGZqTuzjsGfXOBWfjS/fDIbDdmVDug+7ykVe1IKT4c1gakrvlfFYp5NhAXH/lyqLM8wsAPo5wNy73Feg==}
+
+  '@shikijs/types@1.24.0':
+    resolution: {integrity: sha512-aptbEuq1Pk88DMlCe+FzXNnBZ17LCiLIGWAeCWhoFDzia5Q5Krx3DgnULLiouSdd6+LUM39XwXGppqYE0Ghtug==}
 
   '@shikijs/vscode-textmate@9.3.0':
     resolution: {integrity: sha512-jn7/7ky30idSkd/O5yDBfAnVt+JJpepofP/POZ1iMOxK59cOfqIgg/Dj0eFsjOTMw+4ycJN0uhZH/Eb0bs/EUA==}
@@ -13215,8 +13224,8 @@ packages:
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
-  typedoc-better-json@0.9.2:
-    resolution: {integrity: sha512-p2D1/0KixD/mVdsB0hQHwd2il2ksjfRN42RloOkEp4vmok5F2dvoqIJwgU8+HgdTS3aOW0OeR7L8jp1ALW6Nzg==}
+  typedoc-better-json@0.9.4:
+    resolution: {integrity: sha512-Yi7I988jPTbd3o6CS+zpo7Wn8hIPshymnDyGUG02JpKBYRZ6QCLOPI747NkZCoTmAkH0aHAkpc07SFHxfO4K9g==}
 
   typedoc@0.25.13:
     resolution: {integrity: sha512-pQqiwiJ+Z4pigfOnnysObszLiU3mVLWAExSPf+Mu06G/qsc3wzbuM56SZQvONhHLncLUhYzOVkjFFpFfL5AzhQ==}
@@ -13225,12 +13234,12 @@ packages:
     peerDependencies:
       typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x
 
-  typedoc@0.26.11:
-    resolution: {integrity: sha512-sFEgRRtrcDl2FxVP58Ze++ZK2UQAEvtvvH8rRlig1Ja3o7dDaMHmaBfvJmdGnNEFaLTpQsN8dpvZaTqJSu/Ugw==}
+  typedoc@0.27.2:
+    resolution: {integrity: sha512-C2ima5TZJHU3ecnRIz50lKd1BsYck5LhYQIy7MRPmjuSEJreUEAt+uAVcZgY7wZsSORzEI7xW8miZIdxv/cbmw==}
     engines: {node: '>= 18'}
     hasBin: true
     peerDependencies:
-      typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x
+      typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x
 
   types-ramda@0.30.1:
     resolution: {integrity: sha512-1HTsf5/QVRmLzcGfldPFvkVsAdi1db1BBKzi7iW3KBUlOICg/nKnFS+jGqDJS3YD8VsWbAh7JiHeBvbsw8RPxA==}
@@ -16925,6 +16934,12 @@ snapshots:
 
   '@floating-ui/utils@0.2.8': {}
 
+  '@gerrit0/mini-shiki@1.24.1':
+    dependencies:
+      '@shikijs/engine-oniguruma': 1.24.0
+      '@shikijs/types': 1.24.0
+      '@shikijs/vscode-textmate': 9.3.0
+
   '@google/model-viewer@2.1.1':
     dependencies:
       lit: 2.8.0
@@ -19140,7 +19155,17 @@ snapshots:
       '@shikijs/types': 1.22.2
       '@shikijs/vscode-textmate': 9.3.0
 
+  '@shikijs/engine-oniguruma@1.24.0':
+    dependencies:
+      '@shikijs/types': 1.24.0
+      '@shikijs/vscode-textmate': 9.3.0
+
   '@shikijs/types@1.22.2':
+    dependencies:
+      '@shikijs/vscode-textmate': 9.3.0
+      '@types/hast': 3.0.4
+
+  '@shikijs/types@1.24.0':
     dependencies:
       '@shikijs/vscode-textmate': 9.3.0
       '@types/hast': 3.0.4
@@ -30379,7 +30404,7 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typedoc-better-json@0.9.2(typescript@5.7.2):
+  typedoc-better-json@0.9.4(typescript@5.7.2):
     dependencies:
       mdast: 3.0.0
       mdast-util-from-markdown: 2.0.1
@@ -30396,12 +30421,12 @@ snapshots:
       shiki: 0.14.7
       typescript: 5.7.2
 
-  typedoc@0.26.11(typescript@5.7.2):
+  typedoc@0.27.2(typescript@5.7.2):
     dependencies:
+      '@gerrit0/mini-shiki': 1.24.1
       lunr: 2.3.9
       markdown-it: 14.1.0
       minimatch: 9.0.5
-      shiki: 1.22.2
       typescript: 5.7.2
       yaml: 2.6.1
 


### PR DESCRIPTION
closes: DASH-501

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating dependencies and making adjustments to the `typedoc` integration within the project. It includes version upgrades and some refactoring in the `typedoc` usage.

### Detailed summary
- Updated `typedoc-better-json` from `0.9.2` to `0.9.4`.
- Updated `typedoc` from `0.26.11` to `0.27.2`.
- Refactored import of `TypeDoc` to `Application` in `typedoc.mjs`.
- Simplified `entryPoints` array in `typedoc.mjs`.
- Updated `typesVersions` in `package.json` to a more concise format.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->