### PR TITLE
Update CTA

### DIFF
--- a/apps/playground-web/src/app/engine/airdrop/page.tsx
+++ b/apps/playground-web/src/app/engine/airdrop/page.tsx
@@ -15,6 +15,7 @@ export default function Page() {
               address!
             </>
           }
+          deployLink="https://thirdweb.com/team/~/~/engine/create?utm_source=playground"
           docsLink="https://thirdweb-engine.apidocumentation.com/reference#tag/erc20/POST/contract/{chain}/{contractAddress}/erc20/mint-batch-to?utm_source=playground"
           heroLink="/airdrop.avif"
         />

--- a/apps/playground-web/src/app/engine/minting/page.tsx
+++ b/apps/playground-web/src/app/engine/minting/page.tsx
@@ -14,6 +14,7 @@ export default function Page() {
               sponsor the gas so your users only need a wallet address!
             </>
           }
+          deployLink="https://thirdweb.com/team/~/~/engine/create?utm_source=playground"
           docsLink="https://thirdweb-engine.apidocumentation.com/reference#tag/erc1155/POST/contract/{chain}/{contractAddress}/erc1155/mint-to?utm_source=playground"
           heroLink="/minting.avif"
         />

--- a/apps/playground-web/src/app/engine/webhooks/page.tsx
+++ b/apps/playground-web/src/app/engine/webhooks/page.tsx
@@ -14,6 +14,7 @@ export default function Page() {
               transaction or backend wallet events.
             </>
           }
+          deployLink="https://thirdweb.com/team/~/~/engine/create?utm_source=playground"
           docsLink="https://portal.thirdweb.com/engine/features/webhooks?utm_source=playground"
           heroLink="/webhooks.avif"
         />

--- a/apps/playground-web/src/components/blocks/EngineAPIHeader.tsx
+++ b/apps/playground-web/src/components/blocks/EngineAPIHeader.tsx
@@ -5,6 +5,7 @@ import { Button } from "../ui/button";
 export function EngineAPIHeader(props: {
   title: string;
   description: React.ReactNode;
+  deployLink: string;
   docsLink: string;
   heroLink: string;
 }) {
@@ -27,6 +28,11 @@ export function EngineAPIHeader(props: {
 
         <div className="flex flex-col gap-3 md:flex-row">
           <Button asChild size="lg">
+            <Link target="_blank" href={props.deployLink}>
+              Deploy an Instance
+            </Link>
+          </Button>
+          <Button asChild variant="outline" size="lg">
             <Link target="_blank" href={props.docsLink}>
               View docs
             </Link>
@@ -37,14 +43,6 @@ export function EngineAPIHeader(props: {
               href="https://thirdweb.com/contact-us?utm_source=playground"
             >
               Book a Demo
-            </Link>
-          </Button>
-          <Button asChild variant="outline" size="lg">
-            <Link
-              target="_blank"
-              href="https://thirdweb.com/team/~/~/engine/create?utm_source=playground"
-            >
-              Deploy an Instance
             </Link>
           </Button>
         </div>


### PR DESCRIPTION
Set CTA for Engine Playground to "Deploy an Instance"

## Problem solved
Update for [DASH-535](https://linear.app/thirdweb/issue/DASH-535/make-deploy-an-instance-the-primary-cta-in-playground)

Set CTA for Engine Playground to "Deploy an Instance"

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding `deployLink` properties and corresponding links to various pages in the `playground-web` application, enhancing user navigation to deployment and documentation resources. 

### Detailed summary
- Added `deployLink` to `page.tsx` files for `webhooks`, `minting`, and `airdrop` sections.
- Updated the `EngineAPIHeader` component to include a new `deployLink` prop.
- Removed hardcoded `Deploy an Instance` button from `EngineAPIHeader` and replaced it with a dynamic link using `props.deployLink`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->