### PR TITLE
[Service Utils] Feature: Accept Request in `authorizeNode`

### DIFF
--- a/.changeset/tidy-squids-end.md
+++ b/.changeset/tidy-squids-end.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+Accept Request in authorizeNode


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `authorizeNode` function in the `service-utils` package by improving type handling for request headers and refactoring header retrieval logic.

### Detailed summary
- Updated `req` type in `AuthInput` to allow `Request`.
- Added `isNodeHeaders` type guard to distinguish between `IncomingHttpHeaders` and `Headers`.
- Refactored `getHeader` function to utilize `isNodeHeaders`.
- Modified `extractAuthorizationData` to use `getHeader` for host retrieval.
- Updated `logHttpRequest` to use `getHeader` for various header fields.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->