### PR TITLE
[Dashboard] Enhance NFT Reveal feature

### DIFF
--- a/apps/dashboard/next-env.d.ts
+++ b/apps/dashboard/next-env.d.ts
@@ -3,4 +3,4 @@
 /// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/nfts/components/reveal-button.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/nfts/components/reveal-button.tsx
@@ -8,6 +8,7 @@ import {
   SheetTitle,
   SheetTrigger,
 } from "@/components/ui/sheet";
+import { ToolTipLabel } from "@/components/ui/tooltip";
 import { MinterOnly } from "@3rdweb-sdk/react/components/roles/minter-only";
 import type { Account } from "@3rdweb-sdk/react/hooks/useApi";
 import { FormControl, Input, Select } from "@chakra-ui/react";
@@ -47,6 +48,27 @@ export const NFTRevealButton: React.FC<NFTRevealButtonProps> = ({
   } = useForm<{ batchId: string; password: string }>();
 
   const [open, setOpen] = useState(false);
+
+  if (!batchesQuery.data?.length) {
+    return null;
+  }
+
+  /**
+   * When a batch is revealed / decrypted / non-revealable, its batchUri will be "0x"
+   */
+  const allBatchesRevealed = batchesQuery.data.every(
+    (o) => o.batchUri === "0x",
+  );
+
+  if (allBatchesRevealed) {
+    return (
+      <ToolTipLabel label="All batches are revealed">
+        <Button variant="primary" className="gap-2" disabled>
+          <EyeIcon className="size-4" /> Reveal NFTs
+        </Button>
+      </ToolTipLabel>
+    );
+  }
 
   return batchesQuery.data?.length ? (
     <MinterOnly contract={contract}>
@@ -109,9 +131,11 @@ export const NFTRevealButton: React.FC<NFTRevealButtonProps> = ({
                   <option
                     key={batch.batchId.toString()}
                     value={batch.batchId.toString()}
+                    disabled={batch.batchUri === "0x"}
                   >
                     {batch.placeholderMetadata?.name ||
-                      batch.batchId.toString()}
+                      batch.batchId.toString()}{" "}
+                    {batch.batchUri === "0x" && "(REVEALED)"}
                   </option>
                 ))}
               </Select>


### PR DESCRIPTION
TOOL-2730
TOOL-2733
TOOL-2738

[x] Dont show Reveal-button if nothing to reveal
[x] Dont allow to select batches that were revealed already
[x] Show UI for the un-revealed. metadata

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `nfts/components/reveal-button.tsx` file to enhance the NFT reveal button's functionality and user experience. It introduces checks for batch reveal status and integrates a tooltip for better user feedback.

### Detailed summary
- Updated the documentation link in `next-env.d.ts`.
- Added `ToolTipLabel` import in `reveal-button.tsx`.
- Implemented a check to return `null` if no batches are available.
- Added logic to display a tooltip and disabled button when all batches are revealed.
- Disabled option in the select dropdown for revealed batches.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->