### PR TITLE
[SDK] Pass through desired chain when signing in with wallet for ecosystems

### DIFF
--- a/.changeset/orange-suns-attack.md
+++ b/.changeset/orange-suns-attack.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Pass through desired chain when signing in with wallet for ecosystems

--- a/packages/thirdweb/src/react/web/wallets/ecosystem/EcosystemWalletConnectUI.tsx
+++ b/packages/thirdweb/src/react/web/wallets/ecosystem/EcosystemWalletConnectUI.tsx
@@ -121,6 +121,7 @@ function EcosystemWalletConnectUI(props: {
     return (
       <WalletAuth
         meta={props.meta}
+        chain={props.chain}
         inAppLocale={locale}
         walletConnect={props.walletConnect}
         wallet={props.wallet}

--- a/packages/thirdweb/src/react/web/wallets/in-app/InAppWalletConnectUI.tsx
+++ b/packages/thirdweb/src/react/web/wallets/in-app/InAppWalletConnectUI.tsx
@@ -113,6 +113,7 @@ function InAppWalletConnectUI(props: {
         wallet={props.wallet}
         client={props.client}
         size={props.size}
+        chain={props.chain}
         done={done}
         onBack={goBackToMain || (() => setSelectionData({}))}
         locale={props.connectLocale}


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `WalletAuth` component by allowing it to accept a `chain` prop, which is passed through when signing in with a wallet for ecosystems. This change improves the flexibility of wallet connections in different blockchain environments.

### Detailed summary
- Added a `chain` prop to the `WalletAuth` component.
- Updated `EcosystemWalletConnectUI.tsx` to pass `chain` from props.
- Updated `InAppWalletConnectUI.tsx` to include `chain` from props.
- Modified the `login` function in `WalletAuth.tsx` to use the `chain` prop when connecting wallets.
- Improved error handling in the `login` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->