### PR TITLE
[SDK/Dashboard] fix: ERC1155 single phase claim conditions

### DIFF
--- a/.changeset/blue-geese-refuse.md
+++ b/.changeset/blue-geese-refuse.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Single phase functionality for erc1155

--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/_components/claim-conditions/claim-conditions-form/hooks.ts
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/_components/claim-conditions/claim-conditions-form/hooks.ts
@@ -126,7 +126,7 @@ export async function getClaimPhasesInLegacyFormat(
 type PhaseInput = z.input<typeof LegacyClaimConditionInputSchema>;
 
 export function setClaimPhasesTx(
-  baseOptions: BaseTransactionOptions<Options>,
+  baseOptions: BaseTransactionOptions<Options> & { isSinglePhase?: boolean },
   rawPhases: PhaseInput[],
 ) {
   const phases = rawPhases.map((phase) => {
@@ -172,6 +172,7 @@ export function setClaimPhasesTx(
         contract: baseOptions.contract,
         phases,
         tokenId: baseOptions.tokenId,
+        singlePhaseDrop: baseOptions.isSinglePhase,
       });
   }
 }

--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/_components/claim-conditions/claim-conditions-form/index.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/_components/claim-conditions/claim-conditions-form/index.tsx
@@ -226,7 +226,10 @@ export const ClaimConditionsForm: React.FC<ClaimConditionsFormProps> = ({
       ? { type: "erc20", decimals: tokenDecimals.data }
       : isErc721
         ? { type: "erc721" }
-        : { type: "erc1155", tokenId: BigInt(tokenId || 0) }),
+        : {
+            type: "erc1155",
+            tokenId: BigInt(tokenId || 0),
+          }),
   });
 
   const transformedQueryData = useMemo(() => {
@@ -370,6 +373,7 @@ export const ClaimConditionsForm: React.FC<ClaimConditionsFormProps> = ({
       const tx = setClaimPhasesTx(
         {
           contract,
+          isSinglePhase: !isMultiPhase,
           ...(isErc20
             ? { type: "erc20", decimals: tokenDecimals.data }
             : isErc721
@@ -635,6 +639,7 @@ export const ClaimConditionsForm: React.FC<ClaimConditionsFormProps> = ({
                   isErc20={isErc20}
                   contract={contract}
                   tokenId={tokenId}
+                  isMultiphase={isMultiPhase}
                 />
               )}
             </div>

--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/_components/claim-conditions/claim-conditions.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/_components/claim-conditions/claim-conditions.tsx
@@ -10,6 +10,7 @@ interface ClaimConditionsProps {
   isColumn?: true;
   isERC20: boolean;
   twAccount: Account | undefined;
+  isMultiphase: boolean;
 }
 export const ClaimConditions: React.FC<ClaimConditionsProps> = ({
   contract,
@@ -17,6 +18,7 @@ export const ClaimConditions: React.FC<ClaimConditionsProps> = ({
   isColumn,
   isERC20,
   twAccount,
+  isMultiphase,
 }) => {
   return (
     <div className="flex w-full flex-col gap-6">
@@ -37,8 +39,7 @@ export const ClaimConditions: React.FC<ClaimConditionsProps> = ({
         contract={contract}
         tokenId={tokenId}
         isColumn={isColumn}
-        // always multi phase!
-        isMultiPhase={true}
+        isMultiPhase={isMultiphase}
       />
     </div>
   );

--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/_components/claim-conditions/reset-claim-eligibility.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/_components/claim-conditions/reset-claim-eligibility.tsx
@@ -18,6 +18,7 @@ interface ResetClaimEligibilityProps {
   contract: ThirdwebContract;
   tokenId?: string;
   twAccount: Account | undefined;
+  isMultiphase: boolean;
 }
 
 export const ResetClaimEligibility: React.FC<ResetClaimEligibilityProps> = ({
@@ -25,6 +26,7 @@ export const ResetClaimEligibility: React.FC<ResetClaimEligibilityProps> = ({
   tokenId,
   isErc20,
   twAccount,
+  isMultiphase,
 }) => {
   const trackEvent = useTrack();
 
@@ -55,6 +57,7 @@ export const ResetClaimEligibility: React.FC<ResetClaimEligibilityProps> = ({
           return ERC1155Ext.resetClaimEligibility({
             contract,
             tokenId: BigInt(tokenId),
+            singlePhaseDrop: !isMultiphase,
           });
         }
         // assume erc 721

--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/claim-conditions/ClaimConditions.client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/claim-conditions/ClaimConditions.client.tsx
@@ -36,6 +36,7 @@ export function ClaimConditionsClient(props: {
       contract={props.contract}
       isERC20={supportedERCs.isERC20}
       twAccount={props.twAccount}
+      isMultiphase={true}
     />
   );
 }

--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/claim-conditions/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/claim-conditions/page.tsx
@@ -41,6 +41,7 @@ export default async function Page(props: {
       contract={contract}
       isERC20={supportedERCs.isERC20}
       twAccount={account}
+      isMultiphase={true}
     />
   );
 }

--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/nfts/[tokenId]/useNftDrawerTabs.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/nfts/[tokenId]/useNftDrawerTabs.tsx
@@ -68,13 +68,16 @@ export function useNFTDrawerTabs({
     const hasERC1155ClaimConditions = (() => {
       return [
         // reads
-        ERC1155Ext.isGetClaimConditionByIdSupported(functionSelectors),
         ERC1155Ext.isGetClaimConditionsSupported(functionSelectors),
         ERC1155Ext.isGetActiveClaimConditionSupported(functionSelectors),
         // writes
         ERC1155Ext.isSetClaimConditionsSupported(functionSelectors),
         ERC1155Ext.isResetClaimEligibilitySupported(functionSelectors),
       ].every(Boolean);
+    })();
+
+    const isERC1155Multiphase = (() => {
+      return ERC1155Ext.isGetClaimConditionByIdSupported(functionSelectors);
     })();
 
     const isBurnable = (() => {
@@ -130,6 +133,7 @@ export function useNFTDrawerTabs({
               tokenId={tokenId}
               isColumn
               twAccount={twAccount}
+              isMultiphase={isERC1155Multiphase}
             />
           ),
         },

--- a/packages/thirdweb/scripts/generate/abis/erc1155/IDropSinglePhase1155.json
+++ b/packages/thirdweb/scripts/generate/abis/erc1155/IDropSinglePhase1155.json
@@ -1,7 +1,7 @@
 [
   "function claim(address receiver, uint256 tokenId, uint256 quantity, address currency, uint256 pricePerToken, (bytes32[] proof, uint256 quantityLimitPerWallet, uint256 pricePerToken, address currency) allowlistProof, bytes data) payable",
   "function setClaimConditions(uint256 tokenId, (uint256 startTimestamp, uint256 maxClaimableSupply, uint256 supplyClaimed, uint256 quantityLimitPerWallet, bytes32 merkleRoot, uint256 pricePerToken, address currency, string metadata) phase, bool resetClaimEligibility)",
-  "function claimCondition(uint256 tokenId) view returns ((uint256 startTimestamp, uint256 maxClaimableSupply, uint256 supplyClaimed, uint256 quantityLimitPerWallet, bytes32 merkleRoot, uint256 pricePerToken, address currency, string metadata) condition)",
+  "function claimCondition(uint256 tokenId) view returns (uint256 startTimestamp, uint256 maxClaimableSupply, uint256 supplyClaimed, uint256 quantityLimitPerWallet, bytes32 merkleRoot, uint256 pricePerToken, address currency, string metadata)",
   "event ClaimConditionUpdated(uint256 indexed tokenId, (uint256 startTimestamp, uint256 maxClaimableSupply, uint256 supplyClaimed, uint256 quantityLimitPerWallet, bytes32 merkleRoot, uint256 pricePerToken, address currency, string metadata) condition, bool resetEligibility)",
   "event TokensClaimed(address indexed claimer, address indexed receiver, uint256 indexed tokenId, uint256 quantityClaimed)"
 ]

--- a/packages/thirdweb/src/exports/extensions/erc1155.ts
+++ b/packages/thirdweb/src/exports/extensions/erc1155.ts
@@ -112,6 +112,7 @@ export {
   type CanClaimParams,
   type CanClaimResult,
 } from "../../extensions/erc1155/drops/read/canClaim.js";
+export { claimCondition } from "../../extensions/erc1155/__generated__/IDropSinglePhase1155/read/claimCondition.js";
 
 // WRITE
 export {

--- a/packages/thirdweb/src/extensions/erc1155/__generated__/IDropSinglePhase1155/read/claimCondition.ts
+++ b/packages/thirdweb/src/extensions/erc1155/__generated__/IDropSinglePhase1155/read/claimCondition.ts
@@ -22,42 +22,36 @@ const FN_INPUTS = [
 ] as const;
 const FN_OUTPUTS = [
   {
-    type: "tuple",
-    name: "condition",
-    components: [
-      {
-        type: "uint256",
-        name: "startTimestamp",
-      },
-      {
-        type: "uint256",
-        name: "maxClaimableSupply",
-      },
-      {
-        type: "uint256",
-        name: "supplyClaimed",
-      },
-      {
-        type: "uint256",
-        name: "quantityLimitPerWallet",
-      },
-      {
-        type: "bytes32",
-        name: "merkleRoot",
-      },
-      {
-        type: "uint256",
-        name: "pricePerToken",
-      },
-      {
-        type: "address",
-        name: "currency",
-      },
-      {
-        type: "string",
-        name: "metadata",
-      },
-    ],
+    type: "uint256",
+    name: "startTimestamp",
+  },
+  {
+    type: "uint256",
+    name: "maxClaimableSupply",
+  },
+  {
+    type: "uint256",
+    name: "supplyClaimed",
+  },
+  {
+    type: "uint256",
+    name: "quantityLimitPerWallet",
+  },
+  {
+    type: "bytes32",
+    name: "merkleRoot",
+  },
+  {
+    type: "uint256",
+    name: "pricePerToken",
+  },
+  {
+    type: "address",
+    name: "currency",
+  },
+  {
+    type: "string",
+    name: "metadata",
   },
 ] as const;
 
@@ -130,7 +124,7 @@ export function encodeClaimCondition(options: ClaimConditionParams) {
  * ```
  */
 export function decodeClaimConditionResult(result: Hex) {
-  return decodeAbiParameters(FN_OUTPUTS, result)[0];
+  return decodeAbiParameters(FN_OUTPUTS, result);
 }
 
 /**

--- a/packages/thirdweb/src/utils/extensions/drops/get-claim-params.ts
+++ b/packages/thirdweb/src/utils/extensions/drops/get-claim-params.ts
@@ -50,15 +50,6 @@ export async function getClaimParams(options: GetClaimParamsOptions) {
   const cc: ClaimCondition = await (async () => {
     if (options.type === "erc1155") {
       // lazy-load the getActiveClaimCondition function
-      if (options.singlePhaseDrop) {
-        const { claimCondition } = await import(
-          "../../../extensions/erc1155/__generated__/IDropSinglePhase1155/read/claimCondition.js"
-        );
-        return await claimCondition({
-          contract: options.contract,
-          tokenId: options.tokenId,
-        });
-      }
       const { getActiveClaimCondition } = await import(
         "../../../extensions/erc1155/drops/read/getActiveClaimCondition.js"
       );


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces single-phase functionality for the `erc1155` extension in the `thirdweb` package, enhancing claim conditions and eligibility management. It modifies various components and utility functions to support the new single-phase feature.

### Detailed summary
- Added `isMultiphase` prop to several components for claim conditions.
- Updated `setClaimPhasesTx` to accept `isSinglePhase` option.
- Modified `ResetClaimEligibility` to handle single-phase drops.
- Enhanced `getActiveClaimCondition` to support both multi-phase and single-phase.
- Updated `getClaimConditions` to retrieve conditions for both phases.
- Refactored `resetClaimEligibility` to manage eligibility resets in single-phase scenarios.
- Adjusted tests to validate new single-phase functionality.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->