### PR TITLE
[SDK] Fix caching issue with headless UI when custom resolvers are used

### DIFF
--- a/.changeset/fluffy-pets-tie.md
+++ b/.changeset/fluffy-pets-tie.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix caching issues for headless component; improve code coverage

--- a/packages/thirdweb/src/react/web/ui/prebuilt/Chain/icon.tsx
+++ b/packages/thirdweb/src/react/web/ui/prebuilt/Chain/icon.tsx
@@ -4,6 +4,7 @@ import { type UseQueryOptions, useQuery } from "@tanstack/react-query";
 import type { JSX } from "react";
 import { getChainMetadata } from "../../../../../chains/utils.js";
 import type { ThirdwebClient } from "../../../../../client/client.js";
+import { getFunctionId } from "../../../../../utils/function-id.js";
 import { resolveScheme } from "../../../../../utils/ipfs.js";
 import { useChainContext } from "./provider.js";
 
@@ -121,7 +122,18 @@ export function ChainIcon({
 }: ChainIconProps) {
   const { chain } = useChainContext();
   const iconQuery = useQuery({
-    queryKey: ["_internal_chain_icon_", chain.id] as const,
+    queryKey: [
+      "_internal_chain_icon_",
+      chain.id,
+      {
+        resolver:
+          typeof iconResolver === "string"
+            ? iconResolver
+            : typeof iconResolver === "function"
+              ? getFunctionId(iconResolver)
+              : undefined,
+      },
+    ] as const,
     queryFn: async () => {
       if (typeof iconResolver === "string") {
         return iconResolver;

--- a/packages/thirdweb/src/react/web/ui/prebuilt/Chain/name.test.tsx
+++ b/packages/thirdweb/src/react/web/ui/prebuilt/Chain/name.test.tsx
@@ -2,17 +2,17 @@ import { describe, expect, it } from "vitest";
 import { render, screen, waitFor } from "~test/react-render.js";
 import { ethereum } from "../../../../../chains/chain-definitions/ethereum.js";
 import { defineChain } from "../../../../../chains/utils.js";
-import { ChainName } from "./name.js";
+import { ChainName, fetchChainName } from "./name.js";
 import { ChainProvider } from "./provider.js";
 
 describe.runIf(process.env.TW_SECRET_KEY)("ChainName component", () => {
-  it("should return the correct chain name, if the name exists in the chain object", () => {
+  it("should return the correct chain name, if the name exists in the chain object", async () => {
     render(
       <ChainProvider chain={ethereum}>
         <ChainName />
       </ChainProvider>,
     );
-    waitFor(() =>
+    await waitFor(() =>
       expect(
         screen.getByText("Ethereum", {
           exact: true,
@@ -22,13 +22,13 @@ describe.runIf(process.env.TW_SECRET_KEY)("ChainName component", () => {
     );
   });
 
-  it("should return the correct chain name, if the name is loaded from the server", () => {
+  it("should return the correct chain name, if the name is loaded from the server", async () => {
     render(
       <ChainProvider chain={defineChain(1)}>
         <ChainName />
       </ChainProvider>,
     );
-    waitFor(() =>
+    await waitFor(() =>
       expect(
         screen.getByText("Ethereum Mainnet", {
           exact: true,
@@ -38,13 +38,13 @@ describe.runIf(process.env.TW_SECRET_KEY)("ChainName component", () => {
     );
   });
 
-  it("should return the correct FORMATTED chain name", () => {
+  it("should return the correct FORMATTED chain name", async () => {
     render(
       <ChainProvider chain={ethereum}>
         <ChainName formatFn={(str: string) => `${str}-formatted`} />
       </ChainProvider>,
     );
-    waitFor(() =>
+    await waitFor(() =>
       expect(
         screen.getByText("Ethereum-formatted", {
           exact: true,
@@ -54,14 +54,14 @@ describe.runIf(process.env.TW_SECRET_KEY)("ChainName component", () => {
     );
   });
 
-  it("should fallback properly when fail to resolve chain name", () => {
+  it("should fallback properly when fail to resolve chain name", async () => {
     render(
       <ChainProvider chain={defineChain(-1)}>
         <ChainName fallbackComponent={<span>oops</span>} />
       </ChainProvider>,
     );
 
-    waitFor(() =>
+    await waitFor(() =>
       expect(
         screen.getByText("oops", {
           exact: true,
@@ -69,5 +69,32 @@ describe.runIf(process.env.TW_SECRET_KEY)("ChainName component", () => {
         }),
       ).toBeInTheDocument(),
     );
+  });
+
+  it("fetchChainName should respect nameResolver as a string", async () => {
+    const res = await fetchChainName({
+      chain: ethereum,
+      nameResolver: "eth_mainnet",
+    });
+    expect(res).toBe("eth_mainnet");
+  });
+
+  it("fetchChainName should respect nameResolver as a non-async function", async () => {
+    const res = await fetchChainName({
+      chain: ethereum,
+      nameResolver: () => "eth_mainnet",
+    });
+    expect(res).toBe("eth_mainnet");
+  });
+
+  it("fetchChainName should respect nameResolver as an async function", async () => {
+    const res = await fetchChainName({
+      chain: ethereum,
+      nameResolver: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 2000));
+        return "eth_mainnet";
+      },
+    });
+    expect(res).toBe("eth_mainnet");
   });
 });

--- a/packages/thirdweb/src/react/web/ui/prebuilt/NFT/description.tsx
+++ b/packages/thirdweb/src/react/web/ui/prebuilt/NFT/description.tsx
@@ -3,6 +3,7 @@
 import { type UseQueryOptions, useQuery } from "@tanstack/react-query";
 import type { JSX } from "react";
 import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { getFunctionId } from "../../../../../utils/function-id.js";
 import { useNFTContext } from "./provider.js";
 import { getNFTInfo } from "./utils.js";
 
@@ -100,7 +101,7 @@ export function NFTDescription({
           typeof descriptionResolver === "string"
             ? descriptionResolver
             : typeof descriptionResolver === "function"
-              ? descriptionResolver.toString()
+              ? getFunctionId(descriptionResolver)
               : undefined,
       },
     ],

--- a/packages/thirdweb/src/react/web/ui/prebuilt/NFT/media.tsx
+++ b/packages/thirdweb/src/react/web/ui/prebuilt/NFT/media.tsx
@@ -3,6 +3,7 @@
 import { type UseQueryOptions, useQuery } from "@tanstack/react-query";
 import type { JSX } from "react";
 import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { getFunctionId } from "../../../../../utils/function-id.js";
 import { MediaRenderer } from "../../MediaRenderer/MediaRenderer.js";
 import type { MediaRendererProps } from "../../MediaRenderer/types.js";
 import { useNFTContext } from "./provider.js";
@@ -140,7 +141,7 @@ export function NFTMedia({
           typeof mediaResolver === "object"
             ? mediaResolver
             : typeof mediaResolver === "function"
-              ? mediaResolver.toString()
+              ? getFunctionId(mediaResolver)
               : undefined,
       },
     ],

--- a/packages/thirdweb/src/react/web/ui/prebuilt/NFT/name.tsx
+++ b/packages/thirdweb/src/react/web/ui/prebuilt/NFT/name.tsx
@@ -3,6 +3,7 @@
 import { type UseQueryOptions, useQuery } from "@tanstack/react-query";
 import type { JSX } from "react";
 import type { ThirdwebContract } from "../../../../../contract/contract.js";
+import { getFunctionId } from "../../../../../utils/function-id.js";
 import { useNFTContext } from "./provider.js";
 import { getNFTInfo } from "./utils.js";
 
@@ -102,7 +103,7 @@ export function NFTName({
           typeof nameResolver === "string"
             ? nameResolver
             : typeof nameResolver === "function"
-              ? nameResolver.toString()
+              ? getFunctionId(nameResolver)
               : undefined,
       },
     ],

--- a/packages/thirdweb/src/react/web/ui/prebuilt/Token/icon.tsx
+++ b/packages/thirdweb/src/react/web/ui/prebuilt/Token/icon.tsx
@@ -6,6 +6,7 @@ import { getChainMetadata } from "../../../../../chains/utils.js";
 import { NATIVE_TOKEN_ADDRESS } from "../../../../../constants/addresses.js";
 import { getContract } from "../../../../../contract/contract.js";
 import { getContractMetadata } from "../../../../../extensions/common/read/getContractMetadata.js";
+import { getFunctionId } from "../../../../../utils/function-id.js";
 import { resolveScheme } from "../../../../../utils/ipfs.js";
 import { useTokenContext } from "./provider.js";
 
@@ -117,7 +118,19 @@ export function TokenIcon({
 }: TokenIconProps) {
   const { address, client, chain } = useTokenContext();
   const iconQuery = useQuery({
-    queryKey: ["_internal_token_icon_", chain.id, address] as const,
+    queryKey: [
+      "_internal_token_icon_",
+      chain.id,
+      address,
+      {
+        resolver:
+          typeof iconResolver === "string"
+            ? iconResolver
+            : typeof iconResolver === "function"
+              ? getFunctionId(iconResolver)
+              : undefined,
+      },
+    ] as const,
     queryFn: async () => {
       if (typeof iconResolver === "string") {
         return iconResolver;

--- a/packages/thirdweb/src/react/web/ui/prebuilt/Token/name.test.tsx
+++ b/packages/thirdweb/src/react/web/ui/prebuilt/Token/name.test.tsx
@@ -9,38 +9,38 @@ import {
 import { ethereum } from "../../../../../chains/chain-definitions/ethereum.js";
 import { NATIVE_TOKEN_ADDRESS } from "../../../../../constants/addresses.js";
 import { getFunctionId } from "../../../../../utils/function-id.js";
-import { fetchTokenSymbol, getQueryKeys } from "./symbol.js";
+import { fetchTokenName, getQueryKeys } from "./name.js";
 
 const client = TEST_CLIENT;
 
-describe.runIf(process.env.TW_SECRET_KEY)("TokenSymbol component", () => {
-  it("fetchTokenSymbol should respect the symbolResolver being a string", async () => {
-    const res = await fetchTokenSymbol({
+describe.runIf(process.env.TW_SECRET_KEY)("TokenName component", () => {
+  it("fetchTokenName should respect the nameResolver being a string", async () => {
+    const res = await fetchTokenName({
       address: "thing",
       client,
       chain: ANVIL_CHAIN,
-      symbolResolver: "tw",
+      nameResolver: "tw",
     });
     expect(res).toBe("tw");
   });
 
-  it("fetchTokenSymbol should respect the symbolResolver being a non-async function", async () => {
-    const res = await fetchTokenSymbol({
+  it("fetchTokenName should respect the nameResolver being a non-async function", async () => {
+    const res = await fetchTokenName({
       address: "thing",
       client,
       chain: ANVIL_CHAIN,
-      symbolResolver: () => "tw",
+      nameResolver: () => "tw",
     });
 
     expect(res).toBe("tw");
   });
 
-  it("fetchTokenSymbol should respect the symbolResolver being an async function", async () => {
-    const res = await fetchTokenSymbol({
+  it("fetchTokenName should respect the nameResolver being an async function", async () => {
+    const res = await fetchTokenName({
       address: "thing",
       client,
       chain: ANVIL_CHAIN,
-      symbolResolver: async () => {
+      nameResolver: async () => {
         await new Promise((resolve) => setTimeout(resolve, 2000));
         return "tw";
       },
@@ -49,45 +49,45 @@ describe.runIf(process.env.TW_SECRET_KEY)("TokenSymbol component", () => {
     expect(res).toBe("tw");
   });
 
-  it("fetchTokenSymbol should work for contract with `symbol` function", async () => {
-    const res = await fetchTokenSymbol({
+  it("fetchTokenName should work for contract with `name` function", async () => {
+    const res = await fetchTokenName({
       address: USDT_CONTRACT.address,
       client,
       chain: USDT_CONTRACT.chain,
     });
 
-    expect(res).toBe("USDT");
+    expect(res).toBe("Tether USD");
   });
 
-  it("fetchTokenSymbol should work for native token", async () => {
-    const res = await fetchTokenSymbol({
+  it("fetchTokenName should work for native token", async () => {
+    const res = await fetchTokenName({
       address: NATIVE_TOKEN_ADDRESS,
       client,
       chain: ethereum,
     });
 
-    expect(res).toBe("ETH");
+    expect(res).toBe("Ether");
   });
 
-  it("fetchTokenSymbol should try to fallback to the contract metadata if fails to resolves from `symbol()`", async () => {
-    // todo: find a contract with symbol in contractMetadata, but does not have a symbol function
+  it("fetchTokenName should try to fallback to the contract metadata if fails to resolves from `name()`", async () => {
+    // todo: find a contract with name in contractMetadata, but does not have a name function
   });
 
-  it("fetchTokenSymbol should throw in the end where all fallback solutions failed to resolve to any symbol", async () => {
+  it("fetchTokenName should throw in the end where all fallback solutions failed to resolve to any name", async () => {
     await expect(() =>
-      fetchTokenSymbol({
+      fetchTokenName({
         address: UNISWAPV3_FACTORY_CONTRACT.address,
         client,
         chain: UNISWAPV3_FACTORY_CONTRACT.chain,
       }),
     ).rejects.toThrowError(
-      "Failed to resolve symbol from both symbol() and contract metadata",
+      "Failed to resolve name from both name() and contract metadata",
     );
   });
 
   it("getQueryKeys should work without resolver", () => {
     expect(getQueryKeys({ chainId: 1, address: "0x" })).toStrictEqual([
-      "_internal_token_symbol_",
+      "_internal_token_name_",
       1,
       "0x",
       {
@@ -98,9 +98,9 @@ describe.runIf(process.env.TW_SECRET_KEY)("TokenSymbol component", () => {
 
   it("getQueryKeys should work with resolver being a string", () => {
     expect(
-      getQueryKeys({ chainId: 1, address: "0x", symbolResolver: "tw" }),
+      getQueryKeys({ chainId: 1, address: "0x", nameResolver: "tw" }),
     ).toStrictEqual([
-      "_internal_token_symbol_",
+      "_internal_token_name_",
       1,
       "0x",
       {
@@ -113,9 +113,9 @@ describe.runIf(process.env.TW_SECRET_KEY)("TokenSymbol component", () => {
     const fn = () => "tw";
     const fnId = getFunctionId(fn);
     expect(
-      getQueryKeys({ chainId: 1, address: "0x", symbolResolver: fn }),
+      getQueryKeys({ chainId: 1, address: "0x", nameResolver: fn }),
     ).toStrictEqual([
-      "_internal_token_symbol_",
+      "_internal_token_name_",
       1,
       "0x",
       {
@@ -134,10 +134,10 @@ describe.runIf(process.env.TW_SECRET_KEY)("TokenSymbol component", () => {
       getQueryKeys({
         chainId: 1,
         address: "0x",
-        symbolResolver: fn,
+        nameResolver: fn,
       }),
     ).toStrictEqual([
-      "_internal_token_symbol_",
+      "_internal_token_name_",
       1,
       "0x",
       {

--- a/packages/thirdweb/src/react/web/ui/prebuilt/Token/provider.test.tsx
+++ b/packages/thirdweb/src/react/web/ui/prebuilt/Token/provider.test.tsx
@@ -5,6 +5,7 @@ import { ethereum } from "../../../../../chains/chain-definitions/ethereum.js";
 import { NATIVE_TOKEN_ADDRESS } from "../../../../../constants/addresses.js";
 import { TokenName } from "./name.js";
 import { TokenProvider } from "./provider.js";
+import { TokenSymbol } from "./symbol.js";
 
 describe.runIf(process.env.TW_SECRET_KEY)("TokenProvider component", () => {
   it("should render children correctly", () => {
@@ -29,12 +30,22 @@ describe.runIf(process.env.TW_SECRET_KEY)("TokenProvider component", () => {
         chain={ethereum}
       >
         <TokenName />
+        <TokenSymbol />
       </TokenProvider>,
     );
 
     waitFor(() =>
       expect(
         screen.getByText("Ether", {
+          exact: true,
+          selector: "span",
+        }),
+      ).toBeInTheDocument(),
+    );
+
+    waitFor(() =>
+      expect(
+        screen.getByText("ETH", {
           exact: true,
           selector: "span",
         }),


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing caching issues for headless components and improving code coverage in the `thirdweb` package.

### Detailed summary
- Updated `nameResolver` and `descriptionResolver` in `NFTName` and `NFTDescription` to use `getFunctionId`.
- Enhanced `NFTMedia` to utilize `getFunctionId` for `mediaResolver`.
- Introduced `fetchChainName` and `fetchTokenName` functions for better name resolution.
- Added tests for `fetchChainName`, `fetchTokenName`, and `fetchTokenSymbol` to ensure proper functionality.
- Improved `getQueryKeys` to handle resolvers more effectively in both `TokenName` and `TokenSymbol`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->