### PR TITLE
[portal] added module warning

### DIFF
--- a/apps/portal/src/app/contracts/modular-contracts/module-contracts/cross-chain/agglayer/page.mdx
+++ b/apps/portal/src/app/contracts/modular-contracts/module-contracts/cross-chain/agglayer/page.mdx
@@ -16,6 +16,10 @@ interoperable smart contract for trustless and secure transfers across any chain
 
 Learn how to add the Agglayer module to your modular contract and enable cross-chain transfers.
 
+<Callout variant="warning" title="Beta Module">
+This module is currently in beta while the Agglayer bridge is not live in implementation. This means deployments are limited to Sepolia and Cardona as it requires Ethereum as an L1 and zkEVM as L2.
+</Callout>
+
 ### Prerequisites
 
 - [Deployed ERC-20 Base Contract](/contracts/modular-contracts/tutorials/deploy-erc20-core)


### PR DESCRIPTION
CORE-0000

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a warning callout to the `page.mdx` file for the `Agglayer` module, indicating its beta status and deployment limitations.

### Detailed summary
- Added a warning callout with the title "Beta Module".
- Explained that the `Agglayer` module is in beta and that deployments are limited to `Sepolia` and `Cardona`.
- Mentioned the requirement of `Ethereum` as L1 and `zkEVM` as L2 for the module.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->