### PR TITLE
Edit [DOCS]: Updated import. @thirdweb-dev/contracts and add _defaultAdmin 

### DIFF
--- a/apps/portal/src/app/contracts/build/base-contracts/erc-4337/account-factory/page.mdx
+++ b/apps/portal/src/app/contracts/build/base-contracts/erc-4337/account-factory/page.mdx
@@ -15,7 +15,7 @@ export const metadata = createMetadata({
 # AccountFactory
 
 ```solidity
-import "@thirdweb-dev/contracts/smart-wallet/non-upgradeable/AccountFactory.sol";
+import "@thirdweb-dev/contracts/prebuilts/account/non-upgradeable/AccountFactory.sol";
 ```
 
 This contract inherits from the [`BaseAccountFactory`](/contracts/build/extensions/erc-4337/SmartWalletFactory) contract.
@@ -54,17 +54,23 @@ npx thirdweb create contract
 ```bash
 npx thirdweb deploy
 ```
+> **Note: If there is a problem, it is necessary to add `-k <SECRRET_KEY_API_THIRDWEB>`**
 
 Or import the contract into your existing project and inherit from it.
 
 ```solidity
-import "@thirdweb-dev/contracts/smart-wallet/non-upgradable/AccountFactory.sol";
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.12;
+
+import "@thirdweb-dev/contracts/prebuilts/account/non-upgradeable/AccountFactory.sol";
 
 contract MyAccountFactory is AccountFactory {
 	  constructor(
+	address _defaultAdmin,
         IEntryPoint _entrypoint
     )
         AccountFactory(
+	    _defaultAdmin,
             _entrypoint
         )
     {}

--- a/apps/portal/src/app/contracts/build/base-contracts/erc-4337/account-factory/page.mdx
+++ b/apps/portal/src/app/contracts/build/base-contracts/erc-4337/account-factory/page.mdx
@@ -54,7 +54,7 @@ npx thirdweb create contract
 ```bash
 npx thirdweb deploy
 ```
-> **Note: If there is a problem, it is necessary to add `-k <SECRRET_KEY_API_THIRDWEB>`**
+> **Note: secret key required for this command `-k <YOUR_SECRET_KEY>`**
 
 Or import the contract into your existing project and inherit from it.
 


### PR DESCRIPTION
Edit: Updated import. @thirdweb-dev/contracts and add _defaultAdmin Latest required to AccountFactory.sol

## Problem review
**1. Importing @thirdweb-dev/contracts update**
❌ 
![image](https://github.com/user-attachments/assets/065a77ba-04b7-440f-83f3-f58cfa0b4ec6)
✅ 
![image](https://github.com/user-attachments/assets/d358ce12-3159-4748-94f7-98ee3def9463)

<br/>

**2. Add required _defaultAdmin**
❌ 
![image](https://github.com/user-attachments/assets/8cbb1191-928b-44ef-82ba-285b6e4d7ba4)
✅ 
![image](https://github.com/user-attachments/assets/3faf5011-6a84-4ff1-82d6-9afdbeba83f6)

<br/>

**3. Deployments that require adding the -k secret key as well.**
❌ 
![image](https://github.com/user-attachments/assets/be184f2b-e366-4587-b72e-6e1e02c89ce9)
✅ 
![image](https://github.com/user-attachments/assets/73924ea5-9a4d-4506-985f-f9ea2400841c)


refer.
docs:  https://portal.thirdweb.com/contracts/build/base-contracts/erc-4337/account-factory
smartcontract: https://github.com/thirdweb-dev/contracts/blob/main/contracts/prebuilts/account/non-upgradeable/AccountFactory.sol

Please check again. and consider as appropriate **_Thanks._**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the import path for the `AccountFactory` contract and modifies the `MyAccountFactory` contract to include a new constructor parameter.

### Detailed summary
- Changed the import path for `AccountFactory` from `smart-wallet/non-upgradeable` to `prebuilts/account/non-upgradeable`.
- Added the `// SPDX-License-Identifier: GPL-3.0` license declaration.
- Updated the Solidity version to `^0.8.12`.
- Modified the constructor of `MyAccountFactory` to include an `address _defaultAdmin` parameter.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->