### PR TITLE
[TOOL-3396] Dashboard: Fix inputMode for OTP input, Use text instead of default numeric

### DIFF
--- a/apps/dashboard/src/app/account/settings/AccountSettingsPageUI.tsx
+++ b/apps/dashboard/src/app/account/settings/AccountSettingsPageUI.tsx
@@ -428,6 +428,7 @@ function EnterEmailOTP(props: {
         <InputOTP
           maxLength={6}
           pattern={REGEXP_ONLY_DIGITS_AND_CHARS}
+          inputMode="text"
           value={otp}
           onChange={(v) => {
             setOtp(v);

--- a/apps/dashboard/src/app/login/onboarding/ConfirmEmail.tsx
+++ b/apps/dashboard/src/app/login/onboarding/ConfirmEmail.tsx
@@ -206,6 +206,7 @@ export const OnboardingConfirmEmail: React.FC<OnboardingConfirmEmailProps> = ({
           <InputOTP
             maxLength={6}
             pattern={REGEXP_ONLY_DIGITS_AND_CHARS}
+            inputMode="text"
             value={token}
             onChange={handleChange}
             disabled={saving}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing user input handling in two components by adding the `inputMode` attribute to improve the experience when entering text.

### Detailed summary
- In the `AccountSettingsPageUI.tsx`, added `inputMode="text"` to the input element for `otp`.
- In the `ConfirmEmail.tsx`, added `inputMode="text"` to the input element for `token`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->