### PR TITLE
[Portal] Fix: updates broken-links on nebula sessions docs

### DIFF
--- a/apps/portal/src/app/nebula/key-concepts/sessions/page.mdx
+++ b/apps/portal/src/app/nebula/key-concepts/sessions/page.mdx
@@ -5,11 +5,11 @@ Sessions are a way to maintain context across multiple interactions with a user.
 
 - Sessions are created automatically when calling `/chat` without a `session_id` or can be created explicitly by calling the `/session` endpoint.
 - Sessions can be managed through the following endpoints:
-    - [Create Session](/api-reference/create-session)
-    - [Get Session](/api-reference/get-session)
-    - [Clear Session](/api-reference/clear-session)
-    - [Update Session](/api-reference/update-session)
-    - [Delete Session](/api-reference/delete-session)
-    - [List Sessions](/api-reference/list-sessions)
+    - [Create Session](/nebula/api-reference/create-session)
+    - [Get Session](/nebula/api-reference/get-session)
+    - [Clear Session](/nebula/api-reference/clear-session)
+    - [Update Session](/nebula/api-reference/update-session)
+    - [Delete Session](/nebula/api-reference/delete-session)
+    - [List Sessions](/nebula/api-reference/list-sessions)
 
 - Sessions persist your conversation history, custom configurations for blockchain data, and thirdweb tools interactions.


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the documentation in the `page.mdx` file for sessions in the application. It modifies the API reference links to include the `/nebula` prefix, ensuring consistency in the endpoint URLs.

### Detailed summary
- Changed API reference links to include `/nebula` in the following endpoints:
  - `Create Session`
  - `Get Session`
  - `Clear Session`
  - `Update Session`
  - `Delete Session`
  - `List Sessions`
- Retained the description about session persistence.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->