### PR TITLE
[SDK] fix: Improve smart wallet signature verification

### DIFF
--- a/.changeset/kind-beers-fold.md
+++ b/.changeset/kind-beers-fold.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Always use 712 signature verification if the smart account is already deployed

--- a/apps/playground-web/src/components/account-abstraction/sponsored-tx-zksync.tsx
+++ b/apps/playground-web/src/components/account-abstraction/sponsored-tx-zksync.tsx
@@ -1,5 +1,4 @@
 "use client";
-
 import { useState } from "react";
 import { getContract } from "thirdweb";
 import { zkSyncSepolia } from "thirdweb/chains";
@@ -15,6 +14,12 @@ import { shortenHex } from "thirdweb/utils";
 import { THIRDWEB_CLIENT } from "../../lib/client";
 import { WALLETS } from "../../lib/constants";
 
+// const chain = abstractTestnet;
+// const editionDropContract = getContract({
+//   client: THIRDWEB_CLIENT,
+//   address: "0x8A24a7Df38fA5fCCcFD1259e90Fb6996fDdfcADa",
+//   chain,
+// });
 const chain = zkSyncSepolia;
 const editionDropContract = getContract({
   client: THIRDWEB_CLIENT,
@@ -83,6 +88,7 @@ export function SponsoredTxZksyncPreview() {
                   metadata: nft?.metadata,
                 }}
                 onError={(error) => {
+                  console.error("error", error);
                   alert(`Error: ${error.message}`);
                 }}
                 onClick={() => {

--- a/packages/thirdweb/src/wallets/smart/lib/signing.ts
+++ b/packages/thirdweb/src/wallets/smart/lib/signing.ts
@@ -268,7 +268,7 @@ async function checkFor712Factory({
 }
 
 /**
- * Deployes a smart account via a dummy transaction.
+ * Deployes a smart account via a dummy transaction. If the account is already deployed, this will do nothing.
  *
  * @param args - Arguments for the deployment.
  * @param args.smartAccount - The smart account to deploy.


### PR DESCRIPTION
FIxes TOOL-3138

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the signature verification process for smart accounts, specifically ensuring that the `712` signature verification is used when the smart account is already deployed. It also includes minor adjustments to error handling and code comments.

### Detailed summary
- Updated documentation in `packages/thirdweb/src/wallets/smart/lib/signing.ts` to clarify behavior when deploying smart accounts.
- Added logic in `packages/thirdweb/src/auth/verify-hash.ts` to check if a contract is deployed before verifying the signature.
- Improved error handling in `apps/playground-web/src/components/account-abstraction/sponsored-tx-zksync.tsx` by logging errors to the console.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->