### PR TITLE
[SDK] expose getUserOpHash utility function

### DIFF
--- a/.changeset/proud-rockets-play.md
+++ b/.changeset/proud-rockets-play.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Expose getUserOpHash utility function

--- a/packages/thirdweb/src/exports/wallets/smart.ts
+++ b/packages/thirdweb/src/exports/wallets/smart.ts
@@ -5,6 +5,7 @@ export {
   createUnsignedUserOp,
   signUserOp,
   createAndSignUserOp,
+  getUserOpHash,
 } from "../../wallets/smart/lib/userop.js";
 
 export {

--- a/packages/thirdweb/src/wallets/in-app/core/actions/sign-message.enclave.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/actions/sign-message.enclave.ts
@@ -6,13 +6,15 @@ import type { ClientScopedStorage } from "../authentication/client-scoped-storag
 
 export async function signMessage({
   client,
-  payload: { message, isRaw },
+  payload: { message, isRaw, originalMessage, chainId },
   storage,
 }: {
   client: ThirdwebClient;
   payload: {
     message: string;
     isRaw: boolean;
+    originalMessage?: string;
+    chainId?: number;
   };
   storage: ClientScopedStorage;
 }) {
@@ -37,6 +39,8 @@ export async function signMessage({
         messagePayload: {
           message,
           isRaw,
+          originalMessage,
+          chainId,
         },
       }),
     },

--- a/packages/thirdweb/src/wallets/in-app/core/wallet/enclave-wallet.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/wallet/enclave-wallet.ts
@@ -217,10 +217,10 @@ export class EnclaveWallet implements IWebWallet {
 
         return { transactionHash };
       },
-      async signMessage({ message }) {
+      async signMessage({ message, originalMessage, chainId }) {
         const messagePayload = (() => {
           if (typeof message === "string") {
-            return { message, isRaw: false };
+            return { message, isRaw: false, originalMessage, chainId };
           }
           return {
             message:
@@ -228,6 +228,8 @@ export class EnclaveWallet implements IWebWallet {
                 ? message.raw
                 : bytesToHex(message.raw),
             isRaw: true,
+            originalMessage,
+            chainId,
           };
         })();
 

--- a/packages/thirdweb/src/wallets/interfaces/wallet.ts
+++ b/packages/thirdweb/src/wallets/interfaces/wallet.ts
@@ -182,7 +182,15 @@ export type Account = {
    * const signature = await account.signMessage({ message: 'hello!' });
    * ```
    */
-  signMessage: ({ message }: { message: SignableMessage }) => Promise<Hex>;
+  signMessage: ({
+    message,
+    originalMessage,
+    chainId,
+  }: {
+    message: SignableMessage;
+    originalMessage?: string;
+    chainId?: number;
+  }) => Promise<Hex>;
   /**
    * Sign the given typed data and return the signature
    * @example


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `signMessage` functionality across several components in the `thirdweb` wallet library, while introducing a new utility function `getUserOpHash` for hashing user operations.

### Detailed summary
- Added `getUserOpHash` function to hash user operations.
- Modified `signMessage` in `wallet.ts` to accept `originalMessage` and `chainId`.
- Updated `signMessage` in `sign-message.enclave.ts` to include new parameters.
- Altered `signMessage` in `enclave-wallet.ts` to handle additional data.
- Adjusted `signUserOp` to utilize `getUserOpHash` and pass new parameters.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->