### PR TITLE
use resolved ENS name if available

### DIFF
--- a/apps/dashboard/next-env.d.ts
+++ b/apps/dashboard/next-env.d.ts
@@ -3,4 +3,4 @@
 /// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "preinstall": "npx only-allow pnpm",
-    "dev": "next dev",
+    "dev": "next dev --turbo",
     "build": "NODE_OPTIONS=--max-old-space-size=6144 next build",
     "start": "next start",
     "format": "biome format ./src --write",

--- a/apps/dashboard/src/app/(dashboard)/profile/[addressOrEns]/ProfileUI.tsx
+++ b/apps/dashboard/src/app/(dashboard)/profile/[addressOrEns]/ProfileUI.tsx
@@ -14,7 +14,7 @@ export function ProfileUI(props: {
 
   return (
     <div className="container pt-8 pb-20">
-      <ProfileHeader profileAddress={profileAddress} />
+      <ProfileHeader profileAddress={profileAddress} ensName={ensName} />
       <div className="h-8" />
 
       <div>

--- a/apps/dashboard/src/app/(dashboard)/profile/[addressOrEns]/components/profile-header.tsx
+++ b/apps/dashboard/src/app/(dashboard)/profile/[addressOrEns]/components/profile-header.tsx
@@ -12,7 +12,10 @@ import {
 } from "thirdweb/react";
 import { shortenIfAddress } from "utils/usedapp-external";
 
-export function ProfileHeader(props: { profileAddress: string }) {
+export function ProfileHeader(props: {
+  profileAddress: string;
+  ensName: string | undefined;
+}) {
   const client = useThirdwebClient();
   return (
     <AccountProvider address={props.profileAddress} client={client}>
@@ -27,17 +30,22 @@ export function ProfileHeader(props: { profileAddress: string }) {
           />
           <div>
             <h1 className="font-semibold text-4xl tracking-tight">
-              <AccountName
-                fallbackComponent={
-                  <AccountAddress
-                    formatFn={(addr) =>
-                      shortenIfAddress(replaceDeployerAddress(addr))
-                    }
-                  />
-                }
-                loadingComponent={<Skeleton className="h-8 w-40" />}
-                formatFn={(name) => replaceDeployerAddress(name)}
-              />
+              {/* if we already have an ensName just use it */}
+              {props.ensName ? (
+                props.ensName
+              ) : (
+                <AccountName
+                  fallbackComponent={
+                    <AccountAddress
+                      formatFn={(addr) =>
+                        shortenIfAddress(replaceDeployerAddress(addr))
+                      }
+                    />
+                  }
+                  loadingComponent={<Skeleton className="h-8 w-40" />}
+                  formatFn={(name) => replaceDeployerAddress(name)}
+                />
+              )}
             </h1>
           </div>
         </div>

--- a/apps/dashboard/src/app/(dashboard)/profile/[addressOrEns]/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/profile/[addressOrEns]/page.tsx
@@ -21,7 +21,7 @@ export default async function Page(props: PageProps) {
 
   return (
     <ProfileUI
-      ensName={resolvedInfo.ensName}
+      ensName={replaceDeployerAddress(resolvedInfo.ensName || "")}
       profileAddress={resolvedInfo.address}
     />
   );


### PR DESCRIPTION
fixes: DASH-572

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `ProfileUI` and `ProfileHeader` components by adding the `ensName` property, improving how the ENS name is displayed. It also updates the `dev` script in `package.json` to use the Turbo feature and modifies a comment in `next-env.d.ts`.

### Detailed summary
- In `page.tsx`, `ensName` is now set using `replaceDeployerAddress`.
- The `ProfileHeader` component now accepts `ensName` as a prop.
- In `ProfileHeader`, the ENS name is conditionally displayed if available.
- The `dev` script in `package.json` has been updated to use `--turbo`.
- Updated the comment in `next-env.d.ts` for clarity on TypeScript configuration.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->