### PR TITLE
[SDK] Use insight for erc721/getNFTs and erc721/getOwnedNFTs

### DIFF
--- a/.changeset/purple-bats-march.md
+++ b/.changeset/purple-bats-march.md
@@ -1,0 +1,34 @@
+---
+"thirdweb": patch
+---
+
+Use insight for erc821/getNFT, erc721/getNFTs and erc721/getOwnedNFTs
+
+Standard ERC721 getNFT, getNFTs and getOwnedNFTs now use insight, our in house indexer by default. If indexer is not availbale, will fallback to RPC.
+
+You can also use the indexer directly using the Insight API:
+
+for an entire collection
+
+```ts
+import { Insight } from "thirdweb";
+
+const events = await Insight.getContractNFTs({
+  client,
+  chains: [sepolia],
+  contractAddress: "0x1234567890123456789012345678901234567890",
+});
+```
+
+or for a single NFT
+
+```ts
+import { Insight } from "thirdweb";
+
+const events = await Insight.getNFT({
+  client,
+  chains: [sepolia],
+  contractAddress: "0x1234567890123456789012345678901234567890",
+  tokenId: 1n,
+});
+```

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,6 +16,7 @@ env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
   TW_SECRET_KEY: ${{ secrets.TW_SECRET_KEY }}
+  TW_CLIENT_ID: ${{ secrets.TW_CLIENT_ID }}
   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
 jobs:

--- a/apps/dashboard/src/@/actions/getWalletNFTs.ts
+++ b/apps/dashboard/src/@/actions/getWalletNFTs.ts
@@ -81,6 +81,7 @@ export async function getWalletNFTs(params: {
       const result = await transformMoralisResponseToNFT(
         await parsedResponse,
         owner,
+        chainId,
       );
 
       return { result };
@@ -194,6 +195,8 @@ async function getWalletNFTsFromInsight(params: {
       tokenURI: nft.metadata_url,
       type: nft.token_type === "erc721" ? "ERC721" : "ERC1155",
       supply: nft.balance,
+      tokenAddress: nft.contract.address,
+      chainId: nft.contract.chain_id,
     };
 
     return walletNFT;

--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/(marketplace)/components/list-form.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/(marketplace)/components/list-form.tsx
@@ -205,6 +205,8 @@ export const CreateListingsForm: React.FC<CreateListingsFormProps> = ({
           owner: nft.owner,
           type: "ERC721",
           tokenURI: nft.tokenURI,
+          chainId: nft.chainId,
+          tokenAddress: nft.tokenAddress,
         };
       }
       return {
@@ -216,6 +218,8 @@ export const CreateListingsForm: React.FC<CreateListingsFormProps> = ({
         owner: nft.owner,
         type: "ERC1155",
         tokenURI: nft.tokenURI,
+        chainId: nft.chainId,
+        tokenAddress: nft.tokenAddress,
       };
     }) as WalletNFT[];
   }, [ownedNFTs, form]);

--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/_components/NFTCards.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/_components/NFTCards.tsx
@@ -21,6 +21,7 @@ const dummyMetadata: (idx: number) => NFTWithContract = (idx) => ({
   owner: `0x_fake_${idx}`,
   type: "ERC721",
   supply: 1n,
+  tokenAddress: ZERO_ADDRESS,
 });
 
 interface NFTCardsProps {

--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/account/components/nfts-owned.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/account/components/nfts-owned.tsx
@@ -33,6 +33,7 @@ export const NftsOwned: React.FC<NftsOwnedProps> = ({
         type: nft.type,
         contractAddress: nft.contractAddress,
         chainId: contract.chain.id,
+        tokenAddress: nft.tokenAddress,
       }))}
       allNfts
       isPending={isWalletNFTsLoading}

--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/overview/components/MarketplaceDetails.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/overview/components/MarketplaceDetails.tsx
@@ -7,7 +7,7 @@ import { SkeletonContainer } from "@/components/ui/skeleton";
 import { TrackedLinkTW } from "@/components/ui/tracked-link";
 import { ArrowRightIcon } from "lucide-react";
 import { useMemo } from "react";
-import type { ThirdwebContract } from "thirdweb";
+import { type ThirdwebContract, ZERO_ADDRESS } from "thirdweb";
 import {
   type DirectListing,
   type EnglishAuction,
@@ -237,6 +237,8 @@ const dummyMetadata: (idx: number) => ListingData = (idx) => ({
     supply: BigInt(1),
     tokenURI: "",
     type: "ERC721",
+    tokenAddress: ZERO_ADDRESS,
+    chainId: 1,
   },
   currencyValuePerToken: {
     decimals: 18,
@@ -244,6 +246,8 @@ const dummyMetadata: (idx: number) => ListingData = (idx) => ({
     name: "Ether",
     symbol: "ETH",
     value: 0n,
+    tokenAddress: ZERO_ADDRESS,
+    chainId: 1,
   },
   creatorAddress: "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
   type: "direct-listing",
@@ -253,6 +257,8 @@ const dummyMetadata: (idx: number) => ListingData = (idx) => ({
     value: 0n,
     displayValue: "0.0",
     decimals: 18,
+    tokenAddress: ZERO_ADDRESS,
+    chainId: 1,
   },
 });
 

--- a/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/tokens/components/supply.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(chain)/[chain_id]/[contractAddress]/tokens/components/supply.tsx
@@ -46,8 +46,15 @@ export const TokenDetailsCard: React.FC<TokenBalancesProps> = ({
         tokenSupplyQuery.data,
         tokenMetadataQuery.data.decimals,
       ),
+      tokenAddress: contract.address,
+      chainId: contract.chain.id,
     };
-  }, [tokenMetadataQuery.data, tokenSupplyQuery.data]);
+  }, [
+    tokenMetadataQuery.data,
+    tokenSupplyQuery.data,
+    contract.address,
+    contract.chain.id,
+  ]);
 
   return (
     <TokenDetailsCardUI

--- a/apps/dashboard/src/lib/wallet/nfts/moralis.ts
+++ b/apps/dashboard/src/lib/wallet/nfts/moralis.ts
@@ -26,6 +26,7 @@ export function generateMoralisUrl({ chainId, owner }: GenerateURLParams) {
 export async function transformMoralisResponseToNFT(
   moralisResponse: MoralisResponse,
   owner: string,
+  chainId: number,
 ): Promise<WalletNFT[]> {
   return (
     await Promise.all(
@@ -47,6 +48,8 @@ export async function transformMoralisResponseToNFT(
             tokenURI: moralisNft.token_uri,
             supply: moralisNft.amount || "1",
             type: moralisNft.contract_type,
+            tokenAddress: moralisNft.token_address,
+            chainId,
           } as WalletNFT;
         } catch {
           return undefined as unknown as WalletNFT;

--- a/packages/thirdweb/src/chains/utils.ts
+++ b/packages/thirdweb/src/chains/utils.ts
@@ -296,8 +296,9 @@ export function getChainMetadata(chain: Chain): Promise<ChainMetadata> {
           `https://api.thirdweb.com/v1/chains/${chainId}`,
         );
         if (!res.ok) {
-          res.body?.cancel();
-          throw new Error(`Failed to fetch chain data for chainId ${chainId}`);
+          throw new Error(
+            `Failed to fetch chain data for chainId ${chainId}. ${res.status} ${res.statusText}`,
+          );
         }
 
         const response = (await res.json()) as FetchChainResponse;
@@ -356,8 +357,9 @@ export function getChainServices(chain: Chain): Promise<ChainService[]> {
           `https://api.thirdweb.com/v1/chains/${chainId}/services`,
         );
         if (!res.ok) {
-          res.body?.cancel();
-          throw new Error(`Failed to fetch services for chainId ${chainId}`);
+          throw new Error(
+            `Failed to fetch services for chainId ${chainId}. ${res.status} ${res.statusText}`,
+          );
         }
 
         const response = (await res.json()) as FetchChainServiceResponse;

--- a/packages/thirdweb/src/event/actions/get-events.ts
+++ b/packages/thirdweb/src/event/actions/get-events.ts
@@ -5,7 +5,6 @@ import type {
   ExtractAbiEventNames,
 } from "abitype";
 import { type Log, formatLog } from "viem";
-import { getChainServices } from "../../chains/utils.js";
 import { resolveContractAbi } from "../../contract/actions/resolve-abi.js";
 import type { ThirdwebContract } from "../../contract/contract.js";
 import { getContractEvents as getContractEventsInsight } from "../../insight/get-events.js";
@@ -197,7 +196,7 @@ export async function getContractEvents<
         ),
       );
     } catch (e) {
-      console.warn("Error fetching from insight", e);
+      console.warn("Error fetching from insight, falling back to rpc", e);
       // fetch from rpc
       logs = await Promise.all(
         logsParams.map((ethLogParams) => eth_getLogs(rpcRequest, ethLogParams)),
@@ -224,17 +223,6 @@ async function getLogsFromInsight(options: {
   contract: ThirdwebContract<Abi>;
 }): Promise<Log[]> {
   const { params, contract } = options;
-
-  const chainServices = await getChainServices(contract.chain);
-  const insightEnabled = chainServices.some(
-    (c) => c.service === "insight" && c.enabled,
-  );
-
-  if (!insightEnabled) {
-    throw new Error(
-      `Insight is not available for chainId ${contract.chain.id}`,
-    );
-  }
 
   const fromBlock =
     typeof params.fromBlock === "bigint" ? Number(params.fromBlock) : undefined;

--- a/packages/thirdweb/src/extensions/erc1155/read/getNFT.test.ts
+++ b/packages/thirdweb/src/extensions/erc1155/read/getNFT.test.ts
@@ -11,6 +11,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("erc1155.getNFT", () => {
     });
     expect(nft).toMatchInlineSnapshot(`
       {
+        "chainId": 1,
         "id": 2n,
         "metadata": {
           "animation_url": "ipfs://QmYoM63qaumQznBRx38tQjkY4ewbymeFb2KWBhkfMqNHax/3.mp4",
@@ -36,6 +37,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("erc1155.getNFT", () => {
         },
         "owner": null,
         "supply": 2519n,
+        "tokenAddress": "0x42d3641255C946CC451474295d29D3505173F22A",
         "tokenURI": "ipfs://QmbMXdbnNUAuGRoY6c6G792c6T9utfaBGqRUaMaRUf52Cb/2",
         "type": "ERC1155",
       }

--- a/packages/thirdweb/src/extensions/erc1155/read/getNFT.ts
+++ b/packages/thirdweb/src/extensions/erc1155/read/getNFT.ts
@@ -58,6 +58,8 @@ export async function getNFT(
       type: "ERC1155",
       owner: null,
       supply,
+      tokenAddress: options.contract.address,
+      chainId: options.contract.chain.id,
     },
   );
 }

--- a/packages/thirdweb/src/extensions/erc20/drop20.test.ts
+++ b/packages/thirdweb/src/extensions/erc20/drop20.test.ts
@@ -59,17 +59,10 @@ describe.runIf(process.env.TW_SECRET_KEY)(
     }, 60_000);
 
     it("should allow to claim tokens", async () => {
-      await expect(
-        getBalance({ contract, address: TEST_ACCOUNT_A.address }),
-      ).resolves.toMatchInlineSnapshot(`
-        {
-          "decimals": 18,
-          "displayValue": "0",
-          "name": "Test DropERC20",
-          "symbol": "",
-          "value": 0n,
-        }
-      `);
+      expect(
+        (await getBalance({ contract, address: TEST_ACCOUNT_A.address }))
+          .displayValue,
+      ).toBe("0");
       await sendAndConfirmTransaction({
         transaction: setClaimConditions({
           contract,
@@ -98,31 +91,17 @@ describe.runIf(process.env.TW_SECRET_KEY)(
         transaction: claimTx,
         account: TEST_ACCOUNT_A,
       });
-      await expect(
-        getBalance({ contract, address: TEST_ACCOUNT_A.address }),
-      ).resolves.toMatchInlineSnapshot(`
-        {
-          "decimals": 18,
-          "displayValue": "1",
-          "name": "Test DropERC20",
-          "symbol": "",
-          "value": 1000000000000000000n,
-        }
-      `);
+      expect(
+        (await getBalance({ contract, address: TEST_ACCOUNT_A.address }))
+          .displayValue,
+      ).toBe("1");
     });
 
     it("should allow to claim tokens with value", async () => {
-      await expect(
-        getBalance({ contract, address: TEST_ACCOUNT_C.address }),
-      ).resolves.toMatchInlineSnapshot(`
-        {
-          "decimals": 18,
-          "displayValue": "0",
-          "name": "Test DropERC20",
-          "symbol": "",
-          "value": 0n,
-        }
-      `);
+      expect(
+        (await getBalance({ contract, address: TEST_ACCOUNT_C.address }))
+          .displayValue,
+      ).toBe("0");
       // set cc with price
       await sendAndConfirmTransaction({
         transaction: setClaimConditions({
@@ -150,17 +129,10 @@ describe.runIf(process.env.TW_SECRET_KEY)(
         transaction: claimTx,
         account: TEST_ACCOUNT_C,
       });
-      await expect(
-        getBalance({ contract, address: TEST_ACCOUNT_C.address }),
-      ).resolves.toMatchInlineSnapshot(`
-        {
-          "decimals": 18,
-          "displayValue": "2",
-          "name": "Test DropERC20",
-          "symbol": "",
-          "value": 2000000000000000000n,
-        }
-      `);
+      expect(
+        (await getBalance({ contract, address: TEST_ACCOUNT_C.address }))
+          .displayValue,
+      ).toBe("2");
     });
 
     describe("Allowlists", () => {
@@ -181,17 +153,10 @@ describe.runIf(process.env.TW_SECRET_KEY)(
           account: TEST_ACCOUNT_A,
         });
 
-        await expect(
-          getBalance({ contract, address: TEST_ACCOUNT_B.address }),
-        ).resolves.toMatchInlineSnapshot(`
-          {
-            "decimals": 18,
-            "displayValue": "0",
-            "name": "Test DropERC20",
-            "symbol": "",
-            "value": 0n,
-          }
-        `);
+        expect(
+          (await getBalance({ contract, address: TEST_ACCOUNT_B.address }))
+            .displayValue,
+        ).toBe("0");
 
         expect(
           await canClaim({
@@ -228,17 +193,10 @@ describe.runIf(process.env.TW_SECRET_KEY)(
           }),
         });
 
-        await expect(
-          getBalance({ contract, address: TEST_ACCOUNT_B.address }),
-        ).resolves.toMatchInlineSnapshot(`
-          {
-            "decimals": 18,
-            "displayValue": "1",
-            "name": "Test DropERC20",
-            "symbol": "",
-            "value": 1000000000000000000n,
-          }
-        `);
+        expect(
+          (await getBalance({ contract, address: TEST_ACCOUNT_B.address }))
+            .displayValue,
+        ).toBe("1");
 
         await expect(
           sendAndConfirmTransaction({
@@ -274,17 +232,10 @@ describe.runIf(process.env.TW_SECRET_KEY)(
           account: TEST_ACCOUNT_A,
         });
 
-        await expect(
-          getBalance({ contract, address: TEST_ACCOUNT_A.address }),
-        ).resolves.toMatchInlineSnapshot(`
-          {
-            "decimals": 18,
-            "displayValue": "1",
-            "name": "Test DropERC20",
-            "symbol": "",
-            "value": 1000000000000000000n,
-          }
-        `);
+        expect(
+          (await getBalance({ contract, address: TEST_ACCOUNT_A.address }))
+            .displayValue,
+        ).toBe("1");
 
         // we try to claim an extra `2` tokens
         // this should faile bcause the max claimable is `3` and we have previously already claimed 2 tokens (one for ourselves, one for the other wallet)
@@ -318,17 +269,10 @@ describe.runIf(process.env.TW_SECRET_KEY)(
           }),
         });
 
-        await expect(
-          getBalance({ contract, address: TEST_ACCOUNT_A.address }),
-        ).resolves.toMatchInlineSnapshot(`
-          {
-            "decimals": 18,
-            "displayValue": "2",
-            "name": "Test DropERC20",
-            "symbol": "",
-            "value": 2000000000000000000n,
-          }
-        `);
+        expect(
+          (await getBalance({ contract, address: TEST_ACCOUNT_A.address }))
+            .displayValue,
+        ).toBe("2");
       });
     });
 
@@ -353,17 +297,10 @@ describe.runIf(process.env.TW_SECRET_KEY)(
         account: TEST_ACCOUNT_A,
       });
 
-      await expect(
-        getBalance({ contract, address: TEST_ACCOUNT_A.address }),
-      ).resolves.toMatchInlineSnapshot(`
-        {
-          "decimals": 18,
-          "displayValue": "2",
-          "name": "Test DropERC20",
-          "symbol": "",
-          "value": 2000000000000000000n,
-        }
-      `);
+      expect(
+        (await getBalance({ contract, address: TEST_ACCOUNT_A.address }))
+          .displayValue,
+      ).toBe("2");
 
       await sendAndConfirmTransaction({
         account: TEST_ACCOUNT_A,
@@ -374,17 +311,10 @@ describe.runIf(process.env.TW_SECRET_KEY)(
         }),
       });
 
-      await expect(
-        getBalance({ contract, address: TEST_ACCOUNT_A.address }),
-      ).resolves.toMatchInlineSnapshot(`
-        {
-          "decimals": 18,
-          "displayValue": "3",
-          "name": "Test DropERC20",
-          "symbol": "",
-          "value": 3000000000000000000n,
-        }
-      `);
+      expect(
+        (await getBalance({ contract, address: TEST_ACCOUNT_A.address }))
+          .displayValue,
+      ).toBe("3");
     });
 
     it("should be able to retrieve multiple phases", async () => {
@@ -436,17 +366,10 @@ describe.runIf(process.env.TW_SECRET_KEY)(
         account: TEST_ACCOUNT_D,
       });
       // check that the account has claimed one token
-      await expect(
-        getBalance({ contract, address: TEST_ACCOUNT_D.address }),
-      ).resolves.toMatchInlineSnapshot(`
-        {
-          "decimals": 18,
-          "displayValue": "0.000000000000000001",
-          "name": "Test DropERC20",
-          "symbol": "",
-          "value": 1n,
-        }
-      `);
+      expect(
+        (await getBalance({ contract, address: TEST_ACCOUNT_D.address }))
+          .displayValue,
+      ).toBe("0.000000000000000001");
 
       // attempt to claim another token (this should fail)
       await expect(
@@ -482,17 +405,10 @@ describe.runIf(process.env.TW_SECRET_KEY)(
         account: TEST_ACCOUNT_D,
       });
       // check that the account has claimed two tokens
-      await expect(
-        getBalance({ contract, address: TEST_ACCOUNT_D.address }),
-      ).resolves.toMatchInlineSnapshot(`
-        {
-          "decimals": 18,
-          "displayValue": "0.000000000000000002",
-          "name": "Test DropERC20",
-          "symbol": "",
-          "value": 2n,
-        }
-      `);
+      expect(
+        (await getBalance({ contract, address: TEST_ACCOUNT_D.address }))
+          .displayValue,
+      ).toBe("0.000000000000000002");
     });
   },
 );

--- a/packages/thirdweb/src/extensions/erc20/read/getBalance.test.ts
+++ b/packages/thirdweb/src/extensions/erc20/read/getBalance.test.ts
@@ -10,14 +10,10 @@ describe.runIf(process.env.TW_SECRET_KEY)("erc20.getBalance", () => {
       contract: USDT_CONTRACT,
       address: VITALIK_WALLET,
     });
-    expect(balance).toMatchInlineSnapshot(`
-      {
-        "decimals": 6,
-        "displayValue": "1544.900798",
-        "name": "Tether USD",
-        "symbol": "USDT",
-        "value": 1544900798n,
-      }
-    `);
+    expect(balance.displayValue).toBe("1544.900798");
+    expect(balance.name).toBe("Tether USD");
+    expect(balance.symbol).toBe("USDT");
+    expect(balance.value).toBe(1544900798n);
+    expect(balance.decimals).toBe(6);
   });
 });

--- a/packages/thirdweb/src/extensions/erc20/read/getBalance.ts
+++ b/packages/thirdweb/src/extensions/erc20/read/getBalance.ts
@@ -23,6 +23,8 @@ export type GetBalanceResult = {
   displayValue: string;
   symbol: string;
   name: string;
+  tokenAddress: string;
+  chainId: number;
 };
 
 /**
@@ -48,5 +50,7 @@ export async function getBalance(
     ...currencyMetadata,
     value: balanceWei,
     displayValue: toTokens(balanceWei, currencyMetadata.decimals),
+    tokenAddress: options.contract.address,
+    chainId: options.contract.chain.id,
   };
 }

--- a/packages/thirdweb/src/extensions/erc721/read/getNFT.test.ts
+++ b/packages/thirdweb/src/extensions/erc721/read/getNFT.test.ts
@@ -3,14 +3,118 @@ import { DOODLES_CONTRACT } from "~test/test-contracts.js";
 import { getNFT } from "./getNFT.js";
 
 describe.runIf(process.env.TW_SECRET_KEY)("erc721.getNFT", () => {
+  it("without owner using indexer", async () => {
+    const nft = await getNFT({
+      contract: DOODLES_CONTRACT,
+      tokenId: 1n,
+      includeOwner: false,
+    });
+    expect(nft.metadata.name).toBe("Doodle #1");
+    // TODO (insight): re-enable once insight fixes the client id caching issue
+    // expect(nft).toMatchInlineSnapshot(`
+    //   {
+    //     "chainId": 1,
+    //     "id": 1n,
+    //     "metadata": {
+    //       "attributes": [
+    //         {
+    //           "trait_type": "face",
+    //           "value": "holographic beard",
+    //         },
+    //         {
+    //           "trait_type": "hair",
+    //           "value": "white bucket cap",
+    //         },
+    //         {
+    //           "trait_type": "body",
+    //           "value": "purple sweater with satchel",
+    //         },
+    //         {
+    //           "trait_type": "background",
+    //           "value": "grey",
+    //         },
+    //         {
+    //           "trait_type": "head",
+    //           "value": "gradient 2",
+    //         },
+    //       ],
+    //       "description": "A community-driven collectibles project featuring art by Burnt Toast. Doodles come in a joyful range of colors, traits and sizes with a collection size of 10,000. Each Doodle allows its owner to vote for experiences and activations paid for by the Doodles Community Treasury. Burnt Toast is the working alias for Scott Martin, a Canadian–based illustrator, designer, animator and muralist.",
+    //       "image": "https://${clientId}.ipfscdn.io/ipfs/QmTDxnzcvj2p3xBrKcGv1wxoyhAn2yzCQnZZ9LmFjReuH9",
+    //       "image_url": "https://${clientId}.ipfscdn.io/ipfs/QmTDxnzcvj2p3xBrKcGv1wxoyhAn2yzCQnZZ9LmFjReuH9",
+    //       "name": "Doodle #1",
+    //       "uri": "https://${clientId}.ipfscdn.io/ipfs/QmPMc4tcBsMqLRuCQtPmPe84bpSjrC3Ky7t3JWuHXYB4aS/1",
+    //     },
+    //     "owner": null,
+    //     "tokenAddress": "0x8a90cab2b38dba80c64b7734e58ee1db38b8992e",
+    //     "tokenURI": "https://${clientId}.ipfscdn.io/ipfs/QmPMc4tcBsMqLRuCQtPmPe84bpSjrC3Ky7t3JWuHXYB4aS/1",
+    //     "type": "ERC721",
+    //   }
+    // `);
+  });
+
+  it("with owner using indexer", async () => {
+    const nft = await getNFT({
+      contract: { ...DOODLES_CONTRACT },
+      tokenId: 1n,
+      includeOwner: true,
+    });
+    expect(nft.metadata.name).toBe("Doodle #1");
+    expect(nft.owner).toBe("0xbe9936fcfc50666f5425fde4a9decc59cef73b24");
+    // TODO (insight): re-enable once insight fixes the client id caching issue
+    // expect(nft).toMatchInlineSnapshot(`
+    //   {
+    //     "chainId": 1,
+    //     "id": 1n,
+    //     "metadata": {
+    //       "attributes": [
+    //         {
+    //           "trait_type": "face",
+    //           "value": "holographic beard",
+    //         },
+    //         {
+    //           "trait_type": "hair",
+    //           "value": "white bucket cap",
+    //         },
+    //         {
+    //           "trait_type": "body",
+    //           "value": "purple sweater with satchel",
+    //         },
+    //         {
+    //           "trait_type": "background",
+    //           "value": "grey",
+    //         },
+    //         {
+    //           "trait_type": "head",
+    //           "value": "gradient 2",
+    //         },
+    //       ],
+    //       "description": "A community-driven collectibles project featuring art by Burnt Toast. Doodles come in a joyful range of colors, traits and sizes with a collection size of 10,000. Each Doodle allows its owner to vote for experiences and activations paid for by the Doodles Community Treasury. Burnt Toast is the working alias for Scott Martin, a Canadian–based illustrator, designer, animator and muralist.",
+    //       "image": "https://${clientId}.ipfscdn.io/ipfs/QmTDxnzcvj2p3xBrKcGv1wxoyhAn2yzCQnZZ9LmFjReuH9",
+    //       "image_url": "https://${clientId}.ipfscdn.io/ipfs/QmTDxnzcvj2p3xBrKcGv1wxoyhAn2yzCQnZZ9LmFjReuH9",
+    //       "name": "Doodle #1",
+    //       "owner_addresses": [
+    //         "0xbe9936fcfc50666f5425fde4a9decc59cef73b24",
+    //       ],
+    //       "uri": "https://${clientId}.ipfscdn.io/ipfs/QmPMc4tcBsMqLRuCQtPmPe84bpSjrC3Ky7t3JWuHXYB4aS/1",
+    //     },
+    //     "owner": "0xbe9936fcfc50666f5425fde4a9decc59cef73b24",
+    //     "tokenAddress": "0x8a90cab2b38dba80c64b7734e58ee1db38b8992e",
+    //     "tokenURI": "https://${clientId}.ipfscdn.io/ipfs/QmPMc4tcBsMqLRuCQtPmPe84bpSjrC3Ky7t3JWuHXYB4aS/1",
+    //     "type": "ERC721",
+    //   }
+    // `);
+  });
+
   it("without owner", async () => {
     const nft = await getNFT({
       contract: { ...DOODLES_CONTRACT },
       tokenId: 1n,
       includeOwner: false,
+      useIndexer: false,
     });
     expect(nft).toMatchInlineSnapshot(`
       {
+        "chainId": 1,
         "id": 1n,
         "metadata": {
           "attributes": [
@@ -40,6 +144,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("erc721.getNFT", () => {
           "name": "Doodle #1",
         },
         "owner": null,
+        "tokenAddress": "0x8a90cab2b38dba80c64b7734e58ee1db38b8992e",
         "tokenURI": "ipfs://QmPMc4tcBsMqLRuCQtPmPe84bpSjrC3Ky7t3JWuHXYB4aS/1",
         "type": "ERC721",
       }
@@ -51,9 +156,11 @@ describe.runIf(process.env.TW_SECRET_KEY)("erc721.getNFT", () => {
       contract: { ...DOODLES_CONTRACT },
       tokenId: 1n,
       includeOwner: true,
+      useIndexer: false,
     });
     expect(nft).toMatchInlineSnapshot(`
       {
+        "chainId": 1,
         "id": 1n,
         "metadata": {
           "attributes": [
@@ -83,6 +190,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("erc721.getNFT", () => {
           "name": "Doodle #1",
         },
         "owner": "0xbE9936FCFC50666f5425FDE4A9decC59cEF73b24",
+        "tokenAddress": "0x8a90cab2b38dba80c64b7734e58ee1db38b8992e",
         "tokenURI": "ipfs://QmPMc4tcBsMqLRuCQtPmPe84bpSjrC3Ky7t3JWuHXYB4aS/1",
         "type": "ERC721",
       }

--- a/packages/thirdweb/src/extensions/erc721/read/getNFTs.test.ts
+++ b/packages/thirdweb/src/extensions/erc721/read/getNFTs.test.ts
@@ -6,16 +6,225 @@ import {
 import { getNFTs } from "./getNFTs.js";
 
 describe.runIf(process.env.TW_SECRET_KEY)("erc721.getNFTs", () => {
-  it("works for a contract with 0 indexed NFTs", async () => {
+  it("works for a contract with indexer", async () => {
     const nfts = await getNFTs({
       contract: DOODLES_CONTRACT,
       count: 5,
     });
 
     expect(nfts.length).toBe(5);
+    // TODO (insight): re-enable once insight fixes the client id caching issue
+    // expect(nfts).toMatchInlineSnapshot(`
+    //   [
+    //     {
+    //       "chainId": 1,
+    //       "id": 0n,
+    //       "metadata": {
+    //         "attributes": [
+    //           {
+    //             "trait_type": "face",
+    //             "value": "mustache",
+    //           },
+    //           {
+    //             "trait_type": "hair",
+    //             "value": "purple long",
+    //           },
+    //           {
+    //             "trait_type": "body",
+    //             "value": "blue and yellow jacket",
+    //           },
+    //           {
+    //             "trait_type": "background",
+    //             "value": "green",
+    //           },
+    //           {
+    //             "trait_type": "head",
+    //             "value": "tan",
+    //           },
+    //         ],
+    //         "description": "A community-driven collectibles project featuring art by Burnt Toast. Doodles come in a joyful range of colors, traits and sizes with a collection size of 10,000. Each Doodle allows its owner to vote for experiences and activations paid for by the Doodles Community Treasury. Burnt Toast is the working alias for Scott Martin, a Canadian–based illustrator, designer, animator and muralist.",
+    //         "image": "https://${clientId}.ipfscdn.io/ipfs/QmUEfFfwAh4wyB5UfHCVPUxis4j4Q4kJXtm5x5p3g1fVUn",
+    //         "image_url": "https://${clientId}.ipfscdn.io/ipfs/QmUEfFfwAh4wyB5UfHCVPUxis4j4Q4kJXtm5x5p3g1fVUn",
+    //         "name": "Doodle #0",
+    //         "uri": "https://${clientId}.ipfscdn.io/ipfs/QmPMc4tcBsMqLRuCQtPmPe84bpSjrC3Ky7t3JWuHXYB4aS/0",
+    //       },
+    //       "owner": null,
+    //       "tokenAddress": "0x8a90cab2b38dba80c64b7734e58ee1db38b8992e",
+    //       "tokenURI": "https://${clientId}.ipfscdn.io/ipfs/QmPMc4tcBsMqLRuCQtPmPe84bpSjrC3Ky7t3JWuHXYB4aS/0",
+    //       "type": "ERC721",
+    //     },
+    //     {
+    //       "chainId": 1,
+    //       "id": 1n,
+    //       "metadata": {
+    //         "attributes": [
+    //           {
+    //             "trait_type": "face",
+    //             "value": "holographic beard",
+    //           },
+    //           {
+    //             "trait_type": "hair",
+    //             "value": "white bucket cap",
+    //           },
+    //           {
+    //             "trait_type": "body",
+    //             "value": "purple sweater with satchel",
+    //           },
+    //           {
+    //             "trait_type": "background",
+    //             "value": "grey",
+    //           },
+    //           {
+    //             "trait_type": "head",
+    //             "value": "gradient 2",
+    //           },
+    //         ],
+    //         "description": "A community-driven collectibles project featuring art by Burnt Toast. Doodles come in a joyful range of colors, traits and sizes with a collection size of 10,000. Each Doodle allows its owner to vote for experiences and activations paid for by the Doodles Community Treasury. Burnt Toast is the working alias for Scott Martin, a Canadian–based illustrator, designer, animator and muralist.",
+    //         "image": "https://${clientId}.ipfscdn.io/ipfs/QmTDxnzcvj2p3xBrKcGv1wxoyhAn2yzCQnZZ9LmFjReuH9",
+    //         "image_url": "https://${clientId}.ipfscdn.io/ipfs/QmTDxnzcvj2p3xBrKcGv1wxoyhAn2yzCQnZZ9LmFjReuH9",
+    //         "name": "Doodle #1",
+    //         "uri": "https://${clientId}.ipfscdn.io/ipfs/QmPMc4tcBsMqLRuCQtPmPe84bpSjrC3Ky7t3JWuHXYB4aS/1",
+    //       },
+    //       "owner": null,
+    //       "tokenAddress": "0x8a90cab2b38dba80c64b7734e58ee1db38b8992e",
+    //       "tokenURI": "https://${clientId}.ipfscdn.io/ipfs/QmPMc4tcBsMqLRuCQtPmPe84bpSjrC3Ky7t3JWuHXYB4aS/1",
+    //       "type": "ERC721",
+    //     },
+    //     {
+    //       "chainId": 1,
+    //       "id": 2n,
+    //       "metadata": {
+    //         "attributes": [
+    //           {
+    //             "trait_type": "face",
+    //             "value": "designer glasses",
+    //           },
+    //           {
+    //             "trait_type": "hair",
+    //             "value": "poopie",
+    //           },
+    //           {
+    //             "trait_type": "body",
+    //             "value": "blue fleece",
+    //           },
+    //           {
+    //             "trait_type": "background",
+    //             "value": "yellow",
+    //           },
+    //           {
+    //             "trait_type": "head",
+    //             "value": "purple",
+    //           },
+    //         ],
+    //         "description": "A community-driven collectibles project featuring art by Burnt Toast. Doodles come in a joyful range of colors, traits and sizes with a collection size of 10,000. Each Doodle allows its owner to vote for experiences and activations paid for by the Doodles Community Treasury. Burnt Toast is the working alias for Scott Martin, a Canadian–based illustrator, designer, animator and muralist.",
+    //         "image": "https://${clientId}.ipfscdn.io/ipfs/QmbvZ2hbF3nEq5r3ijMEiSGssAmJvtyFwiejTAGHv74LR5",
+    //         "image_url": "https://${clientId}.ipfscdn.io/ipfs/QmbvZ2hbF3nEq5r3ijMEiSGssAmJvtyFwiejTAGHv74LR5",
+    //         "name": "Doodle #2",
+    //         "uri": "https://${clientId}.ipfscdn.io/ipfs/QmPMc4tcBsMqLRuCQtPmPe84bpSjrC3Ky7t3JWuHXYB4aS/2",
+    //       },
+    //       "owner": null,
+    //       "tokenAddress": "0x8a90cab2b38dba80c64b7734e58ee1db38b8992e",
+    //       "tokenURI": "https://${clientId}.ipfscdn.io/ipfs/QmPMc4tcBsMqLRuCQtPmPe84bpSjrC3Ky7t3JWuHXYB4aS/2",
+    //       "type": "ERC721",
+    //     },
+    //     {
+    //       "chainId": 1,
+    //       "id": 3n,
+    //       "metadata": {
+    //         "attributes": [
+    //           {
+    //             "trait_type": "face",
+    //             "value": "designer glasses",
+    //           },
+    //           {
+    //             "trait_type": "hair",
+    //             "value": "holographic mohawk",
+    //           },
+    //           {
+    //             "trait_type": "body",
+    //             "value": "pink fleece",
+    //           },
+    //           {
+    //             "trait_type": "background",
+    //             "value": "gradient 1",
+    //           },
+    //           {
+    //             "trait_type": "head",
+    //             "value": "pale",
+    //           },
+    //         ],
+    //         "description": "A community-driven collectibles project featuring art by Burnt Toast. Doodles come in a joyful range of colors, traits and sizes with a collection size of 10,000. Each Doodle allows its owner to vote for experiences and activations paid for by the Doodles Community Treasury. Burnt Toast is the working alias for Scott Martin, a Canadian–based illustrator, designer, animator and muralist.",
+    //         "image": "https://${clientId}.ipfscdn.io/ipfs/QmVpwaCqLut3wqwB5KSQr2fGnbLuJt5e3LhNvzvcisewZB",
+    //         "image_url": "https://${clientId}.ipfscdn.io/ipfs/QmVpwaCqLut3wqwB5KSQr2fGnbLuJt5e3LhNvzvcisewZB",
+    //         "name": "Doodle #3",
+    //         "uri": "https://${clientId}.ipfscdn.io/ipfs/QmPMc4tcBsMqLRuCQtPmPe84bpSjrC3Ky7t3JWuHXYB4aS/3",
+    //       },
+    //       "owner": null,
+    //       "tokenAddress": "0x8a90cab2b38dba80c64b7734e58ee1db38b8992e",
+    //       "tokenURI": "https://${clientId}.ipfscdn.io/ipfs/QmPMc4tcBsMqLRuCQtPmPe84bpSjrC3Ky7t3JWuHXYB4aS/3",
+    //       "type": "ERC721",
+    //     },
+    //     {
+    //       "chainId": 1,
+    //       "id": 4n,
+    //       "metadata": {
+    //         "attributes": [
+    //           {
+    //             "trait_type": "face",
+    //             "value": "happy",
+    //           },
+    //           {
+    //             "trait_type": "hair",
+    //             "value": "purple long",
+    //           },
+    //           {
+    //             "trait_type": "body",
+    //             "value": "spotted hoodie",
+    //           },
+    //           {
+    //             "trait_type": "background",
+    //             "value": "gradient 2",
+    //           },
+    //           {
+    //             "trait_type": "head",
+    //             "value": "purple",
+    //           },
+    //         ],
+    //         "description": "A community-driven collectibles project featuring art by Burnt Toast. Doodles come in a joyful range of colors, traits and sizes with a collection size of 10,000. Each Doodle allows its owner to vote for experiences and activations paid for by the Doodles Community Treasury. Burnt Toast is the working alias for Scott Martin, a Canadian–based illustrator, designer, animator and muralist.",
+    //         "image": "https://${clientId}.ipfscdn.io/ipfs/QmcyuFVLbfBmSeQ9ynu4dk67r97nB1abEekotuVuRGWedm",
+    //         "image_url": "https://${clientId}.ipfscdn.io/ipfs/QmcyuFVLbfBmSeQ9ynu4dk67r97nB1abEekotuVuRGWedm",
+    //         "name": "Doodle #4",
+    //         "uri": "https://${clientId}.ipfscdn.io/ipfs/QmPMc4tcBsMqLRuCQtPmPe84bpSjrC3Ky7t3JWuHXYB4aS/4",
+    //       },
+    //       "owner": null,
+    //       "tokenAddress": "0x8a90cab2b38dba80c64b7734e58ee1db38b8992e",
+    //       "tokenURI": "https://${clientId}.ipfscdn.io/ipfs/QmPMc4tcBsMqLRuCQtPmPe84bpSjrC3Ky7t3JWuHXYB4aS/4",
+    //       "type": "ERC721",
+    //     },
+    //   ]
+    // `);
+  });
+
+  it("should throw error if totalSupply and nextTokenIdToMint are not supported", async () => {
+    await expect(
+      getNFTs({ contract: UNISWAPV3_FACTORY_CONTRACT, useIndexer: false }),
+    ).rejects.toThrowError(
+      "Contract requires either `nextTokenIdToMint` or `totalSupply` function available to determine the next token ID to mint",
+    );
+  });
+
+  it("works for a contract with 0 indexed NFTs using RPC", async () => {
+    const nfts = await getNFTs({
+      contract: DOODLES_CONTRACT,
+      count: 5,
+      useIndexer: false,
+    });
+
+    expect(nfts.length).toBe(5);
     expect(nfts).toMatchInlineSnapshot(`
       [
         {
+          "chainId": 1,
           "id": 0n,
           "metadata": {
             "attributes": [
@@ -45,10 +254,12 @@ describe.runIf(process.env.TW_SECRET_KEY)("erc721.getNFTs", () => {
             "name": "Doodle #0",
           },
           "owner": null,
+          "tokenAddress": "0x8a90cab2b38dba80c64b7734e58ee1db38b8992e",
           "tokenURI": "ipfs://QmPMc4tcBsMqLRuCQtPmPe84bpSjrC3Ky7t3JWuHXYB4aS/0",
           "type": "ERC721",
         },
         {
+          "chainId": 1,
           "id": 1n,
           "metadata": {
             "attributes": [
@@ -78,10 +289,12 @@ describe.runIf(process.env.TW_SECRET_KEY)("erc721.getNFTs", () => {
             "name": "Doodle #1",
           },
           "owner": null,
+          "tokenAddress": "0x8a90cab2b38dba80c64b7734e58ee1db38b8992e",
           "tokenURI": "ipfs://QmPMc4tcBsMqLRuCQtPmPe84bpSjrC3Ky7t3JWuHXYB4aS/1",
           "type": "ERC721",
         },
         {
+          "chainId": 1,
           "id": 2n,
           "metadata": {
             "attributes": [
@@ -111,10 +324,12 @@ describe.runIf(process.env.TW_SECRET_KEY)("erc721.getNFTs", () => {
             "name": "Doodle #2",
           },
           "owner": null,
+          "tokenAddress": "0x8a90cab2b38dba80c64b7734e58ee1db38b8992e",
           "tokenURI": "ipfs://QmPMc4tcBsMqLRuCQtPmPe84bpSjrC3Ky7t3JWuHXYB4aS/2",
           "type": "ERC721",
         },
         {
+          "chainId": 1,
           "id": 3n,
           "metadata": {
             "attributes": [
@@ -144,10 +359,12 @@ describe.runIf(process.env.TW_SECRET_KEY)("erc721.getNFTs", () => {
             "name": "Doodle #3",
           },
           "owner": null,
+          "tokenAddress": "0x8a90cab2b38dba80c64b7734e58ee1db38b8992e",
           "tokenURI": "ipfs://QmPMc4tcBsMqLRuCQtPmPe84bpSjrC3Ky7t3JWuHXYB4aS/3",
           "type": "ERC721",
         },
         {
+          "chainId": 1,
           "id": 4n,
           "metadata": {
             "attributes": [
@@ -177,22 +394,11 @@ describe.runIf(process.env.TW_SECRET_KEY)("erc721.getNFTs", () => {
             "name": "Doodle #4",
           },
           "owner": null,
+          "tokenAddress": "0x8a90cab2b38dba80c64b7734e58ee1db38b8992e",
           "tokenURI": "ipfs://QmPMc4tcBsMqLRuCQtPmPe84bpSjrC3Ky7t3JWuHXYB4aS/4",
           "type": "ERC721",
         },
       ]
     `);
-  });
-
-  it.todo("works for a contract with `1` indexed NFTs", async () => {
-    // TODO find a contract that we can use that has "1 indexed" NFTs, then re-enable this test
-  });
-
-  it("should throw error if totalSupply and nextTokenIdToMint are not supported", async () => {
-    await expect(
-      getNFTs({ contract: UNISWAPV3_FACTORY_CONTRACT }),
-    ).rejects.toThrowError(
-      "Contract requires either `nextTokenIdToMint` or `totalSupply` function available to determine the next token ID to mint",
-    );
   });
 });

--- a/packages/thirdweb/src/extensions/erc721/read/getOwnedNFTs.test.ts
+++ b/packages/thirdweb/src/extensions/erc721/read/getOwnedNFTs.test.ts
@@ -6,11 +6,35 @@ import { getContract } from "../../../contract/contract.js";
 import { getOwnedNFTs } from "./getOwnedNFTs.js";
 
 describe.runIf(process.env.TW_SECRET_KEY)("erc721.getOwnedNFTs", () => {
-  it("should return the correct data", async () => {
+  it("should return the correct data using indexer", async () => {
     const owner = "0x3010775D16E7B79AF280035c64a1Df5F705CfdDb";
     const nfts = await getOwnedNFTs({
       contract: DOODLES_CONTRACT,
       owner,
+    });
+    expect(nfts.length).greaterThan(0);
+  });
+
+  it("should detect ownership functions using indexer", async () => {
+    const contract = getContract({
+      client: TEST_CLIENT,
+      chain: defineChain(421614),
+      address: "0x90450885977EE8F8F21AC79Fc2Dd51a18B13123E",
+    });
+
+    const ownedNFTs = await getOwnedNFTs({
+      contract,
+      owner: "0x1813D5Ff6f2B229a6Ba8FcDFa14004d91aa58e36",
+    });
+    expect(ownedNFTs.length).greaterThan(0);
+  });
+
+  it("should return the correct data using RPC", async () => {
+    const owner = "0x3010775D16E7B79AF280035c64a1Df5F705CfdDb";
+    const nfts = await getOwnedNFTs({
+      contract: DOODLES_CONTRACT,
+      owner,
+      useIndexer: false,
     });
 
     // The following code is based on the state of the forked chain
@@ -21,7 +45,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("erc721.getOwnedNFTs", () => {
     }
   });
 
-  it("should detect ownership functions", async () => {
+  it("should detect ownership functions using RPC", async () => {
     const contract = getContract({
       client: TEST_CLIENT,
       chain: defineChain(421614),
@@ -31,6 +55,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("erc721.getOwnedNFTs", () => {
     const ownedNFTs = await getOwnedNFTs({
       contract,
       owner: "0x1813D5Ff6f2B229a6Ba8FcDFa14004d91aa58e36",
+      useIndexer: false,
     });
     expect(ownedNFTs.length).greaterThan(0);
   });

--- a/packages/thirdweb/src/extensions/erc721/token721.test.ts
+++ b/packages/thirdweb/src/extensions/erc721/token721.test.ts
@@ -108,6 +108,8 @@ describe.runIf(process.env.TW_SECRET_KEY)("deployERC721", () => {
           tokenUri: "",
           type: "ERC721",
           owner: null,
+          tokenAddress: token721Contract.address,
+          chainId: token721Contract.chain.id,
         },
       ),
     );

--- a/packages/thirdweb/src/extensions/marketplace/direct-listings/direct-listings.test.ts
+++ b/packages/thirdweb/src/extensions/marketplace/direct-listings/direct-listings.test.ts
@@ -204,15 +204,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("Marketplace Direct Listings", () => {
     expect(firstListing.creatorAddress).toBe(TEST_ACCOUNT_B.address);
     expect(firstListing.assetContractAddress).toBe(erc721Contract.address);
     expect(firstListing.tokenId).toBe(0n);
-    expect(firstListing.currencyValuePerToken).toMatchInlineSnapshot(`
-    {
-      "decimals": 18,
-      "displayValue": "1",
-      "name": "Anvil Ether",
-      "symbol": "ETH",
-      "value": 1000000000000000000n,
-    }
-  `);
+    expect(firstListing.currencyValuePerToken.displayValue).toBe("1");
     expect(firstListing.asset.metadata.name).toBe("erc721 #0");
     expect(firstListing.asset.id).toBe(0n);
     expect(firstListing.asset.owner).toBe(null);
@@ -351,15 +343,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("Marketplace Direct Listings", () => {
     expect(secondListing.creatorAddress).toBe(TEST_ACCOUNT_C.address);
     expect(secondListing.assetContractAddress).toBe(erc1155Contract.address);
     expect(secondListing.tokenId).toBe(0n);
-    expect(secondListing.currencyValuePerToken).toMatchInlineSnapshot(`
-      {
-        "decimals": 18,
-        "displayValue": "0.05",
-        "name": "Anvil Ether",
-        "symbol": "ETH",
-        "value": 50000000000000000n,
-      }
-    `);
+    expect(secondListing.currencyValuePerToken.displayValue).toBe("0.05");
     expect(secondListing.asset.metadata.name).toBe("erc1155 #0");
     expect(secondListing.asset.id).toBe(0n);
 

--- a/packages/thirdweb/src/extensions/marketplace/direct-listings/utils.ts
+++ b/packages/thirdweb/src/extensions/marketplace/direct-listings/utils.ts
@@ -26,12 +26,13 @@ export async function mapDirectListing(
     endTimestamp: rawListing.endTimestamp,
   });
 
+  const currencyContract = getContract({
+    ...options.contract,
+    address: rawListing.currency,
+  });
   const [currencyValuePerToken, nftAsset] = await Promise.all([
     getCurrencyMetadata({
-      contract: getContract({
-        ...options.contract,
-        address: rawListing.currency,
-      }),
+      contract: currencyContract,
     }),
     getNFTAsset({
       ...options,
@@ -57,6 +58,8 @@ export async function mapDirectListing(
         rawListing.pricePerToken,
         currencyValuePerToken.decimals,
       ),
+      tokenAddress: currencyContract.address,
+      chainId: currencyContract.chain.id,
     },
     pricePerToken: rawListing.pricePerToken,
     asset: nftAsset,

--- a/packages/thirdweb/src/extensions/marketplace/english-auctions/utils.ts
+++ b/packages/thirdweb/src/extensions/marketplace/english-auctions/utils.ts
@@ -24,12 +24,13 @@ export async function mapEnglishAuction(
     endTimestamp: rawAuction.endTimestamp,
   });
 
+  const currencyContract = getContract({
+    ...options.contract,
+    address: rawAuction.currency,
+  });
   const [auctionCurrencyMetadata, nftAsset] = await Promise.all([
     getCurrencyMetadata({
-      contract: getContract({
-        ...options.contract,
-        address: rawAuction.currency,
-      }),
+      contract: currencyContract,
     }),
     getNFTAsset({
       ...options,
@@ -60,6 +61,8 @@ export async function mapEnglishAuction(
         rawAuction.minimumBidAmount,
         auctionCurrencyMetadata.decimals,
       ),
+      tokenAddress: currencyContract.address,
+      chainId: currencyContract.chain.id,
     },
     buyoutBidAmount: rawAuction.buyoutBidAmount,
     buyoutCurrencyValue: {
@@ -69,6 +72,8 @@ export async function mapEnglishAuction(
         rawAuction.buyoutBidAmount,
         auctionCurrencyMetadata.decimals,
       ),
+      tokenAddress: currencyContract.address,
+      chainId: currencyContract.chain.id,
     },
     timeBufferInSeconds: rawAuction.timeBufferInSeconds,
     bidBufferBps: rawAuction.bidBufferBps,

--- a/packages/thirdweb/src/extensions/marketplace/offers/utils.ts
+++ b/packages/thirdweb/src/extensions/marketplace/offers/utils.ts
@@ -25,12 +25,13 @@ export async function mapOffer(
     endTimestamp: rawOffer.expirationTimestamp,
   });
 
+  const currencyContract = getContract({
+    ...options.contract,
+    address: rawOffer.currency,
+  });
   const [currencyValuePerToken, nftAsset] = await Promise.all([
     getCurrencyMetadata({
-      contract: getContract({
-        ...options.contract,
-        address: rawOffer.currency,
-      }),
+      contract: currencyContract,
     }),
     getNFTAsset({
       ...options,
@@ -56,6 +57,8 @@ export async function mapOffer(
         rawOffer.totalPrice,
         currencyValuePerToken.decimals,
       ),
+      tokenAddress: currencyContract.address,
+      chainId: currencyContract.chain.id,
     },
     totalPrice: rawOffer.totalPrice,
     asset: nftAsset,

--- a/packages/thirdweb/src/insight/common.ts
+++ b/packages/thirdweb/src/insight/common.ts
@@ -1,0 +1,24 @@
+import type { Chain } from "../chains/types.js";
+import { getChainServices } from "../chains/utils.js";
+
+export async function assertInsightEnabled(chains: Chain[]) {
+  const chainData = await Promise.all(
+    chains.map((chain) =>
+      getChainServices(chain).then((services) => ({
+        chain,
+        enabled: services.some((c) => c.service === "insight" && c.enabled),
+      })),
+    ),
+  );
+
+  const insightEnabled = chainData.every((c) => c.enabled);
+
+  if (!insightEnabled) {
+    throw new Error(
+      `Insight is not available for chains ${chainData
+        .filter((c) => !c.enabled)
+        .map((c) => c.chain.id)
+        .join(", ")}`,
+    );
+  }
+}

--- a/packages/thirdweb/src/insight/get-nfts.ts
+++ b/packages/thirdweb/src/insight/get-nfts.ts
@@ -1,15 +1,16 @@
-import {
-  type GetV1NftsBalanceByOwnerAddressData,
-  type GetV1NftsBalanceByOwnerAddressResponse,
-  getV1NftsBalanceByOwnerAddress,
+import type {
+  GetV1NftsByContractAddressByTokenIdData,
+  GetV1NftsByContractAddressData,
+  GetV1NftsByContractAddressResponse,
+  GetV1NftsData,
+  GetV1NftsResponse,
 } from "@thirdweb-dev/insight";
-import { stringify } from "viem";
 import type { Chain } from "../chains/types.js";
 import type { ThirdwebClient } from "../client/client.js";
-import { getThirdwebDomains } from "../utils/domains.js";
-import { getClientFetch } from "../utils/fetch.js";
+import type { NFT } from "../utils/nft/parseNft.js";
 
-export type OwnedNFT = GetV1NftsBalanceByOwnerAddressResponse["data"][number];
+type OwnedNFT = GetV1NftsResponse["data"][number];
+type ContractNFT = GetV1NftsByContractAddressResponse["data"][number];
 
 /**
  * Get NFTs owned by an address
@@ -29,28 +30,40 @@ export async function getOwnedNFTs(args: {
   client: ThirdwebClient;
   chains: Chain[];
   ownerAddress: string;
-  queryOptions?: GetV1NftsBalanceByOwnerAddressData["query"];
-}): Promise<OwnedNFT[]> {
-  const {
-    client,
-    chains,
-    ownerAddress,
-    queryOptions = {
-      chain: chains.map((chain) => chain.id),
-      metadata: "true",
-      limit: 100,
-      page: 1,
-    },
-  } = args;
+  includeMetadata?: boolean;
+  queryOptions?: Omit<GetV1NftsData["query"], "owner_address" | "chain">;
+}): Promise<(NFT & { quantityOwned: bigint })[]> {
+  const [
+    { getV1Nfts },
+    { getThirdwebDomains },
+    { getClientFetch },
+    { assertInsightEnabled },
+    { stringify },
+  ] = await Promise.all([
+    import("@thirdweb-dev/insight"),
+    import("../utils/domains.js"),
+    import("../utils/fetch.js"),
+    import("./common.js"),
+    import("viem"),
+  ]);
 
-  const result = await getV1NftsBalanceByOwnerAddress({
+  // TODO (insight): add support for contract address filters
+  const { client, chains, ownerAddress, queryOptions } = args;
+
+  await assertInsightEnabled(chains);
+
+  const defaultQueryOptions: GetV1NftsData["query"] = {
+    chain: chains.map((chain) => chain.id),
+    // metadata: includeMetadata ? "true" : "false", TODO (insight): add support for this
+    limit: 50,
+    owner_address: ownerAddress,
+  };
+
+  const result = await getV1Nfts({
     baseUrl: `https://${getThirdwebDomains().insight}`,
     fetch: getClientFetch(client),
-    path: {
-      ownerAddress: ownerAddress,
-    },
     query: {
-      chain: chains.map((chain) => chain.id),
+      ...defaultQueryOptions,
       ...queryOptions,
     },
   });
@@ -61,5 +74,223 @@ export async function getOwnedNFTs(args: {
     );
   }
 
-  return result.data?.data ?? [];
+  const transformedNfts = await transformNFTModel(
+    result.data?.data ?? [],
+    ownerAddress,
+  );
+  return transformedNfts.map((nft) => ({
+    ...nft,
+    quantityOwned: nft.quantityOwned ?? 1n,
+  }));
+}
+
+/**
+ * Get all NFTs from a contract
+ * @example
+ * ```ts
+ * import { Insight } from "thirdweb";
+ *
+ * const nfts = await Insight.getContractNFTs({
+ *   client,
+ *   chains: [sepolia],
+ *   contractAddress: "0x1234567890123456789012345678901234567890",
+ * });
+ * ```
+ * @insight
+ */
+export async function getContractNFTs(args: {
+  client: ThirdwebClient;
+  chains: Chain[];
+  contractAddress: string;
+  includeMetadata?: boolean;
+  includeOwners?: boolean;
+  queryOptions?: Omit<GetV1NftsByContractAddressData["query"], "chain">;
+}): Promise<NFT[]> {
+  const [
+    { getV1NftsByContractAddress },
+    { getThirdwebDomains },
+    { getClientFetch },
+    { assertInsightEnabled },
+    { stringify },
+  ] = await Promise.all([
+    import("@thirdweb-dev/insight"),
+    import("../utils/domains.js"),
+    import("../utils/fetch.js"),
+    import("./common.js"),
+    import("../utils/json.js"),
+  ]);
+
+  const {
+    client,
+    chains,
+    contractAddress,
+    includeOwners = true,
+    queryOptions,
+  } = args;
+
+  const defaultQueryOptions: GetV1NftsByContractAddressData["query"] = {
+    chain: chains.map((chain) => chain.id),
+    // metadata: includeMetadata ? "true" : "false", TODO (insight): add support for this
+    limit: 50,
+    include_owners:
+      includeOwners === true ? ("true" as const) : ("false" as const),
+  };
+
+  await assertInsightEnabled(chains);
+
+  const result = await getV1NftsByContractAddress({
+    baseUrl: `https://${getThirdwebDomains().insight}`,
+    fetch: getClientFetch(client),
+    path: {
+      contract_address: contractAddress,
+    },
+    query: {
+      ...defaultQueryOptions,
+      ...queryOptions,
+    },
+  });
+
+  if (result.error) {
+    throw new Error(
+      `${result.response.status} ${result.response.statusText} - ${result.error ? stringify(result.error) : "Unknown error"}`,
+    );
+  }
+
+  return transformNFTModel(result.data?.data ?? []);
+}
+
+/**
+ * Get NFT metadata by contract address and token id
+ * @example
+ * ```ts
+ * import { Insight } from "thirdweb";
+ *
+ * const nft = await Insight.getNFT({
+ *   client,
+ *   chain: sepolia,
+ *   contractAddress: "0x1234567890123456789012345678901234567890",
+ *   tokenId: 1n,
+ * });
+ * ```
+ * @insight
+ */
+export async function getNFT(args: {
+  client: ThirdwebClient;
+  chain: Chain;
+  contractAddress: string;
+  tokenId: bigint | number | string;
+  includeOwners?: boolean;
+  queryOptions?: GetV1NftsByContractAddressByTokenIdData["query"];
+}): Promise<NFT | undefined> {
+  const [
+    { getV1NftsByContractAddressByTokenId },
+    { getThirdwebDomains },
+    { getClientFetch },
+    { assertInsightEnabled },
+    { stringify },
+  ] = await Promise.all([
+    import("@thirdweb-dev/insight"),
+    import("../utils/domains.js"),
+    import("../utils/fetch.js"),
+    import("./common.js"),
+    import("../utils/json.js"),
+  ]);
+
+  const {
+    client,
+    chain,
+    contractAddress,
+    tokenId,
+    includeOwners = true,
+    queryOptions,
+  } = args;
+
+  await assertInsightEnabled([chain]);
+
+  const defaultQueryOptions: GetV1NftsByContractAddressByTokenIdData["query"] =
+    {
+      chain: chain.id,
+      include_owners:
+        includeOwners === true ? ("true" as const) : ("false" as const),
+    };
+
+  const result = await getV1NftsByContractAddressByTokenId({
+    baseUrl: `https://${getThirdwebDomains().insight}`,
+    fetch: getClientFetch(client),
+    path: {
+      contract_address: contractAddress,
+      token_id: tokenId.toString(),
+    },
+    query: {
+      ...defaultQueryOptions,
+      ...queryOptions,
+    },
+  });
+
+  if (result.error) {
+    throw new Error(
+      `${result.response.status} ${result.response.statusText} - ${result.error ? stringify(result.error) : "Unknown error"}`,
+    );
+  }
+
+  const transformedNfts = await transformNFTModel(result.data?.data ?? []);
+  return transformedNfts?.[0];
+}
+
+async function transformNFTModel(
+  nfts: (ContractNFT | OwnedNFT)[],
+  ownerAddress?: string,
+): Promise<(NFT & { quantityOwned?: bigint })[]> {
+  const { parseNFT } = await import("../utils/nft/parseNft.js");
+
+  return nfts.map((nft) => {
+    let parsedNft: NFT;
+    const {
+      contract,
+      extra_metadata,
+      collection,
+      metadata_url,
+      chain_id,
+      token_id,
+      status,
+      balance,
+      token_type,
+      ...rest
+    } = nft;
+    const metadata = {
+      uri: nft.metadata_url ?? "",
+      image: nft.image_url,
+      attributes: nft.extra_metadata?.attributes ?? undefined,
+      ...rest,
+    };
+
+    const owner_addresses = ownerAddress
+      ? [ownerAddress]
+      : "owner_addresses" in nft
+        ? nft.owner_addresses
+        : undefined;
+
+    if (contract?.type === "erc1155") {
+      parsedNft = parseNFT(metadata, {
+        tokenId: BigInt(token_id),
+        tokenUri: metadata_url ?? "",
+        type: "ERC1155",
+        owner: owner_addresses?.[0],
+        tokenAddress: contract?.address ?? "",
+        chainId: contract?.chain_id ?? 0,
+        supply: balance ? BigInt(balance) : 0n, // TODO (insight): this is wrong, needs to be added in the API
+      });
+    } else {
+      parsedNft = parseNFT(metadata, {
+        tokenId: BigInt(token_id),
+        type: "ERC721",
+        owner: owner_addresses?.[0],
+        tokenUri: metadata_url ?? "",
+        tokenAddress: contract?.address ?? "",
+        chainId: contract?.chain_id ?? 0,
+      });
+    }
+
+    return parsedNft;
+  });
 }

--- a/packages/thirdweb/src/insight/index.ts
+++ b/packages/thirdweb/src/insight/index.ts
@@ -1,4 +1,8 @@
-export { getOwnedNFTs, type OwnedNFT } from "./get-nfts.js";
-export { getOwnedTokens, type OwnedToken } from "./get-tokens.js";
+export {
+  getContractNFTs,
+  getOwnedNFTs,
+  getNFT,
+} from "./get-nfts.js";
+export { getOwnedTokens } from "./get-tokens.js";
 export { getTransactions, type Transaction } from "./get-transactions.js";
 export { getContractEvents, type ContractEvent } from "./get-events.js";

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/ViewTokens.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/ViewTokens.tsx
@@ -2,7 +2,6 @@ import { useQuery } from "@tanstack/react-query";
 import type { Chain } from "../../../../../chains/types.js";
 import type { ThirdwebClient } from "../../../../../client/client.js";
 import { getOwnedTokens } from "../../../../../insight/get-tokens.js";
-import { toTokens } from "../../../../../utils/units.js";
 import { fontSize } from "../../../../core/design-system/index.js";
 import { useWalletBalance } from "../../../../core/hooks/others/useWalletBalance.js";
 import { useActiveAccount } from "../../../../core/hooks/wallets/useActiveAccount.js";
@@ -94,8 +93,7 @@ export function ViewTokensContent(props: {
       return result.filter(
         (token) =>
           !defaultTokens[activeChain.id]?.some(
-            (t) =>
-              t.address.toLowerCase() === token.token_address.toLowerCase(),
+            (t) => t.address.toLowerCase() === token.tokenAddress.toLowerCase(),
           ),
       );
     },
@@ -139,22 +137,14 @@ export function ViewTokensContent(props: {
         return (
           <TokenInfo
             token={{
-              address: token.token_address,
+              address: token.tokenAddress,
               name: token.name ?? "",
               symbol: token.symbol ?? "",
             }}
-            key={token.token_address}
+            key={token.tokenAddress}
             chain={activeChain}
             client={props.client}
-            balanceData={{
-              symbol: token.symbol ?? "",
-              name: token.name ?? "",
-              decimals: token.decimals ?? 18,
-              displayValue: toTokens(
-                BigInt(token.balance),
-                token.decimals ?? 18,
-              ),
-            }}
+            balanceData={token}
           />
         );
       })}

--- a/packages/thirdweb/src/react/web/ui/components/TokenIcon.tsx
+++ b/packages/thirdweb/src/react/web/ui/components/TokenIcon.tsx
@@ -6,12 +6,13 @@ import { NATIVE_TOKEN_ADDRESS } from "../../../../constants/addresses.js";
 import { iconSize } from "../../../core/design-system/index.js";
 import { useChainIconUrl } from "../../../core/hooks/others/useChainQuery.js";
 import { genericTokenIcon } from "../../../core/utils/walletIcon.js";
+import { CoinsIcon } from "../ConnectWallet/icons/CoinsIcon.js";
 import {
   type NativeToken,
   isNativeToken,
 } from "../ConnectWallet/screens/nativeToken.js";
 import { Img } from "./Img.js";
-
+import { Container } from "./basic.js";
 /**
  * @internal
  */
@@ -38,13 +39,21 @@ export function TokenIcon(props: {
     return props.token.icon;
   }, [props.token, chainIconQuery.url]);
 
-  return (
+  return tokenImage ? (
     <Img
-      src={tokenImage || ""}
+      src={tokenImage}
       width={iconSize[props.size]}
       height={iconSize[props.size]}
       fallbackImage={genericTokenIcon}
       client={props.client}
     />
+  ) : (
+    <Container
+      center="both"
+      style={{ width: iconSize[props.size], height: iconSize[props.size] }}
+      color="secondaryText"
+    >
+      <CoinsIcon size={iconSize[props.size]} />
+    </Container>
   );
 }

--- a/packages/thirdweb/src/react/web/ui/prebuilt/NFT/utils.test.ts
+++ b/packages/thirdweb/src/react/web/ui/prebuilt/NFT/utils.test.ts
@@ -12,40 +12,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("getNFTInfo", () => {
       contract: DOODLES_CONTRACT,
       tokenId: 0n,
     });
-    expect(nft).toStrictEqual({
-      id: 0n,
-      metadata: {
-        attributes: [
-          {
-            trait_type: "face",
-            value: "mustache",
-          },
-          {
-            trait_type: "hair",
-            value: "purple long",
-          },
-          {
-            trait_type: "body",
-            value: "blue and yellow jacket",
-          },
-          {
-            trait_type: "background",
-            value: "green",
-          },
-          {
-            trait_type: "head",
-            value: "tan",
-          },
-        ],
-        description:
-          "A community-driven collectibles project featuring art by Burnt Toast. Doodles come in a joyful range of colors, traits and sizes with a collection size of 10,000. Each Doodle allows its owner to vote for experiences and activations paid for by the Doodles Community Treasury. Burnt Toast is the working alias for Scott Martin, a Canadian–based illustrator, designer, animator and muralist.",
-        image: "ipfs://QmUEfFfwAh4wyB5UfHCVPUxis4j4Q4kJXtm5x5p3g1fVUn",
-        name: "Doodle #0",
-      },
-      owner: null,
-      tokenURI: "ipfs://QmPMc4tcBsMqLRuCQtPmPe84bpSjrC3Ky7t3JWuHXYB4aS/0",
-      type: "ERC721",
-    });
+    expect(nft.metadata.name).toBe("Doodle #0");
   });
 
   it("should work with ERC1155", async () => {
@@ -53,36 +20,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("getNFTInfo", () => {
       contract: DROP1155_CONTRACT,
       tokenId: 0n,
     });
-    expect(nft).toStrictEqual({
-      id: 0n,
-      metadata: {
-        animation_url:
-          "ipfs://QmeGCqV1mSHTZrvuFzW1XZdCRRGXB6AmSotTqHoxA2xfDo/1.mp4",
-        attributes: [
-          {
-            trait_type: "Revenue Share",
-            value: "40%",
-          },
-          {
-            trait_type: "Max Supply",
-            value: "50",
-          },
-          {
-            trait_type: "Max Per Wallet",
-            value: "1",
-          },
-        ],
-        background_color: "",
-        description: "",
-        external_url: "https://auraexchange.org",
-        image: "ipfs://QmeGCqV1mSHTZrvuFzW1XZdCRRGXB6AmSotTqHoxA2xfDo/0.png",
-        name: "Aura OG",
-      },
-      owner: null,
-      supply: 33n,
-      tokenURI: "ipfs://QmNgevzVNwJWJdErFY2B7KsuKdJz3gVuBraNKaSxPktLh5/0",
-      type: "ERC1155",
-    });
+    expect(nft.metadata.name).toBe("Aura OG");
   });
 
   it("should throw error if failed to load nft info", async () => {

--- a/packages/thirdweb/src/react/web/ui/prebuilt/NFT/utils.ts
+++ b/packages/thirdweb/src/react/web/ui/prebuilt/NFT/utils.ts
@@ -11,8 +11,13 @@ export async function getNFTInfo(options: NFTProviderProps): Promise<NFT> {
   return withCache(
     async () => {
       const nft = await Promise.allSettled([
-        getNFT721(options),
-        getNFT1155(options),
+        getNFT721({
+          ...options,
+          useIndexer: false, // TODO (insight): switch this call to only call insight once
+        }),
+        getNFT1155({
+          ...options,
+        }),
       ]).then(([possibleNFT721, possibleNFT1155]) => {
         // getNFT extension always return an NFT object
         // so we need to check if the tokenURI exists

--- a/packages/thirdweb/src/social/profiles.ts
+++ b/packages/thirdweb/src/social/profiles.ts
@@ -32,15 +32,11 @@ export async function getSocialProfiles(args: {
     `${getThirdwebBaseUrl("social")}/v1/profiles/${address}`,
   );
 
-  if (response.status !== 200) {
-    try {
-      const errorBody = await response.json();
-      throw new Error(`Failed to fetch profile: ${errorBody.message}`);
-    } catch {
-      throw new Error(
-        `Failed to fetch profile: ${response.status}\n${await response.text()}`,
-      );
-    }
+  if (!response.ok) {
+    const errorBody = await response.text().catch(() => "Unknown error");
+    throw new Error(
+      `Failed to fetch profile: ${response.status} ${response.statusText} - ${errorBody}`,
+    );
   }
 
   return (await response.json()).data as SocialProfile[];

--- a/packages/thirdweb/src/storage/download.ts
+++ b/packages/thirdweb/src/storage/download.ts
@@ -99,8 +99,10 @@ export async function download(options: DownloadOptions) {
   });
 
   if (!res.ok) {
-    res.body?.cancel();
-    throw new Error(`Failed to download file: ${res.statusText}`);
+    const error = await res.text();
+    throw new Error(
+      `Failed to download file: ${res.status} ${res.statusText} ${error || ""}`,
+    );
   }
   return res;
 }

--- a/packages/thirdweb/src/storage/unpin.ts
+++ b/packages/thirdweb/src/storage/unpin.ts
@@ -41,12 +41,14 @@ export async function unpin(options: UnpinOptions) {
   );
 
   if (!res.ok) {
-    res.body?.cancel();
     if (res.status === 401) {
       throw new Error(
         "Unauthorized - You don't have permission to use this service.",
       );
     }
-    throw new Error(`Failed to unpin file - ${res.status} - ${res.statusText}`);
+    const error = await res.text();
+    throw new Error(
+      `Failed to unpin file - ${res.status} - ${res.statusText} ${error || ""}`,
+    );
   }
 }

--- a/packages/thirdweb/src/storage/upload/web-node.ts
+++ b/packages/thirdweb/src/storage/upload/web-node.ts
@@ -29,7 +29,6 @@ export async function uploadBatch<const TFiles extends UploadableFile[]>(
   );
 
   if (!res.ok) {
-    res.body?.cancel();
     if (res.status === 401) {
       throw new Error(
         "Unauthorized - You don't have permission to use this service.",

--- a/packages/thirdweb/src/utils/nft/parseNft.test.ts
+++ b/packages/thirdweb/src/utils/nft/parseNft.test.ts
@@ -21,6 +21,8 @@ describe("parseNft", () => {
       tokenId: 0n,
       tokenUri: "ipfs://",
       type: "ERC721",
+      tokenAddress: "0x1234567890123456789012345678901234567890",
+      chainId: 1,
     };
     const result = parseNFT(base, option);
     const expectedResult: NFT = {
@@ -29,6 +31,8 @@ describe("parseNft", () => {
       id: option.tokenId,
       tokenURI: option.tokenUri,
       type: option.type,
+      tokenAddress: option.tokenAddress,
+      chainId: option.chainId,
     };
     expect(result).toMatchObject(expectedResult);
   });
@@ -39,6 +43,8 @@ describe("parseNft", () => {
       tokenUri: "ipfs://",
       type: "ERC1155",
       supply: 10n,
+      tokenAddress: "0x1234567890123456789012345678901234567890",
+      chainId: 1,
     };
     const expectedResult: NFT = {
       metadata: base,
@@ -47,6 +53,8 @@ describe("parseNft", () => {
       tokenURI: option.tokenUri,
       type: option.type,
       supply: option.supply,
+      tokenAddress: option.tokenAddress,
+      chainId: option.chainId,
     };
     const result = parseNFT(base, option);
     expect(result).toMatchObject(expectedResult);

--- a/packages/thirdweb/src/utils/nft/parseNft.ts
+++ b/packages/thirdweb/src/utils/nft/parseNft.ts
@@ -41,6 +41,8 @@ export type NFT =
       id: bigint;
       tokenURI: string;
       type: "ERC721";
+      tokenAddress: string;
+      chainId: number;
     }
   | {
       metadata: NFTMetadata;
@@ -49,6 +51,8 @@ export type NFT =
       tokenURI: string;
       type: "ERC1155";
       supply: bigint;
+      tokenAddress: string;
+      chainId: number;
     };
 
 /**
@@ -60,6 +64,8 @@ export type ParseNFTOptions =
       tokenUri: string;
       type: "ERC721";
       owner?: string | null;
+      tokenAddress: string;
+      chainId: number;
     }
   | {
       tokenId: bigint;
@@ -67,6 +73,8 @@ export type ParseNFTOptions =
       type: "ERC1155";
       owner?: string | null;
       supply: bigint;
+      tokenAddress: string;
+      chainId: number;
     };
 
 /**
@@ -85,6 +93,8 @@ export function parseNFT(base: NFTMetadata, options: ParseNFTOptions): NFT {
         id: options.tokenId,
         tokenURI: options.tokenUri,
         type: options.type,
+        tokenAddress: options.tokenAddress,
+        chainId: options.chainId,
       };
     case "ERC1155":
       return {
@@ -94,6 +104,8 @@ export function parseNFT(base: NFTMetadata, options: ParseNFTOptions): NFT {
         tokenURI: options.tokenUri,
         type: options.type,
         supply: options.supply,
+        tokenAddress: options.tokenAddress,
+        chainId: options.chainId,
       };
     default:
       throw new Error("Invalid NFT type");

--- a/packages/thirdweb/src/utils/signatures/resolve-signature.ts
+++ b/packages/thirdweb/src/utils/signatures/resolve-signature.ts
@@ -17,7 +17,6 @@ async function resolveFunctionSignature(
     `${SIGNATURE_API}/signatures/?format=json&hex_signature=${hexSig}`,
   );
   if (!res.ok) {
-    res.body?.cancel();
     return null;
   }
   const data = await res.json();
@@ -39,7 +38,6 @@ async function resolveEventSignature(
     `${SIGNATURE_API}/event-signatures/?format=json&hex_signature=${hexSig}`,
   );
   if (!res.ok) {
-    res.body?.cancel();
     return null;
   }
   const data = await res.json();

--- a/packages/thirdweb/src/wallets/smart/lib/calls.ts
+++ b/packages/thirdweb/src/wallets/smart/lib/calls.ts
@@ -114,8 +114,8 @@ export async function predictAddress(args: {
             throw error;
           }
 
-          // Exponential backoff: 2^(retries + 1) * 100ms (200ms, 400ms, 800ms)
-          const delay = 2 ** (retries + 1) * 100;
+          // Exponential backoff: 2^(retries + 1) * 200ms (400ms, 800ms, 1600ms)
+          const delay = 2 ** (retries + 1) * 200;
           await new Promise((resolve) => setTimeout(resolve, delay));
           retries++;
         }

--- a/packages/thirdweb/src/wallets/utils/getWalletBalance.ts
+++ b/packages/thirdweb/src/wallets/utils/getWalletBalance.ts
@@ -5,7 +5,9 @@ import {
   getChainSymbol,
 } from "../../chains/utils.js";
 import type { ThirdwebClient } from "../../client/client.js";
+import { NATIVE_TOKEN_ADDRESS } from "../../constants/addresses.js";
 import { getContract } from "../../contract/contract.js";
+import type { GetBalanceResult } from "../../extensions/erc20/read/getBalance.js";
 import { eth_getBalance } from "../../rpc/actions/eth_getBalance.js";
 import { getRpcClient } from "../../rpc/rpc.js";
 import { toTokens } from "../../utils/units.js";
@@ -20,13 +22,7 @@ export type GetWalletBalanceOptions = {
   tokenAddress?: string;
 };
 
-export type GetWalletBalanceResult = {
-  value: bigint;
-  decimals: number;
-  displayValue: string;
-  symbol: string;
-  name: string;
-};
+export type GetWalletBalanceResult = GetBalanceResult;
 
 /**
  * Retrieves the balance of a token or native currency for a given wallet.
@@ -75,5 +71,7 @@ export async function getWalletBalance(
     displayValue: toTokens(nativeBalance, nativeDecimals),
     symbol: nativeSymbol,
     name: nativeName,
+    tokenAddress: tokenAddress ?? NATIVE_TOKEN_ADDRESS,
+    chainId: chain.id,
   };
 }

--- a/packages/thirdweb/test/src/test-clients.ts
+++ b/packages/thirdweb/test/src/test-clients.ts
@@ -1,11 +1,13 @@
 import { createThirdwebClient } from "../../src/client/client.js";
 
 const secretKey = process.env.TW_SECRET_KEY;
+const clientId = process.env.TW_CLIENT_ID;
 
 export const TEST_CLIENT = createThirdwebClient(
   secretKey
     ? {
         secretKey,
+        clientId: clientId ?? undefined,
       }
     : {
         clientId: "TEST",


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the NFT functionality by integrating an insight API for fetching NFT data across various extensions, allowing for improved performance and reliability when retrieving NFT information.

### Detailed summary
- Added `tokenAddress` and `chainId` fields to multiple NFT-related functions.
- Integrated insight API for `getNFT`, `getNFTs`, and `getOwnedNFTs`.
- Updated tests to verify functionality with the insight API.
- Improved error handling for API responses.
- Refactored code for consistency and clarity.

> The following files were skipped due to too many changes: `packages/thirdweb/src/extensions/erc721/read/getNFTs.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->