### PR TITLE
Add team capabilities to service-utils

### DIFF
--- a/.changeset/loose-comics-serve.md
+++ b/.changeset/loose-comics-serve.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+add team capabilities

--- a/apps/dashboard/src/stories/stubs.ts
+++ b/apps/dashboard/src/stories/stubs.ts
@@ -67,6 +67,7 @@ export function teamStub(id: string, billingPlan: Team["billingPlan"]): Team {
           rateLimit: 1000,
         },
         upload: {
+          totalFileSizeBytesLimit: 1_000_000_000,
           rateLimit: 1000,
         },
       },

--- a/apps/dashboard/src/stories/stubs.ts
+++ b/apps/dashboard/src/stories/stubs.ts
@@ -56,6 +56,39 @@ export function teamStub(id: string, billingPlan: Team["billingPlan"]): Team {
       "chainsaw",
     ],
     stripeCustomerId: "cus_1234567890",
+    capabilities: {
+      rpc: {
+        enabled: true,
+        rateLimit: 1000,
+      },
+      storage: {
+        enabled: true,
+        download: {
+          rateLimit: 1000,
+        },
+        upload: {
+          rateLimit: 1000,
+        },
+      },
+      bundler: {
+        enabled: true,
+        rateLimit: 1000,
+        mainnetEnabled: true,
+      },
+      insight: {
+        enabled: true,
+        rateLimit: 1000,
+      },
+      embeddedWallets: {
+        enabled: true,
+        customAuth: true,
+        customBranding: true,
+      },
+      nebula: {
+        enabled: true,
+        rateLimit: 1000,
+      },
+    },
   };
 
   return team;

--- a/packages/service-utils/src/core/api.ts
+++ b/packages/service-utils/src/core/api.ts
@@ -43,6 +43,41 @@ export type ApiResponse = {
   };
 };
 
+// needs to be kept in sync with the capabilities from the backend
+type TeamCapabilities = {
+  rpc: {
+    enabled: boolean;
+    rateLimit: number;
+  };
+  insight: {
+    enabled: boolean;
+    rateLimit: number;
+  };
+  storage: {
+    enabled: boolean;
+    download: {
+      rateLimit: number;
+    };
+    upload: {
+      rateLimit: number;
+    };
+  };
+  nebula: {
+    enabled: boolean;
+    rateLimit: number;
+  };
+  bundler: {
+    enabled: boolean;
+    mainnetEnabled: boolean;
+    rateLimit: number;
+  };
+  embeddedWallets: {
+    enabled: boolean;
+    customAuth: boolean;
+    customBranding: boolean;
+  };
+};
+
 export type TeamResponse = {
   id: string;
   name: string;
@@ -68,6 +103,7 @@ export type TeamResponse = {
   canCreatePublicChains: boolean | null;
   enabledScopes: ServiceName[];
   isOnboarded: boolean;
+  capabilities: TeamCapabilities;
 };
 
 export type ProjectSecretKey = {

--- a/packages/service-utils/src/core/api.ts
+++ b/packages/service-utils/src/core/api.ts
@@ -43,7 +43,10 @@ export type ApiResponse = {
   };
 };
 
-// needs to be kept in sync with the capabilities from the backend
+/**
+ * Stores service-specific capabilities.
+ * This type should match the schema from API server.
+ */
 type TeamCapabilities = {
   rpc: {
     enabled: boolean;
@@ -59,6 +62,7 @@ type TeamCapabilities = {
       rateLimit: number;
     };
     upload: {
+      totalFileSizeBytesLimit: number;
       rateLimit: number;
     };
   };

--- a/packages/service-utils/src/mocks.ts
+++ b/packages/service-utils/src/mocks.ts
@@ -74,6 +74,7 @@ export const validTeamResponse: TeamResponse = {
         rateLimit: 1000,
       },
       upload: {
+        totalFileSizeBytesLimit: 1_000_000_000,
         rateLimit: 1000,
       },
     },

--- a/packages/service-utils/src/mocks.ts
+++ b/packages/service-utils/src/mocks.ts
@@ -59,6 +59,39 @@ export const validTeamResponse: TeamResponse = {
   canCreatePublicChains: false,
   enabledScopes: ["storage", "rpc", "bundler"],
   isOnboarded: true,
+  capabilities: {
+    rpc: {
+      enabled: true,
+      rateLimit: 1000,
+    },
+    insight: {
+      enabled: true,
+      rateLimit: 1000,
+    },
+    storage: {
+      enabled: true,
+      download: {
+        rateLimit: 1000,
+      },
+      upload: {
+        rateLimit: 1000,
+      },
+    },
+    nebula: {
+      enabled: true,
+      rateLimit: 1000,
+    },
+    bundler: {
+      enabled: true,
+      mainnetEnabled: true,
+      rateLimit: 1000,
+    },
+    embeddedWallets: {
+      enabled: true,
+      customAuth: true,
+      customBranding: true,
+    },
+  },
 };
 
 export const validTeamAndProjectResponse: TeamAndProjectResponse = {


### PR DESCRIPTION
blocked by: https://github.com/thirdweb-dev/api-server/pull/1500

# Add Team Capabilities

This PR adds a `TeamCapabilities` type to the service-utils package, which defines the structure of team capabilities that need to be kept in sync with the backend. The type includes capabilities for:

- RPC Edge
- Insight
- Storage (download and upload)
- Nebula
- Bundler
- Embedded Wallets

The `TeamResponse` type is also updated to include a `capabilities` field of the new `TeamCapabilities` type.

A changeset is added to track this patch update.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a comprehensive set of `capabilities` for team services, enhancing functionality related to storage, RPC, and other services. It ensures proper authorization checks based on these capabilities, enabling better service management and control.

### Detailed summary
- Added `capabilities` object to team configuration in `stubs.ts`.
- Defined `TeamCapabilities` type in `api.ts` to match service capabilities schema.
- Updated `TeamResponse` type to include `capabilities`.
- Implemented service enablement checks in `authorize` function.
- Created `isServiceEnabledForTeam` function to validate service access based on capabilities.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->