### PR TITLE
redirect unlimited-wallets campaign to home

### DIFF
--- a/apps/dashboard/framer-rewrites.js
+++ b/apps/dashboard/framer-rewrites.js
@@ -26,7 +26,7 @@ module.exports = [
   "/solutions/defi",
   "/solutions/ecosystem",
   // -- campaigns --
-  "/unlimited-wallets",
+  // "/unlimited-wallets", -- OFF for now
   // -- TPP --
   "/trusted-partner-program",
   "/trusted-partner-program/:partner_slug",

--- a/apps/dashboard/redirects.js
+++ b/apps/dashboard/redirects.js
@@ -331,6 +331,12 @@ async function redirects() {
       destination: "/templates/:slug",
       permanent: false,
     },
+    // PREVIOUS CAMPAIGNS
+    {
+      source: "/unlimited-wallets",
+      destination: "/",
+      permanent: false,
+    },
     ...legacyDashboardToTeamRedirects,
   ];
 }


### PR DESCRIPTION
closes: CORE-682

### TL;DR
Disabled the unlimited wallets campaign page and redirected its URL to the homepage.

### What changed?
- Commented out the `/unlimited-wallets` route in framer-rewrites.js
- Added a new redirect rule to send `/unlimited-wallets` traffic to the homepage

### How to test?
1. Visit `/unlimited-wallets`
2. Verify you are redirected to the homepage
3. Ensure no 404 errors occur

### Why make this change?
The unlimited wallets campaign has concluded, and we need to gracefully handle any remaining traffic to this URL by redirecting users to the homepage instead of showing a broken or missing page.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying redirect rules in the `apps/dashboard/redirects.js` and `apps/dashboard/framer-rewrites.js` files, specifically related to the handling of the `/unlimited-wallets` route.

### Detailed summary
- Added a new redirect rule for `/unlimited-wallets` to redirect to `/` in `apps/dashboard/redirects.js`.
- Commented out the existing redirect for `/unlimited-wallets` in `apps/dashboard/framer-rewrites.js`, marking it as "OFF for now".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->