### PR TITLE
[SDK] Fix: allow 0 values for gasPrice

### DIFF
--- a/packages/thirdweb/src/gas/fee-data.ts
+++ b/packages/thirdweb/src/gas/fee-data.ts
@@ -61,7 +61,7 @@ export async function getGasOverridesForTransaction(
       maxPriorityFeePerGas,
     };
   }
-  if (gasPrice) {
+  if (typeof gasPrice === "bigint") {
     return { gasPrice };
   }
 


### PR DESCRIPTION
## Problem solved

Allow `0` value for gasPrice, important for gasless chains
Fixes TOOL-2865

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the conditional check for `gasPrice` in the `fee-data.ts` file to ensure it specifically checks if `gasPrice` is of type `bigint`, enhancing type safety.

### Detailed summary
- Changed the condition from `if (gasPrice)` to `if (typeof gasPrice === "bigint")` in the `fee-data.ts` file.
- This modification ensures that the subsequent code block only executes when `gasPrice` is a `bigint`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->