### PR TITLE
fix: usageV2 API endpoint

### DIFF
--- a/packages/service-utils/src/cf-worker/usageV2.ts
+++ b/packages/service-utils/src/cf-worker/usageV2.ts
@@ -1,5 +1,5 @@
 import type { ServiceName } from "../core/services.js";
-import { type UsageV2Event, getTopicName } from "../core/usageV2.js";
+import { type UsageV2Event } from "../core/usageV2.js";
 
 /**
  * Send events to Kafka.
@@ -29,8 +29,7 @@ export async function sendUsageV2Events(
       ? "https://u.thirdweb.com"
       : "https://u.thirdweb-dev.com";
 
-  const topic = getTopicName(options.productName);
-  const resp = await fetch(`${baseUrl}/usage-v2/${topic}`, {
+  const resp = await fetch(`${baseUrl}/usage-v2/${options.productName}`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR modifies the `sendUsageV2Events` function in the `usageV2.ts` file, removing the dependency on the `getTopicName` function and directly using `options.productName` for constructing the fetch URL.

### Detailed summary
- Removed the import of `getTopicName` from `../core/usageV2.js`.
- Changed the fetch URL construction to use `options.productName` instead of the `topic` variable.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->