### PR TITLE
[service-utils] usage_v2 accepts a project_id field

### DIFF
--- a/.changeset/friendly-lamps-think.md
+++ b/.changeset/friendly-lamps-think.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+Export usageV2 utils

--- a/.changeset/friendly-lamps-think.md
+++ b/.changeset/friendly-lamps-think.md
@@ -2,4 +2,4 @@
 "@thirdweb-dev/service-utils": patch
 ---
 
-Export usageV2 utils
+Export usageV2 util functions

--- a/packages/service-utils/src/cf-worker/index.ts
+++ b/packages/service-utils/src/cf-worker/index.ts
@@ -11,6 +11,7 @@ import type { AuthorizationResult } from "../core/authorize/types.js";
 import type { CoreAuthInput } from "../core/types.js";
 
 export * from "./usage.js";
+export * from "./usageV2.js";
 export * from "../core/services.js";
 export * from "../core/rateLimit/index.js";
 

--- a/packages/service-utils/src/cf-worker/index.ts
+++ b/packages/service-utils/src/cf-worker/index.ts
@@ -12,6 +12,7 @@ import type { CoreAuthInput } from "../core/types.js";
 
 export * from "./usage.js";
 export * from "./usageV2.js";
+export * from "../core/usageV2.js";
 export * from "../core/services.js";
 export * from "../core/rateLimit/index.js";
 

--- a/packages/service-utils/src/core/usageV2.ts
+++ b/packages/service-utils/src/core/usageV2.ts
@@ -21,9 +21,9 @@ export interface UsageV2Event {
    */
   team_id: string;
   /**
-   * The client ID, if available.
+   * The project ID, if available.
    */
-  client_id?: string;
+  project_id?: string;
   /**
    * The SDK name, if available.
    */

--- a/packages/service-utils/src/node/index.ts
+++ b/packages/service-utils/src/node/index.ts
@@ -12,9 +12,12 @@ import type {
 } from "../core/authorize/index.js";
 import type { AuthorizationResult } from "../core/authorize/types.js";
 import type { CoreAuthInput } from "../core/types.js";
+
+export * from "./usageV2.js";
 export * from "../core/usage.js";
 export * from "../core/rateLimit/index.js";
 export * from "../core/services.js";
+
 type NodeServiceConfig = CoreServiceConfig;
 
 export type AuthInput = CoreAuthInput & {

--- a/packages/service-utils/src/node/index.ts
+++ b/packages/service-utils/src/node/index.ts
@@ -15,6 +15,7 @@ import type { CoreAuthInput } from "../core/types.js";
 
 export * from "./usageV2.js";
 export * from "../core/usage.js";
+export * from "../core/usageV2.js";
 export * from "../core/rateLimit/index.js";
 export * from "../core/services.js";
 


### PR DESCRIPTION
Fixes: CORE-713

<!-- start pr-codex -->

## PR-Codex overview
This PR primarily focuses on updating the `usageV2` structure by renaming a property and ensuring its export across various modules.

### Detailed summary
- In `packages/service-utils/src/core/usageV2.ts`:
  - Renamed property `client_id` to `project_id`.
  
- In `packages/service-utils/src/cf-worker/index.ts`:
  - Added export for `../core/usageV2.js`.

- In `packages/service-utils/src/node/index.ts`:
  - Added export for `../core/usageV2.js`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->