### PR TITLE
chore: update mainnet AA message

### DIFF
--- a/apps/dashboard/src/components/settings/ApiKeys/Alerts.tsx
+++ b/apps/dashboard/src/components/settings/ApiKeys/Alerts.tsx
@@ -44,11 +44,10 @@ export const SmartWalletsBillingAlert = ({
           <AlertTitle>Account Abstraction on Mainnet</AlertTitle>
           <AlertDescription>
             <Text as="span" pr={1}>
-              You&apos;ve enabled Account Abstraction for one of your API keys
-              and haven&apos;t added a payment method.
+              You&apos;ve enabled Account Abstraction for one of your API keys.
               <br />
-              To use them on Mainnet,
-            </Text>
+              To enable AA on mainnet chains,
+            </Text>{" "}
             <TrackedLink
               href="/team/~/~/settings/billing"
               category="api_keys"
@@ -57,7 +56,7 @@ export const SmartWalletsBillingAlert = ({
               color="blue.500"
             >
               <Text as="span" color="blue.500">
-                add a payment method.
+                subscribe to a billing plan.
               </Text>
             </TrackedLink>
           </AlertDescription>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the text in the `Alerts.tsx` component to clarify messaging regarding Account Abstraction and billing requirements for API keys.

### Detailed summary
- Updated alert message to specify that users need to "subscribe to a billing plan" instead of just needing to "add a payment method."
- Changed instruction from "To use them on Mainnet," to "To enable AA on mainnet chains," for clarity.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->