### PR TITLE
Add support for starter, accelerate, and scale tiers

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/support/create-ticket/components/create-ticket.action.ts
+++ b/apps/dashboard/src/app/(dashboard)/support/create-ticket/components/create-ticket.action.ts
@@ -15,7 +15,11 @@ const UNTHREAD_API_KEY = process.env.UNTHREAD_API_KEY || "";
 
 const planToCustomerId = {
   free: process.env.UNTHREAD_FREE_TIER_ID as string,
+  // treat starter as free
+  starter: process.env.UNTHREAD_FREE_TIER_ID as string,
   growth: process.env.UNTHREAD_GROWTH_TIER_ID as string,
+  accelerate: process.env.UNTHREAD_ACCELERATE_TIER_ID as string,
+  scale: process.env.UNTHREAD_SCALE_TIER_ID as string,
   pro: process.env.UNTHREAD_PRO_TIER_ID as string,
 } as const;
 
@@ -99,7 +103,8 @@ export async function createTicketAction(
   }
 
   const customerId = isValidPlan(team.supportPlan)
-    ? planToCustomerId[team.supportPlan]
+    ? // fall back to "free" tier
+      planToCustomerId[team.supportPlan] || planToCustomerId.free
     : // fallback to "free" tier
       planToCustomerId.free;
 


### PR DESCRIPTION
fixes: CORE-826

# Add support for new pricing tiers in ticket creation

This PR adds support for the new pricing tiers (starter, accelerate, scale) in the ticket creation system. It updates the `planToCustomerId` mapping to include these new tiers and improves the fallback logic to use the free tier when a customer's plan doesn't have a corresponding Unthread customer ID.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `planToCustomerId` mapping in the `create-ticket.action.ts` file by adding support for new tiers and improving the fallback logic for customer IDs based on the support plan.

### Detailed summary
- Added `starter`, `accelerate`, and `scale` tiers to the `planToCustomerId` mapping.
- Updated fallback logic in `createTicketAction` to return `planToCustomerId.free` if the `team.supportPlan` is invalid.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->