### PR TITLE
[SDK] Show past transactions in transactions modal screen

### DIFF
--- a/.changeset/fruity-cooks-know.md
+++ b/.changeset/fruity-cooks-know.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Show past transactions in transactions modal screen

--- a/apps/playground-web/src/app/insight/[blueprint_slug]/blueprint-playground.client.tsx
+++ b/apps/playground-web/src/app/insight/[blueprint_slug]/blueprint-playground.client.tsx
@@ -160,6 +160,10 @@ export function BlueprintPlaygroundUI(props: {
     for (const param of parameters) {
       if (param.schema && "type" in param.schema && param.schema.default) {
         values[param.name] = param.schema.default;
+      } else if (param.name === "filter_block_timestamp_gte") {
+        values[param.name] = Math.floor(
+          (Date.now() - 3 * 30 * 24 * 60 * 60 * 1000) / 1000,
+        );
       } else {
         values[param.name] = "";
       }

--- a/packages/thirdweb/src/react/core/hooks/contract/useWaitForReceipt.ts
+++ b/packages/thirdweb/src/react/core/hooks/contract/useWaitForReceipt.ts
@@ -17,7 +17,9 @@ import {
  * @transaction
  */
 export function useWaitForReceipt(
-  options: WaitForReceiptOptions | undefined,
+  options:
+    | (WaitForReceiptOptions & { queryOptions?: { enabled?: boolean } })
+    | undefined,
 ): UseQueryResult<TransactionReceipt> {
   return useQuery({
     queryKey: [
@@ -32,7 +34,8 @@ export function useWaitForReceipt(
       }
       return waitForReceipt(options);
     },
-    enabled: !!options?.transactionHash,
+    enabled:
+      !!options?.transactionHash && (options?.queryOptions?.enabled ?? true),
     retry: false,
   });
 }

--- a/packages/thirdweb/src/transaction/transaction-store.ts
+++ b/packages/thirdweb/src/transaction/transaction-store.ts
@@ -1,9 +1,17 @@
+import type { Chain } from "../chains/types.js";
+import type { ThirdwebClient } from "../client/client.js";
 import { type Store, createStore } from "../reactive/store.js";
+import { getThirdwebDomains } from "../utils/domains.js";
 import type { Hex } from "../utils/encoding/hex.js";
+import { getClientFetch } from "../utils/fetch.js";
 
 export type StoredTransaction = {
   transactionHash: Hex;
   chainId: number;
+  receipt?: {
+    status: "success" | "failed";
+    to: string;
+  };
 };
 
 const transactionsByAddress = new Map<string, Store<StoredTransaction[]>>();
@@ -33,6 +41,7 @@ export function getTransactionStore(
 
   const newStore = createStore<StoredTransaction[]>([]);
   transactionsByAddress.set(address, newStore);
+
   return newStore;
 }
 
@@ -53,4 +62,45 @@ export function addTransactionToStore(options: {
   ]);
 
   transactionsByAddress.set(address, tranasctionStore);
+}
+
+/**
+ * @internal for now
+ */
+export async function getPastTransactions(options: {
+  walletAddress: string;
+  chain: Chain;
+  client: ThirdwebClient;
+}): Promise<StoredTransaction[]> {
+  const { walletAddress, chain, client } = options;
+  const oneMonthsAgoInSeconds = Math.floor(
+    (Date.now() - 1 * 30 * 24 * 60 * 60 * 1000) / 1000,
+  );
+  const url = new URL(
+    `https://${getThirdwebDomains().insight}/v1/wallets/${walletAddress}/transactions`,
+  );
+  url.searchParams.set("limit", "10");
+  url.searchParams.set("chain", chain.id.toString());
+  url.searchParams.set(
+    "filter_block_timestamp_gte",
+    oneMonthsAgoInSeconds.toString(),
+  );
+  const clientFetch = getClientFetch(client);
+  const result = await clientFetch(url.toString());
+  const json = (await result.json()) as {
+    data: {
+      chain_id: number;
+      hash: string;
+      status: number;
+      to_address: string;
+    }[];
+  };
+  return json.data.map((tx) => ({
+    transactionHash: tx.hash as Hex,
+    chainId: tx.chain_id,
+    receipt: {
+      status: tx.status === 1 ? "success" : "failed",
+      to: tx.to_address,
+    },
+  }));
 }

--- a/packages/thirdweb/src/utils/domain.test.ts
+++ b/packages/thirdweb/src/utils/domain.test.ts
@@ -15,6 +15,7 @@ describe("Thirdweb Domains", () => {
     storage: "storage.thirdweb.com",
     bundler: "bundler.thirdweb.com",
     analytics: "c.thirdweb.com",
+    insight: "insight.thirdweb.com",
   };
 
   beforeEach(() => {

--- a/packages/thirdweb/src/utils/domains.ts
+++ b/packages/thirdweb/src/utils/domains.ts
@@ -34,6 +34,11 @@ type DomainOverrides = {
    * @default "c.thirdweb.com"
    */
   analytics?: string;
+  /**
+   * The base URL for the insight server.
+   * @default "insight.thirdweb.com"
+   */
+  insight?: string;
 };
 
 export const DEFAULT_RPC_URL = "rpc.thirdweb.com";
@@ -43,7 +48,7 @@ const DEFAULT_PAY_URL = "pay.thirdweb.com";
 const DEFAULT_STORAGE_URL = "storage.thirdweb.com";
 const DEFAULT_BUNDLER_URL = "bundler.thirdweb.com";
 const DEFAULT_ANALYTICS_URL = "c.thirdweb.com";
-
+const DEFAULT_INSIGHT_URL = "insight.thirdweb.com";
 let domains: { [k in keyof DomainOverrides]-?: string } = {
   rpc: DEFAULT_RPC_URL,
   inAppWallet: DEFAULT_IN_APP_WALLET_URL,
@@ -52,6 +57,7 @@ let domains: { [k in keyof DomainOverrides]-?: string } = {
   storage: DEFAULT_STORAGE_URL,
   bundler: DEFAULT_BUNDLER_URL,
   analytics: DEFAULT_ANALYTICS_URL,
+  insight: DEFAULT_INSIGHT_URL,
 };
 
 /**
@@ -66,6 +72,7 @@ export const setThirdwebDomains = (DomainOverrides: DomainOverrides) => {
     storage: DomainOverrides.storage ?? DEFAULT_STORAGE_URL,
     bundler: DomainOverrides.bundler ?? DEFAULT_BUNDLER_URL,
     analytics: DomainOverrides.analytics ?? DEFAULT_ANALYTICS_URL,
+    insight: DomainOverrides.insight ?? DEFAULT_INSIGHT_URL,
   };
 };
 


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `thirdweb` package by adding functionality to fetch and display past transactions in the wallet's transaction history. It introduces a new API endpoint for retrieving transactions and updates the UI to show this data.

### Detailed summary
- Added `insight` URL configuration to `domains`.
- Introduced `getPastTransactions` function to fetch recent transactions.
- Updated `WalletTransactionHistory` component to integrate transaction fetching.
- Enhanced `TransactionButton` to handle transaction receipts.
- Improved loading state handling for transaction data.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->