### PR TITLE
fix: corrected comment to reflect actual changes merge-queue

### DIFF
--- a/scripts/pre-nightly.mjs
+++ b/scripts/pre-nightly.mjs
@@ -3,7 +3,7 @@ import fs from "node:fs";
 const changesetsConfig = JSON.parse(
   fs.readFileSync("./.changeset/config.json", "utf8"),
 );
-// add useCalculatedVersion: true to the config
+// enable useCalculatedVersion in the snapshot configuration
 const nightlyChangesetsConfig = {
   ...changesetsConfig,
   snapshot: { ...changesetsConfig.snapshot, useCalculatedVersion: true },


### PR DESCRIPTION
I noticed that the comment in the code wasn't accurate. The `useCalculatedVersion` property is added to the `snapshot` object, not the root of the configuration.

This update fixes the comment to better reflect where the change is applied.  


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the configuration for nightly changesets by enabling the `useCalculatedVersion` feature in the snapshot configuration.

### Detailed summary
- Changed comment from "// add useCalculatedVersion: true to the config" to "// enable useCalculatedVersion in the snapshot configuration".
- Added `useCalculatedVersion: true` to the `snapshot` property in `nightlyChangesetsConfig`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->