### PR TITLE
fix: should always contain gas price info even if it's 0

### DIFF
--- a/.changeset/nervous-pots-smell.md
+++ b/.changeset/nervous-pots-smell.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+always include gas price information even if it's 0 for enclave wallets

--- a/packages/thirdweb/src/wallets/in-app/core/wallet/enclave-wallet.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/wallet/enclave-wallet.ts
@@ -162,7 +162,7 @@ export class EnclaveWallet implements IWebWallet {
         chainId: toHex(tx.chainId),
       };
 
-      if (tx.maxFeePerGas) {
+      if (typeof tx.maxFeePerGas === "bigint") {
         transaction.maxFeePerGas = toHex(tx.maxFeePerGas);
         transaction.maxPriorityFeePerGas =
           typeof tx.maxPriorityFeePerGas === "bigint"


### PR DESCRIPTION
https://linear.app/thirdweb/issue/CNCT-2602/issue-signing-deploy-tx-on-saakura

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on ensuring that gas price information is always included for enclave wallets, even when it is set to 0. It modifies the condition for checking `maxFeePerGas` to ensure proper handling of gas fees.

### Detailed summary
- Updated the condition for `maxFeePerGas` to check if it is of type `bigint`.
- Ensured that gas price information is always included for enclave wallets, even if it is 0.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->