### PR TITLE
[TOOL-2999] SDK: automatically sign message for SIWE in connect UI for Ecosystem wallets

### DIFF
--- a/.changeset/six-snails-reflect.md
+++ b/.changeset/six-snails-reflect.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Do not prompt user for signing message for SIWE auth in Connect UI for Ecosystem wallets

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/SignatureScreen.test.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/SignatureScreen.test.tsx
@@ -1,10 +1,10 @@
 import { userEvent } from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { TEST_ACCOUNT_A } from "~test/test-wallets.js";
+import { ANVIL_CHAIN } from "../../../../../../test/src/chains.js";
 import { render, waitFor } from "../../../../../../test/src/react-render.js";
 import { TEST_CLIENT } from "../../../../../../test/src/test-clients.js";
 import { createWallet } from "../../../../../wallets/create-wallet.js";
-import { useActiveWallet } from "../../../../core/hooks/wallets/useActiveWallet.js";
 import type { ConnectLocale } from "../locale/types.js";
 import { SignatureScreen } from "./SignatureScreen.js";
 
@@ -15,12 +15,18 @@ const mockAuth = vi.hoisted(() => ({
   isLoggedIn: vi.fn().mockResolvedValue(true),
 }));
 
+const useActiveWalletMock = vi.hoisted(() =>
+  vi.fn().mockReturnValue(undefined),
+);
+
+const useAdminWalletMock = vi.hoisted(() => vi.fn().mockReturnValue(undefined));
+
 vi.mock("../../../../core/hooks/auth/useSiweAuth", () => ({
   useSiweAuth: () => mockAuth,
 }));
 
 vi.mock("../../../../core/hooks/wallets/useActiveWallet", () => ({
-  useActiveWallet: vi.fn().mockReturnValue(createWallet("io.metamask")),
+  useActiveWallet: useActiveWalletMock,
 }));
 
 vi.mock("../../../../core/hooks/wallets/useActiveAccount", () => ({
@@ -28,7 +34,7 @@ vi.mock("../../../../core/hooks/wallets/useActiveAccount", () => ({
 }));
 
 vi.mock("../../../../core/hooks/wallets/useAdminWallet", () => ({
-  useAdminWallet: () => vi.fn().mockReturnValue(null),
+  useAdminWallet: useAdminWalletMock,
 }));
 
 const mockConnectLocale = {
@@ -56,52 +62,88 @@ const mockConnectLocale = {
   },
 } as unknown as ConnectLocale;
 
-describe("SignatureScreen", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockAuth.doLogin.mockResolvedValue(undefined);
-  });
+describe("Signature screen", () => {
+  describe("Signature prompt screen", () => {
+    beforeEach(() => {
+      const metamaskWallet = createWallet("io.metamask");
+      useActiveWalletMock.mockReturnValue(metamaskWallet);
+      vi.clearAllMocks();
+      mockAuth.doLogin.mockResolvedValue(undefined);
+    });
 
-  it("renders initial state correctly", () => {
-    const { getByTestId } = render(
-      <SignatureScreen
-        onDone={() => {}}
-        modalSize="wide"
-        connectLocale={mockConnectLocale}
-        client={TEST_CLIENT}
-        auth={mockAuth}
-      />,
-      { setConnectedWallet: true },
-    );
+    it("renders initial state correctly", () => {
+      const { getByTestId } = render(
+        <SignatureScreen
+          onDone={() => {}}
+          modalSize="wide"
+          connectLocale={mockConnectLocale}
+          client={TEST_CLIENT}
+          auth={mockAuth}
+        />,
+        { setConnectedWallet: true },
+      );
 
-    expect(getByTestId("sign-in-button")).toBeInTheDocument();
-    expect(getByTestId("disconnect-button")).toBeInTheDocument();
-  });
+      expect(getByTestId("sign-in-button")).toBeInTheDocument();
+      expect(getByTestId("disconnect-button")).toBeInTheDocument();
+    });
 
-  it("handles signing flow", async () => {
-    const onDoneMock = vi.fn();
-    const { getByRole, getByText } = render(
-      <SignatureScreen
-        onDone={onDoneMock}
-        modalSize="wide"
-        connectLocale={mockConnectLocale}
-        client={TEST_CLIENT}
-        auth={mockAuth}
-      />,
-      { setConnectedWallet: true },
-    );
+    it("handles signing flow", async () => {
+      const onDoneMock = vi.fn();
+      const { getByRole, getByText } = render(
+        <SignatureScreen
+          onDone={onDoneMock}
+          modalSize="wide"
+          connectLocale={mockConnectLocale}
+          client={TEST_CLIENT}
+          auth={mockAuth}
+        />,
+        { setConnectedWallet: true },
+      );
 
-    const signInButton = getByRole("button", { name: "Sign In" });
-    await userEvent.click(signInButton);
+      const signInButton = getByRole("button", { name: "Sign In" });
+      await userEvent.click(signInButton);
 
-    // Should show signing in progress
-    await waitFor(() => {
-      expect(getByText("Signing in progress...")).toBeInTheDocument();
+      // Should show signing in progress
+      await waitFor(() => {
+        expect(getByText("Signing in progress...")).toBeInTheDocument();
+      });
+    });
+
+    it("handles error state", async () => {
+      mockAuth.doLogin.mockRejectedValueOnce(new Error("Signing failed"));
+      const { getByTestId, getByRole, getByText } = render(
+        <SignatureScreen
+          onDone={() => {}}
+          modalSize="wide"
+          connectLocale={mockConnectLocale}
+          client={TEST_CLIENT}
+          auth={mockAuth}
+        />,
+        { setConnectedWallet: true },
+      );
+
+      const signInButton = await waitFor(() => {
+        return getByTestId("sign-in-button");
+      });
+      await userEvent.click(signInButton);
+
+      // Should show error state
+      await waitFor(
+        () => {
+          expect(getByText("Signing failed")).toBeInTheDocument();
+          expect(
+            getByRole("button", { name: "Try Again" }),
+          ).toBeInTheDocument();
+        },
+        {
+          timeout: 2000,
+        },
+      );
     });
   });
 
-  it("shows loading state when wallet is undefined", async () => {
-    vi.mocked(useActiveWallet).mockReturnValueOnce(undefined);
+  it("Shows loading state when wallet is disconnected", async () => {
+    useActiveWalletMock.mockReturnValueOnce(undefined);
 
     const { queryByTestId } = render(
       <SignatureScreen
@@ -117,171 +159,180 @@ describe("SignatureScreen", () => {
     expect(queryByTestId("sign-in-button")).not.toBeInTheDocument();
   });
 
-  it("handles error state", async () => {
-    mockAuth.doLogin.mockRejectedValueOnce(new Error("Signing failed"));
-    const { getByTestId, getByRole, getByText } = render(
-      <SignatureScreen
-        onDone={() => {}}
-        modalSize="wide"
-        connectLocale={mockConnectLocale}
-        client={TEST_CLIENT}
-        auth={mockAuth}
-      />,
-      { setConnectedWallet: true },
-    );
+  describe("Headless signature screen", () => {
+    function headlessTests() {
+      it("automatically triggers sign in on mount", async () => {
+        render(
+          <SignatureScreen
+            onDone={() => {}}
+            modalSize="wide"
+            connectLocale={mockConnectLocale}
+            client={TEST_CLIENT}
+            auth={mockAuth}
+          />,
+          { setConnectedWallet: true },
+        );
 
-    const signInButton = await waitFor(() => {
-      return getByTestId("sign-in-button");
-    });
-    await userEvent.click(signInButton);
-
-    // Should show error state
-    await waitFor(
-      () => {
-        expect(getByText("Signing failed")).toBeInTheDocument();
-        expect(getByRole("button", { name: "Try Again" })).toBeInTheDocument();
-      },
-      {
-        timeout: 2000,
-      },
-    );
-  });
-
-  describe("HeadlessSignIn", () => {
-    const mockWallet = createWallet("inApp");
-    beforeEach(() => {
-      vi.mocked(useActiveWallet).mockReturnValue(mockWallet);
-    });
-
-    it("automatically triggers sign in on mount", async () => {
-      render(
-        <SignatureScreen
-          onDone={() => {}}
-          modalSize="wide"
-          connectLocale={mockConnectLocale}
-          client={TEST_CLIENT}
-          auth={mockAuth}
-        />,
-        { setConnectedWallet: true },
-      );
-
-      await waitFor(() => {
-        expect(mockAuth.doLogin).toHaveBeenCalledTimes(1);
-      });
-    });
-
-    it("shows signing message during signing state", async () => {
-      const { getByText } = render(
-        <SignatureScreen
-          onDone={() => {}}
-          modalSize="wide"
-          connectLocale={mockConnectLocale}
-          client={TEST_CLIENT}
-          auth={mockAuth}
-        />,
-        { setConnectedWallet: true },
-      );
-
-      await waitFor(() => {
-        expect(getByText("Signing")).toBeInTheDocument();
-      });
-    });
-
-    it("shows error and retry button when signing fails", async () => {
-      mockAuth.doLogin.mockRejectedValueOnce(
-        new Error("Headless signing failed"),
-      );
-
-      const { getByText, getByRole } = render(
-        <SignatureScreen
-          onDone={() => {}}
-          modalSize="wide"
-          connectLocale={mockConnectLocale}
-          client={TEST_CLIENT}
-          auth={mockAuth}
-        />,
-        { setConnectedWallet: true },
-      );
-
-      await waitFor(
-        () => {
-          expect(getByText("Headless signing failed")).toBeInTheDocument();
-          expect(
-            getByRole("button", { name: "Try Again" }),
-          ).toBeInTheDocument();
-        },
-        { timeout: 2000 },
-      );
-    });
-
-    it("allows retry after failure", async () => {
-      mockAuth.doLogin
-        .mockRejectedValueOnce(new Error("Failed first time"))
-        .mockResolvedValueOnce(undefined);
-
-      const { getByRole, getByText } = render(
-        <SignatureScreen
-          onDone={() => {}}
-          modalSize="wide"
-          connectLocale={mockConnectLocale}
-          client={TEST_CLIENT}
-          auth={mockAuth}
-        />,
-        { setConnectedWallet: true },
-      );
-
-      // Wait for initial failure
-      await waitFor(
-        () => {
-          expect(getByText("Failed first time")).toBeInTheDocument();
-        },
-        { timeout: 2000 },
-      );
-
-      // Click retry
-      const retryButton = getByRole("button", { name: "Try Again" });
-      await userEvent.click(retryButton);
-
-      // Should show loading again
-      await waitFor(() => {
-        expect(getByText("Signing")).toBeInTheDocument();
+        await waitFor(() => {
+          expect(mockAuth.doLogin).toHaveBeenCalledTimes(1);
+        });
       });
 
-      // Should have called login twice
-      expect(mockAuth.doLogin).toHaveBeenCalledTimes(2);
+      it("shows signing message during signing state", async () => {
+        const { getByText } = render(
+          <SignatureScreen
+            onDone={() => {}}
+            modalSize="wide"
+            connectLocale={mockConnectLocale}
+            client={TEST_CLIENT}
+            auth={mockAuth}
+          />,
+          { setConnectedWallet: true },
+        );
+
+        await waitFor(() => {
+          expect(getByText("Signing")).toBeInTheDocument();
+        });
+      });
+
+      it("shows error and retry button when signing fails", async () => {
+        mockAuth.doLogin.mockRejectedValueOnce(
+          new Error("Headless signing failed"),
+        );
+
+        const { getByText, getByRole } = render(
+          <SignatureScreen
+            onDone={() => {}}
+            modalSize="wide"
+            connectLocale={mockConnectLocale}
+            client={TEST_CLIENT}
+            auth={mockAuth}
+          />,
+          { setConnectedWallet: true },
+        );
+
+        await waitFor(
+          () => {
+            expect(getByText("Headless signing failed")).toBeInTheDocument();
+            expect(
+              getByRole("button", { name: "Try Again" }),
+            ).toBeInTheDocument();
+          },
+          { timeout: 2000 },
+        );
+      });
+
+      it("allows retry after failure", async () => {
+        mockAuth.doLogin
+          .mockRejectedValueOnce(new Error("Failed first time"))
+          .mockResolvedValueOnce(undefined);
+
+        const { getByRole, getByText } = render(
+          <SignatureScreen
+            onDone={() => {}}
+            modalSize="wide"
+            connectLocale={mockConnectLocale}
+            client={TEST_CLIENT}
+            auth={mockAuth}
+          />,
+          { setConnectedWallet: true },
+        );
+
+        // Wait for initial failure
+        await waitFor(
+          () => {
+            expect(getByText("Failed first time")).toBeInTheDocument();
+          },
+          { timeout: 2000 },
+        );
+
+        // Click retry
+        const retryButton = getByRole("button", { name: "Try Again" });
+        await userEvent.click(retryButton);
+
+        // Should show loading again
+        await waitFor(() => {
+          expect(getByText("Signing")).toBeInTheDocument();
+        });
+
+        // Should have called login twice
+        expect(mockAuth.doLogin).toHaveBeenCalledTimes(2);
+      });
+
+      it("allows disconnecting wallet after failure", async () => {
+        const mockDisconnect = vi.fn().mockResolvedValue(undefined);
+        mockAuth.doLogin.mockRejectedValueOnce(new Error("Failed"));
+        useActiveWalletMock.mockReturnValueOnce({
+          ...createWallet("io.metamask"),
+          disconnect: mockDisconnect,
+        });
+
+        const { getByTestId } = render(
+          <SignatureScreen
+            onDone={() => {}}
+            modalSize="wide"
+            connectLocale={mockConnectLocale}
+            client={TEST_CLIENT}
+            auth={mockAuth}
+          />,
+          { setConnectedWallet: true },
+        );
+
+        // Wait for failure and click disconnect
+        await waitFor(
+          () => {
+            return getByTestId("disconnect-button");
+          },
+          { timeout: 2000 },
+        ).then((button) => userEvent.click(button));
+
+        // Should have attempted to disconnect
+        await waitFor(() => {
+          expect(mockDisconnect).toHaveBeenCalled();
+        });
+      });
+    }
+
+    describe("InApp wallet", () => {
+      const inAppWallet = createWallet("inApp");
+      beforeEach(() => {
+        useActiveWalletMock.mockReturnValue(inAppWallet);
+      });
+      headlessTests();
     });
 
-    it("allows disconnecting wallet after failure", async () => {
-      const mockDisconnect = vi.fn().mockResolvedValue(undefined);
-      mockAuth.doLogin.mockRejectedValueOnce(new Error("Failed"));
-      vi.mocked(useActiveWallet).mockReturnValueOnce({
-        ...createWallet("io.metamask"),
-        disconnect: mockDisconnect,
+    describe("Ecosystem wallet", () => {
+      const ecosystemWallet = createWallet("ecosystem.foo");
+      beforeEach(() => {
+        useActiveWalletMock.mockReturnValue(ecosystemWallet);
       });
+      headlessTests();
+    });
 
-      const { getByTestId } = render(
-        <SignatureScreen
-          onDone={() => {}}
-          modalSize="wide"
-          connectLocale={mockConnectLocale}
-          client={TEST_CLIENT}
-          auth={mockAuth}
-        />,
-        { setConnectedWallet: true },
-      );
-
-      // Wait for failure and click disconnect
-      await waitFor(
-        () => {
-          return getByTestId("disconnect-button");
-        },
-        { timeout: 2000 },
-      ).then((button) => userEvent.click(button));
-
-      // Should have attempted to disconnect
-      await waitFor(() => {
-        expect(mockDisconnect).toHaveBeenCalled();
+    describe("Smart Wallet (active) + Ecosystem wallet (admin)", () => {
+      const ecosystemWallet = createWallet("ecosystem.foo");
+      const smartWallet = createWallet("smart", {
+        chain: ANVIL_CHAIN,
+        sponsorGas: false,
       });
+      beforeEach(() => {
+        useActiveWalletMock.mockReturnValue(smartWallet);
+        useAdminWalletMock.mockReturnValue(ecosystemWallet);
+      });
+      headlessTests();
+    });
+
+    describe("Smart Wallet (active) + InApp wallet (admin)", () => {
+      const ecosystemWallet = createWallet("inApp");
+      const smartWallet = createWallet("smart", {
+        chain: ANVIL_CHAIN,
+        sponsorGas: false,
+      });
+      beforeEach(() => {
+        useActiveWalletMock.mockReturnValue(smartWallet);
+        useAdminWalletMock.mockReturnValue(ecosystemWallet);
+      });
+      headlessTests();
     });
   });
 });

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/SignatureScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/SignatureScreen.tsx
@@ -74,9 +74,10 @@ export const SignatureScreen: React.FC<{
   }
 
   if (
-    wallet.id === "inApp" ||
-    wallet.id === "embedded" ||
-    (wallet.id === "smart" && adminWallet?.id === "inApp")
+    isHeadlessSignSupported(wallet.id) ||
+    (wallet.id === "smart" &&
+      adminWallet &&
+      isHeadlessSignSupported(adminWallet.id))
   ) {
     return (
       <HeadlessSignIn
@@ -226,6 +227,14 @@ export const SignatureScreen: React.FC<{
     </Container>
   );
 };
+
+function isHeadlessSignSupported(walletId: Wallet["id"]) {
+  return (
+    walletId === "inApp" ||
+    walletId === "embedded" ||
+    walletId.startsWith("ecosystem")
+  );
+}
 
 function HeadlessSignIn({
   signIn,


### PR DESCRIPTION
---
title: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"
---

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer
Anything important to call out? Be sure to also clarify these in your comments.

## How to test
Unit tests, playground, etc.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the `ConnectWallet` UI by modifying the `SignatureScreen` component to enhance the signing process for ecosystem wallets and streamline the user experience during authentication.

### Detailed summary
- Added `isHeadlessSignSupported` function to determine wallet support.
- Updated wallet checks in `SignatureScreen` to utilize the new function.
- Refactored tests in `SignatureScreen.test.tsx` for clarity and organization.
- Introduced mocks for `useActiveWallet` and `useAdminWallet`.
- Enhanced error handling and user feedback during signing processes.
- Organized tests into groups for different wallet types (InApp, Ecosystem, Smart).

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->