### PR TITLE
[Wagmi Adapter] Fix: use smart account chain in getProvider

### DIFF
--- a/.changeset/fair-trains-reply.md
+++ b/.changeset/fair-trains-reply.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/wagmi-adapter": patch
+---
+
+Fixes getProvider autoconnections with account factory

--- a/packages/wagmi-adapter/src/connector.ts
+++ b/packages/wagmi-adapter/src/connector.ts
@@ -148,7 +148,9 @@ export function inAppWalletConnector(
     },
     getProvider: async (params) => {
       const lastChainId = await config.storage?.getItem("tw.lastChainId");
-      const chain = defineChain(params?.chainId || lastChainId || 1);
+      const chain = defineChain(
+        params?.chainId || args.smartAccount?.chain?.id || lastChainId || 1,
+      );
       if (!wallet.getAccount()) {
         const { autoConnect } = await import("thirdweb/wallets");
         await autoConnect({


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the `getProvider` function in the `@thirdweb-dev/wagmi-adapter` package to improve autoconnections with the account factory by including additional logic for determining the chain ID.

### Detailed summary
- Updated `getProvider` function to include `args.smartAccount?.chain?.id` when determining the `chain` value.
- Ensured fallback to `lastChainId` or default to `1` if no chain ID is provided.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->