### PR TITLE
.NET Docs - Synchronous EngineWallet.Create

### DIFF
--- a/apps/portal/src/app/dotnet/wallets/providers/engine-wallet/page.mdx
+++ b/apps/portal/src/app/dotnet/wallets/providers/engine-wallet/page.mdx
@@ -16,7 +16,7 @@ Instantiate a `Engine` with a given private key. This wallet is capable of signi
 
 ```csharp
 // EngineWallet is compatible with IThirdwebWallet and can be used with any SDK method/extension
-var engineWallet = await EngineWallet.Create(
+var engineWallet = EngineWallet.Create(
     client: client,
     engineUrl: Environment.GetEnvironmentVariable("ENGINE_URL"),
     authToken: Environment.GetEnvironmentVariable("ENGINE_ACCESS_TOKEN"),


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on modifying the instantiation of the `engineWallet` variable by removing the `await` keyword, indicating a change in how the `EngineWallet.Create` method is called.

### Detailed summary
- Removed `await` from the instantiation of `engineWallet`.
- Changed the line from:
  ```csharp
  var engineWallet = await EngineWallet.Create(
  ```
  to:
  ```csharp
  var engineWallet = EngineWallet.Create(
  ```

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->