### PR TITLE
[SDK] fix: Disable quote retries and show fiat values

### DIFF
--- a/.changeset/cool-pumpkins-punch.md
+++ b/.changeset/cool-pumpkins-punch.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Dont retry on quote errors, show fiat value in every step

--- a/packages/thirdweb/src/react/core/hooks/pay/useBuyWithCryptoQuote.ts
+++ b/packages/thirdweb/src/react/core/hooks/pay/useBuyWithCryptoQuote.ts
@@ -18,15 +18,6 @@ export type BuyWithCryptoQuoteQueryOptions = Omit<
 >;
 
 /**
- * @internal
- */
-type BuyWithCryptoQuoteError = {
-  status: string;
-  code: string;
-  statusCode: number;
-};
-
-/**
  * Hook to get a price quote for performing a "Buy with crypto" transaction that allows users to buy a token with another token - aka a swap.
  *
  * The price quote is an object of type [`BuyWithCryptoQuote`](https://portal.thirdweb.com/references/typescript/v5/BuyWithCryptoQuote).
@@ -97,26 +88,6 @@ export function useBuyWithCryptoQuote(
       return getBuyWithCryptoQuote(params);
     },
     enabled: !!params,
-    retry(failureCount, error) {
-      if (failureCount > 3) {
-        return false;
-      }
-      try {
-        // biome-ignore lint/suspicious/noExplicitAny: <explanation>
-        const serverError = (error as any).error as BuyWithCryptoQuoteError;
-
-        if (serverError.code === "MINIMUM_PURCHASE_AMOUNT") {
-          return false;
-        }
-
-        if (serverError.statusCode === 404 || serverError.statusCode >= 500) {
-          return false;
-        }
-      } catch {
-        return true;
-      }
-
-      return true;
-    },
+    retry: false,
   });
 }

--- a/packages/thirdweb/src/react/core/hooks/pay/useBuyWithFiatQuote.ts
+++ b/packages/thirdweb/src/react/core/hooks/pay/useBuyWithFiatQuote.ts
@@ -18,15 +18,6 @@ export type BuyWithFiatQuoteQueryOptions = Omit<
 >;
 
 /**
- * @internal
- */
-type BuyWithFiatQuoteError = {
-  status: string;
-  code: string;
-  statusCode: number;
-};
-
-/**
  * Hook to get a price quote for performing a "Buy with Fiat" transaction that allows users to buy a token with fiat currency.
  *
  * The price quote is an object of type [`BuyWithFiatQuote`](https://portal.thirdweb.com/references/typescript/v5/BuyWithFiatQuote).
@@ -85,26 +76,6 @@ export function useBuyWithFiatQuote(
       return getBuyWithFiatQuote(params);
     },
     enabled: !!params,
-    retry(failureCount, error) {
-      if (failureCount > 3) {
-        return false;
-      }
-      try {
-        // biome-ignore lint/suspicious/noExplicitAny: <explanation>
-        const serverError = (error as any).error as BuyWithFiatQuoteError;
-
-        if (serverError.code === "MINIMUM_PURCHASE_AMOUNT") {
-          return false;
-        }
-
-        if (serverError.statusCode === 404 || serverError.statusCode >= 500) {
-          return false;
-        }
-      } catch {
-        return true;
-      }
-
-      return true;
-    },
+    retry: false,
   });
 }

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx
@@ -52,6 +52,7 @@ import {
   useToTokenSelectionStates,
 } from "./main/useUISelectionStates.js";
 import { BuyTokenInput } from "./swap/BuyTokenInput.js";
+import { FiatValue } from "./swap/FiatValue.js";
 import { PaymentSelectionScreen } from "./swap/PaymentSelectionScreen.js";
 import { SwapFlow } from "./swap/SwapFlow.js";
 import { SwapScreenContent } from "./swap/SwapScreenContent.js";
@@ -669,7 +670,7 @@ function SelectedTokenInfo(props: {
           justifyContent: "space-between",
         }}
       >
-        <Container flex="row" gap="xs" center="y">
+        <Container flex="row" gap="xxs" center="y">
           <Input
             variant="outline"
             pattern="^[0-9]*[.,]?[0-9]*$"
@@ -738,6 +739,14 @@ function SelectedTokenInfo(props: {
               token={props.selectedToken}
             />
           </Container>
+
+          <FiatValue
+            chain={props.selectedChain}
+            client={props.client}
+            tokenAmount={props.tokenAmount}
+            token={props.selectedToken}
+            size="sm"
+          />
         </Container>
 
         <ChainName

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/fiat/FiatSteps.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/fiat/FiatSteps.tsx
@@ -233,7 +233,7 @@ export function FiatSteps(props: {
 
   const toTokenInfo = partialSuccessToTokenInfo || (
     <Text color="primaryText" size="sm">
-      {formatNumber(Number(toTokenAmount), 6)}
+      {formatNumber(Number(toTokenAmount), 6)}{" "}
       <TokenSymbol token={toToken} chain={toChain} size="sm" inline />
     </Text>
   );


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the handling of fiat transactions in the `thirdweb` package by eliminating retries on quote errors and ensuring the fiat value is displayed at every step.

### Detailed summary
- Updated the `toTokenInfo` to include a space after the formatted number.
- Removed the retry logic from `useBuyWithFiatQuote` and `useBuyWithCryptoQuote`, setting `retry` to `false`.
- Added the `FiatValue` component to `SelectedTokenInfo` to display fiat value based on the selected token and chain.
- Adjusted the `Container` gap from `xs` to `xxs` in `SelectedTokenInfo`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->