### PR TITLE
[SDK] fix: Skip swap approvals and use local gas prices

### DIFF
--- a/.changeset/cuddly-wombats-boil.md
+++ b/.changeset/cuddly-wombats-boil.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Skip swap approvals if already approved and always calculate gas prices locally

--- a/apps/playground-web/src/components/pay/embed.tsx
+++ b/apps/playground-web/src/components/pay/embed.tsx
@@ -4,24 +4,29 @@ import { THIRDWEB_CLIENT } from "@/lib/client";
 import { useTheme } from "next-themes";
 import { base } from "thirdweb/chains";
 import { PayEmbed } from "thirdweb/react";
+import { StyledConnectButton } from "../styled-connect-button";
 
 export function StyledPayEmbedPreview() {
   const { theme } = useTheme();
 
   return (
-    <PayEmbed
-      client={THIRDWEB_CLIENT}
-      theme={theme === "light" ? "light" : "dark"}
-      payOptions={{
-        mode: "fund_wallet",
-        metadata: {
-          name: "Get funds",
-        },
-        prefillBuy: {
-          chain: base,
-          amount: "0.01",
-        },
-      }}
-    />
+    <>
+      <StyledConnectButton />
+      <div className="h-10" />
+      <PayEmbed
+        client={THIRDWEB_CLIENT}
+        theme={theme === "light" ? "light" : "dark"}
+        payOptions={{
+          mode: "fund_wallet",
+          metadata: {
+            name: "Get funds",
+          },
+          prefillBuy: {
+            chain: base,
+            amount: "0.01",
+          },
+        }}
+      />
+    </>
   );
 }

--- a/packages/thirdweb/src/pay/utils/commonTypes.ts
+++ b/packages/thirdweb/src/pay/utils/commonTypes.ts
@@ -17,4 +17,4 @@ export type PayOnChainTransactionDetails = {
   explorerLink?: string;
 };
 
-export type FiatProvider = "STRIPE" | "TRANSAK" | "KADO";
+export type FiatProvider = "STRIPE" | "TRANSAK" | "KADO" | "COINBASE";

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/fiat/FiatStatusScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/fiat/FiatStatusScreen.tsx
@@ -248,11 +248,9 @@ function OnrampStatusScreenUI(props: {
             </>
           )}
 
-          {!props.isEmbed && (
-            <Button variant="accent" fullWidth onClick={props.onDone}>
-              {props.transactionMode ? "Continue Transaction" : "Done"}
-            </Button>
-          )}
+          <Button variant="accent" fullWidth onClick={props.onDone}>
+            {props.transactionMode ? "Continue Transaction" : "Done"}
+          </Button>
         </>
       )}
     </Container>

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/ConfirmationScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/ConfirmationScreen.tsx
@@ -236,19 +236,7 @@ export function SwapConfirmationScreen(props: {
             if (step === "swap") {
               setStatus("pending");
               try {
-                let tx = props.quote.transactionRequest;
-
-                // Fix for inApp wallet
-                // Ideally - the pay server sends a non-legacy transaction to avoid this issue
-                if (
-                  props.payer.wallet.id === "inApp" ||
-                  props.payer.wallet.id === "embedded"
-                ) {
-                  tx = {
-                    ...props.quote.transactionRequest,
-                    gasPrice: undefined,
-                  };
-                }
+                const tx = props.quote.transactionRequest;
 
                 trackPayEvent({
                   event: "prompt_swap_execution",

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/SwapStatusScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/SwapStatusScreen.tsx
@@ -113,11 +113,9 @@ export function SwapStatusScreen(props: {
             <Spacer y="xl" />
             {swapDetails}
             <Spacer y="sm" />
-            {!props.isEmbed && (
-              <Button variant="accent" fullWidth onClick={props.onDone}>
-                {props.transactionMode ? "Continue Transaction" : "Done"}
-              </Button>
-            )}
+            <Button variant="accent" fullWidth onClick={props.onDone}>
+              {props.transactionMode ? "Continue Transaction" : "Done"}
+            </Button>
           </>
         )}
 


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `thirdweb` package by adding a new `FiatProvider` option, optimizing button rendering in several screens, improving gas price handling, and refining error message management for better user feedback during transactions.

### Detailed summary
- Added `"COINBASE"` to `FiatProvider` type.
- Simplified button rendering in `FiatStatusScreen` and `SwapStatusScreen`.
- Refined transaction request handling in `ConfirmationScreen` to manage gas prices locally.
- Implemented approval check in `getQuote.ts`.
- Improved error message handling in `BuyScreen` and `FiatScreen`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->