### PR TITLE
[SDK] fix: Update contract ABI caching strategy

### DIFF
--- a/.changeset/thick-bees-deny.md
+++ b/.changeset/thick-bees-deny.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Change caching strategy for contract ABI

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   optimize_ci:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8
     outputs:
       skip: ${{ steps.check_skip.outputs.skip }}
     steps:
@@ -34,7 +34,7 @@ jobs:
   build:
     needs: optimize_ci
     if: needs.optimize_ci.outputs.skip == 'false'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8
     name: Build Packages
     steps:
       - name: Check out the code
@@ -51,7 +51,7 @@ jobs:
     if: needs.optimize_ci.outputs.skip == 'false'
     timeout-minutes: 15
     name: Lint Packages
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8
     steps:
       - name: Check out the code
         uses: actions/checkout@v4
@@ -71,7 +71,7 @@ jobs:
     if: needs.optimize_ci.outputs.skip == 'false'
     timeout-minutes: 15
     name: Unit Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8
     steps:
       - name: Check out the code
         uses: actions/checkout@v4
@@ -99,7 +99,7 @@ jobs:
     if: needs.optimize_ci.outputs.skip == 'false'
     timeout-minutes: 15
     name: E2E Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8
     strategy:
       matrix:
         package_manager: [npm, yarn, pnpm, bun]
@@ -169,7 +169,7 @@ jobs:
     if:  github.event_name == 'pull_request' && needs.optimize_ci.outputs.skip == 'false'
     timeout-minutes: 15
     name: "Size"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8
     steps:
       - name: Check out the code
         uses: actions/checkout@v4


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the caching strategy for resolving contract ABIs in the `resolve-abi.ts` file and modifying the CI workflow to run on a different Ubuntu version.

### Detailed summary
- Updated the `runs-on` parameter in `.github/workflows/CI.yml` from `ubuntu-latest` to `ubuntu-latest-8` across multiple jobs.
- Introduced `withCache` for caching in the `resolveContractAbi` function in `packages/thirdweb/src/contract/actions/resolve-abi.ts`.
- Removed the previous `ABI_RESOLUTION_CACHE` implementation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->