### PR TITLE
use supportPlan instead of billingPlan for support tickets

### DIFF
--- a/apps/dashboard/src/@/api/team.ts
+++ b/apps/dashboard/src/@/api/team.ts
@@ -24,6 +24,7 @@ export type Team = {
   image?: string;
   billingPlan: "pro" | "growth" | "free" | "starter";
   billingStatus: "validPayment" | (string & {}) | null;
+  supportPlan: "pro" | "growth" | "free" | "starter";
   billingEmail: string | null;
   growthTrialEligible: false;
   enabledScopes: EnabledTeamScope[];

--- a/apps/dashboard/src/app/(dashboard)/support/create-ticket/components/create-ticket.action.ts
+++ b/apps/dashboard/src/app/(dashboard)/support/create-ticket/components/create-ticket.action.ts
@@ -98,9 +98,10 @@ export async function createTicketAction(
     loginRedirect("/support");
   }
 
-  const customerId = isValidPlan(team.billingPlan)
-    ? planToCustomerId[team.billingPlan]
-    : undefined;
+  const customerId = isValidPlan(team.supportPlan)
+    ? planToCustomerId[team.supportPlan]
+    : // fallback to "free" tier
+      planToCustomerId.free;
 
   const product = formData.get("product")?.toString() || "";
   const problemArea = formData.get("extraInfo_Problem_Area")?.toString() || "";

--- a/apps/dashboard/src/stories/stubs.ts
+++ b/apps/dashboard/src/stories/stubs.ts
@@ -36,6 +36,7 @@ export function teamStub(id: string, billingPlan: Team["billingPlan"]): Team {
   const team: Team = {
     id: `team-${id}-id`,
     billingPlan: billingPlan,
+    supportPlan: billingPlan,
     billingStatus: "validPayment",
     name: `Team ${id}`,
     slug: `team-${id}`,


### PR DESCRIPTION
TOOL-0000

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `supportPlan` property and updates related logic to accommodate it in the dashboard application. It ensures that the `supportPlan` is treated similarly to the existing `billingPlan`, affecting how customer IDs are determined.

### Detailed summary
- Added `supportPlan` property to the `stubs.ts` file.
- Updated `team.ts` to include `supportPlan` in the type definitions.
- Changed logic in `create-ticket.action.ts` to derive `customerId` from `supportPlan` instead of `billingPlan`, with a fallback to the "free" tier.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->