### PR TITLE
Deprecate pack

### DIFF
--- a/.changeset/fluffy-bars-crash.md
+++ b/.changeset/fluffy-bars-crash.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Deprecate Pack

--- a/packages/thirdweb/src/extensions/pack/createNewPack.ts
+++ b/packages/thirdweb/src/extensions/pack/createNewPack.ts
@@ -78,6 +78,8 @@ export type CreateNewPackParams = {
 };
 
 /**
+ * * @deprecated [Pack contract is incompatible with Pectra update. Support for this contract is being removed in next release.]
+ *
  * @extension PACK
  * @example
  * ```ts

--- a/packages/thirdweb/src/extensions/prebuilts/deploy-pack.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/deploy-pack.ts
@@ -55,6 +55,8 @@ export type DeployPackContractOptions = Prettify<
 >;
 
 /**
+ * @deprecated [Pack contract is incompatible with Pectra update. Support for this contract is being removed in next release.]
+ *
  * Deploy a thirdweb Pack contract
  * @param options params for deploying [`Pack contract`](https://thirdweb.com/thirdweb.eth/Pack)
  * @returns


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on deprecating the `Pack` contract in the `thirdweb` package due to its incompatibility with the Pectra update, indicating that support will be removed in the next release.

### Detailed summary
- Added deprecation notice for the `Pack` contract in:
  - `packages/thirdweb/src/extensions/pack/createNewPack.ts`
  - `packages/thirdweb/src/extensions/prebuilts/deploy-pack.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->