### PR TITLE
[SDK] fix: Handle serialized bigints for packing userops

### DIFF
--- a/.changeset/funny-facts-beam.md
+++ b/.changeset/funny-facts-beam.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Handle serialized bigints for packing userops

--- a/packages/thirdweb/src/wallets/smart/lib/packUserOp.ts
+++ b/packages/thirdweb/src/wallets/smart/lib/packUserOp.ts
@@ -12,19 +12,19 @@ function getInitCode(unpackedUserOperation: UserOperationV07) {
 
 function getAccountGasLimits(unpackedUserOperation: UserOperationV07) {
   return concat([
-    pad(toHex(unpackedUserOperation.verificationGasLimit), {
+    pad(toHex(BigInt(unpackedUserOperation.verificationGasLimit)), {
       size: 16,
     }),
-    pad(toHex(unpackedUserOperation.callGasLimit), { size: 16 }),
+    pad(toHex(BigInt(unpackedUserOperation.callGasLimit)), { size: 16 }),
   ]) as Hex;
 }
 
 function getGasLimits(unpackedUserOperation: UserOperationV07) {
   return concat([
-    pad(toHex(unpackedUserOperation.maxPriorityFeePerGas), {
+    pad(toHex(BigInt(unpackedUserOperation.maxPriorityFeePerGas)), {
       size: 16,
     }),
-    pad(toHex(unpackedUserOperation.maxFeePerGas), { size: 16 }),
+    pad(toHex(BigInt(unpackedUserOperation.maxFeePerGas)), { size: 16 }),
   ]) as Hex;
 }
 
@@ -34,13 +34,13 @@ function getPaymasterAndData(unpackedUserOperation: UserOperationV07) {
         unpackedUserOperation.paymaster as Hex,
         pad(
           toHex(
-            unpackedUserOperation.paymasterVerificationGasLimit || BigInt(0),
+            BigInt(unpackedUserOperation.paymasterVerificationGasLimit || 0),
           ),
           {
             size: 16,
           },
         ),
-        pad(toHex(unpackedUserOperation.paymasterPostOpGasLimit || BigInt(0)), {
+        pad(toHex(BigInt(unpackedUserOperation.paymasterPostOpGasLimit || 0)), {
           size: 16,
         }),
         unpackedUserOperation.paymasterData || ("0x" as Hex),
@@ -53,11 +53,11 @@ export const getPackedUserOperation = (
 ): PackedUserOperation => {
   return {
     sender: userOperation.sender,
-    nonce: userOperation.nonce,
+    nonce: BigInt(userOperation.nonce),
     initCode: getInitCode(userOperation),
     callData: userOperation.callData,
     accountGasLimits: getAccountGasLimits(userOperation),
-    preVerificationGas: userOperation.preVerificationGas,
+    preVerificationGas: BigInt(userOperation.preVerificationGas),
     gasFees: getGasLimits(userOperation),
     paymasterAndData: getPaymasterAndData(userOperation),
     signature: userOperation.signature,


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on handling serialized `bigint` values for packing user operations in the `thirdweb` wallet library, ensuring proper conversion and padding of gas limits and other numeric fields.

### Detailed summary
- Updated `getAccountGasLimits` to convert `verificationGasLimit` and `callGasLimit` to `BigInt`.
- Updated `getGasLimits` to convert `maxPriorityFeePerGas` and `maxFeePerGas` to `BigInt`.
- Modified `getPaymasterAndData` to handle `paymasterVerificationGasLimit` and `paymasterPostOpGasLimit` as `BigInt`.
- Changed `getPackedUserOperation` to convert `nonce` and `preVerificationGas` to `BigInt`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->