### PR TITLE
[SDK]Fix: use base autoconnect in wagmi adapter

### DIFF
--- a/.changeset/four-ties-cough.md
+++ b/.changeset/four-ties-cough.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/wagmi-adapter": minor
+---
+
+Accept url token parameters on autoconnection

--- a/packages/wagmi-adapter/package.json
+++ b/packages/wagmi-adapter/package.json
@@ -1,58 +1,55 @@
 {
-  "name": "@thirdweb-dev/wagmi-adapter",
-  "version": "0.1.9",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/thirdweb-dev/js.git#main"
-  },
-  "license": "Apache-2.0",
-  "bugs": {
-    "url": "https://github.com/thirdweb-dev/js/issues"
-  },
-  "author": "thirdweb eng <eng@thirdweb.com>",
-  "type": "module",
-  "main": "./dist/cjs/exports/thirdweb.js",
-  "module": "./dist/esm/exports/thirdweb.js",
-  "types": "./dist/types/exports/thirdweb.d.ts",
-  "typings": "./dist/types/exports/thirdweb.d.ts",
-  "exports": {
-    ".": {
-      "types": "./dist/types/exports/thirdweb.d.ts",
-      "import": "./dist/esm/exports/thirdweb.js",
-      "default": "./dist/cjs/exports/thirdweb.js"
-    },
-    "./package.json": "./package.json"
-  },
-  "files": [
-    "dist/*",
-    "src/*"
-  ],
-  "devDependencies": {
-    "@wagmi/core": "2.16.0",
-    "rimraf": "6.0.1",
-    "thirdweb": "workspace:*"
-  },
-  "peerDependencies": {
-    "@wagmi/core": "^2.16.0",
-    "thirdweb": "^5",
-    "typescript": ">=5.0.4"
-  },
-  "peerDependenciesMeta": {
-    "typescript": {
-      "optional": true
-    }
-  },
-  "scripts": {
-    "format": "biome format ./src --write",
-    "lint": "biome check ./src",
-    "fix": "biome check ./src --fix",
-    "build": "pnpm clean && pnpm build:cjs && pnpm build:esm && pnpm build:types",
-    "build:cjs": "tsc --project ./tsconfig.build.json --module commonjs --outDir ./dist/cjs --verbatimModuleSyntax false && printf '{\"type\":\"commonjs\"}' > ./dist/cjs/package.json",
-    "build:esm": "tsc --project ./tsconfig.build.json --module es2020 --outDir ./dist/esm && printf '{\"type\": \"module\",\"sideEffects\":false}' > ./dist/esm/package.json",
-    "build:types": "tsc --project ./tsconfig.build.json --module esnext --declarationDir ./dist/types --emitDeclarationOnly --declaration --declarationMap",
-    "clean": "rimraf dist"
-  },
-  "engines": {
-    "node": ">=18"
-  }
+	"name": "@thirdweb-dev/wagmi-adapter",
+	"version": "0.1.9",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/thirdweb-dev/js.git#main"
+	},
+	"license": "Apache-2.0",
+	"bugs": {
+		"url": "https://github.com/thirdweb-dev/js/issues"
+	},
+	"author": "thirdweb eng <eng@thirdweb.com>",
+	"type": "module",
+	"main": "./dist/cjs/exports/thirdweb.js",
+	"module": "./dist/esm/exports/thirdweb.js",
+	"types": "./dist/types/exports/thirdweb.d.ts",
+	"typings": "./dist/types/exports/thirdweb.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/types/exports/thirdweb.d.ts",
+			"import": "./dist/esm/exports/thirdweb.js",
+			"default": "./dist/cjs/exports/thirdweb.js"
+		},
+		"./package.json": "./package.json"
+	},
+	"files": ["dist/*", "src/*"],
+	"devDependencies": {
+		"@wagmi/core": "2.16.0",
+		"rimraf": "6.0.1",
+		"thirdweb": "workspace:*"
+	},
+	"peerDependencies": {
+		"@wagmi/core": "^2.16.0",
+		"thirdweb": "^5.85.0",
+		"typescript": ">=5.0.4"
+	},
+	"peerDependenciesMeta": {
+		"typescript": {
+			"optional": true
+		}
+	},
+	"scripts": {
+		"format": "biome format ./src --write",
+		"lint": "biome check ./src",
+		"fix": "biome check ./src --fix",
+		"build": "pnpm clean && pnpm build:cjs && pnpm build:esm && pnpm build:types",
+		"build:cjs": "tsc --project ./tsconfig.build.json --module commonjs --outDir ./dist/cjs --verbatimModuleSyntax false && printf '{\"type\":\"commonjs\"}' > ./dist/cjs/package.json",
+		"build:esm": "tsc --project ./tsconfig.build.json --module es2020 --outDir ./dist/esm && printf '{\"type\": \"module\",\"sideEffects\":false}' > ./dist/esm/package.json",
+		"build:types": "tsc --project ./tsconfig.build.json --module esnext --declarationDir ./dist/types --emitDeclarationOnly --declaration --declarationMap",
+		"clean": "rimraf dist"
+	},
+	"engines": {
+		"node": ">=18"
+	}
 }

--- a/packages/wagmi-adapter/src/connector.ts
+++ b/packages/wagmi-adapter/src/connector.ts
@@ -1,6 +1,7 @@
 import { type CreateConnectorFn, createConnector } from "@wagmi/core";
 import type { Prettify } from "@wagmi/core/chains";
 import { type ThirdwebClient, defineChain, getAddress } from "thirdweb";
+import { autoConnect } from "thirdweb/wallets";
 import {
   EIP1193,
   type InAppWalletConnectionOptions,
@@ -136,9 +137,10 @@ export function inAppWalletConnector(
       const lastChainId = await config.storage?.getItem("tw.lastChainId");
       const chain = defineChain(params?.chainId || lastChainId || 1);
       if (!wallet.getAccount()) {
-        await wallet.autoConnect({
+        await autoConnect({
           client,
           chain,
+          wallets: [wallet],
         });
       }
       return EIP1193.toProvider({


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the `@thirdweb-dev/wagmi-adapter` by adding support for accepting URL token parameters during auto-connection and updating the `autoConnect` function usage.

### Detailed summary
- Added support for URL token parameters in auto-connection.
- Updated the usage of `autoConnect` in `packages/wagmi-adapter/src/connector.ts`.
- Maintained the existing `package.json` structure while ensuring dependencies and scripts are preserved.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->