### PR TITLE
[TOOL-3483] Dashboard: Fix Nebula subdomain rewrite for Vercel preview links

### DIFF
--- a/apps/dashboard/src/middleware.ts
+++ b/apps/dashboard/src/middleware.ts
@@ -33,7 +33,11 @@ export async function middleware(request: NextRequest) {
   const paths = pathname.slice(1).split("/");
 
   // nebula.thirdweb.com -> render page at app/nebula-app
-  if (subdomain === "nebula" && host) {
+  // on vercel preview, the format is nebula---thirdweb-www-git-<branch-name>.thirdweb-preview.com
+  if (
+    subdomain &&
+    (subdomain === "nebula" || subdomain.startsWith("nebula---"))
+  ) {
     const newPaths = ["nebula-app", ...paths];
     return rewrite(request, `/${newPaths.join("/")}`, undefined);
   }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the middleware logic for handling subdomains related to the `nebula` application. It allows for a broader range of subdomain formats, particularly for Vercel preview environments.

### Detailed summary
- Changed the condition to check for `subdomain` presence.
- Allowed subdomains to match either `nebula` or any subdomain starting with `nebula---`.
- Updated the path rewrite logic to accommodate the new subdomain formats.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->