### PR TITLE
[TOOL-3430] SDK: Fix ConnectEmbed showing a flash of Sign In prompt screen even if user is already signed in

### DIFF
--- a/.changeset/warm-eggs-relate.md
+++ b/.changeset/warm-eggs-relate.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix ConnectEmbed briefly showing "Sign In" prompt while the login status is not known - show loading indicator instead

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/SignatureScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/SignatureScreen.tsx
@@ -69,7 +69,7 @@ export const SignatureScreen: React.FC<{
     }
   }, [onDone, siweAuth]);
 
-  if (!wallet) {
+  if (!wallet || siweAuth.isLoading) {
     return <LoadingScreen data-testid="loading-screen" />;
   }
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on improving the user experience in the `ConnectWallet` component by preventing the "Sign In" prompt from appearing when the login status is unknown. Instead, a loading indicator is displayed during the authentication process.

### Detailed summary
- Modified the conditional check in `SignatureScreen.tsx` to include `siweAuth.isLoading`.
- Updated the return statement to show a `LoadingScreen` when `wallet` is not available or the authentication is loading.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->