### PR TITLE
fix: Handle NFT fetch failures gracefully and add Treasure chain

### DIFF
--- a/apps/wallet-ui/src/components/ConnectButton.tsx
+++ b/apps/wallet-ui/src/components/ConnectButton.tsx
@@ -5,6 +5,7 @@ import {
   arbitrum,
   base,
   blast,
+  defineChain,
   mainnet,
   optimism,
   zkSync,
@@ -19,7 +20,15 @@ export default function ConnectButton({
 
   return (
     <ThirdwebConnectButton
-      chains={[mainnet, base, optimism, arbitrum, blast, zkSync]}
+      chains={[
+        mainnet,
+        base,
+        optimism,
+        arbitrum,
+        blast,
+        zkSync,
+        defineChain(61166), // Treasure mainnet
+      ]}
       wallets={[ecosystemWallet(ecosystem)]}
       client={client}
       theme={theme === "light" ? "light" : "dark"}

--- a/apps/wallet-ui/src/lib/assets/erc721.ts
+++ b/apps/wallet-ui/src/lib/assets/erc721.ts
@@ -61,7 +61,11 @@ export async function getErc721Tokens({
 
   if (!response.ok) {
     response.body?.cancel();
-    throw new Error("Failed to fetch NFTs");
+    console.error("Failed to fetch NFTs");
+    return {
+      nextCursor: undefined,
+      tokens: [],
+    };
   }
   const data = await response.json();
 

--- a/apps/wallet-ui/src/util/simplehash.ts
+++ b/apps/wallet-ui/src/util/simplehash.ts
@@ -26,6 +26,7 @@ const chainIdNameMap = [
   { id: 660279, name: "xai", label: "Xai" },
   { id: 324, name: "zksync-era", label: "zkSync Era" },
   { id: 7777777, name: "zora", label: "Zora" },
+  { id: 61166, name: "treasure", label: "Treasure" },
 ];
 
 if (process.env.NEXT_PUBLIC_INCLUDE_TESTNETS) {


### PR DESCRIPTION
## Problem solved

fixes CNCT-2713



<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the wallet UI by adding support for the `Treasure` chain and improving error handling for NFT fetching.

### Detailed summary
- Added support for `Treasure` with `id: 61166` in `simplehash.ts`.
- Modified error handling in `erc721.ts` to log the error and return an empty response instead of throwing an error.
- Updated `ConnectButton.tsx` to include `Treasure` in the list of chains for the `ThirdwebConnectButton`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->