### PR TITLE
[SDK] fix: Update ecosystem name and admin wallet handling

### DIFF
--- a/apps/playground-web/src/components/in-app-wallet/ecosystem.tsx
+++ b/apps/playground-web/src/components/in-app-wallet/ecosystem.tsx
@@ -11,7 +11,7 @@ const getEcosystem = () => {
     return "ecosystem.catlovers";
   }
   // prod ecosystem
-  return "ecosystem.new-age";
+  return "ecosystem.thirdweb-engs";
 };
 
 export function EcosystemConnectEmbed(

--- a/packages/thirdweb/src/react/core/hooks/wallets/useAdminWallet.ts
+++ b/packages/thirdweb/src/react/core/hooks/wallets/useAdminWallet.ts
@@ -11,7 +11,6 @@ export function useAdminWallet() {
   const activeWallet = useActiveWallet();
   const connectedWallets = useConnectedWallets();
   const adminAccount = activeWallet?.getAdminAccount?.();
-
   if (!adminAccount) {
     // If the active wallet doesn't have an admin account, return the active wallet
     return activeWallet;

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/ManageWalletScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/ManageWalletScreen.tsx
@@ -28,7 +28,8 @@ export function ManageWalletScreen(props: {
   client: ThirdwebClient;
   manageWallet?: ConnectButton_detailsModalOptions["manageWallet"];
 }) {
-  const activeWallet = useAdminWallet();
+  const adminWallet = useAdminWallet();
+  const activeWallet = useActiveWallet();
 
   return (
     <Container
@@ -92,9 +93,9 @@ export function ManageWalletScreen(props: {
           </MenuButton>
 
           {/* Private Key Export (if enabled) */}
-          {activeWallet &&
-            isInAppWallet(activeWallet) &&
-            !activeWallet.getConfig()?.hidePrivateKeyExport && (
+          {adminWallet &&
+            isInAppWallet(adminWallet) &&
+            !adminWallet.getConfig()?.hidePrivateKeyExport && (
               <MenuButton
                 onClick={() => {
                   props.setScreen("private-key");


### PR DESCRIPTION
---
title: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"
---

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer
Anything important to call out? Be sure to also clarify these in your comments.

## How to test
Unit tests, playground, etc.



<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the ecosystem name in the `ecosystem.tsx` file and refactoring wallet-related variables in the `ManageWalletScreen.tsx` to improve clarity and functionality.

### Detailed summary
- Changed the return value in `ecosystem.tsx` from `"ecosystem.new-age"` to `"ecosystem.thirdweb-engs"`.
- Renamed `activeWallet` to `adminWallet` in `ManageWalletScreen.tsx`.
- Introduced `activeWallet` as a new variable using `useActiveWallet()`.
- Updated conditional rendering to use `adminWallet` instead of `activeWallet` for private key export.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->