### PR TITLE
[SDK] Fix: Account for bigint values in engine typed data

### DIFF
--- a/.changeset/social-shoes-start.md
+++ b/.changeset/social-shoes-start.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Account for bigint values in engine wallet typed data

--- a/packages/thirdweb/src/wallets/engine/index.ts
+++ b/packages/thirdweb/src/wallets/engine/index.ts
@@ -1,3 +1,4 @@
+import { stringify } from "../../utils/json.js";
 import type { Chain } from "../../chains/types.js";
 import type { Hex } from "../../utils/encoding/hex.js";
 import { toHex } from "../../utils/encoding/hex.js";
@@ -108,7 +109,7 @@ export function engineAccount(options: EngineAccountOptions): Account {
       const engineRes = await fetch(ENGINE_URL, {
         method: "POST",
         headers,
-        body: JSON.stringify(engineData),
+        body: stringify(engineData),
       });
       if (!engineRes.ok) {
         const body = await engineRes.text();
@@ -178,7 +179,7 @@ export function engineAccount(options: EngineAccountOptions): Account {
       const engineRes = await fetch(ENGINE_URL, {
         method: "POST",
         headers,
-        body: JSON.stringify({
+        body: stringify({
           message: engineMessage,
           isBytes,
           chainId: chain?.id,
@@ -201,7 +202,7 @@ export function engineAccount(options: EngineAccountOptions): Account {
       const engineRes = await fetch(ENGINE_URL, {
         method: "POST",
         headers,
-        body: JSON.stringify({
+        body: stringify({
           domain: _typedData.domain,
           types: _typedData.types,
           value: _typedData.message,

--- a/packages/thirdweb/src/wallets/engine/index.ts
+++ b/packages/thirdweb/src/wallets/engine/index.ts
@@ -1,7 +1,7 @@
-import { stringify } from "../../utils/json.js";
 import type { Chain } from "../../chains/types.js";
 import type { Hex } from "../../utils/encoding/hex.js";
 import { toHex } from "../../utils/encoding/hex.js";
+import { stringify } from "../../utils/json.js";
 import type { Account, SendTransactionOption } from "../interfaces/wallet.js";
 
 /**


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the handling of wallet typed data in the `thirdweb` package to properly account for `bigint` values by replacing `JSON.stringify` with a custom `stringify` method.

### Detailed summary
- Updated `import` statement to include `stringify` from `../../utils/json.js`.
- Replaced `JSON.stringify(engineData)` with `stringify(engineData)` in the `engineAccount` function.
- Modified subsequent calls to `stringify` for consistency in handling typed data.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->