### PR TITLE
update insight playground routes

### DIFF
--- a/apps/playground-web/src/app/insight/insightBlueprints.ts
+++ b/apps/playground-web/src/app/insight/insightBlueprints.ts
@@ -78,6 +78,10 @@ export const insightBlueprints: MinimalBlueprintSpec[] = [
         name: "Get token price",
         path: "/v1/tokens/price",
       },
+      {
+        name: "Token lookup",
+        path: "/v1/tokens/lookup",
+      },
     ],
   },
   {
@@ -129,6 +133,10 @@ export const insightBlueprints: MinimalBlueprintSpec[] = [
     name: "Nfts",
     paths: [
       {
+        name: "Get collection",
+        path: "/v1/nfts/collections/{contract_address}",
+      },
+      {
         name: "Get NFTs by owner",
         path: "/v1/nfts",
       },
@@ -161,7 +169,7 @@ export const insightBlueprints: MinimalBlueprintSpec[] = [
         path: "/v1/nfts/transfers/{contract_address}/{token_id}",
       },
       {
-        name: "Get NFT by token",
+        name: "Get NFT by token ID",
         path: "/v1/nfts/{contract_address}/{token_id}",
       },
       {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `insightBlueprints` configuration by adding new token and NFT-related endpoints and renaming an existing endpoint for clarity.

### Detailed summary
- Added a new endpoint for token lookup: 
  - `name`: "Token lookup"
  - `path`: "/v1/tokens/lookup"
- Added a new endpoint for getting NFT collections: 
  - `name`: "Get collection"
  - `path`: "/v1/nfts/collections/{contract_address}"
- Renamed the existing endpoint from "Get NFT by token" to "Get NFT by token ID".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->