### PR TITLE
[TOOL-3046]: Do not show invalid string error if NFT description is undefined

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/nfts/components/table.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/nfts/components/table.tsx
@@ -95,7 +95,7 @@ export const NFTGetAllTable: React.FC<ContractOverviewNFTGetAllProps> = ({
         Header: "Description",
         accessor: (row) => row.metadata.description,
         Cell: (cell: CellProps<NFT, string>) => {
-          if (typeof cell.value !== "string") {
+          if (cell.value && typeof cell.value !== "string") {
             return (
               <UnexpectedValueErrorMessage
                 title="Invalid description"


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR improves the validation of the `description` field in the `nfts/components/table.tsx` file by ensuring that the check for a valid string also accounts for the possibility of `cell.value` being `null` or `undefined`.

### Detailed summary
- Modified the condition in the `Cell` function to check if `cell.value` exists before verifying its type.
- This change ensures that only valid string values are processed, enhancing error handling for the `description` field.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->