### PR TITLE
Marketplace implementation addresses

### DIFF
--- a/apps/dashboard/src/components/contract-components/contract-deploy-form/custom-contract.tsx
+++ b/apps/dashboard/src/components/contract-components/contract-deploy-form/custom-contract.tsx
@@ -34,6 +34,7 @@ import {
 } from "thirdweb/deploys";
 import { useActiveAccount, useActiveWalletChain } from "thirdweb/react";
 import { upload } from "thirdweb/storage";
+import { isZkSyncChain } from "thirdweb/utils";
 import { FormHelperText, FormLabel, Heading, Text } from "tw-components";
 import { useCustomFactoryAbi, useFunctionParamsFromABI } from "../hooks";
 import { addContractToMultiChainRegistry } from "../utils";
@@ -426,7 +427,10 @@ export const CustomContractForm: React.FC<CustomContractFormProps> = ({
         }
       }
 
-      if (metadata.name === "MarketplaceV3") {
+      if (
+        metadata.name === "MarketplaceV3" &&
+        !(await isZkSyncChain(walletChain))
+      ) {
         // special case for marketplace
         return await deployMarketplaceContract({
           account: activeAccount,

--- a/packages/thirdweb/src/contract/deployment/utils/bootstrap.test.ts
+++ b/packages/thirdweb/src/contract/deployment/utils/bootstrap.test.ts
@@ -3,7 +3,12 @@ import { describe, expect, it } from "vitest";
 import { ANVIL_CHAIN } from "../../../../test/src/chains.js";
 import { TEST_CLIENT } from "../../../../test/src/test-clients.js";
 import { TEST_ACCOUNT_A } from "../../../../test/src/test-wallets.js";
-import { deployCloneFactory } from "./bootstrap.js";
+import { defineChain } from "../../../chains/utils.js";
+import {
+  deployCloneFactory,
+  getOrDeployInfraContract,
+  getOrDeployInfraForPublishedContract,
+} from "./bootstrap.js";
 import { getDeployedCreate2Factory } from "./create-2-factory.js";
 import { getDeployedInfraContract } from "./infra.js";
 
@@ -41,5 +46,43 @@ describe.runIf(process.env.TW_SECRET_KEY)("bootstrap", () => {
       },
     });
     expect(cloneFactory).not.toBeNull();
+  });
+
+  it("should return saved implementations for zksync chains", async () => {
+    let infra = await getOrDeployInfraForPublishedContract({
+      client: TEST_CLIENT,
+      chain: defineChain(300),
+      account: TEST_ACCOUNT_A,
+      contractId: "MarketplaceV3",
+    });
+
+    expect(infra.cloneFactoryContract.address).to.eq(
+      "0xa51baf6a9c0ef5Db8C1898d5aDD92Bf3227d6088",
+    );
+    expect(infra.implementationContract.address).to.eq(
+      "0x58e0F289C7dD2025eBd0696d913ECC0fdc1CC8bc",
+    );
+
+    infra = await getOrDeployInfraForPublishedContract({
+      client: TEST_CLIENT,
+      chain: defineChain(300),
+      account: TEST_ACCOUNT_A,
+      contractId: "DropERC721",
+      version: "5.0.4",
+    });
+
+    expect(infra.cloneFactoryContract.address).to.eq(
+      "0xa51baf6a9c0ef5Db8C1898d5aDD92Bf3227d6088",
+    );
+    expect(infra.implementationContract.address).toBeDefined();
+
+    const weth = await getOrDeployInfraContract({
+      client: TEST_CLIENT,
+      chain: defineChain(300),
+      account: TEST_ACCOUNT_A,
+      contractId: "WETH9",
+    });
+
+    expect(weth.address).to.eq("0x0462C05457Fed440740Ff3696bDd2D0577411e34");
   });
 });

--- a/packages/thirdweb/src/contract/deployment/zksync/implementations.ts
+++ b/packages/thirdweb/src/contract/deployment/zksync/implementations.ts
@@ -1,0 +1,20 @@
+export const ZKSYNC_IMPLEMENTATIONS: Record<number, Record<string, string>> = {
+  [300]: {
+    MarketplaceV3: "0x58e0F289C7dD2025eBd0696d913ECC0fdc1CC8bc",
+  },
+  [302]: {
+    MarketplaceV3: "0x8b0DBCf5b7D01eBB0F24525CE8AB72F16CE4F8C8",
+  },
+  [324]: {
+    MarketplaceV3: "0xBc02441a36Bb4029Cd191b20243c2e41B862F118",
+  },
+  [11124]: {
+    MarketplaceV3: "0x2dA4Dd326A6482679547071be21f74685d730504",
+  },
+};
+
+export const ZKSYNC_WETH: Record<number, string> = {
+  [300]: "0x0462C05457Fed440740Ff3696bDd2D0577411e34",
+  [324]: "0x5AEa5775959fBC2557Cc8789bC1bf90A239D9a91",
+  [11124]: "0x9EDCde0257F2386Ce177C3a7FCdd97787F0D841d",
+};

--- a/packages/thirdweb/src/extensions/prebuilts/get-required-transactions.test.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/get-required-transactions.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { CLEAN_ANVIL_CHAIN } from "../../../test/src/chains.js";
 import { TEST_CLIENT } from "../../../test/src/test-clients.js";
+import { defineChain } from "../../chains/utils.js";
 import { fetchPublishedContractMetadata } from "../../contract/deployment/publisher.js";
-import { getRequiredTransactions } from "./get-required-transactions.js";
+import {
+  getAllDefaultConstructorParamsForImplementation,
+  getRequiredTransactions,
+} from "./get-required-transactions.js";
 
 describe.runIf(process.env.TW_SECRET_KEY)(
   "getRequiredTransactions",
@@ -58,6 +62,15 @@ describe.runIf(process.env.TW_SECRET_KEY)(
         ),
       });
       expect(results.length).toBe(7);
+    });
+
+    it("should return default constructor params for zksync chains", async () => {
+      const params = await getAllDefaultConstructorParamsForImplementation({
+        chain: defineChain(300),
+        client: TEST_CLIENT,
+      });
+
+      expect(params.nativeTokenWrapper).toBeDefined();
     });
   },
 );

--- a/packages/thirdweb/src/extensions/prebuilts/get-required-transactions.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/get-required-transactions.ts
@@ -3,6 +3,7 @@ import type { ThirdwebClient } from "../../client/client.js";
 import { getDeployedCreate2Factory } from "../../contract/deployment/utils/create-2-factory.js";
 import { getDeployedInfraContract } from "../../contract/deployment/utils/infra.js";
 import { getDeployedInfraContractFromMetadata } from "../../contract/deployment/utils/infra.js";
+import { ZKSYNC_WETH } from "../../contract/deployment/zksync/implementations.js";
 import { computePublishedContractAddress } from "../../utils/any-evm/compute-published-contract-address.js";
 import type { FetchDeployMetadataResult } from "../../utils/any-evm/deploy-metadata.js";
 import { isZkSyncChain } from "../../utils/any-evm/zksync/isZkSyncChain.js";
@@ -227,8 +228,11 @@ export async function getAllDefaultConstructorParamsForImplementation(args: {
   const { chain, client } = args;
   const isZkSync = await isZkSyncChain(chain);
   if (isZkSync) {
-    // zksync contracts dont need these implementation constructor params
-    return {};
+    const weth = ZKSYNC_WETH[chain.id];
+
+    return {
+      nativeTokenWrapper: weth,
+    };
   }
   const [forwarder, weth] = await Promise.all([
     computePublishedContractAddress({


### PR DESCRIPTION
TOOL-2813

## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces support for `ZkSync` chains by defining implementations and WETH addresses, updating contract deployment logic, and adding tests to ensure correct behavior for these chains.

### Detailed summary
- Added `ZKSYNC_IMPLEMENTATIONS` and `ZKSYNC_WETH` for `ZkSync` chain configurations.
- Updated `CustomContractForm` to handle `MarketplaceV3` for `ZkSync` chains.
- Enhanced `getAllDefaultConstructorParamsForImplementation` to return `WETH` for `ZkSync`.
- Introduced tests for retrieving implementations and default constructor parameters for `ZkSync`.
- Modified `getOrDeployInfraForPublishedContract` to utilize `ZkSync` implementations.
- Updated `getOrDeployInfraContract` to return `WETH` for `ZkSync` chains.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->