### PR TITLE
fix: defaultChainId should be validated in `refine`

### DIFF
--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/components/client/auth-options-form.client.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/components/client/auth-options-form.client.tsx
@@ -86,9 +86,11 @@ export function AuthOptionsForm({ ecosystem }: { ecosystem: Ecosystem }) {
             .optional(),
           useSmartAccount: z.boolean(),
           sponsorGas: z.boolean(),
-          defaultChainId: z.coerce.number({
-            invalid_type_error: "Please enter a valid chain ID",
-          }),
+          defaultChainId: z.coerce
+            .number({
+              invalid_type_error: "Please enter a valid chain ID",
+            })
+            .optional(),
           accountFactoryType: z.enum(["v0.6", "v0.7", "custom"]),
           customAccountFactoryAddress: z.string().optional(),
         })
@@ -106,6 +108,18 @@ export function AuthOptionsForm({ ecosystem }: { ecosystem: Ecosystem }) {
           {
             message: "Please enter a valid custom account factory address",
             path: ["customAccountFactoryAddress"],
+          },
+        )
+        .refine(
+          (data) => {
+            if (data.useSmartAccount && (data.defaultChainId ?? 0) <= 0) {
+              return false;
+            }
+            return true;
+          },
+          {
+            message: "Please enter a valid chain ID",
+            path: ["defaultChainId"],
           },
         )
         .refine(

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/components/client/update-partner-modal.client.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/components/client/update-partner-modal.client.tsx
@@ -19,7 +19,7 @@ export function UpdatePartnerModal({
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger>{children}</DialogTrigger>
+      <DialogTrigger asChild>{children}</DialogTrigger>
       <DialogContent className="z-[10001]" dialogOverlayClassName="z-[10000]">
         <DialogHeader className="mb-2">
           <DialogTitle>Update {partner.name}</DialogTitle>


### PR DESCRIPTION
https://linear.app/thirdweb/issue/DASH-546/can-not-update-ecosystem-settings-form-if-default-chain-id-is-not-set

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on enhancing the validation logic in the `AuthOptionsForm` component and making a minor adjustment to the `DialogTrigger` in the `update-partner-modal.client.tsx`.

### Detailed summary
- Changed `DialogTrigger` to use `asChild` prop in `update-partner-modal.client.tsx`.
- Modified `defaultChainId` to be optional in `auth-options-form.client.tsx`.
- Added a refinement to validate `defaultChainId` based on `useSmartAccount` in `auth-options-form.client.tsx`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->