### PR TITLE
change insight auth in docs

### DIFF
--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, edited]
 
 env:
-  VALID_ISSUE_PREFIXES: "CNCT|DASH|PROT"
+  VALID_ISSUE_PREFIXES: "CNCT|DASH|PROT|INSIGHT"
 
 jobs:
   linear:

--- a/apps/portal/src/app/insight/get-started/page.mdx
+++ b/apps/portal/src/app/insight/get-started/page.mdx
@@ -16,8 +16,9 @@ In this guide we will learn how to use the events blueprint in insight.
 
 ## Pre-requisites
 
-- [Create a project](https://thirdweb.com/team) and navigate to the project settings to get a clientId
-- Use insight API with the base URL below
+- [Create a project](https://thirdweb.com/team) and navigate to the project settings to get a client ID
+- Use insight API with the base URL below.
+- To authenticate use your client ID in the `x-client-id` header or `clientId` query parameter
 
 ```
 https://<chain-id>.insight.thirdweb.com
@@ -27,7 +28,11 @@ https://<chain-id>.insight.thirdweb.com
 ```typescript
 const getUsdtTransfers = async () => {
  try {
-   const response = await fetch('https://1.insight.thirdweb.com/v1/<client-id>/events/0xdAC17F958D2ee523a2206206994597C13D831ec7/Transfer(address,address,uint256)?limit=5');
+   const response = await fetch('https://1.insight.thirdweb.com/v1/events/0xdAC17F958D2ee523a2206206994597C13D831ec7/Transfer(address,address,uint256)?limit=5', {
+    headers: {
+      'x-client-id': <YOUR_THIRDWEB_CLIENT_ID>
+    }
+   });
    const transfersInfo = await response.json();
    return transfersInfo
  } catch (error) {


### PR DESCRIPTION
## Problem solved

https://linear.app/thirdweb/issue/INSIGHT-480/improvements-required-for-insight-playground

Updated the authentication method in the Insight API documentation to use the `x-client-id` header instead of embedding the client ID in the URL path.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the configuration for issue prefixes and enhances the documentation for the `insight` API usage, including a new authentication method.

### Detailed summary
- Updated `VALID_ISSUE_PREFIXES` to include `INSIGHT`.
- Corrected the formatting of "client ID" in the Markdown file.
- Added a note on using the `client ID` in the `x-client-id` header or `clientId` query parameter.
- Modified the fetch request in the `getUsdtTransfers` function to include headers for authentication.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->