### PR TITLE
[SDK] fix: Respect chain param in in-app wallet connection

### DIFF
--- a/.changeset/kind-starfishes-sell.md
+++ b/.changeset/kind-starfishes-sell.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Respect passed in chain when connecting to inapp wallet with wallet strategy

--- a/packages/thirdweb/src/wallets/in-app/core/authentication/siwe.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/authentication/siwe.ts
@@ -18,11 +18,11 @@ export async function siweAuthenticate(args: {
   client: ThirdwebClient;
   ecosystem?: Ecosystem;
 }): Promise<AuthStoredTokenWithCookieReturnType> {
-  const { wallet, chain } = args;
+  const { wallet, chain, client, ecosystem } = args;
   // only connect if the wallet doesn't already have an account
   const account =
-    wallet.getAccount() || (await wallet.connect({ client: args.client }));
-  const clientFetch = getClientFetch(args.client, args.ecosystem);
+    wallet.getAccount() || (await wallet.connect({ client, chain }));
+  const clientFetch = getClientFetch(client, ecosystem);
 
   const payload = await (async () => {
     const path = getLoginUrl({


### PR DESCRIPTION
---
title: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"
---

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer
Anything important to call out? Be sure to also clarify these in your comments.

## How to test
Unit tests, playground, etc.



<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the connection process to in-app wallets by ensuring that the passed chain is respected in the wallet strategy.

### Detailed summary
- Added `ecosystem` to the destructured `args` in the function signature.
- Updated the connection logic to use `client` and `chain` from `args`.
- Modified the `clientFetch` call to use `client` and `ecosystem`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->