### PR TITLE
only validate Turnstile captcha on Vercel environments

### DIFF
--- a/apps/dashboard/src/lib/vercel-utils.ts
+++ b/apps/dashboard/src/lib/vercel-utils.ts
@@ -1,8 +1,11 @@
 import { isBrowser } from "utils/isBrowser";
 
+export function isVercel() {
+  return !!(process.env.vercel || process.env.NEXT_PUBLIC_VERCEL_ENV);
+}
+
 export function getVercelEnv() {
-  const onVercel = process.env.vercel || process.env.NEXT_PUBLIC_VERCEL_ENV;
-  if (!onVercel) {
+  if (!isVercel()) {
     return "development";
   }
   return (process.env.VERCEL_ENV ||


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a utility function `isVercel` to check if the application is running in a Vercel environment. It refactors the login handling process to conditionally validate a Turnstile token based on the environment, streamlining error handling and improving code readability.

### Detailed summary
- Added `isVercel` function to check Vercel environment.
- Refactored `getVercelEnv` to use `isVercel`.
- Updated login process to validate Turnstile token only in Vercel environment.
- Improved error handling for IP address retrieval.
- Enhanced readability of the code structure.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->