### PR TITLE
add roleBytes utility for contract role usage

### DIFF
--- a/packages/thirdweb/src/utils/encoding/helpers/role-bytes.test.ts
+++ b/packages/thirdweb/src/utils/encoding/helpers/role-bytes.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { roleBytes } from "./role-bytes.js";
+
+describe("roleBytes", () => {
+  it('should calculate the value of lister role', () => {
+    expect(roleBytes("LISTER_ROLE"))
+      .toBe(
+        "0xf94103142c1baabe9ac2b5d1487bf783de9e69cfeea9a72f5c9c94afd7877b8c"
+      );
+  });
+});

--- a/packages/thirdweb/src/utils/encoding/helpers/role-bytes.test.ts
+++ b/packages/thirdweb/src/utils/encoding/helpers/role-bytes.test.ts
@@ -2,10 +2,9 @@ import { describe, expect, it } from "vitest";
 import { roleBytes } from "./role-bytes.js";
 
 describe("roleBytes", () => {
-  it('should calculate the value of lister role', () => {
-    expect(roleBytes("LISTER_ROLE"))
-      .toBe(
-        "0xf94103142c1baabe9ac2b5d1487bf783de9e69cfeea9a72f5c9c94afd7877b8c"
-      );
+  it("should calculate the value of lister role", () => {
+    expect(roleBytes("LISTER_ROLE")).toBe(
+      "0xf94103142c1baabe9ac2b5d1487bf783de9e69cfeea9a72f5c9c94afd7877b8c",
+    );
   });
 });

--- a/packages/thirdweb/src/utils/encoding/helpers/role-bytes.ts
+++ b/packages/thirdweb/src/utils/encoding/helpers/role-bytes.ts
@@ -1,0 +1,20 @@
+import { type Hex, isHex } from "../hex.js";
+
+/**
+ * Calculates the byte size of a Hex string or Uint8Array.
+ * If the value is a Hex string, it accounts for the leading "0x" prefix.
+ * @param value The Hex string or Uint8Array.
+ * @returns The byte size of the value.
+ * @example
+ * ```ts
+ * import { byteSize } from "thirdweb/utils";
+ * const size = byteSize("0x1a4");
+ * console.log(size); // 2
+ * ```
+ */
+export function byteSize(value: Hex | Uint8Array) {
+  if (isHex(value, { strict: false })) {
+    return Math.ceil((value.length - 2) / 2);
+  }
+  return value.length;
+}

--- a/packages/thirdweb/src/utils/encoding/helpers/role-bytes.ts
+++ b/packages/thirdweb/src/utils/encoding/helpers/role-bytes.ts
@@ -1,20 +1,16 @@
-import { type Hex, isHex } from "../hex.js";
+import { keccak256 } from "../../hashing/keccak256.js";
+import { toBytes } from "../to-bytes.js";
 
+
+///
 /**
- * Calculates the byte size of a Hex string or Uint8Array.
- * If the value is a Hex string, it accounts for the leading "0x" prefix.
- * @param value The Hex string or Uint8Array.
- * @returns The byte size of the value.
+ * Generates a 256-bit hash of a given role string in bytes form using the keccak256 algorithm.
+ *
+ * @param {string} role - The role string to be converted into bytes and hashed.
+ * @returns {`0x${string}`} A 256-bit hash of the input role as a byte array.
  * @example
- * ```ts
- * import { byteSize } from "thirdweb/utils";
- * const size = byteSize("0x1a4");
- * console.log(size); // 2
- * ```
+ *   const AdminRole = roleBytes("ADMIN_ROLE");
  */
-export function byteSize(value: Hex | Uint8Array) {
-  if (isHex(value, { strict: false })) {
-    return Math.ceil((value.length - 2) / 2);
-  }
-  return value.length;
+export const roleBytes = (role: string) => {
+  return keccak256(toBytes(role));
 }

--- a/packages/thirdweb/src/utils/encoding/helpers/role-bytes.ts
+++ b/packages/thirdweb/src/utils/encoding/helpers/role-bytes.ts
@@ -9,6 +9,6 @@ import { toBytes } from "../to-bytes.js";
  * @example
  *   const AdminRole = roleBytes("ADMIN_ROLE");
  */
-export const roleBytes = (role: string) => {
+export const roleBytes = (role: string): `0x${string}` => {
   return keccak256(toBytes(role));
 }

--- a/packages/thirdweb/src/utils/encoding/helpers/role-bytes.ts
+++ b/packages/thirdweb/src/utils/encoding/helpers/role-bytes.ts
@@ -11,4 +11,4 @@ import { toBytes } from "../to-bytes.js";
  */
 export const roleBytes = (role: string): `0x${string}` => {
   return keccak256(toBytes(role));
-}
+};

--- a/packages/thirdweb/src/utils/encoding/helpers/role-bytes.ts
+++ b/packages/thirdweb/src/utils/encoding/helpers/role-bytes.ts
@@ -1,8 +1,6 @@
 import { keccak256 } from "../../hashing/keccak256.js";
 import { toBytes } from "../to-bytes.js";
 
-
-///
 /**
  * Generates a 256-bit hash of a given role string in bytes form using the keccak256 algorithm.
  *


### PR DESCRIPTION
## Problem solved

CNCT-2631
Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new utility function `roleBytes` that generates a 256-bit hash for role strings using the `keccak256` algorithm. Additionally, it adds a test suite for this function to ensure its correctness.

### Detailed summary
- Added `roleBytes` function in `role-bytes.ts` to hash role strings.
- The `roleBytes` function returns a 256-bit hash formatted as `0x${string}`.
- Created a test suite in `role-bytes.test.ts` to validate the `roleBytes` function.
- Added a test case for the `LISTER_ROLE`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->