### PR TITLE
[Dashboard] Add team ID to ecosystem API requests

### DIFF
--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/add-partner/page.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/add-partner/page.tsx
@@ -1,4 +1,6 @@
 import {} from "@/components/ui/breadcrumb";
+import { notFound } from "next/navigation";
+import { getTeamBySlug } from "../../../../../../../../../../@/api/team";
 import { getAuthToken } from "../../../../../../../../../api/lib/getAuthToken";
 import { loginRedirect } from "../../../../../../../../../login/loginRedirect";
 import { AddPartnerForm } from "../components/client/add-partner-form.client";
@@ -10,10 +12,17 @@ export default async function AddPartnerPage({
   params: Promise<{ slug: string; team_slug: string }>;
 }) {
   const { slug, team_slug } = await params;
-  const authToken = await getAuthToken();
+  const [authToken, team] = await Promise.all([
+    getAuthToken(),
+    getTeamBySlug(team_slug),
+  ]);
 
   if (!authToken) {
     loginRedirect(`/team/${team_slug}/~/ecosystem/${slug}`);
+  }
+
+  if (!team) {
+    notFound();
   }
 
   const teamSlug = team_slug;
@@ -32,7 +41,11 @@ export default async function AddPartnerPage({
           <h1 className="mb-6 font-semibold text-2xl tracking-tight">
             Add New Partner
           </h1>
-          <AddPartnerForm ecosystem={ecosystem} authToken={authToken} />
+          <AddPartnerForm
+            ecosystem={ecosystem}
+            authToken={authToken}
+            teamId={team.id}
+          />
         </div>
       </div>
     );

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/components/client/EcosystemPermissionsPage.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/components/client/EcosystemPermissionsPage.tsx
@@ -7,7 +7,12 @@ import { IntegrationPermissionsSection } from "../server/integration-permissions
 export function EcosystemPermissionsPage({
   params,
   authToken,
-}: { params: { slug: string; team_slug: string }; authToken: string }) {
+  teamId,
+}: {
+  params: { slug: string; team_slug: string };
+  authToken: string;
+  teamId: string;
+}) {
   const { data: ecosystem } = useEcosystem({
     slug: params.slug,
     teamIdOrSlug: params.team_slug,
@@ -18,13 +23,19 @@ export function EcosystemPermissionsPage({
       <IntegrationPermissionsSection
         ecosystem={ecosystem}
         authToken={authToken}
+        teamId={teamId}
       />
-      <AuthOptionsSection ecosystem={ecosystem} authToken={authToken} />
+      <AuthOptionsSection
+        ecosystem={ecosystem}
+        authToken={authToken}
+        teamId={teamId}
+      />
       {ecosystem?.permission === "PARTNER_WHITELIST" && (
         <EcosystemPartnersSection
           teamSlug={params.team_slug}
           ecosystem={ecosystem}
           authToken={authToken}
+          teamId={teamId}
         />
       )}
     </div>

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/components/client/add-partner-form.client.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/components/client/add-partner-form.client.tsx
@@ -9,9 +9,11 @@ import { PartnerForm, type PartnerFormValues } from "./partner-form.client";
 export function AddPartnerForm({
   ecosystem,
   authToken,
+  teamId,
 }: {
   ecosystem: Ecosystem;
   authToken: string;
+  teamId: string;
 }) {
   const router = useDashboardRouter();
   const params = useParams();
@@ -21,6 +23,7 @@ export function AddPartnerForm({
   const { mutateAsync: addPartner, isPending } = useAddPartner(
     {
       authToken,
+      teamId,
     },
     {
       onSuccess: () => {

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/components/client/auth-options-form.client.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/components/client/auth-options-form.client.tsx
@@ -52,7 +52,8 @@ type AuthOptionsFormData = {
 export function AuthOptionsForm({
   ecosystem,
   authToken,
-}: { ecosystem: Ecosystem; authToken: string }) {
+  teamId,
+}: { ecosystem: Ecosystem; authToken: string; teamId: string }) {
   const form = useForm<AuthOptionsFormData>({
     defaultValues: {
       authOptions: ecosystem.authOptions || [],
@@ -147,6 +148,7 @@ export function AuthOptionsForm({
   const { mutateAsync: updateEcosystem, isPending } = useUpdateEcosystem(
     {
       authToken,
+      teamId,
     },
     {
       onError: (error) => {

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/components/client/integration-permissions-toggle.client.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/components/client/integration-permissions-toggle.client.tsx
@@ -12,7 +12,8 @@ import { useUpdateEcosystem } from "../../hooks/use-update-ecosystem";
 export function IntegrationPermissionsToggle({
   ecosystem,
   authToken,
-}: { ecosystem: Ecosystem; authToken: string }) {
+  teamId,
+}: { ecosystem: Ecosystem; authToken: string; teamId: string }) {
   const [messageToConfirm, setMessageToConfirm] = useState<
     | {
         title: string;
@@ -28,6 +29,7 @@ export function IntegrationPermissionsToggle({
   } = useUpdateEcosystem(
     {
       authToken,
+      teamId,
     },
     {
       onError: (error) => {

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/components/client/update-partner-form.client.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/components/client/update-partner-form.client.tsx
@@ -10,10 +10,12 @@ export function UpdatePartnerForm({
   ecosystem,
   partner,
   authToken,
+  teamId,
 }: {
   ecosystem: Ecosystem;
   partner: Partner;
   authToken: string;
+  teamId: string;
 }) {
   const router = useDashboardRouter();
   const params = useParams();
@@ -23,6 +25,7 @@ export function UpdatePartnerForm({
   const { mutateAsync: updatePartner, isPending } = useUpdatePartner(
     {
       authToken,
+      teamId,
     },
     {
       onSuccess: () => {

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/components/server/auth-options-section.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/components/server/auth-options-section.tsx
@@ -7,11 +7,16 @@ import {
 export function AuthOptionsSection({
   ecosystem,
   authToken,
-}: { ecosystem?: Ecosystem; authToken: string }) {
+  teamId,
+}: { ecosystem?: Ecosystem; authToken: string; teamId: string }) {
   return (
     <section className="flex flex-col gap-4 md:gap-8">
       {ecosystem ? (
-        <AuthOptionsForm ecosystem={ecosystem} authToken={authToken} />
+        <AuthOptionsForm
+          ecosystem={ecosystem}
+          authToken={authToken}
+          teamId={teamId}
+        />
       ) : (
         <AuthOptionsFormSkeleton />
       )}

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/components/server/ecosystem-partners-section.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/components/server/ecosystem-partners-section.tsx
@@ -6,7 +6,13 @@ export function EcosystemPartnersSection({
   teamSlug,
   ecosystem,
   authToken,
-}: { teamSlug: string; ecosystem: Ecosystem; authToken: string }) {
+  teamId,
+}: {
+  teamSlug: string;
+  ecosystem: Ecosystem;
+  authToken: string;
+  teamId: string;
+}) {
   return (
     <div className="rounded-lg border border-border bg-card px-4 py-6 lg:px-6">
       <div className="flex flex-col items-start justify-between max-sm:mb-5 lg:flex-row">
@@ -33,6 +39,7 @@ export function EcosystemPartnersSection({
         ecosystem={ecosystem}
         authToken={authToken}
         teamSlug={teamSlug}
+        teamId={teamId}
       />
     </div>
   );

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/components/server/integration-permissions-section.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/components/server/integration-permissions-section.tsx
@@ -7,7 +7,8 @@ import {
 export function IntegrationPermissionsSection({
   ecosystem,
   authToken,
-}: { ecosystem?: Ecosystem; authToken: string }) {
+  teamId,
+}: { ecosystem?: Ecosystem; authToken: string; teamId: string }) {
   return (
     <div className="relative rounded-lg border border-border bg-card px-4 py-6 lg:px-6">
       <h3 className="font-semibold text-xl tracking-tight">
@@ -27,6 +28,7 @@ export function IntegrationPermissionsSection({
           <IntegrationPermissionsToggle
             ecosystem={ecosystem}
             authToken={authToken}
+            teamId={teamId}
           />
         ) : (
           <IntegrationPermissionsToggleSkeleton />

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/components/server/partners-table.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/components/server/partners-table.tsx
@@ -25,14 +25,17 @@ export function PartnersTable({
   ecosystem,
   authToken,
   teamSlug,
+  teamId,
 }: {
   ecosystem: Ecosystem;
   authToken: string;
   teamSlug: string;
+  teamId: string;
 }) {
   const { partners, isPending } = usePartners({
     ecosystem,
     authToken,
+    teamId,
   });
 
   if (isPending) {
@@ -68,6 +71,7 @@ export function PartnersTable({
               ecosystem={ecosystem}
               authToken={authToken}
               teamSlug={teamSlug}
+              teamId={teamId}
             />
           ))}
         </TableBody>
@@ -81,12 +85,14 @@ function PartnerRow(props: {
   ecosystem: Ecosystem;
   teamSlug: string;
   authToken: string;
+  teamId: string;
 }) {
   const router = useDashboardRouter();
   const { mutateAsync: deletePartner, isPending: isDeleting } =
     useDeletePartner(
       {
         authToken: props.authToken,
+        teamId: props.teamId,
       },
       {
         onError: (error) => {

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/hooks/fetchPartnerDetails.ts
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/hooks/fetchPartnerDetails.ts
@@ -4,8 +4,9 @@ export async function fetchPartnerDetails(args: {
   authToken: string;
   ecosystem: Ecosystem;
   partnerId: string;
+  teamId: string;
 }): Promise<Partner> {
-  const { authToken, ecosystem, partnerId } = args;
+  const { authToken, ecosystem, partnerId, teamId } = args;
 
   try {
     const response = await fetch(
@@ -14,6 +15,7 @@ export async function fetchPartnerDetails(args: {
         method: "GET",
         headers: {
           Authorization: `Bearer ${authToken}`,
+          "x-thirdweb-team-id": teamId,
         },
       },
     );

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/hooks/fetchPartners.ts
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/hooks/fetchPartners.ts
@@ -6,13 +6,16 @@ import type { Ecosystem, Partner } from "../../../../types";
 export async function fetchPartners({
   ecosystem,
   authToken,
+  teamId,
 }: {
   ecosystem: Ecosystem;
   authToken: string;
+  teamId: string;
 }): Promise<Partner[]> {
   const res = await fetch(`${ecosystem.url}/${ecosystem.id}/partners`, {
     headers: {
       Authorization: `Bearer ${authToken}`,
+      "x-thirdweb-team-id": teamId,
     },
     next: {
       revalidate: 0,

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/hooks/use-add-partner.ts
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/hooks/use-add-partner.ts
@@ -16,13 +16,14 @@ type AddPartnerParams = {
 export function useAddPartner(
   params: {
     authToken: string;
+    teamId: string;
   },
   options?: Omit<
     UseMutationOptions<Partner, unknown, AddPartnerParams>,
     "mutationFn"
   >,
 ) {
-  const { authToken } = params;
+  const { authToken, teamId } = params;
   const { onSuccess, ...queryOptions } = options || {};
   const queryClient = useQueryClient();
 
@@ -37,6 +38,7 @@ export function useAddPartner(
           headers: {
             "Content-Type": "application/json",
             Authorization: `Bearer ${authToken}`,
+            "x-thirdweb-team-id": teamId,
           },
           body: JSON.stringify({
             name: params.name,

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/hooks/use-delete-partner.ts
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/hooks/use-delete-partner.ts
@@ -13,13 +13,14 @@ type DeletePartnerParams = {
 export function useDeletePartner(
   params: {
     authToken: string;
+    teamId: string;
   },
   options?: Omit<
     UseMutationOptions<boolean, unknown, DeletePartnerParams>,
     "mutationFn"
   >,
 ) {
-  const { authToken } = params;
+  const { authToken, teamId } = params;
   const { onSuccess, ...queryOptions } = options || {};
   const queryClient = useQueryClient();
 
@@ -33,6 +34,7 @@ export function useDeletePartner(
         {
           method: "DELETE",
           headers: {
+            "x-thirdweb-team-id": teamId,
             Authorization: `Bearer ${authToken}`,
           },
         },

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/hooks/use-update-ecosystem.ts
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/hooks/use-update-ecosystem.ts
@@ -8,10 +8,11 @@ import type { Ecosystem } from "../../../../types";
 export function useUpdateEcosystem(
   params: {
     authToken: string;
+    teamId: string;
   },
   options?: Omit<UseMutationOptions<boolean, unknown, Ecosystem>, "mutationFn">,
 ) {
-  const { authToken } = params;
+  const { authToken, teamId } = params;
   const { onSuccess, ...queryOptions } = options || {};
   const queryClient = useQueryClient();
 
@@ -22,6 +23,7 @@ export function useUpdateEcosystem(
         method: "PATCH",
         headers: {
           "Content-Type": "application/json",
+          "x-thirdweb-team-id": teamId,
           Authorization: `Bearer ${authToken}`,
         },
         body: JSON.stringify(params),

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/hooks/use-update-partner.ts
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/hooks/use-update-partner.ts
@@ -22,13 +22,14 @@ type UpdatePartnerParams = {
 export function useUpdatePartner(
   params: {
     authToken: string;
+    teamId: string;
   },
   options?: Omit<
     UseMutationOptions<Partner, unknown, UpdatePartnerParams>,
     "mutationFn"
   >,
 ) {
-  const { authToken } = params;
+  const { authToken, teamId } = params;
   const { onSuccess, ...queryOptions } = options || {};
   const queryClient = useQueryClient();
 
@@ -43,6 +44,7 @@ export function useUpdatePartner(
           headers: {
             "Content-Type": "application/json",
             Authorization: `Bearer ${authToken}`,
+            "x-thirdweb-team-id": teamId,
           },
           body: JSON.stringify({
             name: params.name,

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/partners/[partner_id]/edit/page.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/partners/[partner_id]/edit/page.tsx
@@ -1,4 +1,6 @@
 import {} from "@/components/ui/breadcrumb";
+import { notFound } from "next/navigation";
+import { getTeamBySlug } from "../../../../../../../../../../../../@/api/team";
 import { getAuthToken } from "../../../../../../../../../../../api/lib/getAuthToken";
 import { loginRedirect } from "../../../../../../../../../../../login/loginRedirect";
 import { UpdatePartnerForm } from "../../../components/client/update-partner-form.client";
@@ -11,10 +13,17 @@ export default async function EditPartnerPage({
   params: Promise<{ slug: string; team_slug: string; partner_id: string }>;
 }) {
   const { slug, team_slug, partner_id } = await params;
-  const authToken = await getAuthToken();
+  const [authToken, team] = await Promise.all([
+    getAuthToken(),
+    getTeamBySlug(team_slug),
+  ]);
 
   if (!authToken) {
     loginRedirect(`/team/${team_slug}/~/ecosystem/${slug}/configuration`);
+  }
+
+  if (!team) {
+    notFound();
   }
 
   const teamSlug = team_slug;
@@ -29,18 +38,12 @@ export default async function EditPartnerPage({
     });
 
     try {
-      // TODO re-enable this once IAW service is re deployed
       const partner = await fetchPartnerDetails({
         ecosystem,
         partnerId,
         authToken,
+        teamId: team.id,
       });
-      //   const partners = await fetchPartners({
-      //     ecosystem,
-      //     authToken,
-      //   });
-
-      //   const partner = partners.find((p) => p.id === partnerId);
 
       if (!partner) {
         return (
@@ -65,6 +68,7 @@ export default async function EditPartnerPage({
               ecosystem={ecosystem}
               partner={partner}
               authToken={authToken}
+              teamId={team.id}
             />
           </div>
         </div>

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/hooks/use-partners.ts
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/hooks/use-partners.ts
@@ -5,11 +5,12 @@ import { fetchPartners } from "../configuration/hooks/fetchPartners";
 export function usePartners({
   ecosystem,
   authToken,
-}: { ecosystem: Ecosystem; authToken: string }) {
+  teamId,
+}: { ecosystem: Ecosystem; authToken: string; teamId: string }) {
   const partnersQuery = useQuery({
     queryKey: ["ecosystem", ecosystem.id, "partners"],
     queryFn: async () => {
-      return fetchPartners({ ecosystem, authToken });
+      return fetchPartners({ ecosystem, authToken, teamId });
     },
     retry: false,
   });

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/page.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/page.tsx
@@ -1,3 +1,5 @@
+import { notFound } from "next/navigation";
+import { getTeamBySlug } from "../../../../../../../../@/api/team";
 import { getAuthToken } from "../../../../../../../api/lib/getAuthToken";
 import { loginRedirect } from "../../../../../../../login/loginRedirect";
 import { EcosystemPermissionsPage } from "./configuration/components/client/EcosystemPermissionsPage";
@@ -6,11 +8,24 @@ export default async function Page(props: {
   params: Promise<{ slug: string; team_slug: string }>;
 }) {
   const params = await props.params;
-  const authToken = await getAuthToken();
+  const [authToken, team] = await Promise.all([
+    getAuthToken(),
+    getTeamBySlug(params.team_slug),
+  ]);
+
+  if (!team) {
+    notFound();
+  }
 
   if (!authToken) {
     loginRedirect(`/team/${params.team_slug}/~/ecosystem/${params.slug}`);
   }
 
-  return <EcosystemPermissionsPage params={params} authToken={authToken} />;
+  return (
+    <EcosystemPermissionsPage
+      params={params}
+      authToken={authToken}
+      teamId={team.id}
+    />
+  );
 }


### PR DESCRIPTION
Fixes TOOL-3965

<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding `teamId` as a parameter across various functions and components in the application, enhancing the ability to manage partners within different teams in the ecosystem.

### Detailed summary
- Added `teamId` to function parameters in `fetchPartners`, `AddPartnerForm`, `UpdatePartnerForm`, and others.
- Updated API calls to include `teamId` in headers.
- Modified components to pass `teamId` when rendering forms and sections.
- Enhanced error handling for team retrieval.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->