### PR TITLE
[SDK] Update implementation addr extraction logic

### DIFF
--- a/.changeset/thick-kangaroos-smoke.md
+++ b/.changeset/thick-kangaroos-smoke.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+7702 delegation designator

--- a/packages/thirdweb/src/utils/bytecode/extractMinimalProxyImplementationAddress.test.ts
+++ b/packages/thirdweb/src/utils/bytecode/extractMinimalProxyImplementationAddress.test.ts
@@ -51,6 +51,12 @@ describe("extractMinimalProxyImplementationAddress", () => {
     expect(result).toBe("0xbebebebebebebebebebebebebebebebebebebebe");
   });
 
+  it("should extract address from EIP-7702 delegation designator", () => {
+    const bytecode = "0xef0100bebebebebebebebebebebebebebebebebebebebe";
+    const result = extractMinimalProxyImplementationAddress(bytecode);
+    expect(result).toBe("0xbebebebebebebebebebebebebebebebebebebebe");
+  });
+
   it("should return undefined for non-matching bytecode", () => {
     const bytecode =
       "0x60806040526000805534801561001457600080fd5b50610150806100246000396000f3fe";

--- a/packages/thirdweb/src/utils/bytecode/extractMinimalProxyImplementationAddress.ts
+++ b/packages/thirdweb/src/utils/bytecode/extractMinimalProxyImplementationAddress.ts
@@ -54,5 +54,11 @@ export function extractMinimalProxyImplementationAddress(
     return `0x${implementationAddress}`;
   }
 
+  // EIP-7702 - https://eips.ethereum.org/EIPS/eip-7702#abstract
+  if (bytecode.length === 48 && bytecode.startsWith("0xef0100")) {
+    const implementationAddress = bytecode.slice(8, 48);
+    return `0x${implementationAddress}`;
+  }
+
   return undefined;
 }


### PR DESCRIPTION
TOOL-3258

<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces support for extracting implementation addresses from bytecode that conforms to the EIP-7702 specification. It adds a new utility function and a corresponding test to ensure the functionality works as expected.

### Detailed summary
- Added logic to `extractMinimalProxyImplementationAddress.ts` to handle EIP-7702 delegation designator.
- Implemented extraction of the implementation address from bytecode starting with `0xef0100`.
- Added a test case in `extractMinimalProxyImplementationAddress.test.ts` to verify correct extraction of address from EIP-7702 bytecode.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->