### PR TITLE
[Dashboard] fix: Update dashboard redirect paths to /team

### DIFF
--- a/apps/dashboard/redirects.js
+++ b/apps/dashboard/redirects.js
@@ -21,7 +21,7 @@ const legacyDashboardToTeamRedirects = [
   },
   {
     source: "/dashboard/settings/api-keys",
-    destination: "/team/~/~/projects",
+    destination: "/team",
     permanent: false,
   },
   {
@@ -160,12 +160,12 @@ async function redirects() {
     },
     {
       source: "/create-api-key",
-      destination: "/team/~/~/projects",
+      destination: "/team",
       permanent: false,
     },
     {
       source: "/dashboard/settings",
-      destination: "/team/~/~/projects",
+      destination: "/team",
       permanent: false,
     },
     {


### PR DESCRIPTION
Fixes: TOOL-3144

Updates redirects for `/create-api-key` and `/dashboard/settings` to point to `/team` instead of `/team/~/~/projects`