### PR TITLE
[service-utils] Allow sending client-side usageV2 events 

### DIFF
--- a/.changeset/metal-crabs-beg.md
+++ b/.changeset/metal-crabs-beg.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+[service-utils] Allow client-side usageV2 reporting

--- a/packages/service-utils/src/cf-worker/usageV2.ts
+++ b/packages/service-utils/src/cf-worker/usageV2.ts
@@ -1,5 +1,4 @@
-import type { ServiceName } from "../core/services.js";
-import type { UsageV2Event } from "../core/usageV2.js";
+import type { UsageV2Event, UsageV2Source } from "../core/usageV2.js";
 
 /**
  * Send events to Kafka.
@@ -20,8 +19,8 @@ export async function sendUsageV2Events(
   events: UsageV2Event[],
   options: {
     environment: "development" | "production";
-    productName: ServiceName;
-    serviceKey: string;
+    source: UsageV2Source;
+    serviceKey?: string;
   },
 ): Promise<void> {
   const baseUrl =
@@ -29,12 +28,16 @@ export async function sendUsageV2Events(
       ? "https://u.thirdweb.com"
       : "https://u.thirdweb-dev.com";
 
-  const resp = await fetch(`${baseUrl}/usage-v2/${options.productName}`, {
+  const headers: HeadersInit = {
+    "Content-Type": "application/json",
+  };
+  if (options.serviceKey) {
+    headers["x-service-api-key"] = options.serviceKey;
+  }
+
+  const resp = await fetch(`${baseUrl}/usage-v2/${options.source}`, {
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "x-service-api-key": options.serviceKey,
-    },
+    headers,
     body: JSON.stringify({ events }),
   });
 

--- a/packages/service-utils/src/cf-worker/usageV2.ts
+++ b/packages/service-utils/src/cf-worker/usageV2.ts
@@ -28,14 +28,23 @@ export async function sendUsageV2Events(
       ? "https://u.thirdweb.com"
       : "https://u.thirdweb-dev.com";
 
-  const headers: HeadersInit = {
-    "Content-Type": "application/json",
-  };
+  // Unauthed calls are routed to the /client path
+  let url: string;
+  let headers: HeadersInit;
   if (options.serviceKey) {
-    headers["x-service-api-key"] = options.serviceKey;
+    url = `${baseUrl}/usage-v2/${options.source}`;
+    headers = {
+      "Content-Type": "application/json",
+      "x-service-api-key": options.serviceKey,
+    };
+  } else {
+    url = `${baseUrl}/usage-v2/${options.source}/client`;
+    headers = {
+      "Content-Type": "application/json",
+    };
   }
 
-  const resp = await fetch(`${baseUrl}/usage-v2/${options.source}`, {
+  const resp = await fetch(url, {
     method: "POST",
     headers,
     body: JSON.stringify({ events }),


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the `sendUsageV2Events` function in the `service-utils` package to allow client-side usage reporting by introducing a new `UsageV2Source` type and modifying the function's parameters and fetch logic.

### Detailed summary
- Added `UsageV2Source` to the import statement in `usageV2.ts`.
- Modified the `options` parameter in `sendUsageV2Events` to include `source` and make `serviceKey` optional.
- Updated the fetch URL logic to handle unauthenticated calls to the `/client` path based on the presence of `serviceKey`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->