### PR TITLE
[CI] Feature: Deploy typedoc to permalink

### DIFF
--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -1,0 +1,50 @@
+name: TypeDoc
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment
+concurrency:
+  group: "typedoc"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: "Generate TypeDoc"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        
+      - name: Install
+        uses: ./.github/composite-actions/install
+
+      - name: Run TypeDoc
+        run: pnpm typedoc
+
+      - name: Update Gist
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GIST_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const content = fs.readFileSync('./packages/thirdweb/typedoc/parsed.json', 'utf8');
+            const gistId = '678fe1f331a01270bb002fee660f285d';
+            
+            await github.rest.gists.update({
+              gist_id: gistId,
+              files: {
+                'data.json': {
+                  content: content
+                }
+              }
+            });
+          
+            console.log(`Permalink: https://gist.githubusercontent.com/raw/${gistId}/data.json`);

--- a/packages/thirdweb/package.json
+++ b/packages/thirdweb/package.json
@@ -1,376 +1,377 @@
 {
-  "name": "thirdweb",
-  "version": "5.78.0",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/thirdweb-dev/js.git#main"
-  },
-  "license": "Apache-2.0",
-  "bugs": {
-    "url": "https://github.com/thirdweb-dev/js/issues"
-  },
-  "author": "thirdweb eng <eng@thirdweb.com>",
-  "type": "module",
-  "bin": {
-    "thirdweb": "./dist/esm/cli/bin.js",
-    "thirdweb-cli": "./dist/esm/cli/bin.js"
-  },
-  "main": "./dist/cjs/exports/thirdweb.js",
-  "module": "./dist/esm/exports/thirdweb.js",
-  "types": "./dist/types/exports/thirdweb.d.ts",
-  "typings": "./dist/types/exports/thirdweb.d.ts",
-  "exports": {
-    ".": {
-      "types": "./dist/types/exports/thirdweb.d.ts",
-      "import": "./dist/esm/exports/thirdweb.js",
-      "default": "./dist/cjs/exports/thirdweb.js"
-    },
-    "./adapters/*": {
-      "types": "./dist/types/exports/adapters/*.d.ts",
-      "import": "./dist/esm/exports/adapters/*.js",
-      "default": "./dist/cjs/exports/adapters/*.js"
-    },
-    "./auth": {
-      "types": "./dist/types/exports/auth.d.ts",
-      "import": "./dist/esm/exports/auth.js",
-      "default": "./dist/cjs/exports/auth.js"
-    },
-    "./chains": {
-      "types": "./dist/types/exports/chains.d.ts",
-      "import": "./dist/esm/exports/chains.js",
-      "default": "./dist/cjs/exports/chains.js"
-    },
-    "./contract": {
-      "types": "./dist/types/exports/contract.d.ts",
-      "import": "./dist/esm/exports/contract.js",
-      "default": "./dist/cjs/exports/contract.js"
-    },
-    "./deploys": {
-      "types": "./dist/types/exports/deploys.d.ts",
-      "import": "./dist/esm/exports/deploys.js",
-      "default": "./dist/cjs/exports/deploys.js"
-    },
-    "./event": {
-      "types": "./dist/types/exports/event.d.ts",
-      "import": "./dist/esm/exports/event.js",
-      "default": "./dist/cjs/exports/event.js"
-    },
-    "./extensions/*": {
-      "types": "./dist/types/exports/extensions/*.d.ts",
-      "import": "./dist/esm/exports/extensions/*.js",
-      "default": "./dist/cjs/exports/extensions/*.js"
-    },
-    "./pay": {
-      "types": "./dist/types/exports/pay.d.ts",
-      "import": "./dist/esm/exports/pay.js",
-      "default": "./dist/cjs/exports/pay.js"
-    },
-    "./react": {
-      "types": "./dist/types/exports/react.d.ts",
-      "import": "./dist/esm/exports/react.js",
-      "react-native": "./dist/esm/exports/react.native.js",
-      "default": "./dist/cjs/exports/react.js"
-    },
-    "./react-native": {
-      "types": "./dist/types/exports/react-native.d.ts",
-      "import": "./dist/esm/exports/react-native.js",
-      "default": "./dist/cjs/exports/react-native.js"
-    },
-    "./rpc": {
-      "types": "./dist/types/exports/rpc.d.ts",
-      "import": "./dist/esm/exports/rpc.js",
-      "default": "./dist/cjs/exports/rpc.js"
-    },
-    "./storage": {
-      "types": "./dist/types/exports/storage.d.ts",
-      "import": "./dist/esm/exports/storage.js",
-      "default": "./dist/cjs/exports/storage.js"
-    },
-    "./transaction": {
-      "types": "./dist/types/exports/transaction.d.ts",
-      "import": "./dist/esm/exports/transaction.js",
-      "default": "./dist/cjs/exports/transaction.js"
-    },
-    "./utils": {
-      "types": "./dist/types/exports/utils.d.ts",
-      "import": "./dist/esm/exports/utils.js",
-      "default": "./dist/cjs/exports/utils.js"
-    },
-    "./wallets": {
-      "types": "./dist/types/exports/wallets.d.ts",
-      "import": "./dist/esm/exports/wallets.js",
-      "react-native": "./dist/esm/exports/wallets.native.js",
-      "default": "./dist/cjs/exports/wallets.js"
-    },
-    "./wallets/in-app": {
-      "types": "./dist/types/exports/wallets/in-app.d.ts",
-      "import": "./dist/esm/exports/wallets/in-app.js",
-      "react-native": "./dist/esm/exports/wallets/in-app.native.js",
-      "default": "./dist/cjs/exports/wallets/in-app.js"
-    },
-    "./wallets/*": {
-      "types": "./dist/types/exports/wallets/*.d.ts",
-      "import": "./dist/esm/exports/wallets/*.js",
-      "default": "./dist/cjs/exports/wallets/*.js"
-    },
-    "./modules": {
-      "types": "./dist/types/exports/modules.d.ts",
-      "import": "./dist/esm/exports/modules.js",
-      "default": "./dist/cjs/exports/modules.js"
-    },
-    "./social": {
-      "types": "./dist/types/exports/social.d.ts",
-      "import": "./dist/esm/exports/social.js",
-      "default": "./dist/cjs/exports/social.js"
-    },
-    "./package.json": "./package.json"
-  },
-  "typesVersions": {
-    "*": {
-      "adapters/*": [
-        "./dist/types/exports/adapters/*.d.ts"
-      ],
-      "auth": [
-        "./dist/types/exports/auth.d.ts"
-      ],
-      "chains": [
-        "./dist/types/exports/chains.d.ts"
-      ],
-      "contract": [
-        "./dist/types/exports/contract.d.ts"
-      ],
-      "deploys": [
-        "./dist/types/exports/deploys.d.ts"
-      ],
-      "event": [
-        "./dist/types/exports/event.d.ts"
-      ],
-      "extensions/*": [
-        "./dist/types/exports/extensions/*.d.ts"
-      ],
-      "pay": [
-        "./dist/types/exports/pay.d.ts"
-      ],
-      "react": [
-        "./dist/types/exports/react.d.ts"
-      ],
-      "react-native": [
-        "./dist/types/exports/react-native.d.ts"
-      ],
-      "rpc": [
-        "./dist/types/exports/rpc.d.ts"
-      ],
-      "storage": [
-        "./dist/types/exports/storage.d.ts"
-      ],
-      "transaction": [
-        "./dist/types/exports/transaction.d.ts"
-      ],
-      "utils": [
-        "./dist/types/exports/utils.d.ts"
-      ],
-      "wallets": [
-        "./dist/types/exports/wallets.d.ts"
-      ],
-      "wallets/*": [
-        "./dist/types/exports/wallets/*.d.ts"
-      ],
-      "modules": [
-        "./dist/types/exports/modules.d.ts"
-      ],
-      "social": [
-        "./dist/types/exports/social.d.ts"
-      ]
-    }
-  },
-  "browser": {
-    "crypto": false
-  },
-  "sideEffects": false,
-  "files": [
-    "dist/*",
-    "src/*",
-    "!**/*.tsbuildinfo",
-    "!**/*.test.ts",
-    "!**/*.test.tsx",
-    "!**/*.test.ts.snap",
-    "!**/*.test-d.ts",
-    "!**/*.bench.ts",
-    "!tsconfig.build.json"
-  ],
-  "dependencies": {
-    "@coinbase/wallet-sdk": "4.2.4",
-    "@emotion/react": "11.14.0",
-    "@emotion/styled": "11.14.0",
-    "@google/model-viewer": "2.1.1",
-    "@noble/curves": "1.7.0",
-    "@noble/hashes": "1.6.1",
-    "@passwordless-id/webauthn": "^2.1.2",
-    "@radix-ui/react-dialog": "1.1.2",
-    "@radix-ui/react-focus-scope": "1.1.0",
-    "@radix-ui/react-icons": "1.3.2",
-    "@radix-ui/react-tooltip": "1.1.4",
-    "@tanstack/react-query": "5.62.7",
-    "@walletconnect/ethereum-provider": "2.17.2",
-    "@walletconnect/sign-client": "2.17.2",
-    "abitype": "1.0.7",
-    "fuse.js": "7.0.0",
-    "input-otp": "^1.4.1",
-    "mipd": "0.0.7",
-    "ox": "0.4.1",
-    "uqr": "0.1.2",
-    "viem": "2.21.54"
-  },
-  "peerDependencies": {
-    "@aws-sdk/client-lambda": "^3",
-    "@aws-sdk/credential-providers": "^3",
-    "@coinbase/wallet-mobile-sdk": "^1",
-    "@mobile-wallet-protocol/client": "0.1.1",
-    "@react-native-async-storage/async-storage": "^1 || ^2",
-    "ethers": "^5 || ^6",
-    "expo-linking": "^6",
-    "expo-web-browser": "^13 || ^14",
-    "react": "^18 || ^19",
-    "react-native": "*",
-    "react-native-aes-gcm-crypto": "^0.2",
-    "react-native-passkey": "^3",
-    "react-native-quick-crypto": ">=0.7.0-rc.6 || >=0.7",
-    "react-native-svg": "^15",
-    "typescript": ">=5.0.4"
-  },
-  "peerDependenciesMeta": {
-    "react": {
-      "optional": true
-    },
-    "react-native": {
-      "optional": true
-    },
-    "ethers": {
-      "optional": true
-    },
-    "typescript": {
-      "optional": true
-    },
-    "react-native-aes-gcm-crypto": {
-      "optional": true
-    },
-    "expo-linking": {
-      "optional": true
-    },
-    "expo-web-browser": {
-      "optional": true
-    },
-    "react-native-quick-crypto": {
-      "optional": true
-    },
-    "react-native-passkey": {
-      "optional": true
-    },
-    "react-native-svg": {
-      "optional": true
-    },
-    "@aws-sdk/client-lambda": {
-      "optional": true
-    },
-    "@aws-sdk/client-kms": {
-      "optional": true
-    },
-    "@aws-sdk/credential-providers": {
-      "optional": true
-    },
-    "@react-native-async-storage/async-storage": {
-      "optional": true
-    },
-    "@coinbase/wallet-mobile-sdk": {
-      "optional": true
-    },
-    "@mobile-wallet-protocol/client": {
-      "optional": true
-    }
-  },
-  "scripts": {
-    "bench:compare": "bun run ./benchmarks/run.ts",
-    "bench": "vitest -c ./test/vitest.config.ts bench",
-    "format": "biome format ./src --write",
-    "lint": "knip && biome check ./src && tsc --project ./tsconfig.build.json --module esnext --noEmit",
-    "fix": "biome check ./src --fix",
-    "knip": "knip",
-    "build:generate": "bun scripts/generate/generate.ts",
-    "build:generate-wallets": "bun scripts/wallets/generate.ts",
-    "dev": "tsc --project ./tsconfig.build.json --module es2020 --outDir ./dist/esm --watch",
-    "dev:cjs": "printf '{\"type\":\"commonjs\"}' > ./dist/cjs/package.json && tsc --noCheck --project ./tsconfig.build.json --module commonjs --outDir ./dist/cjs --verbatimModuleSyntax false --watch",
-    "dev:esm": "printf '{\"type\": \"module\",\"sideEffects\":false}' > ./dist/esm/package.json && tsc --noCheck --project ./tsconfig.build.json --module es2020 --outDir ./dist/esm --watch",
-    "build": "pnpm clean && pnpm build:types && pnpm build:cjs && pnpm build:esm",
-    "build:cjs": "tsc --noCheck --project ./tsconfig.build.json --module commonjs --outDir ./dist/cjs --verbatimModuleSyntax false && printf '{\"type\":\"commonjs\"}' > ./dist/cjs/package.json",
-    "build:esm": "tsc --noCheck --project ./tsconfig.build.json --module es2020 --outDir ./dist/esm && printf '{\"type\": \"module\",\"sideEffects\":false}' > ./dist/esm/package.json",
-    "build:types": "tsc --project ./tsconfig.build.json --module esnext --declarationDir ./dist/types --emitDeclarationOnly --declaration --declarationMap",
-    "clean": "rimraf dist",
-    "size": "size-limit",
-    "test:watch": "vitest -c ./test/vitest.config.ts dev",
-    "test": "vitest run -c ./test/vitest.config.ts --coverage",
-    "test:cov": "vitest dev -c ./test/vitest.config.ts --coverage",
-    "test:ui": "vitest dev -c ./test/vitest.config.ts --coverage --ui",
-    "test:dev": "vitest run -c ./test/vitest.config.ts",
-    "test:react": "vitest run -c ./test/vitest.config.ts dev --ui src/react",
-    "typedoc": "bun run scripts/typedoc.mjs",
-    "update-version": "node scripts/version.mjs",
-    "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
-  },
-  "engines": {
-    "node": ">=18"
-  },
-  "devDependencies": {
-    "@aws-sdk/client-kms": "3.709.0",
-    "@aws-sdk/client-lambda": "3.709.0",
-    "@aws-sdk/credential-providers": "3.709.0",
-    "@biomejs/biome": "1.9.4",
-    "@chromatic-com/storybook": "3.2.2",
-    "@codspeed/vitest-plugin": "4.0.0",
-    "@coinbase/wallet-mobile-sdk": "1.1.2",
-    "@mobile-wallet-protocol/client": "0.1.2",
-    "@react-native-async-storage/async-storage": "2.1.0",
-    "@size-limit/preset-big-lib": "11.1.6",
-    "@storybook/addon-essentials": "8.4.7",
-    "@storybook/addon-interactions": "8.4.7",
-    "@storybook/addon-links": "8.4.7",
-    "@storybook/addon-onboarding": "8.4.7",
-    "@storybook/react": "8.4.7",
-    "@storybook/react-vite": "8.4.7",
-    "@storybook/test": "8.4.7",
-    "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.1.0",
-    "@testing-library/user-event": "^14.5.2",
-    "@types/cross-spawn": "^6.0.6",
-    "@types/react": "19.0.1",
-    "@viem/anvil": "0.0.10",
-    "@vitejs/plugin-react": "^4.3.4",
-    "@vitest/coverage-v8": "2.1.8",
-    "@vitest/ui": "2.1.8",
-    "cross-spawn": "7.0.6",
-    "dotenv-mono": "^1.3.14",
-    "ethers5": "npm:ethers@5",
-    "ethers6": "npm:ethers@6",
-    "expo-linking": "7.0.3",
-    "expo-web-browser": "14.0.1",
-    "happy-dom": "15.11.7",
-    "knip": "5.39.4",
-    "msw": "2.6.8",
-    "prettier": "3.3.3",
-    "react": "19.0.0",
-    "react-dom": "19.0.0",
-    "react-native": "0.76.5",
-    "react-native-aes-gcm-crypto": "0.2.2",
-    "react-native-passkey": "3.0.0",
-    "react-native-quick-crypto": "0.7.8",
-    "react-native-svg": "15.10.1",
-    "rimraf": "6.0.1",
-    "sharp": "^0.33.5",
-    "size-limit": "11.1.6",
-    "storybook": "8.4.7",
-    "typedoc": "0.27.4",
-    "typescript": "5.7.2",
-    "vite": "6.0.3",
-    "vitest": "2.1.8"
-  }
+	"name": "thirdweb",
+	"version": "5.78.0",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/thirdweb-dev/js.git#main"
+	},
+	"license": "Apache-2.0",
+	"bugs": {
+		"url": "https://github.com/thirdweb-dev/js/issues"
+	},
+	"author": "thirdweb eng <eng@thirdweb.com>",
+	"type": "module",
+	"bin": {
+		"thirdweb": "./dist/esm/cli/bin.js",
+		"thirdweb-cli": "./dist/esm/cli/bin.js"
+	},
+	"main": "./dist/cjs/exports/thirdweb.js",
+	"module": "./dist/esm/exports/thirdweb.js",
+	"types": "./dist/types/exports/thirdweb.d.ts",
+	"typings": "./dist/types/exports/thirdweb.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/types/exports/thirdweb.d.ts",
+			"import": "./dist/esm/exports/thirdweb.js",
+			"default": "./dist/cjs/exports/thirdweb.js"
+		},
+		"./adapters/*": {
+			"types": "./dist/types/exports/adapters/*.d.ts",
+			"import": "./dist/esm/exports/adapters/*.js",
+			"default": "./dist/cjs/exports/adapters/*.js"
+		},
+		"./auth": {
+			"types": "./dist/types/exports/auth.d.ts",
+			"import": "./dist/esm/exports/auth.js",
+			"default": "./dist/cjs/exports/auth.js"
+		},
+		"./chains": {
+			"types": "./dist/types/exports/chains.d.ts",
+			"import": "./dist/esm/exports/chains.js",
+			"default": "./dist/cjs/exports/chains.js"
+		},
+		"./contract": {
+			"types": "./dist/types/exports/contract.d.ts",
+			"import": "./dist/esm/exports/contract.js",
+			"default": "./dist/cjs/exports/contract.js"
+		},
+		"./deploys": {
+			"types": "./dist/types/exports/deploys.d.ts",
+			"import": "./dist/esm/exports/deploys.js",
+			"default": "./dist/cjs/exports/deploys.js"
+		},
+		"./event": {
+			"types": "./dist/types/exports/event.d.ts",
+			"import": "./dist/esm/exports/event.js",
+			"default": "./dist/cjs/exports/event.js"
+		},
+		"./extensions/*": {
+			"types": "./dist/types/exports/extensions/*.d.ts",
+			"import": "./dist/esm/exports/extensions/*.js",
+			"default": "./dist/cjs/exports/extensions/*.js"
+		},
+		"./pay": {
+			"types": "./dist/types/exports/pay.d.ts",
+			"import": "./dist/esm/exports/pay.js",
+			"default": "./dist/cjs/exports/pay.js"
+		},
+		"./react": {
+			"types": "./dist/types/exports/react.d.ts",
+			"import": "./dist/esm/exports/react.js",
+			"react-native": "./dist/esm/exports/react.native.js",
+			"default": "./dist/cjs/exports/react.js"
+		},
+		"./react-native": {
+			"types": "./dist/types/exports/react-native.d.ts",
+			"import": "./dist/esm/exports/react-native.js",
+			"default": "./dist/cjs/exports/react-native.js"
+		},
+		"./rpc": {
+			"types": "./dist/types/exports/rpc.d.ts",
+			"import": "./dist/esm/exports/rpc.js",
+			"default": "./dist/cjs/exports/rpc.js"
+		},
+		"./storage": {
+			"types": "./dist/types/exports/storage.d.ts",
+			"import": "./dist/esm/exports/storage.js",
+			"default": "./dist/cjs/exports/storage.js"
+		},
+		"./transaction": {
+			"types": "./dist/types/exports/transaction.d.ts",
+			"import": "./dist/esm/exports/transaction.js",
+			"default": "./dist/cjs/exports/transaction.js"
+		},
+		"./utils": {
+			"types": "./dist/types/exports/utils.d.ts",
+			"import": "./dist/esm/exports/utils.js",
+			"default": "./dist/cjs/exports/utils.js"
+		},
+		"./wallets": {
+			"types": "./dist/types/exports/wallets.d.ts",
+			"import": "./dist/esm/exports/wallets.js",
+			"react-native": "./dist/esm/exports/wallets.native.js",
+			"default": "./dist/cjs/exports/wallets.js"
+		},
+		"./wallets/in-app": {
+			"types": "./dist/types/exports/wallets/in-app.d.ts",
+			"import": "./dist/esm/exports/wallets/in-app.js",
+			"react-native": "./dist/esm/exports/wallets/in-app.native.js",
+			"default": "./dist/cjs/exports/wallets/in-app.js"
+		},
+		"./wallets/*": {
+			"types": "./dist/types/exports/wallets/*.d.ts",
+			"import": "./dist/esm/exports/wallets/*.js",
+			"default": "./dist/cjs/exports/wallets/*.js"
+		},
+		"./modules": {
+			"types": "./dist/types/exports/modules.d.ts",
+			"import": "./dist/esm/exports/modules.js",
+			"default": "./dist/cjs/exports/modules.js"
+		},
+		"./social": {
+			"types": "./dist/types/exports/social.d.ts",
+			"import": "./dist/esm/exports/social.js",
+			"default": "./dist/cjs/exports/social.js"
+		},
+		"./package.json": "./package.json"
+	},
+	"typesVersions": {
+		"*": {
+			"adapters/*": [
+				"./dist/types/exports/adapters/*.d.ts"
+			],
+			"auth": [
+				"./dist/types/exports/auth.d.ts"
+			],
+			"chains": [
+				"./dist/types/exports/chains.d.ts"
+			],
+			"contract": [
+				"./dist/types/exports/contract.d.ts"
+			],
+			"deploys": [
+				"./dist/types/exports/deploys.d.ts"
+			],
+			"event": [
+				"./dist/types/exports/event.d.ts"
+			],
+			"extensions/*": [
+				"./dist/types/exports/extensions/*.d.ts"
+			],
+			"pay": [
+				"./dist/types/exports/pay.d.ts"
+			],
+			"react": [
+				"./dist/types/exports/react.d.ts"
+			],
+			"react-native": [
+				"./dist/types/exports/react-native.d.ts"
+			],
+			"rpc": [
+				"./dist/types/exports/rpc.d.ts"
+			],
+			"storage": [
+				"./dist/types/exports/storage.d.ts"
+			],
+			"transaction": [
+				"./dist/types/exports/transaction.d.ts"
+			],
+			"utils": [
+				"./dist/types/exports/utils.d.ts"
+			],
+			"wallets": [
+				"./dist/types/exports/wallets.d.ts"
+			],
+			"wallets/*": [
+				"./dist/types/exports/wallets/*.d.ts"
+			],
+			"modules": [
+				"./dist/types/exports/modules.d.ts"
+			],
+			"social": [
+				"./dist/types/exports/social.d.ts"
+			]
+		}
+	},
+	"browser": {
+		"crypto": false
+	},
+	"sideEffects": false,
+	"files": [
+		"dist/*",
+		"src/*",
+		"!**/*.tsbuildinfo",
+		"!**/*.test.ts",
+		"!**/*.test.tsx",
+		"!**/*.test.ts.snap",
+		"!**/*.test-d.ts",
+		"!**/*.bench.ts",
+		"!tsconfig.build.json"
+	],
+	"dependencies": {
+		"@coinbase/wallet-sdk": "4.2.4",
+		"@emotion/react": "11.14.0",
+		"@emotion/styled": "11.14.0",
+		"@google/model-viewer": "2.1.1",
+		"@noble/curves": "1.7.0",
+		"@noble/hashes": "1.6.1",
+		"@passwordless-id/webauthn": "^2.1.2",
+		"@radix-ui/react-dialog": "1.1.2",
+		"@radix-ui/react-focus-scope": "1.1.0",
+		"@radix-ui/react-icons": "1.3.2",
+		"@radix-ui/react-tooltip": "1.1.4",
+		"@tanstack/react-query": "5.62.7",
+		"@walletconnect/ethereum-provider": "2.17.2",
+		"@walletconnect/sign-client": "2.17.2",
+		"abitype": "1.0.7",
+		"fuse.js": "7.0.0",
+		"input-otp": "^1.4.1",
+		"mipd": "0.0.7",
+		"ox": "0.4.1",
+		"uqr": "0.1.2",
+		"viem": "2.21.54"
+	},
+	"peerDependencies": {
+		"@aws-sdk/client-lambda": "^3",
+		"@aws-sdk/credential-providers": "^3",
+		"@coinbase/wallet-mobile-sdk": "^1",
+		"@mobile-wallet-protocol/client": "0.1.1",
+		"@react-native-async-storage/async-storage": "^1 || ^2",
+		"ethers": "^5 || ^6",
+		"expo-linking": "^6",
+		"expo-web-browser": "^13 || ^14",
+		"react": "^18 || ^19",
+		"react-native": "*",
+		"react-native-aes-gcm-crypto": "^0.2",
+		"react-native-passkey": "^3",
+		"react-native-quick-crypto": ">=0.7.0-rc.6 || >=0.7",
+		"react-native-svg": "^15",
+		"typescript": ">=5.0.4"
+	},
+	"peerDependenciesMeta": {
+		"react": {
+			"optional": true
+		},
+		"react-native": {
+			"optional": true
+		},
+		"ethers": {
+			"optional": true
+		},
+		"typescript": {
+			"optional": true
+		},
+		"react-native-aes-gcm-crypto": {
+			"optional": true
+		},
+		"expo-linking": {
+			"optional": true
+		},
+		"expo-web-browser": {
+			"optional": true
+		},
+		"react-native-quick-crypto": {
+			"optional": true
+		},
+		"react-native-passkey": {
+			"optional": true
+		},
+		"react-native-svg": {
+			"optional": true
+		},
+		"@aws-sdk/client-lambda": {
+			"optional": true
+		},
+		"@aws-sdk/client-kms": {
+			"optional": true
+		},
+		"@aws-sdk/credential-providers": {
+			"optional": true
+		},
+		"@react-native-async-storage/async-storage": {
+			"optional": true
+		},
+		"@coinbase/wallet-mobile-sdk": {
+			"optional": true
+		},
+		"@mobile-wallet-protocol/client": {
+			"optional": true
+		}
+	},
+	"scripts": {
+		"bench:compare": "bun run ./benchmarks/run.ts",
+		"bench": "vitest -c ./test/vitest.config.ts bench",
+		"format": "biome format ./src --write",
+		"lint": "knip && biome check ./src && tsc --project ./tsconfig.build.json --module esnext --noEmit",
+		"fix": "biome check ./src --fix",
+		"knip": "knip",
+		"build:generate": "bun scripts/generate/generate.ts",
+		"build:generate-wallets": "bun scripts/wallets/generate.ts",
+		"dev": "tsc --project ./tsconfig.build.json --module es2020 --outDir ./dist/esm --watch",
+		"dev:cjs": "printf '{\"type\":\"commonjs\"}' > ./dist/cjs/package.json && tsc --noCheck --project ./tsconfig.build.json --module commonjs --outDir ./dist/cjs --verbatimModuleSyntax false --watch",
+		"dev:esm": "printf '{\"type\": \"module\",\"sideEffects\":false}' > ./dist/esm/package.json && tsc --noCheck --project ./tsconfig.build.json --module es2020 --outDir ./dist/esm --watch",
+		"build": "pnpm clean && pnpm build:types && pnpm build:cjs && pnpm build:esm",
+		"build:cjs": "tsc --noCheck --project ./tsconfig.build.json --module commonjs --outDir ./dist/cjs --verbatimModuleSyntax false && printf '{\"type\":\"commonjs\"}' > ./dist/cjs/package.json",
+		"build:esm": "tsc --noCheck --project ./tsconfig.build.json --module es2020 --outDir ./dist/esm && printf '{\"type\": \"module\",\"sideEffects\":false}' > ./dist/esm/package.json",
+		"build:types": "tsc --project ./tsconfig.build.json --module esnext --declarationDir ./dist/types --emitDeclarationOnly --declaration --declarationMap",
+		"clean": "rimraf dist",
+		"size": "size-limit",
+		"test:watch": "vitest -c ./test/vitest.config.ts dev",
+		"test": "vitest run -c ./test/vitest.config.ts --coverage",
+		"test:cov": "vitest dev -c ./test/vitest.config.ts --coverage",
+		"test:ui": "vitest dev -c ./test/vitest.config.ts --coverage --ui",
+		"test:dev": "vitest run -c ./test/vitest.config.ts",
+		"test:react": "vitest run -c ./test/vitest.config.ts dev --ui src/react",
+		"typedoc": "node scripts/typedoc.mjs && node scripts/parse.mjs",
+		"update-version": "node scripts/version.mjs",
+		"storybook": "storybook dev -p 6006",
+		"build-storybook": "storybook build"
+	},
+	"engines": {
+		"node": ">=18"
+	},
+	"devDependencies": {
+		"@aws-sdk/client-kms": "3.709.0",
+		"@aws-sdk/client-lambda": "3.709.0",
+		"@aws-sdk/credential-providers": "3.709.0",
+		"@biomejs/biome": "1.9.4",
+		"@chromatic-com/storybook": "3.2.2",
+		"@codspeed/vitest-plugin": "4.0.0",
+		"@coinbase/wallet-mobile-sdk": "1.1.2",
+		"@mobile-wallet-protocol/client": "0.1.2",
+		"@react-native-async-storage/async-storage": "2.1.0",
+		"@size-limit/preset-big-lib": "11.1.6",
+		"@storybook/addon-essentials": "8.4.7",
+		"@storybook/addon-interactions": "8.4.7",
+		"@storybook/addon-links": "8.4.7",
+		"@storybook/addon-onboarding": "8.4.7",
+		"@storybook/react": "8.4.7",
+		"@storybook/react-vite": "8.4.7",
+		"@storybook/test": "8.4.7",
+		"@testing-library/jest-dom": "^6.6.3",
+		"@testing-library/react": "^16.1.0",
+		"@testing-library/user-event": "^14.5.2",
+		"@types/cross-spawn": "^6.0.6",
+		"@types/react": "19.0.1",
+		"@viem/anvil": "0.0.10",
+		"@vitejs/plugin-react": "^4.3.4",
+		"@vitest/coverage-v8": "2.1.8",
+		"@vitest/ui": "2.1.8",
+		"cross-spawn": "7.0.6",
+		"dotenv-mono": "^1.3.14",
+		"ethers5": "npm:ethers@5",
+		"ethers6": "npm:ethers@6",
+		"expo-linking": "7.0.3",
+		"expo-web-browser": "14.0.1",
+		"happy-dom": "15.11.7",
+		"knip": "5.39.4",
+		"msw": "2.6.8",
+		"prettier": "3.3.3",
+		"react": "19.0.0",
+		"react-dom": "19.0.0",
+		"react-native": "0.76.5",
+		"react-native-aes-gcm-crypto": "0.2.2",
+		"react-native-passkey": "3.0.0",
+		"react-native-quick-crypto": "0.7.8",
+		"react-native-svg": "15.10.1",
+		"rimraf": "6.0.1",
+		"sharp": "^0.33.5",
+		"size-limit": "11.1.6",
+		"storybook": "8.4.7",
+		"typedoc": "0.27.4",
+		"typedoc-better-json": "0.9.4",
+		"typescript": "5.7.2",
+		"vite": "6.0.3",
+		"vitest": "2.1.8"
+	}
 }

--- a/packages/thirdweb/scripts/parse.mjs
+++ b/packages/thirdweb/scripts/parse.mjs
@@ -1,0 +1,19 @@
+import { transform } from "typedoc-better-json";
+import { readFile, writeFile } from "fs/promises";
+
+const inputPath = "typedoc/documentation.json";
+const outputPath = "typedoc/parsed.json";
+
+try {
+	const fileContent = await readFile(inputPath, "utf-8");
+	const fileData = JSON.parse(fileContent);
+
+	const transformedData = transform(fileData);
+
+	await writeFile(outputPath, JSON.stringify(transformedData, null, 2));
+
+	console.log(`File saved at ${outputPath}`);
+} catch (error) {
+	console.error("Error:", error);
+	process.exit(1);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,7 +135,7 @@ importers:
         version: 1.1.4(@types/react-dom@19.0.2(@types/react@19.0.1))(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@sentry/nextjs':
         specifier: 8.43.0
-        version: 8.43.0(@opentelemetry/core@1.29.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.56.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.29.0(@opentelemetry/api@1.9.0))(next@15.1.0(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0))
+        version: 8.43.0(@opentelemetry/core@1.29.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.56.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.29.0(@opentelemetry/api@1.9.0))(next@15.1.0(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)(webpack@5.97.1(@swc/core@1.10.1))
       '@shazow/whatsabi':
         specifier: ^0.17.0
         version: 0.17.0(@noble/hashes@1.6.1)(typescript@5.7.2)(zod@3.24.1)
@@ -150,7 +150,7 @@ importers:
         version: link:../../packages/service-utils
       '@vercel/functions':
         specifier: ^1.5.1
-        version: 1.5.1(@aws-sdk/credential-provider-web-identity@3.709.0(@aws-sdk/client-sts@3.709.0))
+        version: 1.5.1(@aws-sdk/credential-provider-web-identity@3.709.0)
       '@vercel/og':
         specifier: ^0.6.4
         version: 0.6.4
@@ -279,7 +279,7 @@ importers:
         version: 2.5.5
       tailwindcss-animate:
         specifier: ^1.0.7
-        version: 1.0.7(tailwindcss@3.4.16(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.7.2)))
+        version: 1.0.7(tailwindcss@3.4.16(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2)))
       thirdweb:
         specifier: workspace:*
         version: link:../../packages/thirdweb
@@ -328,7 +328,7 @@ importers:
         version: 8.4.7(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.4.7(bufferutil@4.0.8)(prettier@3.4.2)(utf-8-validate@5.0.10))
       '@storybook/nextjs':
         specifier: 8.4.7
-        version: 8.4.7(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0)(next@15.1.0(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.4.7(bufferutil@4.0.8)(prettier@3.4.2)(utf-8-validate@5.0.10))(type-fest@4.30.0)(typescript@5.7.2)(webpack-hot-middleware@2.26.1)(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0))
+        version: 8.4.7(@swc/core@1.10.1)(next@15.1.0(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.4.7(bufferutil@4.0.8)(prettier@3.4.2)(utf-8-validate@5.0.10))(type-fest@4.30.0)(typescript@5.7.2)(webpack-hot-middleware@2.26.1)(webpack@5.97.1(@swc/core@1.10.1))
       '@storybook/react':
         specifier: 8.4.7
         version: 8.4.7(@storybook/test@8.4.7(storybook@8.4.7(bufferutil@4.0.8)(prettier@3.4.2)(utf-8-validate@5.0.10)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.4.7(bufferutil@4.0.8)(prettier@3.4.2)(utf-8-validate@5.0.10))(typescript@5.7.2)
@@ -376,7 +376,7 @@ importers:
         version: 10.4.20(postcss@8.4.49)
       checkly:
         specifier: ^4.15.0
-        version: 4.15.0(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)
+        version: 4.15.0(@swc/core@1.10.1)(@types/node@22.10.2)(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)
       eslint:
         specifier: 8.57.0
         version: 8.57.0
@@ -403,7 +403,7 @@ importers:
         version: 8.4.7(bufferutil@4.0.8)(prettier@3.4.2)(utf-8-validate@5.0.10)
       tailwindcss:
         specifier: 3.4.16
-        version: 3.4.16(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.7.2))
+        version: 3.4.16(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2))
       typescript:
         specifier: 5.7.2
         version: 5.7.2
@@ -527,10 +527,10 @@ importers:
         version: 8.4.49
       tailwindcss:
         specifier: 3.4.16
-        version: 3.4.16(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.7.2))
+        version: 3.4.16(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2))
       tailwindcss-animate:
         specifier: ^1.0.7
-        version: 1.0.7(tailwindcss@3.4.16(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.7.2)))
+        version: 1.0.7(tailwindcss@3.4.16(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2)))
       typescript:
         specifier: 5.7.2
         version: 5.7.2
@@ -542,13 +542,13 @@ importers:
         version: 1.0.6(react@19.0.0)
       '@mdx-js/loader':
         specifier: ^2.3.0
-        version: 2.3.0(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15)))
+        version: 2.3.0(webpack@5.97.1)
       '@mdx-js/react':
         specifier: ^2.3.0
         version: 2.3.0(react@19.0.0)
       '@next/mdx':
         specifier: 15.1.0
-        version: 15.1.0(@mdx-js/loader@2.3.0(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))))(@mdx-js/react@2.3.0(react@19.0.0))
+        version: 15.1.0(@mdx-js/loader@2.3.0(webpack@5.97.1))(@mdx-js/react@2.3.0(react@19.0.0))
       '@radix-ui/react-dialog':
         specifier: 1.1.2
         version: 1.1.2(@types/react-dom@19.0.2(@types/react@19.0.1))(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -629,7 +629,7 @@ importers:
         version: 2.5.5
       tailwindcss-animate:
         specifier: ^1.0.7
-        version: 1.0.7(tailwindcss@3.4.16(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.7.2)))
+        version: 1.0.7(tailwindcss@3.4.16(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2)))
       thirdweb:
         specifier: workspace:*
         version: link:../../packages/thirdweb
@@ -687,7 +687,7 @@ importers:
         version: 1.2.4
       eslint-plugin-tailwindcss:
         specifier: ^3.17.5
-        version: 3.17.5(tailwindcss@3.4.16(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.7.2)))
+        version: 3.17.5(tailwindcss@3.4.16(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2)))
       next-sitemap:
         specifier: ^4.2.3
         version: 4.2.3(next@15.1.0(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
@@ -696,7 +696,7 @@ importers:
         version: 8.4.49
       tailwindcss:
         specifier: 3.4.16
-        version: 3.4.16(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.7.2))
+        version: 3.4.16(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2))
       tsx:
         specifier: 4.19.2
         version: 4.19.2
@@ -765,7 +765,7 @@ importers:
         version: 2.5.5
       tailwindcss-animate:
         specifier: ^1.0.7
-        version: 1.0.7(tailwindcss@3.4.16(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.7.2)))
+        version: 1.0.7(tailwindcss@3.4.16(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2)))
       thirdweb:
         specifier: workspace:*
         version: link:../../packages/thirdweb
@@ -814,7 +814,7 @@ importers:
         version: 6.0.1(jiti@2.4.1)(postcss@8.4.49)(tsx@4.19.2)(yaml@2.6.1)
       tailwindcss:
         specifier: 3.4.16
-        version: 3.4.16(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.7.2))
+        version: 3.4.16(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2))
       typescript:
         specifier: 5.7.2
         version: 5.7.2
@@ -997,7 +997,7 @@ importers:
         version: 2.1.0(react-native@0.76.5(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@16.0.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@types/react@19.0.1)(bufferutil@4.0.8)(react@19.0.0)(utf-8-validate@5.0.10))
       '@size-limit/preset-big-lib':
         specifier: 11.1.6
-        version: 11.1.6(bufferutil@4.0.8)(size-limit@11.1.6)(utf-8-validate@5.0.10)
+        version: 11.1.6(bufferutil@4.0.8)(esbuild@0.24.0)(size-limit@11.1.6)(utf-8-validate@5.0.10)
       '@storybook/addon-essentials':
         specifier: 8.4.7
         version: 8.4.7(@types/react@19.0.1)(storybook@8.4.7(bufferutil@4.0.8)(prettier@3.3.3)(utf-8-validate@5.0.10))
@@ -1112,6 +1112,9 @@ importers:
       typedoc:
         specifier: 0.27.4
         version: 0.27.4(typescript@5.7.2)
+      typedoc-better-json:
+        specifier: 0.9.4
+        version: 0.9.4(typescript@5.7.2)
       typescript:
         specifier: 5.7.2
         version: 5.7.2
@@ -17267,11 +17270,11 @@ snapshots:
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
 
-  '@mdx-js/loader@2.3.0(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15)))':
+  '@mdx-js/loader@2.3.0(webpack@5.97.1)':
     dependencies:
       '@mdx-js/mdx': 2.3.0
       source-map: 0.7.4
-      webpack: 5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))
+      webpack: 5.97.1
     transitivePeerDependencies:
       - supports-color
 
@@ -17411,11 +17414,11 @@ snapshots:
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/mdx@15.1.0(@mdx-js/loader@2.3.0(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))))(@mdx-js/react@2.3.0(react@19.0.0))':
+  '@next/mdx@15.1.0(@mdx-js/loader@2.3.0(webpack@5.97.1))(@mdx-js/react@2.3.0(react@19.0.0))':
     dependencies:
       source-map: 0.7.4
     optionalDependencies:
-      '@mdx-js/loader': 2.3.0(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15)))
+      '@mdx-js/loader': 2.3.0(webpack@5.97.1)
       '@mdx-js/react': 2.3.0(react@19.0.0)
 
   '@next/swc-darwin-arm64@15.1.0':
@@ -17567,7 +17570,7 @@ snapshots:
       widest-line: 3.1.0
       wrap-ansi: 7.0.0
 
-  '@oclif/core@2.8.11(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.7.2)':
+  '@oclif/core@2.8.11(@swc/core@1.10.1)(@types/node@22.10.2)(typescript@5.7.2)':
     dependencies:
       '@types/cli-progress': 3.11.6
       ansi-escapes: 4.3.2
@@ -17593,7 +17596,7 @@ snapshots:
       strip-ansi: 6.0.1
       supports-color: 8.1.1
       supports-hyperlinks: 2.3.0
-      ts-node: 10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.7.2)
+      ts-node: 10.9.2(@swc/core@1.10.1)(@types/node@22.10.2)(typescript@5.7.2)
       tslib: 2.8.1
       widest-line: 3.1.0
       wordwrap: 1.0.0
@@ -17631,10 +17634,10 @@ snapshots:
     dependencies:
       '@oclif/core': 1.26.2
 
-  '@oclif/plugin-not-found@2.3.23(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.7.2)':
+  '@oclif/plugin-not-found@2.3.23(@swc/core@1.10.1)(@types/node@22.10.2)(typescript@5.7.2)':
     dependencies:
       '@oclif/color': 1.0.13
-      '@oclif/core': 2.8.11(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.7.2)
+      '@oclif/core': 2.8.11(@swc/core@1.10.1)(@types/node@22.10.2)(typescript@5.7.2)
       fast-levenshtein: 3.0.0
       lodash: 4.17.21
     transitivePeerDependencies:
@@ -17659,9 +17662,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@oclif/plugin-warn-if-update-available@2.0.24(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.7.2)':
+  '@oclif/plugin-warn-if-update-available@2.0.24(@swc/core@1.10.1)(@types/node@22.10.2)(typescript@5.7.2)':
     dependencies:
-      '@oclif/core': 2.8.11(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.7.2)
+      '@oclif/core': 2.8.11(@swc/core@1.10.1)(@types/node@22.10.2)(typescript@5.7.2)
       chalk: 4.1.2
       debug: 4.4.0(supports-color@8.1.1)
       fs-extra: 9.1.0
@@ -18033,7 +18036,7 @@ snapshots:
     dependencies:
       playwright: 1.49.1
 
-  '@pmmmwh/react-refresh-webpack-plugin@0.5.15(react-refresh@0.14.2)(type-fest@4.30.0)(webpack-hot-middleware@2.26.1)(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0))':
+  '@pmmmwh/react-refresh-webpack-plugin@0.5.15(react-refresh@0.14.2)(type-fest@4.30.0)(webpack-hot-middleware@2.26.1)(webpack@5.97.1(@swc/core@1.10.1))':
     dependencies:
       ansi-html: 0.0.9
       core-js-pure: 3.39.0
@@ -18043,7 +18046,7 @@ snapshots:
       react-refresh: 0.14.2
       schema-utils: 4.2.0
       source-map: 0.7.4
-      webpack: 5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0)
+      webpack: 5.97.1(@swc/core@1.10.1)
     optionalDependencies:
       type-fest: 4.30.0
       webpack-hot-middleware: 2.26.1
@@ -19034,7 +19037,7 @@ snapshots:
 
   '@sentry/core@8.43.0': {}
 
-  '@sentry/nextjs@8.43.0(@opentelemetry/core@1.29.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.56.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.29.0(@opentelemetry/api@1.9.0))(next@15.1.0(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0))':
+  '@sentry/nextjs@8.43.0(@opentelemetry/core@1.29.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.56.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.29.0(@opentelemetry/api@1.9.0))(next@15.1.0(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)(webpack@5.97.1(@swc/core@1.10.1))':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.28.0
@@ -19045,7 +19048,7 @@ snapshots:
       '@sentry/opentelemetry': 8.43.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.29.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.56.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.29.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.28.0)
       '@sentry/react': 8.43.0(react@19.0.0)
       '@sentry/vercel-edge': 8.43.0
-      '@sentry/webpack-plugin': 2.22.7(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0))
+      '@sentry/webpack-plugin': 2.22.7(webpack@5.97.1(@swc/core@1.10.1))
       chalk: 3.0.0
       next: 15.1.0(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       resolve: 1.22.8
@@ -19121,12 +19124,12 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@sentry/core': 8.43.0
 
-  '@sentry/webpack-plugin@2.22.7(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0))':
+  '@sentry/webpack-plugin@2.22.7(webpack@5.97.1(@swc/core@1.10.1))':
     dependencies:
       '@sentry/bundler-plugin-core': 2.22.7
       unplugin: 1.0.1
       uuid: 9.0.1
-      webpack: 5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0)
+      webpack: 5.97.1(@swc/core@1.10.1)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -19193,11 +19196,11 @@ snapshots:
     dependencies:
       size-limit: 11.1.6
 
-  '@size-limit/preset-big-lib@11.1.6(bufferutil@4.0.8)(size-limit@11.1.6)(utf-8-validate@5.0.10)':
+  '@size-limit/preset-big-lib@11.1.6(bufferutil@4.0.8)(esbuild@0.24.0)(size-limit@11.1.6)(utf-8-validate@5.0.10)':
     dependencies:
       '@size-limit/file': 11.1.6(size-limit@11.1.6)
       '@size-limit/time': 11.1.6(bufferutil@4.0.8)(size-limit@11.1.6)(utf-8-validate@5.0.10)
-      '@size-limit/webpack': 11.1.6(size-limit@11.1.6)
+      '@size-limit/webpack': 11.1.6(esbuild@0.24.0)(size-limit@11.1.6)
       size-limit: 11.1.6
     transitivePeerDependencies:
       - '@swc/core'
@@ -19217,11 +19220,11 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@size-limit/webpack@11.1.6(size-limit@11.1.6)':
+  '@size-limit/webpack@11.1.6(esbuild@0.24.0)(size-limit@11.1.6)':
     dependencies:
       nanoid: 5.0.7
       size-limit: 11.1.6
-      webpack: 5.97.1
+      webpack: 5.97.1(esbuild@0.24.0)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -19861,7 +19864,7 @@ snapshots:
       ts-dedent: 2.2.0
       vite: 6.0.3(@types/node@22.10.2)(jiti@2.4.1)(lightningcss@1.28.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1)
 
-  '@storybook/builder-webpack5@8.4.7(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0)(storybook@8.4.7(bufferutil@4.0.8)(prettier@3.4.2)(utf-8-validate@5.0.10))(typescript@5.7.2)':
+  '@storybook/builder-webpack5@8.4.7(@swc/core@1.10.1)(storybook@8.4.7(bufferutil@4.0.8)(prettier@3.4.2)(utf-8-validate@5.0.10))(typescript@5.7.2)':
     dependencies:
       '@storybook/core-webpack': 8.4.7(storybook@8.4.7(bufferutil@4.0.8)(prettier@3.4.2)(utf-8-validate@5.0.10))
       '@types/node': 22.10.2
@@ -19870,23 +19873,23 @@ snapshots:
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.4.1
       constants-browserify: 1.0.0
-      css-loader: 6.11.0(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0))
+      css-loader: 6.11.0(webpack@5.97.1(@swc/core@1.10.1))
       es-module-lexer: 1.5.4
-      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.7.2)(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0))
-      html-webpack-plugin: 5.6.3(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0))
+      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.7.2)(webpack@5.97.1(@swc/core@1.10.1))
+      html-webpack-plugin: 5.6.3(webpack@5.97.1(@swc/core@1.10.1))
       magic-string: 0.30.15
       path-browserify: 1.0.1
       process: 0.11.10
       semver: 7.6.3
       storybook: 8.4.7(bufferutil@4.0.8)(prettier@3.4.2)(utf-8-validate@5.0.10)
-      style-loader: 3.3.4(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0))
-      terser-webpack-plugin: 5.3.10(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0)(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0))
+      style-loader: 3.3.4(webpack@5.97.1(@swc/core@1.10.1))
+      terser-webpack-plugin: 5.3.10(@swc/core@1.10.1)(webpack@5.97.1(@swc/core@1.10.1))
       ts-dedent: 2.2.0
       url: 0.11.4
       util: 0.12.5
       util-deprecate: 1.0.2
-      webpack: 5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0)
-      webpack-dev-middleware: 6.1.3(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0))
+      webpack: 5.97.1(@swc/core@1.10.1)
+      webpack-dev-middleware: 6.1.3(webpack@5.97.1(@swc/core@1.10.1))
       webpack-hot-middleware: 2.26.1
       webpack-virtual-modules: 0.6.2
     optionalDependencies:
@@ -19998,7 +20001,7 @@ snapshots:
     dependencies:
       storybook: 8.4.7(bufferutil@4.0.8)(prettier@3.4.2)(utf-8-validate@5.0.10)
 
-  '@storybook/nextjs@8.4.7(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0)(next@15.1.0(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.4.7(bufferutil@4.0.8)(prettier@3.4.2)(utf-8-validate@5.0.10))(type-fest@4.30.0)(typescript@5.7.2)(webpack-hot-middleware@2.26.1)(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0))':
+  '@storybook/nextjs@8.4.7(@swc/core@1.10.1)(next@15.1.0(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.4.7(bufferutil@4.0.8)(prettier@3.4.2)(utf-8-validate@5.0.10))(type-fest@4.30.0)(typescript@5.7.2)(webpack-hot-middleware@2.26.1)(webpack@5.97.1(@swc/core@1.10.1))':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.26.0)
@@ -20013,31 +20016,31 @@ snapshots:
       '@babel/preset-react': 7.26.3(@babel/core@7.26.0)
       '@babel/preset-typescript': 7.26.0(@babel/core@7.26.0)
       '@babel/runtime': 7.26.0
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(react-refresh@0.14.2)(type-fest@4.30.0)(webpack-hot-middleware@2.26.1)(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0))
-      '@storybook/builder-webpack5': 8.4.7(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0)(storybook@8.4.7(bufferutil@4.0.8)(prettier@3.4.2)(utf-8-validate@5.0.10))(typescript@5.7.2)
-      '@storybook/preset-react-webpack': 8.4.7(@storybook/test@8.4.7(storybook@8.4.7(bufferutil@4.0.8)(prettier@3.4.2)(utf-8-validate@5.0.10)))(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.4.7(bufferutil@4.0.8)(prettier@3.4.2)(utf-8-validate@5.0.10))(typescript@5.7.2)
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(react-refresh@0.14.2)(type-fest@4.30.0)(webpack-hot-middleware@2.26.1)(webpack@5.97.1(@swc/core@1.10.1))
+      '@storybook/builder-webpack5': 8.4.7(@swc/core@1.10.1)(storybook@8.4.7(bufferutil@4.0.8)(prettier@3.4.2)(utf-8-validate@5.0.10))(typescript@5.7.2)
+      '@storybook/preset-react-webpack': 8.4.7(@storybook/test@8.4.7(storybook@8.4.7(bufferutil@4.0.8)(prettier@3.4.2)(utf-8-validate@5.0.10)))(@swc/core@1.10.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.4.7(bufferutil@4.0.8)(prettier@3.4.2)(utf-8-validate@5.0.10))(typescript@5.7.2)
       '@storybook/react': 8.4.7(@storybook/test@8.4.7(storybook@8.4.7(bufferutil@4.0.8)(prettier@3.4.2)(utf-8-validate@5.0.10)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.4.7(bufferutil@4.0.8)(prettier@3.4.2)(utf-8-validate@5.0.10))(typescript@5.7.2)
       '@storybook/test': 8.4.7(storybook@8.4.7(bufferutil@4.0.8)(prettier@3.4.2)(utf-8-validate@5.0.10))
       '@types/node': 22.10.2
       '@types/semver': 7.5.8
-      babel-loader: 9.2.1(@babel/core@7.26.0)(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0))
-      css-loader: 6.11.0(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0))
+      babel-loader: 9.2.1(@babel/core@7.26.0)(webpack@5.97.1(@swc/core@1.10.1))
+      css-loader: 6.11.0(webpack@5.97.1(@swc/core@1.10.1))
       find-up: 5.0.0
       image-size: 1.1.1
       loader-utils: 3.3.1
       next: 15.1.0(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      node-polyfill-webpack-plugin: 2.0.1(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0))
+      node-polyfill-webpack-plugin: 2.0.1(webpack@5.97.1(@swc/core@1.10.1))
       pnp-webpack-plugin: 1.7.0(typescript@5.7.2)
       postcss: 8.4.49
-      postcss-loader: 8.1.1(postcss@8.4.49)(typescript@5.7.2)(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0))
+      postcss-loader: 8.1.1(postcss@8.4.49)(typescript@5.7.2)(webpack@5.97.1(@swc/core@1.10.1))
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       react-refresh: 0.14.2
       resolve-url-loader: 5.0.0
-      sass-loader: 13.3.3(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0))
+      sass-loader: 13.3.3(webpack@5.97.1(@swc/core@1.10.1))
       semver: 7.6.3
       storybook: 8.4.7(bufferutil@4.0.8)(prettier@3.4.2)(utf-8-validate@5.0.10)
-      style-loader: 3.3.4(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0))
+      style-loader: 3.3.4(webpack@5.97.1(@swc/core@1.10.1))
       styled-jsx: 5.1.6(@babel/core@7.26.0)(react@19.0.0)
       ts-dedent: 2.2.0
       tsconfig-paths: 4.2.0
@@ -20045,7 +20048,7 @@ snapshots:
     optionalDependencies:
       sharp: 0.33.5
       typescript: 5.7.2
-      webpack: 5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0)
+      webpack: 5.97.1(@swc/core@1.10.1)
     transitivePeerDependencies:
       - '@rspack/core'
       - '@swc/core'
@@ -20065,11 +20068,11 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@storybook/preset-react-webpack@8.4.7(@storybook/test@8.4.7(storybook@8.4.7(bufferutil@4.0.8)(prettier@3.4.2)(utf-8-validate@5.0.10)))(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.4.7(bufferutil@4.0.8)(prettier@3.4.2)(utf-8-validate@5.0.10))(typescript@5.7.2)':
+  '@storybook/preset-react-webpack@8.4.7(@storybook/test@8.4.7(storybook@8.4.7(bufferutil@4.0.8)(prettier@3.4.2)(utf-8-validate@5.0.10)))(@swc/core@1.10.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.4.7(bufferutil@4.0.8)(prettier@3.4.2)(utf-8-validate@5.0.10))(typescript@5.7.2)':
     dependencies:
       '@storybook/core-webpack': 8.4.7(storybook@8.4.7(bufferutil@4.0.8)(prettier@3.4.2)(utf-8-validate@5.0.10))
       '@storybook/react': 8.4.7(@storybook/test@8.4.7(storybook@8.4.7(bufferutil@4.0.8)(prettier@3.4.2)(utf-8-validate@5.0.10)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.4.7(bufferutil@4.0.8)(prettier@3.4.2)(utf-8-validate@5.0.10))(typescript@5.7.2)
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.7.2)(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0))
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.7.2)(webpack@5.97.1(@swc/core@1.10.1))
       '@types/node': 22.10.2
       '@types/semver': 7.5.8
       find-up: 5.0.0
@@ -20081,7 +20084,7 @@ snapshots:
       semver: 7.6.3
       storybook: 8.4.7(bufferutil@4.0.8)(prettier@3.4.2)(utf-8-validate@5.0.10)
       tsconfig-paths: 4.2.0
-      webpack: 5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0)
+      webpack: 5.97.1(@swc/core@1.10.1)
     optionalDependencies:
       typescript: 5.7.2
     transitivePeerDependencies:
@@ -20100,7 +20103,7 @@ snapshots:
     dependencies:
       storybook: 8.4.7(bufferutil@4.0.8)(prettier@3.4.2)(utf-8-validate@5.0.10)
 
-  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.7.2)(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0))':
+  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.7.2)(webpack@5.97.1(@swc/core@1.10.1))':
     dependencies:
       debug: 4.4.0(supports-color@8.1.1)
       endent: 2.1.0
@@ -20110,7 +20113,7 @@ snapshots:
       react-docgen-typescript: 2.2.2(typescript@5.7.2)
       tslib: 2.8.1
       typescript: 5.7.2
-      webpack: 5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0)
+      webpack: 5.97.1(@swc/core@1.10.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -20598,7 +20601,7 @@ snapshots:
   '@swc/core-win32-x64-msvc@1.10.1':
     optional: true
 
-  '@swc/core@1.10.1(@swc/helpers@0.5.15)':
+  '@swc/core@1.10.1':
     dependencies:
       '@swc/counter': 0.1.3
       '@swc/types': 0.1.17
@@ -20613,7 +20616,6 @@ snapshots:
       '@swc/core-win32-arm64-msvc': 1.10.1
       '@swc/core-win32-ia32-msvc': 1.10.1
       '@swc/core-win32-x64-msvc': 1.10.1
-      '@swc/helpers': 0.5.15
     optional: true
 
   '@swc/counter@0.1.3': {}
@@ -21166,7 +21168,7 @@ snapshots:
       '@urql/core': 5.1.0(graphql@16.9.0)
       wonka: 6.3.4
 
-  '@vercel/functions@1.5.1(@aws-sdk/credential-provider-web-identity@3.709.0(@aws-sdk/client-sts@3.709.0))':
+  '@vercel/functions@1.5.1(@aws-sdk/credential-provider-web-identity@3.709.0)':
     optionalDependencies:
       '@aws-sdk/credential-provider-web-identity': 3.709.0(@aws-sdk/client-sts@3.709.0)
 
@@ -22065,12 +22067,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@9.2.1(@babel/core@7.26.0)(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0)):
+  babel-loader@9.2.1(@babel/core@7.26.0)(webpack@5.97.1(@swc/core@1.10.1)):
     dependencies:
       '@babel/core': 7.26.0
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
-      webpack: 5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0)
+      webpack: 5.97.1(@swc/core@1.10.1)
 
   babel-plugin-istanbul@6.1.1:
     dependencies:
@@ -22540,13 +22542,13 @@ snapshots:
 
   check-error@2.1.1: {}
 
-  checkly@4.15.0(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10):
+  checkly@4.15.0(@swc/core@1.10.1)(@types/node@22.10.2)(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10):
     dependencies:
-      '@oclif/core': 2.8.11(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.7.2)
+      '@oclif/core': 2.8.11(@swc/core@1.10.1)(@types/node@22.10.2)(typescript@5.7.2)
       '@oclif/plugin-help': 5.1.20
-      '@oclif/plugin-not-found': 2.3.23(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.7.2)
+      '@oclif/plugin-not-found': 2.3.23(@swc/core@1.10.1)(@types/node@22.10.2)(typescript@5.7.2)
       '@oclif/plugin-plugins': 5.4.4
-      '@oclif/plugin-warn-if-update-available': 2.0.24(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.7.2)
+      '@oclif/plugin-warn-if-update-available': 2.0.24(@swc/core@1.10.1)(@types/node@22.10.2)(typescript@5.7.2)
       '@typescript-eslint/typescript-estree': 6.19.0(typescript@5.7.2)
       acorn: 8.8.1
       acorn-walk: 8.2.0
@@ -22992,7 +22994,7 @@ snapshots:
 
   css-gradient-parser@0.0.16: {}
 
-  css-loader@6.11.0(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0)):
+  css-loader@6.11.0(webpack@5.97.1(@swc/core@1.10.1)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.49)
       postcss: 8.4.49
@@ -23003,7 +23005,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.6.3
     optionalDependencies:
-      webpack: 5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0)
+      webpack: 5.97.1(@swc/core@1.10.1)
 
   css-select@4.3.0:
     dependencies:
@@ -23893,11 +23895,11 @@ snapshots:
 
   eslint-plugin-svg-jsx@1.2.4: {}
 
-  eslint-plugin-tailwindcss@3.17.5(tailwindcss@3.4.16(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.7.2))):
+  eslint-plugin-tailwindcss@3.17.5(tailwindcss@3.4.16(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2))):
     dependencies:
       fast-glob: 3.3.2
       postcss: 8.4.49
-      tailwindcss: 3.4.16(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.7.2))
+      tailwindcss: 3.4.16(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2))
 
   eslint-scope@5.1.1:
     dependencies:
@@ -24579,7 +24581,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.7.2)(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0)):
+  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.7.2)(webpack@5.97.1(@swc/core@1.10.1)):
     dependencies:
       '@babel/code-frame': 7.26.2
       chalk: 4.1.2
@@ -24594,7 +24596,7 @@ snapshots:
       semver: 7.6.3
       tapable: 2.2.1
       typescript: 5.7.2
-      webpack: 5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0)
+      webpack: 5.97.1(@swc/core@1.10.1)
 
   form-data-encoder@2.1.4: {}
 
@@ -25067,7 +25069,7 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  html-webpack-plugin@5.6.3(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0)):
+  html-webpack-plugin@5.6.3(webpack@5.97.1(@swc/core@1.10.1)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -25075,7 +25077,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.2.1
     optionalDependencies:
-      webpack: 5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0)
+      webpack: 5.97.1(@swc/core@1.10.1)
 
   htmlparser2@3.10.1:
     dependencies:
@@ -27571,7 +27573,7 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-polyfill-webpack-plugin@2.0.1(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0)):
+  node-polyfill-webpack-plugin@2.0.1(webpack@5.97.1(@swc/core@1.10.1)):
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -27598,7 +27600,7 @@ snapshots:
       url: 0.11.4
       util: 0.12.5
       vm-browserify: 1.1.2
-      webpack: 5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0)
+      webpack: 5.97.1(@swc/core@1.10.1)
 
   node-releases@2.0.18: {}
 
@@ -28223,13 +28225,13 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.4.49
 
-  postcss-load-config@4.0.2(postcss@8.4.49)(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.7.2)):
+  postcss-load-config@4.0.2(postcss@8.4.49)(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2)):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.6.1
     optionalDependencies:
       postcss: 8.4.49
-      ts-node: 10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.7.2)
+      ts-node: 10.9.2(@swc/core@1.10.1)(@types/node@22.10.2)(typescript@5.7.2)
 
   postcss-load-config@6.0.1(jiti@2.4.1)(postcss@8.4.49)(tsx@4.19.2)(yaml@2.6.1):
     dependencies:
@@ -28240,14 +28242,14 @@ snapshots:
       tsx: 4.19.2
       yaml: 2.6.1
 
-  postcss-loader@8.1.1(postcss@8.4.49)(typescript@5.7.2)(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0)):
+  postcss-loader@8.1.1(postcss@8.4.49)(typescript@5.7.2)(webpack@5.97.1(@swc/core@1.10.1)):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.7.2)
       jiti: 1.21.6
       postcss: 8.4.49
       semver: 7.6.3
     optionalDependencies:
-      webpack: 5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0)
+      webpack: 5.97.1(@swc/core@1.10.1)
     transitivePeerDependencies:
       - typescript
 
@@ -29404,10 +29406,10 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@13.3.3(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0)):
+  sass-loader@13.3.3(webpack@5.97.1(@swc/core@1.10.1)):
     dependencies:
       neo-async: 2.6.2
-      webpack: 5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0)
+      webpack: 5.97.1(@swc/core@1.10.1)
 
   satori@0.12.0:
     dependencies:
@@ -29956,9 +29958,9 @@ snapshots:
 
   structured-headers@0.4.1: {}
 
-  style-loader@3.3.4(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0)):
+  style-loader@3.3.4(webpack@5.97.1(@swc/core@1.10.1)):
     dependencies:
-      webpack: 5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0)
+      webpack: 5.97.1(@swc/core@1.10.1)
 
   style-to-object@0.4.4:
     dependencies:
@@ -30103,11 +30105,11 @@ snapshots:
 
   tailwind-merge@2.5.5: {}
 
-  tailwindcss-animate@1.0.7(tailwindcss@3.4.16(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.7.2))):
+  tailwindcss-animate@1.0.7(tailwindcss@3.4.16(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2))):
     dependencies:
-      tailwindcss: 3.4.16(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.7.2))
+      tailwindcss: 3.4.16(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2))
 
-  tailwindcss@3.4.16(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.7.2)):
+  tailwindcss@3.4.16(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -30126,7 +30128,7 @@ snapshots:
       postcss: 8.4.49
       postcss-import: 15.1.0(postcss@8.4.49)
       postcss-js: 4.0.1(postcss@8.4.49)
-      postcss-load-config: 4.0.2(postcss@8.4.49)(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.7.2))
+      postcss-load-config: 4.0.2(postcss@8.4.49)(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2))
       postcss-nested: 6.2.0(postcss@8.4.49)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.8
@@ -30188,28 +30190,27 @@ snapshots:
       ansi-escapes: 4.3.2
       supports-hyperlinks: 2.3.0
 
-  terser-webpack-plugin@5.3.10(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0)(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0)):
+  terser-webpack-plugin@5.3.10(@swc/core@1.10.1)(webpack@5.97.1(@swc/core@1.10.1)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
       terser: 5.37.0
-      webpack: 5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0)
+      webpack: 5.97.1(@swc/core@1.10.1)
     optionalDependencies:
-      '@swc/core': 1.10.1(@swc/helpers@0.5.15)
-      esbuild: 0.24.0
+      '@swc/core': 1.10.1
 
-  terser-webpack-plugin@5.3.10(@swc/core@1.10.1(@swc/helpers@0.5.15))(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))):
+  terser-webpack-plugin@5.3.10(esbuild@0.24.0)(webpack@5.97.1(esbuild@0.24.0)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
       terser: 5.37.0
-      webpack: 5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))
+      webpack: 5.97.1(esbuild@0.24.0)
     optionalDependencies:
-      '@swc/core': 1.10.1(@swc/helpers@0.5.15)
+      esbuild: 0.24.0
 
   terser-webpack-plugin@5.3.10(webpack@5.97.1):
     dependencies:
@@ -30348,7 +30349,7 @@ snapshots:
 
   ts-mixer@6.0.4: {}
 
-  ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.7.2):
+  ts-node@10.9.2(@swc/core@1.10.1)(@types/node@22.10.2)(typescript@5.7.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -30366,7 +30367,7 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optionalDependencies:
-      '@swc/core': 1.10.1(@swc/helpers@0.5.15)
+      '@swc/core': 1.10.1
 
   ts-pnp@1.2.0(typescript@5.7.2):
     optionalDependencies:
@@ -31116,7 +31117,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  webpack-dev-middleware@6.1.3(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0)):
+  webpack-dev-middleware@6.1.3(webpack@5.97.1(@swc/core@1.10.1)):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3
@@ -31124,7 +31125,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.2.0
     optionalDependencies:
-      webpack: 5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0)
+      webpack: 5.97.1(@swc/core@1.10.1)
 
   webpack-hot-middleware@2.26.1:
     dependencies:
@@ -31168,7 +31169,7 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15)):
+  webpack@5.97.1(@swc/core@1.10.1):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.6
@@ -31190,7 +31191,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(@swc/core@1.10.1(@swc/helpers@0.5.15))(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15)))
+      terser-webpack-plugin: 5.3.10(@swc/core@1.10.1)(webpack@5.97.1(@swc/core@1.10.1))
       watchpack: 2.4.2
       webpack-sources: 3.2.3
     transitivePeerDependencies:
@@ -31198,7 +31199,7 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0):
+  webpack@5.97.1(esbuild@0.24.0):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.6
@@ -31220,7 +31221,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0)(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0))
+      terser-webpack-plugin: 5.3.10(esbuild@0.24.0)(webpack@5.97.1(esbuild@0.24.0))
       watchpack: 2.4.2
       webpack-sources: 3.2.3
     transitivePeerDependencies:


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a script to parse TypeDoc output and a GitHub Actions workflow for generating and updating documentation. It also updates the `package.json` and `pnpm-lock.yaml` files to include new dependencies and scripts.

### Detailed summary
- Added `parse.mjs` script to read, transform, and save TypeDoc JSON data.
- Created `.github/workflows/typedoc.yml` for automated TypeDoc generation and Gist update.
- Updated `package.json` to include `typedoc-better-json` and new scripts.
- Modified `pnpm-lock.yaml` to reflect changes in dependencies.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->