### PR TITLE
Add universal bridge landing pages to framer-rewrites

### DIFF
--- a/apps/dashboard/framer-rewrites.js
+++ b/apps/dashboard/framer-rewrites.js
@@ -58,4 +58,7 @@ module.exports = [
   "/faucets",
   // -- brand kit --
   "/brand-kit",
+  // -- universal bridge landing pages --
+  "/universal-bridge-regions/:region_slug",
+  "/enterprise",
 ];


### PR DESCRIPTION
### TL;DR

Added URL rewrites for Universal Bridge landing pages and Enterprise page.

### What changed?

Added two new URL paths to the framer-rewrites.js file:
- `/universal-bridge-regions/:region_slug` for region-specific Universal Bridge landing pages
- `/enterprise` for the Enterprise page

### How to test?

1. Navigate to `/universal-bridge-regions/[any-region-slug]` and verify the page loads correctly
2. Navigate to `/enterprise` and verify the page loads correctly
3. Ensure both pages render with the expected content and styling

### Why make this change?

These URL paths need to be included in the framer-rewrites to ensure proper routing and rendering of the Universal Bridge landing pages by region and the Enterprise page.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the routing in the `framer-rewrites.js` file by adding a new path for universal bridge landing pages.

### Detailed summary
- Added a new route for universal bridge landing pages: `"/universal-bridge-regions/:region_slug"` 
- The new route is added alongside an existing route for the brand kit: `"/brand-kit"` 
- The route for `"/enterprise"` remains unchanged.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->