### PR TITLE
feat: Add warning for rejected sponsorship policies

### DIFF
--- a/.changeset/tame-melons-poke.md
+++ b/.changeset/tame-melons-poke.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Show warning when sponsorship policy rejects a transaction

--- a/packages/thirdweb/src/wallets/smart/lib/paymaster.ts
+++ b/packages/thirdweb/src/wallets/smart/lib/paymaster.ts
@@ -83,6 +83,13 @@ Code: ${code}`,
         paymasterAndData: res.result,
       };
     }
+    // check for policy errors
+    if (res.result.policyId && res.result.reason) {
+      console.warn(
+        `Paymaster policy rejected this transaction with reason: ${res.result.reason} (policyId: ${res.result.policyId})`,
+      );
+    }
+
     return {
       paymasterAndData: res.result.paymasterAndData,
       verificationGasLimit: res.result.verificationGasLimit


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a warning mechanism in the `paymaster.ts` file to alert users when a sponsorship policy rejects a transaction.

### Detailed summary
- Added a warning log when a transaction is rejected due to a sponsorship policy.
- The log includes the reason for rejection and the associated `policyId`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->