### PR TITLE
[SDK] Fix: Upload storage timeout

### DIFF
--- a/.changeset/twelve-walls-teach.md
+++ b/.changeset/twelve-walls-teach.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix storage upload timeout

--- a/packages/thirdweb/src/storage/upload/mobile.ts
+++ b/packages/thirdweb/src/storage/upload/mobile.ts
@@ -41,7 +41,7 @@ export async function uploadBatchMobile(
             "Request to upload timed out! No upload progress received in 30s",
           ),
         );
-      }, 30000);
+      }, client.config?.storage?.fetch?.requestTimeoutMs ?? 30000);
 
       xhr.upload.addEventListener("progress", (event) => {
         clearTimeout(timer);

--- a/packages/thirdweb/src/storage/upload/web-node.ts
+++ b/packages/thirdweb/src/storage/upload/web-node.ts
@@ -17,6 +17,7 @@ export async function uploadBatch<const TFiles extends UploadableFile[]>(
       method: "POST",
       headers,
       body: form,
+      requestTimeoutMs: client.config?.storage?.fetch?.requestTimeoutMs,
     },
   );
 


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the storage upload timeout in the `thirdweb` package by allowing the timeout to be configurable through client settings.

### Detailed summary
- Updated `requestTimeoutMs` in `web-node.ts` to use `client.config?.storage?.fetch?.requestTimeoutMs`.
- Modified the timeout in `mobile.ts` to default to `client.config?.storage?.fetch?.requestTimeoutMs` or 30000 if not set.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->