### PR TITLE
[thirdweb] fix: Respect supportedTokens override in PayEmbed

### DIFF
--- a/.changeset/sweet-items-compare.md
+++ b/.changeset/sweet-items-compare.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Respect supportedTokens override in PayEmbed

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx
@@ -932,12 +932,14 @@ function createSupportedTokens(
   payOptions: PayUIOptions,
   supportedTokensOverrides?: SupportedTokens,
 ): SupportedTokens {
-  const tokens: SupportedTokens = {};
+  // dev override
+  if (supportedTokensOverrides) {
+    return supportedTokensOverrides;
+  }
 
+  const tokens: SupportedTokens = {};
   const isBuyWithFiatDisabled = payOptions.buyWithFiat === false;
   const isBuyWithCryptoDisabled = payOptions.buyWithCrypto === false;
-
-  // FIXME (pay) when buywithFiat is disabled, missing a bunch of tokens on base??
 
   for (const x of data) {
     tokens[x.chain.id] = x.tokens.filter((t) => {
@@ -966,19 +968,6 @@ function createSupportedTokens(
       return true; // include the token
     });
   }
-
-  // override with props.supportedTokens
-  if (supportedTokensOverrides) {
-    for (const k in supportedTokensOverrides) {
-      const key = Number(k);
-      const tokenList = supportedTokensOverrides[key];
-
-      if (tokenList) {
-        tokens[key] = tokenList;
-      }
-    }
-  }
-
   return tokens;
 }
 


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `PayEmbed` functionality to respect the `supportedTokensOverrides` parameter in the `createSupportedTokens` function, allowing custom token lists to be returned when provided.

### Detailed summary
- Added handling for `supportedTokensOverrides` in `createSupportedTokens` function.
- If `supportedTokensOverrides` is provided, it directly returns this list instead of constructing a default token list.
- Removed the previous logic that merged `supportedTokensOverrides` into the default tokens.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->