### PR TITLE
[SDK] fix: Account linking for ecosystem smart wallets

### DIFF
--- a/.changeset/new-maps-enjoy.md
+++ b/.changeset/new-maps-enjoy.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix account linking for ecosystem smart wallets

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/LinkProfileScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/LinkProfileScreen.tsx
@@ -7,6 +7,7 @@ import { isEcosystemWallet } from "../../../../../wallets/ecosystem/is-ecosystem
 import type { Wallet } from "../../../../../wallets/interfaces/wallet.js";
 import type { EcosystemWalletId } from "../../../../../wallets/wallet-types.js";
 import { iconSize } from "../../../../core/design-system/index.js";
+import { useActiveWallet } from "../../../../core/hooks/wallets/useActiveWallet.js";
 import { useActiveWalletChain } from "../../../../core/hooks/wallets/useActiveWalletChain.js";
 import { useAdminWallet } from "../../../../core/hooks/wallets/useAdminWallet.js";
 import EcosystemWalletConnectUI from "../../../wallets/ecosystem/EcosystemWalletConnectUI.js";
@@ -28,20 +29,23 @@ export function LinkProfileScreen(props: {
   client: ThirdwebClient;
   walletConnect: { projectId?: string } | undefined;
 }) {
-  const activeWallet = useAdminWallet();
+  const adminWallet = useAdminWallet();
+  const activeWallet = useActiveWallet();
   const chain = useActiveWalletChain();
   const queryClient = useQueryClient();
 
-  if (!activeWallet) {
+  const wallet = adminWallet || activeWallet;
+
+  if (!wallet) {
     return <LoadingScreen />;
   }
 
-  if (activeWallet.id === "inApp") {
+  if (wallet.id === "inApp") {
     return (
       <Suspense fallback={<LoadingScreen />}>
         <InAppWalletConnectUI
           walletConnect={props.walletConnect}
-          wallet={activeWallet as Wallet<"inApp">}
+          wallet={wallet as Wallet<"inApp">}
           done={() => {
             setTimeout(() => {
               queryClient.invalidateQueries({ queryKey: ["profiles"] });
@@ -63,11 +67,11 @@ export function LinkProfileScreen(props: {
     );
   }
 
-  if (isEcosystemWallet(activeWallet)) {
+  if (isEcosystemWallet(wallet)) {
     return (
       <Suspense fallback={<LoadingScreen />}>
         <EcosystemWalletConnectUI
-          wallet={activeWallet as Wallet<EcosystemWalletId>}
+          wallet={wallet as Wallet<EcosystemWalletId>}
           done={() => {
             setTimeout(() => {
               queryClient.invalidateQueries({ queryKey: ["profiles"] });


### PR DESCRIPTION
---
title: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"
---

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer
Anything important to call out? Be sure to also clarify these in your comments.

## How to test
Unit tests, playground, etc.



<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the account linking for ecosystem smart wallets in the `LinkProfileScreen` component. It updates how active and admin wallets are managed and ensures the correct wallet is used for connecting.

### Detailed summary
- Renamed `activeWallet` to `adminWallet` and used `useActiveWallet` for the active wallet.
- Combined `adminWallet` and `activeWallet` into a single `wallet` variable.
- Updated conditional checks to use the new `wallet` variable.
- Adjusted wallet type casting for `InAppWalletConnectUI` and `EcosystemWalletConnectUI`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->