### PR TITLE
[service-utils] fix usageV2 caller

### DIFF
--- a/.changeset/social-icons-mix.md
+++ b/.changeset/social-icons-mix.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+[service-utils] fix usageV2 caller

--- a/packages/service-utils/src/cf-worker/usageV2.ts
+++ b/packages/service-utils/src/cf-worker/usageV2.ts
@@ -5,7 +5,7 @@ import type {
 } from "../core/usageV2.js";
 
 type UsageV2Options = {
-  environment: "development" | "production";
+  usageBaseUrl: string;
   source: UsageV2Source;
 } & (
   | { serviceKey: string; thirdwebClientId?: never; thirdwebSecretKey?: never }
@@ -34,23 +34,18 @@ export async function sendUsageV2Events<T extends UsageV2Options>(
     : ClientUsageV2Event[],
   options: T,
 ): Promise<void> {
-  const baseUrl =
-    options.environment === "production"
-      ? "https://u.thirdweb.com"
-      : "https://u.thirdweb-dev.com";
-
   // Determine endpoint and auth header based on provided credentials.
   let url: string;
   const headers: HeadersInit = { "Content-Type": "application/json" };
 
   if (options.serviceKey) {
-    url = `${baseUrl}/usage-v2/${options.source}`;
+    url = `${options.usageBaseUrl}/usage-v2/${options.source}`;
     headers["x-service-api-key"] = options.serviceKey;
   } else if (options.thirdwebSecretKey) {
-    url = `${baseUrl}/usage-v2/${options.source}/client`;
+    url = `${options.usageBaseUrl}/usage-v2/${options.source}/client`;
     headers["x-secret-key"] = options.thirdwebSecretKey;
   } else if (options.thirdwebClientId) {
-    url = `${baseUrl}/usage-v2/${options.source}/client`;
+    url = `${options.usageBaseUrl}/usage-v2/${options.source}/client`;
     headers["x-client-id"] = options.thirdwebClientId;
   } else {
     throw new Error("[UsageV2] No authentication method provided.");

--- a/packages/service-utils/src/node/usageV2.ts
+++ b/packages/service-utils/src/node/usageV2.ts
@@ -30,7 +30,7 @@ export class UsageV2Producer {
     /**
      * A comma-separated list of `host[:port]` Kafka servers.
      */
-    kafkaServers: "development" | "production";
+    kafkaServers: string;
     /**
      * The product where usage is coming from.
      */

--- a/packages/service-utils/src/node/usageV2.ts
+++ b/packages/service-utils/src/node/usageV2.ts
@@ -28,9 +28,9 @@ export class UsageV2Producer {
      */
     producerName: string;
     /**
-     * The environment the service is running in.
+     * A comma-separated list of `host[:port]` Kafka servers.
      */
-    environment: "development" | "production";
+    kafkaServers: "development" | "production";
     /**
      * The product where usage is coming from.
      */
@@ -41,7 +41,7 @@ export class UsageV2Producer {
   }) {
     this.kafkaProducer = new KafkaProducer({
       producerName: config.producerName,
-      environment: config.environment,
+      kafkaServers: config.kafkaServers,
       username: config.username,
       password: config.password,
     });


### PR DESCRIPTION
---

## PR-Codex overview
This PR focuses on updating the `UsageV2Producer` class in the `service-utils` package to change the configuration from using `environment` to `kafkaServers`, reflecting a shift in how Kafka server connections are managed.

### Detailed summary
- Changed the property from `environment` (string) to `kafkaServers` (string) in the `UsageV2Producer` class.
- Updated the documentation to clarify that `kafkaServers` is a comma-separated list of `host[:port]` Kafka servers.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the `service-utils` package to improve the handling of Kafka server configurations and usage event URLs by replacing the `environment` variable with a `kafkaServers` variable and introducing a `usageBaseUrl` option.

### Detailed summary
- Updated `UsageV2Producer` to replace `environment` with `kafkaServers`.
- Modified the `UsageV2Options` type to include `usageBaseUrl` instead of `environment`.
- Refactored URL construction in `sendUsageV2Events` to use `usageBaseUrl`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the `service-utils` package by replacing the `environment` property with `kafkaServers` in the `UsageV2Producer` class and updating the `sendUsageV2Events` function to use `usageBaseUrl` instead of a conditional base URL.

### Detailed summary
- Replaced `environment` with `kafkaServers` in `UsageV2Producer` class in `packages/service-utils/src/node/usageV2.ts`.
- Updated `UsageV2Options` type to include `usageBaseUrl` instead of `environment` in `packages/service-utils/src/cf-worker/usageV2.ts`.
- Modified `sendUsageV2Events` function to use `options.usageBaseUrl` for constructing URLs.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`