### PR TITLE
[thirdweb] fix: Respect buyWithFiat setting in PayEmbed

### DIFF
--- a/.changeset/eight-pandas-serve.md
+++ b/.changeset/eight-pandas-serve.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Respect buy with fiat disabled in pay embed

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx
@@ -558,6 +558,7 @@ function BuyScreenContent(props: BuyScreenContentProps) {
                 supportedSourcesQuery.data &&
                 sourceSupportedTokens && (
                   <TokenSelectorScreen
+                    fiatSupported={props.payOptions.buyWithFiat !== false}
                     client={props.client}
                     sourceTokens={sourceSupportedTokens}
                     sourceSupportedTokens={sourceSupportedTokens}

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/TokenSelectorScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/TokenSelectorScreen.tsx
@@ -69,6 +69,7 @@ export function TokenSelectorScreen(props: {
   onSelectToken: (wallet: Wallet, token: TokenInfo, chain: Chain) => void;
   onConnect: () => void;
   onPayWithFiat: () => void;
+  fiatSupported: boolean;
 }) {
   const connectedWallets = useConnectedWallets();
   const activeAccount = useActiveAccount();
@@ -255,29 +256,31 @@ export function TokenSelectorScreen(props: {
               </Text>
             </Container>
           </Button>
-          <Button
-            variant="secondary"
-            fullWidth
-            onClick={props.onPayWithFiat}
-            bg="tertiaryBg"
-            style={{
-              border: `1px solid ${theme.colors.borderColor}`,
-              padding: spacing.sm,
-            }}
-          >
-            <Container
-              flex="row"
-              gap="sm"
-              center="y"
-              expand
-              color="secondaryIconColor"
+          {props.fiatSupported && (
+            <Button
+              variant="secondary"
+              fullWidth
+              onClick={props.onPayWithFiat}
+              bg="tertiaryBg"
+              style={{
+                border: `1px solid ${theme.colors.borderColor}`,
+                padding: spacing.sm,
+              }}
             >
-              <CardStackIcon width={iconSize.md} height={iconSize.md} />
-              <Text size="sm" color="primaryText">
-                Pay with credit card
-              </Text>
-            </Container>
-          </Button>
+              <Container
+                flex="row"
+                gap="sm"
+                center="y"
+                expand
+                color="secondaryIconColor"
+              >
+                <CardStackIcon width={iconSize.md} height={iconSize.md} />
+                <Text size="sm" color="primaryText">
+                  Pay with credit card
+                </Text>
+              </Container>
+            </Button>
+          )}
         </Container>
       </Container>
     </Container>


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on respecting the `buyWithFiat` option in the payment embed, ensuring that the option to pay with fiat is only available when explicitly supported.

### Detailed summary
- Updated `TokenSelectorScreen` to include a new prop `fiatSupported`.
- Conditional rendering of the "Pay with credit card" button based on the `fiatSupported` prop.
- Removed the always rendered button for paying with fiat, now it only appears if `fiatSupported` is true.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->