### PR TITLE
Nebula: Fix chat session randomly showing empty state after first prompt

### DIFF
--- a/apps/dashboard/src/app/nebula-app/(app)/components/ChatPageContent.tsx
+++ b/apps/dashboard/src/app/nebula-app/(app)/components/ChatPageContent.tsx
@@ -161,7 +161,9 @@ export function ChatPageContent(props: {
     (sessionId: string) => {
       _setSessionId(sessionId);
       // update page URL without reloading
-      window.history.replaceState({}, "", `/chat/${sessionId}`);
+      // THIS DOES NOT WORK ANYMORE!! - NEXT JS IS MONKEY PATCHING THIS TOO
+      // Until we find a better solution, we are just not gonna update the URL
+      // window.history.replaceState({}, "", `/chat/${sessionId}`);
 
       // if the current page is landing page, link to /chat
       // if current page is new /chat page, link to landing page


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR addresses an issue with updating the page URL in the `ChatPageContent.tsx` file due to a change in behavior by Next.js. The code that attempted to update the URL using `window.history.replaceState` has been commented out as it no longer functions as intended.

### Detailed summary
- Commented out the line that updates the URL with `window.history.replaceState`.
- Added comments explaining the reason for the change and the current limitation regarding URL updates.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->