### PR TITLE
bump thirdweb cjs size limit

### DIFF
--- a/packages/thirdweb/.size-limit.json
+++ b/packages/thirdweb/.size-limit.json
@@ -8,7 +8,7 @@
   {
     "name": "thirdweb (cjs)",
     "path": "./dist/cjs/exports/thirdweb.js",
-    "limit": "110 kB"
+    "limit": "120 kB"
   },
   {
     "name": "thirdweb (minimal + tree-shaking)",


### PR DESCRIPTION
fixes: CNCT-2534

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the size limit for the `thirdweb (cjs)` package in the `.size-limit.json` configuration file.

### Detailed summary
- Updated the `limit` for `thirdweb (cjs)` from `110 kB` to `120 kB` in `packages/thirdweb/.size-limit.json`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->