### PR TITLE
updated description of using session keys with Engine

### DIFF
--- a/apps/portal/src/app/engine/features/account-abstraction/page.mdx
+++ b/apps/portal/src/app/engine/features/account-abstraction/page.mdx
@@ -64,12 +64,12 @@ Grant & revoke admins on an account with the `/contract/<chain>/<account_address
 
 Grant & revoke sessions on an account which allow specific wallets to interact with specified contracts for a given period of time with the `/contract/<chain>/<account_address>/account/sessions` endpoints.
 
-## Transact with an account
+## Transact with an account using session keys
 
 Make write calls with a smart account by calling a write endpoint and specify the `x-backend-wallet-address` and `x-account-address` headers.
 
-The `x-backend-wallet-address` should be set to the engine backend wallet that is an admin over the account.
+The `x-backend-wallet-address` should be set to the engine backend wallet that has been given by the user admin of the smart account signer permission via a [session key](https://portal.thirdweb.com/references/typescript/v5/erc4337/addSessionKey)
 
-The `x-account-address` should be set to the deployed account address itself.
+The `x-account-address` should be set to the deployed smart account address itself.
 
 Write calls made using these headers will initiate a `UserOperation` sent from the specified account.

--- a/apps/portal/src/app/engine/features/account-abstraction/page.mdx
+++ b/apps/portal/src/app/engine/features/account-abstraction/page.mdx
@@ -68,7 +68,7 @@ Grant & revoke sessions on an account which allow specific wallets to interact w
 
 Make write calls with a smart account by calling a write endpoint and specify the `x-backend-wallet-address` and `x-account-address` headers.
 
-The `x-backend-wallet-address` should be set to the engine backend wallet that has been given by the user admin of the smart account signer permission via a [session key](https://portal.thirdweb.com/references/typescript/v5/erc4337/addSessionKey)
+The `x-backend-wallet-address` should be set to the Engine backend wallet that has been granted signing permission by the smart account's admin through a [session key](https://portal.thirdweb.com/references/typescript/v5/erc4337/addSessionKey)
 
 The `x-account-address` should be set to the deployed smart account address itself.
 

--- a/apps/portal/src/app/engine/features/account-abstraction/page.mdx
+++ b/apps/portal/src/app/engine/features/account-abstraction/page.mdx
@@ -68,7 +68,7 @@ Grant & revoke sessions on an account which allow specific wallets to interact w
 
 Make write calls with a smart account by calling a write endpoint and specify the `x-backend-wallet-address` and `x-account-address` headers.
 
-The `x-backend-wallet-address` should be set to the Engine backend wallet that has been granted signing permission by the smart account's admin through a [session key](https://portal.thirdweb.com/references/typescript/v5/erc4337/addSessionKey)
+The `x-backend-wallet-address` should be set to the Engine backend wallet that has been granted signing permission by the smart account's admin through a [session key](https://portal.thirdweb.com/references/typescript/v5/erc4337/addSessionKey).
 
 The `x-account-address` should be set to the deployed smart account address itself.
 


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the documentation for account transactions, emphasizing the use of session keys for interacting with smart accounts. It clarifies the roles of the `x-backend-wallet-address` and `x-account-address` headers.

### Detailed summary
- Updated section title to `Transact with an account using session keys`.
- Clarified that the `x-backend-wallet-address` must be from a wallet granted signing permission via a session key.
- Specified that the `x-account-address` refers to the deployed smart account address.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->