### PR TITLE
chore: Update CODEOWNERS for Portal

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,7 +20,7 @@ apps/ @jnsdls @joaquim-verges
 apps/dashboard/ @jnsdls @MananTank @joaquim-verges
 apps/playground-web/ @joaquim-verges @gregfromstl @jnsdls @joaquim-verges
 apps/wallet-ui/ @gregfromstl @jnsdls @joaquim-verges @MananTank
-apps/portal/ @gregfromstl @jnsdls @joaquim-verges @MananTank
+apps/portal/ @thirdweb-dev/product @thirdweb-dev/platform @thirdweb-dev/infra
 
 # .github folder + .changeset + turbo config is owned by jonas for now
 scripts/ @jnsdls @joaquim-verges


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the ownership configuration for the `apps/portal/` directory in the `.github/CODEOWNERS` file, changing the assigned users to a new set of teams.

### Detailed summary
- Updated ownership for `apps/portal/` from `@gregfromstl`, `@jnsdls`, `@joaquim-verges`, and `@MananTank` to `@thirdweb-dev/product`, `@thirdweb-dev/platform`, and `@thirdweb-dev/infra`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->