### PR TITLE
Fix: Not Found Status should show Pending

### DIFF
--- a/.changeset/all-grapes-own.md
+++ b/.changeset/all-grapes-own.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix bug with PayEmbed incorrectly showing failed state

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/fiat/OnRampScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/fiat/OnRampScreen.tsx
@@ -583,10 +583,10 @@ function useSwapStatus(props: {
       uiStatus = "completed";
       break;
     case "FAILED":
-    case "NOT_FOUND":
       uiStatus = "failed";
       break;
     case "PENDING":
+    case "NOT_FOUND":
       uiStatus = "pending";
       break;
     case "NONE":


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing a bug in the `OnRampScreen.tsx` file related to the handling of different UI statuses during the payment process.

### Detailed summary
- Updated the `case` structure for handling payment statuses in `OnRampScreen.tsx`.
- Changed the handling of the `FAILED` case to ensure it correctly sets `uiStatus` to "failed".
- Adjusted the `PENDING` case to set `uiStatus` to "pending" when the `NOT_FOUND` case is encountered.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->