### PR TITLE
[SDK] Fix tsdocs for isERC20

### DIFF
--- a/packages/thirdweb/src/extensions/erc20/read/isERC20.ts
+++ b/packages/thirdweb/src/extensions/erc20/read/isERC20.ts
@@ -16,7 +16,14 @@ import { isTransferFromSupported } from "../__generated__/IERC20/write/transferF
  * @example
  * ```ts
  * import { isERC20 } from "thirdweb/extensions/erc20";
- * const result = await isERC20({ contract });
+ * import { resolveContractAbi } from "thirdweb/contract";
+ *
+ * const abi = await resolveContractAbi(contract);
+ * const selectors = abi
+ *   .filter((f) => f.type === "function")
+ *   .map((f) => toFunctionSelector(f));
+ *
+ * const result = await isERC20(selectors);
  * ```
  */
 export function isERC20(availableSelectors: string[]) {


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `isERC20` function to use contract ABI resolution and function selectors instead of directly passing the contract to check if it is an ERC20.

### Detailed summary
- Added import for `resolveContractAbi` from `thirdweb/contract`.
- Resolved the contract ABI using `resolveContractAbi(contract)`.
- Extracted function selectors from the ABI.
- Modified the call to `isERC20` to use the extracted selectors instead of the contract.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->