### PR TITLE
[Nebula] Fix page not redirected to new chat page when deleting active chat

### DIFF
--- a/apps/dashboard/src/app/nebula-app/(app)/components/ChatPageContent.tsx
+++ b/apps/dashboard/src/app/nebula-app/(app)/components/ChatPageContent.tsx
@@ -66,17 +66,13 @@ export function ChatPageContent(props: {
     // update page URL without reloading
     window.history.replaceState({}, "", `/chat/${sessionId}`);
 
-    const url = new URL(window.location.origin);
-
     // if the current page is landing page, link to /chat
     // if current page is new /chat page, link to landing page
     if (props.type === "landing") {
-      url.pathname = "/chat";
+      newChatPageUrlStore.setValue("/chat");
     } else {
-      url.pathname = "/";
+      newChatPageUrlStore.setValue("/");
     }
-
-    newChatPageUrlStore.setValue(url.href);
   }
 
   const messagesEndRef = useRef<HTMLDivElement>(null);

--- a/apps/dashboard/src/app/nebula-app/(app)/components/ChatSidebar.tsx
+++ b/apps/dashboard/src/app/nebula-app/(app)/components/ChatSidebar.tsx
@@ -1,14 +1,13 @@
 "use client";
 import { ScrollShadow } from "@/components/ui/ScrollShadow/ScrollShadow";
 import { Button } from "@/components/ui/button";
-import { useStore } from "@/lib/reactive";
 import type { Account } from "@3rdweb-sdk/react/hooks/useApi";
 import { ChevronRightIcon, MessageSquareDashedIcon } from "lucide-react";
 import Link from "next/link";
 import type { TruncatedSessionInfo } from "../api/types";
+import { useNewChatPageLink } from "../hooks/useNewChatPageLink";
 import { useSessionsWithLocalOverrides } from "../hooks/useSessionsWithLocalOverrides";
 import { NebulaIcon } from "../icons/NebulaIcon";
-import { newChatPageUrlStore } from "../stores";
 import { ChatSidebarLink } from "./ChatSidebarLink";
 import { NebulaAccountButton } from "./NebulaAccountButton";
 
@@ -79,9 +78,4 @@ export function ChatSidebar(props: {
       />
     </div>
   );
-}
-
-export function useNewChatPageLink() {
-  const newChatPage = useStore(newChatPageUrlStore);
-  return newChatPage || "/chat";
 }

--- a/apps/dashboard/src/app/nebula-app/(app)/components/ChatSidebarLink.tsx
+++ b/apps/dashboard/src/app/nebula-app/(app)/components/ChatSidebarLink.tsx
@@ -14,6 +14,7 @@ import { EllipsisIcon, TrashIcon } from "lucide-react";
 import { usePathname } from "next/navigation";
 import { toast } from "sonner";
 import { deleteSession } from "../api/session";
+import { useNewChatPageLink } from "../hooks/useNewChatPageLink";
 import { deletedSessionsStore } from "../stores";
 
 // TODO - add delete chat confirmation dialog
@@ -27,6 +28,7 @@ export function ChatSidebarLink(props: {
   const pathname = usePathname();
   const linkPath = `/chat/${props.sessionId}`;
   const isDeletingCurrentPage = pathname === linkPath;
+  const newChatLink = useNewChatPageLink();
   const deleteChat = useMutation({
     mutationFn: () => {
       return deleteSession({
@@ -38,7 +40,7 @@ export function ChatSidebarLink(props: {
       const prev = deletedSessionsStore.getValue();
       deletedSessionsStore.setValue([...prev, props.sessionId]);
       if (isDeletingCurrentPage) {
-        router.replace("/");
+        router.replace(newChatLink);
       }
     },
   });

--- a/apps/dashboard/src/app/nebula-app/(app)/components/NebulaMobileNav.tsx
+++ b/apps/dashboard/src/app/nebula-app/(app)/components/NebulaMobileNav.tsx
@@ -12,7 +12,8 @@ import { MenuIcon } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
 import type { TruncatedSessionInfo } from "../api/types";
-import { ChatSidebar, useNewChatPageLink } from "./ChatSidebar";
+import { useNewChatPageLink } from "../hooks/useNewChatPageLink";
+import { ChatSidebar } from "./ChatSidebar";
 
 export function MobileNav(props: {
   sessions: TruncatedSessionInfo[];

--- a/apps/dashboard/src/app/nebula-app/(app)/hooks/useNewChatPageLink.ts
+++ b/apps/dashboard/src/app/nebula-app/(app)/hooks/useNewChatPageLink.ts
@@ -1,0 +1,9 @@
+"use client";
+
+import { useStore } from "@/lib/reactive";
+import { newChatPageUrlStore } from "../stores";
+
+export function useNewChatPageLink() {
+  const newChatPage = useStore(newChatPageUrlStore);
+  return newChatPage || "/chat";
+}


### PR DESCRIPTION
Fixes: DASH-613

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the chat page link management by introducing the `useNewChatPageLink` hook and updating various components to use it, improving the code structure and maintainability.

### Detailed summary
- Added `useNewChatPageLink` hook in `useNewChatPageLink.ts`.
- Updated `MobileNav` to import `useNewChatPageLink` from hooks.
- Modified `ChatPageContent` to set the chat page URL in `newChatPageUrlStore`.
- Integrated `useNewChatPageLink` in `ChatSidebarLink` and adjusted navigation logic.
- Removed duplicate `useNewChatPageLink` function from `ChatSidebar`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->