### PR TITLE
[service-utils]H elper to call client usageV2 reporting endpoint

### DIFF
--- a/.changeset/breezy-balloons-ring.md
+++ b/.changeset/breezy-balloons-ring.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+[service-utils] Helper to call client usageV2 reporting endpoint


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new helper function for sending usageV2 events, enhancing authentication options for internal services and public clients. It updates the documentation and refines the logic for determining the endpoint and headers based on the provided authentication method.

### Detailed summary
- Added `UsageV2Options` type to define authentication options.
- Updated documentation for `sendUsageV2Events` to clarify authentication requirements.
- Refined logic for determining the endpoint and headers based on `serviceKey`, `thirdwebSecretKey`, or `thirdwebClientId`.
- Improved error message for unexpected responses.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->