### PR TITLE
Custom factory addr for Chiliz mainnet

### DIFF
--- a/.changeset/whole-planets-heal.md
+++ b/.changeset/whole-planets-heal.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Custom factory addr for Chiliz mainnet

--- a/packages/thirdweb/src/contract/deployment/utils/create-2-factory.ts
+++ b/packages/thirdweb/src/contract/deployment/utils/create-2-factory.ts
@@ -322,6 +322,7 @@ const CUSTOM_GAS_FOR_CHAIN: Record<string, CustomChain> = {
 const FACTORIES: Record<string, string> = {
   "420120000": COMMON_FACTORY_ADDRESS,
   "420120001": COMMON_FACTORY_ADDRESS,
+  "88888": "0xc501b9abf5540de1dd24f66633b1ecf35ff7101f", // EIP155 is enforced, but the check fails, hence we hardcode the address here instead of computing dynamically
 };
 
 const CUSTOM_GAS_BINS = [


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a custom factory address for the Chiliz mainnet in the `thirdweb` package and updates the relevant code to include this new address.

### Detailed summary
- Added a custom factory address for Chiliz mainnet: `88888` set to `"0xc501b9abf5540de1dd24f66633b1ecf35ff7101f"` in `packages/thirdweb/src/contract/deployment/utils/create-2-factory.ts`.
- Commented on the enforcement of EIP155 and the reason for hardcoding the address.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->