### PR TITLE
[SDK] fix: Use default contract params with optional overrides

### DIFF
--- a/packages/thirdweb/src/extensions/prebuilts/deploy-published.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/deploy-published.ts
@@ -110,9 +110,14 @@ export async function deployPublishedContract(
     chain,
     deployMetadata,
     client,
-    initializeParams: contractParams || deployMetadata.constructorParams,
-    implementationConstructorParams:
-      implementationConstructorParams || deployMetadata.implConstructorParams,
+    initializeParams: {
+      ...deployMetadata.constructorParams,
+      ...contractParams,
+    },
+    implementationConstructorParams: {
+      ...deployMetadata.implConstructorParams,
+      ...implementationConstructorParams,
+    },
     salt,
   });
 }

--- a/packages/thirdweb/src/extensions/prebuilts/deploy-published.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/deploy-published.ts
@@ -240,14 +240,15 @@ export async function deployContractfromDeployMetadata(
           client,
           account,
           contractId: deployMetadata.name,
-          constructorParams:
-            processedImplParams ||
-            (await getAllDefaultConstructorParamsForImplementation({
+          constructorParams: {
+            ...(await getAllDefaultConstructorParamsForImplementation({
               chain,
               client,
               contractId: deployMetadata.name,
               defaultExtensions: deployMetadata.defaultExtensions,
             })),
+            ...processedImplParams,
+          },
           publisher: deployMetadata.publisher,
           version: deployMetadata.version,
         });


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the way parameters are initialized and passed to the `deployContractfromDeployMetadata` function, enhancing the merging of constructor parameters for better clarity and maintainability.

### Detailed summary
- Changed `initializeParams` to merge `deployMetadata.constructorParams` and `contractParams` using the spread operator.
- Changed `implementationConstructorParams` to merge `deployMetadata.implConstructorParams` and `implementationConstructorParams` using the spread operator.
- Updated `constructorParams` to merge the result of `getAllDefaultConstructorParamsForImplementation` with `processedImplParams` using the spread operator.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->