### PR TITLE
[TypeDoc] Remove Gist update from workflow

### DIFF
--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -28,23 +28,3 @@ jobs:
 
       - name: Run TypeDoc
         run: pnpm typedoc
-
-      - name: Update Gist
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        with:
-          github-token: ${{ secrets.GIST_TOKEN }}
-          script: |
-            const fs = require('fs');
-            const content = fs.readFileSync('./packages/thirdweb/typedoc/parsed.json', 'utf8');
-            const gistId = '678fe1f331a01270bb002fee660f285d';
-            
-            await github.rest.gists.update({
-              gist_id: gistId,
-              files: {
-                'data.json': {
-                  content: content
-                }
-              }
-            });
-          
-            console.log(`Permalink: https://gist.githubusercontent.com/raw/${gistId}/data.json`);


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes the `Update Gist` step from the `.github/workflows/typedoc.yml` file, which previously updated a GitHub Gist with parsed TypeDoc JSON data.

### Detailed summary
- Removed the `Update Gist` step from the workflow.
- Deleted the usage of `actions/github-script` for updating Gist.
- Removed the script that read `parsed.json` and updated the Gist with its content.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->