### PR TITLE
fix metadata base to set proper canonical urls

### DIFF
--- a/apps/dashboard/next-sitemap.config.js
+++ b/apps/dashboard/next-sitemap.config.js
@@ -48,10 +48,14 @@ module.exports = {
     policies: [
       {
         userAgent: "*",
-        [process.env.VERCEL_ENV !== "preview" &&
-        process.env.VERCEL_ENV !== "development"
-          ? "allow"
-          : "disallow"]: "/",
+        // allow all if production
+        allow: process.env.VERCEL_ENV === "production" ? ["/"] : [],
+        // disallow all if not production
+        disallow:
+          process.env.VERCEL_ENV !== "production"
+            ? ["/"]
+            : // disallow `/team` and `/team/*` if production
+              ["/team", "/team/*"],
       },
     ],
   },

--- a/apps/dashboard/src/app/layout.tsx
+++ b/apps/dashboard/src/app/layout.tsx
@@ -17,6 +17,10 @@ const fontSans = Inter({
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL("https://thirdweb.com"),
+  alternates: {
+    canonical: "./",
+  },
   title: "thirdweb: The complete web3 development platform",
   description:
     "Build web3 apps easily with thirdweb's powerful SDKs, audited smart contracts, and developer tools—for Ethereum & 700+ EVM chains. Try now.",


### PR DESCRIPTION
fixes: DASH-492

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces updates to the `metadata` in `layout.tsx` for improved SEO and modifies the `next-sitemap.config.js` to adjust sitemap behavior based on the environment.

### Detailed summary
- In `layout.tsx`:
  - Added `metadataBase` with URL `https://thirdweb.com`.
  - Added `alternates` object with a `canonical` path set to `"./"`.

- In `next-sitemap.config.js`:
  - Changed sitemap rules to allow all paths in production and disallow specific paths in non-production environments.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->