### PR TITLE
fix contract subscriptions info on features

### DIFF
--- a/apps/portal/src/app/engine/features/contract-subscriptions/page.mdx
+++ b/apps/portal/src/app/engine/features/contract-subscriptions/page.mdx
@@ -14,12 +14,6 @@ A **log** is an event emitted from a successfully executed transaction. Example:
 
 A **receipt** contains onchain details for any transaction. This may be useful for tracking onchain failures (reverted executions).
 
-<Callout title="Contract Subscriptions is in Early Access" variant="info">
-
-Please [contact us](https://thirdweb.com/contact-us) to enable this feature.
-
-</Callout>
-
 ## Use cases
 
 Your app may trigger an action when an onchain event occurs, such as:


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added
Contract subscriptions are enabled by default now.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the content in the `page.mdx` file related to `Contract Subscriptions`. It removes a callout about the feature being in early access and adds context regarding the utility of receipts in tracking onchain transaction details.

### Detailed summary
- Added explanation that a **receipt** contains onchain details for transactions, useful for tracking onchain failures.
- Removed the callout about `Contract Subscriptions` being in early access and the contact link for enabling the feature.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->