### PR TITLE
[TOOL-3260] SDK: Fix Pay Modal logging react-query error when opened

### DIFF
--- a/.changeset/gentle-dancers-raise.md
+++ b/.changeset/gentle-dancers-raise.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix thirdweb Pay Modal logging react-query error when opened

--- a/packages/thirdweb/src/react/web/ui/TransactionButton/TransactionModal.tsx
+++ b/packages/thirdweb/src/react/web/ui/TransactionButton/TransactionModal.tsx
@@ -37,7 +37,10 @@ export function TransactionModal(props: ModalProps) {
   useQuery({
     queryKey: ["transaction-modal-event"],
     queryFn: () => {
-      if (!account || !wallet) return;
+      // Query data cannot be undefined, return null
+      if (!account || !wallet) {
+        return null;
+      }
       trackPayEvent({
         client: props.client,
         walletAddress: account.address,
@@ -45,6 +48,8 @@ export function TransactionModal(props: ModalProps) {
         dstChainId: props.tx.chain.id,
         event: "open_pay_transaction_modal",
       });
+
+      return null;
     },
     enabled: !!wallet,
   });

--- a/packages/thirdweb/src/react/web/ui/TransactionButton/TransactionModal.tsx
+++ b/packages/thirdweb/src/react/web/ui/TransactionButton/TransactionModal.tsx
@@ -37,9 +37,8 @@ export function TransactionModal(props: ModalProps) {
   useQuery({
     queryKey: ["transaction-modal-event"],
     queryFn: () => {
-      // Query data cannot be undefined, return null
       if (!account || !wallet) {
-        return null;
+        throw new Error(); // never happens, because enabled is false
       }
       trackPayEvent({
         client: props.client,
@@ -51,7 +50,7 @@ export function TransactionModal(props: ModalProps) {
 
       return null;
     },
-    enabled: !!wallet,
+    enabled: !!wallet && !!account,
   });
 
   return (


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on fixing the logging of a react-query error in the `thirdweb` Pay Modal when it is opened, ensuring that an error is thrown only when both `account` and `wallet` are not available.

### Detailed summary
- Updated the condition in `TransactionModal` to throw an error if `account` or `wallet` is missing.
- Added a `return null` statement after the error throw.
- Modified the `enabled` property to check both `wallet` and `account`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->