### PR TITLE
[SDK] Add service key functionality for API requests

### DIFF
--- a/.changeset/legal-pots-boil.md
+++ b/.changeset/legal-pots-boil.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+expose setServiceKey

--- a/packages/thirdweb/src/exports/utils.ts
+++ b/packages/thirdweb/src/exports/utils.ts
@@ -151,7 +151,7 @@ export {
 } from "viem";
 
 // Useful helpers
-export { setThirdwebDomains } from "../utils/domains.js";
+export { setThirdwebDomains, setServiceKey } from "../utils/domains.js";
 export { resolvePromisedValue } from "../utils/promise/resolve-promised-value.js";
 export {
   setTransactionDecorator,

--- a/packages/thirdweb/src/utils/domains.ts
+++ b/packages/thirdweb/src/utils/domains.ts
@@ -90,3 +90,13 @@ export const getThirdwebBaseUrl = (service: keyof DomainOverrides) => {
   }
   return `https://${origin}`;
 };
+
+let serviceKey: string | null = null;
+
+export const setServiceKey = (key: string | null) => {
+  serviceKey = key;
+};
+
+export const getServiceKey = () => {
+  return serviceKey;
+};

--- a/packages/thirdweb/src/utils/fetch.ts
+++ b/packages/thirdweb/src/utils/fetch.ts
@@ -7,6 +7,7 @@ import {
   detectOS,
   detectPlatform,
 } from "./detect-platform.js";
+import { getServiceKey } from "./domains.js";
 import { isJWT } from "./jwt/is-jwt.js";
 import { IS_DEV } from "./process.js";
 
@@ -74,6 +75,11 @@ export function getClientFetch(client: ThirdwebClient, ecosystem?: Ecosystem) {
       // this already internally caches
       for (const [key, value] of getPlatformHeaders()) {
         (headers as Headers).set(key, value);
+      }
+
+      const serviceKey = getServiceKey();
+      if (serviceKey) {
+        headers.set("x-service-api-key", serviceKey);
       }
     }
 


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new functionality to manage a `serviceKey` in the `thirdweb` package, allowing it to be set and retrieved. This key is then utilized in the `getClientFetch` function to set a custom header for API requests.

### Detailed summary
- Added `setServiceKey` and `getServiceKey` functions in `packages/thirdweb/src/utils/domains.ts` to manage `serviceKey`.
- Updated `packages/thirdweb/src/exports/utils.ts` to export `setServiceKey`.
- Modified `packages/thirdweb/src/utils/fetch.ts` to include `serviceKey` in headers if set.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->