### PR TITLE
[service-utils] CJS import for kafkajs-lz4

### DIFF
--- a/packages/service-utils/src/node/usageV2.ts
+++ b/packages/service-utils/src/node/usageV2.ts
@@ -1,7 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { checkServerIdentity } from "node:tls";
 import {
-  CompressionCodecs,
   CompressionTypes,
   Kafka,
   type Producer,
@@ -10,6 +9,10 @@ import {
 import LZ4Codec from "kafkajs-lz4";
 import type { ServiceName } from "../core/services.js";
 import { type UsageV2Event, getTopicName } from "../core/usageV2.js";
+
+// Import KafkaJS with CJS pattern (source: https://github.com/tulios/kafkajs/issues/1391)
+import KafkaJS from "kafkajs";
+const { CompressionCodecs } = KafkaJS;
 
 /**
  * Creates a UsageV2Producer which opens a persistent TCP connection.
@@ -88,7 +91,7 @@ export class UsageV2Producer {
    */
   async init(configOverrides?: ProducerConfig) {
     if (this.compression === CompressionTypes.LZ4) {
-      CompressionCodecs[CompressionTypes.LZ4] = new LZ4Codec().codec;
+      CompressionCodecs[CompressionTypes.LZ4] = new LZ4Codec.default().codec;
     }
 
     this.producer = this.kafka.producer({

--- a/packages/service-utils/src/node/usageV2.ts
+++ b/packages/service-utils/src/node/usageV2.ts
@@ -1,6 +1,12 @@
 import { randomUUID } from "node:crypto";
 import { checkServerIdentity } from "node:tls";
-import * as KafkaJS from "kafkajs";
+import {
+  CompressionCodecs,
+  CompressionTypes,
+  Kafka,
+  type Producer,
+  type ProducerConfig,
+} from "kafkajs";
 import LZ4Codec from "kafkajs-lz4";
 import type { ServiceName } from "../core/services.js";
 import { type UsageV2Event, getTopicName } from "../core/usageV2.js";
@@ -19,10 +25,10 @@ import { type UsageV2Event, getTopicName } from "../core/usageV2.js";
  * ```
  */
 export class UsageV2Producer {
-  private kafka: KafkaJS.Kafka;
-  private producer: KafkaJS.Producer | null = null;
+  private kafka: Kafka;
+  private producer: Producer | null = null;
   private topic: string;
-  private compression: KafkaJS.CompressionTypes;
+  private compression: CompressionTypes;
 
   constructor(config: {
     /**
@@ -40,7 +46,7 @@ export class UsageV2Producer {
     /**
      * The compression algorithm to use.
      */
-    compression?: KafkaJS.CompressionTypes;
+    compression?: CompressionTypes;
 
     username: string;
     password: string;
@@ -49,12 +55,12 @@ export class UsageV2Producer {
       producerName,
       environment,
       productName,
-      compression = KafkaJS.CompressionTypes.LZ4,
+      compression = CompressionTypes.LZ4,
       username,
       password,
     } = config;
 
-    this.kafka = new KafkaJS.Kafka({
+    this.kafka = new Kafka({
       clientId: `${producerName}-${environment}`,
       brokers:
         environment === "production"
@@ -80,10 +86,9 @@ export class UsageV2Producer {
    * Connect the producer.
    * This must be called before calling `sendEvents()`.
    */
-  async init(configOverrides?: KafkaJS.ProducerConfig) {
-    if (this.compression === KafkaJS.CompressionTypes.LZ4) {
-      KafkaJS.CompressionCodecs[KafkaJS.CompressionTypes.LZ4] =
-        new LZ4Codec().codec;
+  async init(configOverrides?: ProducerConfig) {
+    if (this.compression === CompressionTypes.LZ4) {
+      CompressionCodecs[CompressionTypes.LZ4] = new LZ4Codec().codec;
     }
 
     this.producer = this.kafka.producer({

--- a/packages/service-utils/src/node/usageV2.ts
+++ b/packages/service-utils/src/node/usageV2.ts
@@ -91,7 +91,7 @@ export class UsageV2Producer {
    */
   async init(configOverrides?: ProducerConfig) {
     if (this.compression === CompressionTypes.LZ4) {
-      CompressionCodecs[CompressionTypes.LZ4] = new LZ4Codec.default().codec;
+      CompressionCodecs[CompressionTypes.LZ4] = new LZ4Codec().codec;
     }
 
     this.producer = this.kafka.producer({


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `UsageV2Producer` class to use the new import style for `kafkajs`, transitioning from a namespace import to a named import. It also refines type usage for Kafka-related types and compression settings.

### Detailed summary
- Changed import of `kafkajs` from namespace to named imports.
- Updated type declarations for `kafka`, `producer`, and `compression`.
- Adjusted default value for `compression` to use the new import style.
- Refined the `init` method to utilize the new `ProducerConfig` type.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->