### PR TITLE
[Playground] Fix: Filter UB Backend API for only GETs

### DIFF
--- a/apps/playground-web/src/app/connect/pay/backend/page.tsx
+++ b/apps/playground-web/src/app/connect/pay/backend/page.tsx
@@ -1,3 +1,4 @@
+import { Button } from "@/components/ui/button";
 import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table";
 import Link from "next/link";
 import { getBridgePaths } from "./utils";
@@ -7,27 +8,39 @@ export default async function Page() {
     const paths = await getBridgePaths();
     return (
       <div className="pb-20">
-        <h2 className="mb-2 font-semibold text-2xl tracking-tight">
-          Universal Bridge REST API
-        </h2>
-        <p className="mb-5 text-muted-foreground">
-          Directly interact with the Universal Bridge API from your backend,
-          using standard REST api.
-        </p>
+        <div className="flex flex-col justify-between py-6 md:flex-row md:gap-8">
+          <div>
+            <h2 className="mb-2 font-semibold text-2xl tracking-tight">
+              Universal Bridge REST API
+            </h2>
+            <p className="mb-5 text-muted-foreground">
+              Directly interact with the Universal Bridge API from your backend,
+              using standard REST APIs.
+            </p>
+          </div>
+
+          <Link href="https://bridge.thirdweb.com/reference" target="_blank">
+            <Button className="max-md:w-full">View all endpoints</Button>
+          </Link>
+        </div>
 
         <div className="flex flex-col gap-8">
           <BlueprintSection
-            title="Available endpoints"
-            blueprints={paths.map(([pathName, pathObj]) => {
-              if (!pathObj) {
-                throw new Error(`Path not found: ${pathName}`);
-              }
-              return {
-                name: pathName,
-                description: pathObj.get?.description || "",
-                link: `/connect/pay/backend/reference?route=${pathName}`,
-              };
-            })}
+            title="Available GET endpoints"
+            blueprints={paths
+              .filter(
+                ([_pathName, pathObj]) => typeof pathObj?.get !== "undefined",
+              )
+              .map(([pathName, pathObj]) => {
+                if (!pathObj) {
+                  throw new Error(`Path not found: ${pathName}`);
+                }
+                return {
+                  name: pathName,
+                  description: pathObj.get?.description || "",
+                  link: `/connect/pay/backend/reference?route=${pathName}`,
+                };
+              })}
           />
         </div>
       </div>


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the user interface of the `Page` component in the `page.tsx` file by restructuring the layout and adding a link to view API endpoints. It also refines the filtering of available endpoints to only include those with a defined `get` method.

### Detailed summary
- Wrapped the heading and description in a new `div` for better layout.
- Added a `Link` component to navigate to API reference.
- Changed the title of the `BlueprintSection` from "Available endpoints" to "Available GET endpoints".
- Updated the filtering logic to only include endpoints with a defined `get` method.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->