### PR TITLE
[TOOL-2815] Nebula - handle disconnected wallet state, use connected account address in execute config

### DIFF
--- a/apps/dashboard/src/app/nebula-app/(app)/api/chat.ts
+++ b/apps/dashboard/src/app/nebula-app/(app)/api/chat.ts
@@ -13,7 +13,7 @@ export type ContextFilters = {
 export async function promptNebula(params: {
   message: string;
   sessionId: string;
-  config: ExecuteConfig;
+  config: ExecuteConfig | null;
   authToken: string;
   handleStream: (res: ChatStreamedResponse) => void;
   abortController: AbortController;
@@ -24,7 +24,6 @@ export async function promptNebula(params: {
     user_id: "default-user",
     session_id: params.sessionId,
     stream: true,
-    execute_config: params.config,
   };
 
   if (params.contextFilters) {
@@ -32,6 +31,10 @@ export async function promptNebula(params: {
       chain_ids: params.contextFilters.chainIds || [],
       contract_addresses: params.contextFilters.contractAddresses || [],
     };
+  }
+
+  if (params.config) {
+    body.execute_config = params.config;
   }
 
   const events = await stream(`${NEXT_PUBLIC_NEBULA_URL}/chat`, {

--- a/apps/dashboard/src/app/nebula-app/(app)/chat/[session_id]/page.tsx
+++ b/apps/dashboard/src/app/nebula-app/(app)/chat/[session_id]/page.tsx
@@ -1,9 +1,6 @@
 import { redirect } from "next/navigation";
 import { getValidAccount } from "../../../../account/settings/getAccount";
-import {
-  getAuthToken,
-  getAuthTokenWalletAddress,
-} from "../../../../api/lib/getAuthToken";
+import { getAuthToken } from "../../../../api/lib/getAuthToken";
 import { loginRedirect } from "../../../../login/loginRedirect";
 import { getSessionById } from "../../api/session";
 import { ChatPageContent } from "../../components/ChatPageContent";
@@ -22,12 +19,6 @@ export default async function Page(props: {
     loginRedirect(pagePath);
   }
 
-  const accountAddress = await getAuthTokenWalletAddress();
-
-  if (!accountAddress) {
-    loginRedirect(pagePath);
-  }
-
   const session = await getSessionById({
     authToken,
     sessionId: params.session_id,
@@ -39,7 +30,6 @@ export default async function Page(props: {
 
   return (
     <ChatPageContent
-      accountAddress={accountAddress}
       authToken={authToken}
       session={session}
       type="new-chat"

--- a/apps/dashboard/src/app/nebula-app/(app)/chat/page.tsx
+++ b/apps/dashboard/src/app/nebula-app/(app)/chat/page.tsx
@@ -1,8 +1,5 @@
 import { getValidAccount } from "../../../account/settings/getAccount";
-import {
-  getAuthToken,
-  getAuthTokenWalletAddress,
-} from "../../../api/lib/getAuthToken";
+import { getAuthToken } from "../../../api/lib/getAuthToken";
 import { loginRedirect } from "../../../login/loginRedirect";
 import { ChatPageContent } from "../components/ChatPageContent";
 
@@ -14,15 +11,8 @@ export default async function Page() {
     loginRedirect();
   }
 
-  const accountAddress = await getAuthTokenWalletAddress();
-
-  if (!accountAddress) {
-    loginRedirect();
-  }
-
   return (
     <ChatPageContent
-      accountAddress={accountAddress}
       authToken={authToken}
       session={undefined}
       type="new-chat"

--- a/apps/dashboard/src/app/nebula-app/(app)/components/ChatBar.tsx
+++ b/apps/dashboard/src/app/nebula-app/(app)/components/ChatBar.tsx
@@ -25,6 +25,7 @@ export function Chatbar(props: {
             return;
           }
           if (e.key === "Enter" && !props.isChatStreaming) {
+            e.preventDefault();
             setMessage("");
             props.sendMessage(message);
           }

--- a/apps/dashboard/src/app/nebula-app/(app)/page.tsx
+++ b/apps/dashboard/src/app/nebula-app/(app)/page.tsx
@@ -1,8 +1,5 @@
 import { getValidAccount } from "../../account/settings/getAccount";
-import {
-  getAuthToken,
-  getAuthTokenWalletAddress,
-} from "../../api/lib/getAuthToken";
+import { getAuthToken } from "../../api/lib/getAuthToken";
 import { loginRedirect } from "../../login/loginRedirect";
 import { ChatPageContent } from "./components/ChatPageContent";
 
@@ -20,16 +17,10 @@ export default async function Page(props: {
     loginRedirect();
   }
 
-  const accountAddress = await getAuthTokenWalletAddress();
   const account = await getValidAccount();
-
-  if (!accountAddress) {
-    loginRedirect();
-  }
 
   return (
     <ChatPageContent
-      accountAddress={accountAddress}
       authToken={authToken}
       session={undefined}
       type="landing"

--- a/apps/dashboard/src/app/nebula-app/login/NebulaLoginPage.tsx
+++ b/apps/dashboard/src/app/nebula-app/login/NebulaLoginPage.tsx
@@ -12,10 +12,12 @@ export function NebulaLoginPage(props: {
   account: Account | undefined;
 }) {
   const [message, setMessage] = useState<string | undefined>(undefined);
-  const [showLoginPage, setShowLoginPage] = useState<boolean>(false);
-
+  const [showPage, setShowPage] = useState<"connect" | "welcome">(
+    props.account ? "connect" : "welcome",
+  );
   return (
     <div className="relative flex min-h-screen flex-col overflow-hidden bg-background">
+      {/* nav */}
       <header className="border-b">
         <div className="container flex items-center justify-between p-4">
           <NebulaIcon className="size-8 shrink-0 text-foreground" />
@@ -37,8 +39,8 @@ export function NebulaLoginPage(props: {
               Docs
             </Link>
 
-            {!showLoginPage && (
-              <Button size="sm" onClick={() => setShowLoginPage(true)}>
+            {showPage === "welcome" && (
+              <Button size="sm" onClick={() => setShowPage("connect")}>
                 Sign in
               </Button>
             )}
@@ -46,19 +48,21 @@ export function NebulaLoginPage(props: {
         </div>
       </header>
 
-      {showLoginPage ? (
+      {showPage === "connect" && (
         <LoginAndOnboardingPageContent
           account={props.account}
           redirectPath={
             message ? `/?prompt=${encodeURIComponent(message)}` : "/"
           }
         />
-      ) : (
+      )}
+
+      {showPage === "welcome" && (
         <div className="container relative flex max-w-[800px] grow flex-col justify-center overflow-hidden rounded-lg pb-6">
           <EmptyStateChatPageContent
             sendMessage={(msg) => {
               setMessage(msg);
-              setShowLoginPage(true);
+              setShowPage("connect");
             }}
           />
         </div>


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing user experience in the chat application by preventing default behavior on the Enter key, simplifying authentication logic, and introducing a modal dialog for wallet connection issues.

### Detailed summary
- Prevent default action on `Enter` key in `ChatBar`.
- Remove unused `getAuthTokenWalletAddress` calls for account address retrieval.
- Update `promptNebula` to handle `config` as nullable.
- Introduce `showConnectModal` state for wallet connection prompts in `ChatPageContent`.
- Add `WalletDisconnectedDialog` for handling wallet disconnection scenarios.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->