### PR TITLE
fix: Add validation for getContract params

### DIFF
--- a/.changeset/shy-bats-eat.md
+++ b/.changeset/shy-bats-eat.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Validate getContract params

--- a/packages/thirdweb/src/contract/contract.ts
+++ b/packages/thirdweb/src/contract/contract.ts
@@ -1,6 +1,7 @@
 import type { Abi } from "abitype";
 import type { Chain } from "../chains/types.js";
 import type { ThirdwebClient } from "../client/client.js";
+import { isAddress } from "../utils/address.js";
 
 /**
  * @contract
@@ -42,5 +43,20 @@ export type ThirdwebContract<abi extends Abi = []> = Readonly<
 export function getContract<const abi extends Abi = []>(
   options: ContractOptions<abi>,
 ): ThirdwebContract<abi> {
+  if (!options.client) {
+    throw new Error(
+      `getContract validation error - invalid client: ${options.client}`,
+    );
+  }
+  if (!isAddress(options.address)) {
+    throw new Error(
+      `getContract validation error - invalid address: ${options.address}`,
+    );
+  }
+  if (!options.chain || !options.chain.id) {
+    throw new Error(
+      `getContract validation error - invalid chain: ${options.chain}`,
+    );
+  }
   return options;
 }

--- a/packages/thirdweb/src/wallets/smart/smart-wallet-dev.test.ts
+++ b/packages/thirdweb/src/wallets/smart/smart-wallet-dev.test.ts
@@ -1,5 +1,6 @@
 import { beforeAll, describe, expect, it } from "vitest";
 import { TEST_CLIENT } from "../../../test/src/test-clients.js";
+import { arbitrumSepolia } from "../../chains/chain-definitions/arbitrum-sepolia.js";
 import { type ThirdwebContract, getContract } from "../../contract/contract.js";
 import { balanceOf } from "../../extensions/erc1155/__generated__/IERC1155/read/balanceOf.js";
 import { claimTo } from "../../extensions/erc1155/drops/write/claimTo.js";
@@ -13,7 +14,6 @@ import type { Account, Wallet } from "../interfaces/wallet.js";
 import { generateAccount } from "../utils/generateAccount.js";
 import { smartWallet } from "./smart-wallet.js";
 let wallet: Wallet;
-import { arbitrumSepolia } from "../../chains/chain-definitions/arbitrum-sepolia.js";
 
 let smartAccount: Account;
 let smartWalletAddress: Address;


### PR DESCRIPTION
## Problem solved

Fixes TOOL-2768

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding validation to the `getContract` function in the `thirdweb` package, ensuring that the provided client, address, and chain are valid before proceeding.

### Detailed summary
- Added validation checks in the `getContract` function:
  - Validates if `options.client` is provided.
  - Validates if `options.address` is a valid address using `isAddress`.
  - Validates if `options.chain` and `options.chain.id` are provided.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->