### PR TITLE
[Docs] .NET Fix LoginWithOtp Example

### DIFF
--- a/apps/portal/src/app/dotnet/wallets/providers/in-app-wallet/page.mdx
+++ b/apps/portal/src/app/dotnet/wallets/providers/in-app-wallet/page.mdx
@@ -46,7 +46,7 @@ var isConnected = await wallet.IsConnected();
 
 // Email & Phone (OTP)
 await wallet.SendOTP(); // and fetch the otp
-var (address, canRetry) = await wallet.LoginWithOtp("userEnteredOTP");
+var address = await wallet.LoginWithOtp("userEnteredOTP"); // try catch and retry if needed
 
 // Socials (OAuth)
 var address = await wallet.LoginWithOauth(
@@ -121,12 +121,8 @@ await wallet.SendOTP();
 **Submit OTP:** Once the user receives the OTP, they submit it back to the application, which then calls LoginWithOtp on the InAppWallet instance to verify the OTP and complete the login process.
 
 ```csharp
-var (address, canRetry) = await wallet.LoginWithOtp("userEnteredOTP");
-if (address != null) {
-    // Login successful
-} else if (canRetry) {
-    // Ask user to retry entering OTP
-}
+var address = await wallet.LoginWithOtp("userEnteredOTP");
+// If this fails, feel free to catch and take in another OTP and retry the login process
 ```
 
 ## Example
@@ -143,18 +139,7 @@ if (!await inAppWallet.IsConnected())
     await inAppWallet.SendOTP();
     Console.WriteLine("Please submit the OTP.");
     var otp = Console.ReadLine();
-    (var inAppWalletAddress, var canRetry) = await inAppWallet.LoginWithOtp(otp);
-    if (inAppWalletAddress == null && canRetry)
-    {
-        Console.WriteLine("Please submit the OTP again.");
-        otp = Console.ReadLine();
-        (inAppWalletAddress, _) = await inAppWallet.LoginWithOtp(otp);
-    }
-    if (inAppWalletAddress == null)
-    {
-        Console.WriteLine("OTP login failed. Please try again.");
-        return;
-    }
+    var inAppWalletAddress = await inAppWallet.LoginWithOtp(otp); // try catch and retry if needed
 }
 
 Console.WriteLine($"InAppWallet address: {await inAppWallet.GetAddress()}");


### PR DESCRIPTION
Closes TOOL-2863

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on simplifying the OTP login process in the `in-app-wallet` functionality by removing the `canRetry` variable and associated logic, encouraging a retry mechanism through exception handling instead.

### Detailed summary
- Removed `canRetry` from `LoginWithOtp` method calls.
- Simplified OTP login logic by eliminating conditional checks for retrying.
- Added comments to suggest using try-catch for handling OTP failures.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->