### PR TITLE
[Portal] Fix: Broken Link

### DIFF
--- a/apps/portal/src/app/connect/wallet/overview/page.mdx
+++ b/apps/portal/src/app/connect/wallet/overview/page.mdx
@@ -91,7 +91,7 @@ A flexible sign-up flow that accommodates different preferences is critical when
 	icon={WalletsConnectIcon}
 	title="Getting started"
 	description="See our get started guide for quickly getting up and running with thirdweb wallets on the various supported platform."
-	href="/wallet/get-started/overview"
+	href="/connect/wallet/get-started"
 />
 
 <DocImage src={customModal} />


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `href` attribute in the `page.mdx` file to correct the link path for the "Getting started" guide related to thirdweb wallets.

### Detailed summary
- Changed the `href` from `/wallet/get-started/overview` to `/connect/wallet/get-started`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->