### PR TITLE
[CI] Fix: Run auto-assign check if user is a prev contributor

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -13,6 +13,7 @@ jobs:
     if: |
       github.event.pull_request.author_association == 'MEMBER' ||
       github.event.pull_request.author_association == 'OWNER' ||
-      github.event.pull_request.author_association == 'COLLABORATOR'
+      github.event.pull_request.author_association == 'COLLABORATOR' ||
+      github.event.pull_request.author_association == 'CONTRIBUTOR'
     steps:
       - uses: toshimaru/auto-author-assign@v2.1.1


### PR DESCRIPTION
---
title: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"
---

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer
Anything important to call out? Be sure to also clarify these in your comments.

## How to test
Unit tests, playground, etc.



<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `auto-assign.yml` workflow to modify the conditions under which a pull request author is automatically assigned. It adds the `CONTRIBUTOR` association type to the list of accepted author associations.

### Detailed summary
- Added `github.event.pull_request.author_association == 'CONTRIBUTOR'` to the conditions.
- Retained `github.event.pull_request.author_association == 'COLLABORATOR'`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->