### PR TITLE
[service-utils] Expose broker settings for usageV2

### DIFF
--- a/.changeset/young-cherries-beg.md
+++ b/.changeset/young-cherries-beg.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+[service-utils] Expose kafkajs config


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the `UsageV2Producer` class in the `service-utils` package by allowing configuration overrides for Kafka producer initialization and message sending, including options for acknowledgments, timeout, and compression.

### Detailed summary
- Modified the `init` method of `UsageV2Producer` to accept optional `configOverrides` of type `ProducerConfig`.
- Updated the `sendEvents` method to accept an optional `configOverrides` parameter with options for `acks`, `timeout`, and `compression`.
- Integrated default values for `acks`, `timeout`, and `compression` in the `sendEvents` method while allowing overrides.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->