### PR TITLE
Add RPC usage dashboard with rate limit monitoring

### DIFF
--- a/apps/dashboard/src/@/components/blocks/charts/area-chart.tsx
+++ b/apps/dashboard/src/@/components/blocks/charts/area-chart.tsx
@@ -4,6 +4,7 @@ import {
   Card,
   CardContent,
   CardDescription,
+  CardFooter,
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
@@ -17,7 +18,7 @@ import {
 } from "@/components/ui/chart";
 import { formatDate } from "date-fns";
 import { useMemo } from "react";
-import { Area, AreaChart, CartesianGrid, XAxis } from "recharts";
+import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts";
 import {
   EmptyChartState,
   LoadingChartState,
@@ -30,11 +31,17 @@ type ThirdwebAreaChartProps<TConfig extends ChartConfig> = {
     description?: string;
     titleClassName?: string;
   };
+  footer?: React.ReactNode;
   customHeader?: React.ReactNode;
   // chart config
   config: TConfig;
   data: Array<Record<keyof TConfig, number> & { time: number | string | Date }>;
   showLegend?: boolean;
+  maxLimit?: number;
+  yAxis?: boolean;
+  xAxis?: {
+    sameDay?: boolean;
+  };
 
   // chart className
   chartClassName?: string;
@@ -70,17 +77,33 @@ export function ThirdwebAreaChart<TConfig extends ChartConfig>(
           ) : props.data.length === 0 ? (
             <EmptyChartState />
           ) : (
-            <AreaChart accessibilityLayer data={props.data}>
+            <AreaChart
+              accessibilityLayer
+              data={
+                props.maxLimit
+                  ? props.data.map((d) => ({
+                      ...d,
+                      maxLimit: props.maxLimit,
+                    }))
+                  : props.data
+              }
+            >
               <CartesianGrid vertical={false} />
+              {props.yAxis && <YAxis tickLine={false} axisLine={false} />}
               <XAxis
                 dataKey="time"
                 tickLine={false}
                 axisLine={false}
                 tickMargin={20}
-                tickFormatter={(value) => formatDate(new Date(value), "MMM dd")}
+                tickFormatter={(value) =>
+                  formatDate(
+                    new Date(value),
+                    props.xAxis?.sameDay ? "MMM dd, HH:mm" : "MMM dd",
+                  )
+                }
               />
               <ChartTooltip
-                cursor={false}
+                cursor={true}
                 content={
                   <ChartTooltipContent
                     hideLabel={
@@ -124,6 +147,16 @@ export function ThirdwebAreaChart<TConfig extends ChartConfig>(
                   stackId="a"
                 />
               ))}
+              {props.maxLimit && (
+                <Area
+                  type="monotone"
+                  dataKey="maxLimit"
+                  stroke="#ef4444"
+                  strokeWidth={2}
+                  strokeDasharray="5 5"
+                  fill="none"
+                />
+              )}
 
               {props.showLegend && (
                 <ChartLegend
@@ -134,6 +167,9 @@ export function ThirdwebAreaChart<TConfig extends ChartConfig>(
           )}
         </ChartContainer>
       </CardContent>
+      {props.footer && (
+        <CardFooter className="w-full">{props.footer}</CardFooter>
+      )}
     </Card>
   );
 }

--- a/apps/dashboard/src/@/components/ui/chart.tsx
+++ b/apps/dashboard/src/@/components/ui/chart.tsx
@@ -243,7 +243,9 @@ const ChartTooltipContent = React.forwardRef<
                       <div className="grid gap-1.5">
                         {nestLabel ? tooltipLabel : null}
                         <span className="text-muted-foreground">
-                          {itemConfig?.label || item.name}
+                          {item.name === "maxLimit"
+                            ? "Upper Limit"
+                            : itemConfig?.label || item.name}
                         </span>
                       </div>
                       {item.value !== undefined && (

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/usage/layout.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/usage/layout.tsx
@@ -24,6 +24,11 @@ export default async function Layout(props: {
             label: "Overview",
           },
           {
+            href: `/team/${params.team_slug}/~/usage/rpc`,
+            exactMatch: true,
+            label: "RPC",
+          },
+          {
             href: `/team/${params.team_slug}/~/usage/storage`,
             exactMatch: true,
             label: "Storage",

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/usage/rpc/components/count-graph.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/usage/rpc/components/count-graph.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { ThirdwebAreaChart } from "@/components/blocks/charts/area-chart";
+import { formatDate } from "date-fns";
+
+export function CountGraph(props: {
+  peakPercentage: number;
+  currentRateLimit: number;
+  data: {
+    date: string;
+    includedCount: number;
+    overageCount: number;
+    rateLimitedCount: number;
+  }[];
+}) {
+  return (
+    <ThirdwebAreaChart
+      chartClassName="aspect-[1.5] lg:aspect-[4]"
+      header={{
+        title: "Requests Over Time",
+        description: "Requests over the last 24 hours. All times in UTC.",
+      }}
+      config={{
+        includedCount: {
+          label: "Successful Requests",
+          color: "hsl(var(--chart-1))",
+        },
+        rateLimitedCount: {
+          label: "Rate Limited Requests",
+          color: "hsl(var(--chart-4))",
+        },
+      }}
+      showLegend
+      yAxis
+      xAxis={{
+        sameDay: true,
+      }}
+      hideLabel={false}
+      toolTipLabelFormatter={(label) => {
+        return formatDate(new Date(label), "MMM dd, HH:mm");
+      }}
+      data={props.data
+        .slice(1, -1)
+        .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
+        .map((v) => ({
+          time: v.date,
+          includedCount: v.includedCount + v.overageCount,
+          rateLimitedCount: v.rateLimitedCount,
+        }))}
+      isPending={false}
+    />
+  );
+}

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/usage/rpc/components/rate-graph.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/usage/rpc/components/rate-graph.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { ThirdwebAreaChart } from "@/components/blocks/charts/area-chart";
+import { formatDate } from "date-fns";
+import { InfoIcon } from "lucide-react";
+
+export function RateGraph(props: {
+  peakPercentage: number;
+  currentRateLimit: number;
+  data: { date: string; averageRate: number }[];
+}) {
+  return (
+    <ThirdwebAreaChart
+      chartClassName="aspect-[1.5] lg:aspect-[4]"
+      header={{
+        title: "Request Rate Over Time",
+        description: "Request rate over the last 24 hours. All times in UTC.",
+      }}
+      // only show the footer if the peak usage is greater than 80%
+      footer={
+        props.peakPercentage > 80 ? (
+          <div className="flex items-center justify-center gap-2">
+            <InfoIcon className="h-4 w-4 text-muted-foreground" />
+            <p className="text-muted-foreground text-xs">
+              The red dashed line represents your current plan rate limit (
+              {props.currentRateLimit} RPS)
+            </p>
+          </div>
+        ) : undefined
+      }
+      config={{
+        averageRate: {
+          label: "Average RPS",
+          color: "hsl(var(--chart-1))",
+        },
+      }}
+      data={props.data
+        .slice(1, -1)
+        .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
+        .map((v) => ({
+          time: v.date,
+          averageRate: Number(v.averageRate.toFixed(2)),
+        }))}
+      yAxis
+      xAxis={{
+        sameDay: true,
+      }}
+      hideLabel={false}
+      toolTipLabelFormatter={(label) => {
+        return formatDate(new Date(label), "MMM dd, HH:mm");
+      }}
+      // only show the upper limit if the peak usage is greater than 80%
+      maxLimit={props.peakPercentage > 80 ? props.currentRateLimit : undefined}
+      isPending={false}
+    />
+  );
+}

--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/usage/rpc/page.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/usage/rpc/page.tsx
@@ -1,0 +1,209 @@
+import { getTeamBySlug } from "@/api/team";
+import { getLast24HoursRPCUsage } from "@/api/usage/rpc";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { format } from "date-fns";
+import {
+  AlertTriangleIcon,
+  CheckCircleIcon,
+  ClockIcon,
+  XCircleIcon,
+} from "lucide-react";
+import { redirect } from "next/navigation";
+import { getAuthToken } from "../../../../../../api/lib/getAuthToken";
+import { TeamPlanBadge } from "../../../../../../components/TeamPlanBadge";
+import { loginRedirect } from "../../../../../../login/loginRedirect";
+import { CountGraph } from "./components/count-graph";
+import { RateGraph } from "./components/rate-graph";
+
+export default async function RPCUsage(props: {
+  params: Promise<{
+    team_slug: string;
+  }>;
+}) {
+  const params = await props.params;
+  const authToken = await getAuthToken();
+
+  if (!authToken) {
+    loginRedirect(`/team/${params.team_slug}/~/usage/storage`);
+  }
+
+  const team = await getTeamBySlug(params.team_slug);
+  if (!team) {
+    redirect("/team");
+  }
+
+  const currentPlan = team.billingPlan;
+  const currentRateLimit = team.capabilities.rpc.rateLimit;
+
+  const apiData = await getLast24HoursRPCUsage({
+    teamId: team.id,
+    authToken,
+  });
+
+  if (!apiData.ok) {
+    return <div>Error fetching data, please try again later</div>;
+  }
+
+  const { peakRate, totalCounts } = apiData.data;
+
+  // Calculate percentage of limit for the peak
+  const peakPercentage = (peakRate.peakRPS / currentRateLimit) * 100;
+
+  // Determine status based on peak percentage
+  const getStatusColor = (percentage: number) => {
+    if (percentage < 70) return "bg-green-500";
+    if (percentage < 90) return "bg-yellow-500";
+    return "bg-red-500";
+  };
+
+  // Calculate total requests
+  const totalRequests =
+    Number(totalCounts.includedCount) +
+    Number(totalCounts.rateLimitedCount) +
+    Number(totalCounts.overageCount);
+
+  return (
+    <div className="container mx-auto space-y-8 py-6">
+      <div className="flex flex-col gap-2">
+        <h2 className="font-bold text-3xl tracking-tight">
+          RPC Usage Dashboard
+        </h2>
+        <p className="text-muted-foreground">
+          Monitor your RPC usage and rate limits for the last 24 hours
+        </p>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="font-medium text-sm">
+              Plan Rate Limit
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="flex items-center justify-between">
+              <div className="font-bold text-2xl capitalize">
+                {currentRateLimit} RPS
+              </div>
+              <TeamPlanBadge plan={currentPlan} />
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="font-medium text-sm">Peak Usage</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="flex items-center justify-between">
+              <div className="font-bold text-2xl">
+                {peakRate.peakRPS.toFixed(1)} RPS
+              </div>
+              <div className="flex items-center gap-2">
+                <div
+                  className={`h-3 w-3 rounded-full ${getStatusColor(peakPercentage)}`}
+                />
+                <span className="text-muted-foreground text-xs">
+                  {peakPercentage > 100
+                    ? `${(peakPercentage - 100).toFixed(0)}% over limit`
+                    : `${peakPercentage.toFixed(0)}% of limit`}
+                </span>
+              </div>
+            </div>
+            <p className="mt-1 text-muted-foreground text-xs">
+              <ClockIcon className="mr-1 inline h-3 w-3" />
+              {format(new Date(peakRate.date), "MMM d, HH:mm")}
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="font-medium text-sm">
+              Total Requests
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="font-bold text-2xl">
+              {totalRequests.toLocaleString()}
+            </div>
+            <div className="mt-1 flex items-center text-muted-foreground text-xs">
+              <CheckCircleIcon className="mr-1 h-3 w-3 text-green-500" />
+              <span>
+                {/* we count both included and overage as included */}
+                {(
+                  ((Number(totalCounts.includedCount) +
+                    Number(totalCounts.overageCount)) /
+                    Number(totalRequests)) *
+                  100
+                ).toFixed(1)}
+                % successful requests
+              </span>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="font-medium text-sm">Rate Limited</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="font-bold text-2xl">
+              {totalCounts.rateLimitedCount.toLocaleString()}
+            </div>
+            <div className="mt-1 flex items-center text-muted-foreground text-xs">
+              <XCircleIcon className="mr-1 h-3 w-3 text-red-500" />
+              <span>
+                {/* if there are no requests, we show 100% success rate */}
+                {totalRequests === 0
+                  ? "100"
+                  : (
+                      (Number(totalCounts.rateLimitedCount) /
+                        Number(totalRequests)) *
+                      100
+                    ).toFixed(1)}
+                % of requests
+              </span>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {peakPercentage > 100 && (
+        <Alert variant="destructive">
+          <AlertTriangleIcon className="h-4 w-4" />
+          <AlertTitle>Rate Limit Exceeded</AlertTitle>
+          <AlertDescription>
+            Your peak usage of {peakRate.peakRPS.toFixed(1)} RPS has exceeded
+            your plan limit of {currentRateLimit} RPS. Consider upgrading your
+            plan to avoid rate limiting.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {peakPercentage > 80 && peakPercentage <= 100 && (
+        <Alert variant="warning" className="border-yellow-500 text-yellow-700">
+          <AlertTriangleIcon className="h-4 w-4" />
+          <AlertTitle>Approaching Rate Limit</AlertTitle>
+          <AlertDescription>
+            Your peak usage is at {peakPercentage.toFixed(0)}% of your plan
+            limit. You may experience rate limiting during high traffic periods.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <RateGraph
+        peakPercentage={peakPercentage}
+        currentRateLimit={currentRateLimit}
+        data={apiData.data.averageRate}
+      />
+
+      <CountGraph
+        peakPercentage={peakPercentage}
+        currentRateLimit={currentRateLimit}
+        data={apiData.data.averageRate}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
currently blocked by analytics API needing to go to prod

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the RPC usage dashboard in the application by adding new components for visualizing request data, updating existing UI elements, and integrating new API responses for more detailed usage analytics.

### Detailed summary
- Added a new navigation label for `RPC` in the usage layout.
- Updated the label for `maxLimit` in the chart component.
- Introduced `CountGraph` and `RateGraph` components to visualize RPC usage over time.
- Implemented a new API response type `Last24HoursRPCUsageApiResponse`.
- Enhanced `getLast24HoursRPCUsage` function to fetch and return detailed usage data.
- Updated `ThirdwebAreaChart` to support `maxLimit` and `footer` props.
- Added detailed error handling and user feedback in the `RPCUsage` component.
- Included alerts for rate limit warnings and exceeded limits in the `RPCUsage` dashboard.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->