### PR TITLE
chore: change to per-product usageV2 topic

### DIFF
--- a/.changeset/pink-melons-relate.md
+++ b/.changeset/pink-melons-relate.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+Change UsageV2 to per-product topics

--- a/packages/service-utils/src/cf-worker/usageV2.ts
+++ b/packages/service-utils/src/cf-worker/usageV2.ts
@@ -1,4 +1,4 @@
-import type { ServiceName } from "src/core/services.js";
+import type { ServiceName } from "../core/services.js";
 import { type UsageV2Event, getTopicName } from "../core/usageV2.js";
 
 /**

--- a/packages/service-utils/src/cf-worker/usageV2.ts
+++ b/packages/service-utils/src/cf-worker/usageV2.ts
@@ -1,4 +1,5 @@
-import type { UsageV2Event } from "../core/usageV2.js";
+import type { ServiceName } from "src/core/services.js";
+import { type UsageV2Event, getTopicName } from "../core/usageV2.js";
 
 /**
  * Send events to Kafka.
@@ -19,6 +20,7 @@ export async function sendUsageV2Events(
   events: UsageV2Event[],
   options: {
     environment: "development" | "production";
+    productName: ServiceName;
     serviceKey: string;
   },
 ): Promise<void> {
@@ -27,7 +29,8 @@ export async function sendUsageV2Events(
       ? "https://u.thirdweb.com"
       : "https://u.thirdweb-dev.com";
 
-  const resp = await fetch(`${baseUrl}/usage-v2/raw-events`, {
+  const topic = getTopicName(options.productName);
+  const resp = await fetch(`${baseUrl}/usage-v2/${topic}`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/packages/service-utils/src/core/usageV2.ts
+++ b/packages/service-utils/src/core/usageV2.ts
@@ -1,4 +1,4 @@
-import type { ServiceName } from "src/node/index.js";
+import type { ServiceName } from "../node/index.js";
 
 export interface UsageV2Event {
   /**

--- a/packages/service-utils/src/core/usageV2.ts
+++ b/packages/service-utils/src/core/usageV2.ts
@@ -1,3 +1,5 @@
+import type { ServiceName } from "src/node/index.js";
+
 export interface UsageV2Event {
   /**
    * A unique identifier for the event. Defaults to a random UUID.
@@ -8,10 +10,6 @@ export interface UsageV2Event {
    * The event timestamp. Defaults to now().
    */
   created_at?: Date;
-  /**
-   * The source of the event. Example: "storage"
-   */
-  source: string;
   /**
    * The action of the event. Example: "upload"
    */
@@ -49,8 +47,12 @@ export interface UsageV2Event {
    */
   product_version?: string;
   /**
-   * An object of service-specific data. Example: "file_size_bytes"
-   * It is safe to pass any new JSON-serializable data here before updating the usageV2 schema.
+   * An object of arbitrary key-value pairs.
+   * Values can be boolean, number, string, Date, or null.
    */
-  data: Record<string, unknown>;
+  [key: string]: boolean | number | string | Date | null | undefined;
+}
+
+export function getTopicName(productName: ServiceName) {
+  return `usage_v2.raw_${productName}`;
 }

--- a/packages/service-utils/src/node/usageV2.ts
+++ b/packages/service-utils/src/node/usageV2.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { checkServerIdentity } from "node:tls";
 import { Kafka, type Producer } from "kafkajs";
-import type { ServiceName } from "src/core/services.js";
+import type { ServiceName } from "../core/services.js";
 import { type UsageV2Event, getTopicName } from "../core/usageV2.js";
 
 /**

--- a/packages/service-utils/src/node/usageV2.ts
+++ b/packages/service-utils/src/node/usageV2.ts
@@ -20,7 +20,7 @@ import { type UsageV2Event, getTopicName } from "../core/usageV2.js";
 export class UsageV2Producer {
   private kafka: Kafka;
   private producer: Producer | null = null;
-  private productName: ServiceName;
+  private topic: string;
 
   constructor(config: {
     /**
@@ -57,7 +57,7 @@ export class UsageV2Producer {
       },
     });
 
-    this.productName = config.productName;
+    this.topic = getTopicName(config.productName);
   }
 
   /**
@@ -99,7 +99,7 @@ export class UsageV2Producer {
     });
 
     await this.producer.send({
-      topic: getTopicName(this.productName),
+      topic: this.topic,
       messages: parsedEvents.map((event) => ({
         value: JSON.stringify(event),
       })),


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on changing the event tracking in the `UsageV2` system to use per-product topics, enhancing the granularity of data collection.

### Detailed summary
- Updated `sendUsageV2Events` to accept `productName` and use it for topic naming.
- Modified `UsageV2Event` interface by removing `source` and changing `data` to allow more flexible types.
- Introduced `getTopicName` function to generate topics based on `productName`.
- Adjusted `UsageV2Producer` to use a dynamic topic based on `productName`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->