### PR TITLE
[SDK] Feature: add flag for skipping default ecosystem info fetch

### DIFF
--- a/.changeset/neat-poems-impress.md
+++ b/.changeset/neat-poems-impress.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Added optional flag to ecosystem wallet creation for skipping fetching of default ecosystem info defined in the dashboard.

--- a/packages/thirdweb/src/wallets/ecosystem/types.ts
+++ b/packages/thirdweb/src/wallets/ecosystem/types.ts
@@ -23,6 +23,10 @@ export type EcosystemWalletCreationOptions = {
    * The partnerId of the ecosystem wallet to connect to
    */
   partnerId?: string;
+  /**
+   * Optional flag to skip fetching and usage of ecosystem's info default account abstraction settings
+   */
+  skipEcosystemInfo?: boolean;
 };
 
 export type EcosystemWalletConnectionOptions = InAppWalletConnectionOptions;

--- a/packages/thirdweb/src/wallets/in-app/core/wallet/in-app-core.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/wallet/in-app-core.ts
@@ -78,7 +78,7 @@ export function createInAppWallet(args: {
         ecosystem,
       );
 
-      if (ecosystem) {
+      if (ecosystem && !createOptions?.skipEcosystemInfo) {
         const ecosystemOptions = await getEcosystemInfo(ecosystem.id);
         const smartAccountOptions = ecosystemOptions?.smartAccountOptions;
         if (smartAccountOptions) {
@@ -132,7 +132,7 @@ export function createInAppWallet(args: {
         ecosystem,
       );
 
-      if (ecosystem) {
+      if (ecosystem && !createOptions?.skipEcosystemInfo) {
         const ecosystemOptions = await getEcosystemInfo(ecosystem.id);
         const smartAccountOptions = ecosystemOptions?.smartAccountOptions;
         if (smartAccountOptions) {
@@ -206,7 +206,7 @@ export function createInAppWallet(args: {
           ecosystem,
         );
 
-        if (ecosystem) {
+        if (ecosystem && !createOptions?.skipEcosystemInfo) {
           const ecosystemOptions = await getEcosystemInfo(ecosystem.id);
           const smartAccountOptions = ecosystemOptions?.smartAccountOptions;
           if (smartAccountOptions) {

--- a/packages/thirdweb/src/wallets/in-app/core/wallet/types.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/wallet/types.ts
@@ -87,5 +87,9 @@ export type InAppWalletCreationOptions =
        * Whether to hide the private key export button in the Connect Modal
        */
       hidePrivateKeyExport?: boolean;
+      /**
+       * Optional flag to skip fetching and usage of ecosystem's info default account abstraction settings
+       */
+      skipEcosystemInfo?: boolean;
     }
   | undefined;

--- a/packages/thirdweb/src/wallets/in-app/web/ecosystem.ts
+++ b/packages/thirdweb/src/wallets/in-app/web/ecosystem.ts
@@ -67,6 +67,7 @@ export function ecosystemWallet(
         options: [], // controlled by ecosystem
       },
       partnerId: ecosystem.partnerId,
+      skipEcosystemInfo: createOptions?.skipEcosystemInfo,
     },
     connectorFactory: async (client: ThirdwebClient) => {
       const { InAppWebConnector } = await import("./lib/web-connector.js");


### PR DESCRIPTION
If an ecosystem has account abstraction settings turned on in the Thirdweb dashboard, there's currently no way through the SDK to allow users to log into their ecosystem wallets - they'll always be wrapped into their smart wallets for chains that use an account factory strategy (e.g., Arbitrum Sepolia chain ID 421614). We have a need to allow ecosystem wallet access for transferring assets that may have been mistakenly sent to that address.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces an optional flag for ecosystem wallet creation that allows users to skip fetching default ecosystem information. This enhances flexibility in wallet creation by providing developers with more control over the data retrieval process.

### Detailed summary
- Added `skipEcosystemInfo` flag in `types.ts` to skip fetching ecosystem info.
- Updated `ecosystem.ts` to pass `skipEcosystemInfo` to wallet creation options.
- Modified `in-app-core.ts` to conditionally fetch ecosystem info based on `skipEcosystemInfo`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->