### PR TITLE
add zero address fallback for publisher header

### DIFF
--- a/apps/dashboard/src/components/contract-components/publisher/publisher-header.tsx
+++ b/apps/dashboard/src/components/contract-components/publisher/publisher-header.tsx
@@ -4,6 +4,7 @@ import { useThirdwebClient } from "@/constants/thirdweb.client";
 import { Flex, Skeleton } from "@chakra-ui/react";
 import { useTrack } from "hooks/analytics/useTrack";
 import { replaceDeployerAddress } from "lib/publisher-utils";
+import { ZERO_ADDRESS } from "thirdweb";
 import {
   AccountAddress,
   AccountAvatar,
@@ -41,7 +42,11 @@ export const PublisherHeader: React.FC<PublisherHeaderProps> = ({
           Published by
         </Heading>
 
-        <AccountProvider address={ensQuery.data?.address || ""} client={client}>
+        <AccountProvider
+          // passing zero address during loading time to prevent the component from crashing
+          address={ensQuery.data?.address || ZERO_ADDRESS}
+          client={client}
+        >
           <div className="flex items-center gap-4">
             <Link
               href={replaceDeployerAddress(


### PR DESCRIPTION
fixes: DASH-563

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the `PublisherHeader` component by handling loading states more gracefully through the use of a placeholder address.

### Detailed summary
- Added import for `ZERO_ADDRESS` from `thirdweb`.
- Modified the `address` prop of `AccountProvider` to use `ZERO_ADDRESS` during loading, preventing the component from crashing when the actual address is not yet available.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->