### PR TITLE
[TOOL-3640] Dashboard: Add sponsored transactions table in team usage page 

### DIFF
--- a/apps/dashboard/src/@/actions/proxies.ts
+++ b/apps/dashboard/src/@/actions/proxies.ts
@@ -5,13 +5,14 @@ import { API_SERVER_URL } from "../constants/env";
 
 type ProxyActionParams = {
   pathname: string;
-  searchParams?: Record<string, string>;
+  searchParams?: Record<string, string | undefined>;
   method: "GET" | "POST" | "PUT" | "DELETE";
   body?: string;
   headers?: Record<string, string>;
+  parseAsText?: boolean;
 };
 
-type ProxyActionResult<T extends object> =
+type ProxyActionResult<T> =
   | {
       status: number;
       ok: true;
@@ -23,7 +24,7 @@ type ProxyActionResult<T extends object> =
       error: string;
     };
 
-async function proxy<T extends object>(
+async function proxy<T>(
   baseUrl: string,
   params: ProxyActionParams,
 ): Promise<ProxyActionResult<T>> {
@@ -34,7 +35,10 @@ async function proxy<T extends object>(
   url.pathname = params.pathname;
   if (params.searchParams) {
     for (const key in params.searchParams) {
-      url.searchParams.append(key, params.searchParams[key] as string);
+      const value = params.searchParams[key];
+      if (value) {
+        url.searchParams.append(key, value);
+      }
     }
   }
 
@@ -67,23 +71,23 @@ async function proxy<T extends object>(
   return {
     status: res.status,
     ok: true,
-    data: await res.json(),
+    data: params.parseAsText ? await res.text() : await res.json(),
   };
 }
 
-export async function apiServerProxy<T extends object = object>(
-  params: ProxyActionParams,
-) {
+export async function apiServerProxy<T>(params: ProxyActionParams) {
   return proxy<T>(API_SERVER_URL, params);
 }
 
-export async function payServerProxy<T extends object = object>(
-  params: ProxyActionParams,
-) {
+export async function payServerProxy<T>(params: ProxyActionParams) {
   return proxy<T>(
     process.env.NEXT_PUBLIC_PAY_URL
       ? `https://${process.env.NEXT_PUBLIC_PAY_URL}`
       : "https://pay.thirdweb-dev.com",
     params,
   );
+}
+
+export async function analyticsServerProxy<T>(params: ProxyActionParams) {
+  return proxy<T>(process.env.ANALYTICS_SERVICE_URL || "", params);
 }

--- a/apps/dashboard/src/@/components/blocks/Img.tsx
+++ b/apps/dashboard/src/@/components/blocks/Img.tsx
@@ -47,7 +47,7 @@ export function Img(props: imgElementProps) {
   }, []);
 
   return (
-    <div className="relative">
+    <div className="relative shrink-0">
       <img
         {...restProps}
         // avoid setting empty src string to prevent request to the entire page

--- a/apps/dashboard/src/@/components/blocks/NetworkSelectors.tsx
+++ b/apps/dashboard/src/@/components/blocks/NetworkSelectors.tsx
@@ -104,6 +104,7 @@ export function SingleNetworkSelector(props: {
   side?: "left" | "right" | "top" | "bottom";
   disableChainId?: boolean;
   align?: "center" | "start" | "end";
+  placeholder?: string;
 }) {
   const { allChains, idToChain } = useAllChainsData();
 
@@ -180,7 +181,11 @@ export function SingleNetworkSelector(props: {
         props.onChange(Number(chainId));
       }}
       closeOnSelect={true}
-      placeholder={isLoadingChains ? "Loading Chains..." : "Select Chain"}
+      placeholder={
+        isLoadingChains
+          ? "Loading Chains..."
+          : props.placeholder || "Select Chain"
+      }
       overrideSearchFn={searchFn}
       renderOption={renderOption}
       className={props.className}

--- a/apps/dashboard/src/@/components/blocks/wallet-address.tsx
+++ b/apps/dashboard/src/@/components/blocks/wallet-address.tsx
@@ -8,7 +8,7 @@ import {
 import { useThirdwebClient } from "@/constants/thirdweb.client";
 import { resolveSchemeWithErrorHandler } from "@/lib/resolveSchemeWithErrorHandler";
 import { useClipboard } from "hooks/useClipboard";
-import { Check, Copy } from "lucide-react";
+import { Check, Copy, XIcon } from "lucide-react";
 import { useMemo } from "react";
 import { type ThirdwebClient, isAddress } from "thirdweb";
 import { ZERO_ADDRESS } from "thirdweb";
@@ -16,6 +16,7 @@ import { Blobbie, type SocialProfile, useSocialProfiles } from "thirdweb/react";
 import { cn } from "../../lib/utils";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
+import { ToolTipLabel } from "../ui/tooltip";
 import { Img } from "./Img";
 
 export function WalletAddress(props: {
@@ -44,7 +45,16 @@ export function WalletAddress(props: {
   const { onCopy, hasCopied } = useClipboard(address, 2000);
 
   if (!isAddress(address)) {
-    return <span>Invalid Address ({address})</span>;
+    return (
+      <ToolTipLabel label={address} hoverable>
+        <span className="flex items-center gap-2 underline-offset-4 hover:underline">
+          <div className="flex size-6 items-center justify-center rounded-full border bg-background">
+            <XIcon className="size-4 text-muted-foreground" />
+          </div>
+          Invalid Address
+        </span>
+      </ToolTipLabel>
+    );
   }
 
   // special case for zero address

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/usage/overview/components/SponsoredTransactionsTable.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/usage/overview/components/SponsoredTransactionsTable.tsx
@@ -1,0 +1,157 @@
+"use client";
+import { analyticsServerProxy } from "@/actions/proxies";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import type { ThirdwebClient } from "thirdweb/dist/types/client/client";
+import {
+  type SponsoredTransaction,
+  SponsoredTransactionsTableUI,
+} from "./SponsoredTransactionsTableUI";
+
+type GetSponsoredTransactionsParams = {
+  teamId: string;
+  limit: number;
+  offset: number;
+  from: string;
+  to: string;
+  // optional
+  projectId?: string;
+  chainId?: string;
+};
+
+const getSponsoredTransactions = async (
+  params: GetSponsoredTransactionsParams,
+) => {
+  const res = await analyticsServerProxy<{
+    data: SponsoredTransaction[];
+    meta: {
+      total: number;
+    };
+  }>({
+    pathname: "/v2/bundler/sponsored-transactions",
+    method: "GET",
+    searchParams: {
+      teamId: params.teamId,
+      limit: params.limit.toString(),
+      offset: params.offset.toString(),
+      projectId: params.projectId,
+      chainId: params.chainId,
+      from: params.from,
+      to: params.to,
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error(res.error);
+  }
+
+  return res.data;
+};
+
+async function getSponsoredTransactionsCSV(params: {
+  teamId: string;
+  from: string;
+  to: string;
+}) {
+  const res = await analyticsServerProxy<string>({
+    method: "GET",
+    pathname: "/v2/bundler/sponsored-transactions/export",
+    parseAsText: true,
+    searchParams: {
+      teamId: params.teamId,
+      from: params.from,
+      to: params.to,
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error(res.error);
+  }
+
+  return res.data;
+}
+
+export function SponsoredTransactionsTable(
+  props: {
+    client: ThirdwebClient;
+    teamId: string;
+    teamSlug: string;
+    from: string;
+    to: string;
+  } & (
+    | {
+        variant: "team";
+        projects: {
+          id: string;
+          name: string;
+          image: string | null;
+          slug: string;
+        }[];
+      }
+    | {
+        variant: "project";
+        projectId: string;
+      }
+  ),
+) {
+  const pageSize = 10;
+  const [page, setPage] = useState(1);
+
+  const [filters, setFilters] = useState<{
+    chainId?: string;
+    projectId?: string;
+  }>({
+    projectId: props.variant === "project" ? props.projectId : undefined,
+  });
+
+  const params = {
+    teamId: props.teamId,
+    limit: pageSize,
+    offset: (page - 1) * pageSize,
+    from: props.from,
+    to: props.to,
+    chainId: filters.chainId,
+    projectId: filters.projectId,
+  };
+
+  const sponsoredTransactionsQuery = useQuery({
+    queryKey: ["sponsored-transactions", params],
+    queryFn: () => {
+      return getSponsoredTransactions(params);
+    },
+    placeholderData: keepPreviousData,
+    refetchOnWindowFocus: false,
+  });
+
+  const totalPages = sponsoredTransactionsQuery.data
+    ? Math.ceil(sponsoredTransactionsQuery.data.meta.total / pageSize)
+    : 0;
+
+  return (
+    <SponsoredTransactionsTableUI
+      filters={filters}
+      variant={props.variant}
+      projects={props.variant === "team" ? props.projects : []}
+      setFilters={(v) => {
+        setFilters(v);
+        setPage(1);
+      }}
+      client={props.client}
+      isError={sponsoredTransactionsQuery.isError}
+      getCSV={() => {
+        return getSponsoredTransactionsCSV({
+          teamId: props.teamId,
+          from: props.from,
+          to: props.to,
+        });
+      }}
+      isPending={sponsoredTransactionsQuery.isFetching}
+      sponsoredTransactions={sponsoredTransactionsQuery.data?.data ?? []}
+      pageNumber={page}
+      setPageNumber={setPage}
+      pageSize={pageSize}
+      teamSlug={props.teamSlug}
+      totalPages={totalPages}
+    />
+  );
+}

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/usage/overview/components/SponsoredTransactionsTableUI.stories.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/usage/overview/components/SponsoredTransactionsTableUI.stories.tsx
@@ -1,0 +1,175 @@
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { getThirdwebClient } from "@/constants/thirdweb.server";
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { ThirdwebProvider } from "thirdweb/react";
+import { projectStub } from "../../../../../../../../stories/stubs";
+import {
+  type SponsoredTransaction,
+  SponsoredTransactionsTableUI,
+} from "./SponsoredTransactionsTableUI";
+
+const meta = {
+  title: "Usage/SponsoredTransactionsTable",
+  component: Variant,
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <div className="container max-w-[1154px] py-10">
+        <ThirdwebProvider>
+          <Story />
+        </ThirdwebProvider>
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof Variant>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const mockProjects = [
+  projectStub("foo", "team-1"),
+  projectStub("bar", "team-1"),
+  projectStub("baz", "team-1"),
+];
+
+function createSponsoredTransactionStub() {
+  const chainIdsToPick = ["1", "137", "8453", "42161", "10", "100"];
+  const randomVal = Math.random();
+  const feeMode = randomVal < 0.2 ? "low" : randomVal < 0.4 ? "zero" : "high";
+  const feeUsd =
+    feeMode === "low"
+      ? Math.random() / 100
+      : feeMode === "zero"
+        ? 0
+        : Math.random();
+
+  return {
+    timestamp: new Date(
+      Date.now() - Math.random() * 1000 * 60 * 60 * 24 * 30,
+    ).toISOString(),
+    teamId: crypto.randomUUID(),
+    projectId:
+      mockProjects[Math.floor(Math.random() * mockProjects.length)]?.id || "",
+    chainId: chainIdsToPick[
+      Math.floor(Math.random() * chainIdsToPick.length)
+    ] as string,
+    transactionFee: randomVal,
+    transactionFeeUsd: feeUsd,
+    walletAddress: "0x1F846F6DAE38E1C88D71EAA191760B15f38B7A37",
+    transactionHash:
+      "0xfedcba0987654321fedcba0987654321fedcba0987654321fedcba0987654321",
+    userOpHash:
+      "0x0987654321fedcba0987654321fedcba0987654321fedcba0987654321fedcba",
+  } satisfies SponsoredTransaction;
+}
+
+const client = getThirdwebClient();
+
+export const Default: Story = {
+  args: {
+    totalPages: 4,
+    sponsoredTransactions: new Array(10)
+      .fill(null)
+      .map(createSponsoredTransactionStub),
+    isPending: false,
+    projectLoadingFails: false,
+    isError: false,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    totalPages: 4,
+    sponsoredTransactions: [],
+    isPending: true,
+    projectLoadingFails: false,
+    isError: false,
+  },
+};
+
+export const NoTransactions: Story = {
+  args: {
+    totalPages: 1,
+    sponsoredTransactions: [],
+    isPending: false,
+    projectLoadingFails: false,
+    isError: false,
+  },
+};
+
+export const NoPagination: Story = {
+  args: {
+    totalPages: 1,
+    sponsoredTransactions: new Array(5)
+      .fill(null)
+      .map(createSponsoredTransactionStub),
+    isPending: false,
+    projectLoadingFails: false,
+    isError: false,
+  },
+};
+
+export const ErrorLoadingTransactions: Story = {
+  args: {
+    totalPages: 1,
+    sponsoredTransactions: [],
+    isPending: false,
+    projectLoadingFails: false,
+    isError: true,
+  },
+};
+
+function Variant(props: {
+  sponsoredTransactions: SponsoredTransaction[];
+  isPending: boolean;
+  projectLoadingFails: boolean;
+  totalPages: number;
+  isError: boolean;
+}) {
+  const [variant, setVariant] = useState<"team" | "project">("team");
+  const [pageNumber, setPageNumber] = useState(1);
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-4">
+        <RadioGroup
+          value={variant}
+          onValueChange={(value) => setVariant(value as "team" | "project")}
+          className="flex items-center gap-4"
+        >
+          <div className="flex items-center space-x-2">
+            <RadioGroupItem value="team" id="team" />
+            <Label htmlFor="team">Team</Label>
+          </div>
+          <div className="flex items-center space-x-2">
+            <RadioGroupItem value="project" id="project" />
+            <Label htmlFor="project">Project</Label>
+          </div>
+        </RadioGroup>
+      </div>
+
+      <SponsoredTransactionsTableUI
+        projects={mockProjects}
+        getCSV={async () => {
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+          return "foo,bar\n1,2\n3,4";
+        }}
+        filters={{}}
+        setFilters={() => {}}
+        isError={props.isError}
+        client={client}
+        totalPages={props.totalPages}
+        isPending={props.isPending}
+        pageNumber={pageNumber}
+        pageSize={10}
+        setPageNumber={setPageNumber}
+        sponsoredTransactions={props.sponsoredTransactions}
+        teamSlug="foo"
+        variant={variant}
+      />
+    </div>
+  );
+}

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/usage/overview/components/SponsoredTransactionsTableUI.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/usage/overview/components/SponsoredTransactionsTableUI.tsx
@@ -1,0 +1,481 @@
+"use client";
+import { ProjectAvatar } from "@/components/blocks/Avatars/ProjectAvatar";
+import { ExportToCSVButton } from "@/components/blocks/ExportToCSVButton";
+import { SingleNetworkSelector } from "@/components/blocks/NetworkSelectors";
+import { SelectWithSearch } from "@/components/blocks/select-with-search";
+import { WalletAddress } from "@/components/blocks/wallet-address";
+import { PaginationButtons } from "@/components/pagination-buttons";
+import { CopyTextButton } from "@/components/ui/CopyTextButton";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { ToolTipLabel } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import { ChainIcon } from "components/icons/ChainIcon";
+import { format, formatDistance } from "date-fns";
+import { useAllChainsData } from "hooks/chains/allChains";
+import { ExternalLinkIcon, XIcon } from "lucide-react";
+import Link from "next/link";
+import type { ThirdwebClient } from "thirdweb";
+
+export type SponsoredTransaction = {
+  timestamp: string;
+  teamId: string;
+  projectId: string;
+  chainId: string;
+  transactionFee: number;
+  transactionFeeUsd: number;
+  walletAddress: string;
+  transactionHash: string;
+  userOpHash: string;
+};
+
+export function SponsoredTransactionsTableUI(
+  props: {
+    sponsoredTransactions: SponsoredTransaction[];
+    isPending: boolean;
+    isError: boolean;
+    teamSlug: string;
+    client: ThirdwebClient;
+    pageSize: number;
+    setPageNumber: (pageNumber: number) => void;
+    pageNumber: number;
+    totalPages: number;
+    filters: { chainId?: string; projectId?: string };
+    setFilters: (filters: { chainId?: string; projectId?: string }) => void;
+  } & (
+    | {
+        variant: "team";
+        projects: {
+          id: string;
+          name: string;
+          image: string | null;
+          slug: string;
+        }[];
+        getCSV: () => Promise<string>;
+      }
+    | {
+        variant: "project";
+      }
+  ),
+) {
+  const showPagination = props.totalPages > 1;
+
+  return (
+    <div className="overflow-hidden rounded-lg border bg-card">
+      {/* header */}
+      <div className="flex flex-col justify-between gap-3 border-b px-4 py-4 lg:flex-row lg:items-center lg:px-6">
+        <h2 className="font-semibold text-lg">Sponsored Transactions</h2>
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-center">
+          {/* Filters */}
+          <div className="flex gap-2">
+            {props.variant === "team" && (
+              <ProjectFilter
+                projectId={props.filters.projectId}
+                setProjectId={(projectId) =>
+                  props.setFilters({ ...props.filters, projectId })
+                }
+                projects={props.projects}
+                client={props.client}
+              />
+            )}
+
+            <ChainFilter
+              chainId={props.filters.chainId}
+              setChainId={(chainId) =>
+                props.setFilters({ ...props.filters, chainId })
+              }
+            />
+          </div>
+
+          {props.variant === "team" && (
+            <>
+              <div className="hidden h-4 w-[1px] border bg-border lg:block" />
+              <ExportToCSVButton
+                className="bg-background"
+                getData={props.getCSV}
+                fileName="sponsored-transactions"
+              />
+            </>
+          )}
+        </div>
+      </div>
+
+      <TableContainer className={"rounded-none border-none"}>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Transaction Hash</TableHead>
+              {props.variant === "team" && <TableHead>Project</TableHead>}
+              <TableHead>Chain</TableHead>
+              <TableHead>Wallet</TableHead>
+              <TableHead>Timestamp</TableHead>
+              <TableHead>Fee</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {!props.isPending
+              ? props.sponsoredTransactions.map((transaction) => (
+                  <TableRow key={transaction.transactionHash}>
+                    {/* Tx Hash */}
+                    <TableCell>
+                      <TransactionHashCell
+                        hash={transaction.transactionHash}
+                        chainId={transaction.chainId}
+                      />
+                    </TableCell>
+
+                    {/* Project */}
+                    {props.variant === "team" && (
+                      <TableCell>
+                        <ProjectCell
+                          teamSlug={props.teamSlug}
+                          project={props.projects.find(
+                            (p) => p.id === transaction.projectId,
+                          )}
+                          client={props.client}
+                        />
+                      </TableCell>
+                    )}
+
+                    {/* Chain */}
+                    <TableCell>
+                      <ChainCell chainId={transaction.chainId} />
+                    </TableCell>
+
+                    {/* Wallet */}
+                    <TableCell>
+                      <WalletAddress address={transaction.walletAddress} />
+                    </TableCell>
+
+                    {/* Time */}
+                    <TableCell>
+                      <ToolTipLabel
+                        hoverable
+                        label={format(new Date(transaction.timestamp), "PPpp")}
+                      >
+                        <span>
+                          {formatDistance(
+                            new Date(transaction.timestamp),
+                            new Date(),
+                            {
+                              addSuffix: true,
+                            },
+                          )}
+                        </span>
+                      </ToolTipLabel>
+                    </TableCell>
+
+                    {/* Fee */}
+                    <TableCell>
+                      <TransactionFeeCell
+                        usdValue={transaction.transactionFeeUsd}
+                      />
+                    </TableCell>
+                  </TableRow>
+                ))
+              : Array.from({ length: props.pageSize }).map((_, index) => (
+                  <SkeletonRow
+                    // biome-ignore lint/suspicious/noArrayIndexKey: <explanation>
+                    key={`skeleton-${index}`}
+                    variant={props.variant}
+                  />
+                ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+
+      {!props.isPending && (
+        // biome-ignore lint/complexity/noUselessFragments: better readability
+        <>
+          {props.isError ? (
+            <div className="px-6 py-24">
+              <div className="mb-4 flex justify-center">
+                <div className="rounded-full border p-2">
+                  <XIcon className="size-5" />
+                </div>
+              </div>
+              <p className="text-center text-destructive-text text-sm">
+                Failed to load sponsored transactions
+              </p>
+            </div>
+          ) : props.sponsoredTransactions.length === 0 ? (
+            <div className="px-6 py-24">
+              <div className="mb-4 flex justify-center">
+                <div className="rounded-full border p-2">
+                  <XIcon className="size-5 text-muted-foreground" />
+                </div>
+              </div>
+              <p className="text-center text-muted-foreground text-sm">
+                No sponsored transactions
+              </p>
+            </div>
+          ) : null}
+        </>
+      )}
+
+      {showPagination && (
+        <div className="flex justify-end gap-3 rounded-b-lg border-t p-4">
+          <PaginationButtons
+            activePage={props.pageNumber}
+            totalPages={props.totalPages}
+            onPageClick={(page) => props.setPageNumber(page)}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SkeletonRow(props: { variant: "team" | "project" }) {
+  return (
+    <TableRow className="h-[72.5px]">
+      {/* Tx Hash */}
+      <TableCell>
+        <Skeleton className="h-7 w-[160px]" />
+      </TableCell>
+
+      {/* Project */}
+      {props.variant === "team" && (
+        <TableCell>
+          <Skeleton className="h-7 w-[145px]" />
+        </TableCell>
+      )}
+
+      {/* Chain */}
+      <TableCell>
+        <Skeleton className="h-7 w-[130px]" />
+      </TableCell>
+
+      {/* Wallet */}
+      <TableCell>
+        <Skeleton className="h-7 w-[130px]" />
+      </TableCell>
+
+      {/* Time */}
+      <TableCell>
+        <Skeleton className="h-7 w-[80px]" />
+      </TableCell>
+
+      {/* Fee */}
+      <TableCell>
+        <Skeleton className="h-7 w-[40px]" />
+      </TableCell>
+    </TableRow>
+  );
+}
+
+function TransactionHashCell(props: { hash: string; chainId: string }) {
+  const { idToChain } = useAllChainsData();
+  const chain = idToChain.get(Number(props.chainId));
+
+  const explorerUrl = chain?.explorers?.[0]?.url;
+  const txHashToShow = `${props.hash.slice(0, 6)}...${props.hash.slice(-4)}`;
+
+  if (explorerUrl) {
+    return (
+      <Button size="sm" variant="ghost" asChild>
+        <Link
+          href={`${explorerUrl}/tx/${props.hash}`}
+          target="_blank"
+          className="-translate-x-2 gap-2 font-mono"
+        >
+          {txHashToShow}
+          <ExternalLinkIcon className="size-3.5 text-muted-foreground" />
+        </Link>
+      </Button>
+    );
+  }
+
+  return (
+    <CopyTextButton
+      textToCopy={props.hash}
+      textToShow={txHashToShow}
+      tooltip="Transaction Hash"
+      copyIconPosition="right"
+      className="-translate-x-2 font-mono"
+      variant="ghost"
+    />
+  );
+}
+
+function ChainCell(props: { chainId: string }) {
+  const { idToChain, allChains } = useAllChainsData();
+  const chain = idToChain.get(Number(props.chainId));
+
+  if (allChains.length === 0) {
+    return <Skeleton className="w-[100px]" />;
+  }
+
+  return (
+    <div className="relative flex w-max items-center gap-2">
+      <ChainIcon ipfsSrc={chain?.icon?.url} className="size-6" />
+      <Link
+        target="_blank"
+        href={`/${chain ? chain.slug : props.chainId}`}
+        className="before:absolute before:inset-0 hover:underline hover:underline-offset-4"
+      >
+        {chain ? chain.name : `Chain #${props.chainId}`}
+      </Link>
+    </div>
+  );
+}
+
+function ProjectCell(props: {
+  teamSlug: string;
+  project:
+    | {
+        id: string;
+        name: string;
+        image: string | null;
+        slug: string;
+      }
+    | undefined;
+  client: ThirdwebClient;
+}) {
+  // just typeguard - never actually happens
+  if (!props.project) {
+    return <Skeleton className="h-6 w-[130px]" />;
+  }
+
+  return (
+    <div className="relative flex w-max items-center gap-2">
+      <ProjectAvatar
+        src={props.project.image || ""}
+        className="size-6 shrink-0"
+        client={props.client}
+      />
+      <Link
+        href={`/team/${props.teamSlug}/${props.project.slug}`}
+        className="before:absolute before:inset-0 hover:underline hover:underline-offset-4"
+        target="_blank"
+      >
+        {props.project.name}
+      </Link>
+    </div>
+  );
+}
+
+function ChainFilter(props: {
+  chainId: string | undefined;
+  setChainId: (chainId: string | undefined) => void;
+}) {
+  const isChainFilterActive = props.chainId !== undefined;
+
+  return (
+    <div className="flex bg-background">
+      {isChainFilterActive && (
+        <ToolTipLabel label="Remove chain filter">
+          <Button
+            variant="outline"
+            size="icon"
+            className="rounded-r-none border-r-0 px-3 text-muted-foreground"
+            onClick={() => props.setChainId(undefined)}
+          >
+            <XIcon className="size-4" />
+          </Button>
+        </ToolTipLabel>
+      )}
+
+      <SingleNetworkSelector
+        className={cn(isChainFilterActive && "rounded-l-none")}
+        chainId={props.chainId ? Number(props.chainId) : undefined}
+        onChange={(chainId) => props.setChainId(chainId.toString())}
+        popoverContentClassName="!w-[80vw] md:!w-[350px]"
+        align="end"
+        placeholder="All Chains"
+        disableChainId
+      />
+    </div>
+  );
+}
+
+function ProjectFilter(props: {
+  projectId: string | undefined;
+  setProjectId: (projectId: string | undefined) => void;
+  projects: { id: string; name: string; image: string | null }[];
+  client: ThirdwebClient;
+}) {
+  const isProjectFilterActive = props.projectId !== undefined;
+
+  return (
+    <div className="flex bg-background">
+      {isProjectFilterActive && (
+        <ToolTipLabel label="Remove project filter">
+          <Button
+            variant="outline"
+            size="icon"
+            className="rounded-r-none border-r-0 px-3 text-muted-foreground"
+            onClick={() => props.setProjectId(undefined)}
+          >
+            <XIcon className="size-4" />
+          </Button>
+        </ToolTipLabel>
+      )}
+
+      <SelectWithSearch
+        onValueChange={(value) => props.setProjectId(value)}
+        options={props.projects.map((project) => ({
+          label: project.name,
+          value: project.id,
+        }))}
+        value={props.projectId}
+        placeholder="All Projects"
+        popoverContentClassName="!w-[80vw] md:!w-[350px]"
+        align="end"
+        className={cn(
+          "min-w-[160px]",
+          isProjectFilterActive && "rounded-l-none",
+        )}
+        renderOption={(option) => {
+          const project = props.projects.find((p) => p.id === option.value);
+          if (!project) {
+            return <></>;
+          }
+          return (
+            <div className="flex items-center gap-2">
+              <ProjectAvatar
+                src={project.image || ""}
+                className="size-6 shrink-0"
+                client={props.client}
+              />
+              <span>{project.name}</span>
+            </div>
+          );
+        }}
+      />
+    </div>
+  );
+}
+
+// for values >= 0.01, show 2 decimal places
+const normalValueUSDFormatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  notation: "standard",
+  maximumFractionDigits: 2,
+});
+
+function formatTransactionFee(usdValue: number) {
+  if (usdValue >= 0.01 || usdValue === 0) {
+    return normalValueUSDFormatter.format(usdValue);
+  }
+
+  return "< $0.01";
+}
+
+function TransactionFeeCell(props: { usdValue: number }) {
+  return (
+    <ToolTipLabel label={`$${props.usdValue}`}>
+      <span>{formatTransactionFee(props.usdValue)}</span>
+    </ToolTipLabel>
+  );
+}

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/usage/overview/components/Usage.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/usage/overview/components/Usage.tsx
@@ -10,8 +10,10 @@ import { InAppWalletUsersChartCardUI } from "components/embedded-wallets/Analyti
 import { subMonths } from "date-fns";
 import Link from "next/link";
 import { Suspense, useMemo } from "react";
+import type { ThirdwebClient } from "thirdweb";
 import { toPercent, toSize } from "utils/number";
 import { TotalSponsoredChartCardUI } from "../../../../_components/TotalSponsoredCard";
+import { SponsoredTransactionsTable } from "./SponsoredTransactionsTable";
 import { UsageCard } from "./UsageCard";
 
 type UsageProps = {
@@ -20,6 +22,13 @@ type UsageProps = {
   subscriptions: TeamSubscription[];
   account: Account;
   team: Team;
+  client: ThirdwebClient;
+  projects: {
+    id: string;
+    name: string;
+    image: string | null;
+    slug: string;
+  }[];
 };
 
 export const Usage: React.FC<UsageProps> = ({
@@ -27,6 +36,8 @@ export const Usage: React.FC<UsageProps> = ({
   subscriptions,
   account,
   team,
+  client,
+  projects,
 }) => {
   // TODO - get this from team instead of account
   const storageMetrics = useMemo(() => {
@@ -103,6 +114,16 @@ export const Usage: React.FC<UsageProps> = ({
         accountId={account.id}
         from={currentPeriodStart}
         to={currentPeriodEnd}
+      />
+
+      <SponsoredTransactionsTable
+        client={client}
+        teamSlug={team.slug}
+        teamId={team.id}
+        from={currentPeriodStart.toISOString()}
+        to={currentPeriodEnd.toISOString()}
+        projects={projects}
+        variant="team"
       />
 
       <UsageCard

--- a/apps/dashboard/src/components/smart-wallets/AccountAbstractionAnalytics/index.tsx
+++ b/apps/dashboard/src/components/smart-wallets/AccountAbstractionAnalytics/index.tsx
@@ -8,13 +8,19 @@ import { IntervalSelector } from "components/analytics/interval-selector";
 import { differenceInDays } from "date-fns";
 import { useQueryState } from "nuqs";
 import { useTransition } from "react";
+import type { ThirdwebClient } from "thirdweb";
 import type { UserOpStats } from "types/analytics";
+import { SponsoredTransactionsTable } from "../../../app/team/[team_slug]/(team)/~/usage/overview/components/SponsoredTransactionsTable";
 import { searchParams } from "../../../app/team/[team_slug]/[project_slug]/connect/account-abstraction/search-params";
 import { SponsoredTransactionsChartCard } from "./SponsoredTransactionsChartCard";
 import { TotalSponsoredChartCard } from "./TotalSponsoredChartCard";
 
 export function AccountAbstractionAnalytics(props: {
   userOpStats: UserOpStats[];
+  teamId: string;
+  teamSlug: string;
+  client: ThirdwebClient;
+  projectId: string;
 }) {
   const [isLoading, startTransition] = useTransition();
 
@@ -97,6 +103,16 @@ export function AccountAbstractionAnalytics(props: {
         <SponsoredTransactionsChartCard
           userOpStats={props.userOpStats}
           isPending={isLoading}
+        />
+
+        <SponsoredTransactionsTable
+          client={props.client}
+          teamId={props.teamId}
+          from={from.toISOString()}
+          to={to.toISOString()}
+          variant="project"
+          projectId={props.projectId}
+          teamSlug={props.teamSlug}
         />
       </div>
     </div>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the `SponsoredTransactionsTable` component and related functionalities by integrating additional props, improving data handling, and refining the UI for better user experience.

### Detailed summary
- Added `placeholder` prop to `SingleNetworkSelector`.
- Integrated `SponsoredTransactionsTable` in `AccountAbstractionAnalytics`.
- Enhanced `Usage` component with `client` and `projects` props.
- Updated `ExportToCSVButton` to handle different data formats.
- Refined `SponsoredTransactionsTable` for improved data fetching and UI.
- Introduced CSV export functionality for sponsored transactions.
- Added loading and error states in `SponsoredTransactionsTableUI`.
- Implemented filters for projects and chains in `SponsoredTransactionsTableUI`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->