### PR TITLE
[SDK] test: Skip Nebula AI tests by default

### DIFF
--- a/packages/thirdweb/src/ai/chat.test.ts
+++ b/packages/thirdweb/src/ai/chat.test.ts
@@ -4,7 +4,8 @@ import { TEST_ACCOUNT_A, TEST_ACCOUNT_B } from "../../test/src/test-wallets.js";
 import { sepolia } from "../chains/chain-definitions/sepolia.js";
 import * as Nebula from "./index.js";
 
-describe.runIf(process.env.TW_SECRET_KEY)("chat", () => {
+// reenable manually for nebula testing
+describe.runIf(process.env.TW_SECRET_KEY).skip("chat", () => {
   it("should respond with a message", async () => {
     const response = await Nebula.chat({
       client: TEST_CLIENT,

--- a/packages/thirdweb/src/ai/execute.test.ts
+++ b/packages/thirdweb/src/ai/execute.test.ts
@@ -5,7 +5,8 @@ import { sepolia } from "../chains/chain-definitions/sepolia.js";
 import { getContract } from "../contract/contract.js";
 import * as Nebula from "./index.js";
 
-describe("execute", () => {
+// reenable manually for nebula testing
+describe.runIf(process.env.TW_SECRET_KEY).skip("execute", () => {
   it("should execute a tx", async () => {
     await expect(
       Nebula.execute({


### PR DESCRIPTION
---
title: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"
---

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer
Anything important to call out? Be sure to also clarify these in your comments.

## How to test
Unit tests, playground, etc.



<!-- start pr-codex -->

---

## PR-Codex overview
This PR modifies test descriptions for `execute` and `chat` functions in the `Nebula` module to be skipped unless a specific environment variable (`TW_SECRET_KEY`) is set. This change is aimed at controlling the execution of these tests manually.

### Detailed summary
- Updated `describe` for `execute` test to `describe.runIf(process.env.TW_SECRET_KEY).skip("execute", ...)`.
- Updated `describe` for `chat` test to `describe.runIf(process.env.TW_SECRET_KEY).skip("chat", ...)`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->