### PR TITLE
[SDK] fix: Auto-connection of in-app wallets in React Native

### DIFF
--- a/.changeset/soft-camels-beg.md
+++ b/.changeset/soft-camels-beg.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix autoconnection of inapp wallets in react native

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/ManageWalletScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/ManageWalletScreen.tsx
@@ -30,6 +30,7 @@ export function ManageWalletScreen(props: {
 }) {
   const adminWallet = useAdminWallet();
   const activeWallet = useActiveWallet();
+  const wallet = adminWallet || activeWallet;
 
   return (
     <Container
@@ -60,7 +61,7 @@ export function ManageWalletScreen(props: {
           />
 
           {/* Unified Identity */}
-          {typeof activeWallet !== "undefined" &&
+          {typeof wallet !== "undefined" &&
             props.manageWallet?.allowLinkingProfiles !== false && (
               <MenuButton
                 onClick={() => {
@@ -93,9 +94,9 @@ export function ManageWalletScreen(props: {
           </MenuButton>
 
           {/* Private Key Export (if enabled) */}
-          {adminWallet &&
-            isInAppWallet(adminWallet) &&
-            !adminWallet.getConfig()?.hidePrivateKeyExport && (
+          {wallet &&
+            isInAppWallet(wallet) &&
+            !wallet.getConfig()?.hidePrivateKeyExport && (
               <MenuButton
                 onClick={() => {
                   props.setScreen("private-key");

--- a/packages/thirdweb/src/wallets/in-app/web/lib/get-url-token.test.tsx
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/get-url-token.test.tsx
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { getUrlToken } from "./get-url-token.js";
 
-describe("getUrlToken", () => {
+describe.runIf(global.window !== undefined)("getUrlToken", () => {
   let originalLocation: Location;
 
   beforeEach(() => {
@@ -25,20 +25,20 @@ describe("getUrlToken", () => {
   });
 
   it("should return an empty object if not in web context", () => {
-    const originalWindow = window;
+    const originalDocument = document;
     // biome-ignore lint/suspicious/noExplicitAny: Test
-    (global as any).window = undefined;
+    (global as any).document = undefined;
 
     const result = getUrlToken();
     // biome-ignore lint/suspicious/noExplicitAny: Test
-    (global as any).window = originalWindow;
+    (global as any).document = originalDocument;
 
-    expect(result).toEqual({});
+    expect(result).toEqual(undefined);
   });
 
   it("should return an empty object if no parameters are present", () => {
     const result = getUrlToken();
-    expect(result).toEqual({});
+    expect(result).toEqual(undefined);
   });
 
   it("should parse walletId and authResult correctly", () => {

--- a/packages/thirdweb/src/wallets/in-app/web/lib/get-url-token.ts
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/get-url-token.ts
@@ -5,15 +5,17 @@ import type { AuthStoredTokenWithCookieReturnType } from "../../core/authenticat
 /**
  * Checks for an auth token and associated metadata in the current URL
  */
-export function getUrlToken(): {
-  walletId?: WalletId;
-  authResult?: AuthStoredTokenWithCookieReturnType;
-  authProvider?: AuthOption;
-  authCookie?: string;
-} {
-  if (typeof window === "undefined") {
+export function getUrlToken():
+  | {
+      walletId?: WalletId;
+      authResult?: AuthStoredTokenWithCookieReturnType;
+      authProvider?: AuthOption;
+      authCookie?: string;
+    }
+  | undefined {
+  if (typeof document === "undefined") {
     // Not in web
-    return {};
+    return undefined;
   }
 
   const queryString = window.location.search;
@@ -40,5 +42,5 @@ export function getUrlToken(): {
     );
     return { walletId, authResult, authProvider, authCookie };
   }
-  return {};
+  return undefined;
 }


### PR DESCRIPTION
---
title: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"
---

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer
Anything important to call out? Be sure to also clarify these in your comments.

## How to test
Unit tests, playground, etc.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the autoconnection of in-app wallets in React Native by improving the handling of the authentication token retrieval and ensuring compatibility with non-web contexts.

### Detailed summary
- Updated `getUrlToken` to return `undefined` instead of an empty object when not in a web context.
- Introduced a `wallet` variable to unify the management of `adminWallet` and `activeWallet`.
- Adjusted conditions to check for `wallet` instead of `activeWallet`.
- Modified tests for `getUrlToken` to expect `undefined` rather than an empty object.
- Changed the handling of the return values from `getUrlToken` in `autoConnectCore` to use the new structure.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->