### PR TITLE
[SDK] Add missing use-client directives to some components

### DIFF
--- a/packages/thirdweb/src/react/web/ui/prebuilt/Account/blobbie.tsx
+++ b/packages/thirdweb/src/react/web/ui/prebuilt/Account/blobbie.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Blobbie, type BlobbieProps } from "../../ConnectWallet/Blobbie.js";
 import { useAccountContext } from "./provider.js";
 

--- a/packages/thirdweb/src/react/web/ui/prebuilt/Account/provider.tsx
+++ b/packages/thirdweb/src/react/web/ui/prebuilt/Account/provider.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import type { Address } from "abitype";
 import type React from "react";
 import { createContext, useContext } from "react";

--- a/packages/thirdweb/src/react/web/ui/prebuilt/Chain/icon.tsx
+++ b/packages/thirdweb/src/react/web/ui/prebuilt/Chain/icon.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { type UseQueryOptions, useQuery } from "@tanstack/react-query";
 import type { JSX } from "react";
 import { getChainMetadata } from "../../../../../chains/utils.js";

--- a/packages/thirdweb/src/react/web/ui/prebuilt/NFT/media.tsx
+++ b/packages/thirdweb/src/react/web/ui/prebuilt/NFT/media.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { type UseQueryOptions, useQuery } from "@tanstack/react-query";
 import type { JSX } from "react";
 import type { ThirdwebContract } from "../../../../../contract/contract.js";

--- a/packages/thirdweb/src/react/web/ui/prebuilt/NFT/name.tsx
+++ b/packages/thirdweb/src/react/web/ui/prebuilt/NFT/name.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { type UseQueryOptions, useQuery } from "@tanstack/react-query";
 import type { JSX } from "react";
 import type { ThirdwebContract } from "../../../../../contract/contract.js";

--- a/packages/thirdweb/src/react/web/ui/prebuilt/NFT/provider.tsx
+++ b/packages/thirdweb/src/react/web/ui/prebuilt/NFT/provider.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { createContext, useContext } from "react";
 import type { ThirdwebContract } from "../../../../../contract/contract.js";
 

--- a/packages/thirdweb/src/react/web/ui/prebuilt/Token/icon.tsx
+++ b/packages/thirdweb/src/react/web/ui/prebuilt/Token/icon.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { type UseQueryOptions, useQuery } from "@tanstack/react-query";
 import type { JSX } from "react";
 import { getChainMetadata } from "../../../../../chains/utils.js";


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on organizing and refining the context and components related to `Account`, `NFT`, and `Token` functionalities in the `thirdweb` package.

### Detailed summary
- Added `useAccountContext` import in `Account/blobbie.tsx`.
- Introduced `ThirdwebContract` type in `NFT/provider.tsx`, `NFT/name.tsx`, and `NFT/media.tsx`.
- Maintained `useQuery` and `getChainMetadata` imports across `Chain/icon.tsx`, `Token/icon.tsx`, and `NFT/name.tsx`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->