### PR TITLE
[Portal] Fix table of contents sidebar not updating on page change

### DIFF
--- a/apps/portal/src/components/others/TableOfContents.tsx
+++ b/apps/portal/src/components/others/TableOfContents.tsx
@@ -2,6 +2,7 @@
 
 import { cn } from "@/lib/utils";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 
 /**
@@ -29,6 +30,7 @@ export function TableOfContentsSideBar(props: {
 }) {
   const [nodes, setNodes] = useState<TableOfContentNode[]>([]);
   const tocRef = useRef<HTMLDivElement>(null);
+  const pathname = usePathname();
 
   const [hideNav, setHideNav] = useState(false);
   const { filterHeading } = props;
@@ -44,6 +46,9 @@ export function TableOfContentsSideBar(props: {
     const anchorsAll = Array.from(
       root.querySelectorAll("a[href^='#']"),
     ) as HTMLAnchorElement[];
+
+    // using pathname to fix exhaustive dependency lint warning without suppressing it entirely
+    tocRef.current?.setAttribute("data-pathname", pathname);
 
     // hide anchors inside hidden elements
     const anchors = anchorsAll.filter((anchor) => {
@@ -104,7 +109,7 @@ export function TableOfContentsSideBar(props: {
     return () => {
       observer.disconnect();
     };
-  }, [filterHeading]);
+  }, [filterHeading, pathname]);
 
   return (
     <nav


### PR DESCRIPTION
Fixes DASH-467

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the `usePathname` hook to the `TableOfContentsSideBar` component, allowing it to track the current pathname. This change helps address a lint warning regarding exhaustive dependencies.

### Detailed summary
- Added `usePathname` from `next/navigation`.
- Introduced `pathname` state to store the current pathname.
- Set `data-pathname` attribute on `tocRef` to the current pathname.
- Updated the dependency array in the `useEffect` hook to include `pathname`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->