### PR TITLE
[SDK] Refactor ERC721 getNFTs to handle token ID offsets correctly

### DIFF
--- a/packages/thirdweb/src/extensions/erc1155/read/getOwnedNFTs.ts
+++ b/packages/thirdweb/src/extensions/erc1155/read/getOwnedNFTs.ts
@@ -97,7 +97,9 @@ async function getOwnedNFTsFromRPC(
   const ownedBalances = await getOwnedTokenIds(options);
 
   const nfts = await Promise.all(
-    ownedBalances.map((ob) => getNFT({ ...options, tokenId: ob.tokenId })),
+    ownedBalances.map((ob) =>
+      getNFT({ ...options, tokenId: ob.tokenId, useIndexer: false }),
+    ),
   );
 
   return nfts.map((nft, index) => ({

--- a/packages/thirdweb/src/extensions/erc721/read/getNFTs.ts
+++ b/packages/thirdweb/src/extensions/erc721/read/getNFTs.ts
@@ -104,7 +104,7 @@ async function getNFTsFromInsight(
 ): Promise<NFT[]> {
   const { contract, start, count = Number(DEFAULT_QUERY_ALL_COUNT) } = options;
 
-  const [result, supply] = await Promise.all([
+  const [result, supplyInfo] = await Promise.all([
     getContractNFTs({
       client: contract.client,
       chains: [contract.chain],
@@ -115,13 +115,21 @@ async function getNFTsFromInsight(
         page: start ? Math.floor(start / count) : undefined,
       },
     }),
-    totalSupply(options),
+    getSupplyInfo(options).catch(() => ({
+      maxSupply: 0,
+      startTokenId: 0,
+    })),
   ]);
 
   const currentOffset = start ?? 0;
   const expectedResultLength = Math.min(
     count,
-    Math.max(0, Number(supply) - currentOffset),
+    Math.max(
+      0,
+      Number(supplyInfo.maxSupply) -
+        Number(supplyInfo.startTokenId) -
+        currentOffset,
+    ),
   );
   if (result.length < expectedResultLength) {
     // fresh contracts might be delayed in indexing, so we fallback to RPC
@@ -134,6 +142,27 @@ async function getNFTsFromInsight(
 async function getNFTsFromRPC(
   options: BaseTransactionOptions<GetNFTsParams>,
 ): Promise<NFT[]> {
+  const { startTokenId, maxSupply } = await getSupplyInfo(options);
+  const start = BigInt(options.start ?? 0) + startTokenId;
+  const count = BigInt(options.count ?? DEFAULT_QUERY_ALL_COUNT);
+  const maxId = min(maxSupply, start + count);
+  const promises: ReturnType<typeof getNFT>[] = [];
+
+  for (let i = start; i < maxId; i++) {
+    promises.push(
+      getNFT({
+        ...options,
+        tokenId: i,
+        includeOwner: options.includeOwners ?? false,
+        useIndexer: false,
+      }),
+    );
+  }
+
+  return await Promise.all(promises);
+}
+
+async function getSupplyInfo(options: BaseTransactionOptions<GetNFTsParams>) {
   const [startTokenId_, maxSupply] = await Promise.allSettled([
     startTokenId(options),
     nextTokenIdToMint(options),
@@ -158,23 +187,9 @@ async function getNFTsFromRPC(
     }
     return [startTokenId__, maxSupply_] as const;
   });
-  const start = BigInt(options.start ?? 0) + startTokenId_;
-  const count = BigInt(options.count ?? DEFAULT_QUERY_ALL_COUNT);
 
-  const maxId = min(maxSupply + startTokenId_, start + count);
-
-  const promises: ReturnType<typeof getNFT>[] = [];
-
-  for (let i = start; i < maxId; i++) {
-    promises.push(
-      getNFT({
-        ...options,
-        tokenId: i,
-        includeOwner: options.includeOwners ?? false,
-        useIndexer: false,
-      }),
-    );
-  }
-
-  return await Promise.all(promises);
+  return {
+    startTokenId: startTokenId_,
+    maxSupply,
+  };
 }

--- a/packages/thirdweb/src/extensions/erc721/read/getOwnedNFTs.ts
+++ b/packages/thirdweb/src/extensions/erc721/read/getOwnedNFTs.ts
@@ -54,6 +54,7 @@ async function getOwnedNFTsFromRPC(
       getNFT({
         contract: options.contract,
         tokenId,
+        useIndexer: false,
       }).then((nft) => ({
         ...nft,
         // add the owner to the NFT since we know it


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying the `getNFTs` functionality across the `erc721` and `erc1155` extensions to include a new parameter `useIndexer`, enhancing NFT retrieval processes and supply information handling.

### Detailed summary
- Added `useIndexer: false` in `getOwnedNFTs` for `erc721` and `erc1155`.
- Updated variable names for clarity (e.g., `supply` to `supplyInfo`).
- Enhanced `getNFTsFromRPC` to calculate `startTokenId` and `maxSupply`.
- Introduced `getSupplyInfo` function to encapsulate supply details retrieval.
- Removed redundant promise handling in `getNFTsFromRPC`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->