### PR TITLE
[SDK] Improve NFT data fallbacks for indexer cache misses

### DIFF
--- a/.changeset/sour-kiwis-wink.md
+++ b/.changeset/sour-kiwis-wink.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Better fallbacks for live NFT data cache miss

--- a/apps/dashboard/src/@/constants/thirdweb.server.ts
+++ b/apps/dashboard/src/@/constants/thirdweb.server.ts
@@ -6,6 +6,7 @@ import {
 import {
   THIRDWEB_BUNDLER_DOMAIN,
   THIRDWEB_INAPP_WALLET_DOMAIN,
+  THIRDWEB_INSIGHT_API_DOMAIN,
   THIRDWEB_PAY_DOMAIN,
   THIRDWEB_RPC_DOMAIN,
   THIRDWEB_SOCIAL_API_DOMAIN,
@@ -32,6 +33,7 @@ export function getThirdwebClient(jwt?: string) {
       storage: THIRDWEB_STORAGE_DOMAIN,
       social: THIRDWEB_SOCIAL_API_DOMAIN,
       bundler: THIRDWEB_BUNDLER_DOMAIN,
+      insight: THIRDWEB_INSIGHT_API_DOMAIN,
     });
   }
 

--- a/apps/dashboard/src/constants/urls.ts
+++ b/apps/dashboard/src/constants/urls.ts
@@ -20,3 +20,6 @@ export const THIRDWEB_SOCIAL_API_DOMAIN =
 
 export const THIRDWEB_BUNDLER_DOMAIN =
   process.env.NEXT_PUBLIC_BUNDLER_URL || "bundler.thirdweb-dev.com";
+
+export const THIRDWEB_INSIGHT_API_DOMAIN =
+  process.env.NEXT_PUBLIC_INSIGHT_API_URL || "insight.thirdweb-dev.com";

--- a/packages/thirdweb/src/extensions/erc1155/read/getNFT.ts
+++ b/packages/thirdweb/src/extensions/erc1155/read/getNFT.ts
@@ -50,7 +50,6 @@ export async function getNFT(
 async function getNFTFromInsight(
   options: BaseTransactionOptions<GetNFTParams>,
 ): Promise<NFT> {
-  const tokenId = options.tokenId;
   const nft = await getNFTInsight({
     client: options.contract.client,
     chain: options.contract.chain,
@@ -58,22 +57,8 @@ async function getNFTFromInsight(
     tokenId: options.tokenId,
   });
   if (!nft) {
-    return parseNFT(
-      {
-        id: tokenId,
-        type: "ERC1155",
-        uri: "",
-      },
-      {
-        tokenId: options.tokenId,
-        tokenUri: "",
-        type: "ERC1155",
-        owner: null,
-        supply: 0n,
-        tokenAddress: options.contract.address,
-        chainId: options.contract.chain.id,
-      },
-    );
+    // fresh contracts might be delayed in indexing, so we fallback to RPC
+    return getNFTFromRPC(options);
   }
   return nft;
 }

--- a/packages/thirdweb/src/extensions/erc721/read/getNFT.ts
+++ b/packages/thirdweb/src/extensions/erc721/read/getNFT.ts
@@ -78,7 +78,6 @@ export async function getNFT(
 async function getNFTFromInsight(
   options: BaseTransactionOptions<GetNFTParams>,
 ): Promise<NFT> {
-  const tokenId = options.tokenId;
   const nft = await getNFTInsight({
     client: options.contract.client,
     chain: options.contract.chain,
@@ -87,21 +86,8 @@ async function getNFTFromInsight(
     includeOwners: options.includeOwner,
   });
   if (!nft) {
-    return parseNFT(
-      {
-        id: tokenId,
-        type: "ERC721",
-        uri: "",
-      },
-      {
-        tokenId,
-        tokenUri: "",
-        type: "ERC721",
-        owner: null,
-        tokenAddress: options.contract.address,
-        chainId: options.contract.chain.id,
-      },
-    );
+    // fresh contracts might be delayed in indexing, so we fallback to RPC
+    return getNFTFromRPC(options);
   }
   return nft;
 }


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the fallback mechanisms for retrieving NFT data when there are cache misses, ensuring more reliable data retrieval from the `thirdweb` ecosystem.

### Detailed summary
- Added `THIRDWEB_INSIGHT_API_DOMAIN` constant.
- Included `THIRDWEB_INSIGHT_API_DOMAIN` in the `getThirdwebClient` function.
- Updated `getNFT` and `getNFTs` functions to fallback to RPC if NFT data is not found.
- Implemented Promise.all for concurrent fetching in `getNFTs`.
- Set `useIndexer` to false in RPC calls for both ERC721 and ERC1155.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->