### PR TITLE
[wagmi-adapter] fix: Improve autoconnect handling and storage

### DIFF
--- a/.changeset/red-eagles-end.md
+++ b/.changeset/red-eagles-end.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/wagmi-adapter": patch
+---
+
+Better autoconnection handling

--- a/packages/thirdweb/src/wallets/connection/autoConnect.ts
+++ b/packages/thirdweb/src/wallets/connection/autoConnect.ts
@@ -29,11 +29,11 @@ import type { AutoConnectProps } from "./types.js";
  * @returns {boolean} a promise resolving to true or false depending on whether the auto connect function connected to a wallet or not
  * @walletConnection
  */
-export const autoConnect = async (
+export async function autoConnect(
   props: AutoConnectProps & {
     wallets?: Wallet[];
   },
-) => {
+): Promise<boolean> {
   const wallets = props.wallets || getDefaultWallets(props);
   const manager = createConnectionManager(webLocalStorage);
   const result = await autoConnectCore({
@@ -56,4 +56,4 @@ export const autoConnect = async (
     manager,
   });
   return result;
-};
+}


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the auto-connection handling for wallets in the `thirdweb` library. It updates the storage keys used for chain IDs and enhances the connectivity functions.

### Detailed summary
- Changed `autoConnect` from a constant to an `async function`.
- Updated storage key from `"tw.lastChainId"` to `"thirdweb:lastChainId"`.
- Introduced `activeWalletIdKey` and `connectedWalletIdsKey` for better wallet management.
- Enhanced error messaging for unsupported chains.
- Set local storage values directly for active and connected wallet IDs.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->