### PR TITLE
enable team invites for starter and growth plans

### DIFF
--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/settings/members/InviteSection.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/settings/members/InviteSection.tsx
@@ -58,9 +58,8 @@ export function InviteSection(props: {
   const teamPlan = getValidTeamPlan(props.team);
   let bottomSection: React.ReactNode = null;
   const maxAllowedInvitesAtOnce = 10;
-  const inviteEnabled =
-    (teamPlan === "starter" || teamPlan === "growth") &&
-    props.userHasEditPermission;
+  // invites are enabled if user has edit permission and team plan is not "free"
+  const inviteEnabled = teamPlan !== "free" && props.userHasEditPermission;
 
   const form = useForm<InviteFormValues>({
     resolver: zodResolver(inviteFormSchema),
@@ -121,13 +120,13 @@ export function InviteSection(props: {
       <div className="flex items-center border-border border-t px-4 py-4 lg:justify-between lg:px-6">
         {teamPlan === "pro" && (
           <p className="text-muted-foreground text-sm">
-            Team invites are not enabled on your plan.{" "}
+            Team members are billed according to your plan.{" "}
             <Link
               href="https://meetings.hubspot.com/sales-thirdweb/thirdweb-pro"
               target="_blank"
               className="text-link-foreground hover:text-foreground"
             >
-              Reach out to sales <ExternalLinkIcon className="inline size-3" />
+              Reach out to sales <ExternalLinkIcon className="inline size-3" />.
             </Link>
           </p>
         )}


### PR DESCRIPTION
blocked by: https://github.com/thirdweb-dev/api-server/pull/1412

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `InviteSection` component to modify the logic for enabling invites based on the team plan and user permissions, and it also refines the messaging displayed to users regarding team invites.

### Detailed summary
- Changed `inviteEnabled` logic to allow invites if the team plan is not "free" and the user has edit permission.
- Updated user messaging to clarify that team members are billed according to the plan instead of stating invites are not enabled.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->