### PR TITLE
[TOOL-3606] playground: Remove Ethereum as default selected chain in insight playground

### DIFF
--- a/apps/playground-web/src/app/insight/[blueprint_slug]/blueprint-playground.client.tsx
+++ b/apps/playground-web/src/app/insight/[blueprint_slug]/blueprint-playground.client.tsx
@@ -157,13 +157,7 @@ export function BlueprintPlaygroundUI(props: {
   const defaultValues = useMemo(() => {
     const values: Record<string, string | number> = {};
     for (const param of parameters) {
-      if (param.name === "chain") {
-        values.chain = "1";
-      } else if (
-        param.schema &&
-        "type" in param.schema &&
-        param.schema.default
-      ) {
+      if (param.schema && "type" in param.schema && param.schema.default) {
         values[param.name] = param.schema.default;
       } else {
         values[param.name] = "";


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on refactoring a conditional block in the `blueprint-playground.client.tsx` file to streamline the assignment of default values to `values`.

### Detailed summary
- Removed the specific check for `param.name === "chain"` and its assignment to `values.chain`.
- Simplified the conditional structure to directly assign `param.schema.default` to `values[param.name]` if it exists.
- Ensured that if no default is found, `values[param.name]` is assigned an empty string.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->