### PR TITLE
monad-faucet-starter+-only

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/(chainPage)/components/client/FaucetButton.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/(chainPage)/components/client/FaucetButton.tsx
@@ -237,6 +237,9 @@ export function FaucetButton({
 
         {canClaimFaucetQuery.data.type === "unsupported-chain" &&
           "Faucet is empty right now"}
+
+        {canClaimFaucetQuery.data.type === "paid-plan-required" &&
+          "Faucet is only available on Starter, Growth and Pro plans."}
       </Button>
     );
   }

--- a/apps/dashboard/src/app/api/testnet-faucet/can-claim/CanClaimResponseType.ts
+++ b/apps/dashboard/src/app/api/testnet-faucet/can-claim/CanClaimResponseType.ts
@@ -7,4 +7,8 @@ export type CanClaimResponseType =
   | {
       canClaim: false;
       type: "unsupported-chain";
+    }
+  | {
+      canClaim: false;
+      type: "paid-plan-required";
     };

--- a/apps/dashboard/src/app/api/testnet-faucet/can-claim/route.ts
+++ b/apps/dashboard/src/app/api/testnet-faucet/can-claim/route.ts
@@ -1,3 +1,4 @@
+import { getTeams } from "@/api/team";
 import {
   DISABLE_FAUCET_CHAIN_IDS,
   THIRDWEB_ACCESS_TOKEN,
@@ -44,6 +45,25 @@ export const GET = async (req: NextRequest) => {
       );
       isFaucetDisabled = disableFaucetChainIds.includes(chainId);
     } catch {}
+  }
+
+  // get the teams for the account
+  const teams = await getTeams();
+  if (!teams) {
+    const res: CanClaimResponseType = {
+      canClaim: false,
+      type: "paid-plan-required",
+    };
+    return NextResponse.json(res);
+  }
+
+  const hasPaidPlan = teams.some((team) => team.billingPlan !== "free");
+  if (!hasPaidPlan) {
+    const res: CanClaimResponseType = {
+      canClaim: false,
+      type: "paid-plan-required",
+    };
+    return NextResponse.json(res);
   }
 
   if (


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new response type for the faucet claiming feature, specifically handling cases where a user cannot claim due to unsupported chains or requiring a paid plan. It also adds checks for user account plans and refines the error handling for account verification.

### Detailed summary
- Added a new `CanClaimResponseType` for "paid-plan-required" status.
- Updated `FaucetButton` to display a message for "paid-plan-required".
- Enhanced the `GET` route to return "paid-plan-required" if no teams are found or if the user has no paid plan.
- Refined error handling in the `POST` route for account verification and team checks.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->