### PR TITLE
[SDK] Increase ESM bundle size limit to 55 kB

### DIFF
--- a/packages/thirdweb/.size-limit.json
+++ b/packages/thirdweb/.size-limit.json
@@ -2,7 +2,7 @@
   {
     "name": "thirdweb (esm)",
     "path": "./dist/esm/exports/thirdweb.js",
-    "limit": "52 kB",
+    "limit": "55 kB",
     "import": "*"
   },
   {


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the size limit for the `thirdweb (esm)` package in the `.size-limit.json` configuration file.

### Detailed summary
- Updated the `limit` for `thirdweb (esm)` from `52 kB` to `55 kB`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->