### PR TITLE
[SDK] Feature: Add Mode chain definition

### DIFF
--- a/.changeset/witty-bugs-roll.md
+++ b/.changeset/witty-bugs-roll.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Added `mode` as a predefined chain

--- a/packages/thirdweb/src/chains/chain-definitions/mode.ts
+++ b/packages/thirdweb/src/chains/chain-definitions/mode.ts
@@ -1,0 +1,16 @@
+import { defineChain } from "../utils.js";
+
+/**
+ * @chain
+ */
+export const mode = /* @__PURE__ */ defineChain({
+  id: 919,
+  name: "Mode",
+  nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
+  blockExplorers: [
+    {
+      name: "Modescout",
+      url: "https://explorer.mode.network/",
+    },
+  ],
+});

--- a/packages/thirdweb/src/exports/chains.ts
+++ b/packages/thirdweb/src/exports/chains.ts
@@ -77,4 +77,5 @@ export { celoAlfajoresTestnet } from "../chains/chain-definitions/celo-alfajores
 export { fraxtalTestnet } from "../chains/chain-definitions/fraxtal-testnet.js";
 export { metalL2Testnet } from "../chains/chain-definitions/metal-l2-testnet.js";
 export { modeTestnet } from "../chains/chain-definitions/mode-testnet.js";
+export { mode } from "../chains/chain-definitions/mode.js";
 export { soneiumMinato } from "../chains/chain-definitions/soneium-minato.js";


### PR DESCRIPTION
---
title: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"
---

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer
Anything important to call out? Be sure to also clarify these in your comments.

## How to test
Unit tests, playground, etc.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new blockchain chain definition for `mode`, including its properties and exports it for use in the application.

### Detailed summary
- Added a patch for `thirdweb`.
- Introduced `mode` as a predefined chain in `packages/thirdweb/src/chains/chain-definitions/mode.ts`.
- Defined `mode` with properties like `id`, `name`, `nativeCurrency`, and `blockExplorers`.
- Exported `mode` from `packages/thirdweb/src/exports/chains.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->