### PR TITLE
[DASH-635] Fix useActiveWalletChain not returning custom chain

### DIFF
--- a/apps/dashboard/src/hooks/chains/allChains.ts
+++ b/apps/dashboard/src/hooks/chains/allChains.ts
@@ -86,6 +86,8 @@ function createAllChainsStore() {
     for (const c of chainOverrides) {
       if (c.isCustom) {
         allChains.push(c);
+        // eslint-disable-next-line no-restricted-syntax
+        allChainsV5.push(mapV4ChainToV5Chain(c));
         idToChain.set(c.chainId, c);
         nameToChain.set(c.name, c);
         slugToChain.set(c.slug, c);


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a modification in the `allChains.ts` file to enhance the handling of custom chains by adding them to the `allChainsV5` array after mapping them from version 4 to version 5.

### Detailed summary
- Added a comment to disable the ESLint rule for restricted syntax.
- Pushed the mapped chain from `mapV4ChainToV5Chain(c)` into the `allChainsV5` array.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->