### PR TITLE
fix: client analytics for ecosystem wallet

### DIFF
--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/analytics/components/EcosystemAnalyticsPage.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/analytics/components/EcosystemAnalyticsPage.tsx
@@ -7,16 +7,16 @@ import { getEcosystemWalletUsage } from "data/analytics/wallets/ecosystem";
 import { EcosystemWalletUsersChartCard } from "./EcosystemWalletUsersChartCard";
 
 export async function EcosystemAnalyticsPage({
-  ecosystemId,
+  ecosystemSlug,
   interval,
   range,
-}: { ecosystemId: string; interval: "day" | "week"; range?: Range }) {
+}: { ecosystemSlug: string; interval: "day" | "week"; range?: Range }) {
   if (!range) {
     range = getLastNDaysRange("last-120");
   }
 
   const stats = await getEcosystemWalletUsage({
-    ecosystemId,
+    ecosystemSlug,
     from: range.from,
     to: range.to,
     period: interval,

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/analytics/page.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/analytics/page.tsx
@@ -22,7 +22,7 @@ export default async function Page(props: {
   const ecosystem = await getEcosystem(params.slug);
   return (
     <EcosystemAnalyticsPage
-      ecosystemId={ecosystem.id}
+      ecosystemSlug={ecosystem.slug}
       interval={searchParams.interval || "week"}
       range={searchParams.range}
     />

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/components/EcosystemSlugLayout.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/components/EcosystemSlugLayout.tsx
@@ -33,14 +33,14 @@ export async function EcosystemLayoutSlug({
   }
 
   const allTimeStatsPromise = getEcosystemWalletUsage({
-    ecosystemId: ecosystem.id,
+    ecosystemSlug: ecosystem.slug,
     from: new Date(2022, 0, 1),
     to: new Date(),
     period: "all",
   });
 
   const monthlyStatsPromise = getEcosystemWalletUsage({
-    ecosystemId: ecosystem.id,
+    ecosystemSlug: ecosystem.slug,
     from: new Date(new Date().getFullYear(), new Date().getMonth(), 1),
     to: new Date(),
     period: "month",

--- a/apps/dashboard/src/data/analytics/wallets/ecosystem.ts
+++ b/apps/dashboard/src/data/analytics/wallets/ecosystem.ts
@@ -2,12 +2,12 @@ import type { EcosystemWalletStats } from "types/analytics";
 import { fetchAnalytics } from "../fetch-analytics";
 
 export async function getEcosystemWalletUsage(args: {
-  ecosystemId: string;
+  ecosystemSlug: string;
   from?: Date;
   to?: Date;
   period?: "day" | "week" | "month" | "year" | "all";
 }) {
-  const { ecosystemId, from, to, period } = args;
+  const { ecosystemSlug, from, to, period } = args;
 
   const searchParams = new URLSearchParams();
   if (from) {
@@ -20,7 +20,7 @@ export async function getEcosystemWalletUsage(args: {
     searchParams.append("period", period);
   }
   const res = await fetchAnalytics(
-    `v1/wallets/ecosystem/${ecosystemId}?${searchParams.toString()}`,
+    `v1/wallets/ecosystem/${ecosystemSlug}?${searchParams.toString()}`,
     {
       method: "GET",
       headers: {
@@ -30,7 +30,7 @@ export async function getEcosystemWalletUsage(args: {
   );
 
   if (res?.status !== 200) {
-    console.error("Failed to fetch in-app wallet stats");
+    console.error("Failed to fetch ecosystem wallet stats");
     return null;
   }
 


### PR DESCRIPTION
https://linear.app/thirdweb/issue/CNCT-2526/analytics-discrepancy-after-migration-to-ecosystem-wallets

This fixes for all queries from Nov onwards.

We have to think of a solution to backfill for data stretching before Nov if customers ask for it

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on changing the parameter used to identify ecosystems from `ecosystemId` to `ecosystemSlug` across various components and functions, enhancing clarity and consistency in the codebase.

### Detailed summary
- Updated `EcosystemAnalyticsPage` to use `ecosystemSlug` instead of `ecosystemId`.
- Modified calls to `getEcosystemWalletUsage` in `EcosystemSlugLayout` to use `ecosystemSlug`.
- Changed the parameter in the `EcosystemAnalyticsPage` function signature from `ecosystemId` to `ecosystemSlug`.
- Adjusted the `getEcosystemWalletUsage` function to accept `ecosystemSlug` instead of `ecosystemId`.
- Updated the fetch URL in `getEcosystemWalletUsage` to reflect the change to `ecosystemSlug`.
- Changed error logging message to specify "ecosystem wallet stats".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->