### PR TITLE
[TOOL-3156] Dashboard: Fix localhost engine not loading, fetch engine permission on client side

### DIFF
--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/(instance)/[engineId]/_components/EnsureEnginePermission.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/(instance)/[engineId]/_components/EnsureEnginePermission.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import type { EngineInstance } from "@3rdweb-sdk/react/hooks/useEngine";
+import { useQuery } from "@tanstack/react-query";
+import type React from "react";
+import GenericLoadingPage from "../../../../ecosystem/loading";
+import { getEngineAccessPermission } from "../../../_utils/getEngineAccessPermission";
+import { EngineErrorPage } from "./EngineErrorPage";
+
+export function EnsureEnginePermission(props: {
+  engineId: string;
+  accountId: string;
+  authToken: string;
+  children: React.ReactNode;
+  teamSlug: string;
+  instance: EngineInstance;
+}) {
+  const { instance } = props;
+  const rootPath = `/team/${props.teamSlug}/~/engine`;
+
+  const permissionQuery = useQuery({
+    queryKey: [
+      "engine-permission",
+      {
+        instanceUrl: instance.url,
+        authToken: props.authToken,
+      },
+    ],
+    queryFn: () => {
+      const url = instance.url;
+      if (!url) {
+        throw new Error();
+      }
+
+      return getEngineAccessPermission({
+        authToken: props.authToken,
+        instanceUrl: url,
+      });
+    },
+    retry: false,
+  });
+
+  if (permissionQuery.isPending) {
+    return <GenericLoadingPage />;
+  }
+
+  if (!permissionQuery.data) {
+    return (
+      <EngineErrorPage rootPath={rootPath}>
+        Failed to verify access to engine instance
+      </EngineErrorPage>
+    );
+  }
+
+  const permission = permissionQuery.data;
+
+  if (!permission.ok) {
+    if (permission.status === 404) {
+      return (
+        <EngineErrorPage rootPath={rootPath}>
+          <p> Engine instance not found </p>
+        </EngineErrorPage>
+      );
+    }
+
+    if (permission.fetchFailed) {
+      return (
+        <EngineErrorPage rootPath={rootPath}>
+          <p> Engine instance could not be reached </p>
+        </EngineErrorPage>
+      );
+    }
+
+    if (permission.status === 401 || permission.status === 500) {
+      return (
+        <EngineErrorPage rootPath={rootPath}>
+          <div>
+            <p>You are not an admin for this Engine instance. </p>
+            <p> Contact the owner to add your wallet as an admin</p>
+          </div>
+        </EngineErrorPage>
+      );
+    }
+  }
+
+  return <div>{props.children}</div>;
+}

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/(instance)/[engineId]/layout.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/(instance)/[engineId]/layout.tsx
@@ -7,10 +7,10 @@ import Link from "next/link";
 import { getValidAccount } from "../../../../../../../account/settings/getAccount";
 import { getAuthToken } from "../../../../../../../api/lib/getAuthToken";
 import { loginRedirect } from "../../../../../../../login/loginRedirect";
-import { getEngineAccessPermission } from "../../_utils/getEngineAccessPermission";
 import { getEngineInstance } from "../../_utils/getEngineInstance";
 import { EngineErrorPage } from "./_components/EngineErrorPage";
 import { EngineSidebarLayout } from "./_components/EnginePageLayout";
+import { EnsureEnginePermission } from "./_components/EnsureEnginePermission";
 import { EngineVersionBadge } from "./_components/version";
 
 export default async function Layout(props: {
@@ -49,75 +49,25 @@ export default async function Layout(props: {
     );
   }
 
-  const permission = await getEngineAccessPermission({
-    authToken,
-    instanceUrl: instance.url,
-  });
-
   return (
     <EngineSidebarLayout engineId={params.engineId} teamSlug={params.team_slug}>
-      <EngineInstanceLayoutContent
+      <EnsureEnginePermission
+        teamSlug={params.team_slug}
+        accountId={account.id}
+        authToken={authToken}
+        engineId={params.engineId}
         instance={instance}
-        permission={permission}
-        rootPath={engineRootLayoutPath}
-        team_slug={params.team_slug}
       >
-        {props.children}
-      </EngineInstanceLayoutContent>
+        <div>
+          <EngineInstanceHeader
+            instance={instance}
+            rootPath={engineRootLayoutPath}
+            teamSlug={params.team_slug}
+          />
+          {props.children}
+        </div>
+      </EnsureEnginePermission>
     </EngineSidebarLayout>
-  );
-}
-
-function EngineInstanceLayoutContent(props: {
-  permission: {
-    ok: boolean;
-    status: number;
-  };
-  instance: EngineInstance;
-  rootPath: string;
-  children: React.ReactNode;
-  team_slug: string;
-}) {
-  const { instance, permission, rootPath, team_slug } = props;
-
-  if (!permission.ok) {
-    if (permission.status === 404) {
-      return (
-        <EngineErrorPage rootPath={rootPath}>
-          <p> Engine Instance Not Found </p>
-        </EngineErrorPage>
-      );
-    }
-
-    if (permission.status === 500) {
-      return (
-        <EngineErrorPage rootPath={rootPath}>
-          <p> Engine Instance Could Not Be Reached </p>
-        </EngineErrorPage>
-      );
-    }
-
-    if (permission.status === 401) {
-      return (
-        <EngineErrorPage rootPath={rootPath}>
-          <div>
-            <p>You are not an admin for this Engine instance. </p>
-            <p> Contact the owner to add your wallet as an admin</p>
-          </div>
-        </EngineErrorPage>
-      );
-    }
-  }
-
-  return (
-    <div>
-      <EngineInstanceHeader
-        instance={instance}
-        rootPath={rootPath}
-        teamSlug={team_slug}
-      />
-      {props.children}
-    </div>
   );
 }
 

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/_utils/getEngineAccessPermission.ts
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/_utils/getEngineAccessPermission.ts
@@ -1,9 +1,17 @@
+"use client";
+
+// can not fetch engine permission on server - instance url can be localhost url
+
 export async function getEngineAccessPermission(params: {
   authToken: string;
   instanceUrl: string;
 }) {
   try {
-    const res = await fetch(`${params.instanceUrl}auth/permissions/get-all`, {
+    const instanceUrl = params.instanceUrl.endsWith("/")
+      ? params.instanceUrl
+      : `${params.instanceUrl}/`;
+
+    const res = await fetch(`${instanceUrl}auth/permissions/get-all`, {
       method: "GET",
       headers: {
         "Content-Type": "application/json",
@@ -19,6 +27,7 @@ export async function getEngineAccessPermission(params: {
     return {
       ok: false,
       status: 500,
+      fetchFailed: true,
     };
   }
 }

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/_utils/getEngineInstancePageMeta.ts
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/_utils/getEngineInstancePageMeta.ts
@@ -30,5 +30,5 @@ export async function engineInstancePageHandler(params: {
     notFound();
   }
 
-  return { instance, authToken };
+  return { instance, authToken, account };
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR enhances engine instance permission handling by adding an `account` return value, improving error handling, and introducing the `EnsureEnginePermission` component to manage permissions more effectively.

### Detailed summary
- Added `account` to the return object in `getEngineInstancePageMeta.ts`.
- Updated `getEngineAccessPermission` to handle URL formatting and added `fetchFailed` to error responses.
- Introduced `EnsureEnginePermission` component to manage engine access permissions in the UI.
- Removed direct permission checks from the `Layout` function, delegating to `EnsureEnginePermission`.
- Simplified error handling in the UI for better user feedback.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->