### PR TITLE
[Pay] Fix: fix fiat value to 2 decimals

### DIFF
--- a/.changeset/tender-frogs-change.md
+++ b/.changeset/tender-frogs-change.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix PayEmbed fiat values to 2 decimal places

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/FiatValue.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/FiatValue.tsx
@@ -42,6 +42,8 @@ export function FiatValue(
   }
 
   return cryptoToFiatQuery.data?.result ? (
-    <Text {...props}>${formatNumber(cryptoToFiatQuery.data.result, 2)}</Text>
+    <Text {...props}>
+      ${formatNumber(cryptoToFiatQuery.data.result, 2).toFixed(2)}
+    </Text>
   ) : null;
 }


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the display of fiat values in the `PayEmbed` component by ensuring they are formatted to two decimal places.

### Detailed summary
- Updated the return statement in the `FiatValue.tsx` file.
- Changed the formatting of the fiat value to use `.toFixed(2)` for consistent two decimal place display.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->