### PR TITLE
[TOOL-3681] Portal: Fix code identation in reference pages

### DIFF
--- a/apps/portal/src/components/Document/Code.tsx
+++ b/apps/portal/src/components/Document/Code.tsx
@@ -68,7 +68,7 @@ export async function CodeBlock(props: {
     <div className={cn("group/code relative mb-5", props.containerClassName)}>
       <code
         className={cn(
-          "relative block rounded-lg border bg-card font-mono text-sm leading-relaxed",
+          "relative block whitespace-pre rounded-lg border bg-card font-mono text-sm leading-relaxed",
           props.className,
         )}
         lang={lang}

--- a/packages/thirdweb/src/react/core/utils/wallet.ts
+++ b/packages/thirdweb/src/react/core/utils/wallet.ts
@@ -157,7 +157,7 @@ export function useConnectedWalletDetails(
  * import { useWalletInfo } from "thirdweb/react";
  *
  * const { data: walletInfo } = useWalletInfo("io.metamask");
- * console.log("Walelt name", walletInfo?.name);
+ * console.log("wallet name", walletInfo?.name);
  * ```
  * @wallet
  */


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on two main changes: correcting a typo in the console log message in `wallet.ts` and modifying the `Code.tsx` component to allow for whitespace preservation in the rendered code block.

### Detailed summary
- In `wallet.ts`, changed the console log message from "Walelt name" to "wallet name".
- In `Code.tsx`, updated the `className` to include `whitespace-pre` for preserving whitespace in the code block.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->