### PR TITLE
[SDK] fix: Remove fixed gas limit for Saga Mainnet

### DIFF
--- a/packages/thirdweb/src/transaction/actions/estimate-gas.ts
+++ b/packages/thirdweb/src/transaction/actions/estimate-gas.ts
@@ -73,10 +73,6 @@ export async function estimateGas(
     // biome-ignore lint/style/noNonNullAssertion: the `has` above ensures that this will always be set
     return cache.get(txWithFrom)!;
   }
-  // Saga Mainnet has a fixed gas limit for all transactions
-  if (options.transaction.chain.id === 5464) {
-    return 20000000n;
-  }
   const { account } = options;
   const promise = (async () => {
     const predefinedGas = await resolvePromisedValue(options.transaction.gas);


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes a fixed gas limit condition for the `Saga Mainnet` in the `estimate-gas.ts` file, allowing for more dynamic gas estimation based on the transaction.

### Detailed summary
- Removed the conditional check for `Saga Mainnet` (chain ID `5464`) that returned a fixed gas limit of `20000000n`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->