### PR TITLE
[Pay] Add extra gas buffer for quote and transfer transactions

### DIFF
--- a/.changeset/young-poets-do.md
+++ b/.changeset/young-poets-do.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Extra gas buffer for quote and transfer transactions

--- a/packages/thirdweb/src/pay/buyWithCrypto/getQuote.ts
+++ b/packages/thirdweb/src/pay/buyWithCrypto/getQuote.ts
@@ -259,6 +259,7 @@ export async function getBuyWithCryptoQuote(
         data: data.transactionRequest.data as Hash,
         to: data.transactionRequest.to,
         value: BigInt(data.transactionRequest.value),
+        extraGas: 50000n, // extra gas buffer
       },
       approvalData,
       swapDetails: {

--- a/packages/thirdweb/src/pay/buyWithCrypto/getTransfer.ts
+++ b/packages/thirdweb/src/pay/buyWithCrypto/getTransfer.ts
@@ -155,6 +155,7 @@ export async function getBuyWithCryptoTransfer(
         data: data.transactionRequest.data as Hash,
         to: data.transactionRequest.to as Address,
         value: BigInt(data.transactionRequest.value),
+        extraGas: 50000n, // extra gas buffer
       },
       approvalData: data.approval,
       fromAddress: data.fromAddress,


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces an extra gas buffer for transaction requests in the `buyWithCrypto` functionality of the `thirdweb` package.

### Detailed summary
- Added an `extraGas` property with a value of `50000n` in the `getQuote.ts` file for transaction requests.
- Added an `extraGas` property with a value of `50000n` in the `getTransfer.ts` file for transaction requests.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->