### PR TITLE
Feature: Adds OTP cooldown timer

### DIFF
--- a/.changeset/deep-shirts-worry.md
+++ b/.changeset/deep-shirts-worry.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Adds countdown for email cooldown

--- a/packages/thirdweb/src/react/web/wallets/shared/OTPLoginUI.tsx
+++ b/packages/thirdweb/src/react/web/wallets/shared/OTPLoginUI.tsx
@@ -53,6 +53,7 @@ export function OTPLoginUI(props: {
   const [verifyStatus, setVerifyStatus] = useState<VerificationStatus>("idle");
   const [error, setError] = useState<string | undefined>();
   const [accountStatus, setAccountStatus] = useState<AccountStatus>("sending");
+  const [countdown, setCountdown] = useState(0);
   const ecosystem = isEcosystemWallet(wallet)
     ? {
         id: wallet.id,
@@ -76,6 +77,7 @@ export function OTPLoginUI(props: {
           client: props.client,
         });
         setAccountStatus("sent");
+        setCountdown(60); // Start 60-second countdown
       } else if ("phone" in userInfo) {
         await preAuthenticate({
           ecosystem,
@@ -84,6 +86,7 @@ export function OTPLoginUI(props: {
           client: props.client,
         });
         setAccountStatus("sent");
+        setCountdown(60); // Start 60-second countdown
       } else {
         throw new Error("Invalid userInfo");
       }
@@ -183,6 +186,23 @@ export function OTPLoginUI(props: {
       sendEmailOrSms();
     }
   }, [sendEmailOrSms]);
+
+  // Handle countdown timer
+  useEffect(() => {
+    if (countdown <= 0) return;
+
+    const timer = setInterval(() => {
+      setCountdown((current) => {
+        if (current <= 1) {
+          clearInterval(timer);
+          return 0;
+        }
+        return current - 1;
+      });
+    }, 1000);
+
+    return () => clearInterval(timer);
+  }, [countdown]);
 
   if (screen === "base") {
     return (
@@ -298,8 +318,17 @@ export function OTPLoginUI(props: {
               )}
 
               {accountStatus !== "sending" && (
-                <LinkButton onClick={sendEmailOrSms} type="button">
-                  {locale.emailLoginScreen.resendCode}
+                <LinkButton
+                  onClick={countdown === 0 ? sendEmailOrSms : undefined}
+                  type="button"
+                  style={{
+                    opacity: countdown > 0 ? 0.5 : 1,
+                    cursor: countdown > 0 ? "default" : "pointer",
+                  }}
+                >
+                  {countdown > 0
+                    ? `Resend code in ${countdown} seconds`
+                    : locale.emailLoginScreen.resendCode}
                 </LinkButton>
               )}
             </Container>


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a countdown feature for email cooldown in the `OTPLoginUI` component. It prevents users from resending the code until the countdown reaches zero, enhancing user experience by visually indicating when they can resend the code.

### Detailed summary
- Added a new state variable `countdown` initialized to 0.
- Set `countdown` to 60 seconds when an email is sent.
- Implemented a `useEffect` hook to manage the countdown timer.
- Updated the `LinkButton` to disable resending while the countdown is active and show the remaining time.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->