### PR TITLE
[PayEmbed] Respect supportedTokens prop

### DIFF
--- a/.changeset/modern-tables-sing.md
+++ b/.changeset/modern-tables-sing.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+respect supportedTokens prop in PayEmbed

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx
@@ -1,6 +1,7 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useMemo, useState } from "react";
 import type { Chain } from "../../../../../../chains/types.js";
+import { getCachedChain } from "../../../../../../chains/utils.js";
 import type { ThirdwebClient } from "../../../../../../client/client.js";
 import { NATIVE_TOKEN_ADDRESS } from "../../../../../../constants/addresses.js";
 import type { BuyWithCryptoStatus } from "../../../../../../pay/buyWithCrypto/getStatus.js";
@@ -112,10 +113,21 @@ export default function BuyScreen(props: BuyScreenProps) {
     return <LoadingScreen />;
   }
 
+  const supportedDestinations = props.supportedTokens
+    ? Object.entries(props.supportedTokens).map(([chainId, tokens]) => ({
+        chain: getCachedChain(Number.parseInt(chainId)),
+        tokens: tokens.map((t) => ({
+          ...t,
+          buyWithCryptoEnabled: true,
+          buyWithFiatEnabled: true,
+        })),
+      }))
+    : supportedDestinationsQuery.data;
+
   return (
     <BuyScreenContent
       {...props}
-      supportedDestinations={supportedDestinationsQuery.data}
+      supportedDestinations={supportedDestinations}
     />
   );
 }


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `BuyScreen` component to respect the `supportedTokens` prop, allowing it to dynamically set supported destinations for buying tokens.

### Detailed summary
- Added logic to handle `supportedTokens` prop in `BuyScreen`.
- If `supportedTokens` is provided, it maps through its entries to create a structured array of supported destinations.
- Updated the `supportedDestinations` prop passed to `BuyScreenContent` to use the new structure.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->