### PR TITLE
[service-utils] fix: crash if Kafka connects more than once

### DIFF
--- a/.changeset/gentle-readers-bet.md
+++ b/.changeset/gentle-readers-bet.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+[service-utils] Add connect promise so it only connects once


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a mechanism in the `KafkaProducer` class to ensure that the `connect()` method is called only once using a promise. This change improves connection management by allowing concurrent calls without redundancy.

### Detailed summary
- Removed the `isConnected` boolean flag.
- Added a `connectPromise` property to manage the connection state.
- Modified the `connect()` method to cache the connection promise.
- Updated the message sending logic to always call `await this.connect()`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->