### PR TITLE
[SDK] Fix: Pause after onramp step

### DIFF
--- a/.changeset/good-mangos-look.md
+++ b/.changeset/good-mangos-look.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix race condition in onramp widget

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/fiat/OnRampScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/fiat/OnRampScreen.tsx
@@ -421,6 +421,7 @@ function useOnRampScreenState(props: {
     } else if (swapQuoteQuery.data && !swapTxHash) {
       // Execute swap/bridge
       try {
+        await new Promise((resolve) => setTimeout(resolve, 1000));
         const result = await swapMutation.mutateAsync({
           quote: swapQuoteQuery.data,
         });


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing a race condition in the `onramp` widget of the `thirdweb` package by introducing a delay before executing a swap/bridge operation.

### Detailed summary
- Updated the `thirdweb` package version to a patch.
- Added a delay of 1000 milliseconds using `setTimeout` before executing the swap/bridge in the `OnRampScreen.tsx` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->