### PR TITLE
[React SDK] Fix: Hides custom_jwt profiles from UI

### DIFF
--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/LinkedProfilesScreen.test.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/LinkedProfilesScreen.test.tsx
@@ -99,17 +99,6 @@ describe("LinkedProfilesScreen", () => {
       expect(screen.getByText("cognito@example.com")).toBeInTheDocument();
     });
 
-    it("should display Custom Profile for custom_auth_endpoint", () => {
-      vi.mocked(useProfiles).mockReturnValue({
-        data: [{ type: "Custom_auth_endpoint", details: {} }],
-        isLoading: false,
-        // biome-ignore lint/suspicious/noExplicitAny: Mocking data
-      } as any);
-
-      render(<LinkedProfilesScreen {...mockProps} />);
-      expect(screen.getByText("Custom Profile")).toBeInTheDocument();
-    });
-
     it("should capitalize unknown profile types", () => {
       vi.mocked(useProfiles).mockReturnValue({
         data: [{ type: "unknown", details: {} }],
@@ -155,6 +144,34 @@ describe("LinkedProfilesScreen", () => {
 
       render(<LinkedProfilesScreen {...mockProps} />);
       expect(screen.queryByLabelText("Unlink")).not.toBeInTheDocument();
+    });
+
+    it("should not display custom_jwt profiles", () => {
+      vi.mocked(useProfiles).mockReturnValue({
+        data: [{ type: "custom_jwt", details: {} }],
+        isLoading: false,
+        // biome-ignore lint/suspicious/noExplicitAny: Mocking data
+      } as any);
+
+      render(<LinkedProfilesScreen {...mockProps} />);
+      expect(screen.queryByText("Custom_jwt")).not.toBeInTheDocument();
+    });
+
+    it("should display profiles that are not guest or custom_jwt", () => {
+      vi.mocked(useProfiles).mockReturnValue({
+        data: [
+          { type: "email", details: { email: "test@example.com" } },
+          { type: "custom_jwt", details: {} },
+          { type: "guest", details: {} },
+        ],
+        isLoading: false,
+        // biome-ignore lint/suspicious/noExplicitAny: Mocking data
+      } as any);
+
+      render(<LinkedProfilesScreen {...mockProps} />);
+      expect(screen.getByText("test@example.com")).toBeInTheDocument();
+      expect(screen.queryByText("Custom_jwt")).not.toBeInTheDocument();
+      expect(screen.queryByText("Guest")).not.toBeInTheDocument();
     });
   });
 });

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/LinkedProfilesScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/LinkedProfilesScreen.tsx
@@ -98,7 +98,12 @@ export function LinkedProfilesScreen(props: {
           <Spacer y="xs" />
           {/* Exclude guest as a profile */}
           {connectedProfiles
-            ?.filter((profile) => profile.type !== "guest")
+            ?.filter(
+              (profile) =>
+                profile.type.toLowerCase() !== "guest" &&
+                profile.type.toLowerCase() !== "custom_jwt" &&
+                profile.type.toLowerCase() !== "custom_auth_endpoint",
+            )
             .map((profile) => (
               <LinkedProfile
                 key={`${JSON.stringify(profile)}`}


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `LinkedProfilesScreen` component by refining the filtering logic for connected profiles, ensuring that profiles of type `guest`, `custom_jwt`, and `custom_auth_endpoint` are excluded from display. It also adds tests to verify these changes.

### Detailed summary
- Updated the filtering logic in `LinkedProfilesScreen.tsx` to exclude profiles of types `guest`, `custom_jwt`, and `custom_auth_endpoint`.
- Added a new test to confirm that `custom_jwt` profiles are not displayed.
- Added a new test to check that profiles not of type `guest` or `custom_jwt` are displayed correctly.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->