### PR TITLE
[service-utils] Add pay as a usage source

### DIFF
--- a/.changeset/slick-eyes-reply.md
+++ b/.changeset/slick-eyes-reply.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+[service-utils] Add "pay" as a usage source

--- a/packages/service-utils/src/core/usageV2.ts
+++ b/packages/service-utils/src/core/usageV2.ts
@@ -7,6 +7,7 @@ export const USAGE_V2_SOURCES = [
   "sdk",
   "storage",
   "wallet",
+  "pay",
 ] as const;
 export type UsageV2Source = (typeof USAGE_V2_SOURCES)[number];
 export function getTopicName(source: UsageV2Source) {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a new usage source, `"pay"`, to the `UsageV2Source` type in the `service-utils` package, enhancing the functionality of usage tracking.

### Detailed summary
- Added `"pay"` to the `USAGE_V2_SOURCES` array in `packages/service-utils/src/core/usageV2.ts`.
- Updated the `UsageV2Source` type to include the new `"pay"` source.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->