### PR TITLE
[SDK] Feature: Allow forcing deploy/skip_deploy behaviour

### DIFF
--- a/packages/thirdweb/src/wallets/smart/lib/calls.ts
+++ b/packages/thirdweb/src/wallets/smart/lib/calls.ts
@@ -73,18 +73,18 @@ export async function predictAddress(args: {
   accountSalt?: string;
   accountAddress?: string;
 }): Promise<string> {
+  const {
+    factoryContract,
+    predictAddressOverride: predictAddress,
+    adminAddress,
+    accountSalt,
+    accountAddress,
+  } = args;
+  if (predictAddress) {
+    return predictAddress(factoryContract, adminAddress);
+  }
   return withCache(
     async () => {
-      const {
-        factoryContract,
-        predictAddressOverride: predictAddress,
-        adminAddress,
-        accountSalt,
-        accountAddress,
-      } = args;
-      if (predictAddress) {
-        return predictAddress(factoryContract, adminAddress);
-      }
       if (accountAddress) {
         return accountAddress;
       }
@@ -104,7 +104,7 @@ export async function predictAddress(args: {
       });
     },
     {
-      cacheKey: `${args.factoryContract.address}-${args.adminAddress}-${args.accountSalt}`,
+      cacheKey: `${args.factoryContract.chain.id}-${args.factoryContract.address}-${args.adminAddress}-${args.accountSalt}`,
       cacheTime: 1000 * 60 * 60 * 24, // 1 day
     },
   );

--- a/packages/thirdweb/src/wallets/smart/lib/calls.ts
+++ b/packages/thirdweb/src/wallets/smart/lib/calls.ts
@@ -83,16 +83,16 @@ export async function predictAddress(args: {
   if (predictAddress) {
     return predictAddress(factoryContract, adminAddress);
   }
+  if (accountAddress) {
+    return accountAddress;
+  }
+  if (!adminAddress) {
+    throw new Error(
+      "Account address is required to predict the smart wallet address.",
+    );
+  }
   return withCache(
     async () => {
-      if (accountAddress) {
-        return accountAddress;
-      }
-      if (!adminAddress) {
-        throw new Error(
-          "Account address is required to predict the smart wallet address.",
-        );
-      }
       const saltHex =
         accountSalt && isHex(accountSalt)
           ? accountSalt

--- a/packages/thirdweb/src/wallets/smart/lib/userop.ts
+++ b/packages/thirdweb/src/wallets/smart/lib/userop.ts
@@ -167,8 +167,9 @@ export async function createUnsignedUserOp(args: {
     await Promise.all([
       typeof isDeployedOverride === "boolean"
         ? isDeployedOverride
-        : isContractDeployed(accountContract) ||
-          isAccountDeploying(accountContract),
+        : isContractDeployed(accountContract).then(
+            (isDeployed) => isDeployed || isAccountDeploying(accountContract),
+          ),
       encode(executeTx),
       resolvePromisedValue(executeTx.gas),
       getGasFees({


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the `predictAddress` function with caching capabilities and adding new parameters to user operation functions for better control over deployment checks.

### Detailed summary
- Added caching to the `predictAddress` function using `withCache`.
- Introduced `isDeployedOverride` parameter in `createUnsignedUserOp` and `createAndSignUserOp` functions.
- Simplified deployment checks by removing redundant conditions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->