### PR TITLE
[SDK] Simplify RPC request handling

### DIFF
--- a/.changeset/orange-icons-hide.md
+++ b/.changeset/orange-icons-hide.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Simplify RPC request handling

--- a/packages/thirdweb/src/rpc/fetch-rpc.ts
+++ b/packages/thirdweb/src/rpc/fetch-rpc.ts
@@ -78,16 +78,7 @@ export async function fetchRpc(
     );
   }
 
-  if (response.headers.get("Content-Type")?.startsWith("application/json")) {
-    return await response.json();
-  }
-  const text = await response.text();
-  try {
-    return JSON.parse(text);
-  } catch (err) {
-    console.error("Error parsing response", err, text);
-    throw err;
-  }
+  return await response.json();
 }
 
 type FetchSingleRpcOptions = {
@@ -121,14 +112,5 @@ export async function fetchSingleRpc(
       `RPC request failed with status ${response.status} - ${response.statusText}: ${error || "unknown error"}`,
     );
   }
-  if (response.headers.get("Content-Type")?.startsWith("application/json")) {
-    return await response.json();
-  }
-  const text = await response.text();
-  try {
-    return JSON.parse(text);
-  } catch (err) {
-    console.error("Error parsing response", err, text);
-    throw err;
-  }
+  return await response.json();
 }

--- a/packages/thirdweb/src/rpc/rpc.ts
+++ b/packages/thirdweb/src/rpc/rpc.ts
@@ -144,7 +144,11 @@ export function getRpcClient(
 
             // No response.
             if (!response) {
-              inflight.reject(new Error("No response"));
+              inflight.reject(
+                new Error(
+                  `No response for index ${index} - all responses: ${stringify(responses)}`,
+                ),
+              );
             }
             // Response is an error or error string.
             else if (response instanceof Error) {


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on simplifying the handling of RPC requests in the `thirdweb` package, improving error reporting, and refining response parsing.

### Detailed summary
- Enhanced error message in `rpc.ts` when no response is received, including index and all responses.
- Removed redundant checks for JSON content type in `fetch-rpc.ts`, directly returning JSON response.
- Streamlined error handling during response parsing in `fetch-rpc.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->