### PR TITLE
[SDK] Fix: Undefined chain ID on eip1193 provider input

### DIFF
--- a/.changeset/yellow-experts-sparkle.md
+++ b/.changeset/yellow-experts-sparkle.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+SDK: Gracefully ignore chain with no chain ID in `fromEip1193Provider`

--- a/packages/thirdweb/src/adapters/eip1193/from-eip1193.test.ts
+++ b/packages/thirdweb/src/adapters/eip1193/from-eip1193.test.ts
@@ -115,6 +115,24 @@ describe("fromProvider", () => {
     expect(chain).toBe(ANVIL_CHAIN);
   });
 
+  test("should handle connection with no chainId", async () => {
+    const wallet = fromProvider({
+      provider: {
+        ...mockProvider,
+        request: () => Promise.resolve([mockAccount.address]),
+      },
+    });
+
+    await wallet.connect({
+      client: TEST_CLIENT,
+      chain: {
+        ...ANVIL_CHAIN,
+        id: undefined,
+        // biome-ignore lint/suspicious/noExplicitAny: Testing unexpected input data
+      } as any,
+    });
+  });
+
   test("should reset state on disconnect", async () => {
     const wallet = fromProvider({
       provider: {

--- a/packages/thirdweb/src/wallets/injected/index.ts
+++ b/packages/thirdweb/src/wallets/injected/index.ts
@@ -85,7 +85,8 @@ export async function connectEip1193Wallet({
     chain && chain.id === chainId ? chain : getCachedChain(chainId);
 
   // if we want a specific chainId and it is not the same as the provider chainId, trigger switchChain
-  if (chain && chain.id !== chainId) {
+  // we check for undefined chain ID since some chain-specific wallets like Abstract will not send a chain ID on connection
+  if (chain && typeof chain.id !== "undefined" && chain.id !== chainId) {
     await switchChain(provider, chain);
     connectedChain = chain;
   }


### PR DESCRIPTION
## Problem solved

Short description of the bug fixed or feature added

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the handling of wallet connections in the `thirdweb` SDK by gracefully managing cases where the chain ID is undefined, particularly for certain wallets.

### Detailed summary
- Updated the check for `chain.id` in `fromEip1193Provider` to ensure it is defined before comparison.
- Added a test case to verify connection handling when the chain ID is not provided.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->