### PR TITLE
[CI] Fix: Stale issue text

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          stale-issue-message: 'This issue has been inactive for 30 days. It is now marked as stale and will be closed in 5 days if no further activity occurs.'
-          stale-pr-message: 'This PR has been inactive for 30 days. It is now marked as stale and will be closed in 5 days if no further activity occurs.'
+          stale-issue-message: 'This issue has been inactive for 7 days. It is now marked as stale and will be closed in 2 days if no further activity occurs.'
+          stale-pr-message: 'This PR has been inactive for 7 days. It is now marked as stale and will be closed in 2 days if no further activity occurs.'
           days-before-stale: 7
           days-before-close: 2


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the configuration for the `stale` action in the `.github/workflows/stale.yml` file, reducing the inactivity period for issues and pull requests before they are marked as stale and the time before they are closed.

### Detailed summary
- Changed `stale-issue-message` to reflect a 7-day inactivity period instead of 30 days.
- Changed `stale-pr-message` to reflect a 7-day inactivity period instead of 30 days.
- Set `days-before-stale` to 7 days.
- Set `days-before-close` to 2 days.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->