### PR TITLE
[thirdweb] fix: Remove icon property check in currency tests

### DIFF
--- a/.changeset/shaggy-flowers-argue.md
+++ b/.changeset/shaggy-flowers-argue.md
@@ -1,5 +1,5 @@
 ---
-"thirdweb": patch
+"thirdweb": minor
 ---
 
 Fiat onramp UI revamp in PayEmbed and support multi hop onramp flows

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/fiat/currencies.test.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/fiat/currencies.test.tsx
@@ -19,7 +19,6 @@ describe("Currency Utilities", () => {
     for (const currency of currencies) {
       expect(currency).toHaveProperty("shorthand");
       expect(currency).toHaveProperty("name");
-      expect(currency).toHaveProperty("icon");
     }
   });
 


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on revamping the Fiat onramp UI in `PayEmbed` and adding support for multi-hop onramp flows. It also updates the version of `thirdweb` from `patch` to `minor`.

### Detailed summary
- Updated the `thirdweb` version from `patch` to `minor`.
- Revamped the Fiat onramp UI in `PayEmbed`.
- Added support for multi-hop onramp flows.
- In the test file `currencies.test.tsx`, removed the expectation for the property `icon` from `currency`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->