### PR TITLE
[Pay] Add feePayer option for direct_payment mode in PayEmbed

### DIFF
--- a/.changeset/brave-wombats-smoke.md
+++ b/.changeset/brave-wombats-smoke.md
@@ -1,0 +1,27 @@
+---
+"thirdweb": minor
+---
+
+Add feePayer option for direct_payment mode of PayEmbed
+
+For direct payments via the PayEmbed, you can now specify the payer of the protocol fee for direct transfers. Can be "sender" or "receiver", defaults to "sender".
+
+```ts
+<PayEmbed
+        client={THIRDWEB_CLIENT}
+        payOptions={{
+          mode: "direct_payment",
+          paymentInfo: {
+            amount: "2",
+            chain: base,
+            token: getDefaultToken(base, "USDC"),
+            sellerAddress: "0x...",
+            feePayer: "receiver", // <-- transfer fee paid by the receiver
+          },
+          metadata: {
+            name: "Black Hoodie (Size L)",
+            image: "/drip-hoodie.png",
+          },
+        }}
+      />
+```

--- a/apps/playground-web/src/components/pay/direct-payment.tsx
+++ b/apps/playground-web/src/components/pay/direct-payment.tsx
@@ -19,6 +19,7 @@ export function BuyMerchPreview() {
             chain: base,
             token: getDefaultToken(base, "USDC"),
             sellerAddress: "0xEb0effdFB4dC5b3d5d3aC6ce29F3ED213E95d675",
+            feePayer: "receiver",
           },
           metadata: {
             name: "Black Hoodie (Size L)",

--- a/packages/thirdweb/src/pay/buyWithCrypto/getTransfer.ts
+++ b/packages/thirdweb/src/pay/buyWithCrypto/getTransfer.ts
@@ -59,6 +59,11 @@ export type GetBuyWithCryptoTransferParams = {
    * This details will be stored with the purchase and can be retrieved later via the status API or Webhook
    */
   purchaseData?: object;
+
+  /**
+   * For direct transfers, specify who will pay for the transfer fee. Can be "sender" or "receiver".
+   */
+  feePayer?: "sender" | "receiver";
 };
 
 /**
@@ -135,6 +140,7 @@ export async function getBuyWithCryptoTransfer(
         tokenAddress: params.tokenAddress,
         amount: params.amount,
         purchaseData: params.purchaseData,
+        feePayer: params.feePayer,
       }),
     });
 

--- a/packages/thirdweb/src/react/core/hooks/connection/ConnectButtonProps.ts
+++ b/packages/thirdweb/src/react/core/hooks/connection/ConnectButtonProps.ts
@@ -39,6 +39,10 @@ export type PaymentInfo = {
    * If not provided, the native token will be used.
    */
   token?: TokenInfo;
+  /**
+   * For direct transfers, specify who will pay the transfer fee. Can be "sender" or "receiver".
+   */
+  feePayer?: "sender" | "receiver";
 } & (
   | {
       /**

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/TransferConfirmationScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/TransferConfirmationScreen.tsx
@@ -99,6 +99,10 @@ export function TransferConfirmationScreen(
           : token.address,
         amount: tokenAmount,
         purchaseData: payOptions?.purchaseData,
+        feePayer:
+          payOptions?.mode === "direct_payment"
+            ? payOptions.paymentInfo.feePayer
+            : undefined,
       });
       return transferResponse;
     },


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a `feePayer` option for the `direct_payment` mode in the PayEmbed component, allowing users to specify who will pay the transfer fee—either the sender or the receiver.

### Detailed summary
- Added `feePayer` option in `ConnectButtonProps.ts` for direct transfers, accepting "sender" or "receiver".
- Updated `TransferConfirmationScreen.tsx` to utilize `feePayer` based on payment mode.
- Modified `getTransfer.ts` to include `feePayer` in transfer parameters.
- Enhanced documentation to clarify `feePayer` usage in the PayEmbed component.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->