### PR TITLE
[SDK] Fix: Remove auth from useConnectModal props as it's not currently supported

### DIFF
--- a/.changeset/tidy-zoos-know.md
+++ b/.changeset/tidy-zoos-know.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix: Removed the auth prop from useConnectModal as it is currently not supported

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/useConnectModal.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/useConnectModal.tsx
@@ -5,7 +5,6 @@ import type { Wallet } from "../../../../wallets/interfaces/wallet.js";
 import type { SmartWalletOptions } from "../../../../wallets/smart/types.js";
 import type { AppMetadata } from "../../../../wallets/types.js";
 import type { Theme } from "../../../core/design-system/index.js";
-import type { SiweAuthOptions } from "../../../core/hooks/auth/useSiweAuth.js";
 import { SetRootElementContext } from "../../../core/providers/RootElementContext.js";
 import { WalletUIStatesProvider } from "../../providers/wallet-ui-states-provider.js";
 import { canFitWideModal } from "../../utils/canFitWideModal.js";
@@ -433,14 +432,6 @@ export type UseConnectModalOptions = {
    * If you want to hide the branding, set this prop to `false`
    */
   showThirdwebBranding?: boolean;
-
-  /**
-   * Enable SIWE (Sign in with Ethererum) by passing an object of type `SiweAuthOptions` to
-   * enforce the users to sign a message after connecting their wallet to authenticate themselves.
-   *
-   * Refer to the [`SiweAuthOptions`](https://portal.thirdweb.com/references/typescript/v5/SiweAuthOptions) for more details
-   */
-  auth?: SiweAuthOptions;
 };
 
 // TODO: consilidate Button/Embed/Modal props into one type with extras


### PR DESCRIPTION
Fixes #5615

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on removing the `auth` property from the `useConnectModal` as it is not currently supported, along with a patch update for the `thirdweb` package.

### Detailed summary
- Removed the `auth` property from `UseConnectModalOptions` in `useConnectModal.tsx`.
- Updated the documentation to reflect the removal of the `auth` prop.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->