### PR TITLE
fix: Disable social profile request retries

### DIFF
--- a/.changeset/wise-birds-rest.md
+++ b/.changeset/wise-birds-rest.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Dont retry social profile requests

--- a/packages/thirdweb/src/react/core/social/useSocialProfiles.ts
+++ b/packages/thirdweb/src/react/core/social/useSocialProfiles.ts
@@ -29,7 +29,7 @@ export function useSocialProfiles(options: {
   return useQuery({
     queryKey: ["social-profiles", address],
     enabled: !!address,
-    retry: 3,
+    retry: false,
     queryFn: async () => {
       if (!address) {
         throw new Error(


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added



<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying the behavior of social profile requests in the `thirdweb` package by disabling the retry mechanism.

### Detailed summary
- Updated the `retry` option in `useSocialProfiles.ts` from `3` to `false` for social profile requests.
- Adjusted the `enabled` condition to ensure it only runs when `address` is truthy.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->