### PR TITLE
[SDK] Fix: Pay not respecting ecosystem AA

### DIFF
--- a/.changeset/lazy-games-cheat.md
+++ b/.changeset/lazy-games-cheat.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix ecosystem wallet AA detection in Pay modal

--- a/packages/thirdweb/src/react/core/utils/wallet.test.ts
+++ b/packages/thirdweb/src/react/core/utils/wallet.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import type { Wallet } from "../../../wallets/interfaces/wallet";
+import { hasSponsoredTransactionsEnabled } from "./wallet";
+
+describe("hasSponsoredTransactionsEnabled", () => {
+  it("should return false for undefined wallet", () => {
+    expect(hasSponsoredTransactionsEnabled(undefined)).toBe(false);
+  });
+
+  it("should handle smart wallet with sponsorGas config", () => {
+    const mockSmartWallet = {
+      id: "smart",
+      getConfig: () => ({ sponsorGas: true }),
+    } as Wallet;
+    expect(hasSponsoredTransactionsEnabled(mockSmartWallet)).toBe(true);
+
+    const mockSmartWalletDisabled = {
+      id: "smart",
+      getConfig: () => ({ sponsorGas: false }),
+    } as Wallet;
+    expect(hasSponsoredTransactionsEnabled(mockSmartWalletDisabled)).toBe(
+      false,
+    );
+  });
+
+  it("should handle smart wallet with gasless config", () => {
+    const mockSmartWallet = {
+      id: "smart",
+      getConfig: () => ({ gasless: true }),
+    } as Wallet;
+    expect(hasSponsoredTransactionsEnabled(mockSmartWallet)).toBe(true);
+  });
+
+  it("should handle inApp wallet with smartAccount config", () => {
+    const mockInAppWallet = {
+      id: "inApp",
+      getConfig: () => ({
+        smartAccount: {
+          sponsorGas: true,
+        },
+      }),
+    } as Wallet;
+    expect(hasSponsoredTransactionsEnabled(mockInAppWallet)).toBe(true);
+
+    const mockInAppWalletDisabled = {
+      id: "inApp",
+      getConfig: () => ({
+        smartAccount: {
+          sponsorGas: false,
+        },
+      }),
+    } as Wallet;
+    expect(hasSponsoredTransactionsEnabled(mockInAppWalletDisabled)).toBe(
+      false,
+    );
+  });
+
+  it("should handle inApp wallet with gasless config", () => {
+    const mockInAppWallet = {
+      id: "inApp",
+      getConfig: () => ({
+        smartAccount: {
+          gasless: true,
+        },
+      }),
+    } as Wallet;
+    expect(hasSponsoredTransactionsEnabled(mockInAppWallet)).toBe(true);
+  });
+
+  it("should return false for regular wallet without smart account config", () => {
+    const mockRegularWallet = {
+      id: "inApp",
+      getConfig: () => ({}),
+    } as Wallet;
+    expect(hasSponsoredTransactionsEnabled(mockRegularWallet)).toBe(false);
+  });
+});

--- a/packages/thirdweb/src/react/core/utils/wallet.ts
+++ b/packages/thirdweb/src/react/core/utils/wallet.ts
@@ -7,6 +7,7 @@ import { resolveName } from "../../../extensions/ens/resolve-name.js";
 import { shortenAddress } from "../../../utils/address.js";
 import { parseAvatarRecord } from "../../../utils/ens/avatar.js";
 import { getWalletInfo } from "../../../wallets/__generated__/getWalletInfo.js";
+import { isEcosystemWallet } from "../../../wallets/ecosystem/is-ecosystem-wallet.js";
 import type { Account, Wallet } from "../../../wallets/interfaces/wallet.js";
 import type { WalletInfo } from "../../../wallets/wallet-info.js";
 import type { WalletId } from "../../../wallets/wallet-types.js";
@@ -223,7 +224,7 @@ export function hasSponsoredTransactionsEnabled(wallet: Wallet | undefined) {
       sponsoredTransactionsEnabled = options.gasless;
     }
   }
-  if (wallet && wallet.id === "inApp") {
+  if (wallet && (wallet.id === "inApp" || isEcosystemWallet(wallet))) {
     const options = (wallet as Wallet<"inApp">).getConfig();
     if (options && "smartAccount" in options && options.smartAccount) {
       const smartOptions = options.smartAccount;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on improving the detection of ecosystem wallets in the `Pay` modal by modifying the logic in the `hasSponsoredTransactionsEnabled` function and adding comprehensive tests for various wallet configurations.

### Detailed summary
- Updated the condition in `hasSponsoredTransactionsEnabled` to check for ecosystem wallets using `isEcosystemWallet`.
- Added tests for `hasSponsoredTransactionsEnabled` covering:
  - Undefined wallets
  - Smart wallets with `sponsorGas` and `gasless` configurations
  - In-app wallets with `smartAccount` configurations
  - Regular wallets without smart account configurations

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->