### PR TITLE
Custom create2 factory deployment for skale chains

### DIFF
--- a/.changeset/funny-bobcats-explode.md
+++ b/.changeset/funny-bobcats-explode.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Custom create2 factory deployment for skale chains

--- a/packages/thirdweb/src/contract/deployment/utils/create-2-factory.test.ts
+++ b/packages/thirdweb/src/contract/deployment/utils/create-2-factory.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { ANVIL_CHAIN } from "../../../../test/src/chains.js";
+import { TEST_CLIENT } from "../../../../test/src/test-clients.js";
+import { TEST_ACCOUNT_A } from "../../../../test/src/test-wallets.js";
+import { defineChain } from "../../../chains/utils.js";
+import {
+  computeCreate2FactoryAddress,
+  deployCreate2Factory,
+  getDeployedCreate2Factory,
+} from "./create-2-factory.js";
+
+describe.runIf(process.env.TW_SECRET_KEY)("create2 factory tests", () => {
+  it("should compute create2 factory address", async () => {
+    const addr = await computeCreate2FactoryAddress({
+      client: TEST_CLIENT,
+      chain: defineChain(1),
+    });
+
+    expect(addr).to.eq("0x4e59b44847b379578588920cA78FbF26c0B4956C");
+  });
+
+  it("should compute create2 factory address with custom gas", async () => {
+    const addr = await computeCreate2FactoryAddress({
+      client: TEST_CLIENT,
+      chain: defineChain(1564830818),
+    });
+
+    expect(addr).to.eq("0x50620b64D9524aC7dC8c967123E87e5b6dB98f0c");
+  });
+
+  it("should deploy create2 factory", async () => {
+    await deployCreate2Factory({
+      client: TEST_CLIENT,
+      account: TEST_ACCOUNT_A,
+      chain: ANVIL_CHAIN,
+    });
+
+    const create2Factory = await getDeployedCreate2Factory({
+      chain: ANVIL_CHAIN,
+      client: TEST_CLIENT,
+    });
+    expect(create2Factory).not.toBeNull();
+  });
+});


### PR DESCRIPTION
TOOL-2779 (XPROT-931)

## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a custom `create2` factory deployment for SKALE chains, enhancing gas management and testing functionalities.

### Detailed summary
- Added tests for `create2` factory address computation and deployment.
- Introduced `Create2FactoryDeploymentInfo` type for deployment details.
- Implemented custom gas price and limit handling for specific SKALE chains.
- Updated `deployCreate2Factory` to accommodate custom gas settings.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->