### PR TITLE
TokenPaymaster (BASE_USDC, CELO_USD, LISK_LSK)

### DIFF
--- a/.changeset/tiny-pugs-hunt.md
+++ b/.changeset/tiny-pugs-hunt.md
@@ -1,0 +1,20 @@
+---
+"thirdweb": minor
+---
+
+ERC20 Token Paymaster support
+
+You can now use ERC20 Token Paymasters with Smart Wallets.
+
+```typescript
+import { base } from "thirdweb/chains";
+import { TokenPaymaster, smartWallet } from "thirdweb/wallets";
+
+const wallet = smartWallet({
+  chain: base,
+  sponsorGas: true, // only sponsor gas for the first ERC20 approval
+  overrides: {
+    tokenPaymaster: TokenPaymaster.BASE_USDC,
+  },
+});
+```

--- a/packages/thirdweb/src/exports/wallets/smart.ts
+++ b/packages/thirdweb/src/exports/wallets/smart.ts
@@ -35,4 +35,5 @@ export {
   ENTRYPOINT_ADDRESS_v0_7,
   DEFAULT_ACCOUNT_FACTORY_V0_6,
   DEFAULT_ACCOUNT_FACTORY_V0_7,
+  TokenPaymaster,
 } from "../../wallets/smart/lib/constants.js";

--- a/packages/thirdweb/src/wallets/smart/index.ts
+++ b/packages/thirdweb/src/wallets/smart/index.ts
@@ -46,6 +46,7 @@ import {
 } from "./lib/calls.js";
 import {
   ENTRYPOINT_ADDRESS_v0_6,
+  ENTRYPOINT_ADDRESS_v0_7,
   getDefaultAccountFactory,
   getEntryPointVersion,
 } from "./lib/constants.js";
@@ -118,6 +119,17 @@ export async function connectSmartWallet(
         entrypointAddress,
       };
     }
+  }
+
+  if (
+    options.overrides?.tokenPaymaster &&
+    !options.overrides?.entrypointAddress
+  ) {
+    // if token paymaster is set, but no entrypoint address, set the entrypoint address to v0.7
+    options.overrides = {
+      ...options.overrides,
+      entrypointAddress: ENTRYPOINT_ADDRESS_v0_7,
+    };
   }
 
   const factoryAddress =
@@ -200,8 +212,8 @@ export async function disconnectSmartWallet(
 async function createSmartAccount(
   options: SmartAccountOptions,
 ): Promise<Account> {
-  let erc20Paymaster = options.overrides?.tokenPaymaster;
-  if (erc20Paymaster && typeof erc20Paymaster === "string") {
+  const erc20Paymaster = options.overrides?.tokenPaymaster;
+  if (erc20Paymaster) {
     if (
       getEntryPointVersion(
         options.overrides?.entrypointAddress || ENTRYPOINT_ADDRESS_v0_6,
@@ -210,32 +222,6 @@ async function createSmartAccount(
       throw new Error(
         "Token paymaster is only supported for entrypoint version v0.7",
       );
-    }
-    switch (erc20Paymaster) {
-      case "BASE_USDC":
-        erc20Paymaster = {
-          chainId: 8453,
-          paymasterAddress: "0x2222f2738BE6bB7aA0Bfe4AEeAf2908172CF5539",
-          tokenAddress: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
-          balanceStorageSlot: 9,
-        };
-        break;
-      case "CELO_CUSD":
-        erc20Paymaster = {
-          chainId: 42220,
-          paymasterAddress: "0x3feA3c5744D715ff46e91C4e5C9a94426DfF2aF9",
-          tokenAddress: "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          balanceStorageSlot: 9,
-        };
-        break;
-      case "LISK_LSK":
-        erc20Paymaster = {
-          chainId: 1135,
-          paymasterAddress: "0x9eb8cf7fBa5ed9EeDCC97a0d52254cc0e9B1AC25",
-          tokenAddress: "0xac485391EB2d7D88253a7F1eF18C37f4242D1A24",
-          balanceStorageSlot: 9,
-        };
-        break;
     }
   }
 

--- a/packages/thirdweb/src/wallets/smart/lib/bundler.ts
+++ b/packages/thirdweb/src/wallets/smart/lib/bundler.ts
@@ -67,16 +67,21 @@ export async function bundleUserOp(args: {
  * ```
  * @walletUtils
  */
-export async function estimateUserOpGas(args: {
-  userOp: UserOperationV06 | UserOperationV07;
-  options: BundlerOptions;
-}): Promise<EstimationResult> {
+export async function estimateUserOpGas(
+  args: {
+    userOp: UserOperationV06 | UserOperationV07;
+    options: BundlerOptions;
+  },
+  // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+  stateOverrides?: any,
+): Promise<EstimationResult> {
   const res = await sendBundlerRequest({
     ...args,
     operation: "eth_estimateUserOperationGas",
     params: [
       hexlifyUserOp(args.userOp),
       args.options.entrypointAddress ?? ENTRYPOINT_ADDRESS_v0_6,
+      stateOverrides,
     ],
   });
 

--- a/packages/thirdweb/src/wallets/smart/lib/bundler.ts
+++ b/packages/thirdweb/src/wallets/smart/lib/bundler.ts
@@ -72,8 +72,13 @@ export async function estimateUserOpGas(
     userOp: UserOperationV06 | UserOperationV07;
     options: BundlerOptions;
   },
-  // biome-ignore lint/suspicious/noExplicitAny: <explanation>
-  stateOverrides?: any,
+  stateOverrides?: {
+    [x: string]: {
+      stateDiff: {
+        [x: string]: `0x${string}`;
+      };
+    };
+  },
 ): Promise<EstimationResult> {
   const res = await sendBundlerRequest({
     ...args,

--- a/packages/thirdweb/src/wallets/smart/lib/constants.ts
+++ b/packages/thirdweb/src/wallets/smart/lib/constants.ts
@@ -1,6 +1,7 @@
 import type { Chain } from "../../../chains/types.js";
 import { getAddress } from "../../../utils/address.js";
 import { getThirdwebDomains } from "../../../utils/domains.js";
+import type { TokenPaymasterConfig } from "../types.js";
 
 export const DUMMY_SIGNATURE =
   "0xfffffffffffffffffffffffffffffff0000000000000000000000000000000007aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1c";
@@ -16,6 +17,28 @@ export const ENTRYPOINT_ADDRESS_v0_7 =
   "0x0000000071727De22E5E9d8BAf0edAc6f37da032"; // v0.7
 
 export const MANAGED_ACCOUNT_GAS_BUFFER = 50000n;
+
+export type PAYMASTERS = "BASE_USDC" | "CELO_CUSD" | "LISK_LSK";
+export const TokenPaymaster: Record<PAYMASTERS, TokenPaymasterConfig> = {
+  BASE_USDC: {
+    chainId: 8453,
+    paymasterAddress: "0x2222f2738BE6bB7aA0Bfe4AEeAf2908172CF5539",
+    tokenAddress: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    balanceStorageSlot: 9n,
+  },
+  CELO_CUSD: {
+    chainId: 42220,
+    paymasterAddress: "0x3feA3c5744D715ff46e91C4e5C9a94426DfF2aF9",
+    tokenAddress: "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+    balanceStorageSlot: 9n,
+  },
+  LISK_LSK: {
+    chainId: 1135,
+    paymasterAddress: "0x9eb8cf7fBa5ed9EeDCC97a0d52254cc0e9B1AC25",
+    tokenAddress: "0xac485391EB2d7D88253a7F1eF18C37f4242D1A24",
+    balanceStorageSlot: 9n,
+  },
+};
 
 /*
  * @internal

--- a/packages/thirdweb/src/wallets/smart/lib/constants.ts
+++ b/packages/thirdweb/src/wallets/smart/lib/constants.ts
@@ -18,7 +18,7 @@ export const ENTRYPOINT_ADDRESS_v0_7 =
 
 export const MANAGED_ACCOUNT_GAS_BUFFER = 50000n;
 
-export type PAYMASTERS = "BASE_USDC" | "CELO_CUSD" | "LISK_LSK";
+type PAYMASTERS = "BASE_USDC" | "CELO_CUSD" | "LISK_LSK";
 export const TokenPaymaster: Record<PAYMASTERS, TokenPaymasterConfig> = {
   BASE_USDC: {
     chainId: 8453,

--- a/packages/thirdweb/src/wallets/smart/smart-wallet-tokenpaymaster.test.ts
+++ b/packages/thirdweb/src/wallets/smart/smart-wallet-tokenpaymaster.test.ts
@@ -1,0 +1,63 @@
+import { base } from "src/chains/chain-definitions/base.js";
+import { sendTransaction } from "src/transaction/actions/send-transaction.js";
+import { prepareTransaction } from "src/transaction/prepare-transaction.js";
+import { beforeAll, describe, expect, it } from "vitest";
+import { TEST_CLIENT } from "../../../test/src/test-clients.js";
+import { setThirdwebDomains } from "../../utils/domains.js";
+import type { Account } from "../interfaces/wallet.js";
+import { privateKeyToAccount } from "../private-key.js";
+import { smartWallet } from "./smart-wallet.js";
+
+let personalAccount: Account;
+
+const client = TEST_CLIENT;
+
+describe.runIf(process.env.TW_SECRET_KEY).skip.sequential(
+  "SmartWallet policy tests",
+  {
+    retry: 0,
+    timeout: 240_000,
+  },
+  () => {
+    beforeAll(async () => {
+      setThirdwebDomains({
+        rpc: "rpc.thirdweb-dev.com",
+        storage: "storage.thirdweb-dev.com",
+        bundler: "bundler.thirdweb-dev.com",
+      });
+      personalAccount = await privateKeyToAccount({
+        client,
+        privateKey:
+          "edf401e8ddbb743f3353b055081cb220ce4c5c04e08da162d86e0dba7c6f0f01", // 0xa470E7c88611364f55B2d7912613e10AF2eA918D
+      });
+    });
+
+    it("can self transfer with BASE_USDC", async () => {
+      const wallet = smartWallet({
+        chain: base,
+        gasless: true,
+        overrides: {
+          tokenPaymaster: "BASE_USDC",
+        },
+      });
+      const smartAccount = await wallet.connect({
+        client: TEST_CLIENT,
+        personalAccount,
+      });
+
+      console.log("smartAccount", smartAccount.address);
+
+      const tx = prepareTransaction({
+        client,
+        chain: base,
+        to: smartAccount.address,
+        value: 0n,
+      });
+      const receipt = await sendTransaction({
+        transaction: tx,
+        account: smartAccount,
+      });
+      expect(receipt.transactionHash).toBeDefined();
+    });
+  },
+);

--- a/packages/thirdweb/src/wallets/smart/smart-wallet-tokenpaymaster.test.ts
+++ b/packages/thirdweb/src/wallets/smart/smart-wallet-tokenpaymaster.test.ts
@@ -1,55 +1,58 @@
-import { base } from "src/chains/chain-definitions/base.js";
-import { sendTransaction } from "src/transaction/actions/send-transaction.js";
-import { prepareTransaction } from "src/transaction/prepare-transaction.js";
-import { beforeAll, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { TEST_CLIENT } from "../../../test/src/test-clients.js";
-import { setThirdwebDomains } from "../../utils/domains.js";
-import type { Account } from "../interfaces/wallet.js";
+import { base } from "../../chains/chain-definitions/base.js";
+import { celo } from "../../chains/chain-definitions/celo.js";
+import { defineChain } from "../../chains/utils.js";
+import { sendTransaction } from "../../transaction/actions/send-transaction.js";
+import { prepareTransaction } from "../../transaction/prepare-transaction.js";
+import type { Address } from "../../utils/address.js";
 import { privateKeyToAccount } from "../private-key.js";
+import { getWalletBalance } from "../utils/getWalletBalance.js";
+import { TokenPaymaster } from "./lib/constants.js";
 import { smartWallet } from "./smart-wallet.js";
-
-let personalAccount: Account;
 
 const client = TEST_CLIENT;
 
 describe.runIf(process.env.TW_SECRET_KEY).skip.sequential(
-  "SmartWallet policy tests",
+  "SmartWallet token paymaster tests",
   {
     retry: 0,
     timeout: 240_000,
   },
   () => {
-    beforeAll(async () => {
-      setThirdwebDomains({
-        rpc: "rpc.thirdweb-dev.com",
-        storage: "storage.thirdweb-dev.com",
-        bundler: "bundler.thirdweb-dev.com",
-      });
-      personalAccount = await privateKeyToAccount({
+    it.skip("should send a transaction with base usdc", async () => {
+      const chain = base;
+      const tokenPaymaster = TokenPaymaster.BASE_USDC;
+      const personalAccount = privateKeyToAccount({
         client,
         privateKey:
           "edf401e8ddbb743f3353b055081cb220ce4c5c04e08da162d86e0dba7c6f0f01", // 0xa470E7c88611364f55B2d7912613e10AF2eA918D
       });
-    });
-
-    it("can self transfer with BASE_USDC", async () => {
       const wallet = smartWallet({
-        chain: base,
+        chain,
         gasless: true,
         overrides: {
-          tokenPaymaster: "BASE_USDC",
+          tokenPaymaster,
         },
       });
       const smartAccount = await wallet.connect({
         client: TEST_CLIENT,
         personalAccount,
       });
-
-      console.log("smartAccount", smartAccount.address);
-
+      const smartWalletAddress = smartAccount.address as Address;
+      console.log("smartWalletAddress", smartWalletAddress);
+      console.log(
+        "balance before",
+        await getWalletBalance({
+          address: smartAccount.address,
+          chain: chain,
+          client,
+          tokenAddress: tokenPaymaster.tokenAddress,
+        }),
+      );
       const tx = prepareTransaction({
         client,
-        chain: base,
+        chain,
         to: smartAccount.address,
         value: 0n,
       });
@@ -58,6 +61,119 @@ describe.runIf(process.env.TW_SECRET_KEY).skip.sequential(
         account: smartAccount,
       });
       expect(receipt.transactionHash).toBeDefined();
+      console.log(
+        "balance after",
+        await getWalletBalance({
+          address: smartAccount.address,
+          chain: chain,
+          client,
+          tokenAddress: tokenPaymaster.tokenAddress,
+        }),
+      );
+    });
+
+    it.skip("should send a transaction with base celo", async () => {
+      const chain = celo;
+      const tokenPaymaster = TokenPaymaster.CELO_CUSD;
+      const personalAccount = privateKeyToAccount({
+        client,
+        privateKey:
+          "edf401e8ddbb743f3353b055081cb220ce4c5c04e08da162d86e0dba7c6f0f01", // 0xa470E7c88611364f55B2d7912613e10AF2eA918D
+      });
+      const wallet = smartWallet({
+        chain,
+        gasless: true,
+        overrides: {
+          tokenPaymaster,
+        },
+      });
+      const smartAccount = await wallet.connect({
+        client: TEST_CLIENT,
+        personalAccount,
+      });
+      const smartWalletAddress = smartAccount.address as Address;
+      console.log("smartWalletAddress", smartWalletAddress);
+      console.log(
+        "balance before",
+        await getWalletBalance({
+          address: smartAccount.address,
+          chain: chain,
+          client,
+          tokenAddress: tokenPaymaster.tokenAddress,
+        }),
+      );
+      const tx = prepareTransaction({
+        client,
+        chain,
+        to: smartAccount.address,
+        value: 0n,
+      });
+      const receipt = await sendTransaction({
+        transaction: tx,
+        account: smartAccount,
+      });
+      expect(receipt.transactionHash).toBeDefined();
+      console.log(
+        "balance after",
+        await getWalletBalance({
+          address: smartAccount.address,
+          chain: chain,
+          client,
+          tokenAddress: tokenPaymaster.tokenAddress,
+        }),
+      );
+    });
+
+    it("should send a transaction with base lisk", async () => {
+      const chain = defineChain(1135);
+      const tokenPaymaster = TokenPaymaster.LISK_LSK;
+      const personalAccount = privateKeyToAccount({
+        client,
+        privateKey:
+          "edf401e8ddbb743f3353b055081cb220ce4c5c04e08da162d86e0dba7c6f0f01", // 0xa470E7c88611364f55B2d7912613e10AF2eA918D
+      });
+      const wallet = smartWallet({
+        chain,
+        gasless: true,
+        overrides: {
+          tokenPaymaster,
+        },
+      });
+      const smartAccount = await wallet.connect({
+        client: TEST_CLIENT,
+        personalAccount,
+      });
+      const smartWalletAddress = smartAccount.address as Address;
+      console.log("smartWalletAddress", smartWalletAddress);
+      console.log(
+        "balance before",
+        await getWalletBalance({
+          address: smartAccount.address,
+          chain: chain,
+          client,
+          tokenAddress: tokenPaymaster.tokenAddress,
+        }),
+      );
+      const tx = prepareTransaction({
+        client,
+        chain,
+        to: smartAccount.address,
+        value: 0n,
+      });
+      const receipt = await sendTransaction({
+        transaction: tx,
+        account: smartAccount,
+      });
+      expect(receipt.transactionHash).toBeDefined();
+      console.log(
+        "balance after",
+        await getWalletBalance({
+          address: smartAccount.address,
+          chain: chain,
+          client,
+          tokenAddress: tokenPaymaster.tokenAddress,
+        }),
+      );
     });
   },
 );

--- a/packages/thirdweb/src/wallets/smart/smart-wallet-tokenpaymaster.test.ts
+++ b/packages/thirdweb/src/wallets/smart/smart-wallet-tokenpaymaster.test.ts
@@ -5,9 +5,7 @@ import { celo } from "../../chains/chain-definitions/celo.js";
 import { defineChain } from "../../chains/utils.js";
 import { sendTransaction } from "../../transaction/actions/send-transaction.js";
 import { prepareTransaction } from "../../transaction/prepare-transaction.js";
-import type { Address } from "../../utils/address.js";
 import { privateKeyToAccount } from "../private-key.js";
-import { getWalletBalance } from "../utils/getWalletBalance.js";
 import { TokenPaymaster } from "./lib/constants.js";
 import { smartWallet } from "./smart-wallet.js";
 
@@ -39,17 +37,6 @@ describe.runIf(process.env.TW_SECRET_KEY).skip.sequential(
         client: TEST_CLIENT,
         personalAccount,
       });
-      const smartWalletAddress = smartAccount.address as Address;
-      console.log("smartWalletAddress", smartWalletAddress);
-      console.log(
-        "balance before",
-        await getWalletBalance({
-          address: smartAccount.address,
-          chain: chain,
-          client,
-          tokenAddress: tokenPaymaster.tokenAddress,
-        }),
-      );
       const tx = prepareTransaction({
         client,
         chain,
@@ -61,15 +48,6 @@ describe.runIf(process.env.TW_SECRET_KEY).skip.sequential(
         account: smartAccount,
       });
       expect(receipt.transactionHash).toBeDefined();
-      console.log(
-        "balance after",
-        await getWalletBalance({
-          address: smartAccount.address,
-          chain: chain,
-          client,
-          tokenAddress: tokenPaymaster.tokenAddress,
-        }),
-      );
     });
 
     it.skip("should send a transaction with base celo", async () => {
@@ -91,17 +69,6 @@ describe.runIf(process.env.TW_SECRET_KEY).skip.sequential(
         client: TEST_CLIENT,
         personalAccount,
       });
-      const smartWalletAddress = smartAccount.address as Address;
-      console.log("smartWalletAddress", smartWalletAddress);
-      console.log(
-        "balance before",
-        await getWalletBalance({
-          address: smartAccount.address,
-          chain: chain,
-          client,
-          tokenAddress: tokenPaymaster.tokenAddress,
-        }),
-      );
       const tx = prepareTransaction({
         client,
         chain,
@@ -113,15 +80,6 @@ describe.runIf(process.env.TW_SECRET_KEY).skip.sequential(
         account: smartAccount,
       });
       expect(receipt.transactionHash).toBeDefined();
-      console.log(
-        "balance after",
-        await getWalletBalance({
-          address: smartAccount.address,
-          chain: chain,
-          client,
-          tokenAddress: tokenPaymaster.tokenAddress,
-        }),
-      );
     });
 
     it("should send a transaction with base lisk", async () => {
@@ -143,17 +101,6 @@ describe.runIf(process.env.TW_SECRET_KEY).skip.sequential(
         client: TEST_CLIENT,
         personalAccount,
       });
-      const smartWalletAddress = smartAccount.address as Address;
-      console.log("smartWalletAddress", smartWalletAddress);
-      console.log(
-        "balance before",
-        await getWalletBalance({
-          address: smartAccount.address,
-          chain: chain,
-          client,
-          tokenAddress: tokenPaymaster.tokenAddress,
-        }),
-      );
       const tx = prepareTransaction({
         client,
         chain,
@@ -165,15 +112,6 @@ describe.runIf(process.env.TW_SECRET_KEY).skip.sequential(
         account: smartAccount,
       });
       expect(receipt.transactionHash).toBeDefined();
-      console.log(
-        "balance after",
-        await getWalletBalance({
-          address: smartAccount.address,
-          chain: chain,
-          client,
-          tokenAddress: tokenPaymaster.tokenAddress,
-        }),
-      );
     });
   },
 );

--- a/packages/thirdweb/src/wallets/smart/smart-wallet.ts
+++ b/packages/thirdweb/src/wallets/smart/smart-wallet.ts
@@ -118,7 +118,7 @@ import { getDefaultAccountFactory } from "./lib/constants.js";
  *    accountAddress: "0x...", // override account address
  *    accountSalt: "0x...", // override account salt
  *    entrypointAddress: "0x...", // override entrypoint address
- *    erc20Paymaster: "BASE_USDC", // enable erc20 paymaster
+ *    tokenPaymaster: TokenPaymaster.BASE_USDC, // enable erc20 paymaster
  *    bundlerUrl: "https://...", // override bundler url
  *    paymaster: (userOp) => { ... }, // override paymaster
  *    ...

--- a/packages/thirdweb/src/wallets/smart/smart-wallet.ts
+++ b/packages/thirdweb/src/wallets/smart/smart-wallet.ts
@@ -118,7 +118,7 @@ import { getDefaultAccountFactory } from "./lib/constants.js";
  *    accountAddress: "0x...", // override account address
  *    accountSalt: "0x...", // override account salt
  *    entrypointAddress: "0x...", // override entrypoint address
- *    erc20Paymaster: { ... }, // enable erc20 paymaster
+ *    erc20Paymaster: "BASE_USDC", // enable erc20 paymaster
  *    bundlerUrl: "https://...", // override bundler url
  *    paymaster: (userOp) => { ... }, // override paymaster
  *    ...

--- a/packages/thirdweb/src/wallets/smart/types.ts
+++ b/packages/thirdweb/src/wallets/smart/types.ts
@@ -12,7 +12,7 @@ export type TokenPaymasterConfig = {
   chainId: number;
   paymasterAddress: string;
   tokenAddress: string;
-  balanceStorageSlot: number;
+  balanceStorageSlot: bigint;
 };
 
 export type SmartWalletOptions = Prettify<
@@ -24,25 +24,21 @@ export type SmartWalletOptions = Prettify<
       accountAddress?: string;
       accountSalt?: string;
       entrypointAddress?: string;
-      tokenPaymaster?:
-        | "BASE_USDC"
-        | "CELO_CUSD"
-        | "LISK_LSK"
-        | TokenPaymasterConfig;
+      tokenPaymaster?: TokenPaymasterConfig;
       paymaster?: (
-        userOp: UserOperationV06 | UserOperationV07
+        userOp: UserOperationV06 | UserOperationV07,
       ) => Promise<PaymasterResult>;
       predictAddress?: (factoryContract: ThirdwebContract) => Promise<string>;
       createAccount?: (
-        factoryContract: ThirdwebContract
+        factoryContract: ThirdwebContract,
       ) => PreparedTransaction;
       execute?: (
         accountContract: ThirdwebContract,
-        transaction: SendTransactionOption
+        transaction: SendTransactionOption,
       ) => PreparedTransaction;
       executeBatch?: (
         accountContract: ThirdwebContract,
-        transactions: SendTransactionOption[]
+        transactions: SendTransactionOption[],
       ) => PreparedTransaction;
       getAccountNonce?: (accountContract: ThirdwebContract) => Promise<bigint>;
     };
@@ -212,7 +208,7 @@ export type UserOperationReceipt = {
 };
 
 export function formatUserOperationReceipt(
-  userOpReceiptRaw: UserOperationReceipt
+  userOpReceiptRaw: UserOperationReceipt,
 ) {
   const { receipt: transactionReceipt } = userOpReceiptRaw;
 

--- a/packages/thirdweb/src/wallets/smart/types.ts
+++ b/packages/thirdweb/src/wallets/smart/types.ts
@@ -8,6 +8,13 @@ import type { Hex } from "../../utils/encoding/hex.js";
 import type { Prettify } from "../../utils/type-utils.js";
 import type { Account, SendTransactionOption } from "../interfaces/wallet.js";
 
+export type TokenPaymasterConfig = {
+  chainId: number;
+  paymasterAddress: string;
+  tokenAddress: string;
+  balanceStorageSlot: number;
+};
+
 export type SmartWalletOptions = Prettify<
   {
     chain: Chain; // TODO consider making default chain optional
@@ -17,24 +24,25 @@ export type SmartWalletOptions = Prettify<
       accountAddress?: string;
       accountSalt?: string;
       entrypointAddress?: string;
-      erc20Paymaster?: {
-        address: string;
-        token: string;
-      };
+      tokenPaymaster?:
+        | "BASE_USDC"
+        | "CELO_CUSD"
+        | "LISK_LSK"
+        | TokenPaymasterConfig;
       paymaster?: (
-        userOp: UserOperationV06 | UserOperationV07,
+        userOp: UserOperationV06 | UserOperationV07
       ) => Promise<PaymasterResult>;
       predictAddress?: (factoryContract: ThirdwebContract) => Promise<string>;
       createAccount?: (
-        factoryContract: ThirdwebContract,
+        factoryContract: ThirdwebContract
       ) => PreparedTransaction;
       execute?: (
         accountContract: ThirdwebContract,
-        transaction: SendTransactionOption,
+        transaction: SendTransactionOption
       ) => PreparedTransaction;
       executeBatch?: (
         accountContract: ThirdwebContract,
-        transactions: SendTransactionOption[],
+        transactions: SendTransactionOption[]
       ) => PreparedTransaction;
       getAccountNonce?: (accountContract: ThirdwebContract) => Promise<bigint>;
     };
@@ -204,7 +212,7 @@ export type UserOperationReceipt = {
 };
 
 export function formatUserOperationReceipt(
-  userOpReceiptRaw: UserOperationReceipt,
+  userOpReceiptRaw: UserOperationReceipt
 ) {
   const { receipt: transactionReceipt } = userOpReceiptRaw;
 


### PR DESCRIPTION
## Problem solved

CNCT-1921

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces support for `ERC20` Token Paymasters in `Smart Wallets`, allowing users to utilize different token paymasters for transactions.

### Detailed summary
- Added `TokenPaymaster` constants for `BASE_USDC`, `CELO_CUSD`, and `LISK_LSK`.
- Replaced `erc20Paymaster` with `tokenPaymaster` in `SmartWalletOptions`.
- Updated `estimateUserOpGas` function to include `stateOverrides`.
- Enhanced `createSmartAccount` to validate token paymaster usage.
- Implemented tests for transactions using different token paymasters.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->