### PR TITLE
[SDK] feat: Enable chain switching for EIP1193 provider

### DIFF
--- a/.changeset/dirty-scissors-shake.md
+++ b/.changeset/dirty-scissors-shake.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Enable chain switching for toEIP1194 provider

--- a/apps/portal/src/app/react/v5/adapters/page.mdx
+++ b/apps/portal/src/app/react/v5/adapters/page.mdx
@@ -1,3 +1,5 @@
+import { Stack, InstallTabs, Callout, Steps, Step, GithubTemplateCard } from "@doc";
+
 # Adapters
 
 The thirdweb SDK can work side by side with:
@@ -16,7 +18,17 @@ Adapters allow you to use contracts, providers and wallets from these libraries 
 
 ### Using thirdweb in-app wallets with wagmi
 
-You can use in-app and ecosystem wallets in your wagmi application by using the `@thirdweb-dev/wagmi-adapter` package.
+View the demo repo for using thirdweb in-app / smart wallets with wagmi:
+
+<Stack>
+<GithubTemplateCard
+	title="wagmi + thirdweb demo repo"
+	description="A demo repo for using thirdweb in-app / smart wallets with wagmi"
+	href="https://github.com/thirdweb-example/wagmi-inapp-smart-wallets"
+  />
+</Stack>
+
+You can use thirdweb's in-app, ecosystem and smart wallets in your wagmi application by using the `@thirdweb-dev/wagmi-adapter` package.
 
 ```shell
 npm install thirdweb @thirdweb-dev/wagmi-adapter


### PR DESCRIPTION
Fixes TOOL-3438

<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces enhancements to the `thirdweb` SDK, enabling chain switching for the `toEIP1193` provider and updating documentation to include a demo repository for using `thirdweb` with `wagmi`.

### Detailed summary
- Added chain switching functionality for `toEIP1193` provider.
- Updated documentation in `apps/portal/src/app/react/v5/adapters/page.mdx` to include a demo repository link for using `thirdweb` in-app wallets with `wagmi`.
- Enhanced error handling for missing chain ID during chain switching.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->