### PR TITLE
[Nebula] Remove presence message when adding an error message

### DIFF
--- a/apps/dashboard/src/app/nebula-app/(app)/components/ChatPageContent.tsx
+++ b/apps/dashboard/src/app/nebula-app/(app)/components/ChatPageContent.tsx
@@ -242,13 +242,21 @@ export function ChatPageContent(props: {
         return;
       }
       console.error(error);
-      setMessages((prev) => [
-        ...prev,
-        {
+
+      setMessages((prev) => {
+        const newMessages = prev.slice(
+          0,
+          prev[prev.length - 1]?.type === "presence" ? -1 : undefined,
+        );
+
+        // add error message
+        newMessages.push({
           text: `Error: ${error instanceof Error ? error.message : "Failed to execute command"}`,
           type: "error",
-        },
-      ]);
+        });
+
+        return newMessages;
+      });
     } finally {
       setIsChatStreaming(false);
     }


### PR DESCRIPTION
Fixes: DASH-614

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving error handling in the `setMessages` function within the `ChatPageContent` component. It modifies how error messages are constructed and added to the message list.

### Detailed summary
- Refactored `setMessages` to create a new array `newMessages`.
- Used `slice` to conditionally exclude the last message if its type is `presence`.
- Added an error message to `newMessages` with a clear error description.
- Returned `newMessages` instead of directly updating the state.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->