### PR TITLE
[service-utils] fix: export kafka producer

### DIFF
--- a/.changeset/lazy-files-act.md
+++ b/.changeset/lazy-files-act.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+[service-utils] export KafkaProducer

--- a/packages/service-utils/src/node/index.ts
+++ b/packages/service-utils/src/node/index.ts
@@ -13,6 +13,7 @@ import type {
 import type { AuthorizationResult } from "../core/authorize/types.js";
 import type { CoreAuthInput } from "../core/types.js";
 
+export * from "./kafka.js";
 export * from "./usageV2.js";
 export * from "../core/usage.js";
 export * from "../core/usageV2.js";


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `@thirdweb-dev/service-utils` package by exporting the `KafkaProducer` and ensuring proper exports from various modules.

### Detailed summary
- Added a patch for the `@thirdweb-dev/service-utils` package.
- Exported `KafkaProducer` from the `service-utils`.
- Updated exports in `packages/service-utils/src/node/index.ts` to include:
  - `./kafka.js`
  - `./usageV2.js`
  - `../core/usage.js`
  - `../core/usageV2.js`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->