### PR TITLE
[TOOL-3610] Dashboard: Fix z-index issue with network selector on chakra modal

### DIFF
--- a/apps/dashboard/src/@/styles/globals.css
+++ b/apps/dashboard/src/@/styles/globals.css
@@ -172,3 +172,10 @@ input:-webkit-autofill:active {
   font-weight: var(--shiki-dark-font-weight) !important;
   text-decoration: var(--shiki-dark-text-decoration) !important;
 }
+
+/* Remove this when chakra is removed */
+/* Make chakra modals have same z-index as shadcn dialog */
+body {
+  --chakra-zIndices-modal: 50;
+  --chakra-zIndices-overlay: 50;
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `globals.css` file to modify z-index values for Chakra UI modals and overlays to align with Shadcn dialog styles.

### Detailed summary
- Added comments indicating the need to remove Chakra when appropriate.
- Set `--chakra-zIndices-modal` and `--chakra-zIndices-overlay` to `50` in the `body` styles.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->