### PR TITLE
update engine API routes to include team slug

### DIFF
--- a/apps/dashboard/src/@3rdweb-sdk/react/hooks/useEngine.ts
+++ b/apps/dashboard/src/@3rdweb-sdk/react/hooks/useEngine.ts
@@ -232,13 +232,15 @@ export function useEngineUpdateDeployment() {
 
 export type RemoveEngineFromDashboardIParams = {
   instanceId: string;
+  teamIdOrSlug: string;
 };
 
 export async function removeEngineFromDashboard({
   instanceId,
+  teamIdOrSlug,
 }: RemoveEngineFromDashboardIParams) {
   const res = await apiServerProxy({
-    pathname: `/v1/engine/${instanceId}`,
+    pathname: `/v1/teams/${teamIdOrSlug}/engine/${instanceId}`,
     method: "DELETE",
   });
 
@@ -273,18 +275,20 @@ export async function deleteCloudHostedEngine({
 }
 
 export type EditEngineInstanceParams = {
+  teamIdOrSlug: string;
   instanceId: string;
   name: string;
   url: string;
 };
 
 export async function editEngineInstance({
+  teamIdOrSlug,
   instanceId,
   name,
   url,
 }: EditEngineInstanceParams) {
   const res = await apiServerProxy({
-    pathname: `/v1/engine/${instanceId}`,
+    pathname: `/v1/teams/${teamIdOrSlug}/engine/${instanceId}`,
     method: "PUT",
     headers: {
       "Content-Type": "application/json",
@@ -1628,7 +1632,7 @@ export function useEngineSubscriptionsLastBlock(params: {
 
 interface EngineResourceMetrics {
   error: string;
-  data: {
+  result: {
     cpu: number;
     memory: number;
     errorRate: ResultItem[];
@@ -1637,7 +1641,7 @@ interface EngineResourceMetrics {
   };
 }
 
-export function useEngineSystemMetrics(engineId: string) {
+export function useEngineSystemMetrics(engineId: string, teamIdOrSlug: string) {
   const [enabled, setEnabled] = useState(true);
 
   return useQuery({
@@ -1645,7 +1649,7 @@ export function useEngineSystemMetrics(engineId: string) {
     queryFn: async () => {
       const res = await apiServerProxy({
         method: "GET",
-        pathname: `/v1/engine/${engineId}/metrics`,
+        pathname: `/v1/teams/${teamIdOrSlug}/engine/${engineId}/metrics`,
       });
 
       if (!res.ok) {
@@ -1674,14 +1678,14 @@ export interface EngineAlertRule {
   pausedAt: Date | null;
 }
 
-export function useEngineAlertRules(engineId: string) {
+export function useEngineAlertRules(engineId: string, teamIdOrSlug: string) {
   return useQuery({
     queryKey: engineKeys.alertRules(engineId),
     queryFn: async () => {
       const res = await apiServerProxy<{
         data: EngineAlertRule[];
       }>({
-        pathname: `/v1/engine/${engineId}/alert-rules`,
+        pathname: `/v1/teams/${teamIdOrSlug}/engine/${engineId}/alert-rules`,
         method: "GET",
       });
 
@@ -1703,14 +1707,19 @@ export interface EngineAlert {
   endsAt: Date | null;
 }
 
-export function useEngineAlerts(engineId: string, limit: number, offset = 0) {
+export function useEngineAlerts(
+  engineId: string,
+  teamIdOrSlug: string,
+  limit: number,
+  offset = 0,
+) {
   return useQuery({
     queryKey: engineKeys.alerts(engineId),
     queryFn: async () => {
       const res = await apiServerProxy<{
         data: EngineAlert[];
       }>({
-        pathname: `/v1/engine/${engineId}/alerts`,
+        pathname: `/v1/teams/${teamIdOrSlug}/engine/${engineId}/alerts`,
         searchParams: {
           limit: `${limit}`,
           offset: `${offset}`,
@@ -1754,14 +1763,17 @@ export type EngineNotificationChannel = {
   subscriptionRoutes: string[];
 };
 
-export function useEngineNotificationChannels(engineId: string) {
+export function useEngineNotificationChannels(
+  engineId: string,
+  teamIdOrSlug: string,
+) {
   return useQuery({
     queryKey: engineKeys.notificationChannels(engineId),
     queryFn: async () => {
       const res = await apiServerProxy<{
         data: EngineNotificationChannel[];
       }>({
-        pathname: `/v1/engine/${engineId}/notification-channels`,
+        pathname: `/v1/teams/${teamIdOrSlug}/engine/${engineId}/notification-channels`,
         method: "GET",
       });
 
@@ -1781,7 +1793,10 @@ export interface CreateNotificationChannelInput {
   value: string;
 }
 
-export function useEngineCreateNotificationChannel(engineId: string) {
+export function useEngineCreateNotificationChannel(
+  engineId: string,
+  teamIdOrSlug: string,
+) {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -1789,7 +1804,7 @@ export function useEngineCreateNotificationChannel(engineId: string) {
       const res = await apiServerProxy<{
         data: EngineNotificationChannel;
       }>({
-        pathname: `/v1/engine/${engineId}/notification-channels`,
+        pathname: `/v1/teams/${teamIdOrSlug}/engine/${engineId}/notification-channels`,
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -1812,13 +1827,16 @@ export function useEngineCreateNotificationChannel(engineId: string) {
   });
 }
 
-export function useEngineDeleteNotificationChannel(engineId: string) {
+export function useEngineDeleteNotificationChannel(
+  engineId: string,
+  teamIdOrSlug: string,
+) {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: async (notificationChannelId: string) => {
       const res = await apiServerProxy({
-        pathname: `/v1/engine/${engineId}/notification-channels/${notificationChannelId}`,
+        pathname: `/v1/teams/${teamIdOrSlug}/engine/${engineId}/notification-channels/${notificationChannelId}`,
         method: "DELETE",
       });
 

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/(general)/import/EngineImportPage.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/(general)/import/EngineImportPage.tsx
@@ -28,12 +28,15 @@ const formSchema = z.object({
 
 type ImportEngineParams = z.infer<typeof formSchema>;
 
-async function importEngine(data: ImportEngineParams) {
+async function importEngine({
+  teamIdOrSlug,
+  ...data
+}: ImportEngineParams & { teamIdOrSlug: string }) {
   // Instance URLs should end with a /.
   const url = data.url.endsWith("/") ? data.url : `${data.url}/`;
 
   const res = await apiServerProxy({
-    pathname: "/v1/engine",
+    pathname: `/v1/teams/${teamIdOrSlug}/engine`,
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -59,7 +62,7 @@ export function EngineImportCard(props: {
     <EngineImportCardUI
       prefillImportUrl={props.prefillImportUrl}
       importEngine={async (params) => {
-        await importEngine(params);
+        await importEngine({ ...params, teamIdOrSlug: props.teamSlug });
         router.push(`/team/${props.teamSlug}/~/engine`);
       }}
     />

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/(general)/overview/engine-instances-table.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/(general)/overview/engine-instances-table.tsx
@@ -74,6 +74,7 @@ type RemovedEngineFromDashboard = (
 ) => Promise<void>;
 
 export function EngineInstancesTable(props: {
+  teamIdOrSlug: string;
   instances: EngineInstance[];
   engineLinkPrefix: string;
 }) {
@@ -81,6 +82,7 @@ export function EngineInstancesTable(props: {
 
   return (
     <EngineInstancesTableUI
+      teamIdOrSlug={props.teamIdOrSlug}
       instances={props.instances}
       engineLinkPrefix={props.engineLinkPrefix}
       deleteCloudHostedEngine={async (params) => {
@@ -100,6 +102,7 @@ export function EngineInstancesTable(props: {
 }
 
 export function EngineInstancesTableUI(props: {
+  teamIdOrSlug: string;
   instances: EngineInstance[];
   engineLinkPrefix: string;
   deleteCloudHostedEngine: DeletedCloudHostedEngine;
@@ -124,6 +127,7 @@ export function EngineInstancesTableUI(props: {
             {props.instances.map((instance) => (
               <EngineInstanceRow
                 key={instance.id}
+                teamIdOrSlug={props.teamIdOrSlug}
                 instance={instance}
                 engineLinkPrefix={props.engineLinkPrefix}
                 deleteCloudHostedEngine={props.deleteCloudHostedEngine}
@@ -145,6 +149,7 @@ export function EngineInstancesTableUI(props: {
 }
 
 function EngineInstanceRow(props: {
+  teamIdOrSlug: string;
   instance: EngineInstance;
   engineLinkPrefix: string;
   deleteCloudHostedEngine: DeletedCloudHostedEngine;
@@ -187,6 +192,7 @@ function EngineInstanceRow(props: {
       </TableRow>
 
       <EditModal
+        teamIdOrSlug={props.teamIdOrSlug}
         instance={instance}
         open={isEditModalOpen}
         onOpenChange={setIsEditModalOpen}
@@ -194,6 +200,7 @@ function EngineInstanceRow(props: {
       />
 
       <RemoveModal
+        teamIdOrSlug={props.teamIdOrSlug}
         instance={instance}
         onOpenChange={setIsRemoveModalOpen}
         open={isRemoveModalOpen}
@@ -349,6 +356,7 @@ function EngineActionsDropdown(props: {
 
 function EditModal(props: {
   open: boolean;
+  teamIdOrSlug: string;
   onOpenChange: (open: boolean) => void;
   instance: EngineInstance;
   editEngineInstance: EditedEngineInstance;
@@ -357,6 +365,7 @@ function EditModal(props: {
     <Dialog open={props.open} onOpenChange={props.onOpenChange}>
       <DialogContent className="overflow-hidden p-0">
         <EditModalContent
+          teamIdOrSlug={props.teamIdOrSlug}
           instance={props.instance}
           editEngineInstance={props.editEngineInstance}
           closeModal={() => props.onOpenChange(false)}
@@ -372,6 +381,7 @@ const editEngineFormSchema = z.object({
 });
 
 function EditModalContent(props: {
+  teamIdOrSlug: string;
   instance: EngineInstance;
   editEngineInstance: EditedEngineInstance;
   closeModal: () => void;
@@ -396,6 +406,7 @@ function EditModalContent(props: {
         onSubmit={form.handleSubmit((data) =>
           editInstance.mutate(
             {
+              teamIdOrSlug: props.teamIdOrSlug,
               instanceId: props.instance.id,
               name: data.name,
               url: data.url,
@@ -475,6 +486,7 @@ function EditModalContent(props: {
 }
 
 function RemoveModal(props: {
+  teamIdOrSlug: string;
   instance: EngineInstance;
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -491,6 +503,7 @@ function RemoveModal(props: {
         (instance.status === "active" && !instance.deploymentId) ? (
           <RemoveEngineFromDashboardModalContent
             instance={instance}
+            teamIdOrSlug={props.teamIdOrSlug}
             close={() => onOpenChange(false)}
             removeEngineFromDashboard={props.removeEngineFromDashboard}
           />
@@ -507,6 +520,7 @@ function RemoveModal(props: {
 }
 
 function RemoveEngineFromDashboardModalContent(props: {
+  teamIdOrSlug: string;
   instance: EngineInstance;
   close: () => void;
   removeEngineFromDashboard: RemovedEngineFromDashboard;
@@ -552,6 +566,7 @@ function RemoveEngineFromDashboardModalContent(props: {
             removeFromDashboard.mutate(
               {
                 instanceId: instance.id,
+                teamIdOrSlug: props.teamIdOrSlug,
               },
               {
                 onSuccess: () => {

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/(general)/overview/engine-list.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/(general)/overview/engine-list.tsx
@@ -12,6 +12,7 @@ export const EngineInstancesList = (props: {
   return (
     <div className="flex grow flex-col">
       <EngineInstancesTable
+        teamIdOrSlug={props.team_slug}
         instances={props.instances}
         engineLinkPrefix={engineLinkPrefix}
       />

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/(general)/page.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/(general)/page.tsx
@@ -29,7 +29,10 @@ export default async function Page(props: {
     loginRedirect(`/team/${params.team_slug}/~/engine`);
   }
 
-  const res = await getEngineInstances({ authToken });
+  const res = await getEngineInstances({
+    authToken,
+    teamIdOrSlug: params.team_slug,
+  });
 
   return (
     <EngineInstancesList

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/(instance)/[engineId]/alerts/components/EngineAlertsPage.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/(instance)/[engineId]/alerts/components/EngineAlertsPage.tsx
@@ -9,8 +9,12 @@ import { RecentEngineAlertsSection } from "./RecentEngineAlerts";
 
 export function EngineAlertsPage(props: {
   instance: EngineInstance;
+  teamIdOrSlug: string;
 }) {
-  const alertRulesQuery = useEngineAlertRules(props.instance.id);
+  const alertRulesQuery = useEngineAlertRules(
+    props.instance.id,
+    props.teamIdOrSlug,
+  );
   const alertRules = alertRulesQuery.data ?? [];
 
   return (
@@ -19,12 +23,14 @@ export function EngineAlertsPage(props: {
         alertRules={alertRules}
         engineId={props.instance.id}
         alertRulesIsLoading={alertRulesQuery.isLoading}
+        teamIdOrSlug={props.teamIdOrSlug}
       />
       <div className="h-8" />
       <RecentEngineAlertsSection
         alertRules={alertRules}
         engineId={props.instance.id}
         alertRulesIsLoading={alertRulesQuery.isLoading}
+        teamIdOrSlug={props.teamIdOrSlug}
       />
     </div>
   );

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/(instance)/[engineId]/alerts/components/ManageEngineAlerts.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/(instance)/[engineId]/alerts/components/ManageEngineAlerts.tsx
@@ -43,19 +43,23 @@ type CreateAlertMutation = UseMutationResult<
 >;
 
 export function ManageEngineAlertsSection(props: {
+  teamIdOrSlug: string;
   alertRules: EngineAlertRule[];
   alertRulesIsLoading: boolean;
   engineId: string;
 }) {
   const notificationChannelsQuery = useEngineNotificationChannels(
     props.engineId,
+    props.teamIdOrSlug,
   );
   const deleteAlertMutation = useEngineDeleteNotificationChannel(
     props.engineId,
+    props.teamIdOrSlug,
   );
 
   const createAlertMutation = useEngineCreateNotificationChannel(
     props.engineId,
+    props.teamIdOrSlug,
   );
 
   // not passing the mutation to avoid multiple rows sharing the same mutation state, we create the new mutation for each row instead in each component instead

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/(instance)/[engineId]/alerts/components/RecentEngineAlerts.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/(instance)/[engineId]/alerts/components/RecentEngineAlerts.tsx
@@ -23,10 +23,16 @@ export function RecentEngineAlertsSection(props: {
   alertRules: EngineAlertRule[];
   alertRulesIsLoading: boolean;
   engineId: string;
+  teamIdOrSlug: string;
 }) {
   // TODO - pagination
   // required : return the total number of alerts in response from API
-  const alertsQuery = useEngineAlerts(props.engineId, 100, 0);
+  const alertsQuery = useEngineAlerts(
+    props.engineId,
+    props.teamIdOrSlug,
+    100,
+    0,
+  );
   const alerts = alertsQuery.data ?? [];
 
   return (

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/(instance)/[engineId]/alerts/page.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/(instance)/[engineId]/alerts/page.tsx
@@ -9,5 +9,7 @@ export default async function Page(props: EngineInstancePageProps) {
     teamSlug: params.team_slug,
   });
 
-  return <EngineAlertsPage instance={instance} />;
+  return (
+    <EngineAlertsPage instance={instance} teamIdOrSlug={params.team_slug} />
+  );
 }

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/(instance)/[engineId]/configuration/components/engine-configuration.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/(instance)/[engineId]/configuration/components/engine-configuration.tsx
@@ -29,7 +29,7 @@ export const EngineConfiguration: React.FC<EngineConfigurationProps> = ({
         instanceUrl={instance.url}
         authToken={authToken}
       />
-      <EngineSystem instance={instance} />
+      <EngineSystem instance={instance} teamIdOrSlug={teamSlug} />
     </div>
   );
 };

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/(instance)/[engineId]/configuration/components/system.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/(instance)/[engineId]/configuration/components/system.tsx
@@ -6,11 +6,15 @@ import {
 
 interface EngineSystemProps {
   instance: EngineInstance;
+  teamIdOrSlug: string;
 }
 
-export const EngineSystem: React.FC<EngineSystemProps> = ({ instance }) => {
+export const EngineSystem: React.FC<EngineSystemProps> = ({
+  instance,
+  teamIdOrSlug,
+}) => {
   const healthQuery = useEngineSystemHealth(instance.url);
-  const metricsQuery = useEngineSystemMetrics(instance.id);
+  const metricsQuery = useEngineSystemMetrics(instance.id, teamIdOrSlug);
   if (!healthQuery.data) {
     return null;
   }
@@ -21,9 +25,9 @@ export const EngineSystem: React.FC<EngineSystemProps> = ({ instance }) => {
       <br />
       Enabled: {healthQuery.data.features?.join(", ")}
       <br />
-      CPU: {metricsQuery.data?.data?.cpu?.toFixed(2) ?? "..."}%
+      CPU: {metricsQuery.data?.result?.cpu?.toFixed(2) ?? "..."}%
       <br />
-      Memory: {metricsQuery.data?.data?.memory?.toFixed(0) ?? "..."}MB
+      Memory: {metricsQuery.data?.result?.memory?.toFixed(0) ?? "..."}MB
     </p>
   );
 };

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/(instance)/[engineId]/layout.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/(instance)/[engineId]/layout.tsx
@@ -33,6 +33,7 @@ export default async function Layout(props: {
   }
 
   const instance = await getEngineInstance({
+    teamIdOrSlug: params.team_slug,
     authToken,
     engineId: params.engineId,
     accountId: account.id,

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/(instance)/[engineId]/metrics/components/EngineSystemMetrics.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/(instance)/[engineId]/metrics/components/EngineSystemMetrics.tsx
@@ -23,7 +23,7 @@ export const EngineSystemMetrics: React.FC<EngineStatusProps> = ({
   teamSlug,
   authToken,
 }) => {
-  const systemMetricsQuery = useEngineSystemMetrics(instance.id);
+  const systemMetricsQuery = useEngineSystemMetrics(instance.id, teamSlug);
   const queueMetricsQuery = useEngineQueueMetrics({
     authToken,
     instanceUrl: instance.url,
@@ -69,8 +69,10 @@ export const EngineSystemMetrics: React.FC<EngineStatusProps> = ({
           <div className="mt-10 grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
             <Healthcheck instance={instance} />
           </div>
-          <StatusCodes datapoints={systemMetricsQuery.data.data.statusCodes} />
-          <ErrorRate datapoints={systemMetricsQuery.data.data.errorRate} />
+          <StatusCodes
+            datapoints={systemMetricsQuery.data.result.statusCodes}
+          />
+          <ErrorRate datapoints={systemMetricsQuery.data.result.errorRate} />
         </div>
       </Card>
     );

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/_utils/getEngineInstance.ts
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/_utils/getEngineInstance.ts
@@ -2,6 +2,7 @@ import { API_SERVER_URL } from "@/constants/env";
 import type { EngineInstance } from "@3rdweb-sdk/react/hooks/useEngine";
 
 export async function getEngineInstance(params: {
+  teamIdOrSlug: string;
   authToken: string;
   engineId: string;
   accountId: string;
@@ -19,11 +20,14 @@ export async function getEngineInstance(params: {
     return sandboxEngine;
   }
 
-  const res = await fetch(`${API_SERVER_URL}/v1/engine/${params.engineId}`, {
-    headers: {
-      Authorization: `Bearer ${params.authToken}`,
+  const res = await fetch(
+    `${API_SERVER_URL}/v1/teams/${params.teamIdOrSlug}/engine/${params.engineId}`,
+    {
+      headers: {
+        Authorization: `Bearer ${params.authToken}`,
+      },
     },
-  });
+  );
 
   if (!res.ok) {
     const errorMessage = await res.text();
@@ -33,8 +37,8 @@ export async function getEngineInstance(params: {
   }
 
   const json = (await res.json()) as {
-    data: EngineInstance;
+    result: EngineInstance;
   };
 
-  return json.data;
+  return json.result;
 }

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/_utils/getEngineInstancePageMeta.ts
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/_utils/getEngineInstancePageMeta.ts
@@ -20,6 +20,7 @@ export async function engineInstancePageHandler(params: {
   }
 
   const instance = await getEngineInstance({
+    teamIdOrSlug: params.teamSlug,
     authToken,
     engineId: params.engineId,
     accountId: account.id,

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/_utils/getEngineInstances.ts
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/_utils/getEngineInstances.ts
@@ -3,12 +3,16 @@ import type { EngineInstance } from "@3rdweb-sdk/react/hooks/useEngine";
 
 export async function getEngineInstances(params: {
   authToken: string;
+  teamIdOrSlug: string;
 }) {
-  const res = await fetch(`${API_SERVER_URL}/v1/engine`, {
-    headers: {
-      Authorization: `Bearer ${params.authToken}`,
+  const res = await fetch(
+    `${API_SERVER_URL}/v1/teams/${params.teamIdOrSlug}/engine`,
+    {
+      headers: {
+        Authorization: `Bearer ${params.authToken}`,
+      },
     },
-  });
+  );
 
   if (!res.ok) {
     const errorMessage = await res.text();
@@ -20,12 +24,10 @@ export async function getEngineInstances(params: {
   }
 
   const json = (await res.json()) as {
-    data: {
-      instances: EngineInstance[];
-    };
+    result: EngineInstance[];
   };
 
   return {
-    data: json.data.instances,
+    data: json.result,
   };
 }


### PR DESCRIPTION
blocked by: https://app.graphite.dev/github/pr/thirdweb-dev/api-server/1437/add-team-engine-management-endpoints

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the handling of `teamIdOrSlug` in various components and utility functions related to engine instances and alerts, ensuring that the correct team context is maintained throughout the application.

### Detailed summary
- Added `teamIdOrSlug` parameter to multiple functions and components.
- Updated API endpoints to include `teamIdOrSlug` in requests.
- Modified components like `EngineAlertsPage`, `EngineSystem`, and `EngineInstancesTable` to pass `teamIdOrSlug`.
- Adjusted query hooks to accept `teamIdOrSlug` for fetching data.
- Ensured consistent usage of `teamIdOrSlug` across engine alert and instance management functionalities.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->