### PR TITLE
docs: Remove duplicate contract section heading

### DIFF
--- a/apps/portal/src/app/react/v5/transactions/page.mdx
+++ b/apps/portal/src/app/react/v5/transactions/page.mdx
@@ -29,8 +29,6 @@ Try out the demo for yourself in the [sending transactions playground](https://p
 />
 </Stack>
 
-## Generic Contract Read
-
 ## Sending a generic contract call
 
 ```ts


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the documentation for sending a generic contract call in the `page.mdx` file, specifically enhancing the clarity of the section.

### Detailed summary
- Removed the header `## Generic Contract Read`.
- Added a new header `## Sending a generic contract call`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->