### PR TITLE
[SDK] Fix: skip factory entrypoint lookup for ZKsync chains

### DIFF
--- a/.changeset/early-adults-travel.md
+++ b/.changeset/early-adults-travel.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Skip factory entrypoint lookup for ZKsync chains

--- a/packages/thirdweb/src/wallets/smart/index.ts
+++ b/packages/thirdweb/src/wallets/smart/index.ts
@@ -95,14 +95,22 @@ export async function connectSmartAccount(
 
   const options = creationOptions;
   const chain = connectChain ?? options.chain;
-  const isZksyncChain = await isZkSyncChain(chain);
+  const sponsorGas =
+    "gasless" in options ? options.gasless : options.sponsorGas;
+  if (await isZkSyncChain(chain)) {
+    return [
+      createZkSyncAccount({
+        creationOptions,
+        connectionOptions,
+        chain,
+        sponsorGas,
+      }),
+      chain,
+    ];
+  }
 
   // if factory is passed, but no entrypoint, try to resolve entrypoint from factory
-  if (
-    !isZksyncChain &&
-    options.factoryAddress &&
-    !options.overrides?.entrypointAddress
-  ) {
+  if (options.factoryAddress && !options.overrides?.entrypointAddress) {
     const entrypointAddress = await getEntrypointFromFactory(
       options.factoryAddress,
       client,
@@ -125,21 +133,6 @@ export async function connectSmartAccount(
       ...options.overrides,
       entrypointAddress: ENTRYPOINT_ADDRESS_v0_7,
     };
-  }
-
-  const sponsorGas =
-    "gasless" in options ? options.gasless : options.sponsorGas;
-
-  if (isZksyncChain) {
-    return [
-      createZkSyncAccount({
-        creationOptions,
-        connectionOptions,
-        chain,
-        sponsorGas,
-      }),
-      chain,
-    ];
   }
 
   const factoryAddress =

--- a/packages/thirdweb/src/wallets/smart/index.ts
+++ b/packages/thirdweb/src/wallets/smart/index.ts
@@ -95,9 +95,14 @@ export async function connectSmartAccount(
 
   const options = creationOptions;
   const chain = connectChain ?? options.chain;
+  const isZksyncChain = await isZkSyncChain(chain);
 
   // if factory is passed, but no entrypoint, try to resolve entrypoint from factory
-  if (options.factoryAddress && !options.overrides?.entrypointAddress) {
+  if (
+    !isZksyncChain &&
+    options.factoryAddress &&
+    !options.overrides?.entrypointAddress
+  ) {
     const entrypointAddress = await getEntrypointFromFactory(
       options.factoryAddress,
       client,
@@ -122,13 +127,10 @@ export async function connectSmartAccount(
     };
   }
 
-  const factoryAddress =
-    options.factoryAddress ??
-    getDefaultAccountFactory(options.overrides?.entrypointAddress);
   const sponsorGas =
     "gasless" in options ? options.gasless : options.sponsorGas;
 
-  if (await isZkSyncChain(chain)) {
+  if (isZksyncChain) {
     return [
       createZkSyncAccount({
         creationOptions,
@@ -139,6 +141,10 @@ export async function connectSmartAccount(
       chain,
     ];
   }
+
+  const factoryAddress =
+    options.factoryAddress ??
+    getDefaultAccountFactory(options.overrides?.entrypointAddress);
 
   const factoryContract = getContract({
     client: client,


### PR DESCRIPTION
When connecting to an ecosystem wallet with smart wallet options configured in the Thirdweb dashboard, there is a lookup made to fetch any missing details for account abstraction, like the entrypoint address. If the default chain on the dashboard is set to a ZKsync chain (e.g., Treasure chain ID 61166), there is an RPC call made to the factory address that always returns `0x` because the factory doesn't exist and is irrelevant for native account abstraction. This change saves the extraneous RPC call during login.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on optimizing the handling of `ZkSync` chains in the `connectSmartAccount` function by adding a direct check for these chains and simplifying the gas management logic.

### Detailed summary
- Added a check for `ZkSync` chains to skip factory entrypoint lookup.
- Introduced `sponsorGas` variable to manage gas settings more effectively.
- Removed redundant code related to `ZkSync` account creation when a factory is passed.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->