### PR TITLE
add teamId parameter to webhook endpoints

### DIFF
--- a/apps/dashboard/src/app/team/[team_slug]/[project_slug]/connect/pay/webhooks/components/webhooks.client.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/[project_slug]/connect/pay/webhooks/components/webhooks.client.tsx
@@ -215,6 +215,7 @@ function CreateWebhookButton(props: PropsWithChildren<PayWebhooksPageProps>) {
           clientId: props.clientId,
           // switching to projectId for lookup, but have to send both during migration
           projectId: props.projectId,
+          teamId: props.teamId,
         }),
         headers: {
           "Content-Type": "application/json",
@@ -349,6 +350,7 @@ function DeleteWebhookButton(
           clientId: props.clientId,
           // switching to projectId for lookup, but have to send both during migration
           projectId: props.projectId,
+          teamId: props.teamId,
         }),
         pathname: "/webhooks/revoke",
       });


### PR DESCRIPTION
### TL;DR
Added `teamId` parameter to webhook creation and deletion API calls.

### What changed?
- Added `teamId` to the request payload when creating new webhooks
- Added `teamId` to the request payload when deleting existing webhooks

### How to test?
1. Navigate to the webhooks page for a project
2. Create a new webhook and verify it succeeds
3. Delete an existing webhook and verify it succeeds
4. Check server logs to confirm `teamId` is being received correctly

### Why make this change?
The `teamId` parameter is required for proper webhook management and authorization at the team level. This ensures webhooks are properly scoped to the correct team context.