### PR TITLE
[SDK] test: Update smart wallet tests to use Arbitrum Sepolia

### DIFF
--- a/packages/thirdweb/src/wallets/smart/smart-wallet-integration-v07.test.ts
+++ b/packages/thirdweb/src/wallets/smart/smart-wallet-integration-v07.test.ts
@@ -8,8 +8,8 @@ import { parseEventLogs } from "../../event/actions/parse-logs.js";
 import { TEST_WALLET_A } from "~test/addresses.js";
 import { verifyEip1271Signature } from "../../auth/verify-hash.js";
 import { verifyTypedData } from "../../auth/verify-typed-data.js";
+import { arbitrumSepolia } from "../../chains/chain-definitions/arbitrum-sepolia.js";
 import { baseSepolia } from "../../chains/chain-definitions/base-sepolia.js";
-import { sepolia } from "../../chains/chain-definitions/sepolia.js";
 import {
   addAdmin,
   adminUpdatedEvent,
@@ -41,12 +41,12 @@ let smartWalletAddress: string;
 let personalAccount: Account;
 let accountContract: ThirdwebContract;
 
-const chain = sepolia;
+const chain = arbitrumSepolia;
 const client = TEST_CLIENT;
 const contract = getContract({
   client,
   chain,
-  address: "0xe2cb0eb5147b42095c2FfA6F7ec953bb0bE347D8",
+  address: "0x6A7a26c9a595E6893C255C9dF0b593e77518e0c3",
 });
 
 describe.runIf(process.env.TW_SECRET_KEY).sequential(
@@ -132,6 +132,8 @@ describe.runIf(process.env.TW_SECRET_KEY).sequential(
       });
       await new Promise((resolve) => setTimeout(resolve, 3000)); // pause for a second to prevent race condition
 
+      expect(await isContractDeployed(accountContract)).toEqual(true);
+
       const signature = await smartAccount.signMessage({
         message: "hello world",
       });
@@ -201,10 +203,10 @@ describe.runIf(process.env.TW_SECRET_KEY).sequential(
       });
 
       await expect(tx).rejects.toMatchInlineSnapshot(`
-        [TransactionError: Execution Reverted: {"code":3,"message":"execution reverted: Not authorized"}
+        [TransactionError: Error - Not authorized
 
         contract: ${contract.address}
-        chainId: 11155111]
+        chainId: 421614]
       `);
     });
 


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the testing for the smart wallet integration by switching the blockchain network from `sepolia` to `arbitrumSepolia`, modifies the contract address, and enhances the test assertions to ensure a contract is deployed.

### Detailed summary
- Added import for `arbitrumSepolia`.
- Changed the `chain` variable from `sepolia` to `arbitrumSepolia`.
- Updated contract address from `0xe2cb0eb5147b42095c2FfA6F7ec953bb0bE347D8` to `0x6A7a26c9a595E6893C255C9dF0b593e77518e0c3`.
- Added assertion to check if the contract is deployed.
- Updated error message in the transaction rejection snapshot to reflect the new chain ID.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->