### PR TITLE
remove www. prefix from plumenetwork.xyz

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/(chain)/utils.ts
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/utils.ts
@@ -585,7 +585,7 @@ const chainMetaRecord = {
     cta: {
       backgroundImageUrl: plumeCTAv2.src,
       title: "Bringing the Real World Onchain",
-      buttonLink: "https://www.plumenetwork.xyz/",
+      buttonLink: "https://plumenetwork.xyz/",
       buttonText: "Learn more",
     },
   },
@@ -597,7 +597,7 @@ const chainMetaRecord = {
     cta: {
       backgroundImageUrl: plumeCTAv2.src,
       title: "Bringing the Real World Onchain",
-      buttonLink: "https://www.plumenetwork.xyz/",
+      buttonLink: "https://plumenetwork.xyz/",
       buttonText: "Learn more",
     },
   },


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `buttonLink` URL in the `chainMetaRecord` object to remove the "www." prefix, ensuring consistency in the URL format.

### Detailed summary
- Updated `buttonLink` from "https://www.plumenetwork.xyz/" to "https://plumenetwork.xyz/" in the `cta` object within `chainMetaRecord`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->