### PR TITLE
fix: Tweak 404 page

### DIFF
--- a/apps/dashboard/src/components/not-found-page.tsx
+++ b/apps/dashboard/src/components/not-found-page.tsx
@@ -13,15 +13,14 @@ export function NotFoundPage() {
 
           <p className="text-center font-bold text-3xl tracking-tighter md:text-5xl">
             <span className="block"> Uh oh. </span>
-            <span className="block">Looks like web3</span>
-            <span className="block">can't be found here.</span>
+            <span className="block">Looks like you're lost!</span>
           </p>
 
           <div className="h-12" />
 
           <div>
             <p className="text-center text-muted-foreground text-xl leading-7">
-              Try our{" "}
+              Find live content on our{" "}
               <TrackedLinkTW
                 category="page-not-found"
                 label="homepage"
@@ -47,8 +46,8 @@ export function NotFoundPage() {
                 className="text-foreground hover:underline"
               >
                 developer portal
-              </TrackedLinkTW>{" "}
-              instead
+              </TrackedLinkTW>
+              .
             </p>
           </div>
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the content of the `NotFoundPage` component to improve the user experience by changing the messaging displayed when a page is not found.

### Detailed summary
- Updated the message from "Looks like web3 can't be found here." to "Looks like you're lost!".
- Changed the prompt from "Try our" to "Find live content on our".
- Adjusted the sentence structure by replacing "instead" with a period for clarity.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->