### PR TITLE
add connect/pay to framer rewrites

### DIFF
--- a/apps/dashboard/framer-rewrites.js
+++ b/apps/dashboard/framer-rewrites.js
@@ -9,6 +9,7 @@ module.exports = [
   // -- connect
   "/connect",
   "/connect/sign-in",
+  "/connect/pay",
   // -- nebula
   "/nebula",
   // --insight


### PR DESCRIPTION
closes: CORE-708

### TL;DR
Added `/connect/pay` route to Framer rewrites

### What changed?
Added a new route `/connect/pay` to the list of Framer rewrites in the dashboard application

### How to test?
1. Navigate to `/connect/pay` in the dashboard
2. Verify the route resolves correctly
3. Ensure the page loads without any routing errors

### Why make this change?
To enable proper routing and rendering of the new payment page in the Connect section of the dashboard

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying the routing paths in the `apps/dashboard/framer-rewrites.js` file by adding a new path and adjusting existing ones.

### Detailed summary
- Added the path `"/connect/pay"` to the routing.
- Retained the existing paths `"/connect"` and `"/connect/sign-in"`.
- Kept the path `"/nebula"` unchanged.
- Removed the comment `// --insight`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->