### PR TITLE
[TOOL-3833] Dashboard: Fix overflow scroll created by sr-only element

### DIFF
--- a/apps/dashboard/src/@/components/ui/breadcrumb.tsx
+++ b/apps/dashboard/src/@/components/ui/breadcrumb.tsx
@@ -96,7 +96,10 @@ const BreadcrumbEllipsis = ({
   <span
     role="presentation"
     aria-hidden="true"
-    className={cn("flex h-9 w-9 items-center justify-center", className)}
+    className={cn(
+      "relative flex h-9 w-9 items-center justify-center",
+      className,
+    )}
     {...props}
   >
     <MoreHorizontal className="h-4 w-4" />

--- a/apps/dashboard/src/@/components/ui/pagination.tsx
+++ b/apps/dashboard/src/@/components/ui/pagination.tsx
@@ -94,7 +94,10 @@ const PaginationEllipsis = ({
 }: React.ComponentProps<"span">) => (
   <span
     aria-hidden
-    className={cn("flex h-9 w-9 items-center justify-center", className)}
+    className={cn(
+      "relative flex h-9 w-9 items-center justify-center",
+      className,
+    )}
     {...props}
   >
     <MoreHorizontal className="h-4 w-4" />


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `className` property in two components, `pagination.tsx` and `breadcrumb.tsx`, to include a `relative` positioning style.

### Detailed summary
- In `pagination.tsx`, the `className` property is modified to include `relative`:
  - Changed from `className={cn("flex h-9 w-9 items-center justify-center", className)}` 
  - To `className={cn("relative flex h-9 w-9 items-center justify-center", className)}`
  
- In `breadcrumb.tsx`, the same change is applied to the `className` property:
  - Changed from `className={cn("flex h-9 w-9 items-center justify-center", className)}` 
  - To `className={cn("relative flex h-9 w-9 items-center justify-center", className)}`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->