### PR TITLE
[React] Feature: Export web `getLastAuthProvider`

### DIFF
--- a/.changeset/warm-students-breathe.md
+++ b/.changeset/warm-students-breathe.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": minor
+---
+
+Adds `getLastAuthProvider` to get the most recently used auth provider for login

--- a/packages/thirdweb/src/exports/react.ts
+++ b/packages/thirdweb/src/exports/react.ts
@@ -269,3 +269,6 @@ export {
   ChainIcon,
   type ChainIconProps,
 } from "../react/web/ui/prebuilt/Chain/icon.js";
+
+// Utils
+export { getLastAuthProvider } from "../react/web/utils/storage.js";

--- a/packages/thirdweb/src/react/core/utils/storage.ts
+++ b/packages/thirdweb/src/react/core/utils/storage.ts
@@ -1,7 +1,7 @@
 import type { AsyncStorage } from "../../../utils/storage/AsyncStorage.js";
 import type { AuthArgsType } from "../../../wallets/in-app/core/authentication/types.js";
 
-const LAST_AUTH_PROVIDER_STORAGE_KEY = "lastAuthProvider";
+export const LAST_AUTH_PROVIDER_STORAGE_KEY = "lastAuthProvider";
 
 export async function setLastAuthProvider(
   authProvider: AuthArgsType["strategy"],

--- a/packages/thirdweb/src/react/web/utils/storage.test.ts
+++ b/packages/thirdweb/src/react/web/utils/storage.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+import { webLocalStorage } from "../../../utils/storage/webStorage.js";
+import { LAST_AUTH_PROVIDER_STORAGE_KEY } from "../../core/utils/storage.js";
+import { getLastAuthProvider } from "./storage.js";
+
+vi.mock("../../../utils/storage/webStorage.js", () => ({
+  webLocalStorage: {
+    getItem: vi.fn().mockResolvedValueOnce("mockStrategy"),
+  },
+}));
+
+describe("getLastAuthProvider", () => {
+  it("should return the last authentication provider strategy if it exists", async () => {
+    const mockStrategy = "mockStrategy";
+    webLocalStorage.getItem = vi.fn().mockResolvedValueOnce(mockStrategy);
+
+    const result = await getLastAuthProvider();
+    expect(result).toBe(mockStrategy);
+  });
+
+  it("should return null if no authentication provider strategy is found", async () => {
+    webLocalStorage.getItem = vi.fn().mockResolvedValueOnce(null);
+
+    const result = await getLastAuthProvider();
+    expect(result).toBeNull();
+  });
+
+  it("should call webLocalStorage.getItem with the correct key", async () => {
+    await getLastAuthProvider();
+    expect(webLocalStorage.getItem).toHaveBeenCalledWith(
+      LAST_AUTH_PROVIDER_STORAGE_KEY,
+    );
+  });
+});

--- a/packages/thirdweb/src/react/web/utils/storage.ts
+++ b/packages/thirdweb/src/react/web/utils/storage.ts
@@ -1,0 +1,23 @@
+import { webLocalStorage } from "../../../utils/storage/webStorage.js";
+import { getLastAuthProvider as getLastAuthProviderCore } from "../../core/utils/storage.js";
+
+/**
+ * Retrieves the last authentication provider used from local storage.
+ *
+ * This function is designed to work only in a browser environment.
+ *
+ * @returns {Promise<AuthArgsType["strategy"] | null>} A promise that resolves to the last
+ * authentication provider strategy used, or `null` if none is found.
+ *
+ * @example
+ * ```typescript
+ * import { getLastAuthProvider } from "thirdweb/react";
+ *
+ * const lastAuthProvider = await getLastAuthProvider();
+ * ```
+ *
+ * @utils
+ */
+export async function getLastAuthProvider() {
+  return getLastAuthProviderCore(webLocalStorage);
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new utility function `getLastAuthProvider` to retrieve the most recently used authentication provider from local storage. It also updates the `LAST_AUTH_PROVIDER_STORAGE_KEY` to be exported and includes tests for the new function.

### Detailed summary
- Added `getLastAuthProvider` function to retrieve the last auth provider from local storage.
- Exported `LAST_AUTH_PROVIDER_STORAGE_KEY` for external use.
- Updated tests for `getLastAuthProvider` to check for existing strategies and null returns.
- Mocked `webLocalStorage` in tests for controlled behavior.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->