### PR TITLE
add redirect from /connect/pay to /connect/universal-bridge

### DIFF
--- a/apps/dashboard/redirects.js
+++ b/apps/dashboard/redirects.js
@@ -337,6 +337,12 @@ async function redirects() {
       destination: "/connect/account-abstraction",
       permanent: false,
     },
+    // redirect /connect/pay to /connect/universal-bridge
+    {
+      source: "/connect/pay",
+      destination: "/connect/universal-bridge",
+      permanent: false,
+    },
     // PREVIOUS CAMPAIGNS
     {
       source: "/unlimited-wallets",


### PR DESCRIPTION
fixes: TOOL-0000

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a new redirect rule in the `apps/dashboard/redirects.js` file to redirect traffic from `/connect/pay` to `/connect/universal-bridge`.

### Detailed summary
- Added a new redirect rule:
  - `source`: `/connect/pay`
  - `destination`: `/connect/universal-bridge`
  - `permanent`: false

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->