### PR TITLE
Add /brand-kit to framer rewrites

### DIFF
--- a/apps/dashboard/framer-rewrites.js
+++ b/apps/dashboard/framer-rewrites.js
@@ -56,4 +56,6 @@ module.exports = [
   "/learn/glossary/:glossary_slug",
   // -- faucets --
   "/faucets",
+  // -- brand kit --
+  "/brand-kit",
 ];


### PR DESCRIPTION
Added a rewrite rule for the `/brand-kit` path in the Framer rewrites configuration.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `apps/dashboard/framer-rewrites.js` file by adding a new route for the `brand kit` section, indicating an enhancement in the dashboard's navigation.

### Detailed summary
- Added a new route for the `brand kit` section: `"/brand-kit"`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->