### PR TITLE
[ci] Chore: Update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,26 +1,18 @@
 # Order is important; the last matching pattern takes the most precedence.
 
 # default ownership group
-- @jnsdls @joaquim-verges @MananTank @gregfromstl
+@thirdweb-dev/developer-tools
 
 # packages
-packages/thirdweb/ @joaquim-verges @gregfromstl @jnsdls
+packages/thirdweb/ @thirdweb-dev/core-platform @thirdweb-dev/developer-tools
 
 ## specific thirdweb pieces
-packages/thirdweb/src/react/ @joaquim-verges @gregfromstl @MananTank @jnsdls @edwardysun
-packages/thirdweb/src/reactive/ @joaquim-verges @gregfromstl @MananTank @jnsdls
-packages/thirdweb/src/gas/ @joaquim-verges @jnsdls
-packages/thirdweb/src/pay/ @joaquim-verges @gregfromstl @MananTank @jnsdls @edwardysun
-packages/service-utils/ @arcoraven @jnsdls @joaquim-verges
-packages/eslint-config-thirdweb/ @jnsdls @joaquim-verges
-packages/tw-tsconfig/ @jnsdls @joaquim-verges
+packages/service-utils/ @thirdweb-dev/core-platform
+packages/eslint-config-thirdweb/ @thirdweb-dev/core-platform @edwardysun
+packages/tw-tsconfig/ @thirdweb-dev/core-platform @edwardysun
 
 # apps
-apps/ @jnsdls @joaquim-verges
-apps/dashboard/ @jnsdls @MananTank @joaquim-verges @jakubkrehel
-apps/playground-web/ @joaquim-verges @gregfromstl @jnsdls @joaquim-verges @jakubkrehel
-apps/wallet-ui/ @gregfromstl @jnsdls @joaquim-verges @MananTank @jakubkrehel
-apps/portal/ @thirdweb-dev/product @thirdweb-dev/platform @thirdweb-dev/infra
+apps/ @thirdweb-dev/developer-tools @thirdweb-dev/core-platform @jakubkrehel
 
 # .github folder + .changeset + turbo config is owned by jonas for now
 scripts/ @jnsdls @joaquim-verges

--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, edited, ready_for_review]
 
 env:
-  VALID_ISSUE_PREFIXES: "CNCT|DASH|PROT|INSIGHT|ENGINE|CS|DES|BIL|DEVX|SOLU|NEB"
+  VALID_ISSUE_PREFIXES: "CORE|TOOL"
 
 jobs:
   linear:


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the ownership configuration in the `.github/CODEOWNERS` file and modifies the `VALID_ISSUE_PREFIXES` in the `.github/workflows/issue.yml`. It reflects a shift in responsibility for various packages and apps to new teams, enhancing clarity in code ownership.

### Detailed summary
- Changed `VALID_ISSUE_PREFIXES` from `"CNCT|DASH|PROT|INSIGHT|ENGINE|CS|DES|BIL|DEVX|SOLU|NEB"` to `"CORE|TOOL"`.
- Updated default ownership group to `@thirdweb-dev/developer-tools`.
- Adjusted package ownership:
  - `packages/thirdweb/` to `@thirdweb-dev/core-platform` and `@thirdweb-dev/developer-tools`.
  - `packages/service-utils/`, `packages/eslint-config-thirdweb/`, and `packages/tw-tsconfig/` now owned by `@thirdweb-dev/core-platform` and `@edwardysun`.
- Changed app ownership for `apps/` to include `@thirdweb-dev/developer-tools` and `@thirdweb-dev/core-platform`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->