### PR TITLE
fix typo in RPC Edge title

### DIFF
--- a/apps/portal/src/app/infrastructure/rpc-edge/overview/page.mdx
+++ b/apps/portal/src/app/infrastructure/rpc-edge/overview/page.mdx
@@ -7,7 +7,7 @@ export const metadata = createMetadata({
 		title: "thirdweb RPC Edge",
 		icon: "rpc",
 	},
-	title: "thridweb RPC Edge",
+	title: "thirdweb RPC Edge",
 	description:
 		"Remote Procedure Call (RPC) Edge provides reliable access to querying data and interacting with the blockchain through global edge RPCs.",
 });


### PR DESCRIPTION
fixes: CORE-587

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting a typo in the title of the `page.mdx` file related to the `rpc-edge` infrastructure.

### Detailed summary
- Changed `-title: "thridweb RPC Edge"` to `+title: "thirdweb RPC Edge"` to fix the spelling of "thirdweb".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->