### PR TITLE
[Portal] Fix: Updating AA supported chains

### DIFF
--- a/apps/portal/src/app/connect/account-abstraction/infrastructure/page.mdx
+++ b/apps/portal/src/app/connect/account-abstraction/infrastructure/page.mdx
@@ -1,4 +1,4 @@
-import { createMetadata, AAChainList } from "@doc";
+import { createMetadata, DocImage } from "@doc";
 import SupportedChains from "../../../_images/supported-chains.png";
 
 

--- a/apps/portal/src/app/connect/account-abstraction/infrastructure/page.mdx
+++ b/apps/portal/src/app/connect/account-abstraction/infrastructure/page.mdx
@@ -1,4 +1,6 @@
 import { createMetadata, AAChainList } from "@doc";
+import SupportedChains from "../../../_images/supported-chains.png";
+
 
 export const metadata = createMetadata({
 	image: {
@@ -23,7 +25,8 @@ You can configure your client ID to restrict interactions only with your own con
 
 With a thirdweb API key, you get access to bundler and paymaster infrastructure on the following chains:
 
-<AAChainList />
+[View all supported chains with Account Abstraction](https://thirdweb.com/chainlist?service=account-abstraction).
+<DocImage src={SupportedChains} />
 
 To support a chain not listed, [contact us](https://thirdweb.com/contact-us).
 


### PR DESCRIPTION
Removing the table of chains and replacing with a link to the chainlist page. 

SOL2-25

## How to test

Visit portal.thirdweb.com 
1. Click on connect
2. Click on account abstraction
3. Click on Bundler & Paymaster 
4. See the previous table of chains has been replaced with a link to the chainlist. 
5. See the attached doc image. 


