### PR TITLE
fix: typos in documentation files

### DIFF
--- a/packages/thirdweb/src/storage/upload/helpers.ts
+++ b/packages/thirdweb/src/storage/upload/helpers.ts
@@ -125,7 +125,7 @@ export function buildFormData(
         // but then we skip because we don't need to upload it multiple times
         continue;
       }
-      // otherwise if file names are the same but they are not the same file then we should throw an error (trying to upload to differnt files but with the same names)
+      // otherwise if file names are the same but they are not the same file then we should throw an error (trying to upload to different files but with the same names)
       throw new Error(
         `[DUPLICATE_FILE_NAME_ERROR] File name ${fileName} was passed for more than one different file.`,
       );


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on correcting a typo in a comment within the `helpers.ts` file, ensuring clarity in the code documentation regarding error handling for duplicate file names.

### Detailed summary
- Fixed a typo in a comment: changed "differnt" to "different" to improve clarity on the error handling for duplicate file names.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->