### PR TITLE
[Docs] Fix: Typo in react/getting-started guide

### DIFF
--- a/apps/portal/src/app/react/v5/getting-started/page.mdx
+++ b/apps/portal/src/app/react/v5/getting-started/page.mdx
@@ -254,4 +254,4 @@ export default function App() {
 
 ## Learn more
 
-You know have all the basics to build your own app with thirdweb. You can also check out the [full thirdweb SDK reference](/references/typescript/v5) to learn more about the different hooks and functions available.
+You now have all the basics to build your own app with thirdweb. You can also check out the [full thirdweb SDK reference](/references/typescript/v5) to learn more about the different hooks and functions available.

--- a/apps/portal/src/app/react/v5/getting-started/page.mdx
+++ b/apps/portal/src/app/react/v5/getting-started/page.mdx
@@ -78,7 +78,7 @@ export const client = createThirdwebClient({
 });
 ```
 
-You only need to define the client once. Exporting the client vartiable will allow you to use anywhere in your app.
+You only need to define the client once. Exporting the client variable will allow you to use anywhere in your app.
 
 </Step>
 


### PR DESCRIPTION
Small typo fix

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting typographical errors in the documentation file `page.mdx` related to using the client variable in an app.

### Detailed summary
- Fixed the spelling of `vartiable` to `variable`.
- Corrected the phrase "You know have" to "You now have".
- Added a newline at the end of the file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->