### PR TITLE
[Portal] Fix: deployContract doc imports

### DIFF
--- a/packages/thirdweb/src/contract/deployment/deploy-with-abi.ts
+++ b/packages/thirdweb/src/contract/deployment/deploy-with-abi.ts
@@ -83,7 +83,7 @@ export function prepareDirectDeployTransaction(
  * ## Deploying a regular contract from ABI and bytecode
  *
  * ```ts
- * import { deployContract } from "thirdweb/deployContract";
+ * import { deployContract } from "thirdweb/deploys";
  *
  * const address = await deployContract({
  *  client,
@@ -101,7 +101,7 @@ export function prepareDirectDeployTransaction(
  * ## Deploying a contract deterministically
  *
  * ```ts
- * import { deployContract } from "thirdweb/deployContract";
+ * import { deployContract } from "thirdweb/deploys";
  *
  * const address = await deployContract({
  *  client,


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the import path for the `deployContract` function in the `deploy-with-abi.ts` file to reflect a change in the module structure.

### Detailed summary
- Changed the import statement for `deployContract` from `"thirdweb/deployContract"` to `"thirdweb/deploys"` in `packages/thirdweb/src/contract/deployment/deploy-with-abi.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->