### PR TITLE
[TOOL-3488] Dashboard: Add disclaimer for starter plan about verification hold on pricing card

### DIFF
--- a/apps/dashboard/src/@/components/blocks/pricing-card.tsx
+++ b/apps/dashboard/src/@/components/blocks/pricing-card.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import { ToolTipLabel } from "@/components/ui/tooltip";
 import { TrackedLinkTW } from "@/components/ui/tracked-link";
 import { cn } from "@/lib/utils";
-import { CheckIcon, CircleDollarSignIcon } from "lucide-react";
+import { CheckIcon, CircleAlertIcon, CircleDollarSignIcon } from "lucide-react";
 import type React from "react";
 import { TEAM_PLANS } from "utils/pricing";
 import { remainingDays } from "../../../utils/date-utils";
@@ -104,6 +104,23 @@ export const PricingCard: React.FC<PricingCardProps> = ({
 
             {!isCustomPrice && (
               <span className="text-muted-foreground">/ month</span>
+            )}
+
+            {billingPlan === "starter" && (
+              <ToolTipLabel
+                contentClassName="max-w-[320px]"
+                label="We will place a temporary hold of $25 to verify your card, this will be immediately released back to you after verification."
+              >
+                <Button
+                  asChild
+                  variant="ghost"
+                  className="h-auto w-auto p-1 text-muted-foreground hover:text-foreground"
+                >
+                  <div>
+                    <CircleAlertIcon className="size-5 shrink-0" />
+                  </div>
+                </Button>
+              </ToolTipLabel>
             )}
           </div>
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a new tooltip feature to the `PricingCard` component, specifically for the "starter" billing plan, which informs users about a temporary hold on their card during verification.

### Detailed summary
- Added `CircleAlertIcon` import from `lucide-react`.
- Introduced a tooltip (`ToolTipLabel`) for the "starter" billing plan.
- The tooltip includes a message about a $25 temporary hold for card verification.
- Wrapped the tooltip content in a button with specific styles.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->