### PR TITLE
remove client ID derivation from secret key

### DIFF
--- a/packages/service-utils/src/cf-worker/index.ts
+++ b/packages/service-utils/src/cf-worker/index.ts
@@ -129,14 +129,6 @@ export async function extractAuthorizationData(
   if (secretKey) {
     // hash the secret key
     secretKeyHash = await hashSecretKey(secretKey);
-    // derive the client id from the secret key hash
-    const derivedClientId = deriveClientIdFromSecretKeyHash(secretKeyHash);
-    // if we already have a client id passed in we need to make sure they match
-    if (clientId && clientId !== derivedClientId) {
-      throw new Error("KEY_CONFLICT");
-    }
-    // otherwise set the client id to the derived client id (client id based off of secret key)
-    clientId = derivedClientId;
   }
 
   let jwt: string | null = null;
@@ -168,10 +160,6 @@ export async function hashSecretKey(secretKey: string) {
   return bufferToHex(
     await crypto.subtle.digest("SHA-256", new TextEncoder().encode(secretKey)),
   );
-}
-
-export function deriveClientIdFromSecretKeyHash(secretKeyHash: string) {
-  return secretKeyHash.slice(0, 32);
 }
 
 function bufferToHex(buffer: ArrayBuffer) {

--- a/packages/service-utils/src/core/api.ts
+++ b/packages/service-utils/src/core/api.ts
@@ -22,7 +22,6 @@ export type CoreServiceConfig = {
   serviceApiKey: string;
   serviceAction?: string;
   useWalletAuth?: boolean;
-  includeUsage?: boolean;
 };
 
 export type TeamAndProjectResponse = {

--- a/packages/service-utils/src/node/index.ts
+++ b/packages/service-utils/src/node/index.ts
@@ -21,23 +21,6 @@ export type AuthInput = CoreAuthInput & {
   req: IncomingMessage | Request;
 };
 
-/**
- *
- * @param {AuthInput['req']} authInput.req - The incoming request from which information will be pulled from. These information includes (checks are in order and terminates on first match):
- * - clientId: Checks header `x-client-id`, search param `clientId`
- * - bundleId: Checks header `x-bundle-id`, search param `bundleId`
- * - secretKey: Checks header `x-secret-key`
- * - origin (the requesting domain): Checks header `origin`, `referer`
- * @param {AuthInput['clientId']} authInput.clientId - Overrides any clientId found on the `req` object
- * @param {AuthInput['targetAddress']} authInput.targetAddress - Only used in smart wallets to determine if the request is authorized to interact with the target address.
- * @param {NodeServiceConfig['enforceAuth']} serviceConfig - Always `true` unless you need to turn auth off. Tells the service whether or not to enforce auth.
- * @param {NodeServiceConfig['apiUrl']} serviceConfig.apiUrl - The url of the api server to fetch information for verification. `https://api.thirdweb.com` for production and `https://api.staging.thirdweb.com` for staging
- * @param {NodeServiceConfig['serviceApiKey']} serviceConfig.serviceApiKey - secret key to be used authenticate the caller of the api-server. Check the api-server's env variable for the keys.
- * @param {NodeServiceConfig['serviceScope']} serviceConfig.serviceScope - The service that we are requesting authorization for. E.g. `relayer`, `rpc`, 'bundler', 'storage' etc.
- * @param {NodeServiceConfig['serviceAction']} serviceConfig.serviceAction - Needed when the `serviceScope` is `storage`. Can be either `read` or `write`.
- * @param {NodeServiceConfig['useWalletAuth']} serviceConfig.useWalletAuth - If true it pings the `wallet/me` or else, `account/me`. You most likely can leave this as false.
- * @returns {AuthorizationResult} authorizationResult - contains if the request is authorized, and information about the account if it is authorized. Otherwise, it contains the error message and status code.
- */
 export async function authorizeNode(
   authInput: AuthInput,
   serviceConfig: NodeServiceConfig,
@@ -150,14 +133,6 @@ export function extractAuthorizationData(
   if (secretKey) {
     // hash the secret key
     secretKeyHash = hashSecretKey(secretKey);
-    // derive the client id from the secret key hash
-    const derivedClientId = deriveClientIdFromSecretKeyHash(secretKeyHash);
-    // if we already have a client id passed in we need to make sure they match
-    if (clientId && clientId !== derivedClientId) {
-      throw new Error("KEY_CONFLICT");
-    }
-    // otherwise set the client id to the derived client id (client id based off of secret key)
-    clientId = derivedClientId;
   }
 
   let jwt: null | string = null;
@@ -193,10 +168,6 @@ export function extractAuthorizationData(
 
 export function hashSecretKey(secretKey: string) {
   return createHash("sha256").update(secretKey).digest("hex");
-}
-
-export function deriveClientIdFromSecretKeyHash(secretKeyHash: string) {
-  return secretKeyHash.slice(0, 32);
 }
 
 export function logHttpRequest({


### PR DESCRIPTION
fixes: DASH-621

we explicitly *DO NOT* want to derive from secretKey anymore - this would otherwise block multi secret key per project

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on removing unused functionality and simplifying the code related to client ID derivation and authorization in the `Node` service, enhancing clarity and maintainability.

### Detailed summary
- Removed `includeUsage` property from the `TeamAndProjectResponse` type.
- Deleted the `deriveClientIdFromSecretKeyHash` function.
- Eliminated client ID validation logic in `authorizeNode` and `extractAuthorizationData` functions.
- Removed extensive comments documenting the parameters of the `authorizeNode` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->