### PR TITLE
[SDK] Add thirdweb branding to PayEmbed

### DIFF
--- a/.changeset/free-pandas-reply.md
+++ b/.changeset/free-pandas-reply.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Add thirdweb branding to PayEmbed

--- a/packages/thirdweb/src/exports/react.ts
+++ b/packages/thirdweb/src/exports/react.ts
@@ -136,7 +136,7 @@ export type {
   PaymentInfo,
   DirectPaymentOptions,
   FundWalletOptions,
-  TranasctionOptions,
+  TransactionOptions,
 } from "../react/core/hooks/connection/ConnectButtonProps.js";
 
 export {

--- a/packages/thirdweb/src/insight/get-nfts.ts
+++ b/packages/thirdweb/src/insight/get-nfts.ts
@@ -292,7 +292,7 @@ async function transformNFTModel(
             client: client,
           }),
           id: BigInt(token_id),
-        });
+        }).catch(() => 0n);
 
         parsedNft = parseNFT(metadata, {
           tokenId: BigInt(token_id),

--- a/packages/thirdweb/src/react/core/hooks/connection/ConnectButtonProps.ts
+++ b/packages/thirdweb/src/react/core/hooks/connection/ConnectButtonProps.ts
@@ -134,7 +134,14 @@ export type PayUIOptions = Prettify<
       name?: string;
       image?: string;
     };
-  } & (FundWalletOptions | DirectPaymentOptions | TranasctionOptions)
+
+    /**
+     * Show the "Powered by Thirdweb" branding at the bottom of the PayEmbed UI.
+     *
+     * By default it is `true`.
+     */
+    showThirdwebBranding?: boolean;
+  } & (FundWalletOptions | DirectPaymentOptions | TransactionOptions)
 >;
 
 export type FundWalletOptions = {
@@ -168,7 +175,7 @@ export type DirectPaymentOptions = {
   paymentInfo: PaymentInfo;
 };
 
-export type TranasctionOptions = {
+export type TransactionOptions = {
   mode: "transaction";
   /**
    * The transaction to be executed.

--- a/packages/thirdweb/src/react/core/hooks/transaction/useSendTransaction.ts
+++ b/packages/thirdweb/src/react/core/hooks/transaction/useSendTransaction.ts
@@ -83,6 +83,7 @@ export type SendTransactionPayModalConfig =
               transactionHash: Hex;
             },
       ) => void;
+      showThirdwebBranding?: boolean;
     }
   | false;
 

--- a/packages/thirdweb/src/react/web/hooks/transaction/useSendTransaction.tsx
+++ b/packages/thirdweb/src/react/web/hooks/transaction/useSendTransaction.tsx
@@ -127,6 +127,7 @@ export function useSendTransaction(config: SendTransactionConfig = {}) {
           transaction: data.tx,
           metadata: payModal?.metadata,
           onPurchaseSuccess: payModal?.onPurchaseSuccess,
+          showThirdwebBranding: payModal?.showThirdwebBranding,
         }}
       />,
     );

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/PoweredByTW.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/PoweredByTW.tsx
@@ -6,13 +6,18 @@ import { ThirdwebTextIcon } from "./icons/ThirdwebTextIcon.js";
 /**
  * @internal
  */
-export function PoweredByThirdweb() {
+export function PoweredByThirdweb(props: {
+  link?: string;
+}) {
+  const link =
+    props.link ||
+    "https://playground.thirdweb.com/connect/sign-in/button?utm_source=cw_text";
   return (
     <Link
       color="secondaryText"
       hoverColor="primaryText"
       target="_blank"
-      href="https://thirdweb.com/connect?utm_source=cw_text"
+      href={link}
     >
       <Container
         flex="row"
@@ -23,7 +28,7 @@ export function PoweredByThirdweb() {
         }}
       >
         <Text
-          size="sm"
+          size="xs"
           weight={600}
           style={{
             color: "currentColor",
@@ -31,7 +36,7 @@ export function PoweredByThirdweb() {
         >
           Powered by
         </Text>
-        <ThirdwebTextIcon height={13} />
+        <ThirdwebTextIcon height={11} />
       </Container>
     </Link>
   );

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx
@@ -32,6 +32,7 @@ import { Input } from "../../../components/formElements.js";
 import { TokenSymbol } from "../../../components/token/TokenSymbol.js";
 import { ConnectButton } from "../../ConnectButton.js";
 import { ChainButton, NetworkSelectorContent } from "../../NetworkSelector.js";
+import { PoweredByThirdweb } from "../../PoweredByTW.js";
 import type { ConnectLocale } from "../../locale/types.js";
 import { TokenSelector } from "../TokenSelector.js";
 import { WalletSwitcherConnectionScreen } from "../WalletSwitcherConnectionScreen.js";
@@ -833,7 +834,8 @@ function MainScreen(props: {
     }
     default: {
       return (
-        <Container p="lg">
+        <Container px="lg">
+          <Spacer y="lg" />
           <ModalHeader title={props.title} onBack={props.onBack} />
 
           <Spacer y="xl" />
@@ -899,6 +901,13 @@ function MainScreen(props: {
               </Button>
             )}
           </Container>
+          <Spacer y="lg" />
+          {payOptions.showThirdwebBranding !== false && (
+            <>
+              <PoweredByThirdweb link="https://playground.thirdweb.com/connect/pay?utm_source=ub_text" />
+              <Spacer y="sm" />
+            </>
+          )}
         </Container>
       );
     }

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/DirectPaymentModeScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/DirectPaymentModeScreen.tsx
@@ -27,6 +27,7 @@ import { Container, Line, ModalHeader } from "../../../components/basic.js";
 import { Button } from "../../../components/buttons.js";
 import { Text } from "../../../components/text.js";
 import { ConnectButton } from "../../ConnectButton.js";
+import { PoweredByThirdweb } from "../../PoweredByTW.js";
 import { type ERC20OrNativeToken, isNativeToken } from "../nativeToken.js";
 import type { SupportedChainAndTokens } from "./swap/useSwapSupportedChains.js";
 
@@ -108,7 +109,8 @@ export function DirectPaymentModeScreen(props: {
       };
 
   return (
-    <Container p="lg">
+    <Container px="lg">
+      <Spacer y="lg" />
       <ModalHeader title={metadata?.name || "Payment Details"} />
 
       <Spacer y="lg" />
@@ -267,6 +269,13 @@ export function DirectPaymentModeScreen(props: {
             }}
           />
         </div>
+      )}
+      <Spacer y="lg" />
+      {payUiOptions.showThirdwebBranding !== false && (
+        <>
+          <PoweredByThirdweb link="https://playground.thirdweb.com/connect/pay?utm_source=ub_text" />
+          <Spacer y="sm" />
+        </>
       )}
     </Container>
   );

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/TransactionModeScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/TransactionModeScreen.tsx
@@ -30,6 +30,7 @@ import { Button } from "../../../components/buttons.js";
 import { Text } from "../../../components/text.js";
 import { TokenSymbol } from "../../../components/token/TokenSymbol.js";
 import { ConnectButton } from "../../ConnectButton.js";
+import { PoweredByThirdweb } from "../../PoweredByTW.js";
 import { OutlineWalletIcon } from "../../icons/OutlineWalletIcon.js";
 import { formatTokenBalance } from "../formatTokenBalance.js";
 import {
@@ -167,7 +168,8 @@ export function TransactionModeScreen(props: {
     balanceQuery.data.value < transactionCostAndData.transactionValueWei;
 
   return (
-    <Container p="lg">
+    <Container px="lg">
+      <Spacer y="lg" />
       <ModalHeader title={metadata?.name || "Transaction"} />
 
       <Spacer y="lg" />
@@ -377,6 +379,13 @@ export function TransactionModeScreen(props: {
             }}
           />
         </div>
+      )}
+      <Spacer y="lg" />
+      {payUiOptions.showThirdwebBranding !== false && (
+        <>
+          <PoweredByThirdweb link="https://playground.thirdweb.com/connect/pay?utm_source=ub_text" />
+          <Spacer y="sm" />
+        </>
       )}
     </Container>
   );


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds branding for `thirdweb` to the `PayEmbed` UI, enhances the `PoweredByThirdweb` component, and corrects some type definitions. It also ensures consistent spacing and layout adjustments across various screens.

### Detailed summary
- Added `showThirdwebBranding` option to enable/disable branding in `PayEmbed`.
- Corrected type name from `TranasctionOptions` to `TransactionOptions`.
- Updated the `PoweredByThirdweb` component to accept an optional `link` prop.
- Adjusted spacing with `Spacer` components in multiple screens.
- Updated `ThirdwebTextIcon` height for better aesthetics.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->