### PR TITLE
[TOOL-3044] Remove static generation of changelog pages

### DIFF
--- a/apps/portal/src/app/changelog/[slug]/page.tsx
+++ b/apps/portal/src/app/changelog/[slug]/page.tsx
@@ -3,7 +3,7 @@
 import { cn } from "@/lib/utils";
 import { notFound } from "next/navigation";
 import ReactHtmlParser from "react-html-parser";
-import { fetchChangeLogs, fetchPost } from "../ghost";
+import { fetchPost } from "../ghost";
 import "./styles.css";
 import { ArrowLeft } from "lucide-react";
 import Link from "next/link";
@@ -71,14 +71,4 @@ export default async function Page(props: {
       })}
     </div>
   );
-}
-
-export async function generateStaticParams() {
-  const changelogs = await fetchChangeLogs();
-
-  return changelogs.map((changelog) => {
-    return {
-      slug: changelog.slug,
-    };
-  });
 }

--- a/apps/portal/src/app/changelog/utils/transform.tsx
+++ b/apps/portal/src/app/changelog/utils/transform.tsx
@@ -49,7 +49,7 @@ export const transform: Transform = (node, index: number) => {
     const level = Number.parseInt(node.name[1] || "");
 
     return (
-      <Heading level={level} id="#" anchorClassName="mt-10">
+      <Heading level={level} anchorClassName="mt-10" id={undefined}>
         {getChildren()}
       </Heading>
     );

--- a/apps/portal/src/components/Document/Heading.tsx
+++ b/apps/portal/src/components/Document/Heading.tsx
@@ -3,7 +3,7 @@ import { Anchor } from "../ui/Anchor";
 
 export function Heading(props: {
   children: React.ReactNode;
-  id: string;
+  id: string | undefined;
   level: number;
   className?: string;
   anchorClassName?: string;

--- a/apps/portal/src/components/ui/Anchor.tsx
+++ b/apps/portal/src/components/ui/Anchor.tsx
@@ -4,7 +4,7 @@ import { cn } from "@/lib/utils";
 import { Link as LinkIcon } from "lucide-react";
 
 export function Anchor(props: {
-  id: string;
+  id: string | undefined;
   children: React.ReactNode;
   className?: string;
 }) {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `id` prop in the `Anchor` and `Heading` components to allow for `undefined` values instead of just strings. Additionally, it removes the `generateStaticParams` function from the `page.tsx` file and adjusts the usage of the `Heading` component.

### Detailed summary
- Modified `id` prop in `Anchor` to accept `string | undefined`.
- Modified `id` prop in `Heading` to accept `string | undefined`.
- Updated `Heading` usage in `transform.tsx` to set `id` as `undefined`.
- Removed `generateStaticParams` function from `page.tsx`.
- Adjusted imports in `page.tsx` by removing `fetchChangeLogs`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->