### PR TITLE
Update team plan pricing

### DIFF
--- a/apps/dashboard/src/utils/pricing.tsx
+++ b/apps/dashboard/src/utils/pricing.tsx
@@ -18,7 +18,7 @@ export const TEAM_PLANS: Record<
   }
 > = {
   starter: {
-    price: 5,
+    price: 9,
     title: "Starter",
     subTitle: null,
     trialPeriodDays: 0,
@@ -34,7 +34,7 @@ export const TEAM_PLANS: Record<
     ],
   },
   growth: {
-    price: 75,
+    price: 79,
     title: "Growth",
     subTitle: "Everything in Starter, plus:",
     trialPeriodDays: 0,
@@ -48,7 +48,7 @@ export const TEAM_PLANS: Record<
     ],
   },
   accelerate: {
-    price: 250,
+    price: 249,
     title: "Accelerate",
     subTitle: "Everything in Growth, plus:",
     trialPeriodDays: 0,
@@ -62,7 +62,7 @@ export const TEAM_PLANS: Record<
     ],
   },
   scale: {
-    price: 500,
+    price: 549,
     title: "Scale",
     description: "For large organizations with custom needs.",
     subTitle: "Everything in Accelerate, plus:",


### PR DESCRIPTION
# Update Team Plan Pricing

This PR updates the pricing for all team plans:

- **Starter**: Increased from $5 to $9
- **Growth**: Increased from $75 to $79
- **Accelerate**: Decreased from $250 to $249
- **Scale**: Increased from $500 to $549

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the pricing values for various plans in the `TEAM_PLANS` object within the `pricing.tsx` file.

### Detailed summary
- Updated `starter` plan price from `5` to `9`.
- Updated `growth` plan price from `75` to `79`.
- Updated `accelerate` plan price from `250` to `249`.
- Updated `scale` plan price from `500` to `549`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->