### PR TITLE
add /learn routes to framer rewrites

### DIFF
--- a/apps/dashboard/framer-rewrites.js
+++ b/apps/dashboard/framer-rewrites.js
@@ -45,4 +45,10 @@ module.exports = [
   // -- templates --
   "/templates",
   "/templates/:template_slug",
+  // -- learn --
+  "/learn",
+  "/learn/tutorials",
+  "/learn/guides",
+  "/learn/courses",
+  "/learn/glossary",
 ];


### PR DESCRIPTION
Added new learn section routes to support the learning platform, including paths for tutorials, guides, courses, and glossary.