### PR TITLE
Docs remove legacy enc key arg

### DIFF
--- a/apps/portal/src/app/unity/v5/wallets/in-app-wallet/page.mdx
+++ b/apps/portal/src/app/unity/v5/wallets/in-app-wallet/page.mdx
@@ -107,7 +107,7 @@ var inAppWalletOptions = new InAppWalletOptions(
 ### Login with Custom Auth - OIDC Compatible
 
 ```csharp
-var inAppWalletOptions = new InAppWalletOptions(authprovider: AuthProvider.JWT, jwtOrPayload: "myjwt", encryptionKey: "myencryptionkey");
+var inAppWalletOptions = new InAppWalletOptions(authprovider: AuthProvider.JWT, jwtOrPayload: "myjwt");
 var options = new WalletOptions(
     provider: WalletProvider.InAppWallet, 
     chainId: 1, 
@@ -121,8 +121,7 @@ var wallet = await ThirdwebManager.Instance.ConnectWallet(options);
 ```csharp
 var inAppWalletOptions = new InAppWalletOptions(
     authprovider: AuthProvider.AuthEndpoint, 
-    jwtOrPayload: "mypayload", 
-    encryptionKey: "myencryptionkey"
+    jwtOrPayload: "mypayload"
 );
 var options = new WalletOptions(
     provider: WalletProvider.InAppWallet, 


### PR DESCRIPTION
Closes TOOL-3348

<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying the initialization of `InAppWalletOptions` by removing the `encryptionKey` parameter from its constructor, simplifying its instantiation.

### Detailed summary
- Removed `encryptionKey: "myencryptionkey"` from the initialization of `inAppWalletOptions`.
- The `InAppWalletOptions` constructor now only includes `authprovider` and `jwtOrPayload`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->