### PR TITLE
[service-utils] Expose more kafka configs, set max in-flight requests

### DIFF
--- a/.changeset/quiet-goats-know.md
+++ b/.changeset/quiet-goats-know.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+[service-utils] Expose maxInFlightRequests in Kafka producer

--- a/packages/service-utils/src/node/kafka.ts
+++ b/packages/service-utils/src/node/kafka.ts
@@ -10,8 +10,12 @@ const { CompressionCodecs } = KafkaJS;
  * Reference: https://kafka.js.org/docs/producing#producing-messages
  */
 export interface KafkaProducerSendOptions {
+  // Per-message settings.
   acks?: number;
   timeout?: number;
+
+  // Per-producer settings.
+  retries?: number;
   allowAutoTopicCreation?: boolean;
   maxInFlightRequests?: number;
 }
@@ -114,6 +118,7 @@ export class KafkaProducer {
       this.producer = this.kafka.producer({
         allowAutoTopicCreation: options?.allowAutoTopicCreation ?? false,
         maxInFlightRequests: options?.maxInFlightRequests ?? 1000,
+        retry: { retries: options?.retries ?? 5 },
       });
       await this.producer.connect();
     }

--- a/packages/service-utils/src/node/kafka.ts
+++ b/packages/service-utils/src/node/kafka.ts
@@ -7,6 +7,16 @@ import KafkaJS from "kafkajs";
 const { CompressionCodecs } = KafkaJS;
 
 /**
+ * Reference: https://kafka.js.org/docs/producing#producing-messages
+ */
+export interface KafkaProducerSendOptions {
+  acks?: number;
+  timeout?: number;
+  allowAutoTopicCreation?: boolean;
+  maxInFlightRequests?: number;
+}
+
+/**
  * Creates a KafkaProducer which opens a persistent TCP connection.
  * This class is thread-safe so your service should re-use one instance.
  *
@@ -98,18 +108,12 @@ export class KafkaProducer {
   async send(
     topic: string,
     messages: Record<string, unknown>[],
-    /**
-     * Reference: https://kafka.js.org/docs/producing#producing-messages
-     */
-    options?: {
-      acks?: number;
-      timeout?: number;
-      allowAutoTopicCreation?: boolean;
-    },
+    options?: KafkaProducerSendOptions,
   ): Promise<void> {
     if (!this.producer) {
       this.producer = this.kafka.producer({
         allowAutoTopicCreation: options?.allowAutoTopicCreation ?? false,
+        maxInFlightRequests: options?.maxInFlightRequests ?? 1000,
       });
       await this.producer.connect();
     }

--- a/packages/service-utils/src/node/kafka.ts
+++ b/packages/service-utils/src/node/kafka.ts
@@ -117,7 +117,7 @@ export class KafkaProducer {
     if (!this.producer) {
       this.producer = this.kafka.producer({
         allowAutoTopicCreation: options?.allowAutoTopicCreation ?? false,
-        maxInFlightRequests: options?.maxInFlightRequests ?? 1000,
+        maxInFlightRequests: options?.maxInFlightRequests ?? 2000,
         retry: { retries: options?.retries ?? 5 },
       });
       await this.producer.connect();

--- a/packages/service-utils/src/node/usageV2.ts
+++ b/packages/service-utils/src/node/usageV2.ts
@@ -4,7 +4,7 @@ import {
   type UsageV2Source,
   getTopicName,
 } from "../core/usageV2.js";
-import { KafkaProducer } from "./kafka.js";
+import { KafkaProducer, type KafkaProducerSendOptions } from "./kafka.js";
 
 /**
  * Creates a UsageV2Producer which opens a persistent TCP connection.
@@ -63,11 +63,7 @@ export class UsageV2Producer {
     /**
      * Reference: https://kafka.js.org/docs/producing#producing-messages
      */
-    options?: {
-      acks?: number;
-      timeout?: number;
-      allowAutoTopicCreation?: boolean;
-    },
+    options?: KafkaProducerSendOptions,
   ): Promise<void> {
     const parsedEvents = events.map((event) => ({
       ...event,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on exposing the `maxInFlightRequests` option in the `KafkaProducer` class, allowing users to configure the maximum number of in-flight requests when sending messages.

### Detailed summary
- Added `maxInFlightRequests` to the `KafkaProducerSendOptions` interface in `packages/service-utils/src/node/kafka.ts`.
- Updated the `send` method in `KafkaProducer` to utilize `maxInFlightRequests`.
- Changed the type of `options` in `UsageV2Producer` to `KafkaProducerSendOptions`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->