### PR TITLE
chore: Add jittered retry on auth call

### DIFF
--- a/packages/service-utils/src/core/api.ts
+++ b/packages/service-utils/src/core/api.ts
@@ -210,8 +210,8 @@ export async function fetchTeamAndProject(
     } catch (err: unknown) {
       error = err;
       if (i < retryCount - 1) {
-        // Add a single retry with a delay between 50ms and 250ms.
-        await sleepRandomMs(50, 250);
+        // Add a single retry with a delay between 20ms and 400ms.
+        await sleepRandomMs(20, 400);
       }
     }
   }

--- a/packages/service-utils/src/core/api.ts
+++ b/packages/service-utils/src/core/api.ts
@@ -22,6 +22,10 @@ export type CoreServiceConfig = {
   serviceApiKey: string;
   serviceAction?: string;
   useWalletAuth?: boolean;
+  /**
+   * The number of times to retry the auth request. Default = 3.
+   */
+  retryCount?: number;
 };
 
 export type TeamAndProjectResponse = {
@@ -179,23 +183,46 @@ export async function fetchTeamAndProject(
   if (teamId) {
     url.searchParams.set("teamId", teamId);
   }
-  const response = await fetch(url, {
-    method: "GET",
-    headers: {
-      ...(authData.secretKey ? { "x-secret-key": authData.secretKey } : {}),
-      ...(authData.jwt ? { Authorization: `Bearer ${authData.jwt}` } : {}),
-      "x-service-api-key": serviceApiKey,
-      "content-type": "application/json",
-    },
-  });
 
-  let text = "";
-  try {
-    text = await response.text();
-    return JSON.parse(text);
-  } catch {
-    throw new Error(
-      `Error fetching key metadata from API: ${response.status} - ${text}`,
-    );
+  const retryCount = config.retryCount ?? 3;
+  let error: unknown | undefined;
+  for (let i = 0; i < retryCount; i++) {
+    try {
+      const response = await fetch(url, {
+        method: "GET",
+        headers: {
+          ...(authData.secretKey ? { "x-secret-key": authData.secretKey } : {}),
+          ...(authData.jwt ? { Authorization: `Bearer ${authData.jwt}` } : {}),
+          "x-service-api-key": serviceApiKey,
+          "content-type": "application/json",
+        },
+      });
+
+      let text = "";
+      try {
+        text = await response.text();
+        return JSON.parse(text);
+      } catch {
+        throw new Error(
+          `Error fetching key metadata from API: ${response.status} - ${text}`,
+        );
+      }
+    } catch (err: unknown) {
+      error = err;
+      if (i < retryCount - 1) {
+        // Add a single retry with a delay between 50ms and 250ms.
+        await sleepRandomMs(50, 250);
+      }
+    }
   }
+  throw error;
+}
+
+/**
+ * Sleeps for a random amount of time between min and max, in milliseconds.
+ */
+function sleepRandomMs(min: number, max: number) {
+  return new Promise((resolve) =>
+    setTimeout(resolve, Math.random() * (max - min) + min),
+  );
 }


### PR DESCRIPTION
Adds a retry (up to 3 attempts) with 20-400ms delay on auth calls

<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a `retryCount` option for the authentication request, allowing it to retry fetching team and project data up to a specified number of times. It also adds a helper function to introduce random delays between retries.

### Detailed summary
- Added optional `retryCount` property to the configuration with a default value of 3.
- Implemented a retry mechanism for the `fetchTeamAndProject` function, allowing up to `retryCount` attempts.
- Introduced `sleepRandomMs` function to add random delays between retries.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->