### PR TITLE
[service-utils] fix auth cache for cf workers

### DIFF
--- a/.changeset/hungry-books-jump.md
+++ b/.changeset/hungry-books-jump.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+[service-utils] fix auth for cf workers

--- a/packages/service-utils/src/cf-worker/index.ts
+++ b/packages/service-utils/src/cf-worker/index.ts
@@ -6,7 +6,10 @@ import type {
 import type { Request } from "@cloudflare/workers-types";
 import type { CoreServiceConfig, TeamAndProjectResponse } from "../core/api.js";
 import { authorize } from "../core/authorize/index.js";
-import type { AuthorizationInput } from "../core/authorize/index.js";
+import type {
+  AuthorizationInput,
+  TeamAndProjectCacheWithPossibleTTL,
+} from "../core/authorize/index.js";
 import type { AuthorizationResult } from "../core/authorize/types.js";
 import type { CoreAuthInput } from "../core/types.js";
 
@@ -54,14 +57,14 @@ export async function authorizeWorker(
 
   return await authorize(authData, serviceConfig, {
     get: async (clientId: string) => serviceConfig.kvStore.get(clientId),
-    put: (clientId: string, data: TeamAndProjectResponse) =>
+    put: (clientId: string, teamAndProjectResponse: TeamAndProjectResponse) =>
       serviceConfig.ctx.waitUntil(
         serviceConfig.kvStore.put(
           clientId,
           JSON.stringify({
             updatedAt: Date.now(),
-            data,
-          }),
+            teamAndProjectResponse,
+          } satisfies TeamAndProjectCacheWithPossibleTTL),
           {
             expirationTtl:
               serviceConfig.cacheTtlSeconds &&

--- a/packages/service-utils/src/core/authorize/index.ts
+++ b/packages/service-utils/src/core/authorize/index.ts
@@ -28,7 +28,7 @@ export type CacheOptions = {
   cacheTtlSeconds: number;
 };
 
-type TeamAndProjectCacheWithPossibleTTL =
+export type TeamAndProjectCacheWithPossibleTTL =
   | {
       teamAndProjectResponse: TeamAndProjectResponse;
       updatedAt: number;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on fixing authentication for Cloudflare workers in the `service-utils` package by refining type definitions and updating how data is handled within the `authorizeWorker` function.

### Detailed summary
- Updated type definition of `TeamAndProjectCacheWithPossibleTTL` to be exported.
- Added `TeamAndProjectCacheWithPossibleTTL` import in `index.ts`.
- Changed parameter name from `data` to `teamAndProjectResponse` in the `put` function.
- Modified the data structure passed to `kvStore.put` to use `teamAndProjectResponse`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->