### PR TITLE
[Portal] Fix: Add erc20Value clarity to buyFromListing

### DIFF
--- a/packages/thirdweb/src/extensions/marketplace/direct-listings/write/buyFromListing.ts
+++ b/packages/thirdweb/src/extensions/marketplace/direct-listings/write/buyFromListing.ts
@@ -34,6 +34,8 @@ export type BuyFromListingParams = {
  *
  * await sendTransaction({ transaction, account });
  * ```
+ *
+ * When using `buyFromListing` with Pay, the `erc20Value` will be automatically set to the listing currency.
  */
 export function buyFromListing(
   options: BaseTransactionOptions<BuyFromListingParams>,


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added



<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds documentation to the `buyFromListing` function, clarifying the behavior when using the function with Pay.

### Detailed summary
- Added a comment explaining that when using `buyFromListing` with Pay, the `erc20Value` is automatically set to the listing currency.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->