### PR TITLE
[TOOL-2764] Dashboard: Fix published contract version selector with duplicate versions

### DIFF
--- a/apps/dashboard/src/components/contract-components/fetch-contracts-with-versions.ts
+++ b/apps/dashboard/src/components/contract-components/fetch-contracts-with-versions.ts
@@ -47,7 +47,18 @@ export async function fetchPublishedContractVersions(
     ),
   );
 
-  return responses.filter((r) => r.status === "fulfilled").map((r) => r.value);
+  const publishedContracts = responses
+    .filter((r) => r.status === "fulfilled")
+    .map((r) => r.value);
+
+  // if there are two published contract with same version, keep the latest (first in list - list is already sorted) one
+  const uniquePublishedContracts = publishedContracts.filter(
+    (contract, idx, arr) =>
+      // if this is the first occurrence of this version in list - keep it
+      arr.findIndex((c) => c.version === contract.version) === idx,
+  );
+
+  return uniquePublishedContracts;
 }
 
 export async function fetchPublishedContractVersion(


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on refining the handling of published contracts by filtering out duplicates based on version, ensuring that only the latest contract for each version is retained.

### Detailed summary
- Introduced `publishedContracts` to filter responses for fulfilled statuses.
- Added logic to create `uniquePublishedContracts` that retains only the latest contract for each version.
- Utilized `findIndex` to identify the first occurrence of each version in the list.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->