### PR TITLE
Fix [Portal]: Link to generate a client ID

### DIFF
--- a/apps/portal/src/app/connect/page.mdx
+++ b/apps/portal/src/app/connect/page.mdx
@@ -97,7 +97,7 @@ Get started with Connect in your preferred language.
 		You'll need a client ID to access Connect's free blockchain APIs, storage, and more.
 	</p>
 	<Link
-			href="https://thirdweb.com/create-api-key"
+			href="https://thirdweb.com/team/"
 			target="_blank"
 		>
 		<Button> 


### PR DESCRIPTION
---
title: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"
---

Fix [Portal]: Link to generate a client ID: ~https://thirdweb.com/create-api-key~  https://thirdweb.com/team/
ref.https://portal.thirdweb.com/connect#with-connect-you-can

## Notes for the reviewer
Problem review
![image](https://github.com/user-attachments/assets/c30c67d3-0bab-416b-8eff-104cd55d0412)
![image](https://github.com/user-attachments/assets/c9f13031-1c26-4bbd-ab05-f788399ed574)


## How to test
yes 👆



<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `href` attribute of a `Link` component in the `page.mdx` file from the previous URL to a new destination.

### Detailed summary
- Changed the `href` attribute of the `Link` from `https://thirdweb.com/create-api-key` to `https://thirdweb.com/team/`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->