### PR TITLE
[CI] Chore: Only run actions for contributors

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -2,7 +2,7 @@ name: Auto Author Assign
 
 on:
   pull_request:
-    types: [ opened, reopened ]
+    types: [opened, reopened]
 
 permissions:
   pull-requests: write
@@ -10,5 +10,9 @@ permissions:
 jobs:
   assign-author:
     runs-on: ubuntu-latest
+    if: |
+      github.event.pull_request.author_association == 'MEMBER' ||
+      github.event.pull_request.author_association == 'OWNER' ||
+      github.event.pull_request.author_association == 'COLLABORATOR'
     steps:
       - uses: toshimaru/auto-author-assign@v2.1.1

--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -2,7 +2,7 @@ name: Linked Issue
 
 on:
   pull_request:
-    types: [opened, edited]
+    types: [opened, edited, ready_for_review]
 
 env:
   VALID_ISSUE_PREFIXES: "CNCT|DASH|PROT|INSIGHT|ENGINE|CS|DES|BIL|DEVX|SOLU|NEB"
@@ -21,6 +21,17 @@ jobs:
               repo: context.repo.repo,
               pull_number: context.issue.number
             });
+
+            // Check if contributor is external
+            const isInternalContributor = ['MEMBER', 'OWNER', 'COLLABORATOR'].includes(
+              context.payload.pull_request.author_association
+            );
+
+            // Automatically pass for external contributors
+            if (!isInternalContributor) {
+              console.log('External contributor detected - automatically passing check');
+              return;
+            }
 
             const body = pr.data.body || '';
             const branchName = pr.data.head.ref;


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates GitHub Actions workflows to enhance pull request handling by adding conditions for author associations and expanding the issue types that trigger actions.

### Detailed summary
- In `.github/workflows/auto-assign.yml`:
  - Added conditions to the `assign-author` job to check if the author is a `MEMBER`, `OWNER`, or `COLLABORATOR`.

- In `.github/workflows/issue.yml`:
  - Expanded the types of pull requests that trigger actions to include `ready_for_review`.
  - Added logic to automatically pass checks for external contributors.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->