### PR TITLE
[TOOL-3276] SDK: Fix JSDoc comments of download function

### DIFF
--- a/packages/thirdweb/src/storage/download.ts
+++ b/packages/thirdweb/src/storage/download.ts
@@ -25,7 +25,7 @@ export type DownloadOptions = Prettify<
  * Download a file from IPFS:
  * ```ts
  * import { download } from "thirdweb/storage";
- * import { createThirdwebClient } from "@thirdweb-dev/sdk";
+ * import { createThirdwebClient } from "thirdweb";
  *
  * const client = createThirdwebClient({ clientId: "YOUR_CLIENT_ID" });
  *
@@ -38,7 +38,7 @@ export type DownloadOptions = Prettify<
  * Download a file from Arweave:
  * ```ts
  * import { download } from "thirdweb/storage";
- * import { createThirdwebClient } from "@thirdweb-dev/sdk";
+ * import { createThirdwebClient } from "thirdweb";
  *
  * const client = createThirdwebClient({ clientId: "YOUR_CLIENT_ID" });
  *
@@ -51,7 +51,7 @@ export type DownloadOptions = Prettify<
  * Download a file from HTTP:
  * ```ts
  * import { download } from "thirdweb/storage";
- * import { createThirdwebClient } from "@thirdweb-dev/sdk";
+ * import { createThirdwebClient } from "thirdweb";
  *
  * const client = createThirdwebClient({ clientId: "YOUR_CLIENT_ID" });
  *


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the import path for the `createThirdwebClient` function in the `download.ts` file, changing it from `@thirdweb-dev/sdk` to `thirdweb`.

### Detailed summary
- Changed import of `createThirdwebClient` from `@thirdweb-dev/sdk` to `thirdweb` in `packages/thirdweb/src/storage/download.ts`.
- This change is reflected in multiple locations within the file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->