### PR TITLE
[thirdweb] feat: Replace walletClient with wallet in viemAdapter

### DIFF
--- a/.changeset/weak-kids-love.md
+++ b/.changeset/weak-kids-love.md
@@ -1,0 +1,31 @@
+---
+"thirdweb": patch
+---
+
+Deprecated `viemAdapter.walletClient` in favor of `viemAdapter.wallet` to take wallet instances instead of accounts
+
+BEFORE:
+
+```ts
+import { viemAdapter } from "thirdweb/adapters/viem";
+
+const walletClient = viemAdapter.walletClient.toViem({
+  account, // Account
+  chain,
+  client,
+});
+```
+
+AFTER:
+
+```ts
+import { viemAdapter } from "thirdweb/adapters/viem";
+
+const walletClient = viemAdapter.wallet.toViem({
+  wallet, // now pass a connected Wallet instance instead of an account
+  chain,
+  client,
+});
+```
+
+This allows for full wallet lifecycle management with the viem adapter, including switching chains, adding chains, events and more.

--- a/apps/portal/src/app/typescript/v5/adapters/page.mdx
+++ b/apps/portal/src/app/typescript/v5/adapters/page.mdx
@@ -56,18 +56,18 @@ You can use an existing wallet client from viem with the thirdweb SDK by convert
 ```ts
 import { viemAdapter } from "thirdweb/adapters/viem";
 
-// convert a viem wallet client to a thirdweb account
+// convert a viem wallet client to a thirdweb wallet
 const walletClient = createWalletClient(...);
-const account = await viemAdapter.walletClient.fromViem({
+const thirdwebWallet = await viemAdapter.wallet.fromViem({
   walletClient,
 });
 
 
 // convert a thirdweb account to viem wallet client
-const viemClientWallet = viemAdapter.walletClient.toViem({
+const viemClientWallet = viemAdapter.wallet.toViem({
   client,
   chain,
-  account,
+  wallet,
 });
 ```
 

--- a/packages/thirdweb/src/adapters/viem-legacy.test.ts
+++ b/packages/thirdweb/src/adapters/viem-legacy.test.ts
@@ -6,26 +6,27 @@ import {
   USDT_CONTRACT_ADDRESS,
   USDT_CONTRACT_WITH_ABI,
 } from "~test/test-contracts.js";
-import {
-  ANVIL_PKEY_A,
-  TEST_ACCOUNT_B,
-  TEST_IN_APP_WALLET_A,
-} from "~test/test-wallets.js";
+import { ANVIL_PKEY_A, TEST_ACCOUNT_B } from "~test/test-wallets.js";
 import { typedData } from "~test/typed-data.js";
+
 import { ANVIL_CHAIN, FORKED_ETHEREUM_CHAIN } from "../../test/src/chains.js";
 import { TEST_CLIENT } from "../../test/src/test-clients.js";
 import { randomBytesBuffer } from "../utils/random.js";
+import { privateKeyToAccount } from "../wallets/private-key.js";
 import { toViemContract, viemAdapter } from "./viem.js";
 
-const wallet = TEST_IN_APP_WALLET_A;
+const account = privateKeyToAccount({
+  privateKey: ANVIL_PKEY_A,
+  client: TEST_CLIENT,
+});
 
 describe("walletClient.toViem", () => {
-  let walletClient: ReturnType<typeof viemAdapter.wallet.toViem>;
+  let walletClient: ReturnType<typeof viemAdapter.walletClient.toViem>;
 
   beforeAll(() => {
-    walletClient = viemAdapter.wallet.toViem({
+    walletClient = viemAdapter.walletClient.toViem({
       client: TEST_CLIENT,
-      wallet,
+      account,
       chain: ANVIL_CHAIN,
     });
   });
@@ -36,8 +37,7 @@ describe("walletClient.toViem", () => {
   });
 
   test("should sign message", async () => {
-    const account = wallet.getAccount();
-    if (!walletClient.account || !account) {
+    if (!walletClient.account) {
       throw new Error("Account not found");
     }
     const expectedSig = await account.signMessage({ message: "hello world" });
@@ -49,8 +49,7 @@ describe("walletClient.toViem", () => {
   });
 
   test("should sign raw message", async () => {
-    const account = wallet.getAccount();
-    if (!walletClient.account || !account) {
+    if (!walletClient.account) {
       throw new Error("Account not found");
     }
     const bytes = randomBytesBuffer(32);
@@ -111,16 +110,12 @@ describe("walletClient.toViem", () => {
   });
 
   test("should get address on live chain", async () => {
-    walletClient = viemAdapter.wallet.toViem({
+    walletClient = viemAdapter.walletClient.toViem({
       client: TEST_CLIENT,
-      wallet,
+      account,
       chain: FORKED_ETHEREUM_CHAIN,
     });
 
-    const account = wallet.getAccount();
-    if (!walletClient.account || !account) {
-      throw new Error("Account not found");
-    }
     const address = await walletClient.getAddresses();
     expect(address[0]).toBeDefined();
     expect(address[0]).toBe(account.address);
@@ -128,10 +123,6 @@ describe("walletClient.toViem", () => {
 
   test("should match thirdweb account signature", async () => {
     const message = "testing123";
-    const account = wallet.getAccount();
-    if (!walletClient.account || !account) {
-      throw new Error("Account not found");
-    }
 
     const rawViemAccount = viemPrivateKeyToAccount(ANVIL_PKEY_A);
     const twSignature = await account.signMessage({ message });
@@ -153,10 +144,16 @@ describe("walletClient.toViem", () => {
     expect(result.address).toBe(USDT_CONTRACT_ADDRESS);
   });
 
-  test("should switch chain", async () => {
-    await walletClient.switchChain({
-      id: FORKED_ETHEREUM_CHAIN.id,
-    });
-    expect(await walletClient.getChainId()).toBe(FORKED_ETHEREUM_CHAIN.id);
+  test("should throw when switching chain", async () => {
+    await expect(
+      walletClient.switchChain({
+        id: FORKED_ETHEREUM_CHAIN.id,
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`
+      [UnknownRpcError: An unknown RPC error occurred.
+
+      Details: Can't switch chains because only an account was passed to 'viemAdapter.walletClient.toViem()', please pass a connected wallet instance instead.
+      Version: viem@2.22.17]
+    `);
   });
 });


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on deprecating the `viemAdapter.walletClient` in favor of `viemAdapter.wallet`, which allows for better management of wallet instances instead of accounts. This change enhances wallet lifecycle management, including chain switching and event handling.

### Detailed summary
- Updated comments and variable names to reflect the transition from `walletClient` to `wallet`.
- Deprecated `viemAdapter.walletClient` methods, replacing them with `viemAdapter.wallet`.
- Modified test files to use the new wallet instance methods.
- Enhanced functionality for switching chains and managing wallet lifecycle.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->