### PR TITLE
[SDK] Fix: Improve PayEmbed error message parsing

### DIFF
--- a/.changeset/tired-windows-clean.md
+++ b/.changeset/tired-windows-clean.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Improve pay error messages

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/ConfirmationScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/ConfirmationScreen.tsx
@@ -68,7 +68,11 @@ export function SwapConfirmationScreen(props: {
 
   const uiErrorMessage = useMemo(() => {
     if (step === "approval" && status === "error" && error) {
-      if (error.toLowerCase().includes("user rejected")) {
+      if (
+        error.toLowerCase().includes("user rejected") ||
+        error.toLowerCase().includes("user closed modal") ||
+        error.toLowerCase().includes("user denied")
+      ) {
         return {
           title: "Failed to Approve",
           message: "Your wallet rejected the approval request.",
@@ -82,7 +86,11 @@ export function SwapConfirmationScreen(props: {
     }
 
     if (step === "swap" && status === "error" && error) {
-      if (error.toLowerCase().includes("user rejected")) {
+      if (
+        error.toLowerCase().includes("user rejected") ||
+        error.toLowerCase().includes("user closed modal") ||
+        error.toLowerCase().includes("user denied")
+      ) {
         return {
           title: "Failed to Confirm",
           message: "Your wallet rejected the confirmation request.",

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/TransferConfirmationScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/TransferConfirmationScreen.tsx
@@ -112,7 +112,11 @@ export function TransferConfirmationScreen(
 
   const uiErrorMessage = useMemo(() => {
     if (step === "approve" && status.id === "error" && status.error) {
-      if (status.error.toLowerCase().includes("user rejected")) {
+      if (
+        status.error.toLowerCase().includes("user rejected") ||
+        status.error.toLowerCase().includes("user closed modal") ||
+        status.error.toLowerCase().includes("user denied")
+      ) {
         return {
           title: "Failed to Approve",
           message: "Your wallet rejected the approval request.",

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/SendFunds.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/SendFunds.tsx
@@ -145,7 +145,11 @@ export function SendFundsForm(props: {
       return locale.transactionFailed;
     }
 
-    if (message.includes("user rejected")) {
+    if (
+      message.includes("user rejected") ||
+      message.includes("user closed modal") ||
+      message.includes("user denied")
+    ) {
       return locale.transactionRejected;
     }
 


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving error messages related to user wallet interactions in the `thirdweb` package. It expands the conditions for handling rejection errors to include cases where the user closed the modal or denied the request.

### Detailed summary
- Updated error handling in `SendFunds.tsx` to include "user closed modal" and "user denied".
- Enhanced error checks in `TransferConfirmationScreen.tsx` for approval errors.
- Modified error conditions in `ConfirmationScreen.tsx` for both approval and swap errors.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->