### PR TITLE
[TOOL-3128] SDK: Fix typo in deployPublishedContract JSDoc example

### DIFF
--- a/packages/thirdweb/src/extensions/prebuilts/deploy-published.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/deploy-published.ts
@@ -50,7 +50,7 @@ export type DeployPublishedContractOptions = {
  * ```ts
  * import { deployPublishedContract } from "thirdweb/deploys";
  *
- * const address = await deployedPublishedContract({
+ * const address = await deployPublishedContract({
  *   client,
  *   chain,
  *   account,
@@ -68,7 +68,7 @@ export type DeployPublishedContractOptions = {
  * ```ts
  * import { deployPublishedContract } from "thirdweb/deploys";
  *
- * const address = await deployedPublishedContract({
+ * const address = await deployPublishedContract({
  *   client,
  *   chain,
  *   account,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on correcting a function name in the `deploy-published.ts` file from `deployedPublishedContract` to `deployPublishedContract`.

### Detailed summary
- Changed the function call from `deployedPublishedContract` to `deployPublishedContract` in the `deploy-published.ts` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->