### PR TITLE
[service-utils] Omit team_id for client usageV2 events

### DIFF
--- a/.changeset/fresh-weeks-deliver.md
+++ b/.changeset/fresh-weeks-deliver.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+[service-utils] Omit team_id for client usageV2 events

--- a/packages/service-utils/src/cf-worker/usageV2.ts
+++ b/packages/service-utils/src/cf-worker/usageV2.ts
@@ -1,4 +1,8 @@
-import type { UsageV2Event, UsageV2Source } from "../core/usageV2.js";
+import type {
+  ClientUsageV2Event,
+  UsageV2Event,
+  UsageV2Source,
+} from "../core/usageV2.js";
 
 type UsageV2Options = {
   environment: "development" | "production";
@@ -17,14 +21,18 @@ type UsageV2Options = {
  * - thirdwebClientId: for public clients (MUST be the user's project)
  * - thirdwebSecretKey: for public clients (MUST be the user's project)
  *
+ * NOTE: `team_id` is required if `serviceKey` is provided.
+ *
  * This method may throw. To call this non-blocking:
  * ```ts
  * void sendUsageV2Events(...).catch((e) => console.error(e))
  * ```
  */
-export async function sendUsageV2Events(
-  events: UsageV2Event[],
-  options: UsageV2Options,
+export async function sendUsageV2Events<T extends UsageV2Options>(
+  events: T extends { serviceKey: string }
+    ? UsageV2Event[]
+    : ClientUsageV2Event[],
+  options: T,
 ): Promise<void> {
   const baseUrl =
     options.environment === "production"

--- a/packages/service-utils/src/core/usageV2.ts
+++ b/packages/service-utils/src/core/usageV2.ts
@@ -13,7 +13,7 @@ export function getTopicName(source: UsageV2Source) {
   return `usage_v2.raw_${source}`;
 }
 
-export interface UsageV2Event {
+export interface ClientUsageV2Event {
   /**
    * A unique identifier for the event. Defaults to a random UUID.
    * Useful if your service retries sending events.
@@ -27,10 +27,6 @@ export interface UsageV2Event {
    * The action of the event. Example: "upload"
    */
   action: string;
-  /**
-   * The team ID.
-   */
-  team_id: string;
   /**
    * The project ID, if available.
    */
@@ -64,4 +60,11 @@ export interface UsageV2Event {
    * Values can be boolean, number, string, Date, or null.
    */
   [key: string]: boolean | number | string | Date | null | undefined;
+}
+
+export interface UsageV2Event extends ClientUsageV2Event {
+  /**
+   * The team ID.
+   */
+  team_id: string;
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on modifying the `UsageV2Event` interface to create a new `ClientUsageV2Event` interface that omits the `team_id` property for client usage events. It also updates the `sendUsageV2Events` function to accommodate this change.

### Detailed summary
- Renamed `UsageV2Event` to `ClientUsageV2Event` and removed `team_id`.
- Added `team_id` back to `UsageV2Event` as an extension of `ClientUsageV2Event`.
- Updated `sendUsageV2Events` function to conditionally accept either `UsageV2Event[]` or `ClientUsageV2Event[]` based on `serviceKey`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->