### PR TITLE
[CI] Chore: adds nebula and infra teams to acceptable linear teams

### DIFF
--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, edited, ready_for_review]
 
 env:
-  VALID_ISSUE_PREFIXES: "CORE|TOOL"
+  VALID_ISSUE_PREFIXES: "CORE|TOOL|NEB|INFRA"
 
 jobs:
   linear:


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added



<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the environment variable `VALID_ISSUE_PREFIXES` in the `.github/workflows/issue.yml` file to include additional prefixes for issue validation.

### Detailed summary
- Modified `VALID_ISSUE_PREFIXES` from `"CORE|TOOL"` to `"CORE|TOOL|NEB|INFRA"` to allow for new issue prefixes `NEB` and `INFRA`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->