### PR TITLE
[TOOL-2809] Nebula - make the chat card a link in chat history page

### DIFF
--- a/apps/dashboard/src/app/nebula-app/(app)/chat/history/ChatHistoryPage.tsx
+++ b/apps/dashboard/src/app/nebula-app/(app)/chat/history/ChatHistoryPage.tsx
@@ -175,9 +175,14 @@ function SessionCard(props: {
   });
 
   return (
-    <div className="overflow-hidden rounded-lg border bg-muted/50 p-4">
+    <div className="relative overflow-hidden rounded-lg border bg-muted/50 p-4">
       <h3 className="line-clamp-3 break-all">
-        {props.session.title || "Untitled"}
+        <Link
+          className="before:absolute before:inset-0"
+          href={`/chat/${props.session.id}`}
+        >
+          {props.session.title || "Untitled"}
+        </Link>
       </h3>
       <div className="mt-4 flex items-center justify-between gap-6 border-t pt-3">
         <p className="text-muted-foreground text-sm">
@@ -189,7 +194,10 @@ function SessionCard(props: {
 
         <Popover>
           <PopoverTrigger asChild>
-            <Button className="h-auto w-auto p-1.5" variant="ghost">
+            <Button
+              className="relative z-10 h-auto w-auto p-1.5"
+              variant="ghost"
+            >
               <EllipsisIcon className="size-4 text-muted-foreground" />
             </Button>
           </PopoverTrigger>


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `ChatHistoryPage` component by improving the structure and interactivity of session titles and buttons.

### Detailed summary
- Changed the `div` class from `overflow-hidden` to `relative overflow-hidden`.
- Wrapped the session title in a `Link` component for better navigation.
- Added a `className` to the `Link` for positioning.
- Updated the `Button` class to include `relative z-10` for improved stacking context.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->