### PR TITLE
[SDK] fix: Requery allowances on quote screen return

### DIFF
--- a/.changeset/stupid-experts-shake.md
+++ b/.changeset/stupid-experts-shake.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Requery allowances when getting back to quote screen

--- a/packages/thirdweb/src/pay/buyWithCrypto/getTransfer.ts
+++ b/packages/thirdweb/src/pay/buyWithCrypto/getTransfer.ts
@@ -1,8 +1,6 @@
 import type { Hash } from "viem";
 import { getCachedChain } from "../../chains/utils.js";
 import type { ThirdwebClient } from "../../client/client.js";
-import { getContract } from "../../contract/contract.js";
-import { approve } from "../../extensions/erc20/write/approve.js";
 import type { PrepareTransactionOptions } from "../../transaction/prepare-transaction.js";
 import type { Address } from "../../utils/address.js";
 import { getClientFetch } from "../../utils/fetch.js";
@@ -83,7 +81,7 @@ type BuyWithCryptoTransferResponse = {
  */
 export type BuyWithCryptoTransfer = {
   transactionRequest: PrepareTransactionOptions;
-  approval?: PrepareTransactionOptions;
+  approvalData?: QuoteApprovalInfo;
   fromAddress: string;
   toAddress: string;
   paymentToken: QuotePaymentToken;
@@ -159,17 +157,7 @@ export async function getBuyWithCryptoTransfer(
         value: BigInt(data.transactionRequest.value),
         gas: BigInt(data.transactionRequest.gasLimit),
       },
-      approval: data.approval
-        ? approve({
-            contract: getContract({
-              client: params.client,
-              address: data.approval.tokenAddress,
-              chain: getCachedChain(data.approval.chainId),
-            }),
-            spender: data.approval.spenderAddress as Address,
-            amountWei: BigInt(data.approval.amountWei),
-          })
-        : undefined,
+      approvalData: data.approval,
       fromAddress: data.fromAddress,
       toAddress: data.toAddress,
       paymentToken: data.paymentToken,

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/main/types.ts
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/main/types.ts
@@ -34,6 +34,7 @@ export type SelectedScreen =
   | {
       id: "swap-flow";
       quote: BuyWithCryptoQuote;
+      approvalAmount?: bigint;
     }
   | {
       id: "fiat-flow";

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/SwapFlow.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/SwapFlow.tsx
@@ -22,6 +22,7 @@ type SwapFlowProps = {
   transactionMode: boolean;
   isEmbed: boolean;
   onSuccess: ((status: BuyWithCryptoStatus) => void) | undefined;
+  approvalAmount?: bigint;
 };
 
 export function SwapFlow(props: SwapFlowProps) {
@@ -109,6 +110,7 @@ export function SwapFlow(props: SwapFlowProps) {
       quote={quote}
       isFiatFlow={props.isFiatFlow}
       payer={props.payer}
+      preApprovedAmount={props.approvalAmount}
     />
   );
 }


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the handling of approval amounts in the `thirdweb` package, specifically in the `Buy` flow. It introduces changes to manage approval data more effectively, ensuring that allowance checks are performed correctly before transactions.

### Detailed summary
- Added `approvalAmount` property in various components.
- Replaced `approval` with `approvalData` in `BuyWithCryptoTransfer` and `BuyWithCryptoQuote` types.
- Implemented allowance checks in `PostOnRampSwap`, `TransferConfirmationScreen`, and `SwapConfirmationScreen`.
- Updated logic to determine if approval is needed based on `approvalData`.
- Adjusted transaction handling to include approval transactions when necessary.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->