### PR TITLE
allow passing `null` to service scope, do not check domains on `secretKey` auth

### DIFF
--- a/.changeset/chatty-llamas-drum.md
+++ b/.changeset/chatty-llamas-drum.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+allow passing `null` to service scope, do not validate domains/bundleids when using secretKey auth method

--- a/packages/service-utils/src/core/api.ts
+++ b/packages/service-utils/src/core/api.ts
@@ -16,7 +16,9 @@ export type PolicyResult = {
 
 export type CoreServiceConfig = {
   apiUrl: string;
-  serviceScope: ServiceName;
+  // if EXPLICITLY set to null, service will not be checked for authorization
+  // this is meant for services that are not possible to be turned off by users, such as "social" and "analytics"
+  serviceScope: ServiceName | null;
   serviceApiKey: string;
   serviceAction?: string;
   useWalletAuth?: boolean;
@@ -24,6 +26,7 @@ export type CoreServiceConfig = {
 };
 
 export type TeamAndProjectResponse = {
+  authMethod: "secretKey" | "publishableKey" | "jwt" | "teamId";
   team: TeamResponse;
   project?: ProjectResponse | null;
 };
@@ -42,11 +45,11 @@ export type TeamResponse = {
   name: string;
   slug: string;
   image: string | null;
-  billingPlan: string;
+  billingPlan: "free" | "starter" | "growth" | "pro";
   createdAt: Date;
   updatedAt: Date | null;
   billingEmail: string | null;
-  billingStatus: string | null;
+  billingStatus: "noPayment" | "validPayment" | "invalidPayment" | null;
   growthTrialEligible: boolean | null;
   enabledScopes: ServiceName[];
 };

--- a/packages/service-utils/src/core/authorize/client.ts
+++ b/packages/service-utils/src/core/authorize/client.ts
@@ -12,15 +12,22 @@ export function authorizeClient(
   teamAndProjectResponse: TeamAndProjectResponse,
 ): AuthorizationResult {
   const { origin, bundleId } = authOptions;
-  const { team, project } = teamAndProjectResponse;
+  const { team, project, authMethod } = teamAndProjectResponse;
 
   const authResult: AuthorizationResult = {
     authorized: true,
     team,
     project,
+    authMethod,
   };
 
+  // if there's no project, we'll return the authResult (JWT or teamId auth)
   if (!project) {
+    return authResult;
+  }
+
+  if (authMethod === "secretKey") {
+    // if the auth was done using secretKey, we do not want to enforce domains or bundleIds
     return authResult;
   }
 

--- a/packages/service-utils/src/core/authorize/index.ts
+++ b/packages/service-utils/src/core/authorize/index.ts
@@ -148,5 +148,6 @@ export async function authorize(
     authorized: true,
     team: teamAndProjectResponse.team,
     project: teamAndProjectResponse.project,
+    authMethod: clientAuth.authMethod,
   };
 }

--- a/packages/service-utils/src/core/authorize/service.ts
+++ b/packages/service-utils/src/core/authorize/service.ts
@@ -5,7 +5,16 @@ export function authorizeService(
   teamAndProjectResponse: TeamAndProjectResponse,
   serviceConfig: CoreServiceConfig,
 ): AuthorizationResult {
-  const { team, project } = teamAndProjectResponse;
+  const { team, project, authMethod } = teamAndProjectResponse;
+
+  if (serviceConfig.serviceScope === null) {
+    // if explicitly set to null, we do not want to check for service level authorization
+    return {
+      authorized: true,
+      team,
+      authMethod,
+    };
+  }
 
   if (!team.enabledScopes.includes(serviceConfig.serviceScope)) {
     return {
@@ -21,6 +30,7 @@ export function authorizeService(
     return {
       authorized: true,
       team,
+      authMethod,
     };
   }
 
@@ -57,5 +67,6 @@ export function authorizeService(
     authorized: true,
     team,
     project,
+    authMethod,
   };
 }

--- a/packages/service-utils/src/mocks.ts
+++ b/packages/service-utils/src/mocks.ts
@@ -43,7 +43,7 @@ export const validTeamResponse: TeamResponse = {
   updatedAt: new Date("2024-06-01"),
   billingPlan: "free",
   billingEmail: "test@example.com",
-  billingStatus: "noCustomer",
+  billingStatus: "noPayment",
   growthTrialEligible: false,
   enabledScopes: ["storage", "rpc", "bundler"],
 };
@@ -51,6 +51,7 @@ export const validTeamResponse: TeamResponse = {
 export const validTeamAndProjectResponse: TeamAndProjectResponse = {
   team: validTeamResponse,
   project: validProjectResponse,
+  authMethod: "publishableKey",
 };
 
 export const validServiceConfig: CoreServiceConfig = {


### PR DESCRIPTION
fixes: DASH-621

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces enhancements to the authorization process by allowing an `authMethod` to be passed, enabling flexibility in service scope validation, and updating billing status options. It also improves type definitions for better clarity on authorization methods.

### Detailed summary
- Added `authMethod` to the `teamAndProjectResponse`.
- Allowed `null` for `serviceScope` in `CoreServiceConfig`.
- Updated `billingStatus` options from `"noCustomer"` to `"noPayment"`.
- Enhanced `authorizeService` and `client` functions to handle `authMethod`.
- Defined `authMethod` in `TeamAndProjectResponse` type.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->