### PR TITLE
[SDK] fix: Handle wallet chain mismatch on post onramp flow

### DIFF
--- a/.changeset/quiet-melons-jump.md
+++ b/.changeset/quiet-melons-jump.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Handle wallet chain mismatch on post onramp flow

--- a/apps/playground-web/src/components/pay/embed.tsx
+++ b/apps/playground-web/src/components/pay/embed.tsx
@@ -18,10 +18,6 @@ export function StyledPayEmbedPreview() {
     <div className="flex flex-col items-center justify-center">
       <StyledConnectButton
         chains={[base, defineChain(466), arbitrum, treasure, arbitrumNova]}
-        accountAbstraction={{
-          sponsorGas: true,
-          chain: base,
-        }}
         supportedTokens={{
           466: [
             {
@@ -54,12 +50,6 @@ export function StyledPayEmbedPreview() {
       <PayEmbed
         client={THIRDWEB_CLIENT}
         theme={theme === "light" ? "light" : "dark"}
-        connectOptions={{
-          accountAbstraction: {
-            sponsorGas: true,
-            chain: base,
-          },
-        }}
         payOptions={{
           mode: "fund_wallet",
           metadata: {

--- a/packages/thirdweb/src/wallets/smart/index.ts
+++ b/packages/thirdweb/src/wallets/smart/index.ts
@@ -264,11 +264,12 @@ async function createSmartAccount(
         executeOverride: options.overrides?.execute,
       });
 
+      const chain = getCachedChain(transaction.chainId);
       const result = await _sendUserOp({
         executeTx,
         options: {
           ...options,
-          chain: getCachedChain(transaction.chainId),
+          chain,
           accountContract,
           overrides: {
             ...options.overrides,
@@ -278,7 +279,7 @@ async function createSmartAccount(
       });
       trackTransaction({
         client: options.client,
-        chainId: options.chain.id,
+        chainId: chain.id,
         transactionHash: result.transactionHash,
         walletAddress: options.accountContract.address,
         walletType: "smart",
@@ -292,17 +293,25 @@ async function createSmartAccount(
         transactions,
         executeBatchOverride: options.overrides?.executeBatch,
       });
+      if (transactions.length === 0) {
+        throw new Error("No transactions to send");
+      }
+      const firstTx = transactions[0];
+      if (!firstTx) {
+        throw new Error("No transactions to send");
+      }
+      const chain = getCachedChain(firstTx.chainId);
       const result = await _sendUserOp({
         executeTx,
         options: {
           ...options,
-          chain: getCachedChain(transactions[0]?.chainId ?? options.chain.id),
+          chain,
           accountContract,
         },
       });
       trackTransaction({
         client: options.client,
-        chainId: options.chain.id,
+        chainId: chain.id,
         transactionHash: result.transactionHash,
         walletAddress: options.accountContract.address,
         walletType: "smart",


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on handling wallet chain mismatches during the onramp flow and improving the account handling in various components within the `thirdweb` library.

### Detailed summary
- Updated wallet chain handling in `apps/playground-web/src/components/pay/embed.tsx`.
- Improved error handling for transactions in `packages/thirdweb/src/wallets/smart/index.ts`.
- Enhanced wallet chain verification and switching in `packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/ConfirmationScreen.tsx`.
- Added wallet chain checks in `packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/fiat/OnRampScreen.tsx`.
- Refactored account access from `props.payer` to direct wallet account access across multiple files.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->