### PR TITLE
[SDK/Dashboard] Fix: Deploy specified version of published contracts

### DIFF
--- a/.changeset/breezy-items-relate.md
+++ b/.changeset/breezy-items-relate.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix deploy version for published contracts

--- a/apps/dashboard/src/components/contract-components/contract-deploy-form/custom-contract.tsx
+++ b/apps/dashboard/src/components/contract-components/contract-deploy-form/custom-contract.tsx
@@ -447,6 +447,7 @@ export const CustomContractForm: React.FC<CustomContractFormProps> = ({
               ? JSON.parse(params.deployParams._trustedForwarders as string)
               : undefined,
           },
+          version: metadata.version,
         });
       }
 

--- a/packages/thirdweb/src/extensions/prebuilts/deploy-marketplace.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/deploy-marketplace.ts
@@ -36,6 +36,8 @@ export type MarketplaceContractParams = {
 export type DeployMarketplaceContractOptions = Prettify<
   ClientAndChainAndAccount & {
     params: MarketplaceContractParams;
+  } & {
+    version?: string;
   }
 >;
 
@@ -46,7 +48,7 @@ export type DeployMarketplaceContractOptions = Prettify<
 export async function deployMarketplaceContract(
   options: DeployMarketplaceContractOptions,
 ) {
-  const { chain, client, account, params } = options;
+  const { chain, client, account, params, version } = options;
   const WETH = await getOrDeployInfraContract({
     chain,
     client,
@@ -127,6 +129,7 @@ export async function deployMarketplaceContract(
           nativeTokenWrapper: WETH.address,
         } as MarketplaceConstructorParams[number],
       },
+      version,
     });
 
   const initializeTransaction = await getInitializeTransaction({

--- a/packages/thirdweb/src/extensions/prebuilts/deploy-pack.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/deploy-pack.ts
@@ -88,7 +88,7 @@ export async function deployPackContract(options: DeployPackContractOptions) {
       chain,
       client,
       account,
-      contractId: "Forwarder",
+      contractId: "ForwarderEOAOnly",
     }),
   ]);
   const { cloneFactoryContract, implementationContract } =

--- a/packages/thirdweb/src/extensions/prebuilts/deploy-published.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/deploy-published.ts
@@ -211,8 +211,10 @@ export async function deployContractfromDeployMetadata(
             (await getAllDefaultConstructorParamsForImplementation({
               chain,
               client,
+              contractId: deployMetadata.name,
             })),
           publisher: deployMetadata.publisher,
+          version: deployMetadata.version,
         });
 
       const initializeTransaction = await getInitializeTransaction({

--- a/packages/thirdweb/src/extensions/prebuilts/get-required-transactions.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/get-required-transactions.ts
@@ -136,6 +136,7 @@ async function getTransactionsForImplementation(options: {
     (await getAllDefaultConstructorParamsForImplementation({
       chain,
       client,
+      contractId: deployMetadata.name,
     }));
 
   const result = await getDeployedInfraContract({
@@ -224,6 +225,7 @@ async function getTransactionsForMaketplaceV3(options: {
 export async function getAllDefaultConstructorParamsForImplementation(args: {
   chain: Chain;
   client: ThirdwebClient;
+  contractId: string;
 }) {
   const { chain, client } = args;
   const isZkSync = await isZkSyncChain(chain);
@@ -234,11 +236,14 @@ export async function getAllDefaultConstructorParamsForImplementation(args: {
       nativeTokenWrapper: weth,
     };
   }
+
+  const forwarderContractId =
+    args.contractId === "Pack" ? "ForwarderEOAOnly" : "Forwarder";
   const [forwarder, weth] = await Promise.all([
     computePublishedContractAddress({
       chain,
       client,
-      contractId: "Forwarder",
+      contractId: forwarderContractId,
     }),
     computePublishedContractAddress({
       chain,


### PR DESCRIPTION
TOOL-3013
TOOL-3014

## Notes for the reviewer
Anything important to call out? Be sure to also clarify these in your comments.

## How to test
Unit tests, playground, etc.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the deployment version and contract identifiers for various components in the `thirdweb` library, ensuring proper version handling for published contracts.

### Detailed summary
- Updated `version` handling in `custom-contract.tsx`.
- Changed `contractId` from `"Forwarder"` to `"ForwarderEOAOnly"` in `deploy-pack.ts`.
- Added `version` to `DeployMarketplaceContractOptions` in `deploy-marketplace.ts`.
- Updated `getAllDefaultConstructorParamsForImplementation` to include `contractId`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->