### PR TITLE
[Dashboard] Fix: Use Secret Key to Fetch Routes on Server

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/(bridge)/utils.ts
+++ b/apps/dashboard/src/app/(dashboard)/(bridge)/utils.ts
@@ -3,6 +3,7 @@ import "server-only";
 import { BRIDGE_URL, DASHBOARD_THIRDWEB_SECRET_KEY } from "@/constants/env";
 import type { Address } from "thirdweb";
 import type { Route } from "./types/route";
+import { getAuthToken } from "app/api/lib/getAuthToken";
 
 export async function getRoutes({
   limit,
@@ -38,8 +39,15 @@ export async function getRoutes({
   if (destinationTokenAddress) {
     url.searchParams.set("destinationTokenAddress", destinationTokenAddress);
   }
+  const token = await getAuthToken();
   const routesResponse = await fetch(url, {
-    headers: { "x-secret-key": DASHBOARD_THIRDWEB_SECRET_KEY },
+    headers: token
+      ? {
+          authorization: `Bearer ${token}`,
+        }
+      : {
+          "x-secret-key": DASHBOARD_THIRDWEB_SECRET_KEY,
+        },
     next: { revalidate: 60 * 60 },
   });
 

--- a/apps/dashboard/src/app/(dashboard)/(bridge)/utils.ts
+++ b/apps/dashboard/src/app/(dashboard)/(bridge)/utils.ts
@@ -1,9 +1,9 @@
 import "server-only";
 
 import { BRIDGE_URL, DASHBOARD_THIRDWEB_SECRET_KEY } from "@/constants/env";
+import { getAuthToken } from "app/api/lib/getAuthToken";
 import type { Address } from "thirdweb";
 import type { Route } from "./types/route";
-import { getAuthToken } from "app/api/lib/getAuthToken";
 
 export async function getRoutes({
   limit,

--- a/apps/dashboard/src/app/(dashboard)/(bridge)/utils.ts
+++ b/apps/dashboard/src/app/(dashboard)/(bridge)/utils.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { BRIDGE_URL, DASHBOARD_THIRDWEB_CLIENT_ID } from "@/constants/env";
+import { BRIDGE_URL, DASHBOARD_THIRDWEB_SECRET_KEY } from "@/constants/env";
 import type { Address } from "thirdweb";
 import type { Route } from "./types/route";
 
@@ -39,7 +39,7 @@ export async function getRoutes({
     url.searchParams.set("destinationTokenAddress", destinationTokenAddress);
   }
   const routesResponse = await fetch(url, {
-    headers: { "x-client-id": DASHBOARD_THIRDWEB_CLIENT_ID },
+    headers: { "x-secret-key": DASHBOARD_THIRDWEB_SECRET_KEY },
     next: { revalidate: 60 * 60 },
   });
 


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the authentication method for fetching routes in the `getRoutes` function, replacing the `DASHBOARD_THIRDWEB_CLIENT_ID` with `DASHBOARD_THIRDWEB_SECRET_KEY` and introducing a call to `getAuthToken()` for bearer token authentication.

### Detailed summary
- Replaced `DASHBOARD_THIRDWEB_CLIENT_ID` with `DASHBOARD_THIRDWEB_SECRET_KEY` in the headers.
- Added a call to `getAuthToken()` to retrieve the bearer token.
- Adjusted the headers to use bearer token authentication if available, otherwise using the secret key.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->