### PR TITLE
[Dashboard] Fix Aidrop button in ERC1155 being disabled

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/nfts/[tokenId]/components/airdrop-tab.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/nfts/[tokenId]/components/airdrop-tab.tsx
@@ -34,7 +34,7 @@ interface AirdropTabProps {
  */
 const AirdropTab: React.FC<AirdropTabProps> = ({ contract, tokenId }) => {
   const address = useActiveAccount()?.address;
-  const { handleSubmit, setValue, watch, reset, formState } = useForm<{
+  const { handleSubmit, setValue, watch, reset } = useForm<{
     addresses: AirdropAddressInput[];
   }>({
     defaultValues: { addresses: [] },
@@ -162,9 +162,7 @@ const AirdropTab: React.FC<AirdropTabProps> = ({ contract, tokenId }) => {
             transactionCount={1}
             isPending={sendAndConfirmTx.isPending}
             type="submit"
-            disabled={
-              (!!address && addresses.length === 0) || !formState.isDirty
-            }
+            disabled={!!address && addresses.length === 0}
             className="self-end"
           >
             Airdrop


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on simplifying the form handling in the `AirdropTab` component by removing the unused `formState` and streamlining the logic for the disabled state of the submit button.

### Detailed summary
- Removed `formState` from the destructured return of `useForm`.
- Updated the `disabled` prop of the submit button to only check if `address` is present and `addresses` length is zero, removing the dependency on `formState.isDirty`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->