### PR TITLE
Fix getClaimConditions

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/_components/claim-conditions/claim-conditions-form/hooks.ts
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/_components/claim-conditions/claim-conditions-form/hooks.ts
@@ -55,7 +55,7 @@ type Options =
     };
 
 export async function getClaimPhasesInLegacyFormat(
-  options: BaseTransactionOptions<Options>,
+  options: BaseTransactionOptions<Options> & { isMultiPhase: boolean },
 ): Promise<CombinedClaimCondition[]> {
   const conditions = await (async () => {
     switch (options.type) {
@@ -64,7 +64,10 @@ export async function getClaimPhasesInLegacyFormat(
       case "erc721":
         return ERC721Ext.getClaimConditions(options);
       case "erc1155":
-        return ERC1155Ext.getClaimConditions(options);
+        return ERC1155Ext.getClaimConditions({
+          ...options,
+          singlePhaseDrop: !options.isMultiPhase,
+        });
     }
   })();
 

--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/_components/claim-conditions/claim-conditions-form/index.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/_components/claim-conditions/claim-conditions-form/index.tsx
@@ -222,6 +222,7 @@ export const ClaimConditionsForm: React.FC<ClaimConditionsFormProps> = ({
 
   const claimConditionsQuery = useReadContract(getClaimPhasesInLegacyFormat, {
     contract,
+    isMultiPhase,
     ...(isErc20
       ? { type: "erc20", decimals: tokenDecimals.data }
       : isErc721


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `getClaimPhasesInLegacyFormat` and `getClaimConditions` functions to support multi-phase claim conditions for ERC20 and ERC721 tokens, improving the handling of single-phase drops.

### Detailed summary
- Added `isMultiPhase` to the `options` parameter in `getClaimPhasesInLegacyFormat`.
- Updated the return statement in `getClaimPhasesInLegacyFormat` for `ERC1155` to include `singlePhaseDrop`.
- Modified `getClaimConditions` to handle `singlePhaseDrop` logic.
- Removed the use of `Promise.allSettled` for single-phase claims.
- Added error handling for cases where claim conditions are not found.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->