### PR TITLE
[DASH-624] Add tracking in insight playground

### DIFF
--- a/apps/dashboard/src/@/components/ui/code/CodeBlockContainer.tsx
+++ b/apps/dashboard/src/@/components/ui/code/CodeBlockContainer.tsx
@@ -14,6 +14,7 @@ export function CodeBlockContainer(props: {
   scrollableContainerClassName?: string;
   copyButtonClassName?: string;
   shadowColor?: string;
+  onCopy?: (code: string) => void;
 }) {
   const { hasCopied, onCopy } = useClipboard(props.codeToCopy);
 
@@ -38,7 +39,10 @@ export function CodeBlockContainer(props: {
       <Button
         size="sm"
         variant="outline"
-        onClick={onCopy}
+        onClick={() => {
+          onCopy();
+          props.onCopy?.(props.codeToCopy);
+        }}
         className={cn(
           "absolute top-3.5 right-3.5 h-auto bg-background p-2",
           props.copyButtonClassName,

--- a/apps/dashboard/src/@/components/ui/code/RenderCode.tsx
+++ b/apps/dashboard/src/@/components/ui/code/RenderCode.tsx
@@ -8,6 +8,7 @@ export function RenderCode(props: {
   copyButtonClassName?: string;
   scrollableContainerClassName?: string;
   shadowColor?: string;
+  onCopy?: (code: string) => void;
 }) {
   return (
     <CodeBlockContainer
@@ -17,6 +18,7 @@ export function RenderCode(props: {
       scrollableClassName={props.scrollableClassName}
       scrollableContainerClassName={props.scrollableContainerClassName}
       shadowColor={props.shadowColor}
+      onCopy={props.onCopy}
     >
       <div
         // biome-ignore lint/security/noDangerouslySetInnerHtml: we know what we're doing here

--- a/apps/dashboard/src/@/components/ui/code/code.client.tsx
+++ b/apps/dashboard/src/@/components/ui/code/code.client.tsx
@@ -15,6 +15,7 @@ export type CodeProps = {
   scrollableContainerClassName?: string;
   shadowColor?: string;
   ignoreFormattingErrors?: boolean;
+  onCopy?: (code: string) => void;
 };
 
 export const CodeClient: React.FC<CodeProps> = ({
@@ -27,6 +28,7 @@ export const CodeClient: React.FC<CodeProps> = ({
   ignoreFormattingErrors,
   scrollableContainerClassName,
   shadowColor,
+  onCopy,
 }) => {
   const codeQuery = useQuery({
     queryKey: ["html", code],
@@ -49,6 +51,7 @@ export const CodeClient: React.FC<CodeProps> = ({
         copyButtonClassName={copyButtonClassName}
         scrollableContainerClassName={scrollableContainerClassName}
         shadowColor={shadowColor}
+        onCopy={onCopy}
       />
     );
   }
@@ -62,6 +65,7 @@ export const CodeClient: React.FC<CodeProps> = ({
       copyButtonClassName={copyButtonClassName}
       scrollableContainerClassName={scrollableContainerClassName}
       shadowColor={shadowColor}
+      onCopy={onCopy}
     />
   );
 };

--- a/apps/dashboard/src/@/components/ui/code/plaintext-code.tsx
+++ b/apps/dashboard/src/@/components/ui/code/plaintext-code.tsx
@@ -9,6 +9,7 @@ export function PlainTextCodeBlock(props: {
   codeClassName?: string;
   scrollableContainerClassName?: string;
   shadowColor?: string;
+  onCopy?: (code: string) => void;
 }) {
   return (
     <CodeBlockContainer
@@ -18,6 +19,7 @@ export function PlainTextCodeBlock(props: {
       scrollableClassName={props.scrollableClassName}
       scrollableContainerClassName={props.scrollableContainerClassName}
       shadowColor={props.shadowColor}
+      onCopy={props.onCopy}
     >
       <code className={cn("block whitespace-pre", props.codeClassName)}>
         {props.code}

--- a/apps/dashboard/src/app/team/[team_slug]/[project_slug]/insight/[blueprint_slug]/blueprint-playground.client.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/[project_slug]/insight/[blueprint_slug]/blueprint-playground.client.tsx
@@ -28,8 +28,11 @@ import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import { type UseFormReturn, useForm } from "react-hook-form";
 import { z } from "zod";
+import { useTrack } from "../../../../../../hooks/analytics/useTrack";
 import { getVercelEnv } from "../../../../../../lib/vercel-utils";
 import type { BlueprintParameter, BlueprintPathMetadata } from "../utils";
+
+const trackingCategory = "insightBlueprint";
 
 export function BlueprintPlayground(props: {
   metadata: BlueprintPathMetadata;
@@ -151,6 +154,7 @@ export function BlueprintPlaygroundUI(props: {
   projectSettingsLink: string;
   supportedChainIds: number[];
 }) {
+  const trackEvent = useTrack();
   const parameters = useMemo(() => {
     return modifyParametersForPlayground(props.metadata.parameters);
   }, [props.metadata.parameters]);
@@ -182,6 +186,12 @@ export function BlueprintPlaygroundUI(props: {
       intent: "run",
     });
 
+    trackEvent({
+      category: trackingCategory,
+      action: "click",
+      label: "run",
+      url: url,
+    });
     props.onRun(url);
   }
 
@@ -306,6 +316,8 @@ function PlaygroundHeader(props: {
   domain: string;
   path: string;
 }) {
+  const trackEvent = useTrack();
+
   const [hasCopied, setHasCopied] = useState(false);
   return (
     <div className="border-b px-4 py-4 lg:flex lg:justify-center lg:py-3">
@@ -325,6 +337,14 @@ function PlaygroundHeader(props: {
                 values: props.getFormValues(),
                 intent: "copy",
               });
+
+              trackEvent({
+                category: trackingCategory,
+                action: "click",
+                label: "copy-url",
+                url: url,
+              });
+
               setTimeout(() => {
                 setHasCopied(false);
               }, 500);
@@ -561,6 +581,7 @@ function ResponseSection(props: {
     | undefined;
   abortRequest: () => void;
 }) {
+  const trackEvent = useTrack();
   const formattedData = useMemo(() => {
     if (!props.response?.data) return undefined;
     try {
@@ -628,6 +649,13 @@ function ResponseSection(props: {
           scrollableContainerClassName="h-full"
           scrollableClassName="h-full"
           shadowColor="hsl(var(--muted)/50%)"
+          onCopy={() => {
+            trackEvent({
+              category: trackingCategory,
+              action: "click",
+              label: "copy-response",
+            });
+          }}
         />
       )}
     </div>


### PR DESCRIPTION
## Problem solved

DASH-624

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `CodeBlockContainer` and related components to support a new `onCopy` callback, which allows for custom actions when code is copied. Additionally, it integrates tracking events for user interactions in the `BlueprintPlayground` component.

### Detailed summary
- Added `onCopy` prop to `CodeBlockContainer`, `RenderCode`, `PlainTextCodeBlock`, and `CodeClient`.
- Updated `onClick` handler in `CodeBlockContainer` to call `onCopy` and execute the new `onCopy` prop.
- Integrated `useTrack` for tracking events in `BlueprintPlayground` and `PlaygroundHeader`.
- Added tracking for "run", "copy-url", and "copy-response" actions in `BlueprintPlayground` and `ResponseSection`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->