### PR TITLE
[SDK] fix: Force pre-EIP1559 transactions on Homeverse chains

### DIFF
--- a/.changeset/violet-planets-remember.md
+++ b/.changeset/violet-planets-remember.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Force pre-eip1559 tx on Homeverse mainnet/testnet

--- a/apps/dashboard/src/components/buttons/MismatchButton.tsx
+++ b/apps/dashboard/src/components/buttons/MismatchButton.tsx
@@ -61,6 +61,8 @@ const GAS_FREE_CHAINS = [
   300, // zksync sepolia
   7225878, // Saakuru Mainnet
   247253, // Saakuru Testnet
+  19011, // Homeverse Mainnet
+  40875, // Homeverse Testnet
 ];
 
 function useIsNetworkMismatch(txChainId: number) {

--- a/apps/login/src/api/login/config.ts
+++ b/apps/login/src/api/login/config.ts
@@ -2,9 +2,16 @@ import "server-only";
 import type { InAppWalletAuth } from "thirdweb/wallets";
 import type { Permission } from "../../components/permission-card";
 
-export async function getLoginConfig(clientId: string) {
+export async function getLoginConfig(clientId: string): Promise<LoginConfig> {
   if (clientId === "demo") {
     return DEMO_ENVIRONMENT;
+  }
+  // temporary manual config
+  if (clientId === "b24106adfb2ec212e6ec4d3b2e04db9e") {
+    return {
+      ...DEFAULT_CONFIG,
+      sessionKeySignerAddress: "0xb89e32a18350d6df5bf0b89a227E098013C4Fa72",
+    };
   }
   // TODO: implement fetch for config from API server
   return DEFAULT_CONFIG;

--- a/packages/thirdweb/src/auth/verify-hash.ts
+++ b/packages/thirdweb/src/auth/verify-hash.ts
@@ -196,7 +196,8 @@ export async function verifyEip1271Signature({
       contract,
     });
     return result === EIP_1271_MAGIC_VALUE;
-  } catch {
+  } catch (err) {
+    console.error("Error verifying EIP-1271 signature", err);
     return false;
   }
 }

--- a/packages/thirdweb/src/gas/fee-data.ts
+++ b/packages/thirdweb/src/gas/fee-data.ts
@@ -40,6 +40,8 @@ const FORCE_GAS_PRICE_CHAIN_IDS = [
   1942999413, // Humanity Testnet
   1952959480, // Lumia Testnet
   994873017, // Lumia Mainnet
+  19011, // Homeverse Mainnet
+  40875, // Homeverse Testnet
 ];
 
 /**
@@ -89,7 +91,7 @@ export async function getGasOverridesForTransaction(
   }
 
   // return as is
-  if (defaultGasOverrides.gasPrice) {
+  if (defaultGasOverrides.gasPrice !== undefined) {
     return defaultGasOverrides;
   }
 

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/fiat/currencies.test.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/fiat/currencies.test.tsx
@@ -8,7 +8,7 @@ import { currencies, getCurrencyMeta, usdCurrency } from "./currencies.js";
 
 describe("Currency Utilities", () => {
   it("should have correct number of currencies", () => {
-    expect(currencies.length).toBe(5);
+    expect(currencies.length).toBe(7);
   });
 
   it("should have USD as the first currency", () => {

--- a/packages/thirdweb/src/transaction/actions/estimate-gas-cost.ts
+++ b/packages/thirdweb/src/transaction/actions/estimate-gas-cost.ts
@@ -38,7 +38,7 @@ export async function estimateGasCost(
     transaction.chain,
   );
   const gasPrice = fees.maxFeePerGas || fees.gasPrice;
-  if (!gasPrice) {
+  if (gasPrice === undefined) {
     throw new Error(
       `Unable to determine gas price for chain ${transaction.chain.id}`,
     );

--- a/packages/thirdweb/src/wallets/smart/smart-wallet-integration-v07.test.ts
+++ b/packages/thirdweb/src/wallets/smart/smart-wallet-integration-v07.test.ts
@@ -109,7 +109,7 @@ describe.runIf(process.env.TW_SECRET_KEY)(
         smartAccount,
         accountContract,
       });
-      await new Promise((resolve) => setTimeout(resolve, 1000)); // pause for a second to prevent race condition
+      await new Promise((resolve) => setTimeout(resolve, 3000)); // pause for a second to prevent race condition
 
       const signature = await smartAccount.signMessage({
         message: "hello world",


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `thirdweb` package by adding support for the Homeverse network, improving error handling, and refining gas price checks. It also updates tests and configurations related to currency utilities and login settings.

### Detailed summary
- Added Homeverse Mainnet and Testnet IDs to `MismatchButton.tsx` and `fee-data.ts`.
- Updated `verify-hash.ts` to log errors during EIP-1271 signature verification.
- Changed gas price validation to check for `undefined` in `estimate-gas-cost.ts`.
- Adjusted expected currency count in `currencies.test.tsx` from 5 to 7.
- Increased delay in `smart-wallet-integration-v07.test.ts` from 1s to 3s.
- Enhanced `getLoginConfig` to return a specific configuration for a demo client ID.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->