### PR TITLE
[TOOL-3683] Dashboard: enforce project creation teams with no projects

### DIFF
--- a/apps/dashboard/src/app/account/components/AccountHeader.tsx
+++ b/apps/dashboard/src/app/account/components/AccountHeader.tsx
@@ -77,7 +77,7 @@ export function AccountHeader(props: {
               isOpen: false,
             })
           }
-          onCreateAndComplete={() => {
+          onCreate={() => {
             // refresh projects
             router.refresh();
           }}

--- a/apps/dashboard/src/app/get-started/team/[team_slug]/create-project/page.tsx
+++ b/apps/dashboard/src/app/get-started/team/[team_slug]/create-project/page.tsx
@@ -1,0 +1,22 @@
+import { getTeamBySlug } from "@/api/team";
+import { notFound } from "next/navigation";
+import { CreateProjectPage } from "../../../../login/onboarding/create-project-onboarding/create-project-page";
+
+export default async function Page(props: {
+  params: Promise<{ team_slug: string }>;
+}) {
+  const params = await props.params;
+  const team = await getTeamBySlug(params.team_slug);
+
+  if (!team) {
+    notFound();
+  }
+
+  return (
+    <CreateProjectPage
+      enableNebulaServiceByDefault={team.enabledScopes.includes("nebula")}
+      teamSlug={team.slug}
+      teamId={team.id}
+    />
+  );
+}

--- a/apps/dashboard/src/app/login/onboarding/create-project-onboarding/CreateProjectPage.stories.tsx
+++ b/apps/dashboard/src/app/login/onboarding/create-project-onboarding/CreateProjectPage.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { projectStub } from "../../../../stories/stubs";
+import { CreateProjectPageUI } from "./CreateProjectPageUI";
+
+const meta = {
+  title: "Onboarding/CreateProject",
+  component: Story,
+  parameters: {
+    nextjs: {
+      appDirectory: true,
+    },
+  },
+} satisfies Meta<typeof Story>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Variants: Story = {
+  args: {},
+};
+
+function Story() {
+  return (
+    <CreateProjectPageUI
+      createProject={async () => {
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        return {
+          project: projectStub("foo", "bar"),
+          secret: "secret",
+        };
+      }}
+      teamSlug="foo"
+      enableNebulaServiceByDefault={false}
+    />
+  );
+}

--- a/apps/dashboard/src/app/login/onboarding/create-project-onboarding/CreateProjectPageUI.tsx
+++ b/apps/dashboard/src/app/login/onboarding/create-project-onboarding/CreateProjectPageUI.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import type { Project } from "@/api/projects";
+import { useState } from "react";
+import {
+  CreateProjectForm,
+  CreatedProjectDetails,
+} from "../../../../components/settings/ApiKeys/Create";
+import { CreateProjectOnboardingLayout } from "../onboarding-layout";
+
+export function CreateProjectPageUI(props: {
+  createProject: (param: Partial<Project>) => Promise<{
+    project: Project;
+    secret: string;
+  }>;
+  enableNebulaServiceByDefault: boolean;
+  teamSlug: string;
+}) {
+  const [screen, setScreen] = useState<
+    { id: "create" } | { id: "api-details"; project: Project; secret: string }
+  >({ id: "create" });
+  return (
+    <CreateProjectOnboardingLayout currentStep={screen.id === "create" ? 1 : 2}>
+      <div className="overflow-hidden rounded-lg border bg-card">
+        {screen.id === "create" && (
+          <CreateProjectForm
+            showTitle={false}
+            closeModal={undefined}
+            createProject={props.createProject}
+            onProjectCreated={(params) => {
+              setScreen({
+                id: "api-details",
+                project: params.project,
+                secret: params.secret,
+              });
+            }}
+            enableNebulaServiceByDefault={props.enableNebulaServiceByDefault}
+          />
+        )}
+
+        {screen.id === "api-details" && (
+          <CreatedProjectDetails
+            project={screen.project}
+            secret={screen.secret}
+            teamSlug={props.teamSlug}
+          />
+        )}
+      </div>
+    </CreateProjectOnboardingLayout>
+  );
+}

--- a/apps/dashboard/src/app/login/onboarding/create-project-onboarding/create-project-page.tsx
+++ b/apps/dashboard/src/app/login/onboarding/create-project-onboarding/create-project-page.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { createProjectClient } from "@3rdweb-sdk/react/hooks/useApi";
+import { CreateProjectPageUI } from "./CreateProjectPageUI";
+
+export function CreateProjectPage(props: {
+  enableNebulaServiceByDefault: boolean;
+  teamSlug: string;
+  teamId: string;
+}) {
+  return (
+    <CreateProjectPageUI
+      enableNebulaServiceByDefault={props.enableNebulaServiceByDefault}
+      teamSlug={props.teamSlug}
+      createProject={async (params) => {
+        const res = await createProjectClient(props.teamId, params);
+        return {
+          project: res.project,
+          secret: res.secret,
+        };
+      }}
+    />
+  );
+}

--- a/apps/dashboard/src/app/login/onboarding/onboarding-layout.tsx
+++ b/apps/dashboard/src/app/login/onboarding/onboarding-layout.tsx
@@ -4,6 +4,7 @@ import { cn } from "@/lib/utils";
 import { useMutation } from "@tanstack/react-query";
 import {
   BoxIcon,
+  KeyRoundIcon,
   LogOutIcon,
   MailIcon,
   UserIcon,
@@ -93,6 +94,36 @@ export function TeamOnboardingLayout(props: {
       steps={teamOnboardingSteps}
       currentStep={props.currentStep}
       title="Setup your team"
+    >
+      {props.children}
+    </OnboardingLayout>
+  );
+}
+
+const createProjectOnboardingSteps: OnboardingStep[] = [
+  {
+    icon: BoxIcon,
+    title: "Configure Project",
+    description: "Provide project details",
+    number: 1,
+  },
+  {
+    icon: KeyRoundIcon,
+    title: "Save Keys",
+    description: "Securely store secret key",
+    number: 2,
+  },
+];
+
+export function CreateProjectOnboardingLayout(props: {
+  children: React.ReactNode;
+  currentStep: 1 | 2;
+}) {
+  return (
+    <OnboardingLayout
+      steps={createProjectOnboardingSteps}
+      currentStep={props.currentStep}
+      title="Create a project"
     >
       {props.children}
     </OnboardingLayout>

--- a/apps/dashboard/src/app/login/onboarding/team-onboarding/team-onboarding.tsx
+++ b/apps/dashboard/src/app/login/onboarding/team-onboarding/team-onboarding.tsx
@@ -104,7 +104,7 @@ export function InviteTeamMembers(props: {
     <InviteTeamMembersUI
       trackEvent={trackEvent}
       onComplete={() => {
-        router.replace(`/team/${props.team.slug}`);
+        router.replace(`/get-started/team/${props.team.slug}/create-project`);
       }}
       getTeam={async () => {
         const res = await apiServerProxy<{

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/page.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/page.tsx
@@ -6,10 +6,8 @@ import { subDays } from "date-fns";
 import { redirect } from "next/navigation";
 import { getAuthToken } from "../../../api/lib/getAuthToken";
 import { loginRedirect } from "../../../login/loginRedirect";
-import {
-  type ProjectWithAnalytics,
-  TeamProjectsPage,
-} from "./~/projects/TeamProjectsPage";
+import { TeamProjectsPage } from "./~/projects/TeamProjectsPage";
+import type { ProjectWithAnalytics } from "./~/projects/TeamProjectsTable";
 
 export default async function Page(props: {
   params: Promise<{ team_slug: string }>;

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/projects/TeamProjectsPage.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/projects/TeamProjectsPage.tsx
@@ -1,234 +1,38 @@
 "use client";
-
-import type { Project } from "@/api/projects";
 import type { Team } from "@/api/team";
-import { ProjectAvatar } from "@/components/blocks/Avatars/ProjectAvatar";
-import { PaginationButtons } from "@/components/pagination-buttons";
-import { CopyTextButton } from "@/components/ui/CopyTextButton";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-} from "@/components/ui/select";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
 import { useDashboardRouter } from "@/lib/DashboardRouter";
-import { cn } from "@/lib/utils";
-import { LazyCreateProjectDialog } from "components/settings/ApiKeys/Create/LazyCreateAPIKeyDialog";
-import { formatDate } from "date-fns";
-import { PlusIcon, SearchIcon } from "lucide-react";
-import Link from "next/link";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import type { ThirdwebClient } from "thirdweb";
-
-type SortById = "name" | "createdAt" | "monthlyActiveUsers";
-
-export type ProjectWithAnalytics = Project & {
-  monthlyActiveUsers: number;
-};
+import { LazyCreateProjectDialog } from "../../../../../../components/settings/ApiKeys/Create/LazyCreateAPIKeyDialog";
+import {
+  type ProjectWithAnalytics,
+  TeamProjectsTable,
+} from "./TeamProjectsTable";
 
 export function TeamProjectsPage(props: {
   projects: ProjectWithAnalytics[];
   team: Team;
   client: ThirdwebClient;
 }) {
-  const { projects } = props;
-  const [searchTerm, setSearchTerm] = useState("");
-  const [sortBy, setSortBy] = useState<SortById>("monthlyActiveUsers");
   const [isCreateProjectDialogOpen, setIsCreateProjectDialogOpen] =
     useState(false);
   const router = useDashboardRouter();
 
-  const sortedProjects = useMemo(() => {
-    let _projectsToShow = !searchTerm
-      ? projects
-      : projects.filter(
-          (project) =>
-            project.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-            project.publishableKey
-              .toLowerCase()
-              .includes(searchTerm.toLowerCase()),
-        );
-
-    if (sortBy === "name") {
-      _projectsToShow = _projectsToShow.sort((a, b) =>
-        a.name.localeCompare(b.name),
-      );
-    } else if (sortBy === "createdAt") {
-      _projectsToShow = _projectsToShow.sort(
-        (a, b) =>
-          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
-      );
-    } else if (sortBy === "monthlyActiveUsers") {
-      _projectsToShow = _projectsToShow.sort(
-        (a, b) => b.monthlyActiveUsers - a.monthlyActiveUsers,
-      );
-    }
-
-    return _projectsToShow;
-  }, [searchTerm, sortBy, projects]);
-
-  const pageSize = 10;
-  const [page, setPage] = useState(1);
-  const paginatedProjects = sortedProjects.slice(
-    (page - 1) * pageSize,
-    page * pageSize,
-  );
-
-  const showPagination = sortedProjects.length > pageSize;
-  const totalPages = Math.ceil(sortedProjects.length / pageSize);
-
   return (
-    <div className="flex grow flex-col">
-      <div className="relative flex flex-col gap-5 rounded-t-lg pb-4 lg:flex-row lg:items-center lg:justify-between lg:border lg:border-b-0 lg:bg-card lg:px-6 lg:py-6">
-        <h2 className="font-semibold text-2xl tracking-tight">Projects</h2>
-
-        {/* Filters + Add New */}
-        <div className="flex flex-col gap-3 md:flex-row md:items-center">
-          <SearchInput
-            value={searchTerm}
-            onValueChange={(v) => {
-              setSearchTerm(v);
-              setPage(1);
-            }}
-          />
-          <div className="flex gap-3">
-            <SelectBy
-              value={sortBy}
-              onChange={(v) => {
-                setSortBy(v);
-                setPage(1);
-              }}
-            />
-            <AddNewButton
-              createProject={() => setIsCreateProjectDialogOpen(true)}
-              teamMembersSettingsPath={`/team/${props.team.slug}/~/settings/members`}
-            />
-          </div>
-        </div>
-      </div>
-
-      {/* Projects Table */}
-      {paginatedProjects.length === 0 ? (
-        <>
-          {searchTerm !== "" ? (
-            <div className="flex min-h-[450px] grow items-center justify-center border border-border bg-card">
-              <div className="flex flex-col items-center">
-                <p className="mb-5 text-center">No projects found</p>
-              </div>
-            </div>
-          ) : (
-            <div className="flex min-h-[450px] grow items-center justify-center rounded-b-lg border border-border bg-card">
-              <div className="flex flex-col items-center">
-                <p className="mb-5 text-center font-semibold text-lg">
-                  No projects created
-                </p>
-                <Button
-                  className="gap-2 bg-background"
-                  onClick={() => setIsCreateProjectDialogOpen(true)}
-                  variant="outline"
-                >
-                  <PlusIcon className="size-4" />
-                  Create Project
-                </Button>
-              </div>
-            </div>
-          )}
-        </>
-      ) : (
-        <div>
-          <TableContainer
-            className={cn(
-              "lg:rounded-t-none",
-              showPagination && "rounded-b-none",
-            )}
-          >
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead className="max-w-[300px]">Project</TableHead>
-                  <TableHead>Monthly Active Users</TableHead>
-                  <TableHead className="w-[250px]">Client ID</TableHead>
-                  <TableHead>Created</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {paginatedProjects.map((project) => (
-                  <TableRow
-                    key={project.id}
-                    linkBox
-                    className="hover:bg-accent/50"
-                  >
-                    <TableCell>
-                      <Link
-                        className="flex items-center gap-3 before:absolute before:inset-0"
-                        href={`/team/${props.team.slug}/${project.slug}`}
-                      >
-                        <ProjectAvatar
-                          className="size-8 rounded-full"
-                          src={project.image || ""}
-                          client={props.client}
-                        />
-                        <span className="font-medium text-sm">
-                          {project.name}
-                        </span>
-                      </Link>
-                    </TableCell>
-                    <TableCell>
-                      {project.monthlyActiveUsers === 0 ? (
-                        <span className="text-muted-foreground">No Users</span>
-                      ) : (
-                        project.monthlyActiveUsers
-                      )}
-                    </TableCell>
-                    <TableCell>
-                      <CopyTextButton
-                        textToCopy={project.publishableKey}
-                        textToShow={`${project.publishableKey.slice(0, 4)}...${project.publishableKey.slice(-4)}`}
-                        copyIconPosition="right"
-                        tooltip={undefined}
-                        variant="ghost"
-                        className="-translate-x-2 z-10 font-mono text-muted-foreground"
-                      />
-                    </TableCell>
-                    <TableCell className="text-muted-foreground">
-                      {formatDate(new Date(project.createdAt), "MMM d, yyyy")}
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </TableContainer>
-
-          {showPagination && (
-            <div className="rounded-b-lg border border-t-0 bg-card p-4">
-              <PaginationButtons
-                activePage={page}
-                onPageClick={setPage}
-                totalPages={totalPages}
-              />
-            </div>
-          )}
-        </div>
-      )}
+    <div>
+      <TeamProjectsTable
+        projects={props.projects}
+        team={props.team}
+        client={props.client}
+        openCreateProjectModal={() => setIsCreateProjectDialogOpen(true)}
+      />
 
       <LazyCreateProjectDialog
         open={isCreateProjectDialogOpen}
         onOpenChange={setIsCreateProjectDialogOpen}
         teamSlug={props.team.slug}
         teamId={props.team.id}
-        onCreateAndComplete={() => {
-          // refresh projects
+        onCreate={() => {
           router.refresh();
         }}
         enableNebulaServiceByDefault={props.team.enabledScopes.includes(
@@ -236,75 +40,5 @@ export function TeamProjectsPage(props: {
         )}
       />
     </div>
-  );
-}
-
-function SearchInput(props: {
-  value: string;
-  onValueChange: (value: string) => void;
-}) {
-  return (
-    <div className="relative grow">
-      <Input
-        placeholder="Search Projects by name or Client ID"
-        value={props.value}
-        onChange={(e) => props.onValueChange(e.target.value)}
-        className="bg-background pl-9 lg:w-[400px]"
-      />
-      <SearchIcon className="-translate-y-1/2 absolute top-1/2 left-3 size-4 text-muted-foreground" />
-    </div>
-  );
-}
-
-function AddNewButton(props: {
-  createProject: () => void;
-  teamMembersSettingsPath: string;
-}) {
-  return (
-    <Button
-      variant="default"
-      className="absolute top-0 right-0 gap-2 lg:static"
-      onClick={props.createProject}
-    >
-      <PlusIcon className="size-4" />
-      <span>
-        <span className="hidden lg:inline">Create</span> Project
-      </span>
-    </Button>
-  );
-}
-
-function SelectBy(props: {
-  value: SortById;
-  onChange: (value: SortById) => void;
-}) {
-  const values: SortById[] = ["name", "createdAt", "monthlyActiveUsers"];
-  const valueToLabel: Record<SortById, string> = {
-    name: "Name",
-    createdAt: "Creation Date",
-    monthlyActiveUsers: "Monthly Active Users",
-  };
-
-  return (
-    <Select
-      value={props.value}
-      onValueChange={(v) => {
-        props.onChange(v as SortById);
-      }}
-    >
-      <SelectTrigger className="min-w-[200px] bg-background capitalize">
-        <div className="flex items-center gap-1.5">
-          <span className="text-muted-foreground">Sort by</span>
-          {valueToLabel[props.value]}
-        </div>
-      </SelectTrigger>
-      <SelectContent>
-        {values.map((value) => (
-          <SelectItem key={value} value={value}>
-            {valueToLabel[value]}
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
   );
 }

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/projects/TeamProjectsTable.stories.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/projects/TeamProjectsTable.stories.tsx
@@ -1,0 +1,83 @@
+import { getThirdwebClient } from "@/constants/thirdweb.server";
+import type { Meta, StoryObj } from "@storybook/react";
+import { projectStub, teamStub } from "../../../../../../stories/stubs";
+import { storybookLog } from "../../../../../../stories/utils";
+import {
+  type ProjectWithAnalytics,
+  TeamProjectsTable,
+} from "./TeamProjectsTable";
+
+const meta: Meta<typeof Variant> = {
+  title: "Team/Projects",
+  component: Variant,
+  parameters: {
+    layout: "fullscreen",
+    nextjs: {
+      appDirectory: true,
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="container py-10">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Variant>;
+
+function createProjectWithAnalyticsStub(len: number) {
+  return Array.from({ length: len }, (_, i) => {
+    return {
+      ...projectStub(`${i + 1}`, "foo"),
+      monthlyActiveUsers: Math.floor(Math.random() * 1000),
+    };
+  });
+}
+
+export const MultipleProjects: Story = {
+  args: {
+    projects: createProjectWithAnalyticsStub(10),
+  },
+};
+
+export const SingleProject: Story = {
+  args: {
+    projects: createProjectWithAnalyticsStub(1),
+  },
+};
+
+export const NoProjects: Story = {
+  args: {
+    projects: [],
+  },
+};
+
+export const NoUsers: Story = {
+  args: {
+    projects: createProjectWithAnalyticsStub(10).map((p) => ({
+      ...p,
+      monthlyActiveUsers: 0,
+    })),
+  },
+};
+
+const client = getThirdwebClient();
+const team = teamStub("foo", "free");
+
+function Variant(props: {
+  projects: ProjectWithAnalytics[];
+}) {
+  return (
+    <TeamProjectsTable
+      team={team}
+      client={client}
+      projects={props.projects}
+      openCreateProjectModal={() => {
+        storybookLog("showCreateProjectModal");
+      }}
+    />
+  );
+}

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/projects/TeamProjectsTable.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/projects/TeamProjectsTable.tsx
@@ -1,0 +1,290 @@
+"use client";
+
+import type { Project } from "@/api/projects";
+import type { Team } from "@/api/team";
+import { ProjectAvatar } from "@/components/blocks/Avatars/ProjectAvatar";
+import { PaginationButtons } from "@/components/pagination-buttons";
+import { CopyTextButton } from "@/components/ui/CopyTextButton";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { cn } from "@/lib/utils";
+import { formatDate } from "date-fns";
+import { PlusIcon, SearchIcon } from "lucide-react";
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import type { ThirdwebClient } from "thirdweb";
+
+type SortById = "name" | "createdAt" | "monthlyActiveUsers";
+
+export type ProjectWithAnalytics = Project & {
+  monthlyActiveUsers: number;
+};
+
+export function TeamProjectsTable(props: {
+  projects: ProjectWithAnalytics[];
+  team: Team;
+  client: ThirdwebClient;
+  openCreateProjectModal: () => void;
+}) {
+  const { projects } = props;
+  const [searchTerm, setSearchTerm] = useState("");
+  const [sortBy, setSortBy] = useState<SortById>("monthlyActiveUsers");
+
+  const sortedProjects = useMemo(() => {
+    let _projectsToShow = !searchTerm
+      ? projects
+      : projects.filter(
+          (project) =>
+            project.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+            project.publishableKey
+              .toLowerCase()
+              .includes(searchTerm.toLowerCase()),
+        );
+
+    if (sortBy === "name") {
+      _projectsToShow = _projectsToShow.sort((a, b) =>
+        a.name.localeCompare(b.name),
+      );
+    } else if (sortBy === "createdAt") {
+      _projectsToShow = _projectsToShow.sort(
+        (a, b) =>
+          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+      );
+    } else if (sortBy === "monthlyActiveUsers") {
+      _projectsToShow = _projectsToShow.sort(
+        (a, b) => b.monthlyActiveUsers - a.monthlyActiveUsers,
+      );
+    }
+
+    return _projectsToShow;
+  }, [searchTerm, sortBy, projects]);
+
+  const pageSize = 10;
+  const [page, setPage] = useState(1);
+  const paginatedProjects = sortedProjects.slice(
+    (page - 1) * pageSize,
+    page * pageSize,
+  );
+
+  const showPagination = sortedProjects.length > pageSize;
+  const totalPages = Math.ceil(sortedProjects.length / pageSize);
+
+  return (
+    <div className="flex grow flex-col">
+      <div className="relative flex flex-col gap-5 rounded-t-lg pb-4 lg:flex-row lg:items-center lg:justify-between lg:border lg:border-b-0 lg:bg-card lg:px-6 lg:py-6">
+        <h2 className="font-semibold text-2xl tracking-tight">Projects</h2>
+
+        {/* Filters + Add New */}
+        <div className="flex flex-col gap-3 md:flex-row md:items-center">
+          <SearchInput
+            value={searchTerm}
+            onValueChange={(v) => {
+              setSearchTerm(v);
+              setPage(1);
+            }}
+          />
+          <div className="flex gap-3">
+            <SelectBy
+              value={sortBy}
+              onChange={(v) => {
+                setSortBy(v);
+                setPage(1);
+              }}
+            />
+            <AddNewButton
+              createProject={() => props.openCreateProjectModal()}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Projects Table */}
+      {paginatedProjects.length === 0 ? (
+        <>
+          {searchTerm !== "" ? (
+            <div className="flex min-h-[450px] grow items-center justify-center border border-border bg-card">
+              <div className="flex flex-col items-center">
+                <p className="mb-5 text-center">No projects found</p>
+              </div>
+            </div>
+          ) : (
+            <div className="flex min-h-[450px] grow items-center justify-center rounded-b-lg border border-border bg-card">
+              <div className="flex flex-col items-center">
+                <p className="mb-3 text-center font-medium text-lg">
+                  No projects created
+                </p>
+                <Button
+                  className="gap-2 bg-background"
+                  onClick={() => props.openCreateProjectModal()}
+                  variant="outline"
+                >
+                  <PlusIcon className="size-4" />
+                  Create Project
+                </Button>
+              </div>
+            </div>
+          )}
+        </>
+      ) : (
+        <div>
+          <TableContainer
+            className={cn(
+              "lg:rounded-t-none",
+              showPagination && "rounded-b-none",
+            )}
+          >
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="max-w-[300px]">Project</TableHead>
+                  <TableHead>Monthly Active Users</TableHead>
+                  <TableHead className="w-[250px]">Client ID</TableHead>
+                  <TableHead>Created</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {paginatedProjects.map((project) => (
+                  <TableRow
+                    key={project.id}
+                    linkBox
+                    className="hover:bg-accent/50"
+                  >
+                    <TableCell>
+                      <Link
+                        className="flex items-center gap-3 before:absolute before:inset-0"
+                        href={`/team/${props.team.slug}/${project.slug}`}
+                      >
+                        <ProjectAvatar
+                          className="size-8 rounded-full"
+                          src={project.image || ""}
+                          client={props.client}
+                        />
+                        <span className="font-medium text-sm">
+                          {project.name}
+                        </span>
+                      </Link>
+                    </TableCell>
+                    <TableCell>
+                      {project.monthlyActiveUsers === 0 ? (
+                        <span className="text-muted-foreground">No Users</span>
+                      ) : (
+                        project.monthlyActiveUsers
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <CopyTextButton
+                        textToCopy={project.publishableKey}
+                        textToShow={`${project.publishableKey.slice(0, 4)}...${project.publishableKey.slice(-4)}`}
+                        copyIconPosition="right"
+                        tooltip={undefined}
+                        variant="ghost"
+                        className="-translate-x-2 z-10 font-mono text-muted-foreground"
+                      />
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">
+                      {formatDate(new Date(project.createdAt), "MMM d, yyyy")}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+
+          {showPagination && (
+            <div className="rounded-b-lg border border-t-0 bg-card p-4">
+              <PaginationButtons
+                activePage={page}
+                onPageClick={setPage}
+                totalPages={totalPages}
+              />
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SearchInput(props: {
+  value: string;
+  onValueChange: (value: string) => void;
+}) {
+  return (
+    <div className="relative grow">
+      <Input
+        placeholder="Search Projects by name or Client ID"
+        value={props.value}
+        onChange={(e) => props.onValueChange(e.target.value)}
+        className="bg-background pl-9 lg:w-[400px]"
+      />
+      <SearchIcon className="-translate-y-1/2 absolute top-1/2 left-3 size-4 text-muted-foreground" />
+    </div>
+  );
+}
+
+function AddNewButton(props: {
+  createProject: () => void;
+}) {
+  return (
+    <Button
+      variant="default"
+      className="absolute top-0 right-0 gap-2 lg:static"
+      onClick={props.createProject}
+    >
+      <PlusIcon className="size-4" />
+      <span>
+        <span className="hidden lg:inline">Create</span> Project
+      </span>
+    </Button>
+  );
+}
+
+function SelectBy(props: {
+  value: SortById;
+  onChange: (value: SortById) => void;
+}) {
+  const values: SortById[] = ["name", "createdAt", "monthlyActiveUsers"];
+  const valueToLabel: Record<SortById, string> = {
+    name: "Name",
+    createdAt: "Creation Date",
+    monthlyActiveUsers: "Monthly Active Users",
+  };
+
+  return (
+    <Select
+      value={props.value}
+      onValueChange={(v) => {
+        props.onChange(v as SortById);
+      }}
+    >
+      <SelectTrigger className="min-w-[200px] bg-background capitalize">
+        <div className="flex items-center gap-1.5">
+          <span className="text-muted-foreground">Sort by</span>
+          {valueToLabel[props.value]}
+        </div>
+      </SelectTrigger>
+      <SelectContent>
+        {values.map((value) => (
+          <SelectItem key={value} value={value}>
+            {valueToLabel[value]}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/apps/dashboard/src/app/team/[team_slug]/layout.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/layout.tsx
@@ -1,3 +1,4 @@
+import { getProjects } from "@/api/projects";
 import { getTeamBySlug } from "@/api/team";
 import { AppFooter } from "@/components/blocks/app-footer";
 import { redirect } from "next/navigation";
@@ -13,7 +14,10 @@ export default async function RootTeamLayout(props: {
   params: Promise<{ team_slug: string }>;
 }) {
   const { team_slug } = await props.params;
-  const team = await getTeamBySlug(team_slug).catch(() => null);
+  const [team, projects] = await Promise.all([
+    getTeamBySlug(team_slug).catch(() => null),
+    getProjects(team_slug),
+  ]);
 
   if (!team) {
     redirect("/team");
@@ -21,6 +25,10 @@ export default async function RootTeamLayout(props: {
 
   if (!isTeamOnboardingComplete(team)) {
     redirect(`/get-started/team/${team.slug}`);
+  }
+
+  if (projects.length === 0) {
+    redirect(`/get-started/team/${team.slug}/create-project`);
   }
 
   return (

--- a/apps/dashboard/src/app/team/components/TeamHeader/team-header-logged-in.client.tsx
+++ b/apps/dashboard/src/app/team/components/TeamHeader/team-header-logged-in.client.tsx
@@ -83,7 +83,7 @@ export function TeamHeaderLoggedIn(props: {
               isOpen: false,
             })
           }
-          onCreateAndComplete={() => {
+          onCreate={() => {
             // refresh projects
             router.refresh();
           }}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the project creation and onboarding experience in the dashboard application. It introduces new components and modifies existing ones to streamline project management and improve user navigation.

### Detailed summary
- Updated `onCreateAndComplete` to `onCreate` in `AccountHeader.tsx` and `TeamHeader.tsx`.
- Changed redirect path in `team-onboarding.tsx` to `/get-started/team/${props.team.slug}/create-project`.
- Added `CreateProjectPage` to handle project creation in `create-project/page.tsx`.
- Introduced `CreateProjectPageUI` for the project creation form in `create-project-page.tsx`.
- Added onboarding steps in `onboarding-layout.tsx` for project configuration and key storage.
- Enhanced `RootTeamLayout` to handle project loading and redirection based on project existence.
- Integrated `TeamProjectsTable` in `TeamProjectsPage.tsx` for displaying projects.
- Removed unused components and simplified logic in `TeamProjectsPage.tsx`.
- Updated `CreateProjectDialog` to use `onCreate` callback for refreshing after project creation.
- Refactored `CreatedProjectDetails` and `CreateProjectForm` for better UI and usability.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->