### PR TITLE
[TOOL-3241] Fix previous account shown after logging out in onboarding flow

### DIFF
--- a/apps/dashboard/src/app/login/onboarding/General.tsx
+++ b/apps/dashboard/src/app/login/onboarding/General.tsx
@@ -14,12 +14,14 @@ type OnboardingGeneralProps = {
   account: Account;
   onSave: (email: string) => void;
   onDuplicate: (email: string) => void;
+  onLogout: () => void;
 };
 
 export const OnboardingGeneral: React.FC<OnboardingGeneralProps> = ({
   account,
   onSave,
   onDuplicate,
+  onLogout,
 }) => {
   const [existing, setExisting] = useState(false);
   const activeWallet = useActiveWallet();
@@ -27,6 +29,7 @@ export const OnboardingGeneral: React.FC<OnboardingGeneralProps> = ({
 
   async function handleLogout() {
     await doLogout();
+    onLogout();
     if (activeWallet) {
       disconnect(activeWallet);
     }

--- a/apps/dashboard/src/app/login/onboarding/on-boarding-ui.client.tsx
+++ b/apps/dashboard/src/app/login/onboarding/on-boarding-ui.client.tsx
@@ -21,6 +21,7 @@ type OnboardingScreen =
 function OnboardingUI(props: {
   account: Account;
   onComplete: () => void;
+  onLogout: () => void;
   // path to redirect from stripe
   redirectPath: string;
   redirectToCheckout: RedirectBillingCheckoutAction;
@@ -68,6 +69,7 @@ function OnboardingUI(props: {
       {screen.id === "onboarding" && (
         <OnboardingGeneral
           account={account}
+          onLogout={props.onLogout}
           onSave={(email) => {
             setUpdatedEmail(email);
             setScreen({


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces the `onLogout` function into the onboarding process and modifies the login page to handle user login and logout more effectively, ensuring proper screen transitions based on the user's connection status.

### Detailed summary
- Added `onLogout` prop to `OnboardingUI` and `OnboardingGeneral` components.
- Implemented `handleLogout` function to call `onLogout` after logging out.
- Enhanced `PageContent` with an `onLogin` function to manage onboarding and login states.
- Used `useEffect` to handle screen state based on connection status.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->