### PR TITLE
Dashboard: Fix table row not clickable in safari because of sticky thead

### DIFF
--- a/apps/dashboard/src/@/components/ui/table.tsx
+++ b/apps/dashboard/src/@/components/ui/table.tsx
@@ -24,11 +24,7 @@ const TableHeader = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <thead
     ref={ref}
-    className={cn(
-      "border-border border-b bg-background",
-      "sticky top-0 z-20 border-none before:absolute before:inset-0 before:border-border before:border-b",
-      className,
-    )}
+    className={cn("relative border-b bg-background", className)}
     {...props}
   />
 ));

--- a/apps/playground-web/src/components/ui/table.tsx
+++ b/apps/playground-web/src/components/ui/table.tsx
@@ -24,11 +24,7 @@ const TableHeader = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <thead
     ref={ref}
-    className={cn(
-      "border-border border-b bg-background",
-      "sticky top-0 z-20 border-none before:absolute before:inset-0 before:border-border before:border-b",
-      className,
-    )}
+    className={cn("relative border-b bg-background", className)}
     {...props}
   />
 ));


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `className` prop in the `thead` component of two files, simplifying the styling by removing unnecessary classes.

### Detailed summary
- In `apps/dashboard/src/@/components/ui/table.tsx`:
  - Removed multiple classes from `className`.
  - Added `relative` class to `className`.

- In `apps/playground-web/src/components/ui/table.tsx`:
  - Same changes as above, updating the `className` similarly.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->