### PR TITLE
[service-utils] fix: build error on kafka disconnect()

### DIFF
--- a/packages/service-utils/src/node/kafka.ts
+++ b/packages/service-utils/src/node/kafka.ts
@@ -105,12 +105,9 @@ export class KafkaProducer {
    * Useful when shutting down the service to flush in-flight events.
    */
   async disconnect() {
-    if (this.isConnected) {
-      try {
-        await this.producer.flush();
-        await this.producer.disconnect();
-      } catch {}
-      this.isConnected = false;
-    }
+    try {
+      await this.producer.flush();
+      await this.producer.disconnect();
+    } catch {}
   }
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR refactors the `disconnect` method in the `kafka.ts` file to simplify the connection handling logic by removing the conditional check for `this.isConnected`.

### Detailed summary
- Removed the conditional check for `this.isConnected` before executing the disconnect logic.
- The `this.isConnected` flag is no longer updated within the `disconnect` method.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->