### PR TITLE
playground: fix pay example imports

### DIFF
--- a/apps/playground-web/src/app/connect/pay/transactions/page.tsx
+++ b/apps/playground-web/src/app/connect/pay/transactions/page.tsx
@@ -114,7 +114,7 @@ function NoFundsPopup() {
       <CodeExample
         preview={<PayTransactionButtonPreview />}
         code={`import { trasnfer } from "thirdweb/extensions/erc1155";
-          import { PayEmbed, useActiveAccount } from "thirdweb/react";
+          import { TransactionButton, useActiveAccount } from "thirdweb/react";
 
 
         function App() {

--- a/apps/playground-web/src/app/connect/pay/transactions/page.tsx
+++ b/apps/playground-web/src/app/connect/pay/transactions/page.tsx
@@ -113,7 +113,7 @@ function NoFundsPopup() {
 
       <CodeExample
         preview={<PayTransactionButtonPreview />}
-        code={`import { trasnfer } from "thirdweb/extensions/erc1155";
+        code={`import { transfer } from "thirdweb/extensions/erc1155";
           import { TransactionButton, useActiveAccount } from "thirdweb/react";
 
 


### PR DESCRIPTION
Fixes the import statement in the example code for Pay > Transactions > Automatic Onramp on the playground app

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting a typo in the import statement and updating the component being imported for better functionality in the `page.tsx` file.

### Detailed summary
- Changed the import of `trasnfer` to the correct `transfer` from `thirdweb/extensions/erc1155`.
- Updated the import of `PayEmbed` to `TransactionButton` from `thirdweb/react`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->