### PR TITLE
Fix API key redirect URL schema on in-app wallet settings and unresponsive general project settings page

### DIFF
--- a/apps/dashboard/src/app/team/[team_slug]/[project_slug]/settings/ProjectGeneralSettingsPage.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/[project_slug]/settings/ProjectGeneralSettingsPage.tsx
@@ -35,9 +35,9 @@ import { type FieldArrayWithId, useFieldArray } from "react-hook-form";
 import { toast } from "sonner";
 import { joinWithComma, toArrFromList } from "utils/string";
 import {
-  type ApiKeyValidationSchema,
   HIDDEN_SERVICES,
-  apiKeyValidationSchema,
+  type ProjectSettingsPageFormSchema,
+  projectSettingsPageFormSchema,
 } from "../../../../../components/settings/ApiKeys/validations";
 
 type EditProjectUIPaths = {
@@ -86,7 +86,7 @@ interface EditApiKeyProps {
   showNebulaSettings: boolean;
 }
 
-type UpdateAPIForm = UseFormReturn<ApiKeyValidationSchema>;
+type UpdateAPIForm = UseFormReturn<ProjectSettingsPageFormSchema>;
 
 export const ProjectGeneralSettingsPageUI: React.FC<EditApiKeyProps> = (
   props,
@@ -94,8 +94,8 @@ export const ProjectGeneralSettingsPageUI: React.FC<EditApiKeyProps> = (
   const { apiKey, updateMutation, deleteMutation } = props;
   const trackEvent = useTrack();
   const router = useDashboardRouter();
-  const form = useForm<ApiKeyValidationSchema>({
-    resolver: zodResolver(apiKeyValidationSchema),
+  const form = useForm<ProjectSettingsPageFormSchema>({
+    resolver: zodResolver(projectSettingsPageFormSchema),
     defaultValues: {
       name: apiKey.name,
       domains: joinWithComma(apiKey.domains),
@@ -484,7 +484,7 @@ function EnabledServicesSetting(props: {
   });
   const handleAction = (
     srvIdx: number,
-    srv: FieldArrayWithId<ApiKeyValidationSchema, "services", "id">,
+    srv: FieldArrayWithId<ProjectSettingsPageFormSchema, "services", "id">,
     actionName: string,
     checked: boolean,
   ) => {

--- a/apps/dashboard/src/components/embedded-wallets/Configure/index.tsx
+++ b/apps/dashboard/src/components/embedded-wallets/Configure/index.tsx
@@ -422,6 +422,10 @@ function AuthEndpointFields(props: {
     name: "customAuthEndpoint.customHeaders",
   });
 
+  const expandCustomAuthEndpointField =
+    form.watch("customAuthEndpoint")?.authEndpoint !== undefined &&
+    canEditAdvancedFeatures;
+
   return (
     <div>
       <SwitchContainer
@@ -445,9 +449,7 @@ function AuthEndpointFields(props: {
       >
         <GatedSwitch
           trackingLabel="customAuthEndpoint"
-          checked={
-            !!form.watch("customAuthEndpoint") && canEditAdvancedFeatures
-          }
+          checked={expandCustomAuthEndpointField}
           upgradeRequired={!canEditAdvancedFeatures}
           onCheckedChange={(checked) => {
             form.setValue(
@@ -464,7 +466,7 @@ function AuthEndpointFields(props: {
       </SwitchContainer>
 
       <AdvancedConfigurationContainer
-        show={canEditAdvancedFeatures && !!form.watch("customAuthEndpoint")}
+        show={expandCustomAuthEndpointField}
         className="grid grid-cols-1 gap-6 lg:grid-cols-2"
       >
         <FormField
@@ -561,7 +563,10 @@ function NativeAppsFieldset(props: {
           <FormItem>
             <FormLabel>Allowed redirect URIs</FormLabel>
             <FormControl>
-              <Textarea {...field} placeholder="appName://" />
+              <Textarea
+                {...field}
+                placeholder="appName://, localhost:3000, https://example.com"
+              />
             </FormControl>
             <FormDescription>
               Enter redirect URIs separated by commas or new lines. This is


### PR DESCRIPTION
## Problem solved

Fixes: DASH-629

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring and enhancing the validation logic for project settings, specifically regarding API key management and redirect URIs. It introduces a new schema for project settings and modifies the handling of advanced features in the `embedded-wallets` component.

### Detailed summary
- Added `expandCustomAuthEndpointField` to manage the visibility of custom auth endpoint settings.
- Updated the `show` prop in `AdvancedConfigurationContainer` to use `expandCustomAuthEndpointField`.
- Changed `UpdateAPIForm` type to use `ProjectSettingsPageFormSchema`.
- Implemented `projectSettingsPageFormSchema` for project settings validation.
- Added `isValidRedirectURI` function to validate redirect URIs.
- Modified `redirectUrls` validation to use the new `redirectUriSchema`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->