### PR TITLE
[Dashboard] Fix: wrong URL

### DIFF
--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/(instance)/[engineId]/wallet-credentials/components/credential-form.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/(instance)/[engineId]/wallet-credentials/components/credential-form.tsx
@@ -79,7 +79,7 @@ export const CredentialForm = ({
                 <DialogTitle>{title}</DialogTitle>
                 <DialogDescription>
                   <TrackedLinkTW
-                    href="https://portal.thirdweb.com/infrastructure/engine/features/wallet-credentials"
+                    href="https://portal.thirdweb.com/engine/features/wallet-credentials"
                     target="_blank"
                     label="learn-more"
                     category="engine"

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/(instance)/[engineId]/wallet-credentials/components/wallet-credentials.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/engine/(instance)/[engineId]/wallet-credentials/components/wallet-credentials.tsx
@@ -65,7 +65,7 @@ export const WalletCredentialsSection: React.FC<WalletCredentialsProps> = ({
           <p className="text-muted-foreground text-sm leading-relaxed">
             Manage your wallet credentials for different providers.{" "}
             <Link
-              href="https://portal.thirdweb.com/infrastructure/engine/features/wallet-credentials"
+              href="https://portal.thirdweb.com/engine/features/wallet-credentials"
               target="_blank"
             >
               Learn more about wallet credentials.


### PR DESCRIPTION
## [Portal] Fix: wrong URL



<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the links in the `credential-form.tsx` and `wallet-credentials.tsx` components to point to a new URL structure for wallet credentials in the thirdweb portal.

### Detailed summary
- In `credential-form.tsx`, the `href` for `TrackedLinkTW` is changed from `https://portal.thirdweb.com/infrastructure/engine/features/wallet-credentials` to `https://portal.thirdweb.com/engine/features/wallet-credentials`.
- In `wallet-credentials.tsx`, the `href` for `Link` is similarly updated from `https://portal.thirdweb.com/infrastructure/engine/features/wallet-credentials` to `https://portal.thirdweb.com/engine/features/wallet-credentials`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->