### PR TITLE
[SDK] Add retry logic to predictAccountAddress

### DIFF
--- a/.changeset/slow-mice-grin.md
+++ b/.changeset/slow-mice-grin.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Add retry logic to predictAccountAddress

--- a/packages/thirdweb/src/extensions/erc1155/customDrop1155.test.ts
+++ b/packages/thirdweb/src/extensions/erc1155/customDrop1155.test.ts
@@ -99,6 +99,7 @@ describe.runIf(process.env.TW_SECRET_KEY)(
       const condition = await getClaimConditions({
         contract,
         tokenId: 0n,
+        singlePhaseDrop: true,
       });
       expect(condition.length).to.eq(1);
       expect(condition[0]?.maxClaimableSupply).to.eq(10n);


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds retry logic to the `predictAccountAddress` function, enhancing its reliability by implementing an exponential backoff strategy for handling errors during contract calls.

### Detailed summary
- Added retry logic to the `predictAccountAddress` function in `packages/thirdweb/src/wallets/smart/lib/calls.ts`.
- Implemented a maximum of 3 retries with exponential backoff for contract calls.
- Introduced error handling to throw an error if no address is found after retries.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->