### PR TITLE
fixes: DASH-541

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/profile/[addressOrEns]/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/profile/[addressOrEns]/page.tsx
@@ -44,42 +44,13 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
     return notFound();
   }
 
-  const publisherProfile = await fetchPublisherProfile(
-    resolvedInfo.address,
-  ).catch(() => null);
-
-  if (!publisherProfile) {
-    return notFound();
-  }
-
   const displayName = shortenIfAddress(
     resolvedInfo.ensName || resolvedInfo.address,
   ).replace("deployer.thirdweb.eth", "thirdweb.eth");
 
-  // TODO - move this to opengraph-image.tsx
-  // this is not working even on prod
-  // const ogImageLink = ProfileOG.toUrl({
-  //   displayName,
-  //   bio: publisherProfile.bio,
-  //   avatar: publisherProfile.avatar,
-  // });
-
   return {
     title: displayName,
     description: `Visit ${displayName}'s profile. See their published contracts and deploy them in one click.`,
-    // openGraph: {
-    //   title: displayName,
-    //   images: ogImageLink
-    //     ? [
-    //         {
-    //           url: ogImageLink.toString(),
-    //           alt: `${displayName}'s profile on thirdweb.com`,
-    //           width: 1200,
-    //           height: 630,
-    //         },
-    //       ]
-    //     : undefined,
-    // },
   };
 }
 

--- a/apps/dashboard/src/components/contract-components/publisher/masked-avatar.tsx
+++ b/apps/dashboard/src/components/contract-components/publisher/masked-avatar.tsx
@@ -28,6 +28,13 @@ export const PublisherAvatar: React.FC<PublisherAvatarProps> = ({
     client,
   });
 
+  if (
+    !(isPending || ensQuery.isPending || publisherProfile.isPending) &&
+    !publisherImageUrl
+  ) {
+    return null;
+  }
+
   return (
     <MaskedAvatar
       isPending={isPending || ensQuery.isPending || publisherProfile.isPending}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on improving the handling of the `MaskedAvatar` component's rendering logic and cleaning up the profile page by removing unused code related to Open Graph image generation.

### Detailed summary
- Added a conditional check to return `null` for `MaskedAvatar` if certain states are pending and `publisherImageUrl` is not available.
- Removed the fetching of `publisherProfile` and handling for cases where it is not found.
- Deleted commented-out code related to Open Graph image generation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->