### PR TITLE
Handle single unnamed param

### DIFF
--- a/packages/thirdweb/src/utils/abi/normalizeFunctionParams.test.ts
+++ b/packages/thirdweb/src/utils/abi/normalizeFunctionParams.test.ts
@@ -56,7 +56,7 @@ describe("normalizeFunctionParams", () => {
   });
 
   it("should throw an error if a parameter name is missing", () => {
-    const abiFunction: AbiFunction = {
+    let abiFunction: AbiFunction = {
       inputs: [{ name: undefined, type: "uint256" }],
       type: "function",
       stateMutability: "pure",
@@ -67,6 +67,31 @@ describe("normalizeFunctionParams", () => {
     expect(() => normalizeFunctionParams(abiFunction, {})).toThrow(
       "Missing named parameter for test at index 0",
     );
+
+    abiFunction = {
+      inputs: [{ name: "", type: "uint256" }],
+      type: "function",
+      stateMutability: "pure",
+      name: "test",
+      outputs: [],
+    };
+
+    expect(() => normalizeFunctionParams(abiFunction, {})).toThrow(
+      "Missing named parameter for test at index 0",
+    );
+
+    abiFunction = {
+      inputs: [{ name: undefined, type: "uint256" }],
+      type: "function",
+      stateMutability: "pure",
+      name: "test",
+      outputs: [],
+    };
+
+    const normalized = normalizeFunctionParams(abiFunction, { "*": 123 });
+
+    expect(normalized.length).to.eq(1);
+    expect(normalized[0]).to.eq(123);
   });
 
   it("should throw an error if a parameter value is missing", () => {

--- a/packages/thirdweb/src/utils/abi/normalizeFunctionParams.ts
+++ b/packages/thirdweb/src/utils/abi/normalizeFunctionParams.ts
@@ -13,10 +13,15 @@ export function normalizeFunctionParams(
     abiFunction.inputs.map((i) => i.type),
     abiFunction.inputs.map((input, index) => {
       const value = input.name;
-      if (value === undefined) {
-        throw new Error(
-          `Missing named parameter for ${"name" in abiFunction ? abiFunction.name : "constructor"} at index ${index}`,
-        );
+      if (value === undefined || value.length === 0) {
+        // TODO: Handle multiple unnamed params
+        if (!params["*"]) {
+          throw new Error(
+            `Missing named parameter for ${"name" in abiFunction ? abiFunction.name : "constructor"} at index ${index}`,
+          );
+        }
+
+        return params["*"];
       }
       const valueWithoutUnderscore = value.replace(/^_+/, "");
       const normalizedValue =


### PR DESCRIPTION
TOOL-3401

Dashboard handles single unnamed param as "*". Handle this in sdk. Throw error for all other cases.

<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `normalizeFunctionParams` function to handle cases where parameter names are either missing or empty. It also updates the associated tests to verify these new conditions.

### Detailed summary
- Updated the condition to check for both `undefined` and empty string parameter names.
- Added a comment for future handling of multiple unnamed parameters.
- Modified tests to cover cases with empty string parameter names.
- Verified that unnamed parameters can be returned when provided.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->