### PR TITLE
fix: display appropriate error message on account status fetch failure outside of unauthorized access

### DIFF
--- a/.changeset/rude-radios-smash.md
+++ b/.changeset/rude-radios-smash.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Display error message when failing to fetch account status from endpoint outside of unauthorized requests

--- a/packages/thirdweb/src/wallets/in-app/core/actions/get-enclave-user-status.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/actions/get-enclave-user-status.ts
@@ -37,7 +37,7 @@ export async function getUserStatus({
       return undefined;
     }
     const result = await response.json();
-    throw new Error(`Failed to get user status: ${result.error}`);
+    throw new Error(`Failed to get user status: ${result.message}`);
   }
 
   return (await response.json()) as UserStatus;


### PR DESCRIPTION
https://linear.app/thirdweb/issue/CNCT-2428/pro-upcade-ecosystem-wallet-restriction-not-working

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving error handling in the `get-enclave-user-status.ts` file by changing the error message thrown when fetching the account status fails. 

### Detailed summary
- Updated error message in `get-enclave-user-status.ts` from `result.error` to `result.message` to provide clearer feedback on failure to fetch user status.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->