### PR TITLE
fix ignore of mimeTime set in mediaRenderer

### DIFF
--- a/packages/thirdweb/src/react/web/ui/MediaRenderer/useResolvedMediaType.ts
+++ b/packages/thirdweb/src/react/web/ui/MediaRenderer/useResolvedMediaType.ts
@@ -43,6 +43,6 @@ export function useResolvedMediaType(
 
   return {
     mediaInfo: { url: resolvedUrl, mimeType: resolvedMimeType.data },
-    isFetched: resolvedMimeType.isFetched,
+    isFetched: resolvedMimeType.isFetched || !!mimeType,
   };
 }


### PR DESCRIPTION
## Problem solved

CNCT-2634

<!-- start pr-codex -->

---

## PR-Codex overview
This PR modifies the return object in the `useResolvedMediaType.ts` file to enhance the `isFetched` property by including a check for `mimeType`.

### Detailed summary
- Updated the `isFetched` property in the returned object.
- Changed the value of `isFetched` from `resolvedMimeType.isFetched` to `resolvedMimeType.isFetched || !!mimeType`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->