### PR TITLE
[SDK] Only onramp for required transaction amount

### DIFF
--- a/.changeset/cyan-kids-hide.md
+++ b/.changeset/cyan-kids-hide.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Only onramp for the amount required for transaction flows in PayEmbed

--- a/packages/thirdweb/src/bridge/Buy.test.ts
+++ b/packages/thirdweb/src/bridge/Buy.test.ts
@@ -35,7 +35,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("Bridge.Buy.quote", () => {
   });
 });
 
-describe("Bridge.Buy.prepare", () => {
+describe.runIf(process.env.TW_SECRET_KEY)("Bridge.Buy.prepare", () => {
   it("should get a valid prepared quote", async () => {
     const quote = await Buy.prepare({
       originChainId: 1,

--- a/packages/thirdweb/src/bridge/Sell.test.ts
+++ b/packages/thirdweb/src/bridge/Sell.test.ts
@@ -35,7 +35,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("Bridge.Sell.quote", () => {
   });
 });
 
-describe("Bridge.Sell.prepare", () => {
+describe.runIf(process.env.TW_SECRET_KEY)("Bridge.Sell.prepare", () => {
   it("should get a valid prepared quote", async () => {
     const quote = await Sell.prepare({
       originChainId: 1,

--- a/packages/thirdweb/src/pay/buyWithCrypto/getQuote.ts
+++ b/packages/thirdweb/src/pay/buyWithCrypto/getQuote.ts
@@ -259,8 +259,6 @@ export async function getBuyWithCryptoQuote(
         data: data.transactionRequest.data as Hash,
         to: data.transactionRequest.to,
         value: BigInt(data.transactionRequest.value),
-        gas: BigInt(data.transactionRequest.gasLimit),
-        gasPrice: undefined, // ignore gas price returned by the quote, we handle it ourselves
       },
       approvalData,
       swapDetails: {

--- a/packages/thirdweb/src/pay/buyWithCrypto/getTransfer.ts
+++ b/packages/thirdweb/src/pay/buyWithCrypto/getTransfer.ts
@@ -155,7 +155,6 @@ export async function getBuyWithCryptoTransfer(
         data: data.transactionRequest.data as Hash,
         to: data.transactionRequest.to as Address,
         value: BigInt(data.transactionRequest.value),
-        gas: BigInt(data.transactionRequest.gasLimit),
       },
       approvalData: data.approval,
       fromAddress: data.fromAddress,

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx
@@ -625,7 +625,7 @@ function SelectedTokenInfo(props: {
   disabled?: boolean;
 }) {
   const getWidth = () => {
-    const amount = formatNumber(Number(props.tokenAmount), 5).toString();
+    const amount = formatNumber(Number(props.tokenAmount), 6).toString();
     let chars = amount.replace(".", "").length;
     const hasDot = amount.includes(".");
     if (hasDot) {

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/TransactionModeScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/TransactionModeScreen.tsx
@@ -334,7 +334,10 @@ export function TransactionModeScreen(props: {
           variant="accent"
           fullWidth
           onClick={() => {
-            let totalCostWei = transactionCostAndData.transactionValueWei;
+            let totalCostWei = insufficientFunds
+              ? transactionCostAndData.transactionValueWei -
+                (balanceQuery.data?.value || 0n)
+              : transactionCostAndData.transactionValueWei;
             if (
               transactionCostAndData.token.address === NATIVE_TOKEN_ADDRESS &&
               !sponsoredTransactionsEnabled


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying the `thirdweb` package, particularly enhancing transaction flow handling in `PayEmbed`, adjusting test descriptions to conditionally run based on an environment variable, and refining the formatting of amounts and transaction cost calculations.

### Detailed summary
- Updated `getTransfer.ts` to remove `gas` from the transaction request.
- Changed test descriptions in `Buy.test.ts` and `Sell.test.ts` to use `describe.runIf(process.env.TW_SECRET_KEY)`.
- Adjusted the number of decimal places in `BuyScreen.tsx` from 5 to 6.
- Modified the calculation of `totalCostWei` in `TransactionModeScreen.tsx` to account for insufficient funds.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->