### PR TITLE
[TOOL-2972] Portal: Add missing redirects for contract references

### DIFF
--- a/apps/portal/redirects.mjs
+++ b/apps/portal/redirects.mjs
@@ -809,6 +809,16 @@ const contractRedirects = {
   "/contracts/design/Pack": "/contracts/design-docs/pack",
   "/contracts/design/SignatureDrop": "/contracts",
   "/interact": "/contracts",
+  // contract references
+  "/contracts/TokenERC20": "/contracts/explore/pre-built-contracts/token",
+  "/contracts/DropERC721": "/contracts/explore/pre-built-contracts/nft-drop",
+  "/contracts/DropERC1155":
+    "/contracts/explore/pre-built-contracts/edition-drop",
+  "/contracts/TokenERC721":
+    "/contracts/explore/pre-built-contracts/nft-collection",
+  "/contracts/TokenERC1155": "/contracts/explore/pre-built-contracts/edition",
+  "/contracts/Multiwrap": "/contracts/design-docs/multiwrap",
+  "/contracts/VoteERC20": "/contracts/build/base-contracts/erc-20/vote",
 };
 
 const infrastructureRedirects = {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the redirect paths for various contract references in the `apps/portal/redirects.mjs` file to point to new locations within the project structure.

### Detailed summary
- Added new redirect paths for the following contracts:
  - `TokenERC20` to `/contracts/explore/pre-built-contracts/token`
  - `DropERC721` to `/contracts/explore/pre-built-contracts/nft-drop`
  - `DropERC1155` to `/contracts/explore/pre-built-contracts/edition-drop`
  - `TokenERC721` to `/contracts/explore/pre-built-contracts/nft-collection`
  - `TokenERC1155` to `/contracts/explore/pre-built-contracts/edition`
  - `Multiwrap` to `/contracts/design-docs/multiwrap`
  - `VoteERC20` to `/contracts/build/base-contracts/erc-20/vote`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->