### PR TITLE
chore: avoid extra fetch for zk chains

### DIFF
--- a/packages/thirdweb/src/utils/any-evm/zksync/isZkSyncChain.ts
+++ b/packages/thirdweb/src/utils/any-evm/zksync/isZkSyncChain.ts
@@ -24,7 +24,10 @@ export async function isZkSyncChain(chain: Chain) {
     chain.id === 978658 ||
     chain.id === 531050104 ||
     chain.id === 4457845 ||
-    chain.id === 2741
+    chain.id === 2741 ||
+    chain.id === 240 ||
+    chain.id === 61166 ||
+    chain.id === 555271
   ) {
     return true;
   }


### PR DESCRIPTION
CNCT-2532

<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `isZkSyncChain.ts` file to include additional chain IDs that are recognized as valid for the ZkSync chain. 

### Detailed summary
- Added `chain.id === 240`
- Added `chain.id === 61166`
- Added `chain.id === 555271`
- The previous check for `chain.id === 2741` remains, but is now followed by the new IDs.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->