### PR TITLE
[TOOL-2925] Dashboard: Redirect to Nebula app if team has access instead of showing waitlist page

### DIFF
--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/nebula/page.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/nebula/page.tsx
@@ -1,4 +1,5 @@
 import { getTeamBySlug } from "@/api/team";
+import { redirect } from "next/navigation";
 import { loginRedirect } from "../../../../../login/loginRedirect";
 import { NebulaWaitListPage } from "../../../[project_slug]/nebula/components/nebula-waitlist-page";
 
@@ -12,6 +13,13 @@ export default async function Page(props: {
 
   if (!team) {
     loginRedirect(`/team/${params.team_slug}/~/nebula`);
+  }
+
+  // if nebula access is already granted, redirect to nebula web app
+  const hasNebulaAccess = team.enabledScopes.includes("nebula");
+
+  if (hasNebulaAccess) {
+    redirect("https://nebula.thirdweb.com");
   }
 
   return <NebulaWaitListPage team={team} />;

--- a/apps/dashboard/src/app/team/[team_slug]/[project_slug]/nebula/page.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/[project_slug]/nebula/page.tsx
@@ -1,4 +1,5 @@
 import { getTeamBySlug } from "@/api/team";
+import { redirect } from "next/navigation";
 import { loginRedirect } from "../../../../login/loginRedirect";
 import { NebulaWaitListPage } from "./components/nebula-waitlist-page";
 
@@ -13,6 +14,13 @@ export default async function Page(props: {
 
   if (!team) {
     loginRedirect(`/team/${params.team_slug}/${params.project_slug}/nebula`);
+  }
+
+  // if nebula access is already granted, redirect to nebula web app
+  const hasNebulaAccess = team.enabledScopes.includes("nebula");
+
+  if (hasNebulaAccess) {
+    redirect("https://nebula.thirdweb.com");
   }
 
   return <NebulaWaitListPage team={team} />;


### PR DESCRIPTION
## PR-Codex overview
This PR introduces a check for `nebula` access in two `page.tsx` files, redirecting users to the Nebula web app if access is granted. It also maintains the existing login redirect functionality.

### Detailed summary
- Added a check for `nebula` access using `team.enabledScopes.includes("nebula")`.
- Redirects to `https://nebula.thirdweb.com` if access is granted.
- Updated login redirect paths in both `page.tsx` files.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a check for `nebula` access in the `Page` component of two different files. If access is granted, it redirects users to the Nebula web app. If not, it displays the `NebulaWaitListPage`.

### Detailed summary
- Added a check for `nebula` access using `team.enabledScopes.includes("nebula")`.
- Implemented a redirect to `https://nebula.thirdweb.com` if access is granted.
- Updated both `page.tsx` files in their respective directories.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->