### PR TITLE
chore: hide Engine projects from list

### DIFF
--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/projects/TeamProjectsPage.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/projects/TeamProjectsPage.tsx
@@ -75,6 +75,11 @@ export function TeamProjectsPage(props: {
       );
     }
 
+    // @TODO: HACK hide Engine projects from the list.
+    _projectsToShow = _projectsToShow.filter(
+      (project) => !project.name.startsWith("Cloud-hosted Engine ("),
+    );
+
     return _projectsToShow;
   }, [searchTerm, sortBy, projects]);
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a filter to exclude projects with names starting with "Cloud-hosted Engine (" from the list of projects displayed in the `TeamProjectsPage`.

### Detailed summary
- Added a filter to `_projectsToShow` to remove projects whose names start with "Cloud-hosted Engine (".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->