### PR TITLE
[SDK] Add erc20Value to buyFromListing transaction

### DIFF
--- a/.changeset/silent-hats-melt.md
+++ b/.changeset/silent-hats-melt.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Add erc20Value to buyFromListing transaction

--- a/packages/thirdweb/src/extensions/marketplace/direct-listings/write/buyFromListing.ts
+++ b/packages/thirdweb/src/extensions/marketplace/direct-listings/write/buyFromListing.ts
@@ -66,6 +66,12 @@ export function buyFromListing(
             ? listing.pricePerToken * options.quantity
             : 0n,
           extraGas: 50_000n, // add extra gas to account for router call
+          erc20Value: isNativeTokenAddress(listing.currencyContractAddress)
+            ? undefined
+            : {
+                amountWei: listing.pricePerToken * options.quantity,
+                tokenAddress: listing.currencyContractAddress,
+              },
         },
       };
     },


### PR DESCRIPTION
CNCT-2555

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds an `erc20Value` property to the `buyFromListing` transaction, enabling proper handling of ERC20 currency in marketplace listings. It also includes tests to ensure the functionality works as expected with ERC20 tokens.

### Detailed summary
- Added `erc20Value` to `buyFromListing` transaction.
- Implemented logic to calculate `erc20Value` based on listing price and quantity.
- Introduced tests for `buyFromListing` with ERC20 currency.
- Included deployment of an ERC20 contract in tests.
- Verified approval transaction for the `buyFromListing`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->