### PR TITLE
[SDK] useAutoConnect to throw error

### DIFF
--- a/packages/thirdweb/src/react/core/hooks/wallets/useAutoConnect.ts
+++ b/packages/thirdweb/src/react/core/hooks/wallets/useAutoConnect.ts
@@ -121,10 +121,11 @@ export function useAutoConnectCore(
           setConnectionStatus("disconnected");
         }
       } catch (e) {
+        setConnectionStatus("disconnected");
         if (e instanceof Error) {
           console.warn("Error auto connecting wallet:", e.message);
+          throw e;
         }
-        setConnectionStatus("disconnected");
       }
     } else {
       setConnectionStatus("disconnected");


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added



<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving error handling in the `useAutoConnect` hook by ensuring the connection status is set to "disconnected" when an error occurs during the wallet auto-connection process.

### Detailed summary
- Added `setConnectionStatus("disconnected");` inside the `catch` block to handle errors.
- Removed redundant `setConnectionStatus("disconnected");` from the else block.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->