### PR TITLE
[SDK]: Chore: Fix AWS dependencies in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,18 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "npm"
+    directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "@aws-sdk/client-kms"
+        versions: ["3.592.0"]
+      - dependency-name: "@aws-sdk/client-lambda"
+        versions: ["3.592.0"]
+      - dependency-name: "@aws-sdk/credential-providers"
+        versions: ["3.592.0"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      # Check for updates to GitHub Actions every week
       interval: "weekly"


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `.github/dependabot.yml` configuration to add an `ignore` section for specific AWS SDK dependencies, preventing Dependabot from suggesting updates for those versions.

### Detailed summary
- Added an `ignore` section for the `npm` package ecosystem.
- Listed `@aws-sdk/client-kms`, `@aws-sdk/client-lambda`, and `@aws-sdk/credential-providers` with version `3.592.0` to be ignored.
- Retained the weekly update schedule for both `npm` and `github-actions`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->