### PR TITLE
[SDK] expose estimateUserOpGasCost

### DIFF
--- a/.changeset/eighty-pens-judge.md
+++ b/.changeset/eighty-pens-judge.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": minor
+---
+
+Added `estimateUserOpGasCost()` utility function for estimating the total gas cost in wei/ether of user operations

--- a/packages/thirdweb/src/chains/constants.ts
+++ b/packages/thirdweb/src/chains/constants.ts
@@ -25,6 +25,21 @@ const opChains = [
  * TODO this should be in the chain definition itself
  * @internal
  */
-export function isOpStackChain(chain: Chain) {
-  return opChains.includes(chain.id);
+export async function isOpStackChain(chain: Chain) {
+  if (chain.id === 1337 || chain.id === 31337) {
+    return false;
+  }
+
+  if (opChains.includes(chain.id)) {
+    return true;
+  }
+  // fallback to checking the stack on rpc
+  try {
+    const { getChainMetadata } = await import("./utils.js");
+    const chainMetadata = await getChainMetadata(chain);
+    return chainMetadata.stackType === "optimism_bedrock";
+  } catch {
+    // If the network check fails, assume it's not a OP chain
+    return false;
+  }
 }

--- a/packages/thirdweb/src/exports/wallets/smart.ts
+++ b/packages/thirdweb/src/exports/wallets/smart.ts
@@ -13,6 +13,7 @@ export {
   bundleUserOp,
   getUserOpGasFees,
   estimateUserOpGas,
+  estimateUserOpGasCost,
 } from "../../wallets/smart/lib/bundler.js";
 
 export {

--- a/packages/thirdweb/src/transaction/actions/estimate-gas-cost.ts
+++ b/packages/thirdweb/src/transaction/actions/estimate-gas-cost.ts
@@ -44,7 +44,7 @@ export async function estimateGasCost(
     );
   }
   let l1Fee: bigint;
-  if (isOpStackChain(transaction.chain)) {
+  if (await isOpStackChain(transaction.chain)) {
     const { estimateL1Fee } = await import("../../gas/estimate-l1-fee.js");
     l1Fee = await estimateL1Fee({
       transaction,

--- a/packages/thirdweb/src/wallets/smart/index.ts
+++ b/packages/thirdweb/src/wallets/smart/index.ts
@@ -556,7 +556,7 @@ async function _sendUserOp(args: {
   }
 }
 
-async function getEntrypointFromFactory(
+export async function getEntrypointFromFactory(
   factoryAddress: string,
   client: ThirdwebClient,
   chain: Chain,

--- a/packages/thirdweb/src/wallets/smart/lib/bundler.ts
+++ b/packages/thirdweb/src/wallets/smart/lib/bundler.ts
@@ -1,27 +1,37 @@
 import { decodeErrorResult } from "viem";
+import type { ThirdwebClient } from "../../../client/client.js";
+import { getContract } from "../../../contract/contract.js";
 import { parseEventLogs } from "../../../event/actions/parse-logs.js";
 import { userOperationRevertReasonEvent } from "../../../extensions/erc4337/__generated__/IEntryPoint/events/UserOperationRevertReason.js";
 import { postOpRevertReasonEvent } from "../../../extensions/erc4337/__generated__/IEntryPoint_v07/events/PostOpRevertReason.js";
+import type { PreparedTransaction } from "../../../transaction/prepare-transaction.js";
 import type { SerializableTransaction } from "../../../transaction/serialize-transaction.js";
 import type { TransactionReceipt } from "../../../transaction/types.js";
+import { isContractDeployed } from "../../../utils/bytecode/is-contract-deployed.js";
 import { type Hex, hexToBigInt } from "../../../utils/encoding/hex.js";
 import { getClientFetch } from "../../../utils/fetch.js";
 import { stringify } from "../../../utils/json.js";
+import { toEther } from "../../../utils/units.js";
+import type { Account } from "../../interfaces/wallet.js";
+import { getEntrypointFromFactory } from "../index.js";
 import {
   type BundlerOptions,
   type EstimationResult,
   type GasPriceResult,
   type PmTransactionData,
+  type SmartWalletOptions,
   type UserOperationReceipt,
   type UserOperationV06,
   type UserOperationV07,
   formatUserOperationReceipt,
 } from "../types.js";
+import { predictSmartAccountAddress } from "./calls.js";
 import {
   ENTRYPOINT_ADDRESS_v0_6,
   MANAGED_ACCOUNT_GAS_BUFFER,
   getDefaultBundlerUrl,
 } from "./constants.js";
+import { prepareUserOp } from "./userop.js";
 import { hexlifyUserOp } from "./utils.js";
 
 /**
@@ -108,6 +118,91 @@ export async function estimateUserOpGas(
       res.paymasterPostOpGasLimit !== undefined
         ? hexToBigInt(res.paymasterPostOpGasLimit)
         : undefined,
+  };
+}
+
+/**
+ * Estimate the gas cost of a user operation.
+ * @param args - The options for estimating the gas cost of a user operation.
+ * @returns The estimated gas cost of the user operation.
+ * @example
+ * ```ts
+ * import { estimateUserOpGasCost } from "thirdweb/wallets/smart";
+ *
+ * const gasCost = await estimateUserOpGasCost({
+ *  transactions,
+ *  adminAccount,
+ *  client,
+ *  smartWalletOptions,
+ * });
+ * ```
+ * @walletUtils
+ */
+export async function estimateUserOpGasCost(args: {
+  transactions: PreparedTransaction[];
+  adminAccount: Account;
+  client: ThirdwebClient;
+  smartWalletOptions: SmartWalletOptions;
+}) {
+  // if factory is passed, but no entrypoint, try to resolve entrypoint from factory
+  if (
+    args.smartWalletOptions.factoryAddress &&
+    !args.smartWalletOptions.overrides?.entrypointAddress
+  ) {
+    const entrypointAddress = await getEntrypointFromFactory(
+      args.smartWalletOptions.factoryAddress,
+      args.client,
+      args.smartWalletOptions.chain,
+    );
+    if (entrypointAddress) {
+      args.smartWalletOptions.overrides = {
+        ...args.smartWalletOptions.overrides,
+        entrypointAddress,
+      };
+    }
+  }
+
+  const userOp = await prepareUserOp({
+    transactions: args.transactions,
+    adminAccount: args.adminAccount,
+    client: args.client,
+    smartWalletOptions: args.smartWalletOptions,
+    isDeployedOverride: await isContractDeployed(
+      getContract({
+        address: await predictSmartAccountAddress({
+          adminAddress: args.adminAccount.address,
+          factoryAddress: args.smartWalletOptions.factoryAddress,
+          chain: args.smartWalletOptions.chain,
+          client: args.client,
+        }),
+        chain: args.smartWalletOptions.chain,
+        client: args.client,
+      }),
+    ),
+  });
+
+  let gasLimit = 0n;
+  if ("paymasterVerificationGasLimit" in userOp) {
+    // v0.7
+    gasLimit =
+      BigInt(userOp.paymasterVerificationGasLimit ?? 0) +
+      BigInt(userOp.paymasterPostOpGasLimit ?? 0) +
+      BigInt(userOp.verificationGasLimit ?? 0) +
+      BigInt(userOp.preVerificationGas ?? 0) +
+      BigInt(userOp.callGasLimit ?? 0);
+  } else {
+    // v0.6
+    gasLimit =
+      BigInt(userOp.verificationGasLimit ?? 0) +
+      BigInt(userOp.preVerificationGas ?? 0) +
+      BigInt(userOp.callGasLimit ?? 0);
+  }
+
+  const gasCost = gasLimit * (userOp.maxFeePerGas ?? 0n);
+
+  return {
+    ether: toEther(gasCost),
+    wei: gasCost,
   };
 }
 

--- a/packages/thirdweb/src/wallets/smart/smart-wallet-integration.test.ts
+++ b/packages/thirdweb/src/wallets/smart/smart-wallet-integration.test.ts
@@ -29,6 +29,7 @@ import { hashTypedData } from "../../utils/hashing/hashTypedData.js";
 import { sleep } from "../../utils/sleep.js";
 import type { Account, Wallet } from "../interfaces/wallet.js";
 import { generateAccount } from "../utils/generateAccount.js";
+import { estimateUserOpGasCost } from "./lib/bundler.js";
 import { predictSmartAccountAddress } from "./lib/calls.js";
 import { deploySmartAccount } from "./lib/signing.js";
 import { smartWallet } from "./smart-wallet.js";
@@ -72,6 +73,26 @@ describe.runIf(process.env.TW_SECRET_KEY).sequential(
         chain,
         client,
       });
+    });
+
+    it("can estimate gas cost", async () => {
+      const gasCost = await estimateUserOpGasCost({
+        transactions: [
+          claimTo({
+            contract,
+            quantity: 1n,
+            to: smartWalletAddress,
+            tokenId: 0n,
+          }),
+        ],
+        adminAccount: personalAccount,
+        client: TEST_CLIENT,
+        smartWalletOptions: {
+          chain,
+          sponsorGas: true,
+        },
+      });
+      expect(gasCost.ether).not.toBe("0");
     });
 
     it("can connect", async () => {


### PR DESCRIPTION
Fixes TOOL-3521

<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new utility function to estimate the gas cost of user operations, enhances existing functions for better async handling, and updates tests to validate the new functionality.

### Detailed summary
- Added `estimateUserOpGasCost()` for estimating gas costs of user operations.
- Updated `getEntrypointFromFactory` to be exported.
- Changed `isOpStackChain` to an async function with additional checks.
- Enhanced tests to include gas cost estimation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->