### PR TITLE
[SDK] Fix loading state in PayEmbed source tokens

### DIFF
--- a/.changeset/tender-parrots-stare.md
+++ b/.changeset/tender-parrots-stare.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix loading state when loading source tokens in PayEmbed

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/TokenSelectorScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/TokenSelectorScreen.tsx
@@ -176,7 +176,12 @@ export function TokenSelectorScreen(props: {
     enabled: !!props.sourceSupportedTokens && !!chainInfo.data,
   });
 
-  if (walletsAndBalances.isLoading || chainInfo.isLoading) {
+  if (
+    walletsAndBalances.isLoading ||
+    chainInfo.isLoading ||
+    !chainInfo.data ||
+    !props.sourceSupportedTokens
+  ) {
     return <LoadingScreen />;
   }
 
@@ -307,6 +312,7 @@ function WalletRowWithBalances(props: {
       style={{
         borderRadius: radius.lg,
         border: `1px solid ${theme.colors.borderColor}`,
+        minHeight: "350px",
       }}
     >
       <Container


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the loading state handling in the `TokenSelectorScreen` component of the `thirdweb` package, ensuring that the UI properly reflects loading conditions when certain data is unavailable.

### Detailed summary
- Updated the conditional check in the `TokenSelectorScreen.tsx` to include checks for `chainInfo.data` and `props.sourceSupportedTokens`.
- Added a minimum height of `350px` to the `WalletRowWithBalances` component's style for better layout consistency.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->