### PR TITLE
[SDK] feat: Add provider selection to fiat onramp

### DIFF
--- a/.changeset/silent-comics-carry.md
+++ b/.changeset/silent-comics-carry.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Add fiat provider selection in PayEmbed

--- a/apps/playground-web/src/components/pay/embed.tsx
+++ b/apps/playground-web/src/components/pay/embed.tsx
@@ -10,7 +10,7 @@ export function StyledPayEmbedPreview() {
   const { theme } = useTheme();
 
   return (
-    <>
+    <div className="flex flex-col items-center justify-center">
       <StyledConnectButton />
       <div className="h-10" />
       <PayEmbed
@@ -27,6 +27,6 @@ export function StyledPayEmbedPreview() {
           },
         }}
       />
-    </>
+    </div>
   );
 }

--- a/packages/thirdweb/src/pay/buyWithFiat/getQuote.ts
+++ b/packages/thirdweb/src/pay/buyWithFiat/getQuote.ts
@@ -238,6 +238,11 @@ export type BuyWithFiatQuote = {
    *
    */
   onRampLink: string;
+
+  /**
+   * The provider that was used to get the quote.
+   */
+  provider: FiatProvider;
 };
 
 /**

--- a/packages/thirdweb/src/pay/utils/commonTypes.ts
+++ b/packages/thirdweb/src/pay/utils/commonTypes.ts
@@ -17,4 +17,6 @@ export type PayOnChainTransactionDetails = {
   explorerLink?: string;
 };
 
-export type FiatProvider = "STRIPE" | "TRANSAK" | "KADO" | "COINBASE";
+export type FiatProvider = (typeof FiatProviders)[number];
+
+export const FiatProviders = ["COINBASE", "STRIPE", "TRANSAK", "KADO"] as const;

--- a/packages/thirdweb/src/react/core/utils/storage.ts
+++ b/packages/thirdweb/src/react/core/utils/storage.ts
@@ -2,6 +2,7 @@ import type { AsyncStorage } from "../../../utils/storage/AsyncStorage.js";
 import type { AuthArgsType } from "../../../wallets/in-app/core/authentication/types.js";
 
 export const LAST_AUTH_PROVIDER_STORAGE_KEY = "lastAuthProvider";
+export const PREFERRED_FIAT_PROVIDER_STORAGE_KEY = "preferredFiatProvider";
 
 export async function setLastAuthProvider(
   authProvider: AuthArgsType["strategy"],

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/fiat/Providers.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/fiat/Providers.tsx
@@ -1,0 +1,57 @@
+import {
+  type FiatProvider,
+  FiatProviders,
+} from "../../../../../../../pay/utils/commonTypes.js";
+import { Container } from "../../../../components/basic.js";
+import { Button } from "../../../../components/buttons.js";
+import { Link } from "../../../../components/text.js";
+/**
+ * @internal
+ */
+export function Providers(props: {
+  preferredProvider?: FiatProvider;
+  onSelect: (provider: FiatProvider) => void;
+}) {
+  return (
+    <Container
+      expand
+      flex="column"
+      gap="sm"
+      style={{
+        alignItems: "flex-start",
+      }}
+    >
+      {FiatProviders.map((provider) => {
+        return (
+          <Container
+            key={provider}
+            flex="row"
+            expand
+            style={{
+              justifyContent: "space-between",
+            }}
+          >
+            <Button
+              fullWidth
+              onClick={() => props.onSelect(provider)}
+              variant={"link"}
+            >
+              <Link
+                color={
+                  props.preferredProvider === provider
+                    ? "primaryText"
+                    : "secondaryText"
+                }
+                size="sm"
+                hoverColor="primaryText"
+              >
+                {provider.charAt(0).toUpperCase() +
+                  provider.slice(1).toLowerCase()}
+              </Link>
+            </Button>
+          </Container>
+        );
+      })}
+    </Container>
+  );
+}


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding fiat provider selection functionality to the `PayEmbed` component, enhancing the user experience when purchasing with fiat currencies.

### Detailed summary
- Added `provider` property in the quote interface.
- Updated `FiatProvider` type to use `FiatProviders` array.
- Introduced `PREFERRED_FIAT_PROVIDER_STORAGE_KEY` for local storage.
- Created `Providers` component to select fiat providers.
- Integrated provider selection in `FiatScreenContent`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->