### PR TITLE
Update page.mdx

### DIFF
--- a/apps/portal/src/app/connect/auth/frameworks/next/page.mdx
+++ b/apps/portal/src/app/connect/auth/frameworks/next/page.mdx
@@ -230,10 +230,10 @@ import { privateKeyToAccount } from "thirdweb/wallets";
 import { client } from "@/lib/client";
 import { cookies } from "next/headers";
 
-const privateKey = process.env.THIRDWEB_ADMIN_PRIVATE_KEY || "";
+const privateKey = process.env.AUTH_PRIVATE_KEY || "";
 
 if (!privateKey) {
-	throw new Error("Missing THIRDWEB_ADMIN_PRIVATE_KEY in .env file.");
+	throw new Error("Missing AUTH_PRIVATE_KEY in .env file.");
 }
 
 const thirdwebAuth = createAuth({


### PR DESCRIPTION
In Server Side Setup change THIRDWEB_ADMIN_PRIVATE_KEY to AUTH_PRIVATE_KEY since the last is used in .env setup proposed

## Problem solved

Fix a env variable typo



<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the environment variable used for authentication in the `page.mdx` file, changing it from `THIRDWEB_ADMIN_PRIVATE_KEY` to `AUTH_PRIVATE_KEY`.

### Detailed summary
- Changed the assignment of `privateKey` from `process.env.THIRDWEB_ADMIN_PRIVATE_KEY` to `process.env.AUTH_PRIVATE_KEY`.
- Updated the error message from "Missing THIRDWEB_ADMIN_PRIVATE_KEY in .env file." to "Missing AUTH_PRIVATE_KEY in .env file."

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->