### PR TITLE
chore: Add modelName, sessionId, requestId usage

### DIFF
--- a/.changeset/gold-gorillas-clap.md
+++ b/.changeset/gold-gorillas-clap.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+Add modelName, sessionId, requestId to usage

--- a/packages/service-utils/src/core/usage.ts
+++ b/packages/service-utils/src/core/usage.ts
@@ -78,5 +78,8 @@ export const usageEventSchema = z.object({
   providerIp: z.string().optional(),
   promptTokens: z.number().int().nonnegative().optional(),
   completionTokens: z.number().int().nonnegative().optional(),
+  modelName: z.string().optional(),
+  sessionId: z.string().optional(),
+  requestId: z.string().optional(),
 });
 export type UsageEvent = z.infer<typeof usageEventSchema>;


### PR DESCRIPTION
https://linear.app/thirdweb/issue/DASH-574/add-nebula-usage-tracker-events

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `usageEventSchema` in the `@thirdweb-dev/service-utils` package by adding new optional fields for better tracking of usage events.

### Detailed summary
- Added `modelName`, `sessionId`, and `requestId` as optional fields to the `usageEventSchema` in `packages/service-utils/src/core/usage.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->