### PR TITLE
add billingPlanVersion to TeamResponse

### DIFF
--- a/.changeset/friendly-trainers-taste.md
+++ b/.changeset/friendly-trainers-taste.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+add `billingPlanVersion` to `TeamResponse`

--- a/packages/service-utils/src/core/api.ts
+++ b/packages/service-utils/src/core/api.ts
@@ -45,6 +45,7 @@ export type TeamResponse = {
   slug: string;
   image: string | null;
   billingPlan: "free" | "starter" | "growth" | "pro";
+  billingPlanVersion: number;
   createdAt: Date;
   updatedAt: Date | null;
   billingEmail: string | null;

--- a/packages/service-utils/src/mocks.ts
+++ b/packages/service-utils/src/mocks.ts
@@ -42,6 +42,7 @@ export const validTeamResponse: TeamResponse = {
   createdAt: new Date("2024-06-01"),
   updatedAt: new Date("2024-06-01"),
   billingPlan: "free",
+  billingPlanVersion: 1,
   billingEmail: "test@example.com",
   billingStatus: "noPayment",
   growthTrialEligible: false,


### PR DESCRIPTION
### TL;DR
Added `billingPlanVersion` field to `TeamResponse` type.

### What changed?
Added a new `billingPlanVersion` number field to the `TeamResponse` type definition in the service-utils package.

### How to test?
1. Verify that the `TeamResponse` type includes the `billingPlanVersion` field
2. Ensure the field is properly populated when making API calls that return team data
3. Confirm that existing team-related functionality continues to work as expected

### Why make this change?
To track different versions of billing plans for teams, enabling better management and versioning of billing features across the platform.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the `billingPlanVersion` field to the `TeamResponse` structure and the relevant parts of the codebase, enhancing the billing information associated with teams.

### Detailed summary
- Added `billingPlanVersion` with type `number` to `TeamResponse`.
- Updated `billingPlanVersion` to `1` in mock data within `mocks.ts`.
- Modified the `api.ts` file to include `billingPlanVersion` in the `TeamResponse` type definition.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->