### PR TITLE
[TOOL-3243] Dashboard: Add redirect for support old engine import link

### DIFF
--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/(general)/page.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/(general)/page.tsx
@@ -1,3 +1,4 @@
+import { redirect } from "next/navigation";
 import { getAuthToken } from "../../../../../../api/lib/getAuthToken";
 import { loginRedirect } from "../../../../../../login/loginRedirect";
 import { getEngineInstances } from "../_utils/getEngineInstances";
@@ -10,8 +11,21 @@ export default async function Page(props: {
   params: Promise<{
     team_slug: string;
   }>;
+  searchParams: Promise<{
+    importUrl?: string;
+  }>;
 }) {
-  const params = await props.params;
+  const [params, searchParams] = await Promise.all([
+    props.params,
+    props.searchParams,
+  ]);
+
+  if (searchParams.importUrl) {
+    redirect(
+      `/team/${params.team_slug}/~/engine/import?importUrl=${searchParams.importUrl}`,
+    );
+  }
+
   const authToken = await getAuthToken();
 
   if (!authToken) {


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds functionality to handle `searchParams` in the `Page` component, allowing for redirection based on the presence of an `importUrl`.

### Detailed summary
- Added `searchParams` to the `Page` function's props.
- Used `Promise.all` to await both `params` and `searchParams`.
- Implemented a conditional redirect if `searchParams.importUrl` is present, directing to the import URL.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->