### PR TITLE
remove growth trial eligibility

### DIFF
--- a/apps/dashboard/src/@/api/team.ts
+++ b/apps/dashboard/src/@/api/team.ts
@@ -25,7 +25,7 @@ export type Team = {
   billingPlan: "pro" | "growth" | "free" | "starter";
   billingStatus: "validPayment" | (string & {}) | null;
   billingEmail: string | null;
-  growthTrialEligible: boolean | null;
+  growthTrialEligible: false;
   enabledScopes: EnabledTeamScope[];
 };
 

--- a/apps/dashboard/src/components/settings/Account/Billing/Pricing.tsx
+++ b/apps/dashboard/src/components/settings/Account/Billing/Pricing.tsx
@@ -57,20 +57,18 @@ export const BillingPricing: React.FC<BillingPricingProps> = ({
   }, [validTeamPlan]);
 
   const growthCardCta: CtaLink | undefined = useMemo(() => {
-    const trialTitle = "Claim your 1-month free";
-
     switch (validTeamPlan) {
       // free > growth
       case "free": {
         return {
-          label: team.growthTrialEligible ? trialTitle : "Get started",
+          label: "Get started",
         };
       }
 
       // starter > growth
       case "starter": {
         return {
-          label: team.growthTrialEligible ? trialTitle : "Upgrade",
+          label: "Upgrade",
         };
       }
 
@@ -87,7 +85,7 @@ export const BillingPricing: React.FC<BillingPricingProps> = ({
         };
       }
     }
-  }, [team, validTeamPlan]);
+  }, [validTeamPlan]);
 
   const proCta: CtaLink | undefined = useMemo(() => {
     // pro > pro
@@ -138,20 +136,16 @@ export const BillingPricing: React.FC<BillingPricingProps> = ({
                 title: growthCardCta.label,
                 tracking: {
                   category: "account",
-                  label: team.growthTrialEligible
-                    ? "claimGrowthTrial"
-                    : "growthPlan",
+                  label: "growthPlan",
                 },
                 variant: "default",
-                hint: team.growthTrialEligible
-                  ? "Your free trial will end after 30 days."
-                  : undefined,
+                hint: undefined,
               }
             : undefined
         }
-        canTrialGrowth={team.growthTrialEligible || false}
+        canTrialGrowth={false}
         // upsell growth plan if user is on free plan
-        highlighted={validTeamPlan === "free"}
+        highlighted={validTeamPlan === "free" || validTeamPlan === "starter"}
         teamSlug={team.slug}
         redirectToCheckout={redirectToCheckout}
       />

--- a/apps/dashboard/src/stories/stubs.ts
+++ b/apps/dashboard/src/stories/stubs.ts
@@ -42,7 +42,7 @@ export function teamStub(id: string, billingPlan: Team["billingPlan"]): Team {
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
     billingEmail: "foo@example.com",
-    growthTrialEligible: true,
+    growthTrialEligible: false,
     enabledScopes: [
       "pay",
       "storage",

--- a/packages/service-utils/src/core/api.ts
+++ b/packages/service-utils/src/core/api.ts
@@ -49,7 +49,7 @@ export type TeamResponse = {
   updatedAt: Date | null;
   billingEmail: string | null;
   billingStatus: "noPayment" | "validPayment" | "invalidPayment" | null;
-  growthTrialEligible: boolean | null;
+  growthTrialEligible: false;
   enabledScopes: ServiceName[];
 };
 


### PR DESCRIPTION
closes: CORE-714

### TL;DR
Removed the Growth plan trial functionality and updated pricing card highlighting

### What changed?
- Changed `growthTrialEligible` type from `boolean | null` to `false`
- Removed trial-related UI elements and messaging from the pricing component
- Added highlighting for starter plan users in the Growth pricing card
- Simplified CTA button labels to "Get started" and "Upgrade"
- Updated tracking labels to remove trial-specific events

### How to test?
1. Visit the billing/pricing page as a free plan user
2. Verify the Growth plan card shows "Get started" without trial messaging
3. Visit as a starter plan user
4. Confirm the Growth plan card shows "Upgrade" without trial messaging
5. Verify both free and starter plan users see the Growth card highlighted

### Why make this change?
To discontinue the Growth plan trial offering and simplify the upgrade path for users on free and starter plans

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `growthTrialEligible` feature across various files, changing its value to `false` and adjusting related logic in the billing settings component.

### Detailed summary
- Set `growthTrialEligible` to `false` in `apps/dashboard/src/stories/stubs.ts`, `apps/dashboard/src/@/api/team.ts`, and `packages/service-utils/src/core/api.ts`.
- Removed conditional labels based on `growthTrialEligible` in `apps/dashboard/src/components/settings/Account/Billing/Pricing.tsx`.
- Adjusted `canTrialGrowth` to always be `false`.
- Updated `highlighted` logic to include `starter` plan in `Pricing.tsx`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->