### PR TITLE
chore: allow passing teamId to service-utils auth

### DIFF
--- a/.changeset/cuddly-plants-wait.md
+++ b/.changeset/cuddly-plants-wait.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+chore: Allow passing teamId with dashboard auth

--- a/packages/service-utils/src/cf-worker/index.ts
+++ b/packages/service-utils/src/cf-worker/index.ts
@@ -157,6 +157,7 @@ export async function extractAuthorizationData(
     origin,
     bundleId,
     secretKeyHash,
+    teamId: authInput.teamId,
     targetAddress: authInput.targetAddress,
   };
 }

--- a/packages/service-utils/src/core/api.ts
+++ b/packages/service-utils/src/core/api.ts
@@ -158,9 +158,15 @@ export async function fetchTeamAndProject(
   config: CoreServiceConfig,
 ): Promise<ApiResponse> {
   const { apiUrl, serviceApiKey } = config;
+  const { teamId, clientId } = authData;
 
-  const clientId = authData.clientId;
-  const url = `${apiUrl}/v2/keys/use${clientId ? `?clientId=${clientId}` : ""}`;
+  const url = new URL("/v2/keys/use", apiUrl);
+  if (clientId) {
+    url.searchParams.set("clientId", clientId);
+  }
+  if (teamId) {
+    url.searchParams.set("teamId", teamId);
+  }
   const response = await fetch(url, {
     method: "GET",
     headers: {

--- a/packages/service-utils/src/core/authorize/index.ts
+++ b/packages/service-utils/src/core/authorize/index.ts
@@ -18,6 +18,7 @@ export type AuthorizationInput = {
   jwt: string | null;
   hashedJWT: string | null;
   targetAddress?: string | string[];
+  teamId?: string;
   // IMPORTANT: this is a stringified boolean! Only pass in true or false here. IK it's not ideal, but it's required to pass it in the headers.
   useWalletAuth?: string | null;
 };
@@ -46,7 +47,7 @@ export async function authorize(
   const cacheKey = authData.secretKeyHash
     ? `key-v2:secret-key:${authData.secretKeyHash}`
     : authData.hashedJWT
-      ? `key-v2:dashboard-jwt:${authData.hashedJWT}`
+      ? `key-v2:dashboard-jwt:${authData.hashedJWT}:${authData.teamId ?? "default"}`
       : authData.clientId
         ? `key-v2:client-id:${authData.clientId}`
         : null;

--- a/packages/service-utils/src/core/types.ts
+++ b/packages/service-utils/src/core/types.ts
@@ -1,6 +1,8 @@
 export type CoreAuthInput = {
   // for passing it from the subdomain or path or other service specific things
   clientId?: string;
+  // For providing a specific team the user is trying to authenticate for. Used only for dashboard auth.
+  teamId?: string;
   // for passing in the address target in RPC or bundler services
   targetAddress?: string | string[];
 };

--- a/packages/service-utils/src/node/index.ts
+++ b/packages/service-utils/src/node/index.ts
@@ -167,6 +167,7 @@ export function extractAuthorizationData(
     origin,
     bundleId,
     targetAddress: authInput.targetAddress,
+    teamId: authInput.teamId,
     useWalletAuth,
   };
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the authentication process by allowing the passing of a `teamId` for dashboard authentication in the `service-utils` package.

### Detailed summary
- Updated `index.ts` and `cf-worker/index.ts` to include `teamId` in the authentication input.
- Added `teamId` optional property in `types.ts`.
- Modified API URL construction in `api.ts` to include `teamId` as a search parameter.
- Adjusted cache key logic in `authorize/index.ts` to incorporate `teamId`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->