### PR TITLE
[SDK] fix: Pass chainId to internal 1193 provider when connecting

### DIFF
--- a/.changeset/cruel-tires-cheer.md
+++ b/.changeset/cruel-tires-cheer.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Pass along chainId to internal 1193 provider when connecting

--- a/packages/thirdweb/src/adapters/eip1193/from-eip1193.ts
+++ b/packages/thirdweb/src/adapters/eip1193/from-eip1193.ts
@@ -15,7 +15,9 @@ import type { EIP1193Provider } from "./types.js";
  * Options for creating an EIP-1193 provider adapter.
  */
 export type FromEip1193AdapterOptions = {
-  provider: EIP1193Provider | (() => Promise<EIP1193Provider>);
+  provider:
+    | EIP1193Provider
+    | ((params?: { chainId?: number }) => Promise<EIP1193Provider>);
   walletId?: WalletId;
 };
 
@@ -63,13 +65,11 @@ export function fromProvider(options: FromEip1193AdapterOptions): Wallet {
   let account: Account | undefined = undefined;
   let chain: Chain | undefined = undefined;
   let provider: EIP1193Provider | undefined = undefined;
-  const getProvider = async () => {
-    if (!provider) {
-      provider =
-        typeof options.provider === "function"
-          ? await options.provider()
-          : options.provider;
-    }
+  const getProvider = async (params?: { chainId?: number }) => {
+    provider =
+      typeof options.provider === "function"
+        ? await options.provider(params)
+        : options.provider;
     return provider;
   };
 
@@ -118,7 +118,7 @@ export function fromProvider(options: FromEip1193AdapterOptions): Wallet {
       const [connectedAccount, connectedChain, doDisconnect, doSwitchChain] =
         await connectEip1193Wallet({
           id,
-          provider: await getProvider(),
+          provider: await getProvider({ chainId: connectOptions.chain?.id }),
           client: connectOptions.client,
           chain: connectOptions.chain,
           emitter,
@@ -141,7 +141,7 @@ export function fromProvider(options: FromEip1193AdapterOptions): Wallet {
       const [connectedAccount, connectedChain, doDisconnect, doSwitchChain] =
         await autoConnectEip1193Wallet({
           id,
-          provider: await getProvider(),
+          provider: await getProvider({ chainId: connectOptions.chain?.id }),
           emitter,
           chain: connectOptions.chain,
           client: connectOptions.client,


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `fromProvider` function by allowing it to pass the `chainId` to the internal `EIP1193Provider` when connecting, improving compatibility with different blockchain networks.

### Detailed summary
- Updated `FromEip1193AdapterOptions` to accept an optional `chainId` parameter in the `provider` function.
- Modified `getProvider` to accept `params` and pass them to the `provider` function.
- Adjusted calls to `getProvider` in `connectEip1193Wallet` and `autoConnectEip1193Wallet` to include the `chainId`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->