### PR TITLE
[TOOL-3598] Dashboard: Add error message in create ecosystem form for image size

### DIFF
--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/create/components/client/create-ecosystem-form.client.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/create/components/client/create-ecosystem-form.client.tsx
@@ -31,9 +31,13 @@ const formSchema = z.object({
     .refine((name) => /^[a-zA-Z0-9 ]*$/.test(name), {
       message: "Name can only contain letters, numbers and spaces",
     }),
-  logo: z.instanceof(File, {
-    message: "Logo is required",
-  }),
+  logo: z
+    .instanceof(File, {
+      message: "Logo is required",
+    })
+    .refine((file) => file.size <= 500 * 1024, {
+      message: "Logo size must be less than 500KB",
+    }),
   permission: z.union([z.literal("PARTNER_WHITELIST"), z.literal("ANYONE")]),
 });
 
@@ -118,8 +122,9 @@ export function CreateEcosystemForm(props: { teamSlug: string }) {
                     accept="image/png, image/jpeg"
                     onUpload={(files) => {
                       if (files[0]) {
-                        form.setValue("logo", files[0]);
-                        form.clearErrors("logo");
+                        form.setValue("logo", files[0], {
+                          shouldValidate: true,
+                        });
                       }
                     }}
                   />


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the validation for the `logo` field in the `create-ecosystem-form.client.tsx` component by adding a file size constraint and modifying how the file is set in the form.

### Detailed summary
- Added a file size validation to the `logo` field, requiring it to be less than 500KB.
- Updated the `form.setValue` method to include `shouldValidate: true` when setting the `logo` value.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->