### PR TITLE
[Dashboard] Fix: If only one time period has analytics events

### DIFF
--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/analytics/page.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/analytics/page.tsx
@@ -257,7 +257,10 @@ function UsersChartCard({
       }
       data={timeSeriesData}
       aggregateFn={(_data, key) =>
-        timeSeriesData[timeSeriesData.length - 2]?.[key]
+        // If there is only one data point, use that one, otherwise use the previous
+        timeSeriesData.filter((d) => (d[key] as number) > 0).length >= 2
+          ? timeSeriesData[timeSeriesData.length - 2]?.[key]
+          : timeSeriesData[timeSeriesData.length - 1]?.[key]
       }
       // Get the trend from the last two COMPLETE periods
       trendFn={(data, key) =>

--- a/apps/dashboard/src/app/team/[team_slug]/[project_slug]/page.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/[project_slug]/page.tsx
@@ -279,7 +279,10 @@ function UsersChartCard({
       queryKey="usersChart"
       data={timeSeriesData}
       aggregateFn={(_data, key) =>
-        timeSeriesData[timeSeriesData.length - 2]?.[key]
+        // If there is only one data point, use that one, otherwise use the previous
+        timeSeriesData.filter((d) => (d[key] as number) > 0).length >= 2
+          ? timeSeriesData[timeSeriesData.length - 2]?.[key]
+          : timeSeriesData[timeSeriesData.length - 1]?.[key]
       }
       // Get the trend from the last two COMPLETE periods
       trendFn={(data, key) =>


### PR DESCRIPTION
## Notes for the reviewer
Adds an edge case if a user only has events for a single time period. Previously, this would show 0 in the analytics summary since it normally takes the most recent *complete* time period. Now, it falls back to show the incomplete period if there is no complete period with data.

## How to test
Run the dashboard and view the project client ID listed in the linear ticket

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the logic for aggregating time series data in two components, ensuring that the correct data point is used based on the number of available data points.

### Detailed summary
- Updated `aggregateFn` in `apps/dashboard/src/app/team/[team_slug]/[project_slug]/page.tsx` to handle cases with fewer data points.
- Similar changes made in `apps/dashboard/src/app/team/[team_slug]/(team)/~/analytics/page.tsx`.
- Added a condition to use the most recent data point if only one is available.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->