### PR TITLE
[SDK] Fix updateListing date handling in marketplace direct listings

### DIFF
--- a/.changeset/new-spoons-lick.md
+++ b/.changeset/new-spoons-lick.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix updateListing date handling

--- a/packages/thirdweb/src/exports/extensions/erc721.ts
+++ b/packages/thirdweb/src/exports/extensions/erc721.ts
@@ -50,6 +50,11 @@ export {
   isApprovedForAll,
   type IsApprovedForAllParams,
 } from "../../extensions/erc721/__generated__/IERC721A/read/isApprovedForAll.js";
+export {
+  type GetApprovedParams,
+  isGetApprovedSupported,
+  getApproved,
+} from "../../extensions/erc721/__generated__/IERC721A/read/getApproved.js";
 export { getTotalUnclaimedSupply } from "../../extensions/erc721/read/getTotalUnclaimedSupply.js";
 export { getTotalClaimedSupply } from "../../extensions/erc721/read/getTotalClaimedSupply.js";
 export {

--- a/packages/thirdweb/src/extensions/marketplace/direct-listings/direct-listings.test.ts
+++ b/packages/thirdweb/src/extensions/marketplace/direct-listings/direct-listings.test.ts
@@ -34,6 +34,7 @@ import { getListing } from "./read/getListing.js";
 import { isListingValid } from "./utils.js";
 import { buyFromListing } from "./write/buyFromListing.js";
 import { createListing } from "./write/createListing.js";
+import { updateListing } from "./write/updateListing.js";
 
 const chain = ANVIL_CHAIN;
 const client = TEST_CLIENT;
@@ -302,6 +303,18 @@ describe.runIf(process.env.TW_SECRET_KEY)("Marketplace Direct Listings", () => {
     expect(listingEvent1155.args.listingCreator).toBe(TEST_ACCOUNT_C.address);
     expect(listingEvent1155.args.assetContract).toBe(erc1155Contract.address);
 
+    await sendAndConfirmTransaction({
+      transaction: updateListing({
+        listingId: listingEvent1155.args.listingId,
+        contract: marketplaceContract,
+        assetContractAddress: erc1155Contract.address,
+        tokenId: 0n,
+        pricePerToken: "0.05",
+        quantity: 1n,
+      }),
+      account: TEST_ACCOUNT_C,
+    });
+
     const [
       listings1155After,
       validListings1155,
@@ -341,10 +354,10 @@ describe.runIf(process.env.TW_SECRET_KEY)("Marketplace Direct Listings", () => {
     expect(secondListing.currencyValuePerToken).toMatchInlineSnapshot(`
       {
         "decimals": 18,
-        "displayValue": "0.01",
+        "displayValue": "0.05",
         "name": "Anvil Ether",
         "symbol": "ETH",
-        "value": 10000000000000000n,
+        "value": 50000000000000000n,
       }
     `);
     expect(secondListing.asset.metadata.name).toBe("erc1155 #0");

--- a/packages/thirdweb/src/extensions/marketplace/direct-listings/write/updateListing.ts
+++ b/packages/thirdweb/src/extensions/marketplace/direct-listings/write/updateListing.ts
@@ -120,25 +120,25 @@ export function updateListing(
       }
 
       // validate the timestamps
-      let startTimestamp = BigInt(
-        Math.floor(
-          (mergedOptions.startTimestamp ?? new Date()).getTime() / 1000,
-        ),
-      );
-      const endTimestamp = BigInt(
-        Math.floor(
-          (
-            mergedOptions.endTimestamp ??
-            new Date(Date.now() + 10 * 365 * 24 * 60 * 60 * 1000)
-          ).getTime() / 1000,
-        ),
-      );
+      let startTimestamp = mergedOptions.startTimestamp
+        ? BigInt(Math.floor(mergedOptions.startTimestamp.getTime() / 1000))
+        : mergedOptions.startTimeInSeconds;
 
-      if (startTimestamp <= lastestBlock.timestamp) {
+      const endTimestamp = mergedOptions.endTimestamp
+        ? BigInt(Math.floor(mergedOptions.endTimestamp.getTime() / 1000))
+        : mergedOptions.endTimeInSeconds;
+
+      if (
+        startTimestamp !== mergedOptions.startTimeInSeconds &&
+        startTimestamp <= lastestBlock.timestamp
+      ) {
         // set the start time to the next block if it is in the past
         startTimestamp = lastestBlock.timestamp + 1n;
       }
-      if (startTimestamp >= endTimestamp) {
+      if (
+        startTimestamp !== mergedOptions.startTimeInSeconds &&
+        startTimestamp >= endTimestamp
+      ) {
         throw new Error("Start time must be before end time.");
       }
 


### PR DESCRIPTION
Fixes TOOL-3924

<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the handling of date timestamps in the `updateListing` function within the `thirdweb` package, ensuring correct validation and assignment of start and end timestamps.

### Detailed summary
- Updated `startTimestamp` and `endTimestamp` assignment logic in `updateListing.ts` to handle cases with `mergedOptions`.
- Added validation to ensure `startTimestamp` is before `endTimestamp`.
- Introduced a test case for `updateListing` in `direct-listings.test.ts`.
- Adjusted expected values for `secondListing` in the test to reflect the new price.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->