### PR TITLE
[DASH-644] Add Saakuru mainnet and Saakuru testnet in GAS_FREE_CHAINS list

### DIFF
--- a/apps/dashboard/src/components/buttons/MismatchButton.tsx
+++ b/apps/dashboard/src/components/buttons/MismatchButton.tsx
@@ -59,6 +59,8 @@ const GAS_FREE_CHAINS = [
   4457845, // zero testnet
   978658, // treasure topaz
   300, // zksync sepolia
+  7225878, // Saakuru Mainnet
+  247253, // Saakuru Testnet
 ];
 
 function useNetworkMismatchAdapter(desiredChainId: number) {
@@ -127,6 +129,7 @@ export const MismatchButton = forwardRef<
       </Button>
     );
   }
+
   const notEnoughBalance =
     (evmBalance.data?.value || 0n) === 0n && !GAS_FREE_CHAINS.includes(chainId);
 


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for two new networks, `Saakuru Mainnet` and `Saakuru Testnet`, in the `MismatchButton` component of the dashboard.

### Detailed summary
- Added `Saakuru Mainnet` with chain ID `7225878`.
- Added `Saakuru Testnet` with chain ID `247253`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->