### PR TITLE
feat: canCreatePublicChains in TeamResponse

### DIFF
--- a/.changeset/chatty-geese-burn.md
+++ b/.changeset/chatty-geese-burn.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+add `canCreatePublicChains` to TeamResponse

--- a/packages/service-utils/src/core/api.ts
+++ b/packages/service-utils/src/core/api.ts
@@ -51,6 +51,7 @@ export type TeamResponse = {
   billingEmail: string | null;
   billingStatus: "noPayment" | "validPayment" | "invalidPayment" | null;
   growthTrialEligible: false;
+  canCreatePublicChains: boolean | null;
   enabledScopes: ServiceName[];
 };
 

--- a/packages/service-utils/src/mocks.ts
+++ b/packages/service-utils/src/mocks.ts
@@ -46,6 +46,7 @@ export const validTeamResponse: TeamResponse = {
   billingEmail: "test@example.com",
   billingStatus: "noPayment",
   growthTrialEligible: false,
+  canCreatePublicChains: false,
   enabledScopes: ["storage", "rpc", "bundler"],
 };
 


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new property, `canCreatePublicChains`, to the `TeamResponse` interface and updates the mock data accordingly.

### Detailed summary
- Added `canCreatePublicChains` property to `TeamResponse` with a default value of `false` in `mocks.ts`.
- Updated `TeamResponse` interface in `api.ts` to include `canCreatePublicChains` as a type of `boolean | null`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->