### PR TITLE
[SDK] feat: Add Saga Mainnet to gas-free chains

### DIFF
--- a/.changeset/silver-chairs-return.md
+++ b/.changeset/silver-chairs-return.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Add Saga in gas free chains definitions

--- a/apps/dashboard/src/components/buttons/MismatchButton.tsx
+++ b/apps/dashboard/src/components/buttons/MismatchButton.tsx
@@ -63,6 +63,7 @@ const GAS_FREE_CHAINS = [
   247253, // Saakuru Testnet
   19011, // Homeverse Mainnet
   40875, // Homeverse Testnet
+  5464, // Saga Mainnet
 ];
 
 function useIsNetworkMismatch(txChainId: number) {

--- a/packages/thirdweb/src/gas/fee-data.ts
+++ b/packages/thirdweb/src/gas/fee-data.ts
@@ -43,6 +43,7 @@ const FORCE_GAS_PRICE_CHAIN_IDS = [
   19011, // Homeverse Mainnet
   40875, // Homeverse Testnet
   1511670449, // GPT Mainnet
+  5464, // Saga Mainnet
 ];
 
 /**


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding the `Saga Mainnet` to the gas-free chains definitions in the `thirdweb` package.

### Detailed summary
- Updated the gas-free chains definitions in `packages/thirdweb/src/gas/fee-data.ts` to include `Saga Mainnet` with ID `5464`.
- Added `Saga Mainnet` to the list in `apps/dashboard/src/components/buttons/MismatchButton.tsx`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->