### PR TITLE
Remove custom config for Ronin

### DIFF
--- a/.changeset/stupid-rice-show.md
+++ b/.changeset/stupid-rice-show.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Remove custom config for Ronin

--- a/packages/thirdweb/src/contract/deployment/utils/create-2-factory.ts
+++ b/packages/thirdweb/src/contract/deployment/utils/create-2-factory.ts
@@ -317,10 +317,6 @@ const CUSTOM_GAS_FOR_CHAIN: Record<string, CustomChain> = {
     name: "Europa",
     gasPrice: 110000n,
   },
-  "2020": {
-    name: "Ronin",
-    gasPrice: 110n * 10n ** 9n,
-  },
 };
 
 const FACTORIES: Record<string, string> = {


### PR DESCRIPTION
Create2 deployer restrictions are lifted by the chain. Enable deployments through default create2 factory.

<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on removing the custom configuration for the `Ronin` network from the `thirdweb` package.

### Detailed summary
- Removed the `Ronin` network configuration, including its `name` and `gasPrice`, from the `create-2-factory.ts` file.
- Updated the `gasPrice` value for another network to `110000n`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->