### PR TITLE
fix: Autoconnect previously linked wallets

### DIFF
--- a/.changeset/happy-suns-nail.md
+++ b/.changeset/happy-suns-nail.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Autoconnect previously linked wallets

--- a/apps/playground-web/src/components/styled-connect-embed.tsx
+++ b/apps/playground-web/src/components/styled-connect-embed.tsx
@@ -25,7 +25,7 @@ export function StyledConnectEmbed(
 
   return account ? (
     <div className="flex flex-col gap-8">
-      <StyledConnectButton />
+      <StyledConnectButton {...props} />
     </div>
   ) : (
     <ConnectEmbed

--- a/packages/thirdweb/src/react/core/hooks/wallets/useAddConnectedWallet.ts
+++ b/packages/thirdweb/src/react/core/hooks/wallets/useAddConnectedWallet.ts
@@ -18,5 +18,5 @@ import { useConnectionManagerCtx } from "../../providers/connection-manager.js";
  */
 export function useAddConnectedWallet() {
   const manager = useConnectionManagerCtx("useAddConnectedWallet");
-  return manager.handleConnection;
+  return manager.addConnectedWallet;
 }

--- a/packages/thirdweb/src/react/core/hooks/wallets/useAutoConnect.ts
+++ b/packages/thirdweb/src/react/core/hooks/wallets/useAutoConnect.ts
@@ -131,7 +131,7 @@ export function useAutoConnectCore(
     }
 
     // then connect wallets that were last connected but were not set as active
-    const otherWallets = wallets.filter(
+    const otherWallets = availableWallets.filter(
       (w) =>
         w.id !== lastActiveWalletId && lastConnectedWalletIds.includes(w.id),
     );

--- a/packages/thirdweb/src/react/native/hooks/wallets/useLinkProfile.ts
+++ b/packages/thirdweb/src/react/native/hooks/wallets/useLinkProfile.ts
@@ -1,9 +1,9 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { isEcosystemWallet } from "../../../../wallets/ecosystem/is-ecosystem-wallet.js";
 import type { AuthArgsType } from "../../../../wallets/in-app/core/authentication/types.js";
 import type { Ecosystem } from "../../../../wallets/in-app/core/wallet/types.js";
 import { linkProfile } from "../../../../wallets/in-app/web/lib/auth/index.js";
-import { useAdminWallet } from "../../../core/hooks/wallets/useAdminWallet.js";
+import { useConnectedWallets } from "../../../core/hooks/wallets/useConnectedWallets.js";
 
 /**
  * Links a web2 or web3 profile to the connected in-app or ecosystem account.
@@ -77,16 +77,25 @@ import { useAdminWallet } from "../../../core/hooks/wallets/useAdminWallet.js";
  * @wallet
  */
 export function useLinkProfile() {
-  const wallet = useAdminWallet();
+  const wallets = useConnectedWallets();
+  const queryClient = useQueryClient();
   return useMutation({
     mutationKey: ["profiles"],
-    mutationFn: async (options: Omit<AuthArgsType, "ecosystem">) => {
-      const ecosystem: Ecosystem | undefined =
-        wallet && isEcosystemWallet(wallet)
-          ? { id: wallet.id, partnerId: wallet.getConfig()?.partnerId }
-          : undefined;
+    mutationFn: async (options: AuthArgsType) => {
+      const ecosystemWallet = wallets.find((w) => isEcosystemWallet(w));
+      const ecosystem: Ecosystem | undefined = ecosystemWallet
+        ? {
+            id: ecosystemWallet.id,
+            partnerId: ecosystemWallet.getConfig()?.partnerId,
+          }
+        : undefined;
       const optionsWithEcosystem = { ...options, ecosystem } as AuthArgsType;
       return linkProfile(optionsWithEcosystem);
+    },
+    onSuccess() {
+      setTimeout(() => {
+        queryClient.invalidateQueries({ queryKey: ["profiles"] });
+      }, 500);
     },
   });
 }

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/LinkProfileScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/LinkProfileScreen.tsx
@@ -43,7 +43,9 @@ export function LinkProfileScreen(props: {
           walletConnect={props.walletConnect}
           wallet={activeWallet as Wallet<"inApp">}
           done={() => {
-            queryClient.invalidateQueries({ queryKey: ["profiles"] });
+            setTimeout(() => {
+              queryClient.invalidateQueries({ queryKey: ["profiles"] });
+            }, 500);
             props.onBack();
           }}
           connectLocale={props.locale}
@@ -67,7 +69,9 @@ export function LinkProfileScreen(props: {
         <EcosystemWalletConnectUI
           wallet={activeWallet as Wallet<EcosystemWalletId>}
           done={() => {
-            queryClient.invalidateQueries({ queryKey: ["profiles"] });
+            setTimeout(() => {
+              queryClient.invalidateQueries({ queryKey: ["profiles"] });
+            }, 500);
             props.onBack();
           }}
           connectLocale={props.locale}

--- a/packages/thirdweb/src/wallets/manager/index.ts
+++ b/packages/thirdweb/src/wallets/manager/index.ts
@@ -230,11 +230,15 @@ export function createConnectionManager(storage: AsyncStorage) {
 
   // save last connected wallet ids to storage
   effect(
-    () => {
+    async () => {
+      const prevAccounts = (await getStoredConnectedWalletIds(storage)) || [];
       const accounts = connectedWallets.getValue();
       const ids = accounts.map((acc) => acc?.id).filter((c) => !!c) as string[];
 
-      storage.setItem(CONNECTED_WALLET_IDS, stringify(ids));
+      storage.setItem(
+        CONNECTED_WALLET_IDS,
+        stringify(Array.from(new Set([...prevAccounts, ...ids]))),
+      );
     },
     [connectedWallets],
     false,


### PR DESCRIPTION
## Problem solved

CNCT-2590

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing wallet connection features by improving the handling of connected wallets, adding auto-connect functionality, and optimizing profile linking processes.

### Detailed summary
- Updated `StyledConnectButton` to accept `props`.
- Changed `useAddConnectedWallet` to return `manager.addConnectedWallet`.
- Refined wallet filtering logic in `useAutoConnect`.
- Modified storage of connected wallet IDs to avoid duplicates.
- Introduced delays in `LinkProfileScreen` for query invalidation.
- Switched from `useAdminWallet` to `useConnectedWallets` in multiple hooks.
- Improved ecosystem wallet handling in profile queries and mutations.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->