### PR TITLE
[TOOL-4028] Dashboard: Limit team name to 32 chars

### DIFF
--- a/apps/dashboard/src/app/login/onboarding/team-onboarding/TeamInfoForm.tsx
+++ b/apps/dashboard/src/app/login/onboarding/team-onboarding/TeamInfoForm.tsx
@@ -155,6 +155,8 @@ export function TeamInfoFormUI(props: {
     });
   }
 
+  const maxTeamNameLength = 32;
+
   return (
     <div className="rounded-lg border bg-card ">
       <Form {...form}>
@@ -199,6 +201,7 @@ export function TeamInfoFormUI(props: {
                       placeholder="Company Inc."
                       autoComplete="off"
                       {...field}
+                      maxLength={maxTeamNameLength}
                     />
                   </FormControl>
                   <FormDescription>

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/settings/general/TeamGeneralSettingsPageUI.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/settings/general/TeamGeneralSettingsPageUI.tsx
@@ -85,8 +85,9 @@ function TeamNameFormControl(props: {
     >
       <Input
         value={teamName}
+        maxLength={maxTeamNameLength}
         onChange={(e) => {
-          setTeamName(e.target.value.slice(0, maxTeamNameLength));
+          setTeamName(e.target.value);
         }}
         className="md:w-[450px]"
       />


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the handling of team name input by enforcing a maximum length and ensuring that the input value respects this limit.

### Detailed summary
- In `TeamGeneralSettingsPageUI.tsx`, added `maxLength` prop to the `<Input>` component for `teamName`.
- Updated the `onChange` handler to set `teamName` directly from the input value without slicing.
- Introduced a constant `maxTeamNameLength` with a value of `32` in `TeamInfoForm.tsx` for consistency.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->