### PR TITLE
fix category page crash

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/explore/[category]/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/explore/[category]/page.tsx
@@ -11,7 +11,7 @@ import {
   ContractCardSkeleton,
 } from "components/explore/contract-card";
 import { DeployUpsellCard } from "components/explore/upsells/deploy-your-own";
-import { ALL_CATEGORIES, getCategory } from "data/explore";
+import { getCategory } from "data/explore";
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
@@ -130,10 +130,4 @@ export default async function ExploreCategoryPage(
       </div>
     </div>
   );
-}
-
-export async function generateStaticParams() {
-  return ALL_CATEGORIES.map((category) => ({
-    params: { category },
-  }));
 }

--- a/apps/dashboard/src/data/explore.ts
+++ b/apps/dashboard/src/data/explore.ts
@@ -309,5 +309,3 @@ function isExploreCategory(category: string): category is ExploreCategoryName {
 export const EXPLORE_PAGE_DATA = Object.values(CATEGORIES).filter((v) =>
   "showInExplore" in v ? v.showInExplore !== false : true,
 );
-
-export const ALL_CATEGORIES = Object.values(CATEGORIES).map((v) => v.id);


### PR DESCRIPTION
fixes: DASH-607

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on removing the usage of `ALL_CATEGORIES` from the `explore.ts` file and its import in `page.tsx`, along with the associated `generateStaticParams` function, which was responsible for generating static parameters based on all categories.

### Detailed summary
- Removed `ALL_CATEGORIES` constant from `apps/dashboard/src/data/explore.ts`.
- Deleted the `generateStaticParams` function from `apps/dashboard/src/app/(dashboard)/explore/[category]/page.tsx`.
- Updated import statements in `page.tsx` to exclude `ALL_CATEGORIES`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->