### PR TITLE
Nebula: Do not override chains set from search params

### DIFF
--- a/apps/dashboard/src/app/nebula-app/(app)/components/ChatPageContent.tsx
+++ b/apps/dashboard/src/app/nebula-app/(app)/components/ChatPageContent.tsx
@@ -132,15 +132,17 @@ export function ChatPageContent(props: {
         updatedContextFilters.walletAddress = address;
       }
 
-      // if we have last used chains in storage, continue using them
-      try {
-        const lastUsedChainIds = getLastUsedChainIds();
-        if (lastUsedChainIds) {
-          updatedContextFilters.chainIds = lastUsedChainIds;
-          return updatedContextFilters;
+      if (updatedContextFilters.chainIds?.length === 0) {
+        // if we have last used chains in storage, continue using them
+        try {
+          const lastUsedChainIds = getLastUsedChainIds();
+          if (lastUsedChainIds) {
+            updatedContextFilters.chainIds = lastUsedChainIds;
+            return updatedContextFilters;
+          }
+        } catch {
+          // ignore local storage errors
         }
-      } catch {
-        // ignore local storage errors
       }
 
       return updatedContextFilters;


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR refactors the logic for setting `chainIds` in `updatedContextFilters` to ensure that the last used chains from storage are only retrieved if `chainIds` is empty. It also maintains error handling for local storage access.

### Detailed summary
- Moved the check for empty `chainIds` to before retrieving last used chains.
- Retained the logic to fetch `lastUsedChainIds` if `chainIds` is empty.
- Preserved error handling for local storage access.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->