### PR TITLE
[service-utils] ESM imports for compression

### DIFF
--- a/.changeset/friendly-candles-walk.md
+++ b/.changeset/friendly-candles-walk.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+[service-utils] Update to ESM for compression typrse


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `service-utils` package to use ECMAScript Modules (ESM) and modifies the `UsageV2Producer` class to change the compression handling from a specified algorithm to a boolean flag indicating whether to compress events.

### Detailed summary
- Updated `service-utils` to ESM for compression types.
- Removed CommonJS import pattern for `KafkaJS`.
- Changed `compression` property to `shouldCompress` in `UsageV2Producer`.
- Default value for `shouldCompress` set to `true`.
- Updated logic to determine compression based on `shouldCompress`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->