### PR TITLE
kv catch cache put in cf worker

### DIFF
--- a/.changeset/gorgeous-rules-protect.md
+++ b/.changeset/gorgeous-rules-protect.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+catch cache puts for auth in cf workers

--- a/packages/service-utils/src/cf-worker/index.ts
+++ b/packages/service-utils/src/cf-worker/index.ts
@@ -59,20 +59,24 @@ export async function authorizeWorker(
     get: async (clientId: string) => serviceConfig.kvStore.get(clientId),
     put: (clientId: string, teamAndProjectResponse: TeamAndProjectResponse) =>
       serviceConfig.ctx.waitUntil(
-        serviceConfig.kvStore.put(
-          clientId,
-          JSON.stringify({
-            updatedAt: Date.now(),
-            teamAndProjectResponse,
-          } satisfies TeamAndProjectCacheWithPossibleTTL),
-          {
-            expirationTtl:
-              serviceConfig.cacheTtlSeconds &&
-              serviceConfig.cacheTtlSeconds >= DEFAULT_CACHE_TTL_SECONDS
-                ? serviceConfig.cacheTtlSeconds
-                : DEFAULT_CACHE_TTL_SECONDS,
-          },
-        ),
+        serviceConfig.kvStore
+          .put(
+            clientId,
+            JSON.stringify({
+              updatedAt: Date.now(),
+              teamAndProjectResponse,
+            } satisfies TeamAndProjectCacheWithPossibleTTL),
+            {
+              expirationTtl:
+                serviceConfig.cacheTtlSeconds &&
+                serviceConfig.cacheTtlSeconds >= DEFAULT_CACHE_TTL_SECONDS
+                  ? serviceConfig.cacheTtlSeconds
+                  : DEFAULT_CACHE_TTL_SECONDS,
+            },
+          )
+          .catch((e) => {
+            console.error(e);
+          }),
       ),
     cacheTtlSeconds: serviceConfig.cacheTtlSeconds ?? DEFAULT_CACHE_TTL_SECONDS,
   });

--- a/packages/service-utils/src/cf-worker/index.ts
+++ b/packages/service-utils/src/cf-worker/index.ts
@@ -75,7 +75,7 @@ export async function authorizeWorker(
             },
           )
           .catch((e) => {
-            console.error(e);
+            console.warn(e);
           }),
       ),
     cacheTtlSeconds: serviceConfig.cacheTtlSeconds ?? DEFAULT_CACHE_TTL_SECONDS,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces error handling for cache operations in Cloudflare workers by adding a `.catch` block to log any errors that occur during the `put` operation in the `kvStore`.

### Detailed summary
- Added a `.catch` block to the `put` method in `packages/service-utils/src/cf-worker/index.ts` to log errors.
- Maintained the original structure of the `put` operation while enhancing its robustness.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->