### PR TITLE
[TOOL-3575] Dashboard: Fix /home link 404 after upgrading to nextjs 15.2

### DIFF
--- a/apps/dashboard/next.config.ts
+++ b/apps/dashboard/next.config.ts
@@ -153,7 +153,7 @@ const baseNextConfig: NextConfig = {
       // re-write /home to / (this is so that logged in users will be able to go to /home and NOT be redirected to the logged in app)
       {
         source: "/home",
-        destination: "/",
+        destination: "https://landing.thirdweb.com",
       },
       ...FRAMER_PATHS.map((path) => ({
         source: path,

--- a/apps/dashboard/src/app/components/MobileBurgerMenuButton.tsx
+++ b/apps/dashboard/src/app/components/MobileBurgerMenuButton.tsx
@@ -166,7 +166,7 @@ export function MobileBurgerMenuButton(
             </Link>
 
             <Link
-              href="/"
+              href="/home"
               className="text-base text-muted-foreground hover:text-foreground"
             >
               Home Page


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the routing and linking within the application to direct users to a new landing page.

### Detailed summary
- In `apps/dashboard/next.config.ts`, changed the `destination` from `"/"` to `"https://landing.thirdweb.com"`.
- In `apps/dashboard/src/app/components/MobileBurgerMenuButton.tsx`, updated the `href` attribute from `"/"` to `"/home"` in the `Link` component.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->