### PR TITLE
add projectId parameter to pay analytics components

### DIFF
--- a/apps/dashboard/src/app/team/[team_slug]/[project_slug]/connect/pay/page.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/[project_slug]/connect/pay/page.tsx
@@ -17,5 +17,11 @@ export default async function Page(props: {
     notFound();
   }
 
-  return <PayAnalytics clientId={project.publishableKey} />;
+  return (
+    <PayAnalytics
+      clientId={project.publishableKey}
+      projectId={project.id}
+      teamId={project.teamId}
+    />
+  );
 }

--- a/apps/dashboard/src/app/team/[team_slug]/[project_slug]/connect/pay/webhooks/components/webhooks.client.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/[project_slug]/connect/pay/webhooks/components/webhooks.client.tsx
@@ -60,7 +60,13 @@ type Webhook = {
 };
 
 type PayWebhooksPageProps = {
+  /**
+   *  @deprecated - remove after migration
+   */
   clientId: string;
+  // switching to projectId for lookup, but have to send both during migration
+  projectId: string;
+  teamId: string;
 };
 
 export function PayWebhooksPage(props: PayWebhooksPageProps) {
@@ -71,7 +77,13 @@ export function PayWebhooksPage(props: PayWebhooksPageProps) {
         method: "GET",
         pathname: "/webhooks/get-all",
         searchParams: {
+          /**
+           *  @deprecated - remove after migration
+           */
           clientId: props.clientId,
+          // switching to projectId for lookup, but have to send both during migration
+          projectId: props.projectId,
+          teamId: props.teamId,
         },
         headers: {
           "Content-Type": "application/json",
@@ -95,7 +107,11 @@ export function PayWebhooksPage(props: PayWebhooksPageProps) {
     return (
       <div className="flex flex-col items-center gap-8 rounded-lg border border-border p-8 text-center">
         <h2 className="font-semibold text-xl">No webhooks configured yet.</h2>
-        <CreateWebhookButton clientId={props.clientId}>
+        <CreateWebhookButton
+          clientId={props.clientId}
+          projectId={props.projectId}
+          teamId={props.teamId}
+        >
           <Button variant="primary" className="gap-1">
             <PlusIcon className="size-4" />
             <span>Create Webhook</span>
@@ -109,7 +125,11 @@ export function PayWebhooksPage(props: PayWebhooksPageProps) {
     <div>
       <div className="flex items-center justify-between">
         <h2 className="font-semibold text-xl tracking-tight">Webhooks</h2>
-        <CreateWebhookButton clientId={props.clientId}>
+        <CreateWebhookButton
+          clientId={props.clientId}
+          projectId={props.projectId}
+          teamId={props.teamId}
+        >
           <Button size="sm" variant="default" className="gap-1">
             <PlusIcon className="size-4" />
             <span>Create Webhook</span>
@@ -149,7 +169,9 @@ export function PayWebhooksPage(props: PayWebhooksPageProps) {
                 <TableCell className="text-right">
                   <DeleteWebhookButton
                     clientId={props.clientId}
+                    projectId={props.projectId}
                     webhookId={webhook.id}
+                    teamId={props.teamId}
                   >
                     <Button variant="ghost" size="icon">
                       <TrashIcon className="size-5" strokeWidth={1} />
@@ -185,7 +207,15 @@ function CreateWebhookButton(props: PropsWithChildren<PayWebhooksPageProps>) {
       const res = await payServerProxy({
         method: "POST",
         pathname: "/webhooks/create",
-        body: JSON.stringify({ ...values, clientId: props.clientId }),
+        body: JSON.stringify({
+          ...values,
+          /**
+           *  @deprecated - remove after migration
+           */
+          clientId: props.clientId,
+          // switching to projectId for lookup, but have to send both during migration
+          projectId: props.projectId,
+        }),
         headers: {
           "Content-Type": "application/json",
         },
@@ -311,7 +341,15 @@ function DeleteWebhookButton(
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ id, clientId: props.clientId }),
+        body: JSON.stringify({
+          id,
+          /**
+           *  @deprecated - remove after migration
+           */
+          clientId: props.clientId,
+          // switching to projectId for lookup, but have to send both during migration
+          projectId: props.projectId,
+        }),
         pathname: "/webhooks/revoke",
       });
 

--- a/apps/dashboard/src/app/team/[team_slug]/[project_slug]/connect/pay/webhooks/page.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/[project_slug]/connect/pay/webhooks/page.tsx
@@ -17,5 +17,11 @@ export default async function Page(props: {
     notFound();
   }
 
-  return <PayWebhooksPage clientId={project.publishableKey} />;
+  return (
+    <PayWebhooksPage
+      clientId={project.publishableKey}
+      projectId={project.id}
+      teamId={project.teamId}
+    />
+  );
 }

--- a/apps/dashboard/src/components/pay/PayAnalytics/PayAnalytics.tsx
+++ b/apps/dashboard/src/components/pay/PayAnalytics/PayAnalytics.tsx
@@ -14,8 +14,18 @@ import { Payouts } from "./components/Payouts";
 import { TotalPayVolume } from "./components/TotalPayVolume";
 import { TotalVolumePieChart } from "./components/TotalVolumePieChart";
 
-export function PayAnalytics(props: { clientId: string }) {
+export function PayAnalytics(props: {
+  /**
+   *  @deprecated - remove after migration
+   */
+  clientId: string;
+  // switching to projectId for lookup, but have to send both during migration
+  projectId: string;
+  teamId: string;
+}) {
   const clientId = props.clientId;
+  const projectId = props.projectId;
+  const teamId = props.teamId;
   const [range, setRange] = useState<Range>(() =>
     getLastNDaysRange("last-120"),
   );
@@ -34,12 +44,16 @@ export function PayAnalytics(props: { clientId: string }) {
           <div className="flex items-center border-border border-b pb-6 xl:border-none xl:pb-0">
             <TotalVolumePieChart
               clientId={clientId}
+              projectId={projectId}
+              teamId={teamId}
               from={range.from}
               to={range.to}
             />
           </div>
           <TotalPayVolume
             clientId={clientId}
+            projectId={projectId}
+            teamId={teamId}
             from={range.from}
             to={range.to}
             numberOfDays={numberOfDays}
@@ -50,6 +64,8 @@ export function PayAnalytics(props: { clientId: string }) {
           <CardContainer>
             <Payouts
               clientId={clientId}
+              projectId={projectId}
+              teamId={teamId}
               from={range.from}
               to={range.to}
               numberOfDays={numberOfDays}
@@ -58,6 +74,8 @@ export function PayAnalytics(props: { clientId: string }) {
           <CardContainer>
             <PaymentsSuccessRate
               clientId={clientId}
+              projectId={projectId}
+              teamId={teamId}
               from={range.from}
               to={range.to}
             />
@@ -68,6 +86,8 @@ export function PayAnalytics(props: { clientId: string }) {
           <div className="border-border border-b pb-6 xl:border-none xl:pb-0">
             <PayNewCustomers
               clientId={clientId}
+              projectId={projectId}
+              teamId={teamId}
               from={range.from}
               to={range.to}
               numberOfDays={numberOfDays}
@@ -75,13 +95,21 @@ export function PayAnalytics(props: { clientId: string }) {
           </div>
           <PayCustomersTable
             clientId={clientId}
+            projectId={projectId}
+            teamId={teamId}
             from={range.from}
             to={range.to}
           />
         </GridWithSeparator>
 
         <CardContainer>
-          <PaymentHistory clientId={clientId} from={range.from} to={range.to} />
+          <PaymentHistory
+            clientId={clientId}
+            projectId={projectId}
+            teamId={teamId}
+            from={range.from}
+            to={range.to}
+          />
         </CardContainer>
       </div>
     </div>

--- a/apps/dashboard/src/components/pay/PayAnalytics/components/PayCustomersTable.tsx
+++ b/apps/dashboard/src/components/pay/PayAnalytics/components/PayCustomersTable.tsx
@@ -71,7 +71,13 @@ function processQuery(
 }
 
 export function PayCustomersTable(props: {
+  /**
+   *  @deprecated - remove after migration
+   */
   clientId: string;
+  // switching to projectId for lookup, but have to send both during migration
+  projectId: string;
+  teamId: string;
   from: Date;
   to: Date;
 }) {
@@ -80,7 +86,13 @@ export function PayCustomersTable(props: {
   );
 
   const topCustomersQuery = usePayCustomers({
+    /**
+     *  @deprecated - remove after migration
+     */
     clientId: props.clientId,
+    // switching to projectId for lookup, but have to send both during migration
+    projectId: props.projectId,
+    teamId: props.teamId,
     from: props.from,
     to: props.to,
     pageSize: 100,

--- a/apps/dashboard/src/components/pay/PayAnalytics/components/PayNewCustomers.tsx
+++ b/apps/dashboard/src/components/pay/PayAnalytics/components/PayNewCustomers.tsx
@@ -69,7 +69,13 @@ function processQuery(
 }
 
 export function PayNewCustomers(props: {
+  /**
+   *  @deprecated - remove after migration
+   */
   clientId: string;
+  // switching to projectId for lookup, but have to send both during migration
+  projectId: string;
+  teamId: string;
   from: Date;
   to: Date;
   numberOfDays: number;
@@ -86,7 +92,13 @@ export function PayNewCustomers(props: {
 
   const uiQuery = processQuery(
     usePayNewCustomers({
+      /**
+       *  @deprecated - remove after migration
+       */
       clientId: props.clientId,
+      // switching to projectId for lookup, but have to send both during migration
+      projectId: props.projectId,
+      teamId: props.teamId,
       from: props.from,
       to: props.to,
       intervalType,

--- a/apps/dashboard/src/components/pay/PayAnalytics/components/PaymentHistory.tsx
+++ b/apps/dashboard/src/components/pay/PayAnalytics/components/PaymentHistory.tsx
@@ -63,14 +63,26 @@ function processQuery(
 }
 
 export function PaymentHistory(props: {
+  /**
+   *  @deprecated - remove after migration
+   */
   clientId: string;
+  // switching to projectId for lookup, but have to send both during migration
+  projectId: string;
+  teamId: string;
   from: Date;
   to: Date;
 }) {
   const [page, setPage] = useState(1);
 
   const purchasesQuery = usePayPurchases({
+    /**
+     *  @deprecated - remove after migration
+     */
     clientId: props.clientId,
+    // switching to projectId for lookup, but have to send both during migration
+    projectId: props.projectId,
+    teamId: props.teamId,
     from: props.from,
     to: props.to,
     start: (page - 1) * pageSize,
@@ -88,7 +100,13 @@ export function PaymentHistory(props: {
             fileName="transaction_history"
             getData={async () => {
               const purchaseData = await getPayPurchases({
+                /**
+                 *  @deprecated - remove after migration
+                 */
                 clientId: props.clientId,
+                // switching to projectId for lookup, but have to send both during migration
+                projectId: props.projectId,
+                teamId: props.teamId,
                 count: 10000,
                 from: props.from,
                 start: 0,

--- a/apps/dashboard/src/components/pay/PayAnalytics/components/PaymentsSuccessRate.tsx
+++ b/apps/dashboard/src/components/pay/PayAnalytics/components/PaymentsSuccessRate.tsx
@@ -89,7 +89,13 @@ function processQuery(
 }
 
 export function PaymentsSuccessRate(props: {
+  /**
+   *  @deprecated - remove after migration
+   */
   clientId: string;
+  // switching to projectId for lookup, but have to send both during migration
+  projectId: string;
+  teamId: string;
   from: Date;
   to: Date;
 }) {
@@ -97,7 +103,13 @@ export function PaymentsSuccessRate(props: {
 
   const uiQuery = processQuery(
     usePayVolume({
+      /**
+       *  @deprecated - remove after migration
+       */
       clientId: props.clientId,
+      // switching to projectId for lookup, but have to send both during migration
+      projectId: props.projectId,
+      teamId: props.teamId,
       from: props.from,
       to: props.to,
       intervalType: "day",

--- a/apps/dashboard/src/components/pay/PayAnalytics/components/Payouts.tsx
+++ b/apps/dashboard/src/components/pay/PayAnalytics/components/Payouts.tsx
@@ -65,7 +65,13 @@ function processQuery(query: ReturnType<typeof usePayVolume>): ProcessedQuery {
 }
 
 export function Payouts(props: {
+  /**
+   *  @deprecated - remove after migration
+   */
   clientId: string;
+  // switching to projectId for lookup, but have to send both during migration
+  projectId: string;
+  teamId: string;
   from: Date;
   to: Date;
   numberOfDays: number;
@@ -82,7 +88,13 @@ export function Payouts(props: {
 
   const uiQuery = processQuery(
     usePayVolume({
+      /**
+       *  @deprecated - remove after migration
+       */
       clientId: props.clientId,
+      // switching to projectId for lookup, but have to send both during migration
+      projectId: props.projectId,
+      teamId: props.teamId,
       from: props.from,
       to: props.to,
       intervalType,

--- a/apps/dashboard/src/components/pay/PayAnalytics/components/TotalPayVolume.tsx
+++ b/apps/dashboard/src/components/pay/PayAnalytics/components/TotalPayVolume.tsx
@@ -54,7 +54,13 @@ function processQuery(
 }
 
 export function TotalPayVolume(props: {
+  /**
+   *  @deprecated - remove after migration
+   */
   clientId: string;
+  // switching to projectId for lookup, but have to send both during migration
+  projectId: string;
+  teamId: string;
   from: Date;
   to: Date;
   numberOfDays: number;
@@ -71,7 +77,13 @@ export function TotalPayVolume(props: {
 
   const volumeQuery = processQuery(
     usePayVolume({
+      /**
+       *  @deprecated - remove after migration
+       */
       clientId: props.clientId,
+      // switching to projectId for lookup, but have to send both during migration
+      projectId: props.projectId,
+      teamId: props.teamId,
       from: props.from,
       intervalType,
       to: props.to,

--- a/apps/dashboard/src/components/pay/PayAnalytics/components/TotalVolumePieChart.tsx
+++ b/apps/dashboard/src/components/pay/PayAnalytics/components/TotalVolumePieChart.tsx
@@ -58,13 +58,25 @@ function processQuery(
 }
 
 export function TotalVolumePieChart(props: {
+  /**
+   *  @deprecated - remove after migration
+   */
   clientId: string;
+  // switching to projectId for lookup, but have to send both during migration
+  projectId: string;
+  teamId: string;
   from: Date;
   to: Date;
 }) {
   const uiQuery = processQuery(
     usePayVolume({
+      /**
+       *  @deprecated - remove after migration
+       */
       clientId: props.clientId,
+      // switching to projectId for lookup, but have to send both during migration
+      projectId: props.projectId,
+      teamId: props.teamId,
       from: props.from,
       intervalType: "day",
       to: props.to,

--- a/apps/dashboard/src/components/pay/PayAnalytics/hooks/usePayCustomers.ts
+++ b/apps/dashboard/src/components/pay/PayAnalytics/hooks/usePayCustomers.ts
@@ -17,7 +17,13 @@ type Response = {
 };
 
 export function usePayCustomers(options: {
+  /**
+   *  @deprecated - remove after migration
+   */
   clientId: string;
+  // switching to projectId for lookup, but have to send both during migration
+  projectId: string;
+  teamId: string;
   from: Date;
   to: Date;
   pageSize: number;
@@ -40,9 +46,15 @@ export function usePayCustomers(options: {
         searchParams: {
           skip: `${start}`,
           take: `${options.pageSize}`,
+          /**
+           *  @deprecated - remove after migration
+           */
           clientId: options.clientId,
+          // switching to projectId for lookup, but have to send both during migration
+          projectId: options.projectId,
           fromDate: `${options.from.getTime()}`,
           toDate: `${options.to.getTime()}`,
+          teamId: options.teamId,
         },
       });
 

--- a/apps/dashboard/src/components/pay/PayAnalytics/hooks/usePayNewCustomers.ts
+++ b/apps/dashboard/src/components/pay/PayAnalytics/hooks/usePayNewCustomers.ts
@@ -25,7 +25,13 @@ type Response = {
 };
 
 export function usePayNewCustomers(options: {
+  /**
+   *  @deprecated - remove after migration
+   */
   clientId: string;
+  // switching to projectId for lookup, but have to send both during migration
+  projectId: string;
+  teamId: string;
   from: Date;
   to: Date;
   intervalType: "day" | "week";
@@ -38,7 +44,13 @@ export function usePayNewCustomers(options: {
         pathname: "/stats/aggregate/customers/v1",
         searchParams: {
           intervalType: options.intervalType,
+          /**
+           *  @deprecated - remove after migration
+           */
           clientId: options.clientId,
+          // switching to projectId for lookup, but have to send both during migration
+          projectId: options.projectId,
+          teamId: options.teamId,
           fromDate: `${options.from.getTime()}`,
           toDate: `${options.to.getTime()}`,
         },

--- a/apps/dashboard/src/components/pay/PayAnalytics/hooks/usePayPurchases.ts
+++ b/apps/dashboard/src/components/pay/PayAnalytics/hooks/usePayPurchases.ts
@@ -54,7 +54,13 @@ type Response = {
 };
 
 type PayPurchaseOptions = {
+  /**
+   *  @deprecated - remove after migration
+   */
   clientId: string;
+  // switching to projectId for lookup, but have to send both during migration
+  projectId: string;
+  teamId: string;
   from: Date;
   to: Date;
   start: number;
@@ -77,7 +83,13 @@ export async function getPayPurchases(options: PayPurchaseOptions) {
     searchParams: {
       skip: `${options.start}`,
       take: `${options.count}`,
+      /**
+       *  @deprecated - remove after migration
+       */
       clientId: options.clientId,
+      // switching to projectId for lookup, but have to send both during migration
+      projectId: options.projectId,
+      teamId: options.teamId,
       fromDate: `${options.from.getTime()}`,
       toDate: `${options.to.getTime()}`,
     },

--- a/apps/dashboard/src/components/pay/PayAnalytics/hooks/usePayVolume.ts
+++ b/apps/dashboard/src/components/pay/PayAnalytics/hooks/usePayVolume.ts
@@ -56,7 +56,13 @@ type Response = {
 };
 
 export function usePayVolume(options: {
+  /**
+   *  @deprecated - remove after migration
+   */
   clientId: string;
+  // switching to projectId for lookup, but have to send both during migration
+  projectId: string;
+  teamId: string;
   from: Date;
   to: Date;
   intervalType: "day" | "week";
@@ -69,7 +75,13 @@ export function usePayVolume(options: {
         pathname: "/stats/aggregate/volume/v1",
         searchParams: {
           intervalType: options.intervalType,
+          /**
+           *  @deprecated - remove after migration
+           */
           clientId: options.clientId,
+          // switching to projectId for lookup, but have to send both during migration
+          projectId: options.projectId,
+          teamId: options.teamId,
           fromDate: `${options.from.getTime()}`,
           toDate: `${options.to.getTime()}`,
         },


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the `Pay` components by transitioning from using `clientId` to a more structured approach that includes `projectId` and `teamId`, marking `clientId` as deprecated during the migration.

### Detailed summary
- Updated `page.tsx` and `webhooks/page.tsx` to include `projectId` and `teamId`.
- Added `projectId` and `teamId` to multiple components: `TotalVolumePieChart`, `Payouts`, `PayCustomersTable`, `TotalPayVolume`, `PaymentsSuccessRate`, `PayNewCustomers`, and `PaymentHistory`.
- Marked `clientId` as deprecated in all related components.
- Adjusted hooks: `usePayCustomers`, `usePayPurchases`, `usePayVolume`, and `usePayNewCustomers` to accept `projectId` and `teamId`.
- Updated `PayWebhooksPage` to incorporate `projectId` and `teamId`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->