### PR TITLE
[SDK] fix: Enforce requireApproval option for wallet connection

### DIFF
--- a/.changeset/full-games-end.md
+++ b/.changeset/full-games-end.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix requireApproval option not enforced for wallet connection

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/WalletSelector.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/WalletSelector.tsx
@@ -183,6 +183,7 @@ const WalletSelectorInner: React.FC<WalletSelectorProps> = (props) => {
         props.selectWallet(localWalletConfig);
       }}
       data-test="continue-as-guest-button"
+      disabled={props.meta.requireApproval && !approvedTOS}
     >
       {props.connectLocale.continueAsGuest}
     </Button>
@@ -227,6 +228,7 @@ const WalletSelectorInner: React.FC<WalletSelectorProps> = (props) => {
     <WalletTypeRowButton
       client={props.client}
       icon={OutlineWalletIcon}
+      disabled={props.meta.requireApproval && !approvedTOS}
       onClick={() => {
         setIsWalletGroupExpanded(true);
       }}


### PR DESCRIPTION
Fixes TOOL-3537

<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR addresses an issue where the `requireApproval` option was not being enforced during wallet connections in the `thirdweb` package, ensuring that users must approve the terms of service before proceeding.

### Detailed summary
- Updated the `requireApproval` logic in the `WalletSelector.tsx` file.
- Added a `disabled` attribute to the `Button` component, which is now conditionally disabled based on `props.meta.requireApproval` and `approvedTOS`.
- Ensured that the `WalletTypeRowButton` also respects the `requireApproval` condition.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->