### PR TITLE
add optional config to webhooks in engine

### DIFF
--- a/apps/dashboard/src/@3rdweb-sdk/react/hooks/useEngine.ts
+++ b/apps/dashboard/src/@3rdweb-sdk/react/hooks/useEngine.ts
@@ -118,7 +118,8 @@ type EngineFeature =
   | "CONTRACT_SUBSCRIPTIONS"
   | "IP_ALLOWLIST"
   | "HETEROGENEOUS_WALLET_TYPES"
-  | "SMART_BACKEND_WALLETS";
+  | "SMART_BACKEND_WALLETS"
+  | "WEBHOOK_CONFIG";
 
 interface EngineSystemHealth {
   status: string;
@@ -835,6 +836,7 @@ export interface EngineWebhook {
   active: boolean;
   createdAt: string;
   id: number;
+  config?: string;
 }
 
 export function useEngineWebhooks(params: {
@@ -1246,6 +1248,7 @@ export type CreateWebhookInput = {
   url: string;
   name: string;
   eventType: string;
+  config?: string;
 };
 
 export function useEngineCreateWebhook(params: {

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/(instance)/[engineId]/webhooks/components/engine-webhooks.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/(instance)/[engineId]/webhooks/components/engine-webhooks.tsx
@@ -1,6 +1,9 @@
 "use client";
 
-import { useEngineWebhooks } from "@3rdweb-sdk/react/hooks/useEngine";
+import {
+  useEngineSystemHealth,
+  useEngineWebhooks,
+} from "@3rdweb-sdk/react/hooks/useEngine";
 import { Heading, Link, Text } from "tw-components";
 import { AddWebhookButton } from "./add-webhook-button";
 import { WebhooksTable } from "./webhooks-table";
@@ -18,6 +21,10 @@ export const EngineWebhooks: React.FC<EngineWebhooksProps> = ({
     authToken,
     instanceUrl,
   });
+  const healthQuery = useEngineSystemHealth(instanceUrl);
+
+  const supportedWebhookConfig =
+    healthQuery.data?.features?.includes("WEBHOOK_CONFIG") || false;
 
   return (
     <div className="flex flex-col gap-4">
@@ -42,8 +49,13 @@ export const EngineWebhooks: React.FC<EngineWebhooksProps> = ({
         isPending={webhooks.isPending}
         isFetched={webhooks.isFetched}
         authToken={authToken}
+        supportedWebhookConfig={supportedWebhookConfig}
       />
-      <AddWebhookButton instanceUrl={instanceUrl} authToken={authToken} />
+      <AddWebhookButton
+        instanceUrl={instanceUrl}
+        authToken={authToken}
+        supportedWebhookConfig={supportedWebhookConfig}
+      />
     </div>
   );
 };


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing webhook functionality by adding support for a new `WEBHOOK_CONFIG` feature, allowing users to provide configuration for webhooks in a structured format.

### Detailed summary
- Added `"WEBHOOK_CONFIG"` to the `features` list.
- Introduced an optional `config` field in `EngineWebhook` and `CreateWebhookInput`.
- Integrated `useEngineSystemHealth` to check for `WEBHOOK_CONFIG` support.
- Updated `AddWebhookButton` to handle `config` input.
- Modified `WebhooksTable` to display `config` if supported.
- Enhanced `DeleteWebhookModal` and `TestWebhookModal` to show `config` if present.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->