### PR TITLE
docs: Add EIP1193 extension documentation

### DIFF
--- a/packages/thirdweb/scripts/typedoc.mjs
+++ b/packages/thirdweb/scripts/typedoc.mjs
@@ -4,7 +4,11 @@ import { Application } from "typedoc";
 const jsonOut = "typedoc/documentation.json";
 
 const app = await Application.bootstrapWithPlugins({
-  entryPoints: ["src/exports/**/*.ts", "src/extensions/modules/**/index.ts"],
+  entryPoints: [
+    "src/exports/**/*.ts",
+    "src/extensions/modules/**/index.ts",
+    "src/adapters/eip1193/index.ts",
+  ],
   exclude: [
     "src/exports/*.native.ts",
     "src/exports/**/*.native.ts",

--- a/packages/thirdweb/src/adapters/eip1193/from-eip1193.ts
+++ b/packages/thirdweb/src/adapters/eip1193/from-eip1193.ts
@@ -54,6 +54,8 @@ export type FromEip1193AdapterOptions = {
  *   value: 1000000000000000000n
  * });
  * ```
+ *
+ * @extension EIP1193
  */
 export function fromProvider(options: FromEip1193AdapterOptions): Wallet {
   const id: WalletId = options.walletId ?? "adapter";

--- a/packages/thirdweb/src/adapters/eip1193/to-eip1193.ts
+++ b/packages/thirdweb/src/adapters/eip1193/to-eip1193.ts
@@ -50,6 +50,8 @@ export type ToEip1193ProviderOptions = {
  *   console.log("Active accounts:", accounts);
  * });
  * ```
+ *
+ * @extension EIP1193
  */
 export function toProvider(options: ToEip1193ProviderOptions): EIP1193Provider {
   const { chain, client, wallet, connectOverride } = options;


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added



<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds documentation annotations for EIP1193 extensions in two adapter files and updates the entry points in the `typedoc.mjs` script to include the new EIP1193 adapter.

### Detailed summary
- Added `@extension EIP1193` annotation in `fromProvider` function in `from-eip1193.ts`.
- Added `@extension EIP1193` annotation in `toProvider` function in `to-eip1193.ts`.
- Updated entry points in `typedoc.mjs` to include `src/adapters/eip1193/index.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->