### PR TITLE
[TOOL-3673] Dashboard: change Turnstile widget appearance on missing turnstile token

### DIFF
--- a/apps/dashboard/src/app/login/auth-actions.ts
+++ b/apps/dashboard/src/app/login/auth-actions.ts
@@ -40,7 +40,7 @@ export async function getLoginPayload(
 
 export async function doLogin(
   payload: VerifyLoginPayloadParams,
-  turnstileToken: string,
+  turnstileToken: string | undefined,
 ) {
   if (!THIRDWEB_API_SECRET) {
     throw new Error("API_SERVER_SECRET is not set");


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the login functionality by updating the handling of the `turnstileToken` parameter and adding a condition to ensure the captcha is completed before proceeding with the login process.

### Detailed summary
- Changed `turnstileToken` type in `doLogin` from `string` to `string | undefined`.
- Updated the initial state of `turnstileToken` to `undefined` in `CustomConnectEmbed`.
- Introduced `alwaysShowTurnstile` state to manage captcha visibility.
- Modified the `Turnstile` component's appearance based on `alwaysShowTurnstile`.
- Added a check in the login function to throw an error if on Vercel and `turnstileToken` is not provided.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->