### PR TITLE
Remove nebula waitlist check

### DIFF
--- a/apps/dashboard/src/app/nebula-app/(app)/layout.tsx
+++ b/apps/dashboard/src/app/nebula-app/(app)/layout.tsx
@@ -37,15 +37,6 @@ export default async function Layout(props: {
     loginRedirect();
   }
 
-  const teamWithNebulaAccess = teams.find((team) =>
-    team.enabledScopes.includes("nebula"),
-  );
-
-  // if none of them teams have nebula access, request access on first team, and show waitlist page
-  if (!teamWithNebulaAccess) {
-    return <NebulaWaitlistPage account={account} team={firstTeam} />;
-  }
-
   const sessions = await getSessions({
     authToken,
   }).catch(() => []);


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes the logic that checks for teams with "nebula" access and the associated waitlist page rendering if no teams have access. 

### Detailed summary
- Removed the `teamWithNebulaAccess` variable and its associated logic.
- Eliminated the conditional rendering of the `NebulaWaitlistPage` when no teams have "nebula" access.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->