### PR TITLE
added invite team button in dash homepage

### DIFF
--- a/apps/dashboard/src/app/team/[team_slug]/(team)/~/projects/TeamProjectsPage.tsx
+++ b/apps/dashboard/src/app/team/[team_slug]/(team)/~/projects/TeamProjectsPage.tsx
@@ -26,7 +26,8 @@ import { useDashboardRouter } from "@/lib/DashboardRouter";
 import { cn } from "@/lib/utils";
 import { LazyCreateProjectDialog } from "components/settings/ApiKeys/Create/LazyCreateAPIKeyDialog";
 import { formatDate } from "date-fns";
-import { PlusIcon, SearchIcon } from "lucide-react";
+import { useTrack } from "hooks/analytics/useTrack";
+import { PlusIcon, SearchIcon, UserPlus } from "lucide-react";
 import Link from "next/link";
 import { useMemo, useState } from "react";
 import type { ThirdwebClient } from "thirdweb";
@@ -119,6 +120,9 @@ export function TeamProjectsPage(props: {
               createProject={() => setIsCreateProjectDialogOpen(true)}
               teamMembersSettingsPath={`/team/${props.team.slug}/~/settings/members`}
             />
+            <Link href={`/team/${props.team.slug}/~/settings/members`}>
+              <ShareButton />
+            </Link>
           </div>
         </div>
       </div>
@@ -274,6 +278,29 @@ function AddNewButton(props: {
       <PlusIcon className="size-4" />
       <span>
         <span className="hidden lg:inline">Create</span> Project
+      </span>
+    </Button>
+  );
+}
+
+function ShareButton() {
+  //track event click
+  const trackEvent = useTrack();
+  return (
+    <Button
+      variant="default"
+      className="absolute top-0 right-0 gap-2 lg:static"
+      onClick={() =>
+        trackEvent({
+          category: "inviteTeam",
+          action: "click",
+          label: "invite-team",
+        })
+      }
+    >
+      <UserPlus className="size-4" />
+      <span>
+        <span className="hidden lg:inline">Invite</span>to Team
       </span>
     </Button>
   );


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `TeamProjectsPage` by adding a new `ShareButton` component for inviting team members and integrating analytics tracking for button clicks.

### Detailed summary
- Added `useTrack` hook for analytics tracking.
- Introduced `ShareButton` component for inviting team members.
- Wrapped `ShareButton` in a `Link` to navigate to the team members settings.
- Updated imports to include `UserPlus` icon.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->