### PR TITLE
[SDK] fix: Fetch fresh quotes before post onramp step in PayEmbed

### DIFF
--- a/.changeset/silly-times-shop.md
+++ b/.changeset/silly-times-shop.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Always fetch fresh quotes before post onramp step in PayEmbed

--- a/apps/playground-web/src/components/pay/embed.tsx
+++ b/apps/playground-web/src/components/pay/embed.tsx
@@ -18,6 +18,10 @@ export function StyledPayEmbedPreview() {
     <div className="flex flex-col items-center justify-center">
       <StyledConnectButton
         chains={[base, defineChain(466), arbitrum, treasure, arbitrumNova]}
+        accountAbstraction={{
+          sponsorGas: true,
+          chain: base,
+        }}
         supportedTokens={{
           466: [
             {
@@ -50,6 +54,12 @@ export function StyledPayEmbedPreview() {
       <PayEmbed
         client={THIRDWEB_CLIENT}
         theme={theme === "light" ? "light" : "dark"}
+        connectOptions={{
+          accountAbstraction: {
+            sponsorGas: true,
+            chain: base,
+          },
+        }}
         payOptions={{
           mode: "fund_wallet",
           metadata: {


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `PayEmbed` component by ensuring it always fetches fresh quotes before executing transactions and updates the handling of token information during the swap process.

### Detailed summary
- Updated `StyledPayEmbedPreview` to include `connectOptions` with `accountAbstraction`.
- Removed old `swapQuoteQuery` logic and replaced it with fresh quote fetching in `useSwapMutation`.
- Modified the mutation function to accept `fromToken`, `toToken`, and `amount` directly.
- Adjusted error handling to only check for `swapMutation` errors.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->