### PR TITLE
fix: Add chain fallback for wallet switching

### DIFF
--- a/.changeset/tasty-emus-promise.md
+++ b/.changeset/tasty-emus-promise.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix add chain not triggering for certain wallets

--- a/packages/thirdweb/src/wallets/injected/index.ts
+++ b/packages/thirdweb/src/wallets/injected/index.ts
@@ -348,25 +348,20 @@ async function switchChain(provider: EIP1193Provider, chain: Chain) {
       method: "wallet_switchEthereumChain",
       params: [{ chainId: hexChainId }],
     });
-    // biome-ignore lint/suspicious/noExplicitAny: TODO: fix any
-  } catch (e: any) {
+  } catch {
     // if chain does not exist, add the chain
-    if (e?.code === 4902 || e?.data?.originalError?.code === 4902) {
-      const apiChain = await getChainMetadata(chain);
-      await provider.request({
-        method: "wallet_addEthereumChain",
-        params: [
-          {
-            chainId: hexChainId,
-            chainName: apiChain.name,
-            nativeCurrency: apiChain.nativeCurrency,
-            rpcUrls: getValidPublicRPCUrl(apiChain), // no client id on purpose here
-            blockExplorerUrls: apiChain.explorers?.map((x) => x.url),
-          },
-        ],
-      });
-    } else {
-      throw e;
-    }
+    const apiChain = await getChainMetadata(chain);
+    await provider.request({
+      method: "wallet_addEthereumChain",
+      params: [
+        {
+          chainId: hexChainId,
+          chainName: apiChain.name,
+          nativeCurrency: apiChain.nativeCurrency,
+          rpcUrls: getValidPublicRPCUrl(apiChain), // no client id on purpose here
+          blockExplorerUrls: apiChain.explorers?.map((x) => x.url),
+        },
+      ],
+    });
   }
 }


### PR DESCRIPTION
## Problem solved

CNCT-2609



<!-- start pr-codex -->

---

## PR-Codex overview
This PR addresses an issue where adding a blockchain network was not triggering for certain wallets. It modifies the error handling in the `wallet_addEthereumChain` process to ensure the chain is added correctly when the error code indicates it does not exist.

### Detailed summary
- Removed explicit `any` type handling in the catch block.
- Simplified error handling by removing the conditional check for error codes.
- Ensured the addition of the chain is attempted unconditionally when an error occurs.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->