### PR TITLE
TOOL-2831 - Update docs for showTestnetFaucet

### DIFF
--- a/packages/thirdweb/src/react/core/hooks/connection/ConnectButtonProps.ts
+++ b/packages/thirdweb/src/react/core/hooks/connection/ConnectButtonProps.ts
@@ -216,10 +216,15 @@ export type ConnectButton_detailsModalOptions = {
   /**
    * Show a "Request Testnet funds" link in `ConnectButton` Details Modal when user is connected to a testnet.
    *
-   * By default it is `false`, If you want to show the "Request Testnet funds" link when user is connected to a testnet, set this prop to `true`
+   * By default it is `false`, If you want to show the "Request Testnet funds" link when user is connected to a testnet, set this prop to `true`.
+   * Keep in mind that the link will only be shown if there are faucet links registered with the chain.
    * @example
    * ```tsx
-   * <ConnectButton showTestnetFaucet={true} />
+   * <ConnectButton
+   *   detailsModal={{
+   *     showTestnetFaucet: true,
+   *   }}
+   * />
    * ```
    */
   showTestnetFaucet?: boolean;


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added



<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `ConnectButtonProps` to enhance the `ConnectButton` Details Modal by introducing a link for requesting testnet funds when connected to a testnet. It clarifies the conditions under which this link will appear.

### Detailed summary
- Added a note that the "Request Testnet funds" link will only show if faucet links are registered with the chain.
- Updated the example for using `ConnectButton` to include the `detailsModal` prop for showing the testnet faucet link.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->