### PR TITLE
[service-utils] switch to lz4 for compression lib

### DIFF
--- a/.changeset/tall-masks-shop.md
+++ b/.changeset/tall-masks-shop.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+[service-utils] switch to lz4js for compression lib


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `@thirdweb-dev/service-utils` package to use `lz4js` as the compression library, enhancing performance and efficiency in data handling.

### Detailed summary
- Updated `@thirdweb-dev/service-utils` to a patch version.
- Switched the compression library to `lz4js`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->