### PR TITLE
Remove tutorial routes from framer rewrites

### DIFF
--- a/apps/dashboard/framer-rewrites.js
+++ b/apps/dashboard/framer-rewrites.js
@@ -49,8 +49,6 @@ module.exports = [
   "/templates/:template_slug",
   // -- learn --
   "/learn",
-  "/learn/tutorials",
-  "/learn/tutorials/:tutorial_slug",
   "/learn/guides",
   "/learn/guides/:guide_slug",
   "/learn/courses",

--- a/apps/dashboard/redirects.js
+++ b/apps/dashboard/redirects.js
@@ -361,6 +361,19 @@ async function redirects() {
         "/team/:team_slug/:project_slug/connect/universal-bridge/:path*",
       permanent: false,
     },
+
+    // all /learn/tutorials (and sub-routes) -> /learn/guides
+    {
+      source: "/learn/tutorials/:path*",
+      destination: "/learn/guides/:path*",
+      permanent: false,
+    },
+    {
+      source: "/learn/tutorials",
+      destination: "/learn/guides",
+      permanent: false,
+    },
+
     ...legacyDashboardToTeamRedirects,
   ];
 }


### PR DESCRIPTION
closes: CORE-802

Redirect `/learn/tutorials` to `/learn/guides`

This PR removes `/learn/tutorials` and `/learn/tutorials/:tutorial_slug` from the framer-rewrites list and adds redirects from these paths to their corresponding `/learn/guides` equivalents.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the routing structure for the `/learn/tutorials` paths, redirecting them to `/learn/guides` instead. This change improves the organization of the dashboard's navigation.

### Detailed summary
- Removed routes for `"/learn/tutorials"` and `"/learn/tutorials/:tutorial_slug"` in `apps/dashboard/framer-rewrites.js`.
- Added redirects in `apps/dashboard/redirects.js`:
  - Redirect all `/learn/tutorials` and sub-routes to `/learn/guides`.
  - Two new entries for redirecting `/learn/tutorials/:path*` and `/learn/tutorials` to `/learn/guides`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->