### PR TITLE
[Dashboard] fix: handle unreachable engine instances

### DIFF
--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/(instance)/[engineId]/layout.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/(instance)/[engineId]/layout.tsx
@@ -89,7 +89,15 @@ function EngineInstanceLayoutContent(props: {
       );
     }
 
-    if (permission.status === 401 || permission.status === 500) {
+    if (permission.status === 500) {
+      return (
+        <EngineErrorPage rootPath={rootPath}>
+          <p> Engine Instance Could Not Be Reached </p>
+        </EngineErrorPage>
+      );
+    }
+
+    if (permission.status === 401) {
       return (
         <EngineErrorPage rootPath={rootPath}>
           <div>

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/_utils/getEngineAccessPermission.ts
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/_utils/getEngineAccessPermission.ts
@@ -2,16 +2,23 @@ export async function getEngineAccessPermission(params: {
   authToken: string;
   instanceUrl: string;
 }) {
-  const res = await fetch(`${params.instanceUrl}auth/permissions/get-all`, {
-    method: "GET",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${params.authToken}`,
-    },
-  });
+  try {
+    const res = await fetch(`${params.instanceUrl}auth/permissions/get-all`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${params.authToken}`,
+      },
+    });
 
-  return {
-    ok: res.ok, // has access if this is true
-    status: res.status,
-  };
+    return {
+      ok: res.ok, // has access if this is true
+      status: res.status,
+    };
+  } catch {
+    return {
+      ok: false,
+      status: 500,
+    };
+  }
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on improving error handling for engine instance permissions in the `layout.tsx` and `getEngineAccessPermission.ts` files. It modifies how errors are returned and displayed to enhance user experience when accessing engine instances.

### Detailed summary
- In `layout.tsx`, the condition for displaying the error page for status `401` is separated from `500`.
- A new error page is returned for status `500` with a custom message.
- In `getEngineAccessPermission.ts`, a `try-catch` block is added around the fetch call to handle potential errors.
- In case of an error, it now returns an object with `ok: false` and `status: 500`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->