### PR TITLE
[SDK] Feature: Makes chain optional on smart wallet config

### DIFF
--- a/.changeset/six-baboons-begin.md
+++ b/.changeset/six-baboons-begin.md
@@ -1,0 +1,13 @@
+---
+"thirdweb": minor
+---
+
+Feature: Chain is no longer required for smart accounts
+
+```ts
+import { smartWallet } from "thirdweb";
+
+const wallet = smartWallet({
+    sponsorGas: true, // enable sponsored transactions
+});
+```

--- a/packages/thirdweb/src/react/core/hooks/connection/ConnectButtonProps.ts
+++ b/packages/thirdweb/src/react/core/hooks/connection/ConnectButtonProps.ts
@@ -948,8 +948,6 @@ export type ConnectButtonProps = {
    * ```tsx
    * <ConnectButton
    *   accountAbstraction={{
-   *    factoryAddress: "0x123...",
-   *    chain: sepolia,
    *    gasless: true;
    *   }}
    * />

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/SmartWalletConnectUI.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/SmartWalletConnectUI.tsx
@@ -129,7 +129,9 @@ function SmartWalletConnecting(props: {
     };
   }, [personalWallet]);
 
-  const wrongNetwork = personalWalletChainId !== smartWalletChain.id;
+  const wrongNetwork =
+    typeof smartWalletChain !== "undefined" &&
+    personalWalletChainId !== smartWalletChain.id;
 
   const [smartWalletConnectionStatus, setSmartWalletConnectionStatus] =
     useState<"connecting" | "connect-error" | "idle">("idle");

--- a/packages/thirdweb/src/wallets/smart/lib/calls.ts
+++ b/packages/thirdweb/src/wallets/smart/lib/calls.ts
@@ -1,4 +1,5 @@
 import type { Chain } from "../../../chains/types.js";
+import { getCachedChain } from "../../../chains/utils.js";
 import type { ThirdwebClient } from "../../../client/client.js";
 import {
   type ThirdwebContract,
@@ -29,7 +30,7 @@ import { DEFAULT_ACCOUNT_FACTORY_V0_6 } from "./constants.js";
  */
 export async function predictSmartAccountAddress(args: {
   client: ThirdwebClient;
-  chain: Chain;
+  chain?: Chain;
   adminAddress: string;
   factoryAddress?: string;
   accountSalt?: string;
@@ -39,7 +40,7 @@ export async function predictSmartAccountAddress(args: {
     accountSalt: args.accountSalt,
     factoryContract: getContract({
       address: args.factoryAddress ?? DEFAULT_ACCOUNT_FACTORY_V0_6,
-      chain: args.chain,
+      chain: args.chain ?? getCachedChain(1),
       client: args.client,
     }),
   });

--- a/packages/thirdweb/src/wallets/smart/lib/signing.ts
+++ b/packages/thirdweb/src/wallets/smart/lib/signing.ts
@@ -57,7 +57,7 @@ export async function smartAccountSignMessage({
       domain: {
         name: "Account",
         version: "1",
-        chainId: options.chain.id,
+        chainId: options.chain?.id ?? 1,
         verifyingContract: accountContract.address,
       },
       primaryType: "AccountMessage",
@@ -155,7 +155,7 @@ export async function smartAccountSignTypedData<
       domain: {
         name: "Account",
         version: "1",
-        chainId: options.chain.id,
+        chainId: options.chain?.id ?? 1,
         verifyingContract: accountContract.address,
       },
       primaryType: "AccountMessage",

--- a/packages/thirdweb/src/wallets/smart/lib/userop.ts
+++ b/packages/thirdweb/src/wallets/smart/lib/userop.ts
@@ -697,7 +697,7 @@ export async function createAndSignUserOp(options: {
   transactions: PreparedTransaction[];
   adminAccount: Account;
   client: ThirdwebClient;
-  smartWalletOptions: SmartWalletOptions;
+  smartWalletOptions: SmartWalletOptions & { chain: Chain };
   waitForDeployment?: boolean;
 }) {
   const config = options.smartWalletOptions;

--- a/packages/thirdweb/src/wallets/smart/smart-wallet-integration-v07.test.ts
+++ b/packages/thirdweb/src/wallets/smart/smart-wallet-integration-v07.test.ts
@@ -77,11 +77,44 @@ describe.runIf(process.env.TW_SECRET_KEY)(
       });
     });
 
-    it("can connect", async () => {
+    it("can deploy with default chain", async () => {
+      const wallet = smartWallet({
+        gasless: true,
+        factoryAddress: DEFAULT_ACCOUNT_FACTORY_V0_7,
+      });
+      const smartAccount = await wallet.connect({
+        client: TEST_CLIENT,
+        personalAccount,
+      });
+      expect(smartAccount.address).toHaveLength(42);
+
+      const signature = await smartAccount.signMessage({
+        message: "hello world",
+      });
+      const isValid = await verifySignature({
+        message: "hello world",
+        signature,
+        address: smartWalletAddress,
+        chain: wallet.getChain(),
+        client,
+      });
+      expect(isValid).toEqual(true);
+    });
+
+    it("can predict account address", async () => {
       expect(smartWalletAddress).toHaveLength(42);
       const predictedAddress = await predictSmartAccountAddress({
         client,
         chain,
+        adminAddress: personalAccount.address,
+        factoryAddress: DEFAULT_ACCOUNT_FACTORY_V0_7,
+      });
+      expect(predictedAddress).toEqual(smartWalletAddress);
+    });
+
+    it("can predict account address with default chain", async () => {
+      const predictedAddress = await predictSmartAccountAddress({
+        client,
         adminAddress: personalAccount.address,
         factoryAddress: DEFAULT_ACCOUNT_FACTORY_V0_7,
       });

--- a/packages/thirdweb/src/wallets/smart/smart-wallet-integration.test.ts
+++ b/packages/thirdweb/src/wallets/smart/smart-wallet-integration.test.ts
@@ -74,11 +74,41 @@ describe.runIf(process.env.TW_SECRET_KEY).sequential(
       });
     });
 
-    it("can connect", async () => {
+    it("can deploy with default chain", async () => {
+      const wallet = smartWallet({
+        gasless: true,
+      });
+      const smartAccount = await wallet.connect({
+        client: TEST_CLIENT,
+        personalAccount,
+      });
+      expect(smartAccount.address).toHaveLength(42);
+      const signature = await smartAccount.signMessage({
+        message: "hello world",
+      });
+      const isValid = await verifySignature({
+        message: "hello world",
+        signature,
+        address: smartWalletAddress,
+        chain: wallet.getChain(),
+        client,
+      });
+      expect(isValid).toEqual(true);
+    });
+
+    it("can predict account address", async () => {
       expect(smartWalletAddress).toHaveLength(42);
       const predictedAddress = await predictSmartAccountAddress({
         client,
         chain,
+        adminAddress: personalAccount.address,
+      });
+      expect(predictedAddress).toEqual(smartWalletAddress);
+    });
+
+    it("can predict account address with default chain", async () => {
+      const predictedAddress = await predictSmartAccountAddress({
+        client,
         adminAddress: personalAccount.address,
       });
       expect(predictedAddress).toEqual(smartWalletAddress);

--- a/packages/thirdweb/src/wallets/smart/smart-wallet.ts
+++ b/packages/thirdweb/src/wallets/smart/smart-wallet.ts
@@ -129,6 +129,12 @@ import type { SmartWalletOptions } from "./types.js";
 export function smartWallet(
   createOptions: SmartWalletOptions,
 ): Wallet<"smart"> {
+  if (
+    typeof createOptions.factoryAddress === "undefined" &&
+    typeof createOptions.chain !== "undefined"
+  ) {
+    throw new Error("You must provide a chain if factory address is specified");
+  }
   const emitter = createWalletEmitter<"smart">();
   let account: Account | undefined = undefined;
   let adminAccount: Account | undefined = undefined;

--- a/packages/thirdweb/src/wallets/smart/smart-wallet.ts
+++ b/packages/thirdweb/src/wallets/smart/smart-wallet.ts
@@ -43,7 +43,6 @@ import type { SmartWalletOptions } from "./types.js";
  * import { sendTransaction } from "thirdweb";
  *
  * const wallet = smartWallet({
- *  chain: sepolia,
  *  sponsorGas: true, // enable sponsored transactions
  * });
  *
@@ -77,7 +76,7 @@ import type { SmartWalletOptions } from "./types.js";
  * import { sepolia } from "thirdweb/chains";
  *
  * const wallet = smartWallet({
- *  chain: sepolia,
+ *  chain: sepolia, // specify a chain if your factory only exists on one chain
  *  sponsorGas: true, // enable sponsored transactions
  *  factoryAddress: "0x...", // custom factory address
  * });
@@ -94,7 +93,6 @@ import type { SmartWalletOptions } from "./types.js";
  * import { sepolia } from "thirdweb/chains";
  *
  * const wallet = smartWallet({
- *  chain: sepolia,
  *  sponsorGas: true, // enable sponsored transactions
  *  factoryAddress: DEFAULT_ACCOUNT_FACTORY_V0_7, // 0.7 factory address
  * });

--- a/packages/thirdweb/src/wallets/smart/types.ts
+++ b/packages/thirdweb/src/wallets/smart/types.ts
@@ -19,7 +19,7 @@ export type TokenPaymasterConfig = {
 
 export type SmartWalletOptions = Prettify<
   {
-    chain: Chain; // TODO consider making default chain optional
+    chain?: Chain;
     factoryAddress?: string;
     overrides?: {
       bundlerUrl?: string;
@@ -81,7 +81,7 @@ export type SmartWalletOptions = Prettify<
 // internal type
 export type SmartAccountOptions = Prettify<
   Omit<SmartWalletOptions, "chain" | "gasless" | "sponsorGas"> & {
-    chain: Chain;
+    chain?: Chain;
     sponsorGas: boolean;
     personalAccount: Account;
     factoryContract: ThirdwebContract;
@@ -89,6 +89,18 @@ export type SmartAccountOptions = Prettify<
     client: ThirdwebClient;
   }
 >;
+
+export type UserOpOptions = Omit<
+  SmartWalletOptions,
+  "chain" | "gasless" | "sponsorGas"
+> & {
+  chain: Chain;
+  sponsorGas: boolean;
+  personalAccount: Account;
+  factoryContract: ThirdwebContract;
+  accountContract: ThirdwebContract;
+  client: ThirdwebClient;
+};
 
 export type BundlerOptions = {
   bundlerUrl?: string;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces changes to make the `chain` parameter optional for smart wallet functionalities, enhancing flexibility in smart account integration. It also updates related tests and documentation to reflect these changes.

### Detailed summary
- Updated `ConnectButton` to make `chain` optional in `smartWalletOptions`.
- Modified type definitions for `SmartWalletOptions` and `SmartAccountOptions` to allow optional `chain`.
- Adjusted logic in several functions to handle cases where `chain` is undefined.
- Updated tests to validate behavior with default chain settings.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->