### PR TITLE
[SDK] Fix: Use transaction-specified chain in smart account

### DIFF
--- a/.changeset/fair-planes-doubt.md
+++ b/.changeset/fair-planes-doubt.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+SDK: Fix chain switching in smart account transactions

--- a/packages/thirdweb/src/wallets/smart/smart-wallet-integration-v07.test.ts
+++ b/packages/thirdweb/src/wallets/smart/smart-wallet-integration-v07.test.ts
@@ -5,7 +5,9 @@ import { verifySignature } from "../../auth/verify-signature.js";
 import { type ThirdwebContract, getContract } from "../../contract/contract.js";
 import { parseEventLogs } from "../../event/actions/parse-logs.js";
 
+import { TEST_WALLET_A } from "~test/addresses.js";
 import { verifyTypedData } from "../../auth/verify-typed-data.js";
+import { baseSepolia } from "../../chains/chain-definitions/base-sepolia.js";
 import { sepolia } from "../../chains/chain-definitions/sepolia.js";
 import {
   addAdmin,
@@ -18,6 +20,7 @@ import { estimateGasCost } from "../../transaction/actions/estimate-gas-cost.js"
 import { sendAndConfirmTransaction } from "../../transaction/actions/send-and-confirm-transaction.js";
 import { sendBatchTransaction } from "../../transaction/actions/send-batch-transaction.js";
 import { waitForReceipt } from "../../transaction/actions/wait-for-tx-receipt.js";
+import { prepareTransaction } from "../../transaction/prepare-transaction.js";
 import { getAddress } from "../../utils/address.js";
 import { isContractDeployed } from "../../utils/bytecode/is-contract-deployed.js";
 import { sleep } from "../../utils/sleep.js";
@@ -105,6 +108,20 @@ describe.runIf(process.env.TW_SECRET_KEY)(
         ...typedData.basic,
       });
       expect(isValid).toEqual(true);
+    });
+
+    it("can send a transaction on another chain", async () => {
+      const tx = await sendAndConfirmTransaction({
+        transaction: prepareTransaction({
+          to: TEST_WALLET_A,
+          client: TEST_CLIENT,
+          chain: baseSepolia,
+          value: 0n,
+        }),
+        // biome-ignore lint/style/noNonNullAssertion: Just trust me
+        account: wallet.getAccount()!,
+      });
+      expect(tx.transactionHash).toHaveLength(66);
     });
 
     it("should revert on unsuccessful transactions", async () => {

--- a/packages/thirdweb/src/wallets/smart/smart-wallet-integration.test.ts
+++ b/packages/thirdweb/src/wallets/smart/smart-wallet-integration.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, describe, expect, it } from "vitest";
+import { TEST_WALLET_A } from "~test/addresses.js";
 import { TEST_CLIENT } from "../../../test/src/test-clients.js";
 import { typedData } from "../../../test/src/typed-data.js";
 import { verifySignature } from "../../auth/verify-signature.js";
@@ -307,6 +308,20 @@ describe.runIf(process.env.TW_SECRET_KEY).sequential(
     it("can switch chains", async () => {
       await wallet.switchChain(baseSepolia);
       expect(wallet.getChain()?.id).toEqual(baseSepolia.id);
+    });
+
+    it("can send a transaction on another chain", async () => {
+      const tx = await sendAndConfirmTransaction({
+        transaction: prepareTransaction({
+          to: TEST_WALLET_A,
+          client: TEST_CLIENT,
+          chain: baseSepolia,
+          value: 0n,
+        }),
+        // biome-ignore lint/style/noNonNullAssertion: Just trust me
+        account: wallet.getAccount()!,
+      });
+      expect(tx.transactionHash).toHaveLength(66);
     });
 
     it("can execute 2 tx in parallel", async () => {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on fixing chain switching in smart account transactions, allowing transactions to be executed on different chains. It also adds tests to ensure this functionality works as expected.

### Detailed summary
- Updated `accountContract` to `accountContractForTransaction` for chain-specific transactions.
- Introduced a new test to verify sending transactions on another chain in `smart-wallet-integration.test.ts`.
- Added a similar test in `smart-wallet-integration-v07.test.ts` for consistency.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->