### PR TITLE
fix: removed login navigation text

### DIFF
--- a/apps/dashboard/src/app/login/LoginPage.tsx
+++ b/apps/dashboard/src/app/login/LoginPage.tsx
@@ -53,9 +53,6 @@ export function LoginAndOnboardingPage(props: {
         <header className="container flex w-full flex-row items-center justify-between px-6 py-4">
           <div className="flex shrink-0 items-center gap-3">
             <ThirdwebMiniLogo className="size-7 md:size-8" />
-            <h1 className="font-medium text-lg tracking-tight md:text-xl">
-              Get started <span className="max-sm:hidden">with thirdweb</span>
-            </h1>
           </div>
 
           <div className="flex items-center gap-3">


### PR DESCRIPTION
Fixes: DASH-579
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on modifying the `LoginPage` component by removing a heading element to streamline the layout.

### Detailed summary
- Removed the `<h1>` element with the text "Get started with thirdweb" from the `LoginPage` component.
- The surrounding `<div>` elements remain unchanged, maintaining the overall structure and styling.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->