### PR TITLE
[SDK] Fix: Do not remove chain listener on disconnect

### DIFF
--- a/.changeset/fuzzy-ants-laugh.md
+++ b/.changeset/fuzzy-ants-laugh.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fixes issue with chain switching breaking after disconnect

--- a/packages/thirdweb/src/extensions/erc1155/write/sigMint1155.test.ts
+++ b/packages/thirdweb/src/extensions/erc1155/write/sigMint1155.test.ts
@@ -11,7 +11,7 @@ import {
   type ThirdwebContract,
   getContract,
 } from "../../../contract/contract.js";
-import { sendTransaction } from "../../../transaction/actions/send-transaction.js";
+import { sendAndConfirmTransaction } from "../../../transaction/actions/send-and-confirm-transaction.js";
 import { toHex } from "../../../utils/encoding/hex.js";
 import { deployERC20Contract } from "../../prebuilts/deploy-erc20.js";
 import { deployERC1155Contract } from "../../prebuilts/deploy-erc1155.js";
@@ -76,7 +76,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("generateMintSignature1155", () => {
       payload,
       signature,
     });
-    const { transactionHash } = await sendTransaction({
+    const { transactionHash } = await sendAndConfirmTransaction({
       transaction,
       account: TEST_ACCOUNT_A,
     });
@@ -107,7 +107,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("generateMintSignature1155", () => {
       payload,
       signature,
     });
-    const { transactionHash } = await sendTransaction({
+    const { transactionHash } = await sendAndConfirmTransaction({
       transaction,
       account: TEST_ACCOUNT_A,
     });
@@ -153,7 +153,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("generateMintSignature1155", () => {
       payload,
       signature,
     });
-    const { transactionHash } = await sendTransaction({
+    const { transactionHash } = await sendAndConfirmTransaction({
       transaction,
       account: TEST_ACCOUNT_A,
     });

--- a/packages/thirdweb/src/wallets/create-wallet.ts
+++ b/packages/thirdweb/src/wallets/create-wallet.ts
@@ -190,10 +190,7 @@ export function createWallet<const ID extends WalletId>(
       const emitter = createWalletEmitter<ID>();
       let account: Account | undefined = undefined;
       let chain: Chain | undefined = undefined;
-
-      const unsubscribeChain = emitter.subscribe("chainChanged", (newChain) => {
-        chain = newChain;
-      });
+      let unsubscribeChain: (() => void) | undefined = undefined;
 
       function reset() {
         account = undefined;
@@ -204,7 +201,7 @@ export function createWallet<const ID extends WalletId>(
 
       const unsubscribeDisconnect = emitter.subscribe("disconnect", () => {
         reset();
-        unsubscribeChain();
+        unsubscribeChain?.();
         unsubscribeDisconnect();
       });
 
@@ -263,6 +260,9 @@ export function createWallet<const ID extends WalletId>(
             chain = connectedChain;
             handleDisconnect = doDisconnect;
             handleSwitchChain = doSwitchChain;
+            unsubscribeChain = emitter.subscribe("chainChanged", (newChain) => {
+              chain = newChain;
+            });
             trackConnect({
               client: options.client,
               walletType: id,
@@ -377,6 +377,9 @@ export function createWallet<const ID extends WalletId>(
             chain = connectedChain;
             handleDisconnect = doDisconnect;
             handleSwitchChain = doSwitchChain;
+            unsubscribeChain = emitter.subscribe("chainChanged", (newChain) => {
+              chain = newChain;
+            });
             trackConnect({
               client: options.client,
               walletType: id,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on fixing issues related to chain switching in the `thirdweb` wallet implementation and updating transaction handling in `sigMint1155` tests.

### Detailed summary
- Updated `unsubscribeChain` to be optional and added safe invocation with `?.`
- Replaced `sendTransaction` with `sendAndConfirmTransaction` in `sigMint1155` tests.
- Enhanced chain change handling by re-subscribing to `chainChanged` events.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->