### PR TITLE
[SDK] Feature: Adds `getAdminAccount` to ecosystem wallets and cleans up smart account creation

### DIFF
--- a/.changeset/afraid-mails-sip.md
+++ b/.changeset/afraid-mails-sip.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": minor
+---
+
+Feature: Adds getAdminAccount to inAppWallet interface for AA ecosystem wallets

--- a/packages/thirdweb/src/wallets/in-app/core/wallet/in-app-core.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/wallet/in-app-core.ts
@@ -48,6 +48,7 @@ export function createInAppWallet(args: {
   const emitter = createWalletEmitter<"inApp">();
   let createOptions = _createOptions;
   let account: Account | undefined = undefined;
+  let adminAccount: Account | undefined = undefined; // Admin account if smartAccountOptions were provided with connection
   let chain: Chain | undefined = undefined;
   let client: ThirdwebClient | undefined;
 
@@ -98,15 +99,16 @@ export function createInAppWallet(args: {
         }
       }
 
-      const [connectedAccount, connectedChain] = await autoConnectInAppWallet(
-        options,
-        createOptions,
-        connector,
-      );
+      const {
+        account: connectedAccount,
+        chain: connectedChain,
+        adminAccount: _adminAccount,
+      } = await autoConnectInAppWallet(options, createOptions, connector);
 
       // set the states
       client = options.client;
       account = connectedAccount;
+      adminAccount = _adminAccount;
       chain = connectedChain;
       trackConnect({
         client: options.client,
@@ -151,14 +153,16 @@ export function createInAppWallet(args: {
         }
       }
 
-      const [connectedAccount, connectedChain] = await connectInAppWallet(
-        options,
-        createOptions,
-        connector,
-      );
+      const {
+        account: connectedAccount,
+        chain: connectedChain,
+        adminAccount: _adminAccount,
+      } = await connectInAppWallet(options, createOptions, connector);
+
       // set the states
       client = options.client;
       account = connectedAccount;
+      adminAccount = _adminAccount;
       chain = connectedChain;
       trackConnect({
         client: options.client,
@@ -184,6 +188,7 @@ export function createInAppWallet(args: {
         }
       }
       account = undefined;
+      adminAccount = undefined;
       chain = undefined;
       emitter.emit("disconnect", undefined);
     },
@@ -212,7 +217,11 @@ export function createInAppWallet(args: {
           }
         }
 
-        const [connectedAccount, connectedChain] = await autoConnectInAppWallet(
+        const {
+          account: connectedAccount,
+          chain: connectedChain,
+          adminAccount: _adminAccount,
+        } = await autoConnectInAppWallet(
           {
             chain: newChain,
             client,
@@ -220,6 +229,7 @@ export function createInAppWallet(args: {
           createOptions,
           connector,
         );
+        adminAccount = _adminAccount;
         account = connectedAccount;
         chain = connectedChain;
       } else {
@@ -228,5 +238,6 @@ export function createInAppWallet(args: {
       }
       emitter.emit("chainChanged", newChain);
     },
+    getAdminAccount: () => adminAccount,
   };
 }

--- a/packages/thirdweb/src/wallets/smart/smart-wallet.ts
+++ b/packages/thirdweb/src/wallets/smart/smart-wallet.ts
@@ -137,7 +137,7 @@ export function smartWallet(
   let chain: Chain | undefined = undefined;
   let lastConnectOptions: WalletConnectionOption<"smart"> | undefined;
 
-  const _smartWallet: Wallet<"smart"> = {
+  return {
     id: "smart",
     subscribe: emitter.subscribe,
     getChain() {
@@ -152,9 +152,10 @@ export function smartWallet(
     getAccount: () => account,
     getAdminAccount: () => adminAccount,
     autoConnect: async (options) => {
-      const { connectSmartWallet } = await import("./index.js");
+      const { connectSmartAccount: connectSmartWallet } = await import(
+        "./index.js"
+      );
       const [connectedAccount, connectedChain] = await connectSmartWallet(
-        _smartWallet,
         options,
         createOptions,
       );
@@ -172,9 +173,8 @@ export function smartWallet(
       return account;
     },
     connect: async (options) => {
-      const { connectSmartWallet } = await import("./index.js");
-      const [connectedAccount, connectedChain] = await connectSmartWallet(
-        _smartWallet,
+      const { connectSmartAccount } = await import("./index.js");
+      const [connectedAccount, connectedChain] = await connectSmartAccount(
         options,
         createOptions,
       );
@@ -194,10 +194,13 @@ export function smartWallet(
       return account;
     },
     disconnect: async () => {
+      if (account) {
+        const { disconnectSmartAccount } = await import("./index.js");
+        await disconnectSmartAccount(account);
+      }
       account = undefined;
+      adminAccount = undefined;
       chain = undefined;
-      const { disconnectSmartWallet } = await import("./index.js");
-      await disconnectSmartWallet(_smartWallet);
       emitter.emit("disconnect", undefined);
     },
     switchChain: async (newChain: Chain) => {
@@ -223,9 +226,8 @@ export function smartWallet(
           );
         }
       }
-      const { connectSmartWallet } = await import("./index.js");
-      const [connectedAccount, connectedChain] = await connectSmartWallet(
-        _smartWallet,
+      const { connectSmartAccount } = await import("./index.js");
+      const [connectedAccount, connectedChain] = await connectSmartAccount(
         { ...lastConnectOptions, chain: newChain },
         createOptions,
       );
@@ -235,6 +237,4 @@ export function smartWallet(
       emitter.emit("chainChanged", newChain);
     },
   };
-
-  return _smartWallet;
 }

--- a/packages/thirdweb/src/wallets/smart/smart.test.ts
+++ b/packages/thirdweb/src/wallets/smart/smart.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 import { TEST_CLIENT } from "../../../test/src/test-clients.js";
 import { defineChain } from "../../chains/utils.js";
 import { generateAccount } from "../utils/generateAccount.js";
-import { connectSmartWallet, disconnectSmartWallet } from "./index.js";
 import { smartWallet } from "./smart-wallet.js";
 
 describe("Smart Wallet Index", () => {
@@ -17,67 +16,48 @@ describe("Smart Wallet Index", () => {
         gasless: true,
       });
 
-      const [account, connectedChain] = await connectSmartWallet(
-        wallet,
-        {
-          client,
-          personalAccount,
-        },
-        {
-          chain,
-          gasless: true,
-        },
-      );
+      await wallet.connect({
+        client,
+        personalAccount,
+      });
 
-      expect(account.address).toBeDefined();
-      expect(account.address).toMatch(/^0x[a-fA-F0-9]{40}$/);
-      expect(connectedChain.id).toBe(chain.id);
+      expect(wallet.getAccount()?.address).toBeDefined();
+      expect(wallet.getAccount()?.address).toMatch(/^0x[a-fA-F0-9]{40}$/);
+      expect(wallet.getChain()?.id).toBe(chain.id);
     });
   });
 
   describe("disconnectSmartWallet", () => {
     it("should disconnect a smart wallet", async () => {
       const personalAccount = await generateAccount({ client });
+
       const wallet = smartWallet({
         chain,
         gasless: true,
       });
 
-      await connectSmartWallet(
-        wallet,
-        {
-          client,
-          personalAccount,
-        },
-        {
-          chain,
-          gasless: true,
-        },
-      );
+      await wallet.connect({
+        client,
+        personalAccount,
+      });
 
-      await expect(disconnectSmartWallet(wallet)).resolves.not.toThrow();
+      await expect(wallet.disconnect()).resolves.not.toThrow();
     });
 
     it("should clear wallet mappings on disconnect", async () => {
       const personalAccount = await generateAccount({ client });
+
       const wallet = smartWallet({
         chain,
         gasless: true,
       });
 
-      await connectSmartWallet(
-        wallet,
-        {
-          client,
-          personalAccount,
-        },
-        {
-          chain,
-          gasless: true,
-        },
-      );
+      await wallet.connect({
+        client,
+        personalAccount,
+      });
 
-      await disconnectSmartWallet(wallet);
+      await wallet.disconnect();
 
       // Verify wallet state is cleared
       expect(wallet.getAccount()).toBeUndefined();


### PR DESCRIPTION
Also Fixes TOOL-2833

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the `getAdminAccount` method to the `inAppWallet` interface, enhancing the functionality for Account Abstraction (AA) ecosystem wallets. It also refines wallet connection and disconnection processes, improving the overall wallet management experience.

### Detailed summary
- Added `getAdminAccount` method to `inAppWallet`.
- Updated `smartWallet` to include `getAdminAccount` and refactored connection methods.
- Replaced `connectSmartWallet` with `connectSmartAccount` across various files.
- Enhanced test cases for wallet connection and admin account retrieval.
- Improved handling of wallet state during connection and disconnection.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->