### PR TITLE
[Dashboard] Add a form to let user manually input data for Marketplace listings

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/(marketplace)/components/list-button.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/(marketplace)/components/list-button.tsx
@@ -8,8 +8,12 @@ import {
   SheetTitle,
   SheetTrigger,
 } from "@/components/ui/sheet";
+import { TabButtons } from "@/components/ui/tabs";
 import { ListerOnly } from "@3rdweb-sdk/react/components/roles/lister-only";
 import type { Account } from "@3rdweb-sdk/react/hooks/useApi";
+import { isAlchemySupported } from "lib/wallet/nfts/alchemy";
+import { isMoralisSupported } from "lib/wallet/nfts/moralis";
+import { isSimpleHashSupported } from "lib/wallet/nfts/simpleHash";
 import { PlusIcon } from "lucide-react";
 import { useState } from "react";
 import type { ThirdwebContract } from "thirdweb";
@@ -23,6 +27,8 @@ interface CreateListingButtonProps {
   twAccount: Account | undefined;
 }
 
+const LISTING_MODES = ["Select NFT", "Manual"] as const;
+
 export const CreateListingButton: React.FC<CreateListingButtonProps> = ({
   createText = "Create",
   type,
@@ -32,7 +38,13 @@ export const CreateListingButton: React.FC<CreateListingButtonProps> = ({
 }) => {
   const address = useActiveAccount()?.address;
   const [open, setOpen] = useState(false);
-
+  const [listingMode, setListingMode] =
+    useState<(typeof LISTING_MODES)[number]>("Select NFT");
+  const isSupportedChain =
+    contract.chain.id &&
+    (isSimpleHashSupported(contract.chain.id) ||
+      isAlchemySupported(contract.chain.id) ||
+      isMoralisSupported(contract.chain.id));
   return (
     <ListerOnly contract={contract}>
       <Sheet open={open} onOpenChange={setOpen}>
@@ -43,15 +55,47 @@ export const CreateListingButton: React.FC<CreateListingButtonProps> = ({
         </SheetTrigger>
         <SheetContent className="w-full overflow-y-auto sm:min-w-[540px] lg:min-w-[700px]">
           <SheetHeader>
-            <SheetTitle className="mb-5 text-left">{createText}</SheetTitle>
+            <SheetTitle className="mb-3 text-left">{createText}</SheetTitle>
           </SheetHeader>
-          <CreateListingsForm
-            twAccount={twAccount}
-            contract={contract}
-            type={type}
-            actionText={createText}
-            setOpen={setOpen}
-          />
+          {/*
+          If the chain is not supported by the indexer providers
+          we don't show the tabs, we only show the Manual input form.
+          Otherwise we show both */}
+          {isSupportedChain ? (
+            <>
+              <TabButtons
+                tabs={LISTING_MODES.map((mode) => ({
+                  name: mode,
+                  isActive: mode === listingMode,
+                  onClick: () => setListingMode(mode),
+                  isEnabled: true,
+                }))}
+                tabClassName="text-sm gap-2 !text-sm"
+                tabContainerClassName="gap-0.5"
+              />
+              <div className="mt-5">
+                <CreateListingsForm
+                  twAccount={twAccount}
+                  contract={contract}
+                  type={type}
+                  actionText={createText}
+                  setOpen={setOpen}
+                  mode={listingMode === "Select NFT" ? "automatic" : "manual"}
+                />
+              </div>
+            </>
+          ) : (
+            <div className="mt-5">
+              <CreateListingsForm
+                twAccount={twAccount}
+                contract={contract}
+                type={type}
+                actionText={createText}
+                setOpen={setOpen}
+                mode="manual"
+              />
+            </div>
+          )}
         </SheetContent>
       </Sheet>
     </ListerOnly>

--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/(marketplace)/components/list-form.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/(marketplace)/components/list-form.tsx
@@ -37,10 +37,14 @@ import {
 import { decimals } from "thirdweb/extensions/erc20";
 import {
   isApprovedForAll as isApprovedForAll721,
+  isERC721,
+  ownerOf,
   setApprovalForAll as setApprovalForAll721,
 } from "thirdweb/extensions/erc721";
 import {
+  balanceOf,
   isApprovedForAll as isApprovedForAll1155,
+  isERC1155,
   setApprovalForAll as setApprovalForAll1155,
 } from "thirdweb/extensions/erc1155";
 import { createAuction, createListing } from "thirdweb/extensions/marketplace";
@@ -49,6 +53,7 @@ import type {
   CreateListingParams,
 } from "thirdweb/extensions/marketplace";
 import { useActiveAccount, useSendAndConfirmTransaction } from "thirdweb/react";
+import { shortenAddress } from "thirdweb/utils";
 import { FormErrorMessage, FormHelperText, FormLabel } from "tw-components";
 import { NFTMediaWithEmptyState } from "tw-components/nft-media";
 import { shortenIfAddress } from "utils/usedapp-external";
@@ -78,6 +83,7 @@ type CreateListingsFormProps = {
   contract: ThirdwebContract;
   actionText: string;
   setOpen: Dispatch<SetStateAction<boolean>>;
+  mode: "automatic" | "manual";
   type?: "direct-listings" | "english-auctions";
   twAccount: Account | undefined;
 };
@@ -98,6 +104,7 @@ export const CreateListingsForm: React.FC<CreateListingsFormProps> = ({
   actionText,
   setOpen,
   twAccount,
+  mode,
 }) => {
   const trackEvent = useTrack();
   const chainId = contract.chain.id;
@@ -162,7 +169,8 @@ export const CreateListingsForm: React.FC<CreateListingsFormProps> = ({
         !selectedContract ||
         isSupportedChain ||
         isWalletNFTsLoading ||
-        (walletNFTs?.result || []).length > 0,
+        (walletNFTs?.result || []).length > 0 ||
+        mode === "manual",
     });
 
   const isSelected = (nft: WalletNFT) => {
@@ -208,34 +216,112 @@ export const CreateListingsForm: React.FC<CreateListingsFormProps> = ({
       className="flex flex-col gap-6 pb-16"
       id={LIST_FORM_ID}
       onSubmit={form.handleSubmit(async (formData) => {
-        if (!formData.selected || !selectedContract) {
-          return;
-        }
-
         if (!account) {
           return toast.error("No account detected");
         }
-
         setIsFormLoading(true);
-
+        let nftType: "ERC1155" | "ERC721";
+        let _selectedContract: ThirdwebContract;
+        let selectedTokenId: bigint;
+        const selectedQuantity = BigInt(formData.quantity);
         try {
+          if (mode === "manual") {
+            if (!formData.assetContractAddress) {
+              setIsFormLoading(false);
+              return toast.error("Enter a valid NFT contract address");
+            }
+            _selectedContract = getContract({
+              address: formData.assetContractAddress,
+              chain: contract.chain,
+              client: contract.client,
+            });
+            /**
+             * In manual mode we need to detect the NFT type ourselves
+             * instead of relying on the third-party providers
+             */
+            const [is721, is1155] = await Promise.all([
+              isERC721({ contract: _selectedContract }),
+              isERC1155({ contract: _selectedContract }),
+            ]);
+            if (!is721 && !is1155) {
+              setIsFormLoading(false);
+              return toast.error(
+                `Error: ${formData.assetContractAddress} is neither an ERC721 or ERC1155 contract`,
+              );
+            }
+            selectedTokenId = BigInt(formData.tokenId);
+            nftType = is721 ? "ERC721" : "ERC1155";
+            /**
+             * Also in manual mode we need to make sure the user owns the tokenId they entered
+             * For ERC1155, the owned balance must be >= the entered quantity
+             * For ERC721, the owner address must match theirs
+             */
+            if (nftType === "ERC1155") {
+              const balance = await balanceOf({
+                contract: _selectedContract,
+                tokenId: selectedTokenId,
+                owner: account.address,
+              });
+              if (balance === 0n) {
+                setIsFormLoading(false);
+                return toast.error(
+                  `You do not own any tokenId #${selectedTokenId.toString()} from the collection: ${shortenAddress(formData.assetContractAddress)}`,
+                );
+              }
+              if (balance < selectedQuantity) {
+                setIsFormLoading(false);
+                return toast.error(
+                  `The balance you own for tokenId #${selectedTokenId.toString()} is less than the quantity (you own ${balance.toString()})`,
+                );
+              }
+            } else {
+              if (selectedQuantity !== 1n) {
+                setIsFormLoading(false);
+                return toast.error(
+                  "The quantity can only be 1 for ERC721 token",
+                );
+              }
+              const owner = await ownerOf({
+                contract: _selectedContract,
+                tokenId: selectedTokenId,
+              }).catch(() => undefined);
+              if (owner?.toLowerCase() !== account.address.toLowerCase()) {
+                setIsFormLoading(false);
+                return toast.error(
+                  `You do not own the tokenId #${selectedTokenId.toString()} from the collection: ${shortenAddress(formData.assetContractAddress)}`,
+                );
+              }
+            }
+          } else {
+            if (!formData.selected || !selectedContract) {
+              setIsFormLoading(false);
+              return toast.error("Please select an NFT to list");
+            }
+            nftType = formData.selected.type;
+            _selectedContract = selectedContract;
+            selectedTokenId = BigInt(formData.selected.id);
+          }
+          /**
+           * Make sure the selected item is approved to be listed on the marketplace contract
+           * todo: We are checking "isApprovedForAll" for both erc1155 and 721.
+           * However for ERC721 there's also a function called "getApproved" which is used to check for approval status of a single token
+           * - might worth adding that logic here.
+           */
           const isNftApproved =
-            formData.selected.type === "ERC1155"
-              ? isApprovedForAll1155
-              : isApprovedForAll721;
+            nftType === "ERC1155" ? isApprovedForAll1155 : isApprovedForAll721;
           const isApproved = await isNftApproved({
-            contract: selectedContract,
+            contract: _selectedContract,
             operator: contract.address,
             owner: account.address,
           });
 
           if (!isApproved) {
             const setNftApproval =
-              formData.selected.type === "ERC1155"
+              nftType === "ERC1155"
                 ? setApprovalForAll1155
                 : setApprovalForAll721;
             const approveTx = setNftApproval({
-              contract: selectedContract,
+              contract: _selectedContract,
               operator: contract.address,
               approved: true,
             });
@@ -256,10 +342,10 @@ export const CreateListingsForm: React.FC<CreateListingsFormProps> = ({
             );
             const transaction = createListing({
               contract,
-              assetContractAddress: formData.selected.contractAddress,
-              tokenId: BigInt(formData.selected.id),
+              assetContractAddress: _selectedContract.address,
+              tokenId: selectedTokenId,
               currencyContractAddress: formData.currencyContractAddress,
-              quantity: BigInt(formData.quantity),
+              quantity: selectedQuantity,
               startTimestamp: formData.startTimestamp,
               pricePerToken: String(formData.pricePerToken),
               endTimestamp,
@@ -305,18 +391,16 @@ export const CreateListingsForm: React.FC<CreateListingsFormProps> = ({
 
             const transaction = createAuction({
               contract,
-              assetContractAddress: formData.selected.contractAddress,
-              tokenId: BigInt(formData.selected.id),
+              assetContractAddress: _selectedContract.address,
+              tokenId: selectedTokenId,
               startTimestamp: formData.startTimestamp,
               currencyContractAddress: formData.currencyContractAddress,
               endTimestamp: new Date(
                 new Date().getTime() +
                   Number.parseInt(formData.listingDurationInSeconds) * 1000,
               ),
-              minimumBidAmountWei:
-                minimumBidAmountWei * BigInt(formData.quantity),
-              buyoutBidAmountWei:
-                buyoutBidAmountWei * BigInt(formData.quantity),
+              minimumBidAmountWei: minimumBidAmountWei * selectedQuantity,
+              buyoutBidAmountWei: buyoutBidAmountWei * selectedQuantity,
             });
 
             const promise = sendAndConfirmTx.mutateAsync(transaction, {
@@ -353,116 +437,138 @@ export const CreateListingsForm: React.FC<CreateListingsFormProps> = ({
         setIsFormLoading(false);
       })}
     >
-      <FormControl>
-        <FormLabel>Select NFT</FormLabel>
-        <FormHelperText mb="8px">
-          Select the NFT you want to list for sale
-        </FormHelperText>
-        {!isSupportedChain ? (
-          <Flex flexDir="column" gap={4} mb={4}>
-            <div className="flex flex-row items-center gap-3 rounded-md border border-border border-orange-100 bg-orange-50 p-[10px] dark:border-orange-300 dark:bg-orange-300">
-              <InfoIcon className="size-6 text-orange-400 dark:text-orange-900" />
-              <p className="text-orange-800 dark:text-orange-900">
-                This chain is not supported by our NFT API yet, please enter the
-                contract address of the NFT you want to list.
-              </p>
-            </div>
-            <FormControl
-              isInvalid={!!form.formState.errors.selected?.contractAddress}
-            >
-              <FormLabel>Contract address</FormLabel>
-              <SolidityInput
-                solidityType="address"
-                formContext={form}
-                {...form.register("selected.contractAddress", {
-                  required: "Contract address is required",
-                })}
-                placeholder="0x..."
-              />
-              <FormErrorMessage>
-                {form.formState.errors.selected?.contractAddress?.message}
-              </FormErrorMessage>
-              <FormHelperText>
-                This will display all the NFTs you own from this contract.
-              </FormHelperText>
-            </FormControl>
-          </Flex>
-        ) : null}
-        {isWalletNFTsLoading ||
-        (isOwnedNFTsLoading &&
-          !isSupportedChain &&
-          form.watch("selected.contractAddress")) ? (
-          <div className="flex h-[60px] items-center justify-center">
-            <Spinner />
-          </div>
-        ) : nfts && nfts.length !== 0 ? (
-          <Flex gap={2} flexWrap="wrap">
-            {nfts?.map((nft) => {
-              return (
-                <Tooltip
-                  bg="transparent"
-                  boxShadow="none"
-                  shouldWrapChildren
-                  placement="left-end"
-                  key={nft.contractAddress + nft.id}
-                  label={
-                    <Card className="p-4">
-                      <ul>
-                        <li>
-                          <strong>Name:</strong> {nft.metadata?.name || "N/A"}
-                        </li>
-                        <li>
-                          <strong>Contract Address:</strong>{" "}
-                          {shortenIfAddress(nft.contractAddress)}
-                        </li>
-                        <li>
-                          <strong>Token ID: </strong> {nft.id.toString()}
-                        </li>
-                        <li>
-                          <strong>Token Standard: </strong> {nft.type}
-                        </li>
-                      </ul>
-                    </Card>
-                  }
+      {mode === "manual" ? (
+        <>
+          <FormControl isRequired>
+            <FormHelperText className="!mt-0 mb-5">
+              Manually enter the contract address and token ID of the NFT you
+              want to list for sale
+            </FormHelperText>
+            <FormLabel>NFT Contract Address</FormLabel>
+            <Input {...form.register("assetContractAddress")} />
+          </FormControl>
+          <FormControl isRequired>
+            <FormLabel>Token ID</FormLabel>
+            <Input {...form.register("tokenId")} />
+          </FormControl>
+        </>
+      ) : (
+        <>
+          <FormControl>
+            <FormHelperText className="!mt-0 mb-5">
+              Select the NFT you want to list for sale
+            </FormHelperText>
+            {!isSupportedChain ? (
+              <Flex flexDir="column" gap={4} mb={4}>
+                <div className="flex flex-row items-center gap-3 rounded-md border border-border border-orange-100 bg-orange-50 p-[10px] dark:border-orange-300 dark:bg-orange-300">
+                  <InfoIcon className="size-6 text-orange-400 dark:text-orange-900" />
+                  <p className="text-orange-800 dark:text-orange-900">
+                    This chain is not supported by our NFT API yet, please enter
+                    the contract address of the NFT you want to list.
+                  </p>
+                </div>
+                <FormControl
+                  isInvalid={!!form.formState.errors.selected?.contractAddress}
                 >
-                  <Box
-                    borderRadius="lg"
-                    cursor="pointer"
-                    onClick={() =>
-                      isSelected(nft)
-                        ? form.setValue("selected", undefined)
-                        : form.setValue("selected", nft)
-                    }
-                    outline={isSelected(nft) ? "3px solid" : undefined}
-                    outlineColor={isSelected(nft) ? "purple.500" : undefined}
-                    overflow="hidden"
-                  >
-                    <NFTMediaWithEmptyState
-                      metadata={nft.metadata}
-                      width="140px"
-                      height="140px"
-                      requireInteraction
-                    />
-                  </Box>
-                </Tooltip>
-              );
-            })}
-          </Flex>
-        ) : nfts && nfts.length === 0 ? (
-          <div className="flex flex-row items-center gap-3 rounded-md border border-border border-orange-100 bg-orange-50 p-[10px] dark:border-orange-300 dark:bg-orange-300">
-            <InfoIcon className="size-6 text-orange-400 dark:text-orange-900" />
-            <p className="text-orange-800 dark:text-orange-900">
-              There are no NFTs owned by this wallet. You need NFTs to create a
-              listing. You can create NFTs with thirdweb.{" "}
-              <Link href="/explore/nft" color="blue.600" target="_blank">
-                Explore NFT contracts
-              </Link>
-              .
-            </p>
-          </div>
-        ) : null}
-      </FormControl>
-      <FormControl isRequired isDisabled={noNfts}>
+                  <FormLabel>Contract address</FormLabel>
+                  <SolidityInput
+                    solidityType="address"
+                    formContext={form}
+                    {...form.register("selected.contractAddress", {
+                      required: "Contract address is required",
+                    })}
+                    placeholder="0x..."
+                  />
+                  <FormErrorMessage>
+                    {form.formState.errors.selected?.contractAddress?.message}
+                  </FormErrorMessage>
+                  <FormHelperText>
+                    This will display all the NFTs you own from this contract.
+                  </FormHelperText>
+                </FormControl>
+              </Flex>
+            ) : null}
+            {isWalletNFTsLoading ||
+            (isOwnedNFTsLoading &&
+              !isSupportedChain &&
+              form.watch("selected.contractAddress")) ? (
+              <div className="flex h-[60px] items-center justify-center">
+                <Spinner />
+              </div>
+            ) : nfts && nfts.length !== 0 ? (
+              <Flex gap={2} flexWrap="wrap">
+                {nfts?.map((nft) => {
+                  return (
+                    <Tooltip
+                      bg="transparent"
+                      boxShadow="none"
+                      shouldWrapChildren
+                      placement="left-end"
+                      key={nft.contractAddress + nft.id}
+                      label={
+                        <Card className="p-4">
+                          <ul>
+                            <li>
+                              <strong>Name:</strong>{" "}
+                              {nft.metadata?.name || "N/A"}
+                            </li>
+                            <li>
+                              <strong>Contract Address:</strong>{" "}
+                              {shortenIfAddress(nft.contractAddress)}
+                            </li>
+                            <li>
+                              <strong>Token ID: </strong> {nft.id.toString()}
+                            </li>
+                            <li>
+                              <strong>Token Standard: </strong> {nft.type}
+                            </li>
+                          </ul>
+                        </Card>
+                      }
+                    >
+                      <Box
+                        borderRadius="lg"
+                        cursor="pointer"
+                        onClick={() =>
+                          isSelected(nft)
+                            ? form.setValue("selected", undefined)
+                            : form.setValue("selected", nft)
+                        }
+                        outline={isSelected(nft) ? "3px solid" : undefined}
+                        outlineColor={
+                          isSelected(nft) ? "purple.500" : undefined
+                        }
+                        overflow="hidden"
+                      >
+                        <NFTMediaWithEmptyState
+                          metadata={nft.metadata}
+                          width="140px"
+                          height="140px"
+                          requireInteraction
+                        />
+                      </Box>
+                    </Tooltip>
+                  );
+                })}
+              </Flex>
+            ) : nfts && nfts.length === 0 ? (
+              <div className="flex flex-row items-center gap-3 rounded-md border border-border border-orange-100 bg-orange-50 p-[10px] dark:border-orange-300 dark:bg-orange-300">
+                <InfoIcon className="size-6 text-orange-400 dark:text-orange-900" />
+                <p className="text-orange-800 dark:text-orange-900">
+                  There are no NFTs owned by this wallet. You need NFTs to
+                  create a listing. You can create NFTs with thirdweb.{" "}
+                  <Link href="/explore/nft" color="blue.600" target="_blank">
+                    Explore NFT contracts
+                  </Link>
+                  .
+                </p>
+              </div>
+            ) : null}
+          </FormControl>
+        </>
+      )}
+
+      <FormControl isRequired isDisabled={mode === "automatic" && noNfts}>
         <FormLabel>Listing Currency</FormLabel>
         <CurrencySelector
           contractChainId={chainId}
@@ -475,7 +581,7 @@ export const CreateListingsForm: React.FC<CreateListingsFormProps> = ({
           The currency you want to sell your tokens for.
         </FormHelperText>
       </FormControl>
-      <FormControl isRequired isDisabled={noNfts}>
+      <FormControl isRequired isDisabled={mode === "automatic" && noNfts}>
         <FormLabel>
           {form.watch("listingType") === "auction"
             ? "Buyout Price Per Token"
@@ -489,7 +595,7 @@ export const CreateListingsForm: React.FC<CreateListingsFormProps> = ({
         </FormHelperText>
       </FormControl>
       {form.watch("selected")?.type?.toLowerCase() !== "erc721" && (
-        <FormControl isRequired isDisabled={noNfts}>
+        <FormControl isRequired isDisabled={mode === "automatic" && noNfts}>
           <div className="flex flex-row justify-between gap-2">
             <FormLabel>Quantity</FormLabel>
           </div>
@@ -501,7 +607,7 @@ export const CreateListingsForm: React.FC<CreateListingsFormProps> = ({
       )}
       {form.watch("listingType") === "auction" && (
         <>
-          <FormControl isRequired isDisabled={noNfts}>
+          <FormControl isRequired isDisabled={mode === "automatic" && noNfts}>
             <FormLabel>Reserve Price Per Token</FormLabel>
             <Input {...form.register("reservePricePerToken")} />
             <FormHelperText>
@@ -522,7 +628,7 @@ export const CreateListingsForm: React.FC<CreateListingsFormProps> = ({
         </>
       )}
 
-      {!form.watch("selected.id") && (
+      {mode === "automatic" && !form.watch("selected.id") && (
         <Alert>
           <CircleAlertIcon className="size-4" />
           <AlertTitle>No NFT selected</AlertTitle>


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `CreateListingButton` and `CreateListingsForm` components to support different listing modes for NFTs. It introduces manual input for NFT contract addresses and token IDs, and integrates checks for supported chains and NFT types.

### Detailed summary
- Added `TabButtons` for listing modes: "Select NFT" and "Manual".
- Implemented state management for `listingMode` in `CreateListingButton`.
- Conditional rendering of `CreateListingsForm` based on `listingMode`.
- Enhanced `CreateListingsForm` to handle manual NFT entry.
- Included checks for NFT type (`ERC721` or `ERC1155`) in manual mode.
- Updated approval logic for NFTs based on selected contract and token ID.
- Adjusted error handling and user feedback messages.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->