### PR TITLE
Remove icon from get started with contracts step card tabs

### DIFF
--- a/apps/dashboard/src/app/account/contracts/_components/GetStartedWithContractsDeploy.tsx
+++ b/apps/dashboard/src/app/account/contracts/_components/GetStartedWithContractsDeploy.tsx
@@ -4,7 +4,6 @@ import { useDashboardRouter } from "@/lib/DashboardRouter";
 import { ImportModal } from "components/contract-components/import-contract/modal";
 import { StepsCard } from "components/dashboard/StepsCard";
 import { useTrack } from "hooks/analytics/useTrack";
-import Image from "next/image";
 import { useMemo, useState } from "react";
 
 export function GetStartedWithContractsDeploy() {
@@ -116,15 +115,6 @@ const DeployOptions = () => {
           });
         }}
       >
-        <Image
-          width={32}
-          height={32}
-          className="size-8"
-          alt=""
-          src={`/assets/dashboard/contracts/${activeTab}.${
-            activeTab === "import" ? "svg" : "png"
-          }`}
-        />
         <div>
           <h4 className="text-start font-semibold text-lg">
             {activeTabContent.title}


### PR DESCRIPTION
DASH-502

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on removing an unused `Image` component from the `GetStartedWithContractsDeploy` function in the `apps/dashboard/src/app/account/contracts/_components/GetStartedWithContractsDeploy.tsx` file.

### Detailed summary
- Removed the `Image` component that displayed an asset based on the `activeTab` value. 
- Adjusted the code structure by eliminating unnecessary lines related to the `Image` component.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->