### PR TITLE
[SDK] Handle entrypoint resolution inside createAndSignUserOp

### DIFF
--- a/.changeset/eight-pants-help.md
+++ b/.changeset/eight-pants-help.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+handle entrypoint resolution inside createAndSignUserOp

--- a/packages/thirdweb/src/wallets/smart/lib/userop.ts
+++ b/packages/thirdweb/src/wallets/smart/lib/userop.ts
@@ -23,6 +23,7 @@ import { keccak256 } from "../../../utils/hashing/keccak256.js";
 import { stringify } from "../../../utils/json.js";
 import { resolvePromisedValue } from "../../../utils/promise/resolve-promised-value.js";
 import type { Account } from "../../interfaces/wallet.js";
+import { getEntrypointFromFactory } from "../index.js";
 import type {
   BundlerOptions,
   PaymasterResult,
@@ -749,6 +750,23 @@ export async function createAndSignUserOp(options: {
   waitForDeployment?: boolean;
   isDeployedOverride?: boolean;
 }) {
+  // if factory is passed, but no entrypoint, try to resolve entrypoint from factory
+  if (
+    options.smartWalletOptions.factoryAddress &&
+    !options.smartWalletOptions.overrides?.entrypointAddress
+  ) {
+    const entrypointAddress = await getEntrypointFromFactory(
+      options.smartWalletOptions.factoryAddress,
+      options.client,
+      options.smartWalletOptions.chain,
+    );
+    if (entrypointAddress) {
+      options.smartWalletOptions.overrides = {
+        ...options.smartWalletOptions.overrides,
+        entrypointAddress,
+      };
+    }
+  }
   const unsignedUserOp = await prepareUserOp({
     transactions: options.transactions,
     adminAccount: options.adminAccount,

--- a/packages/thirdweb/src/wallets/smart/smart-wallet-integration-v07.test.ts
+++ b/packages/thirdweb/src/wallets/smart/smart-wallet-integration-v07.test.ts
@@ -33,6 +33,7 @@ import {
   confirmContractDeployment,
   deploySmartAccount,
 } from "./lib/signing.js";
+import { createAndSignUserOp } from "./lib/userop.js";
 import { smartWallet } from "./smart-wallet.js";
 
 let wallet: Wallet;
@@ -362,6 +363,26 @@ describe.runIf(process.env.TW_SECRET_KEY).sequential(
 
       isDeployed = await isContractDeployed(newSmartAccountContract);
       expect(isDeployed).toEqual(true);
+    });
+
+    it("can prep a 0.7 userop", async () => {
+      const tx = prepareTransaction({
+        client,
+        chain,
+        to: smartAccount.address,
+        value: 0n,
+      });
+      const uo = await createAndSignUserOp({
+        transactions: [tx],
+        adminAccount: personalAccount,
+        client: TEST_CLIENT,
+        smartWalletOptions: {
+          chain,
+          sponsorGas: true,
+          factoryAddress: DEFAULT_ACCOUNT_FACTORY_V0_7,
+        },
+      });
+      expect(uo.callData.length).toBeGreaterThan(0);
     });
   },
 );


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `createAndSignUserOp` function to handle entrypoint resolution when a factory address is provided but no entrypoint is specified. Additionally, it introduces a test for preparing a user operation.

### Detailed summary
- Added a test case to verify preparation of a 0.7 user operation in `smart-wallet-integration-v07.test.ts`.
- Enhanced `createAndSignUserOp` in `userop.ts` to resolve the entrypoint from the factory if not explicitly provided.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->