### PR TITLE
Revert "[Service-Utils] feat: Add engine-cloud service definition

### DIFF
--- a/packages/service-utils/src/core/api.ts
+++ b/packages/service-utils/src/core/api.ts
@@ -136,10 +136,6 @@ export type ProjectService =
       name: "nebula";
       actions: never[];
     }
-  | {
-      name: "engineCloud";
-      actions: never[];
-    }
   | ProjectBundlerService
   | ProjectEmbeddedWalletsService;
 

--- a/packages/service-utils/src/core/services.ts
+++ b/packages/service-utils/src/core/services.ts
@@ -74,14 +74,6 @@ export const SERVICE_DEFINITIONS = {
     // all actions allowed
     actions: [],
   },
-  engineCloud: {
-    name: "engineCloud",
-    title: "Server wallets",
-    description:
-      "Server wallets with high transaction throughput and low latency",
-    // all actions allowed
-    actions: [],
-  },
 } as const;
 
 export const SERVICE_NAMES = Object.keys(


### PR DESCRIPTION
This reverts commit 21389bbef6918a72df3ca1822ea7e5f697931c39.

<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on removing the `engineCloud` service definition from the `api.ts` and `services.ts` files, streamlining the service structure.

### Detailed summary
- Removed the `engineCloud` service definition in `api.ts`.
- Deleted the entire `engineCloud` object in `services.ts`, including its properties: `name`, `title`, `description`, and `actions`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->