### PR TITLE
[SDK] Fix bytecode caching

### DIFF
--- a/.changeset/neat-wasps-count.md
+++ b/.changeset/neat-wasps-count.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix bytecode caching

--- a/packages/thirdweb/src/extensions/prebuilts/process-ref-deployments.test.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/process-ref-deployments.test.ts
@@ -74,9 +74,7 @@ describe.runIf(process.env.TW_SECRET_KEY)(
         chain: ANVIL_CHAIN,
         account: TEST_ACCOUNT_A,
         contractId: "WETH9",
-        version: "0.0.1",
         salt: "",
-        publisher: "0x6453a486d52e0EB6E79Ec4491038E2522a926936",
       });
       forwarderAddress = await deployPublishedContract({
         client: TEST_CLIENT,

--- a/packages/thirdweb/src/utils/any-evm/deploy-metadata.ts
+++ b/packages/thirdweb/src/utils/any-evm/deploy-metadata.ts
@@ -96,7 +96,7 @@ export async function fetchBytecodeFromCompilerMetadata(options: {
       return deployBytecode;
     },
     {
-      cacheKey: `bytecode:${compilerMetadata.name}:${chain.id}`,
+      cacheKey: `bytecode:${compilerMetadata.name}:${compilerMetadata.publisher}:${compilerMetadata.version}:${chain.id}`,
       cacheTime: 24 * 60 * 60 * 1000,
     },
   );


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving bytecode caching in the `thirdweb` package by enhancing the cache key to include additional metadata attributes.

### Detailed summary
- Updated the `cacheKey` in `deploy-metadata.ts` to include `compilerMetadata.publisher` and `compilerMetadata.version`.
- Removed the `version` and `publisher` fields from the test data in `process-ref-deployments.test.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->