### PR TITLE
[SDK] fix: Handle authorizationList tx prop in ethers5 adapter

### DIFF
--- a/.changeset/true-actors-agree.md
+++ b/.changeset/true-actors-agree.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix ethers5 adapter not handling authorizationList tx prop

--- a/packages/thirdweb/src/adapters/ethers5.test.ts
+++ b/packages/thirdweb/src/adapters/ethers5.test.ts
@@ -7,6 +7,8 @@ import { TEST_CLIENT } from "../../test/src/test-clients.js";
 import { ANVIL_PKEY_A, TEST_ACCOUNT_B } from "../../test/src/test-wallets.js";
 import { resolveContractAbi } from "../contract/actions/resolve-abi.js";
 import { decimals } from "../extensions/erc20/__generated__/IERC20/read/decimals.js";
+import { sendTransaction } from "../transaction/actions/send-transaction.js";
+import { prepareTransaction } from "../transaction/prepare-transaction.js";
 import { randomBytesBuffer } from "../utils/random.js";
 import { privateKeyToAccount } from "../wallets/private-key.js";
 import {
@@ -207,6 +209,25 @@ describe("fromEthersSigner", () => {
     const signedTransaction = await account.signTransaction?.(transaction);
 
     expect(signedTransaction).toBe(await wallet.signTransaction(transaction));
+  });
+
+  it("should send a transaction", async () => {
+    const wallet = new ethers5.Wallet(
+      ANVIL_PKEY_A,
+      ethers5.getDefaultProvider(ANVIL_CHAIN.rpc),
+    );
+    const account = await fromEthersSigner(wallet);
+
+    const transaction = prepareTransaction({
+      client: TEST_CLIENT,
+      chain: ANVIL_CHAIN,
+      to: TEST_ACCOUNT_B.address,
+      value: 1n,
+    });
+
+    const txResponse = await sendTransaction({ transaction, account });
+
+    expect(txResponse.transactionHash.length).toBe(66);
   });
 
   it("should sign typed data", async () => {

--- a/packages/thirdweb/src/adapters/ethers5.ts
+++ b/packages/thirdweb/src/adapters/ethers5.ts
@@ -624,6 +624,9 @@ function alignTxToEthers(
     }
   }
 
+  // biome-ignore lint/performance/noDelete: ethers5 doesn't support authorizationList
+  delete rest.authorizationList;
+
   return {
     ...rest,
     gasLimit: gas,


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `ethers5` and `ethers6` adapters in the `thirdweb` package by adding transaction handling, including sending transactions and signing messages. It also fixes an issue with the `authorizationList` in the `ethers5` adapter.

### Detailed summary
- Fixed `ethers5` adapter not handling `authorizationList` by deleting it.
- Added transaction sending tests in `ethers5` and `ethers6` adapters.
- Enhanced `fromEthersSigner` function to support sending transactions and signing messages in `ethers6`.
- Updated test cases for both `ethers5` and `ethers6` to cover new functionality.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->