### PR TITLE
Insight Playground: Show error when no chains selected

### DIFF
--- a/apps/playground-web/src/app/insight/[blueprint_slug]/blueprint-playground.client.tsx
+++ b/apps/playground-web/src/app/insight/[blueprint_slug]/blueprint-playground.client.tsx
@@ -799,7 +799,7 @@ function openAPIV3ParamToZodFormSchema(
 
         if (itemSchema) {
           return isRequired
-            ? z.array(itemSchema)
+            ? z.array(itemSchema).min(1, { message: "Required" })
             : z.array(itemSchema).optional();
         }
       }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing validation for an array in the `blueprint-playground.client.tsx` file by ensuring that if the array is required, it must have at least one item.

### Detailed summary
- Modified the return statement for required arrays to include a minimum length check using `z.array(itemSchema).min(1, { message: "Required" })`.
- The optional case remains unchanged, returning `z.array(itemSchema).optional()`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->