### PR TITLE
[Playground] Feature: Adds smart account auth

### DIFF
--- a/apps/playground-web/src/app/connect/auth/page.tsx
+++ b/apps/playground-web/src/app/connect/auth/page.tsx
@@ -1,5 +1,6 @@
 import { BasicAuthPreview } from "@/components/auth/basic-auth";
 import { GatedContentPreview } from "@/components/auth/gated-content";
+import { SmartAccountAuthPreview } from "@/components/auth/smart-account-auth";
 import { CodeExample } from "@/components/code/code-example";
 import ThirdwebProvider from "@/components/thirdweb-provider";
 import { metadataBase } from "@/lib/constants";
@@ -38,6 +39,12 @@ export default function Page() {
 
         <section className="space-y-8">
           <GatedContent />
+        </section>
+
+        <div className="h-14" />
+
+        <section className="space-y-8">
+          <SmartAccountAuth />
         </section>
       </main>
     </ThirdwebProvider>
@@ -143,6 +150,61 @@ export async function GatedContentPreview() {
     </div>
   );
 }`}
+        lang="tsx"
+      />
+    </>
+  );
+}
+
+function SmartAccountAuth() {
+  return (
+    <>
+      <div className="space-y-2">
+        <h2 className="font-semibold text-2xl tracking-tight sm:text-3xl">
+          Smart Account Auth
+        </h2>
+        <p className="max-w-[600px]">
+          Use smart accounts with Sign in with Ethereum (SIWE)
+        </p>
+      </div>
+
+      <CodeExample
+        preview={<SmartAccountAuthPreview />}
+        code={`"use client";
+
+import {
+  generatePayload,
+  isLoggedIn,
+  login,
+  logout,
+} from "@/app/connect/auth/server/actions/auth";
+import { THIRDWEB_CLIENT } from "@/lib/client";
+import { ConnectButton } from "thirdweb/react";
+import { defineChain } from "thirdweb";
+
+export function AuthButton() {
+  return (
+    <ConnectButton
+      client={THIRDWEB_CLIENT}
+      accountAbstraction={{
+        chain: defineChain(17000),
+        sponsorGas: true
+      }}
+      auth={{
+        // The following methods run on the server (not client)!
+        isLoggedIn: async () => {
+          const authResult = await isLoggedIn();
+          if (!authResult) return false;
+          return true;
+        },
+        doLogin: async (params) => await login(params),
+        getLoginPayload: async ({ address }) => generatePayload({ address }),
+        doLogout: async () => await logout(),
+      }}
+    />
+  );
+}
+`}
         lang="tsx"
       />
     </>

--- a/apps/playground-web/src/components/auth/smart-account-auth-button.tsx
+++ b/apps/playground-web/src/components/auth/smart-account-auth-button.tsx
@@ -1,0 +1,29 @@
+"use client";
+import {
+  generatePayload,
+  isLoggedIn,
+  login,
+  logout,
+} from "@/app/connect/auth/server/actions/auth";
+import { THIRDWEB_CLIENT } from "@/lib/client";
+import { defineChain } from "thirdweb";
+import { ConnectButton } from "thirdweb/react";
+
+export function SmartAccountAuthButton() {
+  return (
+    <ConnectButton
+      client={THIRDWEB_CLIENT}
+      accountAbstraction={{
+        chain: defineChain(17000),
+        sponsorGas: true,
+      }}
+      auth={{
+        isLoggedIn: (address) => isLoggedIn(address),
+        doLogin: (params) => login(params),
+        getLoginPayload: ({ address }) =>
+          generatePayload({ address, chainId: 17000 }),
+        doLogout: () => logout(),
+      }}
+    />
+  );
+}

--- a/apps/playground-web/src/components/auth/smart-account-auth.tsx
+++ b/apps/playground-web/src/components/auth/smart-account-auth.tsx
@@ -1,0 +1,36 @@
+import type { RequestCookie } from "next/dist/compiled/@edge-runtime/cookies";
+import { cookies } from "next/headers";
+import { cn } from "../../lib/utils";
+import { SmartAccountAuthButton } from "./smart-account-auth-button";
+
+export async function SmartAccountAuthPreview() {
+  const jwt = (await cookies()).get("jwt");
+  return (
+    <div className="flex flex-col gap-5">
+      <div className="mx-auto">
+        <SmartAccountAuthButton />
+      </div>
+      {jwt && !!jwt.value && (
+        <table className="table-auto border-collapse rounded-lg backdrop-blur">
+          <tbody>
+            {Object.keys(jwt).map((key) => (
+              <tr key={key} className="">
+                <td className="rounded border p-2">{key}</td>
+                <td
+                  className={cn(
+                    "max-h-[200px] max-w-[250px] overflow-y-auto whitespace-normal break-words border p-2",
+                    {
+                      "text-xs": key === "value",
+                    },
+                  )}
+                >
+                  {jwt[key as keyof RequestCookie]}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
---
title: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"
---

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer
Anything important to call out? Be sure to also clarify these in your comments.

## How to test
Unit tests, playground, etc.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a `SmartAccountAuthButton` component for Ethereum authentication using smart accounts. It leverages the `ConnectButton` from `thirdweb` to manage user login state and integrates JWT handling in the `SmartAccountAuthPreview` component.

### Detailed summary
- Added `SmartAccountAuthButton` component in `smart-account-auth-button.tsx`.
- Integrated Ethereum authentication methods: `isLoggedIn`, `login`, `logout`, and `generatePayload`.
- Introduced `SmartAccountAuthPreview` to display JWT cookies in `smart-account-auth.tsx`.
- Updated the main `Page` component to include `SmartAccountAuth`.
- Created a new `SmartAccountAuth` function to render authentication UI and code example.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->