### PR TITLE
fix: Remove hardcoded chain list from ConnectButton

### DIFF
--- a/apps/wallet-ui/src/components/ConnectButton.tsx
+++ b/apps/wallet-ui/src/components/ConnectButton.tsx
@@ -1,15 +1,6 @@
 "use client";
 import { client } from "@/lib/client";
 import { useTheme } from "next-themes";
-import {
-  arbitrum,
-  base,
-  blast,
-  defineChain,
-  mainnet,
-  optimism,
-  zkSync,
-} from "thirdweb/chains";
 import { ConnectButton as ThirdwebConnectButton } from "thirdweb/react";
 import { ecosystemWallet } from "thirdweb/wallets";
 
@@ -20,15 +11,6 @@ export default function ConnectButton({
 
   return (
     <ThirdwebConnectButton
-      chains={[
-        mainnet,
-        base,
-        optimism,
-        arbitrum,
-        blast,
-        zkSync,
-        defineChain(61166), // Treasure mainnet
-      ]}
       wallets={[ecosystemWallet(ecosystem)]}
       client={client}
       theme={theme === "light" ? "light" : "dark"}


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added



<!-- start pr-codex -->

---

## PR-Codex overview
This PR simplifies the `ConnectButton` component by removing unused chain imports and the associated chains array from the `ThirdwebConnectButton`.

### Detailed summary
- Removed import statements for unused chains: `arbitrum`, `base`, `blast`, `defineChain`, `mainnet`, `optimism`, and `zkSync`.
- Deleted the `chains` prop from the `ThirdwebConnectButton`, which previously included multiple chains.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->