### PR TITLE
[SDK] Don't retry on user connection rejection in EIP1193 connector

### DIFF
--- a/.changeset/tall-terms-slide.md
+++ b/.changeset/tall-terms-slide.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Dont retry on user connection rejection in eip1193 connector

--- a/packages/thirdweb/src/wallets/injected/index.ts
+++ b/packages/thirdweb/src/wallets/injected/index.ts
@@ -63,6 +63,9 @@ export async function connectEip1193Wallet({
       });
     } catch (e) {
       console.error(e);
+      if (extractErrorMessage(e)?.toLowerCase()?.includes("rejected")) {
+        throw e;
+      }
       await new Promise((resolve) => setTimeout(resolve, 500));
     }
     attempts++;
@@ -374,4 +377,17 @@ async function switchChain(provider: EIP1193Provider, chain: Chain) {
       ],
     });
   }
+}
+
+function extractErrorMessage(e: unknown) {
+  if (e instanceof Error) {
+    return e.message;
+  }
+  if (typeof e === "string") {
+    return e;
+  }
+  if (typeof e === "object" && e !== null) {
+    return JSON.stringify(e);
+  }
+  return String(e);
 }


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving error handling in the `eip1193` connector by preventing retries when a user connection is rejected.

### Detailed summary
- Added a check to throw an error if the rejection message from the user is detected in the `catch` block.
- Introduced a new function, `extractErrorMessage`, to standardize error message extraction from various error types.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->