### PR TITLE
[SDK] Fix: Lumia Testnet is pre-1559

### DIFF
--- a/.changeset/yellow-apples-flash.md
+++ b/.changeset/yellow-apples-flash.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Added overrides for Lumia Testnet to use pre-EIP1559 gas values

--- a/packages/thirdweb/src/gas/fee-data.ts
+++ b/packages/thirdweb/src/gas/fee-data.ts
@@ -38,6 +38,7 @@ const FORCE_GAS_PRICE_CHAIN_IDS = [
   9768, // MainnetZ Testnet
   2442, // Polygon zkEVM Cardona Testnet
   1942999413, // Humanity Testnet
+  1952959480, // Lumia Testnet
 ];
 
 /**


### PR DESCRIPTION
---
title: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"
---

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer
Anything important to call out? Be sure to also clarify these in your comments.

## How to test
Unit tests, playground, etc.



<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding support for the `Lumia Testnet` by including pre-EIP1559 gas values in the `thirdweb` package.

### Detailed summary
- Added an entry for `Lumia Testnet` with the gas value `1952959480` in the `packages/thirdweb/src/gas/fee-data.ts` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->