### PR TITLE
fix: relative path import for usageV2

### DIFF
--- a/packages/service-utils/src/cf-worker/usageV2.ts
+++ b/packages/service-utils/src/cf-worker/usageV2.ts
@@ -1,5 +1,5 @@
 import { Headers, type Request, fetch } from "@cloudflare/workers-types";
-import type { CoreAuthInput } from "src/core/types.js";
+import type { CoreAuthInput } from "../core/types.js";
 import type {
   ClientUsageV2Event,
   UsageV2Event,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the import path for `CoreAuthInput` in the `usageV2.ts` file to use a relative path instead of an absolute path.

### Detailed summary
- Changed the import path for `CoreAuthInput` from `"src/core/types.js"` to `"../core/types.js"` in `packages/service-utils/src/cf-worker/usageV2.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->