### PR TITLE
[SDK] Fix ethers6 provider override

### DIFF
--- a/.changeset/solid-aliens-eat.md
+++ b/.changeset/solid-aliens-eat.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix ethers6 provider override

--- a/packages/thirdweb/src/adapters/ethers6.ts
+++ b/packages/thirdweb/src/adapters/ethers6.ts
@@ -374,12 +374,10 @@ export function toEthersSigner(
 ): ethers6.Signer {
   class ThirdwebAdapterSigner extends ethers.AbstractSigner<ethers6.JsonRpcProvider> {
     private address: string;
-    override provider: ethers6.ethers.JsonRpcProvider;
 
     constructor(provider: ethers6.JsonRpcProvider, address: string) {
       super(provider);
       this.address = address;
-      this.provider = provider;
     }
 
     override async getAddress(): Promise<string> {

--- a/packages/thirdweb/src/utils/any-evm/zksync/constants.ts
+++ b/packages/thirdweb/src/utils/any-evm/zksync/constants.ts
@@ -3,7 +3,7 @@ export const ZKSYNC_SINGLETON_FACTORY =
 export const CONTRACT_DEPLOYER_ADDRESS =
   "0x0000000000000000000000000000000000008006" as const;
 export const KNOWN_CODES_STORAGE = "0x0000000000000000000000000000000000008004";
-export const PUBLISHED_PRIVATE_KEY = "";
+export const PUBLISHED_PRIVATE_KEY = process.env.ZKSYNC_PUBLISHED_PRIVATE_KEY;
 
 export const singletonFactoryAbi = [
   "function deploy(bytes32,bytes32,bytes) external payable",


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the `ethers6` provider override in the `ThirdwebAdapterSigner` class and updating the `PUBLISHED_PRIVATE_KEY` constant to use an environment variable.

### Detailed summary
- Updated `ThirdwebAdapterSigner` class to remove the `provider` property assignment.
- Changed `PUBLISHED_PRIVATE_KEY` from an empty string to `process.env.ZKSYNC_PUBLISHED_PRIVATE_KEY`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->