### PR TITLE
[service-utils] Update list of usageV2 sources

### DIFF
--- a/.changeset/healthy-cups-refuse.md
+++ b/.changeset/healthy-cups-refuse.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+[service-utils] Update list of usageV2 sources"

--- a/packages/service-utils/src/core/usageV2.ts
+++ b/packages/service-utils/src/core/usageV2.ts
@@ -1,6 +1,15 @@
-import type { ServiceName } from "./services.js";
-
-export type UsageV2Source = ServiceName | "sdk";
+export type UsageV2Source =
+  | "bundler"
+  | "engine"
+  | "insight"
+  | "nebula"
+  | "rpc"
+  | "sdk"
+  | "storage"
+  | "wallet";
+export function getTopicName(source: UsageV2Source) {
+  return `usage_v2.raw_${source}`;
+}
 
 export interface UsageV2Event {
   /**
@@ -53,8 +62,4 @@ export interface UsageV2Event {
    * Values can be boolean, number, string, Date, or null.
    */
   [key: string]: boolean | number | string | Date | null | undefined;
-}
-
-export function getTopicName(source: UsageV2Source) {
-  return `usage_v2.raw_${source}`;
 }


### PR DESCRIPTION


## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `UsageV2Source` type in the `service-utils` package to include additional source options and removes a duplicate `getTopicName` function.

### Detailed summary
- Modified `UsageV2Source` type to include: `"bundler"`, `"engine"`, `"insight"`, `"nebula"`, and `"rpc"`.
- Removed duplicate `getTopicName` function implementation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->