### PR TITLE
[TOOL-3584] Dashboad: Move turnstile widget above connect embed in login page

### DIFF
--- a/apps/dashboard/src/app/login/LoginPage.tsx
+++ b/apps/dashboard/src/app/login/LoginPage.tsx
@@ -222,6 +222,16 @@ function CustomConnectEmbed(props: {
 
   return (
     <div className="flex flex-col items-center gap-4">
+      <Turnstile
+        options={{
+          // only show if interaction is required
+          appearance: "interaction-only",
+          // match the theme of the rest of the app
+          theme: theme === "light" ? "light" : "dark",
+        }}
+        siteKey={TURNSTILE_SITE_KEY}
+        onSuccess={(token) => setTurnstileToken(token)}
+      />
       <ConnectEmbed
         auth={{
           getLoginPayload,
@@ -254,16 +264,6 @@ function CustomConnectEmbed(props: {
         className="shadow-lg"
         privacyPolicyUrl="/privacy-policy"
         termsOfServiceUrl="/terms"
-      />
-      <Turnstile
-        options={{
-          // only show if interaction is required
-          appearance: "interaction-only",
-          // match the theme of the rest of the app
-          theme: theme === "light" ? "light" : "dark",
-        }}
-        siteKey={TURNSTILE_SITE_KEY}
-        onSuccess={(token) => setTurnstileToken(token)}
       />
     </div>
   );


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `LoginPage.tsx` component by modifying the usage of the `Turnstile` component. It adds a new instance of `Turnstile` while removing the previous one, ensuring that it only appears when interaction is required.

### Detailed summary
- Added a new `Turnstile` component with specific `options` and `siteKey`.
- Set the `onSuccess` handler for the `Turnstile` to update the `turnstileToken`.
- Removed the old `Turnstile` component from the return statement.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->