### PR TITLE
[TOOL-3470] Playground: Fix eslint image warnings

### DIFF
--- a/apps/playground-web/src/components/engine/airdrop/TransactionResults.tsx
+++ b/apps/playground-web/src/components/engine/airdrop/TransactionResults.tsx
@@ -160,6 +160,7 @@ export function ClaimTransactionResults({
                   <TableCell>
                     <span className="flex items-center gap-2">
                       {result.network === "Base Sep" && (
+                        // eslint-disable-next-line @next/next/no-img-element
                         <img
                           src="/BaseSep.png"
                           alt="Base"
@@ -167,6 +168,7 @@ export function ClaimTransactionResults({
                         />
                       )}
                       {result.network === "OP Sep" && (
+                        // eslint-disable-next-line @next/next/no-img-element
                         <img
                           src="/OP.png"
                           alt="Optimism Sep"
@@ -174,6 +176,7 @@ export function ClaimTransactionResults({
                         />
                       )}
                       {result.network === "Ethereum" && (
+                        // eslint-disable-next-line @next/next/no-img-element
                         <img
                           src="/Ethereum.png"
                           alt="Ethereum"

--- a/apps/playground-web/src/components/engine/minting/TransactionResults.tsx
+++ b/apps/playground-web/src/components/engine/minting/TransactionResults.tsx
@@ -158,6 +158,7 @@ export function ClaimTransactionResults({
                   <TableCell>
                     <span className="flex items-center gap-2">
                       {result.network === "Base Sep" && (
+                        // eslint-disable-next-line @next/next/no-img-element
                         <img
                           src="/BaseSep.png"
                           alt="Base"
@@ -165,6 +166,7 @@ export function ClaimTransactionResults({
                         />
                       )}
                       {result.network === "OP Sep" && (
+                        // eslint-disable-next-line @next/next/no-img-element
                         <img
                           src="/OP.png"
                           alt="Optimism Sep"
@@ -172,6 +174,7 @@ export function ClaimTransactionResults({
                         />
                       )}
                       {result.network === "Ethereum" && (
+                        // eslint-disable-next-line @next/next/no-img-element
                         <img
                           src="/Ethereum.png"
                           alt="Ethereum"

--- a/apps/playground-web/src/components/engine/minting/erc1155-mint-to.tsx
+++ b/apps/playground-web/src/components/engine/minting/erc1155-mint-to.tsx
@@ -264,6 +264,7 @@ export function ERC1155MintTo() {
         {account && (
           <div className="mt-6 w-full max-w-[400px]">
             {image ? (
+              // eslint-disable-next-line @next/next/no-img-element
               <img
                 src={resolveIpfsUrl(image)}
                 alt="NFT Preview"


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding `img` elements for network logos in various components while ensuring compliance with ESLint rules related to using `img` tags in Next.js.

### Detailed summary
- In `erc1155-mint-to.tsx`, added an `img` tag for NFT preview with ESLint comment.
- In `TransactionResults.tsx`, added `img` tags for network logos (`BaseSep`, `OP`, `Ethereum`) with ESLint comments for each.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->