### PR TITLE
[Dashboard] feat: Add access control and server verifier to partner configuration

### DIFF
--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/components/client/add-partner-form.client.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/components/client/add-partner-form.client.tsx
@@ -1,33 +1,17 @@
-import { Spinner } from "@/components/ui/Spinner/Spinner";
-import { Button } from "@/components/ui/button";
-import {
-  Form,
-  FormControl,
-  FormDescription,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
-import { cn } from "@/lib/utils";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { useForm } from "react-hook-form";
 import { toast } from "sonner";
-import type { z } from "zod";
-import type { Ecosystem } from "../../../../../types";
-import { partnerFormSchema } from "../../constants";
+import type { Ecosystem, Partner } from "../../../../../types";
 import { useAddPartner } from "../../hooks/use-add-partner";
+import { PartnerForm, type PartnerFormValues } from "./partner-form.client";
 
 export function AddPartnerForm({
   ecosystem,
   onPartnerAdded,
   authToken,
-}: { authToken: string; ecosystem: Ecosystem; onPartnerAdded: () => void }) {
-  const form = useForm<z.input<typeof partnerFormSchema>>({
-    resolver: zodResolver(partnerFormSchema),
-  });
-
+}: {
+  authToken: string;
+  ecosystem: Ecosystem;
+  onPartnerAdded: () => void;
+}) {
   const { mutateAsync: addPartner, isPending } = useAddPartner(
     {
       authToken,
@@ -46,95 +30,28 @@ export function AddPartnerForm({
     },
   );
 
+  const handleSubmit = (
+    values: PartnerFormValues,
+    finalAccessControl: Partner["accessControl"] | null,
+  ) => {
+    addPartner({
+      ecosystem,
+      name: values.name,
+      allowlistedDomains: values.domains
+        .split(/,| /)
+        .filter((d) => d.length > 0),
+      allowlistedBundleIds: values.bundleIds
+        .split(/,| /)
+        .filter((d) => d.length > 0),
+      accessControl: finalAccessControl,
+    });
+  };
+
   return (
-    <Form {...form}>
-      <form
-        onSubmit={form.handleSubmit((values) => {
-          addPartner({
-            ecosystem,
-            name: values.name,
-            allowlistedDomains: values.domains
-              .split(/,| /)
-              .filter((d) => d.length > 0),
-            allowlistedBundleIds: values.bundleIds
-              .split(/,| /)
-              .filter((d) => d.length > 0),
-          });
-        })}
-        className="flex flex-col gap-6"
-      >
-        <div className="flex flex-col gap-4">
-          <FormField
-            control={form.control}
-            name="name"
-            defaultValue="" // Note: you *must* provide a default value here or the field won't reset
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel> App Name </FormLabel>
-                <FormControl>
-                  <Input
-                    placeholder="App name"
-                    {...field}
-                    value={field.value}
-                  />
-                </FormControl>
-                <FormDescription
-                  className={cn(
-                    "text-xs transition-all",
-                    form.formState.errors.name?.message
-                      ? "block translate-y-0 text-destructive opacity-100"
-                      : "lg:-translate-y-4 hidden opacity-0",
-                  )}
-                >
-                  {form.formState.errors.name?.message}
-                </FormDescription>
-              </FormItem>
-            )}
-          />
-          <FormField
-            control={form.control}
-            name="domains"
-            defaultValue="" // Note: you *must* provide a default value here or the field won't reset
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel> Domains </FormLabel>
-                <FormControl>
-                  <Input placeholder="Domains" className="peer" {...field} />
-                </FormControl>
-
-                <FormDescription>
-                  Space or comma-separated list of regex domains (e.g.
-                  *.example.com)
-                </FormDescription>
-              </FormItem>
-            )}
-          />
-          <FormField
-            control={form.control}
-            name="bundleIds"
-            defaultValue="" // Note: you *must* provide a default value here or the field won't reset
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel> Bundle ID </FormLabel>
-                <FormControl>
-                  <Input placeholder="Bundle ID" className="peer" {...field} />
-                </FormControl>
-
-                <FormDescription>
-                  Space or comma-separated list of bundle IDs
-                </FormDescription>
-
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-        </div>
-
-        <Button disabled={isPending} type="submit" className="w-full gap-2">
-          {isPending && <Spinner className="size-4" />}
-          Add
-        </Button>
-      </form>
-    </Form>
+    <PartnerForm
+      onSubmit={handleSubmit}
+      isSubmitting={isPending}
+      submitLabel="Add"
+    />
   );
 }

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/components/client/partner-form.client.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/components/client/partner-form.client.tsx
@@ -1,0 +1,340 @@
+"use client";
+import { Spinner } from "@/components/ui/Spinner/Spinner";
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { cn } from "@/lib/utils";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { PlusIcon, Trash2Icon } from "lucide-react";
+import { useFieldArray, useForm } from "react-hook-form";
+import type { z } from "zod";
+import type { Partner } from "../../../../../types";
+import { partnerFormSchema } from "../../constants";
+
+export type PartnerFormValues = z.infer<typeof partnerFormSchema>;
+
+type PartnerFormProps = {
+  partner?: Partner; // Optional for add form
+  onSubmit: (
+    values: PartnerFormValues,
+    finalAccessControl: Partner["accessControl"] | null,
+  ) => void;
+  isSubmitting: boolean;
+  submitLabel: string;
+};
+
+export function PartnerForm({
+  partner,
+  onSubmit,
+  isSubmitting,
+  submitLabel,
+}: PartnerFormProps) {
+  // Check if partner has accessControl and serverVerifier
+  const hasAccessControl = partner ? !!partner.accessControl : false;
+  const hasServerVerifier =
+    hasAccessControl && !!partner?.accessControl?.serverVerifier;
+
+  const form = useForm<PartnerFormValues>({
+    resolver: zodResolver(partnerFormSchema),
+    defaultValues: {
+      name: partner?.name || "",
+      domains: partner?.allowlistedDomains.join(",") || "",
+      bundleIds: partner?.allowlistedBundleIds.join(",") || "",
+      // Set the actual accessControl data if it exists
+      accessControl: partner?.accessControl,
+      // Set the UI control properties based on existing data
+      accessControlEnabled: hasAccessControl,
+      serverVerifierEnabled: hasServerVerifier,
+    },
+  });
+
+  // Watch the boolean flags for UI state
+  const accessControlEnabled = form.watch("accessControlEnabled");
+  const serverVerifierEnabled = form.watch("serverVerifierEnabled");
+
+  // Setup field array for headers
+  const customHeaderFields = useFieldArray({
+    control: form.control,
+    name: "accessControl.serverVerifier.headers",
+  });
+
+  const handleSubmit = form.handleSubmit(
+    (values) => {
+      // Construct the final accessControl object based on the enabled flags
+      let finalAccessControl: Partner["accessControl"] | null = null;
+
+      if (values.accessControlEnabled) {
+        finalAccessControl = {} as Partner["accessControl"];
+
+        if (finalAccessControl && values.serverVerifierEnabled) {
+          finalAccessControl.serverVerifier = {
+            url: values.accessControl?.serverVerifier?.url || "",
+            headers: values.accessControl?.serverVerifier?.headers || [],
+          };
+        }
+
+        // TODO add signature policies here
+
+        // if no values have been set, remove the accessControl object
+        if (
+          finalAccessControl &&
+          Object.keys(finalAccessControl).length === 0
+        ) {
+          finalAccessControl = null;
+        }
+      }
+
+      onSubmit(values, finalAccessControl);
+    },
+    (errors) => {
+      // Log validation errors for debugging
+      console.error("Form validation errors:", errors);
+    },
+  );
+
+  return (
+    <Form {...form}>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <div className="flex grow flex-col gap-5">
+          <FormField
+            control={form.control}
+            name="name"
+            defaultValue=""
+            render={({ field }) => (
+              <FormItem className="col-span-4">
+                <FormLabel> Name </FormLabel>
+                <FormControl>
+                  <Input
+                    placeholder="App name"
+                    {...field}
+                    value={field.value}
+                  />
+                </FormControl>
+                <FormDescription
+                  className={cn(
+                    "text-xs transition-all",
+                    form.formState.errors.name?.message
+                      ? "block translate-y-0 text-destructive opacity-100"
+                      : "hidden opacity-0",
+                  )}
+                >
+                  {form.formState.errors.name?.message}
+                </FormDescription>
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="domains"
+            defaultValue=""
+            render={({ field }) => (
+              <FormItem className="col-span-4 lg:col-span-4">
+                <FormLabel> Domains </FormLabel>
+                <FormControl>
+                  <Input placeholder="Domains" className="peer" {...field} />
+                </FormControl>
+                <FormDescription
+                  className={cn(
+                    "block text-xs",
+                    form.formState.errors.domains?.message &&
+                      "block translate-y-0 text-destructive opacity-100",
+                  )}
+                >
+                  {form.formState.errors.domains?.message ??
+                    "Space or comma-separated list of regex domains (e.g. *.example.com)"}
+                </FormDescription>
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="bundleIds"
+            defaultValue=""
+            render={({ field }) => (
+              <FormItem className="col-span-4">
+                <FormLabel> Bundle ID </FormLabel>
+                <FormControl>
+                  <Input placeholder="Bundle ID" className="peer" {...field} />
+                </FormControl>
+                <FormDescription
+                  className={cn(
+                    "block text-xs",
+                    form.formState.errors.bundleIds?.message &&
+                      "block text-destructive",
+                  )}
+                >
+                  {form.formState.errors.bundleIds?.message ??
+                    "Space or comma-separated list of bundle IDs"}
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          {/* Access Control Section */}
+          <div className="mb-4 flex items-center justify-between gap-6">
+            <div>
+              <Label htmlFor="access-control-switch" className="text-base">
+                Access Control
+              </Label>
+              <p className="mt-0.5 text-muted-foreground text-xs">
+                Enable access control for this partner
+              </p>
+            </div>
+            <Switch
+              id="access-control-switch"
+              checked={accessControlEnabled}
+              onCheckedChange={(checked) => {
+                form.setValue("accessControlEnabled", checked);
+                // If disabling access control, also disable server verifier
+                if (!checked) {
+                  form.setValue("serverVerifierEnabled", false);
+                }
+              }}
+            />
+          </div>
+
+          {accessControlEnabled && (
+            <div className="rounded-lg border border-border p-4">
+              <div className="mb-4 flex items-center justify-between gap-6">
+                <div>
+                  <Label htmlFor="server-verifier-switch" className="text-base">
+                    Server Verifier
+                  </Label>
+                  <p className="mt-0.5 text-muted-foreground text-xs">
+                    Configure a server verifier for access control
+                  </p>
+                </div>
+                <Switch
+                  id="server-verifier-switch"
+                  checked={serverVerifierEnabled}
+                  onCheckedChange={(checked) => {
+                    form.setValue("serverVerifierEnabled", checked);
+
+                    // Initialize serverVerifier fields if enabling
+                    if (
+                      checked &&
+                      !form.getValues("accessControl.serverVerifier")
+                    ) {
+                      form.setValue("accessControl.serverVerifier", {
+                        url: "",
+                        headers: [],
+                      });
+                    }
+                  }}
+                />
+              </div>
+
+              {serverVerifierEnabled && (
+                <div className="mt-4 grid grid-cols-1 gap-6">
+                  <FormField
+                    control={form.control}
+                    name="accessControl.serverVerifier.url"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Server Verifier URL</FormLabel>
+                        <FormControl>
+                          <Input
+                            {...field}
+                            placeholder="https://example.com/your-verifier"
+                          />
+                        </FormControl>
+                        <FormDescription
+                          className={cn(
+                            "text-xs",
+                            form.formState.errors.accessControl?.serverVerifier
+                              ?.url && "text-destructive",
+                          )}
+                        >
+                          {form.formState.errors.accessControl?.serverVerifier
+                            ?.url?.message ||
+                            "Enter the URL of your server where verification requests will be sent"}
+                        </FormDescription>
+                      </FormItem>
+                    )}
+                  />
+
+                  <div>
+                    <Label className="mb-3 inline-block">Custom Headers</Label>
+                    <div className="flex flex-col gap-4">
+                      {customHeaderFields.fields.map((field, headerIdx) => {
+                        return (
+                          <div className="flex gap-4" key={field.id}>
+                            <Input
+                              placeholder="Name"
+                              type="text"
+                              {...form.register(
+                                `accessControl.serverVerifier.headers.${headerIdx}.key`,
+                              )}
+                            />
+                            <Input
+                              placeholder="Value"
+                              type="text"
+                              {...form.register(
+                                `accessControl.serverVerifier.headers.${headerIdx}.value`,
+                              )}
+                            />
+                            <Button
+                              variant="outline"
+                              aria-label="Remove header"
+                              onClick={() => {
+                                customHeaderFields.remove(headerIdx);
+                              }}
+                              className="!w-auto px-3"
+                              type="button"
+                            >
+                              <Trash2Icon className="size-4 shrink-0 text-destructive-text" />
+                            </Button>
+                          </div>
+                        );
+                      })}
+
+                      <Button
+                        variant="outline"
+                        className="w-full gap-2 bg-background"
+                        onClick={() => {
+                          customHeaderFields.append({
+                            key: "",
+                            value: "",
+                          });
+                        }}
+                        type="button"
+                      >
+                        <PlusIcon className="size-4" />
+                        Add header
+                      </Button>
+                    </div>
+
+                    <p className="mt-3 text-muted-foreground text-xs">
+                      Set custom headers to be sent along with verification
+                      requests
+                    </p>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        <Button
+          disabled={isSubmitting}
+          type="submit"
+          className="mt-4 w-full gap-2"
+        >
+          {isSubmitting && <Spinner className="size-4" />}
+          {submitLabel}
+        </Button>
+      </form>
+    </Form>
+  );
+}

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/components/client/update-partner-form.client.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/components/client/update-partner-form.client.tsx
@@ -1,24 +1,8 @@
 "use client";
-import { Spinner } from "@/components/ui/Spinner/Spinner";
-import { Button } from "@/components/ui/button";
-import {
-  Form,
-  FormControl,
-  FormDescription,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
-import { cn } from "@/lib/utils";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { useForm } from "react-hook-form";
 import { toast } from "sonner";
-import type { z } from "zod";
 import type { Ecosystem, Partner } from "../../../../../types";
-import { partnerFormSchema } from "../../constants";
 import { useUpdatePartner } from "../../hooks/use-update-partner";
+import { PartnerForm, type PartnerFormValues } from "./partner-form.client";
 
 export function UpdatePartnerForm({
   ecosystem,
@@ -31,138 +15,48 @@ export function UpdatePartnerForm({
   onSuccess: () => void;
   authToken: string;
 }) {
-  const form = useForm<z.input<typeof partnerFormSchema>>({
-    resolver: zodResolver(partnerFormSchema),
-    defaultValues: {
-      name: partner.name,
-      domains: partner.allowlistedDomains.join(","),
-      bundleIds: partner.allowlistedBundleIds.join(","),
-    },
-  });
-
   const { mutateAsync: updatePartner, isPending } = useUpdatePartner(
     {
       authToken,
     },
     {
       onSuccess: () => {
-        form.reset();
         onSuccess();
       },
       onError: (error) => {
         const message =
           error instanceof Error
             ? error.message
-            : "Failed to add ecosystem partner";
+            : "Failed to update ecosystem partner";
         toast.error(message);
       },
     },
   );
 
-  return (
-    <Form {...form}>
-      <form
-        onSubmit={form.handleSubmit((values) => {
-          updatePartner({
-            ecosystem,
-            partnerId: partner.id,
-            name: values.name,
-            allowlistedDomains: values.domains
-              .split(/,| /)
-              .filter((d) => d.length > 0),
-            allowlistedBundleIds: values.bundleIds
-              .split(/,| /)
-              .filter((d) => d.length > 0),
-          });
-        })}
-        className="flex flex-col gap-4"
-      >
-        <div className="flex grow flex-col gap-5">
-          <FormField
-            control={form.control}
-            name="name"
-            defaultValue="" // Note: you *must* provide a default value here or the field won't reset
-            render={({ field }) => (
-              <FormItem className="col-span-4">
-                <FormLabel> Name </FormLabel>
-                <FormControl>
-                  <Input
-                    placeholder="App name"
-                    {...field}
-                    value={field.value}
-                  />
-                </FormControl>
-                <FormDescription
-                  className={cn(
-                    "text-xs transition-all",
-                    form.formState.errors.name?.message
-                      ? "block translate-y-0 text-destructive opacity-100"
-                      : "hidden opacity-0",
-                  )}
-                >
-                  {form.formState.errors.name?.message}
-                </FormDescription>
-              </FormItem>
-            )}
-          />
-          <FormField
-            control={form.control}
-            name="domains"
-            defaultValue="" // Note: you *must* provide a default value here or the field won't reset
-            render={({ field }) => (
-              <FormItem className="col-span-4 lg:col-span-4">
-                <FormLabel> Domains </FormLabel>
-                <FormControl>
-                  <Input placeholder="Domains" className="peer" {...field} />
-                </FormControl>
-                <FormDescription
-                  className={cn(
-                    "block text-xs",
-                    form.formState.errors.domains?.message &&
-                      "block translate-y-0 text-destructive opacity-100", // If there are errors show them rather than the tip
-                  )}
-                >
-                  {form.formState.errors.domains?.message ??
-                    "Space or comma-separated list of regex domains (e.g. *.example.com)"}
-                </FormDescription>
-              </FormItem>
-            )}
-          />
-          <FormField
-            control={form.control}
-            name="bundleIds"
-            defaultValue="" // Note: you *must* provide a default value here or the field won't reset
-            render={({ field }) => (
-              <FormItem className="col-span-4">
-                <FormLabel> Bundle ID </FormLabel>
-                <FormControl>
-                  <Input placeholder="Bundle ID" className="peer" {...field} />
-                </FormControl>
-                <FormDescription
-                  className={cn(
-                    "block text-xs",
-                    form.formState.errors.bundleIds?.message &&
-                      "block text-destructive",
-                  )}
-                >
-                  {form.formState.errors.bundleIds?.message ??
-                    "Space or comma-separated list of bundle IDs"}
-                </FormDescription>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-        </div>
+  const handleSubmit = (
+    values: PartnerFormValues,
+    finalAccessControl: Partner["accessControl"] | null,
+  ) => {
+    updatePartner({
+      ecosystem,
+      partnerId: partner.id,
+      name: values.name,
+      allowlistedDomains: values.domains
+        .split(/,| /)
+        .filter((d) => d.length > 0),
+      allowlistedBundleIds: values.bundleIds
+        .split(/,| /)
+        .filter((d) => d.length > 0),
+      accessControl: finalAccessControl,
+    });
+  };
 
-        <Button
-          disabled={isPending}
-          type="submit"
-          className="mt-4 w-full gap-2"
-        >
-          {isPending && <Spinner className="size-4" />}
-          Update
-        </Button>
-      </form>
-    </Form>
+  return (
+    <PartnerForm
+      partner={partner}
+      onSubmit={handleSubmit}
+      isSubmitting={isPending}
+      submitLabel="Update"
+    />
   );
 }

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/constants.ts
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/constants.ts
@@ -3,31 +3,92 @@ import z from "zod";
 const isDomainRegex =
   /^(?:\*|(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)*(?:\*(?:\.[a-z0-9][a-z0-9-]{0,61}[a-z0-9](?:\.[a-z0-9][a-z0-9-]{0,61}[a-z0-9])*)?)|(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]|localhost(?::\d{1,5})?)$/;
 
-export const partnerFormSchema = z.object({
-  name: z
-    .string()
-    .trim()
-    .min(3, {
-      message: "Name must be at least 3 characters",
-    })
-    .refine((name) => /^[a-zA-Z0-9 ]*$/.test(name), {
-      message: "Name can only contain letters, numbers and spaces",
-    }),
-  domains: z
-    .string()
-    .trim()
-    .transform((s) => s.split(/,| /).filter((d) => d.length > 0))
-    .refine((domains) => domains.every((d) => isDomainRegex.test(d)), {
-      message: "Invalid domain format", // This error message CANNOT be within the array iteration, or the FormMessage won't be able to find it in the form state
-    })
-    .transform((s) => s.join(",")), // This is rejoined to return a string (and later split again) since react-hook-form's typings can't handle different input vs output types
-  bundleIds: z
-    .string()
-    .trim()
-    .transform((s) =>
-      s
-        .split(/,| /)
-        .filter((d) => d.length > 0)
-        .join(","),
-    ),
-});
+export const partnerFormSchema = z
+  .object({
+    name: z
+      .string()
+      .trim()
+      .min(3, {
+        message: "Name must be at least 3 characters",
+      })
+      .refine((name) => /^[a-zA-Z0-9 ]*$/.test(name), {
+        message: "Name can only contain letters, numbers and spaces",
+      }),
+    domains: z
+      .string()
+      .trim()
+      .transform((s) => s.split(/,| /).filter((d) => d.length > 0))
+      .refine((domains) => domains.every((d) => isDomainRegex.test(d)), {
+        message: "Invalid domain format", // This error message CANNOT be within the array iteration, or the FormMessage won't be able to find it in the form state
+      })
+      .transform((s) => s.join(",")), // This is rejoined to return a string (and later split again) since react-hook-form's typings can't handle different input vs output types
+    bundleIds: z
+      .string()
+      .trim()
+      .transform((s) =>
+        s
+          .split(/,| /)
+          .filter((d) => d.length > 0)
+          .join(","),
+      ),
+    accessControlEnabled: z.boolean().default(false),
+    serverVerifierEnabled: z.boolean().default(false),
+    accessControl: z
+      .object({
+        serverVerifier: z
+          .object({
+            url: z.string().optional(),
+            headers: z
+              .array(
+                z.object({
+                  key: z.string(),
+                  value: z.string(),
+                }),
+              )
+              .optional(),
+          })
+          .optional(),
+      })
+      .optional(),
+  })
+  .refine(
+    (data) => {
+      // If serverVerifier is enabled, validate the URL
+      if (data.accessControlEnabled && data.serverVerifierEnabled) {
+        return (
+          data.accessControl?.serverVerifier?.url &&
+          data.accessControl.serverVerifier.url.trim() !== ""
+        );
+      }
+      // Otherwise, no validation needed
+      return true;
+    },
+    {
+      message:
+        "Server Verifier URL is required when Server Verifier is enabled",
+      path: ["accessControl", "serverVerifier", "url"],
+    },
+  )
+  .refine(
+    (data) => {
+      // If serverVerifier is enabled, validate the URL format
+      if (
+        data.accessControlEnabled &&
+        data.serverVerifierEnabled &&
+        data.accessControl?.serverVerifier?.url
+      ) {
+        try {
+          new URL(data.accessControl.serverVerifier.url);
+          return true;
+        } catch {
+          return false;
+        }
+      }
+      // Otherwise, no validation needed
+      return true;
+    },
+    {
+      message: "Please enter a valid URL",
+      path: ["accessControl", "serverVerifier", "url"],
+    },
+  );

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/hooks/use-add-partner.ts
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/hooks/use-add-partner.ts
@@ -10,6 +10,7 @@ type AddPartnerParams = {
   name: string;
   allowlistedDomains: string[];
   allowlistedBundleIds: string[];
+  accessControl?: Partner["accessControl"] | null;
 };
 
 export function useAddPartner(
@@ -41,6 +42,7 @@ export function useAddPartner(
             name: params.name,
             allowlistedDomains: params.allowlistedDomains,
             allowlistedBundleIds: params.allowlistedBundleIds,
+            accessControl: params.accessControl ?? undefined,
             // TODO - remove the requirement for permissions in API endpoint
             permissions: ["FULL_CONTROL_V1"],
           }),

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/hooks/use-update-partner.ts
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/hooks/use-update-partner.ts
@@ -11,6 +11,12 @@ type UpdatePartnerParams = {
   name: string;
   allowlistedDomains: string[];
   allowlistedBundleIds: string[];
+  accessControl?: {
+    serverVerifier?: {
+      url: string;
+      headers?: { key: string; value: string }[];
+    } | null;
+  } | null;
 };
 
 export function useUpdatePartner(
@@ -42,6 +48,7 @@ export function useUpdatePartner(
             name: params.name,
             allowlistedDomains: params.allowlistedDomains,
             allowlistedBundleIds: params.allowlistedBundleIds,
+            accessControl: params.accessControl,
           }),
         },
       );

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/hooks/use-partners.ts
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/hooks/use-partners.ts
@@ -22,7 +22,11 @@ export function usePartners({
         );
       }
 
-      return (await res.json()) as Partner[];
+      const partners = (await res.json()) as Partner[];
+      return partners.sort(
+        (a, b) =>
+          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+      );
     },
     retry: false,
   });

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/types.ts
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/types.ts
@@ -55,4 +55,10 @@ export type Partner = {
   permissions: [PartnerPermission];
   createdAt: string;
   updatedAt: string;
+  accessControl?: {
+    serverVerifier?: {
+      url: string;
+      headers?: { key: string; value: string }[];
+    };
+  };
 };


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces an `accessControl` feature, enhancing partner management by adding server verification capabilities. It updates the form handling for adding and updating partners to include access control options and validation.

### Detailed summary
- Added `accessControl` property with `serverVerifier` to partner types.
- Updated `use-partners` hook to sort partners by `createdAt`.
- Enhanced `useUpdatePartner` and `useAddPartner` hooks to handle `accessControl`.
- Introduced a new `PartnerForm` component for form handling.
- Added validation for server verifier URL and headers in the form schema.
- Refactored forms to use `PartnerForm` for adding and updating partners.
- Implemented UI controls for toggling access control and server verifier settings.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->