### PR TITLE
[service-utils] trim project ID prefix

### DIFF
--- a/.changeset/brown-onions-tickle.md
+++ b/.changeset/brown-onions-tickle.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+[service-utils] trim project ID prefix

--- a/packages/service-utils/src/node/usageV2.ts
+++ b/packages/service-utils/src/node/usageV2.ts
@@ -6,6 +6,9 @@ import {
 } from "../core/usageV2.js";
 import { KafkaProducer } from "./kafka.js";
 
+const TEAM_ID_PREFIX = "team_";
+const PROJECT_ID_PREFIX = "prj_";
+
 /**
  * Creates a UsageV2Producer which opens a persistent TCP connection.
  * This class is thread-safe so your service should re-use one instance.
@@ -65,9 +68,13 @@ export class UsageV2Producer {
       // Default to now.
       created_at: event.created_at ?? new Date(),
       // Remove the "team_" prefix, if any.
-      team_id: event.team_id.startsWith("team_")
-        ? event.team_id.slice(5)
+      team_id: event.team_id.startsWith(TEAM_ID_PREFIX)
+        ? event.team_id.slice(TEAM_ID_PREFIX.length)
         : event.team_id,
+      // Remove the "prj_" prefix, if any.
+      project_id: event.project_id?.startsWith(PROJECT_ID_PREFIX)
+        ? event.project_id.slice(PROJECT_ID_PREFIX.length)
+        : event.project_id,
     }));
     await this.kafkaProducer.send(this.topic, parsedEvents);
   }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `UsageV2Producer` class in the `service-utils` package to trim specific prefixes from `team_id` and `project_id` fields.

### Detailed summary
- Added constants `TEAM_ID_PREFIX` and `PROJECT_ID_PREFIX` for prefix management.
- Modified `team_id` to remove the `team_` prefix using the new constant.
- Added logic to remove the `prj_` prefix from `project_id` if present.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->