### PR TITLE
[SDK] feat: Support account overrides in engineAccount()

### DIFF
--- a/.changeset/fifty-hoops-build.md
+++ b/.changeset/fifty-hoops-build.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Support account overrides in engineAccount()

--- a/packages/thirdweb/src/wallets/engine/engine-account.test.ts
+++ b/packages/thirdweb/src/wallets/engine/engine-account.test.ts
@@ -6,6 +6,8 @@ import { sepolia } from "../../chains/chain-definitions/sepolia.js";
 import { getContract } from "../../contract/contract.js";
 import { claimTo } from "../../extensions/erc1155/drops/write/claimTo.js";
 import { sendTransaction } from "../../transaction/actions/send-transaction.js";
+import { smartWallet } from "../smart/smart-wallet.js";
+import { generateAccount } from "../utils/generateAccount.js";
 import { engineAccount } from "./index.js";
 
 describe.runIf(
@@ -63,6 +65,46 @@ describe.runIf(
     const tx = await sendTransaction({
       account: engineAcc,
       transaction: claimTx,
+    });
+    expect(tx).toBeDefined();
+  });
+
+  it.skip("should send a session key tx", async () => {
+    const personalAccount = await generateAccount({
+      client: TEST_CLIENT,
+    });
+    const smart = smartWallet({
+      chain: sepolia,
+      sponsorGas: true,
+      sessionKey: {
+        address: process.env.ENGINE_WALLET_ADDRESS_EOA as string,
+        permissions: {
+          approvedTargets: "*",
+        },
+      },
+    });
+    const smartAccount = await smart.connect({
+      client: TEST_CLIENT,
+      personalAccount,
+    });
+
+    const engineAcc = engineAccount({
+      engineUrl: process.env.ENGINE_URL as string,
+      authToken: process.env.ENGINE_AUTH_TOKEN as string,
+      walletAddress: process.env.ENGINE_WALLET_ADDRESS_EOA as string,
+      chain: sepolia,
+      overrides: {
+        accountAddress: smartAccount.address,
+      },
+    });
+    const tx = await sendTransaction({
+      account: engineAcc,
+      transaction: {
+        client: TEST_CLIENT,
+        chain: sepolia,
+        to: TEST_ACCOUNT_B.address,
+        value: 0n,
+      },
     });
     expect(tx).toBeDefined();
   });


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces support for account overrides in the `engineAccount()` function, allowing transactions to be executed on behalf of smart accounts. It adds new options for account management and includes a test case for sending a session key transaction.

### Detailed summary
- Added `overrides` option to `EngineAccountOptions` in `index.ts`.
- Implemented handling for `accountAddress`, `accountFactoryAddress`, and `accountSalt` in `engineAccount()`.
- Introduced a test case in `engine-account.test.ts` for sending a session key transaction.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->