### PR TITLE
[SDK] Emit accountChanged event when smart wallets switch chains

### DIFF
--- a/.changeset/good-corners-stare.md
+++ b/.changeset/good-corners-stare.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Emit accountChanged event when smart wallets switch chains

--- a/packages/thirdweb/src/wallets/smart/smart-wallet.ts
+++ b/packages/thirdweb/src/wallets/smart/smart-wallet.ts
@@ -234,7 +234,8 @@ export function smartWallet(
       // set the states
       account = connectedAccount;
       chain = connectedChain;
-      emitter.emit("chainChanged", newChain);
+      emitter.emit("accountChanged", connectedAccount);
+      emitter.emit("chainChanged", connectedChain);
     },
   };
 }


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying the event emissions in the `smart-wallet.ts` file to emit an `accountChanged` event when smart wallets switch chains, enhancing the event handling for account and chain changes.

### Detailed summary
- In `packages/thirdweb/src/wallets/smart/smart-wallet.ts`:
  - Changed the event emission from `chainChanged` to `accountChanged` for `connectedAccount`.
  - Retained the `chainChanged` emission for `connectedChain`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->