### PR TITLE
[SDK] Fix: Hide sign in with wallet button when linking

### DIFF
--- a/.changeset/strong-avocados-argue.md
+++ b/.changeset/strong-avocados-argue.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix: Hides Sign in with Wallet button when linking a profile

--- a/packages/thirdweb/src/react/web/wallets/shared/ConnectWalletSocialOptions.test.tsx
+++ b/packages/thirdweb/src/react/web/wallets/shared/ConnectWalletSocialOptions.test.tsx
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  fireEvent,
+  render,
+  screen,
+} from "../../../../../test/src/react-render.js";
+import { TEST_CLIENT } from "../../../../../test/src/test-clients.js";
+import { createWallet } from "../../../../wallets/create-wallet.js";
+import { ConnectWalletSocialOptions } from "./ConnectWalletSocialOptions.js";
+import en from "./locale/en.js";
+
+describe("ConnectWalletSocialOptions", () => {
+  const mockSelect = vi.fn();
+  const mockDone = vi.fn();
+
+  const defaultProps = {
+    select: mockSelect,
+    done: mockDone,
+    locale: en,
+    chain: undefined,
+    client: TEST_CLIENT,
+    size: "compact" as const,
+    isLinking: false,
+    disabled: false,
+  };
+
+  it("renders Sign in with Wallet button when enabled and not linking", () => {
+    render(
+      <ConnectWalletSocialOptions
+        {...defaultProps}
+        wallet={createWallet("inApp", {
+          auth: {
+            options: ["wallet"],
+          },
+        })}
+      />,
+    );
+
+    const walletButton = screen.getByRole("button", {
+      name: /sign in with wallet/i,
+    });
+
+    expect(walletButton).toBeInTheDocument();
+    expect(walletButton).toHaveTextContent("Sign in with Wallet");
+  });
+
+  it("does not render Sign in with Wallet button when isLinking is true", () => {
+    render(
+      <ConnectWalletSocialOptions
+        {...defaultProps}
+        isLinking={true}
+        wallet={createWallet("inApp", {
+          auth: {
+            options: ["wallet"],
+          },
+        })}
+      />,
+    );
+
+    const walletButton = screen.queryByRole("button", {
+      name: /sign in with wallet/i,
+    });
+
+    expect(walletButton).not.toBeInTheDocument();
+  });
+
+  it("calls handleWalletLogin when Sign in with Wallet button is clicked", () => {
+    render(
+      <ConnectWalletSocialOptions
+        {...defaultProps}
+        wallet={createWallet("inApp", {
+          auth: {
+            options: ["wallet"],
+          },
+        })}
+      />,
+    );
+
+    const walletButton = screen.getByRole("button", {
+      name: /sign in with wallet/i,
+    });
+
+    fireEvent.click(walletButton);
+
+    expect(mockSelect).toHaveBeenCalled();
+  });
+});

--- a/packages/thirdweb/src/react/web/wallets/shared/ConnectWalletSocialOptions.tsx
+++ b/packages/thirdweb/src/react/web/wallets/shared/ConnectWalletSocialOptions.tsx
@@ -474,7 +474,7 @@ export const ConnectWalletSocialOptions = (
       )}
 
       {/* SIWE login */}
-      {siweEnabled && (
+      {siweEnabled && !props.isLinking && (
         <WalletTypeRowButton
           client={props.client}
           icon={OutlineWalletIcon}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a fix to hide the "Sign in with Wallet" button when a profile is being linked and adds tests to ensure the button's behavior is correctly managed in different scenarios.

### Detailed summary
- Updated condition to hide the "Sign in with Wallet" button when `isLinking` is `true` in `ConnectWalletSocialOptions.tsx`.
- Added tests in `ConnectWalletSocialOptions.test.tsx` to verify:
  - Button renders when enabled and not linking.
  - Button does not render when `isLinking` is `true`.
  - Button click triggers `handleWalletLogin`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->