### PR TITLE
Add engineCloud plan capability to service-utils

### DIFF
--- a/.changeset/lovely-peas-behave.md
+++ b/.changeset/lovely-peas-behave.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+add engineCloud plan capability

--- a/apps/dashboard/src/stories/stubs.ts
+++ b/apps/dashboard/src/stories/stubs.ts
@@ -89,6 +89,11 @@ export function teamStub(id: string, billingPlan: Team["billingPlan"]): Team {
         enabled: true,
         rateLimit: 1000,
       },
+      engineCloud: {
+        enabled: true,
+        rateLimit: 100,
+        mainnetEnabled: true,
+      },
     },
   };
 

--- a/packages/service-utils/src/core/api.ts
+++ b/packages/service-utils/src/core/api.ts
@@ -80,6 +80,11 @@ type TeamCapabilities = {
     customAuth: boolean;
     customBranding: boolean;
   };
+  engineCloud: {
+    enabled: boolean;
+    mainnetEnabled: boolean;
+    rateLimit: number;
+  };
 };
 
 type TeamPlan =

--- a/packages/service-utils/src/mocks.ts
+++ b/packages/service-utils/src/mocks.ts
@@ -92,6 +92,11 @@ export const validTeamResponse: TeamResponse = {
       customAuth: true,
       customBranding: true,
     },
+    engineCloud: {
+      enabled: true,
+      mainnetEnabled: true,
+      rateLimit: 100,
+    },
   },
 };
 


### PR DESCRIPTION
Added engineCloud plan capability to the TeamCapabilities type in the service-utils package. This includes properties for enabled status, mainnet enablement, and rate limiting. Also updated the mock validTeamResponse to include the new engineCloud capability with sample values.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces an `engineCloud` plan capability across multiple files, enhancing functionality with specific properties such as `enabled`, `mainnetEnabled`, and `rateLimit`.

### Detailed summary
- Added `engineCloud` configuration with properties `enabled`, `rateLimit`, and `mainnetEnabled` in:
  - `apps/dashboard/src/stories/stubs.ts`
  - `packages/service-utils/src/mocks.ts`
  - `packages/service-utils/src/core/api.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->