### PR TITLE
chore: forward origin header to usage tracker

### DIFF
--- a/.changeset/rich-planes-drive.md
+++ b/.changeset/rich-planes-drive.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+[service-utils] Provide CF req to forward origin header

--- a/packages/service-utils/src/cf-worker/usageV2.ts
+++ b/packages/service-utils/src/cf-worker/usageV2.ts
@@ -1,4 +1,4 @@
-import type { Request } from "@cloudflare/workers-types";
+import { Headers, type Request, fetch } from "@cloudflare/workers-types";
 import type { CoreAuthInput } from "src/core/types.js";
 import type {
   ClientUsageV2Event,
@@ -32,14 +32,12 @@ export async function sendUsageV2Events<T extends UsageV2Options>(
   // Forward headers from the origin request.
   // Determine endpoint and auth header based on provided credentials.
   let url: string;
-  const headers: HeadersInit = {
-    ...authInput.req.headers,
-    "Content-Type": "application/json",
-  };
+  const headers = new Headers(authInput.req.headers);
+  headers.set("Content-Type", "application/json");
   if (serviceKey) {
     // If a service key is provided, call the non-public usage endpoint.
     url = `${usageBaseUrl}/usage-v2/${source}`;
-    headers["x-service-api-key"] = serviceKey;
+    headers.set("x-service-api-key", serviceKey);
   } else {
     url = `${usageBaseUrl}/usage-v2/${source}/client`;
   }

--- a/packages/service-utils/src/cf-worker/usageV2.ts
+++ b/packages/service-utils/src/cf-worker/usageV2.ts
@@ -1,27 +1,21 @@
+import type { Request } from "@cloudflare/workers-types";
+import type { CoreAuthInput } from "src/core/types.js";
 import type {
   ClientUsageV2Event,
   UsageV2Event,
   UsageV2Source,
 } from "../core/usageV2.js";
+import { extractAuthorizationData } from "./index.js";
 
 type UsageV2Options = {
   usageBaseUrl: string;
   source: UsageV2Source;
-} & (
-  | { serviceKey: string; thirdwebClientId?: never; thirdwebSecretKey?: never }
-  | { serviceKey?: never; thirdwebClientId: string; thirdwebSecretKey?: never }
-  | { serviceKey?: never; thirdwebClientId?: never; thirdwebSecretKey: string }
-);
+  authInput: CoreAuthInput & { req: Request };
+  serviceKey?: string;
+};
 
 /**
  * Send usageV2 events from either internal services or public clients.
- *
- * Exactly one authentication method must be provided:
- * - serviceKey: for internal services
- * - thirdwebClientId: for public clients (MUST be the user's project)
- * - thirdwebSecretKey: for public clients (MUST be the user's project)
- *
- * NOTE: `team_id` is required if `serviceKey` is provided.
  *
  * This method may throw. To call this non-blocking:
  * ```ts
@@ -34,19 +28,26 @@ export async function sendUsageV2Events<T extends UsageV2Options>(
     : ClientUsageV2Event[],
   options: T,
 ): Promise<void> {
+  const { usageBaseUrl, source, authInput, serviceKey } = options;
+  const { clientId, secretKey } = await extractAuthorizationData(authInput);
+
   // Determine endpoint and auth header based on provided credentials.
   let url: string;
   const headers: HeadersInit = { "Content-Type": "application/json" };
+  const origin = authInput.req.headers.get("Origin");
+  if (origin) {
+    headers["Origin"] = origin;
+  }
 
-  if (options.serviceKey) {
-    url = `${options.usageBaseUrl}/usage-v2/${options.source}`;
-    headers["x-service-api-key"] = options.serviceKey;
-  } else if (options.thirdwebSecretKey) {
-    url = `${options.usageBaseUrl}/usage-v2/${options.source}/client`;
-    headers["x-secret-key"] = options.thirdwebSecretKey;
-  } else if (options.thirdwebClientId) {
-    url = `${options.usageBaseUrl}/usage-v2/${options.source}/client`;
-    headers["x-client-id"] = options.thirdwebClientId;
+  if (serviceKey) {
+    url = `${usageBaseUrl}/usage-v2/${source}`;
+    headers["x-service-api-key"] = serviceKey;
+  } else if (secretKey) {
+    url = `${usageBaseUrl}/usage-v2/${source}/client`;
+    headers["x-secret-key"] = secretKey;
+  } else if (clientId) {
+    url = `${usageBaseUrl}/usage-v2/${source}/client`;
+    headers["x-client-id"] = clientId;
   } else {
     throw new Error("[UsageV2] No authentication method provided.");
   }
@@ -56,7 +57,6 @@ export async function sendUsageV2Events<T extends UsageV2Options>(
     headers,
     body: JSON.stringify({ events }),
   });
-
   if (!resp.ok) {
     throw new Error(
       `[UsageV2] Unexpected response ${resp.status}: ${await resp.text()}`,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the `sendUsageV2Events` function in the `service-utils` package to include the ability to forward the origin request's headers, specifically for authentication, improving the flexibility and security of the API usage.

### Detailed summary
- Updated `UsageV2Options` to include `authInput` with `req: Request`.
- Replaced manual header handling with `Headers` object from the `req` parameter.
- Simplified authentication method checks by directly using `clientId` and `secretKey` from `authInput`.
- Removed deprecated authentication method comments.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->