### PR TITLE
[TOOL-3630] Dashboard: Add cancel subscriptions option in delete account flow

### DIFF
--- a/apps/dashboard/src/app/account/settings/AccountSettingsPage.tsx
+++ b/apps/dashboard/src/app/account/settings/AccountSettingsPage.tsx
@@ -36,6 +36,16 @@ export function AccountSettingsPage(props: {
           client={props.client}
           defaultTeamSlug={props.defaultTeamSlug}
           defaultTeamName={props.defaultTeamName}
+          cancelSubscriptions={async () => {
+            const res = await apiServerProxy({
+              method: "DELETE",
+              pathname: `/v1/teams/${props.defaultTeamSlug}/subscriptions`,
+            });
+
+            if (!res.ok) {
+              throw new Error(res.error);
+            }
+          }}
           onAccountDeleted={async () => {
             await doLogout();
             if (activeWallet) {

--- a/apps/dashboard/src/app/account/settings/AccountSettingsPageUI.stories.tsx
+++ b/apps/dashboard/src/app/account/settings/AccountSettingsPageUI.stories.tsx
@@ -143,6 +143,9 @@ function Variants() {
         onAccountDeleted={() => {
           console.log("Account deleted");
         }}
+        cancelSubscriptions={async () => {
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+        }}
       />
       <Toaster richColors />
     </div>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a feature to cancel subscriptions before account deletion in the `AccountSettingsPage`. It enhances the UI to provide feedback on subscription cancellation and integrates the cancellation logic into the account settings workflow.

### Detailed summary
- Added `cancelSubscriptions` function in `AccountSettingsPage.tsx` to handle subscription cancellation via API.
- Updated `AccountSettingsPageUI.tsx` to include `cancelSubscriptions` prop.
- Modified `DeleteAccountCard` to implement subscription cancellation with user feedback.
- Enhanced error handling and user interface for subscription cancellation, including a loading state and success/error notifications.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->