### PR TITLE
[TOOL-2814] Fix custom factory publish form

### DIFF
--- a/apps/dashboard/src/components/contract-components/hooks.ts
+++ b/apps/dashboard/src/components/contract-components/hooks.ts
@@ -6,8 +6,8 @@ import type { Abi } from "abitype";
 import { isEnsName, resolveEns } from "lib/ens";
 import { useV5DashboardChain } from "lib/v5-adapter";
 import { useMemo } from "react";
-import { type ThirdwebContract, getContract } from "thirdweb";
-import { resolveContractAbi } from "thirdweb/contract";
+import type { ThirdwebContract } from "thirdweb";
+import { getContract, resolveContractAbi } from "thirdweb/contract";
 import { isAddress } from "thirdweb/utils";
 import {
   type PublishedContractWithVersion,
@@ -179,26 +179,24 @@ export function useCustomFactoryAbi(
 ) {
   const chain = useV5DashboardChain(chainId);
   const client = useThirdwebClient();
-  const contract = useMemo(() => {
-    if (!chain) {
-      return undefined;
-    }
-
-    return getContract({
-      client,
-      address: contractAddress,
-      chain,
-    });
-  }, [contractAddress, chain, client]);
 
   return useQuery({
-    queryKey: ["custom-factory-abi", contract],
+    queryKey: ["custom-factory-abi", { contractAddress, chainId }],
     queryFn: () => {
+      const contract = chain
+        ? getContract({
+            client,
+            address: contractAddress,
+            chain,
+          })
+        : undefined;
+
       if (!contract) {
         throw new Error("Contract not found");
       }
+
       return resolveContractAbi<Abi>(contract);
     },
-    enabled: !!contract,
+    enabled: !!contractAddress && !!chainId,
   });
 }


### PR DESCRIPTION
TOOL-2814

## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR refactors the `useCustomFactoryAbi` function in the `hooks.ts` file to improve contract retrieval logic and enhance type imports.

### Detailed summary
- Changed import of `ThirdwebContract` to a type-only import.
- Moved `getContract` and `resolveContractAbi` to a single import statement.
- Updated `useMemo` logic to directly handle contract retrieval within the `useQuery`.
- Changed query key to include `contractAddress` and `chainId`.
- Modified `enabled` condition to check for both `contractAddress` and `chainId`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->