### PR TITLE
prefer explicit clientId over secretKey computation

### DIFF
--- a/.changeset/wicked-chairs-own.md
+++ b/.changeset/wicked-chairs-own.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+when explicitly passing `clientId` to `createThirdwebClient()` prefer it over computing the `clientId` from a passed `secretKey` option

--- a/packages/thirdweb/src/client/client.test.ts
+++ b/packages/thirdweb/src/client/client.test.ts
@@ -13,9 +13,9 @@ describe("client", () => {
     expect(client.clientId).toBe(computeClientIdFromSecretKey("bar"));
     expect(client.secretKey).toBe("bar");
   });
-  it("should ignore clientId if secretKey is provided", () => {
+  it("should NOT ignore clientId if secretKey is provided", () => {
     const client = createThirdwebClient({ clientId: "foo", secretKey: "bar" });
-    expect(client.clientId).toBe(computeClientIdFromSecretKey("bar"));
+    expect(client.clientId).toBe("foo");
     expect(client.secretKey).toBe("bar");
   });
   it("should throw an error if neither clientId nor secretKey is provided", () => {

--- a/packages/thirdweb/src/client/client.ts
+++ b/packages/thirdweb/src/client/client.ts
@@ -114,7 +114,8 @@ export function createThirdwebClient(
         throw new Error("clientId must be provided when using a JWT secretKey");
       }
     } else {
-      realClientId = computeClientIdFromSecretKey(secretKey);
+      // always PREFER the clientId if provided, only compute it from the secretKey if we don't have a clientId passed explicitly
+      realClientId = clientId ?? computeClientIdFromSecretKey(secretKey);
     }
   }
 


### PR DESCRIPTION
TOOL-0000

### TL;DR

Prioritize explicitly passed `clientId` over computed values when creating a Thirdweb client.

### What changed?

Modified the client initialization logic to prefer explicitly passed `clientId` parameters over computing them from `secretKey`. Only falls back to computing the `clientId` from `secretKey` when no explicit `clientId` is provided.

### How to test?

1. Create a Thirdweb client with both `clientId` and `secretKey` parameters
2. Verify that the provided `clientId` is used instead of computing one from the `secretKey`
3. Create a client with only `secretKey` and verify the `clientId` is computed correctly

### Why make this change?

To give developers more control over client configuration by respecting explicitly provided parameters rather than always computing values from the secret key. This allows for more flexible client setup scenarios where the computed `clientId` might not be desired.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the behavior of the `createThirdwebClient()` function to prioritize the explicit `clientId` over a computed `clientId` derived from the `secretKey`. It also adjusts the related test cases to reflect this new behavior.

### Detailed summary
- Updated `client.ts` to prefer the provided `clientId` over computing it from `secretKey`.
- Modified the test case description in `client.test.ts` to clarify that `clientId` will not be ignored if `secretKey` is provided.
- Adjusted the expectation in the test to check for the explicitly passed `clientId` instead of the computed value.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->