### PR TITLE
[DASH-616] Nebula - Add Alpha badge in sidebar

### DIFF
--- a/apps/dashboard/src/app/nebula-app/(app)/components/ChatSidebar.tsx
+++ b/apps/dashboard/src/app/nebula-app/(app)/components/ChatSidebar.tsx
@@ -1,8 +1,13 @@
 "use client";
 import { ScrollShadow } from "@/components/ui/ScrollShadow/ScrollShadow";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import type { Account } from "@3rdweb-sdk/react/hooks/useApi";
-import { ChevronRightIcon, MessageSquareDashedIcon } from "lucide-react";
+import {
+  ChevronRightIcon,
+  FlaskConicalIcon,
+  MessageSquareDashedIcon,
+} from "lucide-react";
 import Link from "next/link";
 import type { TruncatedSessionInfo } from "../api/types";
 import { useNewChatPageLink } from "../hooks/useNewChatPageLink";
@@ -23,10 +28,15 @@ export function ChatSidebar(props: {
 
   return (
     <div className="flex h-full flex-col p-2">
-      <div className="flex justify-start p-2">
+      <div className="flex items-center justify-start gap-3 p-2 lg:justify-between">
         <Link href="/">
           <NebulaIcon className="size-8 text-foreground" />
         </Link>
+
+        <Badge variant="outline" className="gap-1">
+          <FlaskConicalIcon className="size-2.5" />
+          Alpha
+        </Badge>
       </div>
 
       <div className="p-2">

--- a/apps/dashboard/src/app/nebula-app/(app)/components/NebulaMobileNav.tsx
+++ b/apps/dashboard/src/app/nebula-app/(app)/components/NebulaMobileNav.tsx
@@ -32,7 +32,7 @@ export function MobileNav(props: {
             onClick={() => setIsOpen(!isOpen)}
             className="h-auto w-auto p-0.5"
           >
-            <MenuIcon className="size-6" />
+            <MenuIcon className="size-8" />
           </Button>
         </SheetTrigger>
         <SheetContent


### PR DESCRIPTION
## Problem solved

DASH-616

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on UI improvements in the `NebulaMobileNav` and `ChatSidebar` components. It updates icon sizes and enhances layout and styling for better user experience.

### Detailed summary
- In `NebulaMobileNav.tsx`, the size of the `MenuIcon` is increased from `size-6` to `size-8`.
- In `ChatSidebar.tsx`:
  - Added `Badge` component for displaying an "Alpha" label with a `FlaskConicalIcon`.
  - Updated the layout of the top `div` to have a gap and align items centrally. 
  - Imported `FlaskConicalIcon` in addition to existing icons.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->