### PR TITLE
[TOOL-2804] Insight Playground: Render Select for Parameters with enum schema + Show Examples

### DIFF
--- a/apps/dashboard/src/@/components/ui/select.tsx
+++ b/apps/dashboard/src/@/components/ui/select.tsx
@@ -14,8 +14,10 @@ const SelectValue = SelectPrimitive.Value;
 
 const SelectTrigger = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
->(({ className, children, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger> & {
+    chevronClassName?: string;
+  }
+>(({ className, children, chevronClassName, ...props }, ref) => (
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
@@ -26,7 +28,7 @@ const SelectTrigger = React.forwardRef<
   >
     {children}
     <SelectPrimitive.Icon asChild>
-      <ChevronDown className="h-4 w-4 opacity-50" />
+      <ChevronDown className={cn("h-4 w-4 opacity-50", chevronClassName)} />
     </SelectPrimitive.Icon>
   </SelectPrimitive.Trigger>
 ));

--- a/apps/dashboard/src/@/components/ui/tooltip.tsx
+++ b/apps/dashboard/src/@/components/ui/tooltip.tsx
@@ -35,6 +35,7 @@ export function ToolTipLabel(props: {
   rightIcon?: React.ReactNode;
   leftIcon?: React.ReactNode;
   hoverable?: boolean;
+  contentClassName?: string;
 }) {
   if (!props.label) {
     return props.children;
@@ -48,7 +49,10 @@ export function ToolTipLabel(props: {
         </TooltipTrigger>
         <TooltipContent
           sideOffset={10}
-          className="max-w-[400px] whitespace-normal leading-relaxed"
+          className={cn(
+            "max-w-[400px] whitespace-normal leading-relaxed",
+            props.contentClassName,
+          )}
         >
           <div className="flex items-center gap-1.5 p-2 text-sm">
             {props.leftIcon}


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces enhancements to the `ToolTipLabel` and `SelectTrigger` components, adds new properties, and refines the `ParameterSection` functionality. It also introduces a new `ParameterInput` component to streamline input handling.

### Detailed summary
- Added `contentClassName` prop to `ToolTipLabel`.
- Updated `className` in `TooltipContent` to include `props.contentClassName`.
- Extended `SelectTrigger` to accept `chevronClassName`.
- Improved error handling display in `RequestConfigSection`.
- Introduced `ParameterInput` component for better parameter handling.
- Enhanced tooltip display logic with `showTip` and example handling in `ParameterSection`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->