### PR TITLE
[SDK] chore: Increase CJS bundle size limit to 130kb

### DIFF
--- a/packages/thirdweb/.size-limit.json
+++ b/packages/thirdweb/.size-limit.json
@@ -8,7 +8,7 @@
   {
     "name": "thirdweb (cjs)",
     "path": "./dist/cjs/exports/thirdweb.js",
-    "limit": "121 kB"
+    "limit": "130 kB"
   },
   {
     "name": "thirdweb (minimal + tree-shaking)",


### PR DESCRIPTION
---
title: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"
---

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer
Anything important to call out? Be sure to also clarify these in your comments.

## How to test
Unit tests, playground, etc.



<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the size limit for the `thirdweb (cjs)` build in the `.size-limit.json` configuration file.

### Detailed summary
- Updated the `limit` for `thirdweb (cjs)` from `121 kB` to `130 kB` in the `.size-limit.json` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->