### PR TITLE
[TOOL-3047] Dashboard: Fix TransactionButton opening "No funds" Modal when quickly clicking it after switching chain

### DIFF
--- a/apps/dashboard/src/components/buttons/TransactionButton.tsx
+++ b/apps/dashboard/src/components/buttons/TransactionButton.tsx
@@ -71,7 +71,7 @@ export const TransactionButton: React.FC<TransactionButtonProps> = ({
       <PopoverTrigger asChild>
         <ButtonComponent
           variant={variant || "primary"}
-          desiredChainId={txChainID}
+          txChainId={txChainID}
           twAccount={twAccount}
           {...restButtonProps}
           disabled={disabled}
@@ -189,7 +189,7 @@ const ExternalApprovalNotice: React.FC<ExternalApprovalNoticeProps> = ({
       <h4 className="text-foreground">Approve Transaction</h4>
 
       <p className="text-muted-foreground text-sm">
-        You will need to approve this transaction in your connected wallet.
+        Your connected wallet will prompt you to approve this transaction
       </p>
 
       {showHint && (


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on renaming and refactoring variables related to chain ID handling in the `TransactionButton` and `MismatchButton` components to improve clarity and consistency.

### Detailed summary
- Renamed `desiredChainId` to `txChainId` in multiple components.
- Updated function `useNetworkMismatchAdapter` to `useIsNetworkMismatch`.
- Adjusted logic in `MismatchButton` for balance checks using `txChainId`.
- Modified `MismatchNotice` to use `txChainId`.
- Enhanced user prompts for transaction approval messages.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->