### PR TITLE
Nebula scope changes in create project modal and project settings page

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/embed/embed-setup.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/embed/embed-setup.tsx
@@ -313,6 +313,7 @@ export const EmbedSetup: React.FC<EmbedSetupProps> = ({
           });
           apiKeys.refetch();
         }}
+        enableNebulaServiceByDefault={false}
       />
 
       <Flex gap={8} direction={{ base: "column", md: "row" }}>

--- a/apps/dashboard/src/app/account/components/AccountHeader.tsx
+++ b/apps/dashboard/src/app/account/components/AccountHeader.tsx
@@ -21,8 +21,10 @@ export function AccountHeader(props: {
 }) {
   const myAccountQuery = useAccount();
   const router = useDashboardRouter();
-  const [isCreateProjectDialogOpen, setIsCreateProjectDialogOpen] =
-    useState(false);
+  const [createProjectDialogState, setCreateProjectDialogState] = useState<
+    { team: Team; isOpen: true } | { isOpen: false }
+  >({ isOpen: false });
+
   const client = useThirdwebClient();
   const wallet = useActiveWallet();
   const { disconnect } = useDisconnect();
@@ -43,7 +45,11 @@ export function AccountHeader(props: {
     teamsAndProjects: props.teamsAndProjects,
     logout: logout,
     connectButton: <CustomConnectWallet />,
-    createProject: () => setIsCreateProjectDialogOpen(true),
+    createProject: (team: Team) =>
+      setCreateProjectDialogState({
+        team,
+        isOpen: true,
+      }),
     account: myAccountQuery.data,
     client,
   };
@@ -54,12 +60,20 @@ export function AccountHeader(props: {
       <AccountHeaderMobileUI {...headerProps} className="lg:hidden" />
 
       <LazyCreateAPIKeyDialog
-        open={isCreateProjectDialogOpen}
-        onOpenChange={setIsCreateProjectDialogOpen}
+        open={createProjectDialogState.isOpen}
+        onOpenChange={() =>
+          setCreateProjectDialogState({
+            isOpen: false,
+          })
+        }
         onCreateAndComplete={() => {
           // refresh projects
           router.refresh();
         }}
+        enableNebulaServiceByDefault={
+          createProjectDialogState.isOpen &&
+          createProjectDialogState.team.enabledScopes.includes("nebula")
+        }
       />
     </div>
   );

--- a/apps/dashboard/src/app/account/components/AccountHeaderUI.tsx
+++ b/apps/dashboard/src/app/account/components/AccountHeaderUI.tsx
@@ -16,7 +16,7 @@ export type AccountHeaderCompProps = {
   logout: () => void;
   connectButton: React.ReactNode;
   teamsAndProjects: Array<{ team: Team; projects: Project[] }>;
-  createProject: () => void;
+  createProject: (team: Team) => void;
   account: Pick<Account, "email" | "id"> | undefined;
   client: ThirdwebClient;
 };

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/projects/TeamProjectsPage.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/projects/TeamProjectsPage.tsx
@@ -1,6 +1,9 @@
 "use client";
 
 import type { Project } from "@/api/projects";
+import type { Team } from "@/api/team";
+import { ProjectAvatar } from "@/components/blocks/Avatars/ProjectAvatar";
+import { CopyButton } from "@/components/ui/CopyButton";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -8,13 +11,6 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
-import { format } from "date-fns";
-import { ChevronDownIcon, SearchIcon } from "lucide-react";
-import Link from "next/link";
-import { useState } from "react";
-
-import { ProjectAvatar } from "@/components/blocks/Avatars/ProjectAvatar";
-import { CopyButton } from "@/components/ui/CopyButton";
 import {
   Select,
   SelectContent,
@@ -23,12 +19,16 @@ import {
 } from "@/components/ui/select";
 import { useDashboardRouter } from "@/lib/DashboardRouter";
 import { LazyCreateAPIKeyDialog } from "components/settings/ApiKeys/Create/LazyCreateAPIKeyDialog";
+import { format } from "date-fns";
+import { ChevronDownIcon, SearchIcon } from "lucide-react";
+import Link from "next/link";
+import { useState } from "react";
 
 type SortyById = "name" | "createdAt";
 
 export function TeamProjectsPage(props: {
   projects: Project[];
-  team_slug: string;
+  team: Team;
 }) {
   const { projects } = props;
   const [searchTerm, setSearchTerm] = useState("");
@@ -69,7 +69,7 @@ export function TeamProjectsPage(props: {
           <SelectBy value={sortBy} onChange={setSortBy} />
           <AddNewButton
             createProject={() => setIsCreateProjectDialogOpen(true)}
-            teamMembersSettingsPath={`/team/${props.team_slug}/~/settings/members`}
+            teamMembersSettingsPath={`/team/${props.team.slug}/~/settings/members`}
           />
         </div>
       </div>
@@ -88,7 +88,7 @@ export function TeamProjectsPage(props: {
               <ProjectCard
                 key={project.id}
                 project={project}
-                team_slug={props.team_slug}
+                team_slug={props.team.slug}
               />
             );
           })}
@@ -104,6 +104,9 @@ export function TeamProjectsPage(props: {
           // refresh projects
           router.refresh();
         }}
+        enableNebulaServiceByDefault={props.team.enabledScopes.includes(
+          "nebula",
+        )}
       />
     </div>
   );

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/projects/page.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/projects/page.tsx
@@ -1,15 +1,19 @@
 import { getProjects } from "@/api/projects";
+import { getTeamBySlug } from "@/api/team";
+import { redirect } from "next/navigation";
 import { TeamProjectsPage } from "./TeamProjectsPage";
 
 export default async function Page(props: {
   params: Promise<{ team_slug: string }>;
 }) {
-  const projects = await getProjects((await props.params).team_slug);
+  const params = await props.params;
+  const team = await getTeamBySlug(params.team_slug);
 
-  return (
-    <TeamProjectsPage
-      projects={projects}
-      team_slug={(await props.params).team_slug}
-    />
-  );
+  if (!team) {
+    redirect("/team");
+  }
+
+  const projects = await getProjects(params.team_slug);
+
+  return <TeamProjectsPage projects={projects} team={team} />;
 }

--- a/apps/dashboard/src/app/team/[team_slug]/[project_slug]/settings/ProjectGeneralSettingsPage.stories.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/[project_slug]/settings/ProjectGeneralSettingsPage.stories.tsx
@@ -60,6 +60,7 @@ function Story() {
           payConfig: "/payConfig",
         }}
         onKeyUpdated={undefined}
+        showNebulaSettings={false}
       />
 
       <Toaster richColors />

--- a/apps/dashboard/src/app/team/[team_slug]/[project_slug]/settings/ProjectGeneralSettingsPage.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/[project_slug]/settings/ProjectGeneralSettingsPage.tsx
@@ -51,6 +51,7 @@ export function ProjectGeneralSettingsPage(props: {
   apiKey: ApiKey;
   paths: EditProjectUIPaths;
   onKeyUpdated: (() => void) | undefined;
+  showNebulaSettings: boolean;
 }) {
   const updateMutation = useUpdateApiKey();
   const deleteMutation = useRevokeApiKey();
@@ -62,6 +63,7 @@ export function ProjectGeneralSettingsPage(props: {
       deleteMutation={deleteMutation}
       paths={props.paths}
       onKeyUpdated={props.onKeyUpdated}
+      showNebulaSettings={props.showNebulaSettings}
     />
   );
 }
@@ -81,6 +83,7 @@ interface EditApiKeyProps {
   deleteMutation: DeleteMutation;
   paths: EditProjectUIPaths;
   onKeyUpdated: (() => void) | undefined;
+  showNebulaSettings: boolean;
 }
 
 type UpdateAPIForm = UseFormReturn<ApiKeyValidationSchema>;
@@ -233,6 +236,7 @@ export const ProjectGeneralSettingsPageUI: React.FC<EditApiKeyProps> = (
             updateMutation={updateMutation}
             handleSubmit={handleSubmit}
             paths={props.paths}
+            showNebulaSettings={props.showNebulaSettings}
           />
 
           <DeleteProject
@@ -470,6 +474,7 @@ function EnabledServicesSetting(props: {
   handleSubmit: () => void;
   apiKey: ApiKey;
   paths: EditApiKeyProps["paths"];
+  showNebulaSettings: boolean;
 }) {
   const { form, handleSubmit, updateMutation } = props;
 
@@ -512,7 +517,10 @@ function EnabledServicesSetting(props: {
         <div className="flex flex-col">
           {fields.map((srv, idx) => {
             const service = getServiceByName(srv.name as ServiceName);
-            const hidden = HIDDEN_SERVICES.includes(service.name);
+            const hidden =
+              (service.name === "nebula" && !props.showNebulaSettings) ||
+              HIDDEN_SERVICES.includes(service.name);
+
             const serviceName = getServiceByName(service.name as ServiceName);
             const shouldShow = !hidden && serviceName;
 

--- a/apps/dashboard/src/app/team/[team_slug]/[project_slug]/settings/ProjectGeneralSettingsPageForTeams.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/[project_slug]/settings/ProjectGeneralSettingsPageForTeams.tsx
@@ -1,17 +1,18 @@
 "use client";
 
+import type { Team } from "@/api/team";
 import { useDashboardRouter } from "@/lib/DashboardRouter";
 import type { ApiKey } from "@3rdweb-sdk/react/hooks/useApi";
 import { ProjectGeneralSettingsPage } from "./ProjectGeneralSettingsPage";
 
 export function ProjectGeneralSettingsPageForTeams(props: {
-  team_slug: string;
+  team: Team;
   project_slug: string;
   apiKey: ApiKey;
 }) {
   const router = useDashboardRouter();
-  const { team_slug, project_slug, apiKey } = props;
-  const projectSettingsLayout = `/team/${team_slug}/${project_slug}/settings`;
+  const { team, project_slug, apiKey } = props;
+  const projectSettingsLayout = `/team/${team.slug}/${project_slug}/settings`;
 
   // TODO - add a Project Image form field on this page
 
@@ -22,11 +23,12 @@ export function ProjectGeneralSettingsPageForTeams(props: {
         aaConfig: `${projectSettingsLayout}/account-abstraction`,
         inAppConfig: `${projectSettingsLayout}/in-app-wallets`,
         payConfig: `${projectSettingsLayout}/pay`,
-        afterDeleteRedirectTo: `/team/${team_slug}`,
+        afterDeleteRedirectTo: `/team/${team.slug}`,
       }}
       onKeyUpdated={() => {
         router.refresh();
       }}
+      showNebulaSettings={team.enabledScopes.includes("nebula")}
     />
   );
 }

--- a/apps/dashboard/src/app/team/[team_slug]/[project_slug]/settings/page.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/[project_slug]/settings/page.tsx
@@ -1,5 +1,6 @@
 import { getProject } from "@/api/projects";
-import { notFound } from "next/navigation";
+import { getTeamBySlug } from "@/api/team";
+import { notFound, redirect } from "next/navigation";
 import { getAPIKeyForProjectId } from "../../../../api/lib/getAPIKeys";
 import { ProjectGeneralSettingsPageForTeams } from "./ProjectGeneralSettingsPageForTeams";
 
@@ -7,6 +8,13 @@ export default async function Page(props: {
   params: Promise<{ team_slug: string; project_slug: string }>;
 }) {
   const { team_slug, project_slug } = await props.params;
+
+  const team = await getTeamBySlug(team_slug);
+
+  if (!team) {
+    redirect("/team");
+  }
+
   const project = await getProject(team_slug, project_slug);
 
   if (!project) {
@@ -23,7 +31,7 @@ export default async function Page(props: {
     <ProjectGeneralSettingsPageForTeams
       apiKey={apiKey}
       project_slug={project_slug}
-      team_slug={team_slug}
+      team={team}
     />
   );
 }

--- a/apps/dashboard/src/app/team/components/TeamHeader/ProjectSelectorMobileMenuButton.tsx
+++ b/apps/dashboard/src/app/team/components/TeamHeader/ProjectSelectorMobileMenuButton.tsx
@@ -13,7 +13,7 @@ type ProjectSelectorMobileMenuButtonProps = {
   currentProject: Project;
   projects: Project[];
   team: Team;
-  createProject: () => void;
+  createProject: (team: Team) => void;
 };
 
 export function ProjectSelectorMobileMenuButton(
@@ -49,7 +49,7 @@ export function ProjectSelectorMobileMenuButton(
             projects={props.projects}
             team={props.team}
             createProject={() => {
-              props.createProject();
+              props.createProject(props.team);
               setOpen(false);
             }}
           />

--- a/apps/dashboard/src/app/team/components/TeamHeader/TeamAndProjectSelectorPopoverButton.tsx
+++ b/apps/dashboard/src/app/team/components/TeamHeader/TeamAndProjectSelectorPopoverButton.tsx
@@ -21,7 +21,7 @@ type TeamSwitcherProps = {
   currentProject: Project | undefined;
   teamsAndProjects: Array<{ team: Team; projects: Project[] }>;
   focus: "project-selection" | "team-selection";
-  createProject: () => void;
+  createProject: (team: Team) => void;
   account: Pick<Account, "email" | "id"> | undefined;
 };
 
@@ -104,7 +104,7 @@ export function TeamAndProjectSelectorPopoverButton(props: TeamSwitcherProps) {
                 team={projectsToShowOfTeam}
                 createProject={() => {
                   setOpen(false);
-                  props.createProject();
+                  props.createProject(projectsToShowOfTeam);
                 }}
               />
             )}

--- a/apps/dashboard/src/app/team/components/TeamHeader/TeamHeaderUI.tsx
+++ b/apps/dashboard/src/app/team/components/TeamHeader/TeamHeaderUI.tsx
@@ -23,7 +23,7 @@ export type TeamHeaderCompProps = {
   account: Pick<Account, "email" | "id"> | undefined;
   logout: () => void;
   connectButton: React.ReactNode;
-  createProject: () => void;
+  createProject: (team: Team) => void;
   client: ThirdwebClient;
 };
 

--- a/apps/dashboard/src/app/team/components/TeamHeader/team-header-logged-in.client.tsx
+++ b/apps/dashboard/src/app/team/components/TeamHeader/team-header-logged-in.client.tsx
@@ -22,8 +22,9 @@ export function TeamHeaderLoggedIn(props: {
   currentProject: Project | undefined;
   account: Pick<Account, "email" | "id">;
 }) {
-  const [isCreateProjectDialogOpen, setIsCreateProjectDialogOpen] =
-    useState(false);
+  const [createProjectDialogState, setCreateProjectDialogState] = useState<
+    { team: Team; isOpen: true } | { isOpen: false }
+  >({ isOpen: false });
   const activeWallet = useActiveWallet();
   const { disconnect } = useDisconnect();
   const router = useDashboardRouter();
@@ -48,7 +49,12 @@ export function TeamHeaderLoggedIn(props: {
     account: props.account,
     logout: logout,
     connectButton: <CustomConnectWallet />,
-    createProject: () => setIsCreateProjectDialogOpen(true),
+    createProject: (team: Team) => {
+      setCreateProjectDialogState({
+        isOpen: true,
+        team,
+      });
+    },
     client: getThirdwebClient(),
   };
 
@@ -58,12 +64,20 @@ export function TeamHeaderLoggedIn(props: {
       <TeamHeaderMobileUI {...headerProps} className="lg:hidden" />
 
       <LazyCreateAPIKeyDialog
-        open={isCreateProjectDialogOpen}
-        onOpenChange={setIsCreateProjectDialogOpen}
+        open={createProjectDialogState.isOpen}
+        onOpenChange={() =>
+          setCreateProjectDialogState({
+            isOpen: false,
+          })
+        }
         onCreateAndComplete={() => {
           // refresh projects
           router.refresh();
         }}
+        enableNebulaServiceByDefault={
+          createProjectDialogState.isOpen &&
+          createProjectDialogState.team.enabledScopes.includes("nebula")
+        }
       />
     </div>
   );

--- a/apps/dashboard/src/components/settings/ApiKeys/Create/CreateApiKeyModal.stories.tsx
+++ b/apps/dashboard/src/components/settings/ApiKeys/Create/CreateApiKeyModal.stories.tsx
@@ -52,6 +52,7 @@ function Story(props: {
         onOpenChange={setIsOpen}
         createKeyMutation={mutation}
         prefill={props.prefill}
+        enableNebulaServiceByDefault={false}
       />
 
       <Button

--- a/apps/dashboard/src/components/settings/ApiKeys/Create/index.tsx
+++ b/apps/dashboard/src/components/settings/ApiKeys/Create/index.tsx
@@ -53,6 +53,7 @@ export type CreateAPIKeyDialogProps = {
   onOpenChange: (open: boolean) => void;
   onCreateAndComplete?: () => void;
   prefill?: CreateAPIKeyPrefillOptions;
+  enableNebulaServiceByDefault: boolean;
 };
 
 const CreateAPIKeyDialog = (props: CreateAPIKeyDialogProps) => {
@@ -76,6 +77,7 @@ export const CreateAPIKeyDialogUI = (props: {
     unknown
   >;
   prefill?: CreateAPIKeyPrefillOptions;
+  enableNebulaServiceByDefault: boolean;
 }) => {
   const [screen, setScreen] = useState<
     { id: "create" } | { id: "api-details"; key: ApiKey }
@@ -107,6 +109,7 @@ export const CreateAPIKeyDialogUI = (props: {
                 setScreen({ id: "api-details", key });
               }}
               prefill={props.prefill}
+              enableNebulaServiceByDefault={props.enableNebulaServiceByDefault}
             />
           )}
 
@@ -135,6 +138,7 @@ function CreateAPIKeyForm(props: {
   >;
   onAPIKeyCreated: (key: ApiKey) => void;
   prefill?: CreateAPIKeyPrefillOptions;
+  enableNebulaServiceByDefault: boolean;
 }) {
   const [showAlert, setShowAlert] = useState<"no-domain" | "any-domain">();
 
@@ -153,11 +157,15 @@ function CreateAPIKeyForm(props: {
     name: string;
     domains: string;
   }) {
+    const servicesToEnableByDefault = props.enableNebulaServiceByDefault
+      ? SERVICES
+      : SERVICES.filter((srv) => srv.name !== "nebula");
+
     const formattedValues = {
       name: values.name,
       domains: toArrFromList(values.domains),
       // enable all services
-      services: SERVICES.map((srv) => ({
+      services: servicesToEnableByDefault.map((srv) => ({
         name: srv.name,
         targetAddresses: ["*"],
         enabled: true,

--- a/apps/dashboard/src/components/settings/ApiKeys/validations.ts
+++ b/apps/dashboard/src/components/settings/ApiKeys/validations.ts
@@ -149,4 +149,4 @@ export type ApiKeyPayConfigValidationSchema = z.infer<
 >;
 
 // FIXME: Remove
-export const HIDDEN_SERVICES = ["relayer", "chainsaw", "nebula"];
+export const HIDDEN_SERVICES = ["relayer", "chainsaw"];

--- a/packages/service-utils/src/core/services.ts
+++ b/packages/service-utils/src/core/services.ts
@@ -65,6 +65,14 @@ export const SERVICE_DEFINITIONS = {
     // all actions allowed
     actions: [],
   },
+  nebula: {
+    name: "nebula",
+    title: "Nebula",
+    description:
+      "Advanced blockchain reasoning and execution capabilities with AI",
+    // all actions allowed
+    actions: [],
+  },
 } as const;
 
 export const SERVICE_NAMES = Object.keys(


### PR DESCRIPTION
DASH-578

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the handling of `Nebula` settings across various components, including the introduction of `enableNebulaServiceByDefault` and adjustments to team and project management functions.

### Detailed summary
- Added `showNebulaSettings` and `enableNebulaServiceByDefault` props in multiple components.
- Updated `createProject` functions to accept a `team` parameter.
- Refactored project and team-related pages to use `team` instead of `team_slug`.
- Removed `nebula` from `HIDDEN_SERVICES`.
- Enhanced `ProjectGeneralSettingsPageForTeams` to handle `team` directly.
- Adjusted dialogs to reflect `Nebula` settings based on `team` capabilities.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->