### PR TITLE
handle empty address in fetchPublishedContracts

### DIFF
--- a/apps/dashboard/src/components/contract-components/fetchPublishedContracts.ts
+++ b/apps/dashboard/src/components/contract-components/fetchPublishedContracts.ts
@@ -4,25 +4,37 @@ import {
   getAllPublishedContracts,
   getContractPublisher,
 } from "thirdweb/extensions/thirdweb";
-import invariant from "tiny-invariant";
 import { fetchDeployMetadata } from "./fetchDeployMetadata";
 
+// TODO: clean this up, jesus
 export async function fetchPublishedContracts(address?: string | null) {
-  invariant(address, "address is not defined");
-  const resolvedAddress = (await resolveEns(address)).address;
-  invariant(resolvedAddress, "invalid ENS");
-  const tempResult = (
-    (await getAllPublishedContracts({
-      contract: getContractPublisher(getThirdwebClient()),
-      publisher: resolvedAddress,
-    })) || []
-  )
-    .filter((c) => c.contractId)
-    .sort((a, b) => a.contractId.localeCompare(b.contractId));
-  return await Promise.all(
-    tempResult.map(async (c) => ({
-      ...c,
-      metadata: await fetchDeployMetadata(c.publishMetadataUri),
-    })),
-  );
+  try {
+    if (!address) {
+      return [];
+    }
+    const resolvedAddress = (await resolveEns(address)).address;
+
+    if (!resolvedAddress) {
+      return [];
+    }
+
+    const tempResult = (
+      (await getAllPublishedContracts({
+        contract: getContractPublisher(getThirdwebClient()),
+        publisher: resolvedAddress,
+      })) || []
+    )
+      .filter((c) => c.contractId)
+      .sort((a, b) => a.contractId.localeCompare(b.contractId));
+
+    return await Promise.all(
+      tempResult.map(async (c) => ({
+        ...c,
+        metadata: await fetchDeployMetadata(c.publishMetadataUri),
+      })),
+    );
+  } catch (e) {
+    console.error("Error fetching published contracts", e);
+    return [];
+  }
 }


### PR DESCRIPTION
partially fixes: DASH-572

<!-- start pr-codex -->

---

## PR-Codex overview
This PR refactors the `fetchPublishedContracts` function to improve error handling and eliminate the use of `invariant` for address validation. It introduces a try-catch block to handle potential errors gracefully and returns an empty array in case of invalid input or errors.

### Detailed summary
- Removed `invariant` checks for `address` and `resolvedAddress`.
- Added a try-catch block to handle errors.
- Changed error handling to return an empty array instead of throwing errors.
- Kept the logic for fetching and processing published contracts intact.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->