### PR TITLE
[SDK] Add erc20Value for makeOffer extension function

### DIFF
--- a/.changeset/wicked-kings-joke.md
+++ b/.changeset/wicked-kings-joke.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Add erc20Value for makeOffer extension function

--- a/packages/thirdweb/src/extensions/marketplace/offers/write/makeOffer.ts
+++ b/packages/thirdweb/src/extensions/marketplace/offers/write/makeOffer.ts
@@ -94,6 +94,7 @@ export function makeOffer(options: BaseTransactionOptions<MakeOfferParams>) {
           }
           // otherwise determine the wrapped native token address for the chain
 
+          // TODO: auto wrap native tokens if the currency is a native token address
           // TODO: add known wrapped native token addresses for each chain on the chain config
 
           const { getDeployedInfraContract } = await import(
@@ -127,6 +128,14 @@ export function makeOffer(options: BaseTransactionOptions<MakeOfferParams>) {
           quantity: options.quantity ?? 1n,
           tokenId: options.tokenId,
           totalPrice: normalizedPrice,
+        },
+        overrides: {
+          erc20Value: isNativeTokenAddress(currency)
+            ? undefined
+            : {
+                tokenAddress: currency,
+                amountWei: normalizedPrice,
+              },
         },
       };
     },


### PR DESCRIPTION
Fixes TOOL-3864

<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces an `erc20Value` property in the `makeOffer` function of the `thirdweb` marketplace extension, allowing for better handling of offers that involve ERC20 tokens.

### Detailed summary
- Added `erc20Value` in the `overrides` object of the `makeOffer` function.
- The `erc20Value` is conditionally set based on whether the `currency` is a native token address.
- If not a native token, it includes `tokenAddress` and `amountWei` for the ERC20 token.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->