### PR TITLE
pass team instead of project to rateLimit

### DIFF
--- a/.changeset/large-beds-move.md
+++ b/.changeset/large-beds-move.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": minor
+---
+
+pass `team` instead of `project` to `rateLimit`

--- a/packages/service-utils/src/core/api.ts
+++ b/packages/service-utils/src/core/api.ts
@@ -164,24 +164,3 @@ export async function fetchTeamAndProject(
     );
   }
 }
-
-export async function updateRateLimitedAt(
-  projectId: string,
-  config: CoreServiceConfig,
-): Promise<void> {
-  const { apiUrl, serviceScope: scope, serviceApiKey } = config;
-
-  const url = `${apiUrl}/usage/rateLimit`;
-
-  await fetch(url, {
-    method: "PUT",
-    headers: {
-      "x-service-api-key": serviceApiKey,
-      "content-type": "application/json",
-    },
-    body: JSON.stringify({
-      apiKeyId: projectId, // projectId is the apiKeyId
-      scope,
-    }),
-  });
-}

--- a/packages/service-utils/src/core/rateLimit/rateLimit.test.ts
+++ b/packages/service-utils/src/core/rateLimit/rateLimit.test.ts
@@ -1,17 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { validProjectResponse, validServiceConfig } from "../../mocks.js";
-import { updateRateLimitedAt } from "../api.js";
+import { validServiceConfig, validTeamResponse } from "../../mocks.js";
 import { rateLimit } from "./index.js";
 
 const mockRedis = {
   incr: vi.fn(),
   expire: vi.fn(),
 };
-
-// Mocking the updateRateLimitedAt function
-vi.mock("../../../src/core/api", () => ({
-  updateRateLimitedAt: vi.fn().mockResolvedValue({}),
-}));
 
 describe("rateLimit", () => {
   beforeEach(() => {
@@ -27,7 +21,7 @@ describe("rateLimit", () => {
 
   it("should not rate limit if service scope is not in rate limits", async () => {
     const result = await rateLimit({
-      project: validProjectResponse,
+      team: validTeamResponse,
       limitPerSecond: 0,
       serviceConfig: validServiceConfig,
       redis: mockRedis,
@@ -44,7 +38,7 @@ describe("rateLimit", () => {
     mockRedis.incr.mockResolvedValue(50); // Current count is 50 requests in 10 seconds.
 
     const result = await rateLimit({
-      project: validProjectResponse,
+      team: validTeamResponse,
       limitPerSecond: 5,
       serviceConfig: validServiceConfig,
       redis: mockRedis,
@@ -55,7 +49,7 @@ describe("rateLimit", () => {
       requestCount: 50,
       rateLimit: 50,
     });
-    expect(updateRateLimitedAt).not.toHaveBeenCalled();
+
     expect(mockRedis.expire).not.toHaveBeenCalled();
   });
 
@@ -63,7 +57,7 @@ describe("rateLimit", () => {
     mockRedis.incr.mockResolvedValue(51);
 
     const result = await rateLimit({
-      project: validProjectResponse,
+      team: validTeamResponse,
       limitPerSecond: 5,
       serviceConfig: validServiceConfig,
       redis: mockRedis,
@@ -77,7 +71,7 @@ describe("rateLimit", () => {
       errorMessage: `You've exceeded your storage rate limit at 5 reqs/sec. To get higher rate limits, contact us at https://thirdweb.com/contact-us.`,
       errorCode: "RATE_LIMIT_EXCEEDED",
     });
-    expect(updateRateLimitedAt).toHaveBeenCalled();
+
     expect(mockRedis.expire).not.toHaveBeenCalled();
   });
 
@@ -85,7 +79,7 @@ describe("rateLimit", () => {
     mockRedis.incr.mockResolvedValue(1);
 
     const result = await rateLimit({
-      project: validProjectResponse,
+      team: validTeamResponse,
       limitPerSecond: 5,
       serviceConfig: validServiceConfig,
       redis: mockRedis,
@@ -104,7 +98,7 @@ describe("rateLimit", () => {
     vi.spyOn(global.Math, "random").mockReturnValue(0.08);
 
     const result = await rateLimit({
-      project: validProjectResponse,
+      team: validTeamResponse,
       limitPerSecond: 5,
       serviceConfig: validServiceConfig,
       redis: mockRedis,
@@ -127,7 +121,7 @@ describe("rateLimit", () => {
     vi.spyOn(global.Math, "random").mockReturnValue(0.15);
 
     const result = await rateLimit({
-      project: validProjectResponse,
+      team: validTeamResponse,
       limitPerSecond: 5,
       serviceConfig: validServiceConfig,
       redis: mockRedis,

--- a/packages/service-utils/src/index.ts
+++ b/packages/service-utils/src/index.ts
@@ -10,7 +10,7 @@ export type {
   TeamResponse,
 } from "./core/api.js";
 
-export { fetchTeamAndProject, updateRateLimitedAt } from "./core/api.js";
+export { fetchTeamAndProject } from "./core/api.js";
 
 export {
   authorizeBundleId,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `rateLimit` function to use `team` instead of `project`, along with the removal of the `updateRateLimitedAt` function. This change aims to streamline the rate limiting process by focusing on teams rather than projects.

### Detailed summary
- Updated `rateLimit` to accept `team` instead of `project`.
- Removed `updateRateLimitedAt` function from `api.ts`.
- Adjusted related code to reference `team` properties.
- Updated tests to use `validTeamResponse` instead of `validProjectResponse`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->