### PR TITLE
Process deploy param ref only when non-empty

### DIFF
--- a/packages/thirdweb/src/extensions/prebuilts/deploy-published.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/deploy-published.ts
@@ -150,28 +150,35 @@ export async function deployContractfromDeployMetadata(
     salt,
   } = options;
 
-  const processedImplParams: Record<string, string | string[]> = {};
-  for (const key in implementationConstructorParams) {
-    processedImplParams[key] = await processRefDeployments({
-      client,
-      account,
-      chain,
-      paramValue: implementationConstructorParams[key] as
-        | string
-        | ImplementationConstructorParam,
-    });
+  let processedImplParams: Record<string, string | string[]> | undefined;
+  let processedInitializeParams: Record<string, string | string[]> | undefined;
+
+  if (implementationConstructorParams) {
+    processedImplParams = {};
+    for (const key in implementationConstructorParams) {
+      processedImplParams[key] = await processRefDeployments({
+        client,
+        account,
+        chain,
+        paramValue: implementationConstructorParams[key] as
+          | string
+          | ImplementationConstructorParam,
+      });
+    }
   }
 
-  const processedInitializeParams: Record<string, string | string[]> = {};
-  for (const key in initializeParams) {
-    processedInitializeParams[key] = await processRefDeployments({
-      client,
-      account,
-      chain,
-      paramValue: initializeParams[key] as
-        | string
-        | ImplementationConstructorParam,
-    });
+  if (initializeParams) {
+    processedInitializeParams = {};
+    for (const key in initializeParams) {
+      processedInitializeParams[key] = await processRefDeployments({
+        client,
+        account,
+        chain,
+        paramValue: initializeParams[key] as
+          | string
+          | ImplementationConstructorParam,
+      });
+    }
   }
 
   switch (deployMetadata?.deployType) {


### PR DESCRIPTION
PROT-935

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the handling of `implementationConstructorParams` and `initializeParams` by adding checks to ensure they are defined before processing, enhancing code safety and readability.

### Detailed summary
- Changed `processedImplParams` and `processedInitializeParams` to be `undefined` initially.
- Added checks for `implementationConstructorParams` and `initializeParams` to ensure they are defined before processing.
- Retained the logic for processing parameters within the respective conditionals.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->