### PR TITLE
[TOOL-3691] Dashbaord: Keep project settings submit button always enabled

### DIFF
--- a/apps/dashboard/src/app/team/[team_slug]/[project_slug]/settings/ProjectGeneralSettingsPage.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/[project_slug]/settings/ProjectGeneralSettingsPage.tsx
@@ -406,7 +406,6 @@ function ProjectNameSetting(props: {
   handleSubmit: () => void;
 }) {
   const { form, handleSubmit } = props;
-  const isNameDirty = form.getFieldState("name").isDirty;
 
   return (
     <SettingsCard
@@ -419,8 +418,8 @@ function ProjectNameSetting(props: {
       errorText={form.getFieldState("name").error?.message}
       saveButton={{
         onClick: handleSubmit,
-        disabled: !isNameDirty,
-        isPending: props.isUpdatingProject && isNameDirty,
+        disabled: false,
+        isPending: props.isUpdatingProject,
       }}
       bottomText="Please use 64 characters at maximum"
     >
@@ -501,7 +500,6 @@ function AllowedDomainsSetting(props: {
   handleSubmit: () => void;
 }) {
   const { form, handleSubmit } = props;
-  const isDomainsDirty = form.getFieldState("domains").isDirty;
 
   const helperText = (
     <ul className="flex list-disc flex-col gap-1.5 py-1 pl-3 text-muted-foreground text-sm [&>li]:pl-1">
@@ -544,8 +542,8 @@ function AllowedDomainsSetting(props: {
       errorText={form.getFieldState("domains", form.formState).error?.message}
       saveButton={{
         onClick: handleSubmit,
-        disabled: !isDomainsDirty,
-        isPending: props.isUpdatingProject && isDomainsDirty,
+        disabled: false,
+        isPending: props.isUpdatingProject,
       }}
       bottomText="This is only applicable for web applications"
     >
@@ -606,13 +604,12 @@ function AllowedBundleIDsSetting(props: {
   handleSubmit: () => void;
 }) {
   const { form, handleSubmit } = props;
-  const isBundleIdsDirty = form.getFieldState("bundleIds").isDirty;
   return (
     <SettingsCard
       saveButton={{
         onClick: handleSubmit,
-        disabled: !isBundleIdsDirty,
-        isPending: props.isUpdatingProject && isBundleIdsDirty,
+        disabled: false,
+        isPending: props.isUpdatingProject,
       }}
       noPermissionText={undefined}
       header={{
@@ -715,7 +712,7 @@ function EnabledServicesSetting(props: {
       errorText={undefined}
       saveButton={{
         onClick: handleSubmit,
-        disabled: !form.formState.isDirty,
+        disabled: false,
         isPending: props.isUpdatingProject,
       }}
       bottomText=""
@@ -1218,8 +1215,6 @@ function TransferProject(props: {
     !hasOwnerRole ||
     selectedTeamId === props.currentTeamId ||
     !props.isOwnerAccount;
-
-  console.log({ selectedTeam: selectedTeamWithRole, isDisabled });
 
   const handleTransfer = () => {
     if (!hasOwnerRole) {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on improving the handling of form state in the `ProjectGeneralSettingsPage.tsx` file by removing unnecessary checks for whether the form fields are dirty, simplifying the save button logic.

### Detailed summary
- Removed `isDirty` checks for `name`, `domains`, and `bundleIds` fields.
- Set `disabled` property of save buttons to `false` for all settings.
- Adjusted `isPending` property to only depend on `props.isUpdatingProject`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->