### PR TITLE
[SDK] bytes32 salt for deterministic deployment

### DIFF
--- a/.changeset/popular-ligers-taste.md
+++ b/.changeset/popular-ligers-taste.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+bytes32 salt for deterministic deployment

--- a/packages/thirdweb/src/contract/deployment/zksync/zkDeployDeterministic.ts
+++ b/packages/thirdweb/src/contract/deployment/zksync/zkDeployDeterministic.ts
@@ -13,7 +13,11 @@ import {
 } from "../../../utils/any-evm/zksync/constants.js";
 import { isContractDeployed } from "../../../utils/bytecode/is-contract-deployed.js";
 import { ensureBytecodePrefix } from "../../../utils/bytecode/prefix.js";
-import { type Hex, uint8ArrayToHex } from "../../../utils/encoding/hex.js";
+import {
+  type Hex,
+  isHex,
+  uint8ArrayToHex,
+} from "../../../utils/encoding/hex.js";
 import type { ClientAndChainAndAccount } from "../../../utils/types.js";
 import { getContract } from "../../contract.js";
 import { zkDeployContract } from "./zkDeployContract.js";
@@ -89,7 +93,11 @@ export async function zkDeployContractDeterministic(
       abi: parseAbi(singletonFactoryAbi),
     });
 
-    const salt = options?.salt ? keccakId(options.salt) : keccakId("thirdweb");
+    const salt = options?.salt
+      ? isHex(options.salt) && options.salt.length === 66
+        ? options.salt
+        : keccakId(options.salt)
+      : keccakId("thirdweb");
 
     await sendAndConfirmTransaction({
       account: options.account,

--- a/packages/thirdweb/src/utils/any-evm/compute-deployment-address.ts
+++ b/packages/thirdweb/src/utils/any-evm/compute-deployment-address.ts
@@ -1,6 +1,7 @@
 import { type Hex, encodePacked } from "viem";
 import { getAddress } from "../address.js";
 import { ensureBytecodePrefix } from "../bytecode/prefix.js";
+import { isHex } from "../encoding/hex.js";
 import { keccak256 } from "../hashing/keccak256.js";
 import { getSaltHash } from "./get-salt-hash.js";
 import { keccakId } from "./keccak-id.js";
@@ -33,7 +34,9 @@ export function computeDeploymentAddress(
 ) {
   const bytecode = ensureBytecodePrefix(options.bytecode);
   const saltHash = options.salt
-    ? keccakId(options.salt)
+    ? isHex(options.salt) && options.salt.length === 66
+      ? options.salt
+      : keccakId(options.salt)
     : getSaltHash(bytecode);
 
   // 1. create init bytecode hash with contract's bytecode and encoded args

--- a/packages/thirdweb/src/utils/any-evm/compute-published-contract-deploy-info.ts
+++ b/packages/thirdweb/src/utils/any-evm/compute-published-contract-deploy-info.ts
@@ -96,5 +96,6 @@ export async function computeDeploymentInfoFromBytecode(args: {
     initBytecodeWithsalt,
     encodedArgs,
     create2FactoryAddress,
+    salt,
   };
 }

--- a/packages/thirdweb/src/utils/any-evm/get-init-bytecode-with-salt.ts
+++ b/packages/thirdweb/src/utils/any-evm/get-init-bytecode-with-salt.ts
@@ -1,6 +1,6 @@
 import { encodePacked } from "viem/utils";
 import { ensureBytecodePrefix } from "../bytecode/prefix.js";
-import { type Hex, uint8ArrayToHex } from "../encoding/hex.js";
+import { type Hex, isHex, uint8ArrayToHex } from "../encoding/hex.js";
 import { getSaltHash } from "./get-salt-hash.js";
 import { keccakId } from "./keccak-id.js";
 
@@ -29,8 +29,11 @@ export function getInitBytecodeWithSalt(
   options: GetInitiBytecodeWithSaltOptions,
 ): Hex {
   const bytecode = ensureBytecodePrefix(options.bytecode);
+
   const saltHash = options.salt
-    ? keccakId(options.salt)
+    ? isHex(options.salt) && options.salt.length === 66
+      ? options.salt
+      : keccakId(options.salt)
     : getSaltHash(bytecode);
 
   const encodedArgs =

--- a/packages/thirdweb/src/utils/any-evm/zksync/computeDeploymentAddress.ts
+++ b/packages/thirdweb/src/utils/any-evm/zksync/computeDeploymentAddress.ts
@@ -1,5 +1,5 @@
 import type { Address } from "../../address.js";
-import type { Hex } from "../../encoding/hex.js";
+import { type Hex, isHex } from "../../encoding/hex.js";
 import { keccakId } from "../keccak-id.js";
 import { create2Address } from "./create2Address.js";
 
@@ -13,7 +13,11 @@ type ComputeDeploymentAddressOptions = {
 export function computeDeploymentAddress(
   options: ComputeDeploymentAddressOptions,
 ) {
-  const saltHash = options.salt ? keccakId(options.salt) : keccakId("thirdweb");
+  const saltHash = options.salt
+    ? isHex(options.salt) && options.salt.length === 66
+      ? options.salt
+      : keccakId(options.salt)
+    : keccakId("thirdweb");
 
   return create2Address({
     sender: options.create2FactoryAddress,


### PR DESCRIPTION
TOOL-3443

<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the handling of `salt` values for deterministic contract deployments in the `thirdweb` package, ensuring that `salt` values are validated as hex strings and updating related functions and tests.

### Detailed summary
- Updated handling of `salt` in multiple files to validate if it's a hex string of length 66.
- Modified `computeDeploymentAddress`, `getInitBytecodeWithSalt`, and `zkDeployContractDeterministic` to use the new `salt` logic.
- Added tests to ensure computed addresses match deployed addresses for deterministic deployments.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->