### PR TITLE
[SDK] Fix: Opt out of 1559 on lumia mainnet

### DIFF
--- a/packages/thirdweb/src/gas/fee-data.ts
+++ b/packages/thirdweb/src/gas/fee-data.ts
@@ -39,6 +39,7 @@ const FORCE_GAS_PRICE_CHAIN_IDS = [
   2442, // Polygon zkEVM Cardona Testnet
   1942999413, // Humanity Testnet
   1952959480, // Lumia Testnet
+  994873017, // Lumia Mainnet
 ];
 
 /**


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a new network entry for the `Lumia Mainnet` in the `fee-data.ts` file, enhancing the gas fee data for this specific blockchain environment.

### Detailed summary
- Added `Lumia Mainnet` entry to the list of networks in `fee-data.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->