### PR TITLE
[TOOL-2808] Add back freewallets announcement banner + hide it after 31st Dec 2024

### DIFF
--- a/apps/dashboard/src/app/layout.tsx
+++ b/apps/dashboard/src/app/layout.tsx
@@ -7,6 +7,7 @@ import PlausibleProvider from "next-plausible";
 import { Inter } from "next/font/google";
 import NextTopLoader from "nextjs-toploader";
 import { Suspense } from "react";
+import { UnlimitedWalletsBanner } from "../components/notices/AnnouncementBanner";
 import { OpCreditsGrantedModalWrapperServer } from "../components/onboarding/OpCreditsGrantedModalWrapperServer";
 import { EnsureValidConnectedWalletLoginServer } from "./components/EnsureValidConnectedWalletLogin/EnsureValidConnectedWalletLoginServer";
 import { PostHogProvider } from "./components/root-providers";
@@ -71,7 +72,7 @@ export default function RootLayout({
             fontSans.variable,
           )}
         >
-          {/* Banner goes here */}
+          <UnlimitedWalletsBanner />
           <AppRouterProviders>
             {children}
             <Suspense fallback={null}>

--- a/apps/dashboard/src/components/notices/AnnouncementBanner.tsx
+++ b/apps/dashboard/src/components/notices/AnnouncementBanner.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { Button } from "@/components/ui/button";
 import { TrackedLinkTW } from "@/components/ui/tracked-link";
+import { isAfter } from "date-fns";
 import { useLocalStorage } from "hooks/useLocalStorage";
 import { ChevronRightIcon, XIcon } from "lucide-react";
 import { useSelectedLayoutSegment } from "next/navigation";
@@ -54,5 +55,22 @@ export function AnnouncementBanner(props: {
         <XIcon className="size-5" />
       </Button>
     </div>
+  );
+}
+
+export function UnlimitedWalletsBanner() {
+  // hide banner after 31st December 2024
+  const shouldHideBanner = isAfter(new Date(), new Date("31 Dec 2024"));
+
+  if (shouldHideBanner) {
+    return null;
+  }
+
+  return (
+    <AnnouncementBanner
+      href="/team/~/~/settings/billing?coupon=FREEWALLETS24"
+      label='Claim 12 months of free in-app wallets. Use code "FREEWALLETS24". Redeem offer by December 31st!'
+      trackingLabel="unlimited-wallets"
+    />
   );
 }

--- a/apps/dashboard/src/pages/_app.tsx
+++ b/apps/dashboard/src/pages/_app.tsx
@@ -22,6 +22,7 @@ import type { ThirdwebNextPage } from "utils/types";
 import chakraTheme from "../theme";
 import "@/styles/globals.css";
 import { DashboardRouterTopProgressBar } from "@/lib/DashboardRouter";
+import { UnlimitedWalletsBanner } from "../components/notices/AnnouncementBanner";
 
 const inter = interConstructor({
   subsets: ["latin"],
@@ -259,7 +260,7 @@ const ConsoleApp = memo(function ConsoleApp({
       />
 
       <DashboardRouterTopProgressBar />
-      {/* Banner goes here */}
+      <UnlimitedWalletsBanner />
 
       <TailwindTheme>
         <ChakraProvider theme={chakraThemeWithFonts}>


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the `UnlimitedWalletsBanner` component to the dashboard, replacing a placeholder comment with the actual banner in two locations. The banner promotes a limited-time offer for free in-app wallets until December 31, 2024.

### Detailed summary
- Added import of `UnlimitedWalletsBanner` in `apps/dashboard/src/pages/_app.tsx`.
- Replaced comment with `<UnlimitedWalletsBanner />` in `ConsoleApp` component.
- Added import of `UnlimitedWalletsBanner` in `apps/dashboard/src/app/layout.tsx`.
- Replaced comment with `<UnlimitedWalletsBanner />` in `RootLayout` component.
- Created `UnlimitedWalletsBanner` function in `apps/dashboard/src/components/notices/AnnouncementBanner.tsx`.
- Implemented logic to hide the banner after December 31, 2024.
- Configured the banner to link to a settings page with a promotional code.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->