### PR TITLE
[Docs] .NET 2.10.0+

### DIFF
--- a/apps/portal/src/app/dotnet/contracts/extensions/page.mdx
+++ b/apps/portal/src/app/dotnet/contracts/extensions/page.mdx
@@ -12,24 +12,32 @@ Thirdweb's .NET SDK provides a set of useful type-safe extensions for calling sm
 ## Usage
 
 ```csharp
-// Without extensions
+// Write without extensions
 var receiver = await wallet.GetAddress();
 var quantity = BigInteger.One;
 var currency = Constants.NATIVE_TOKEN_ADDRESS;
 var pricePerToken = BigInteger.Zero;
 var allowlistProof = new object[] { new byte[] { }, BigInteger.Zero, BigInteger.Zero, Constants.ADDRESS_ZERO };
 var data = new byte[] { };
-var receipt = await ThirdwebContract.Write(smartAccount, contract, "claim", 0, receiver, quantity, currency, pricePerToken, allowlistProof, data);
+var receipt = await contract.Write(smartAccount, contract, "claim", 0, receiver, quantity, currency, pricePerToken, allowlistProof, data);
 
-// With extensions
+// Write with extensions
 var receipt = await contract.DropERC20_Claim(wallet, receiver, amount);
 
-// Can also do read operations and much more
+// Read without extensions
+var balance = await contract.Read<string>("balanceOf", "0xOwnerAddress");
+
+// Read with extensions
 var balance = await contract.ERC20_BalanceOf("0xOwnerAddress");
+
+// Generate low level calldata
+var calldata = contract.CreateCallData("myFunction", param1, param2);
 ```
 
 ## Available Contract Extensions
 
 Please refer to the `ThirdwebExtensions` [full reference](https://thirdweb-dev.github.io/dotnet/docs/Thirdweb.ThirdwebExtensions.html) for a complete list of available contract extensions.
+
+If you are using our [Marketplace](https://thirdweb.com/thirdweb.eth/MarketplaceV3) contract, check out our [Marketplace-specific](https://thirdweb-dev.github.io/dotnet/docs/Thirdweb.ThirdwebMarketplaceExtensions.html) extensions.
 
 

--- a/apps/portal/src/app/dotnet/contracts/prepare/page.mdx
+++ b/apps/portal/src/app/dotnet/contracts/prepare/page.mdx
@@ -15,7 +15,7 @@ Useful for preparing, simulating and manipulating transactions before sending th
 ## Usage
 
 ```csharp
-ThirdwebTransaction transaction = await ThirdwebContract.Prepare(wallet, contract, "methodName", weiValue, parameters);
+ThirdwebTransaction transaction = await contract.Prepare(wallet, contract, "methodName", weiValue, parameters);
 ```
 
 <Details summary="Parameters">

--- a/apps/portal/src/app/dotnet/contracts/read/page.mdx
+++ b/apps/portal/src/app/dotnet/contracts/read/page.mdx
@@ -12,7 +12,7 @@ Use `ThirdwebContract.Read` to fetch data from a smart contract without making a
 ## Usage
 
 ```csharp
-var result = await ThirdwebContract.Read<T>(contract, "methodName", parameters);
+var result = await contract.Read<T>(contract, "methodName", parameters);
 ```
 
 <Details summary="Parameters">

--- a/apps/portal/src/app/dotnet/contracts/write/page.mdx
+++ b/apps/portal/src/app/dotnet/contracts/write/page.mdx
@@ -12,7 +12,7 @@ The `ThirdwebContract.Write` method allows you to execute transactions that alte
 ## Usage
 
 ```csharp
-var transactionReceipt = await ThirdwebContract.Write(wallet, contract, "methodName", weiValue, parameters);
+var transactionReceipt = await contract.Write(wallet, contract, "methodName", weiValue, parameters);
 ```
 
 <Details summary="Parameters">
@@ -68,7 +68,7 @@ BigInteger amount = new BigInteger(1000); // The amount to transfer
 BigInteger weiValue = BigInteger.Zero;
 
 // Executing the transfer
-var receipt = await ThirdwebContract.Write(wallet, contract, "transfer", weiValue, toAddress, amount);
+var receipt = await contract.Write(wallet, contract, "transfer", weiValue, toAddress, amount);
 Console.WriteLine($"Transaction receipt: {receipt}");
 ```
 

--- a/apps/portal/src/app/dotnet/getting-started/page.mdx
+++ b/apps/portal/src/app/dotnet/getting-started/page.mdx
@@ -39,14 +39,17 @@ This command adds the Thirdweb SDK to your project, allowing you to interact wit
 Create a new instance of the Thirdweb client in your application:
 
 ```csharp
-// For Frontend Applications
+// For Web Applications
+var client = ThirdwebClient.Create(clientId: "yourClientId");
+
+// For Native Applications
 var client = ThirdwebClient.Create(clientId: "yourClientId", bundleId: "yourBundleId");
 
 // For Backend Applications
 var client = ThirdwebClient.Create(secretKey: "yourSecretKey");
 ```
 
-Replace "yourClientId" and "yourBundleId" with your actual client ID and bundle ID. Note that a bundle ID is only required if you are not using the SDK from a web application.
+Replace "yourClientId" and "yourBundleId" with your actual client ID and bundle ID.
 
 </Step>
 <Step title="Interact with Smart Contracts" >
@@ -55,7 +58,7 @@ Now, you can start interacting with smart contracts. For example, to read from a
 
 ```csharp
 var contract = await ThirdwebContract.Create(client: client, address: "contractAddress", chain: chainId);
-var readResult = await ThirdwebContract.Read<string>(contract, "methodName");
+var readResult = await contract.Read<string>(contract, "methodName");
 Console.WriteLine($"Contract read result: {readResult}");
 ```
 

--- a/apps/portal/src/app/dotnet/page.mdx
+++ b/apps/portal/src/app/dotnet/page.mdx
@@ -3,13 +3,13 @@ import { GraduationCap } from "lucide-react";
 
 # .NET SDK
 
-A .NET SDK to integrate blockchain and web3 capabilities into your applications.
+Build decentralized .NET applications and create seamless user experiences using Thirdweb's .NET SDK.
 
 Connect to users’ wallets, interact with smart contracts, sign messages, and utilize common standards such as tokens, NFTs, and marketplaces; all with built-in RPC URLs, IPFS gateways, and more.
 
 <OpenSourceCard
 	title=".NET SDK"
-	href="https://github.com/thirdweb-dev/thirdweb-dotnet"
+	href="https://github.com/thirdweb-dev/dotnet"
 	isLibrary={true}
 />
 

--- a/apps/portal/src/app/dotnet/pay/getbuywithcryptoquote/page.mdx
+++ b/apps/portal/src/app/dotnet/pay/getbuywithcryptoquote/page.mdx
@@ -49,6 +49,7 @@ string toAmountWei; // Optional, amount of to token in wei
 string toAddress; // Optional, address to receive the to token
 int? maxSlippageBPS; // Optional, maximum slippage in basis points
 string intentId; // Optional, intent identifier used to link status to a BuyWithFiat onramp flow if any
+object purchaseData; // Optional, additional data to be passed and retained during the flow
 ```
 
 </Details>

--- a/apps/portal/src/app/dotnet/pay/getbuywithcryptostatus/page.mdx
+++ b/apps/portal/src/app/dotnet/pay/getbuywithcryptostatus/page.mdx
@@ -36,15 +36,16 @@ var status = await ThirdwebPay.GetBuyWithCryptoStatus(client, txHash);
 A `BuyWithCryptoStatusResult` object containing the following properties:
 
 ```csharp
-Quote quote; // The quote object containing the swap details.
-string swapType; // The swap type, see SwapType enum.
-TransactionDetails source; // The source transaction details.
-TransactionDetails destination; // The destination transaction details.
-string status; // The status of the swap, see SwapStatus enum.
-string subStatus; // The sub status of the swap, see SwapSubStatus enum.
-string fromAddress; // The source address.
-string failureMessage; // The failure message if the swap failed.
-string bridge // The bridge used for the swap if applicable.
+Quote Quote; // The quote object containing the swap details.
+string SwapType; // The swap type, see SwapType enum.
+TransactionDetails Source; // The source transaction details.
+TransactionDetails Destination; // The destination transaction details.
+string Status; // The status of the swap, see SwapStatus enum.
+string SubStatus; // The sub status of the swap, see SwapSubStatus enum.
+string FromAddress; // The source address.
+string FailureMessage; // The failure message if the swap failed.
+string Bridge; // The bridge used for the swap if applicable.
+object PurchaseData; // Additional data passed when creating the quote
 ```
 
 </Details>

--- a/apps/portal/src/app/dotnet/pay/getbuywithfiatquote/page.mdx
+++ b/apps/portal/src/app/dotnet/pay/getbuywithfiatquote/page.mdx
@@ -49,6 +49,8 @@ string toAmount; // Optional, amount of to token
 string toAmountWei; // Optional, amount of to token in wei
 double? maxSlippageBPS; // Optional, maximum slippage in basis points
 bool isTestMode; // Optional, enters test mode onramp flow, defaults to false
+string preferredProvider; // Optional, can be set to "STRIPE", "KADO", etc.
+object purchaseData; // Optional, additional data to be passed and retained during the flow
 ```
 
 </Details>

--- a/apps/portal/src/app/dotnet/pay/getbuywithfiatstatus/page.mdx
+++ b/apps/portal/src/app/dotnet/pay/getbuywithfiatstatus/page.mdx
@@ -45,6 +45,7 @@ OnRampQuote Quote; // OnRamp Quote details
 TransactionDetails Source; // Source transaction details
 TransactionDetails Destination; // Destination transaction details
 string FailureMessage; // Failure message if any
+object PurchaseData; // Additional data passed when creating the quote
 ```
 
 </Details>

--- a/apps/portal/src/app/dotnet/sidebar.tsx
+++ b/apps/portal/src/app/dotnet/sidebar.tsx
@@ -72,6 +72,14 @@ const walletActions: SidebarLink = (() => {
             name: "Transfer",
             href: `${parentSlug}/transfer`,
           },
+          {
+            name: "SwitchNetwork",
+            href: `${parentSlug}/switchnetwork`,
+          },
+          {
+            name: "SignAuthorization (Experimental)",
+            href: `${parentSlug}/signauthorization`,
+          },
         ],
       },
       {
@@ -81,6 +89,10 @@ const walletActions: SidebarLink = (() => {
           {
             name: "GetUserDetails",
             href: `${parentSlug}/getuserdetails`,
+          },
+          {
+            name: "GetUserAuthDetails",
+            href: `${parentSlug}/getuserauthdetails`,
           },
           {
             name: "GetEcosystemDetails",

--- a/apps/portal/src/app/dotnet/wallets/actions/getuserauthdetails/page.mdx
+++ b/apps/portal/src/app/dotnet/wallets/actions/getuserauthdetails/page.mdx
@@ -1,0 +1,24 @@
+import { Details, createMetadata } from "@doc";
+
+export const metadata = createMetadata({
+	title: "EcosystemWallet.GetUserAuthDetails | Thirdweb .NET SDK",
+	description: "Gets the user auth details from the corresponding auth provider.",
+});
+
+# EcosystemWallet.GetUserDetails
+
+This method returns information about the connected user auth provider details, for instance Google or Github specific details.
+
+## Usage
+
+```csharp
+var result = ecosystemWallet.GetUserAuthDetails();
+```
+
+<Details summary="Return Value">
+
+### JObject
+
+The user auth provider details as a `JObject`.
+
+</Details>

--- a/apps/portal/src/app/dotnet/wallets/actions/sign/page.mdx
+++ b/apps/portal/src/app/dotnet/wallets/actions/sign/page.mdx
@@ -9,7 +9,7 @@ export const metadata = createMetadata({
 
 This method allows signing a string message using the wallet's private key. The signed message proves the message's integrity and authenticity, demonstrating that the message was indeed created by the owner of the private key.
 
-**Note:** When using `SmartWallet`, calling this method will deploy a smart contract account if it hasn't been deployed yet.
+**Note:** When using `SmartWallet`, calling this method from an undeployed smart account will make use of [EIP-6492](https://eips.ethereum.org/EIPS/eip-6492).
 
 ## Usage
 

--- a/apps/portal/src/app/dotnet/wallets/actions/signauthorization/page.mdx
+++ b/apps/portal/src/app/dotnet/wallets/actions/signauthorization/page.mdx
@@ -1,0 +1,100 @@
+import { Details, createMetadata } from "@doc";
+
+export const metadata = createMetadata({
+	title: "IThirdwebWallet.SignAuthorization | Thirdweb .NET SDK",
+	description: "Sign an EIP-7702 Payload to Set Code to your EOA.",
+});
+
+# [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) Integration (Experimental)
+Integrates `authorizationList` for any transactions.
+This EIP essentially allows you to set code to an EOA, unlocking a world of possibilities to enhance their functionality.
+
+The best way to understand it outside of reading the EIP is looking at the example below; to preface it: we sign an authorization using the wallet we want to set code to. Another wallet sends a transaction with said authorization passed in, essentially activating it. The authority wallet now has code set to it pointing to an (insecure) [Delegation](https://thirdweb.com/odyssey-911867/0x654F42b74885EE6803F403f077bc0409f1066c58) contract in this case, which allows any wallet to execute any call through it on behalf of the authority. In this example, we call the wallet executing both the authorization and the claim transaction afterwards, the exectuor.
+
+An authority may execute its own authorization, the only difference is internal whereby the authorization nonce is incremented by 1.
+
+```csharp
+// Chain and contract addresses
+var chainWith7702 = 911867;
+var erc20ContractAddress = "0xAA462a5BE0fc5214507FDB4fB2474a7d5c69065b"; // Fake ERC20
+var delegationContractAddress = "0x654F42b74885EE6803F403f077bc0409f1066c58"; // BatchCallDelegation
+
+// Initialize contracts normally
+var erc20Contract = await ThirdwebContract.Create(client: client, address: erc20ContractAddress, chain: chainWith7702);
+var delegationContract = await ThirdwebContract.Create(client: client, address: delegationContractAddress, chain: chainWith7702);
+
+// Initialize a (to-be) 7702 EOA
+var eoaWallet = await PrivateKeyWallet.Generate(client);
+var eoaWalletAddress = await eoaWallet.GetAddress();
+Console.WriteLine($"EOA address: {eoaWalletAddress}");
+
+// Initialize another wallet, the "executor" that will hit the eoa's (to-be) execute function
+var executorWallet = await PrivateKeyWallet.Generate(client);
+var executorWalletAddress = await executorWallet.GetAddress();
+Console.WriteLine($"Executor address: {executorWalletAddress}");
+
+// Fund the executor wallet
+var fundingWallet = await PrivateKeyWallet.Create(client, privateKey);
+var fundingHash = (await fundingWallet.Transfer(chainWith7702, executorWalletAddress, BigInteger.Parse("0.001".ToWei()))).TransactionHash;
+Console.WriteLine($"Funded Executor Wallet: {fundingHash}");
+
+// Sign the authorization to make it point to the delegation contract
+var authorization = await eoaWallet.SignAuthorization(chainId: chainWith7702, contractAddress: delegationContractAddress, willSelfExecute: false);
+Console.WriteLine($"Authorization: {JsonConvert.SerializeObject(authorization, Formatting.Indented)}");
+
+// Execute the delegation
+var tx = await ThirdwebTransaction.Create(executorWallet, new ThirdwebTransactionInput(chainId: chainWith7702, to: executorWalletAddress, authorization: authorization));
+var hash = (await ThirdwebTransaction.SendAndWaitForTransactionReceipt(tx)).TransactionHash;
+Console.WriteLine($"Authorization execution transaction hash: {hash}");
+
+// Prove that code has been deployed to the eoa
+var rpc = ThirdwebRPC.GetRpcInstance(client, chainWith7702);
+var code = await rpc.SendRequestAsync<string>("eth_getCode", eoaWalletAddress, "latest");
+Console.WriteLine($"EOA code: {code}");
+
+// Log erc20 balance of executor before the claim
+var executorBalanceBefore = await erc20Contract.ERC20_BalanceOf(executorWalletAddress);
+Console.WriteLine($"Executor balance before: {executorBalanceBefore}");
+
+// Prepare the claim call
+var claimCallData = erc20Contract.CreateCallData(
+    "claim",
+    new object[]
+    {
+        executorWalletAddress, // receiver
+        100, // quantity
+        Constants.NATIVE_TOKEN_ADDRESS, // currency
+        0, // pricePerToken
+        new object[] { Array.Empty<byte>(), BigInteger.Zero, BigInteger.Zero, Constants.ADDRESS_ZERO }, // allowlistProof
+        Array.Empty<byte>() // data
+    }
+);
+
+// Embed the claim call in the execute call
+var executeCallData = delegationContract.CreateCallData(
+    method: "execute",
+    parameters: new object[]
+    {
+        new List<Thirdweb.Console.Call>
+        {
+            new()
+            {
+                Data = claimCallData.HexToBytes(),
+                To = erc20ContractAddress,
+                Value = BigInteger.Zero
+            }
+        }
+    }
+);
+
+// Execute from the executor wallet targeting the eoa which is pointing to the delegation contract
+var tx2 = await ThirdwebTransaction.Create(executorWallet, new ThirdwebTransactionInput(chainId: chainWith7702, to: eoaWalletAddress, data: executeCallData));
+var hash2 = (await ThirdwebTransaction.SendAndWaitForTransactionReceipt(tx2)).TransactionHash;
+Console.WriteLine($"Token claim transaction hash: {hash2}");
+
+// Log erc20 balance of executor after the claim
+var executorBalanceAfter = await erc20Contract.ERC20_BalanceOf(executorWalletAddress);
+Console.WriteLine($"Executor balance after: {executorBalanceAfter}");
+```
+
+_Note that for the time being this only works on 7702-enabled chains such as [Odyssey](https://thirdweb.com/odyssey-911867) and the feature has only been integrated with `PrivateKeyWallet`._

--- a/apps/portal/src/app/dotnet/wallets/actions/switchnetwork/page.mdx
+++ b/apps/portal/src/app/dotnet/wallets/actions/switchnetwork/page.mdx
@@ -1,0 +1,26 @@
+import { Details, createMetadata } from "@doc";
+
+export const metadata = createMetadata({
+	title: "IThirdwebWallet.SwitchNetwork | Thirdweb .NET SDK",
+	description: "Enables setting the active chain of the wallet if applicable.",
+});
+
+# IThirdwebWallet.SwitchNetwork
+
+This method allows setting the active chain of the wallet if applicable.
+
+When using Smart Wallets, make sure any overrides to default contracts, such as factories, are deployed on all chains you intend to switch to. We also support switching between zksync and non-zksync chains.
+
+## Usage
+
+```csharp
+await wallet.SwitchNetwork(chainId);
+```
+
+<Details summary="Parameters">
+
+### chainId (required)
+
+The chain ID to which you want to switch the wallet.
+
+</Details>

--- a/apps/portal/src/app/dotnet/wallets/providers/ecosystem-wallet/page.mdx
+++ b/apps/portal/src/app/dotnet/wallets/providers/ecosystem-wallet/page.mdx
@@ -287,3 +287,10 @@ _ = await ecosystemWalletMain.LinkAccount(walletToLink: phoneWallet, otp: otp);
 ```csharp
 List<LinkedAccount> linkedAccounts = await ecosystemWalletMain.GetLinkedAccounts();
 ```
+
+### Unlinking Accounts
+
+```csharp
+List<LinkedAccount> linkedAccounts = await ecosystemWallet.GetLinkedAccounts();
+List<LinkedAccount> linkedAccountsAfterUnlinking = await ecosystemWallet.UnlinkAccount(linkedAccounts[0]);
+```

--- a/apps/portal/src/app/dotnet/wallets/providers/in-app-wallet/page.mdx
+++ b/apps/portal/src/app/dotnet/wallets/providers/in-app-wallet/page.mdx
@@ -292,3 +292,10 @@ _ = await inAppWalletMain.LinkAccount(walletToLink: phoneWallet, otp: otp);
 ```csharp
 List<LinkedAccount> linkedAccounts = await inAppWalletMain.GetLinkedAccounts();
 ```
+
+### Unlinking Accounts
+
+```csharp
+List<LinkedAccount> linkedAccounts = await inAppWallet.GetLinkedAccounts();
+List<LinkedAccount> linkedAccountsAfterUnlinking = await inAppWallet.UnlinkAccount(linkedAccounts[0]);
+```

--- a/apps/portal/src/app/unity/v5/build-instructions/page.mdx
+++ b/apps/portal/src/app/unity/v5/build-instructions/page.mdx
@@ -13,6 +13,7 @@ export const metadata = createMetadata({
 - **Build Settings:** Use `Smaller (faster) Builds` / `Shorter Build Time`.
 - **Player Settings:** Use IL2CPP over Mono when available.
 - **Stripping Level:** Set `Managed Stripping Level` to `Minimal` (`Player Settings` > `Other Settings` > `Optimization`). (Generally not a hard requirement unless using WalletConnect as a wallet provider option.)
+- **Strip Engine Code:** Make sure this is turned off.
 
 ## WebGL
 
@@ -47,3 +48,8 @@ No action needed for hosted builds.
 
 - **EDM4U:** Comes with the package, resolves dependencies at runtime. Use `Force Resolve` from `Assets` > `External Dependency Manager` > `Android Resolver`.
 - **Redirect Schemes:** Set custom schemes matching your bundle ID in `Plugins/AndroidManifest.xml` or equivalent to ensure OAuth redirects.
+```xml
+<!-- Set your bundle id here -->
+<!-- Replace 'com.thirdweb.unitysdk' with your desired scheme -->
+<data android:scheme="com.thirdweb.unitysdk" />
+```

--- a/apps/portal/src/app/unity/v5/getting-started/page.mdx
+++ b/apps/portal/src/app/unity/v5/getting-started/page.mdx
@@ -32,7 +32,7 @@ We recommend using the 2022 LTS version of Unity.
 
 <Step title="Unity Package Download" >
 
-Download the latest thirdweb Unity SDK package from the [releases page](https://github.com/thirdweb-dev/unity-sdk/releases).
+Download the latest thirdweb Unity SDK package from the [releases page](https://github.com/thirdweb-dev/unity/releases).
 
 </Step>
 
@@ -50,7 +50,7 @@ Play around in our example `Scene_Playground` to test out the SDK!
 
 <Step title="Build it!" >
 
-Refer to the [Build Settings](https://github.com/thirdweb-dev/unity-sdk/tree/v5?tab=readme-ov-file#build-instructions), pick a target platform and build your scene!
+Refer to the [Build Instructions](/unity/v5/build-instructions), pick a target platform and build your scene!
 
 We support all platforms.
 

--- a/apps/portal/src/app/unity/v5/page.mdx
+++ b/apps/portal/src/app/unity/v5/page.mdx
@@ -10,13 +10,15 @@ messages, and utilize common standards such as tokens, NFTs, marketplaces; all w
 
 <OpenSourceCard
 	title="Unity SDK"
-	href="https://github.com/thirdweb-dev/unity-sdk/tree/v5"
+	href="https://github.com/thirdweb-dev/unity"
 	isLibrary={false}
 />
 
 ## Installation
 
-The Unity SDK is distributed as a [Unity Package](https://docs.unity3d.com/Manual/PackagesList.html).
+The Unity SDK is distributed as an [Asset Package](https://docs.unity3d.com/Manual/AssetPackages.html) allowing you to view and edit the source code.
+
+It also wraps our open-source gaming-focused [.NET SDK](https://github.com/thirdweb-dev/dotnet) making version updates extremely simple containing a single DLL filechange.
 
 You can download the latest version of the SDK from our [GitHub releases page](https://github.com/thirdweb-dev/unity-sdk/releases).
 

--- a/apps/portal/src/app/unity/v5/wallets/ecosystem-wallet/page.mdx
+++ b/apps/portal/src/app/unity/v5/wallets/ecosystem-wallet/page.mdx
@@ -161,6 +161,9 @@ var linkedAccounts = await ThirdwebManager.Instance.LinkAccount(mainEcosystemWal
 
 // You can also fetch linked accounts at any time
 List<LinkedAccount> linkedAccounts = await mainEcosystemWallet.GetLinkedAccounts();
+
+// Unlink an account
+List<LinkedAccount> linkedAccounts = await mainEcosystemWallet.UnlinkAccount(linkedAccounts[0]);
 ```
 
 <ArticleIconCard

--- a/apps/portal/src/app/unity/v5/wallets/in-app-wallet/page.mdx
+++ b/apps/portal/src/app/unity/v5/wallets/in-app-wallet/page.mdx
@@ -141,6 +141,9 @@ var linkedAccounts = await ThirdwebManager.Instance.LinkAccount(mainInAppWallet,
 
 // You can also fetch linked accounts at any time
 List<LinkedAccount> linkedAccounts = await mainInAppWallet.GetLinkedAccounts();
+
+// Unlink an account
+List<LinkedAccount> linkedAccounts = await mainInAppWallet.UnlinkAccount(linkedAccounts[0]);
 ```
 
 <ArticleIconCard


### PR DESCRIPTION
Closes TOOL-2440

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on simplifying contract interactions by removing the `ThirdwebContract` prefix in several instances, enhancing the clarity of the code. It also adds new functionalities related to unlinking accounts and introduces new metadata for wallet actions.

### Detailed summary
- Removed `ThirdwebContract` prefix from contract method calls in multiple files.
- Added `PurchaseData` object in various payment-related methods.
- Introduced unlinking account functionality in wallet management.
- Added metadata for `GetUserAuthDetails` and `SignAuthorization` methods.
- Updated documentation to clarify SDK usage and links.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->