### PR TITLE
[TOOL-2924] Catch error on fail-to-load metadata

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/nfts/components/reveal-button.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/nfts/components/reveal-button.tsx
@@ -70,7 +70,7 @@ export const NFTRevealButton: React.FC<NFTRevealButtonProps> = ({
     );
   }
 
-  return batchesQuery.data?.length ? (
+  return (
     <MinterOnly contract={contract}>
       <Sheet open={open} onOpenChange={setOpen}>
         <SheetTrigger asChild>
@@ -168,5 +168,5 @@ export const NFTRevealButton: React.FC<NFTRevealButtonProps> = ({
         </SheetContent>
       </Sheet>
     </MinterOnly>
-  ) : null;
+  );
 };

--- a/packages/thirdweb/src/extensions/erc721/lazyMinting/read/getBatchesToReveal.ts
+++ b/packages/thirdweb/src/extensions/erc721/lazyMinting/read/getBatchesToReveal.ts
@@ -15,7 +15,7 @@ import * as TokenURI from "../../__generated__/IERC721A/read/tokenURI.js";
 export interface BatchToReveal {
   batchId: bigint;
   batchUri: string;
-  placeholderMetadata: NFTMetadata;
+  placeholderMetadata: NFTMetadata | undefined;
 }
 
 /**
@@ -82,7 +82,7 @@ export async function getBatchesToReveal(
         tokenId: BigInt(i),
         tokenUri: uri,
         client: options.contract.client,
-      });
+      }).catch(() => undefined);
     }),
   );
 


### PR DESCRIPTION
TOOL-2924

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces changes to enhance type safety and improve the handling of optional values in the `getBatchesToReveal` function and the `NFTRevealButton` component.

### Detailed summary
- In `getBatchesToReveal.ts`, `placeholderMetadata` is changed from `NFTMetadata` to `NFTMetadata | undefined` for better type handling.
- In `getBatchesToReveal.ts`, an error handling mechanism is added by returning `undefined` in the catch block.
- In `reveal-button.tsx`, the conditional rendering is simplified to always return the `MinterOnly` component, improving readability.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->