### PR TITLE
[CLI] Fix secret key handling

### DIFF
--- a/.changeset/neat-clowns-wish.md
+++ b/.changeset/neat-clowns-wish.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix CLI secret key handling

--- a/packages/thirdweb/src/cli/bin.ts
+++ b/packages/thirdweb/src/cli/bin.ts
@@ -14,7 +14,6 @@ let secretKey: string | undefined;
 const keyIndex = rest.indexOf("-k");
 if (keyIndex !== -1 && rest.length > keyIndex + 1) {
   secretKey = rest[keyIndex + 1];
-  rest.splice(keyIndex, 2);
 }
 
 async function main() {

--- a/packages/thirdweb/src/cli/commands/stylus/builder.ts
+++ b/packages/thirdweb/src/cli/commands/stylus/builder.ts
@@ -29,7 +29,9 @@ export async function deployStylus(secretKey?: string) {
 
 async function buildStylus(spinner: Ora, secretKey?: string) {
   if (!secretKey) {
-    spinner.fail("Error: Secret key is required.");
+    spinner.fail(
+      "Error: Secret key is required. Please pass it via the -k parameter.",
+    );
     process.exit(1);
   }
 


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the handling of the secret key in the CLI for the `thirdweb` package, ensuring better user guidance when the key is not provided.

### Detailed summary
- Updated the error message in `buildStylus` function to specify that the secret key should be passed via the `-k` parameter.
- Removed the line that splices the `rest` array in `bin.ts` after extracting the secret key.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->