### PR TITLE
[service-utils] Replace client_id with project_id in usage_v2

### DIFF
--- a/.changeset/short-carrots-smile.md
+++ b/.changeset/short-carrots-smile.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+[service-utils] replace client_id with project_id in usage_v2

--- a/packages/service-utils/src/node/usageV2.ts
+++ b/packages/service-utils/src/node/usageV2.ts
@@ -90,7 +90,7 @@ export class UsageV2Producer {
         team_id: event.team_id.startsWith("team_")
           ? event.team_id.slice(5)
           : event.team_id,
-        client_id: event.client_id,
+        project_id: event.project_id,
         sdk_name: event.sdk_name,
         sdk_platform: event.sdk_platform,
         sdk_version: event.sdk_version,


### PR DESCRIPTION
Also part of CORE-713.
This PR adds the changeset and fixes a build error.

<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `service-utils` package by replacing the usage of `client_id` with `project_id` in the `usage_v2` function.

### Detailed summary
- In the file `packages/service-utils/src/node/usageV2.ts`:
  - Replaced the line defining `client_id` with `project_id`:
    - From `client_id: event.client_id` to `project_id: event.project_id`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->