### PR TITLE
[SDK] onTimeout for useAutoConnect | TOOL-2673

### DIFF
--- a/.changeset/little-beds-dress.md
+++ b/.changeset/little-beds-dress.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Add onTimeout callback to useAutoConnect

--- a/packages/thirdweb/src/react/core/hooks/connection/types.ts
+++ b/packages/thirdweb/src/react/core/hooks/connection/types.ts
@@ -113,4 +113,9 @@ export type AutoConnectProps = {
    * Optional chain to autoconnect to
    */
   chain?: Chain;
+
+  /**
+   * Callback to be called when the connection is timeout-ed
+   */
+  onTimeout?: () => void;
 };

--- a/packages/thirdweb/src/react/core/hooks/wallets/useAutoConnectCore.test.tsx
+++ b/packages/thirdweb/src/react/core/hooks/wallets/useAutoConnectCore.test.tsx
@@ -1,0 +1,187 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { MockStorage } from "~test/mocks/storage.js";
+import { TEST_CLIENT } from "~test/test-clients.js";
+import { TEST_ACCOUNT_A } from "~test/test-wallets.js";
+import { createWalletAdapter } from "../../../../adapters/wallet-adapter.js";
+import { ethereum } from "../../../../chains/chain-definitions/ethereum.js";
+import { isAddress } from "../../../../utils/address.js";
+import { createConnectionManager } from "../../../../wallets/manager/index.js";
+import type { WalletId } from "../../../../wallets/wallet-types.js";
+import { ThirdwebProvider } from "../../../web/providers/thirdweb-provider.js";
+import { ConnectionManagerCtx } from "../../providers/connection-manager.js";
+import {
+  handleWalletConnection,
+  useAutoConnectCore,
+} from "./useAutoConnect.js";
+
+describe("useAutoConnectCore", () => {
+  const mockStorage = new MockStorage();
+  const manager = createConnectionManager(mockStorage);
+
+  // Create a wrapper component with the mocked context
+  const wrapper = ({ children }: { children: ReactNode }) => {
+    return (
+      <ThirdwebProvider>
+        <ConnectionManagerCtx.Provider value={manager}>
+          {children}
+        </ConnectionManagerCtx.Provider>
+      </ThirdwebProvider>
+    );
+  };
+
+  it("should return a useQuery result", async () => {
+    const wallet = createWalletAdapter({
+      adaptedAccount: TEST_ACCOUNT_A,
+      client: TEST_CLIENT,
+      chain: ethereum,
+      onDisconnect: () => {},
+      switchChain: () => {},
+    });
+    const { result } = renderHook(
+      () =>
+        useAutoConnectCore(
+          mockStorage,
+          {
+            wallets: [wallet],
+            client: TEST_CLIENT,
+          },
+          (id: WalletId) =>
+            createWalletAdapter({
+              adaptedAccount: TEST_ACCOUNT_A,
+              client: TEST_CLIENT,
+              chain: ethereum,
+              onDisconnect: () => {
+                console.warn(id);
+              },
+              switchChain: () => {},
+            }),
+        ),
+      { wrapper },
+    );
+    expect("data" in result.current).toBeTruthy();
+    await waitFor(() => {
+      expect(typeof result.current.data).toBe("boolean");
+    });
+  });
+
+  it("should return `false` if there's no lastConnectedWalletIds", async () => {
+    const wallet = createWalletAdapter({
+      adaptedAccount: TEST_ACCOUNT_A,
+      client: TEST_CLIENT,
+      chain: ethereum,
+      onDisconnect: () => {},
+      switchChain: () => {},
+    });
+    const { result } = renderHook(
+      () =>
+        useAutoConnectCore(
+          mockStorage,
+          {
+            wallets: [wallet],
+            client: TEST_CLIENT,
+          },
+          (id: WalletId) =>
+            createWalletAdapter({
+              adaptedAccount: TEST_ACCOUNT_A,
+              client: TEST_CLIENT,
+              chain: ethereum,
+              onDisconnect: () => {
+                console.warn(id);
+              },
+              switchChain: () => {},
+            }),
+        ),
+      { wrapper },
+    );
+    await waitFor(
+      () => {
+        expect(result.current.data).toBe(false);
+      },
+      { timeout: 1000 },
+    );
+  });
+
+  it("should call onTimeout on ... timeout", async () => {
+    const wallet = createWalletAdapter({
+      adaptedAccount: TEST_ACCOUNT_A,
+      client: TEST_CLIENT,
+      chain: ethereum,
+      onDisconnect: () => {},
+      switchChain: () => {},
+    });
+    mockStorage.setItem("thirdweb:active-wallet-id", wallet.id);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    // Purposefully mock the wallet.autoConnect method to test the timeout logic
+    wallet.autoConnect = () =>
+      new Promise((resolve) => {
+        setTimeout(() => {
+          // @ts-ignore Mock purpose
+          resolve("Connection successful");
+        }, 2100);
+      });
+    renderHook(
+      () =>
+        useAutoConnectCore(
+          mockStorage,
+          {
+            wallets: [wallet],
+            client: TEST_CLIENT,
+            onTimeout: () => console.info("TIMEOUTTED"),
+            timeout: 0,
+          },
+          (id: WalletId) =>
+            createWalletAdapter({
+              adaptedAccount: TEST_ACCOUNT_A,
+              client: TEST_CLIENT,
+              chain: ethereum,
+              onDisconnect: () => {
+                console.warn(id);
+              },
+              switchChain: () => {},
+            }),
+        ),
+      { wrapper },
+    );
+    await waitFor(
+      () => {
+        expect(warnSpy).toHaveBeenCalled();
+        expect(warnSpy).toHaveBeenCalledWith(
+          "AutoConnect timeout: 0ms limit exceeded.",
+        );
+        expect(infoSpy).toHaveBeenCalled();
+        expect(infoSpy).toHaveBeenCalledWith("TIMEOUTTED");
+        warnSpy.mockRestore();
+      },
+      { timeout: 2000 },
+    );
+  });
+});
+
+describe("handleWalletConnection", () => {
+  const wallet = createWalletAdapter({
+    adaptedAccount: TEST_ACCOUNT_A,
+    client: TEST_CLIENT,
+    chain: ethereum,
+    onDisconnect: () => {},
+    switchChain: () => {},
+  });
+  it("should return the correct result", async () => {
+    const result = await handleWalletConnection({
+      client: TEST_CLIENT,
+      lastConnectedChain: ethereum,
+      authResult: undefined,
+      wallet,
+    });
+
+    expect("address" in result).toBe(true);
+    expect(isAddress(result.address)).toBe(true);
+    expect("sendTransaction" in result).toBe(true);
+    expect(typeof result.sendTransaction).toBe("function");
+    expect("signMessage" in result).toBe(true);
+    expect("signTypedData" in result).toBe(true);
+    expect("signTransaction" in result).toBe(true);
+  });
+});

--- a/packages/thirdweb/src/wallets/in-app/web/lib/get-url-token.test.tsx
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/get-url-token.test.tsx
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getUrlToken } from "./get-url-token.js";
+
+describe("getUrlToken", () => {
+  let originalLocation: Location;
+
+  beforeEach(() => {
+    originalLocation = window.location;
+
+    Object.defineProperty(window, "location", {
+      value: {
+        ...originalLocation,
+        search: "",
+      },
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    // Restore the original location object after each test
+    Object.defineProperty(window, "location", {
+      value: originalLocation,
+      writable: true,
+    });
+  });
+
+  it("should return an empty object if not in web context", () => {
+    const originalWindow = window;
+    // biome-ignore lint/suspicious/noExplicitAny: Test
+    (global as any).window = undefined;
+
+    const result = getUrlToken();
+    // biome-ignore lint/suspicious/noExplicitAny: Test
+    (global as any).window = originalWindow;
+
+    expect(result).toEqual({});
+  });
+
+  it("should return an empty object if no parameters are present", () => {
+    const result = getUrlToken();
+    expect(result).toEqual({});
+  });
+
+  it("should parse walletId and authResult correctly", () => {
+    window.location.search =
+      "?walletId=123&authResult=%7B%22token%22%3A%22abc%22%7D";
+
+    const result = getUrlToken();
+
+    expect(result).toEqual({
+      walletId: "123",
+      authResult: { token: "abc" },
+      authProvider: null,
+      authCookie: null,
+    });
+  });
+
+  it("should handle authCookie and update URL correctly", () => {
+    window.location.search = "?walletId=123&authCookie=myCookie";
+
+    const result = getUrlToken();
+
+    expect(result).toEqual({
+      walletId: "123",
+      authResult: undefined,
+      authProvider: null,
+      authCookie: "myCookie",
+    });
+
+    // Check if URL has been updated correctly
+    expect(window.location.search).toBe("?walletId=123&authCookie=myCookie");
+  });
+
+  it("should handle all parameters correctly", () => {
+    window.location.search =
+      "?walletId=123&authResult=%7B%22token%22%3A%22xyz%22%7D&authProvider=provider1&authCookie=myCookie";
+
+    const result = getUrlToken();
+
+    expect(result).toEqual({
+      walletId: "123",
+      authResult: { token: "xyz" },
+      authProvider: "provider1",
+      authCookie: "myCookie",
+    });
+
+    // Check if URL has been updated correctly
+    expect(window.location.search).toBe(
+      "?walletId=123&authResult=%7B%22token%22%3A%22xyz%22%7D&authProvider=provider1&authCookie=myCookie",
+    );
+  });
+});

--- a/packages/thirdweb/test/vitest.config.ts
+++ b/packages/thirdweb/test/vitest.config.ts
@@ -31,7 +31,7 @@ export default defineConfig({
       ],
       include: ["src/**"],
     },
-    environmentMatchGlobs: [["src/react/**/*.test.tsx", "happy-dom"]],
+    environmentMatchGlobs: [["src/**/*.test.tsx", "happy-dom"]],
     environment: "node",
     include: ["src/**/*.test.{ts,tsx}"],
     setupFiles: [join(__dirname, "./reactSetup.ts")],


### PR DESCRIPTION
TOOL-2673

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces an `onTimeout` callback to the `useAutoConnect` functionality in the `thirdweb` package, enhancing connection management. Additionally, it adds tests for the `getUrlToken` function and updates the `vitest` configuration for testing.

### Detailed summary
- Added `onTimeout` callback to `useAutoConnect`.
- Updated `types.ts` to include `onTimeout` in the connection options.
- Modified `useAutoConnectCore` to handle timeout scenarios.
- Added tests for `getUrlToken` covering various cases.
- Adjusted `vitest.config.ts` to include all test files.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->