### PR TITLE
Add plan cancellation and re-subscription functionality

### DIFF
--- a/apps/dashboard/src/@/actions/billing.ts
+++ b/apps/dashboard/src/@/actions/billing.ts
@@ -64,6 +64,83 @@ export async function getBillingCheckoutUrl(
 
 export type GetBillingCheckoutUrlAction = typeof getBillingCheckoutUrl;
 
+export async function getPlanCancelUrl(options: {
+  teamId: string;
+  redirectUrl: string;
+}): Promise<{ status: number; url?: string }> {
+  const token = await getAuthToken();
+  if (!token) {
+    return {
+      status: 401,
+    };
+  }
+
+  const res = await fetch(
+    `${API_SERVER_URL}/v1/teams/${options.teamId}/checkout/cancel-plan-link`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        redirectTo: options.redirectUrl,
+      }),
+    },
+  );
+
+  if (!res.ok) {
+    return {
+      status: res.status,
+    };
+  }
+
+  const json = await res.json();
+
+  if (!json.result) {
+    return {
+      status: 500,
+    };
+  }
+
+  return {
+    status: 200,
+    url: json.result as string,
+  };
+}
+
+export async function reSubscribePlan(options: {
+  teamId: string;
+}): Promise<{ status: number }> {
+  const token = await getAuthToken();
+  if (!token) {
+    return {
+      status: 401,
+    };
+  }
+
+  const res = await fetch(
+    `${API_SERVER_URL}/v1/teams/${options.teamId}/checkout/resubscribe-plan`,
+    {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({}),
+    },
+  );
+
+  if (!res.ok) {
+    return {
+      status: res.status,
+    };
+  }
+
+  return {
+    status: 200,
+  };
+}
 export type GetBillingPortalUrlOptions = {
   teamSlug: string | undefined;
   redirectUrl: string;

--- a/apps/dashboard/src/@/components/blocks/pricing-card.tsx
+++ b/apps/dashboard/src/@/components/blocks/pricing-card.tsx
@@ -8,6 +8,7 @@ import { CheckIcon, CircleDollarSignIcon } from "lucide-react";
 import Link from "next/link";
 import type React from "react";
 import { TEAM_PLANS } from "utils/pricing";
+import { RenewSubscriptionButton } from "../../../components/settings/Account/Billing/renew-subscription/renew-subscription-button";
 import { useTrack } from "../../../hooks/analytics/useTrack";
 import { remainingDays } from "../../../utils/date-utils";
 import type { GetBillingCheckoutUrlAction } from "../../actions/billing";
@@ -16,20 +17,27 @@ import { CheckoutButton } from "../billing";
 
 type PricingCardCta = {
   hint?: string;
-  title: string;
+
   onClick?: () => void;
 } & (
   | {
       type: "link";
       href: string;
+      label: string;
     }
   | {
       type: "checkout";
+      label: string;
+    }
+  | {
+      type: "renew";
     }
 );
 
 type PricingCardProps = {
+  getTeam: () => Promise<Team>;
   teamSlug: string;
+  teamId: string;
   billingStatus: Team["billingStatus"];
   billingPlan: keyof typeof TEAM_PLANS;
   cta?: PricingCardCta;
@@ -41,7 +49,9 @@ type PricingCardProps = {
 };
 
 export const PricingCard: React.FC<PricingCardProps> = ({
+  getTeam,
   teamSlug,
+  teamId,
   billingStatus,
   billingPlan,
   cta,
@@ -131,6 +141,9 @@ export const PricingCard: React.FC<PricingCardProps> = ({
 
       {cta && (
         <div className="flex flex-col gap-3">
+          {cta.type === "renew" && (
+            <RenewSubscriptionButton teamId={teamId} getTeam={getTeam} />
+          )}
           {billingPlanToSkuMap[billingPlan] && cta.type === "checkout" && (
             <CheckoutButton
               billingStatus={billingStatus}
@@ -143,7 +156,7 @@ export const PricingCard: React.FC<PricingCardProps> = ({
               sku={billingPlanToSkuMap[billingPlan]}
               getBillingCheckoutUrl={getBillingCheckoutUrl}
             >
-              {cta.title}
+              {cta.label}
             </CheckoutButton>
           )}
 
@@ -154,7 +167,7 @@ export const PricingCard: React.FC<PricingCardProps> = ({
               asChild
             >
               <Link href={cta.href} target="_blank" onClick={handleCTAClick}>
-                {cta.title}
+                {cta.label}
               </Link>
             </Button>
           )}

--- a/apps/dashboard/src/app/(app)/login/onboarding/team-onboarding/InviteTeamMembers.tsx
+++ b/apps/dashboard/src/app/(app)/login/onboarding/team-onboarding/InviteTeamMembers.tsx
@@ -81,6 +81,8 @@ export function InviteTeamMembersUI(props: {
             teamSlug={props.team.slug}
             getBillingCheckoutUrl={props.getBillingCheckoutUrl}
             trackEvent={props.trackEvent}
+            getTeam={props.getTeam}
+            teamId={props.team.id}
           />
         </SheetContent>
       </Sheet>
@@ -148,6 +150,8 @@ function InviteModalContent(props: {
   billingStatus: Team["billingStatus"];
   getBillingCheckoutUrl: GetBillingCheckoutUrlAction;
   trackEvent: (params: TrackingParams) => void;
+  getTeam: () => Promise<Team>;
+  teamId: string;
 }) {
   const [planToShow, setPlanToShow] = useState<
     "starter" | "growth" | "accelerate" | "scale"
@@ -159,7 +163,7 @@ function InviteModalContent(props: {
       billingStatus={props.billingStatus}
       teamSlug={props.teamSlug}
       cta={{
-        title: "Get Started",
+        label: "Get Started",
         type: "checkout",
         onClick() {
           props.trackEvent({
@@ -171,6 +175,8 @@ function InviteModalContent(props: {
         },
       }}
       getBillingCheckoutUrl={props.getBillingCheckoutUrl}
+      getTeam={props.getTeam}
+      teamId={props.teamId}
     />
   );
 
@@ -180,7 +186,7 @@ function InviteModalContent(props: {
       billingStatus={props.billingStatus}
       teamSlug={props.teamSlug}
       cta={{
-        title: "Get Started",
+        label: "Get Started",
         type: "checkout",
         onClick() {
           props.trackEvent({
@@ -193,6 +199,8 @@ function InviteModalContent(props: {
       }}
       highlighted
       getBillingCheckoutUrl={props.getBillingCheckoutUrl}
+      getTeam={props.getTeam}
+      teamId={props.teamId}
     />
   );
 
@@ -202,7 +210,7 @@ function InviteModalContent(props: {
       billingStatus={props.billingStatus}
       teamSlug={props.teamSlug}
       cta={{
-        title: "Get started",
+        label: "Get started",
         type: "checkout",
         onClick() {
           props.trackEvent({
@@ -214,6 +222,8 @@ function InviteModalContent(props: {
         },
       }}
       getBillingCheckoutUrl={props.getBillingCheckoutUrl}
+      getTeam={props.getTeam}
+      teamId={props.teamId}
     />
   );
 
@@ -223,7 +233,7 @@ function InviteModalContent(props: {
       billingStatus={props.billingStatus}
       teamSlug={props.teamSlug}
       cta={{
-        title: "Get started",
+        label: "Get started",
         type: "checkout",
         onClick() {
           props.trackEvent({
@@ -235,6 +245,8 @@ function InviteModalContent(props: {
         },
       }}
       getBillingCheckoutUrl={props.getBillingCheckoutUrl}
+      getTeam={props.getTeam}
+      teamId={props.teamId}
     />
   );
 

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/settings/billing/components/PlanInfoCard.client.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/settings/billing/components/PlanInfoCard.client.tsx
@@ -30,25 +30,6 @@ export function PlanInfoCardClient(props: {
 
         return res.data.result;
       }}
-      cancelPlan={async (params) => {
-        const res = await apiServerProxy<{
-          data: {
-            result: "success";
-          };
-        }>({
-          pathname: `/v1/teams/${props.team.id}/checkout/cancel-plan`,
-          headers: {
-            "Content-Type": "application/json",
-          },
-          method: "PUT",
-          body: JSON.stringify(params),
-        });
-
-        if (!res.ok) {
-          console.error(res.error);
-          throw new Error(res.error);
-        }
-      }}
     />
   );
 }

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/settings/billing/components/PlanInfoCard.stories.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/settings/billing/components/PlanInfoCard.stories.tsx
@@ -115,11 +115,6 @@ function Story(props: {
     url: "https://example.com",
   });
 
-  const cancelPlanStub = async () => {
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-    return;
-  };
-
   const teamTeamStub = async () =>
     ({
       ...team,
@@ -134,7 +129,19 @@ function Story(props: {
           subscriptions={zeroUsageOnDemandSubs}
           getBillingPortalUrl={getBillingPortalUrlStub}
           getBillingCheckoutUrl={getBillingCheckoutUrlStub}
-          cancelPlan={cancelPlanStub}
+          getTeam={teamTeamStub}
+        />
+      </BadgeContainer>
+
+      <BadgeContainer label="Scheduled to cancel in 10 days">
+        <PlanInfoCardUI
+          team={{
+            ...team,
+            planCancellationDate: addDays(new Date(), 10).toISOString(),
+          }}
+          subscriptions={zeroUsageOnDemandSubs}
+          getBillingPortalUrl={getBillingPortalUrlStub}
+          getBillingCheckoutUrl={getBillingCheckoutUrlStub}
           getTeam={teamTeamStub}
         />
       </BadgeContainer>
@@ -145,7 +152,6 @@ function Story(props: {
           subscriptions={trialPlanZeroUsageOnDemandSubs}
           getBillingPortalUrl={getBillingPortalUrlStub}
           getBillingCheckoutUrl={getBillingCheckoutUrlStub}
-          cancelPlan={cancelPlanStub}
           getTeam={teamTeamStub}
         />
       </BadgeContainer>
@@ -156,7 +162,6 @@ function Story(props: {
           subscriptions={subsWith1Usage}
           getBillingPortalUrl={getBillingPortalUrlStub}
           getBillingCheckoutUrl={getBillingCheckoutUrlStub}
-          cancelPlan={cancelPlanStub}
           getTeam={teamTeamStub}
         />
       </BadgeContainer>
@@ -167,7 +172,6 @@ function Story(props: {
           subscriptions={subsWith4Usage}
           getBillingPortalUrl={getBillingPortalUrlStub}
           getBillingCheckoutUrl={getBillingCheckoutUrlStub}
-          cancelPlan={cancelPlanStub}
           getTeam={teamTeamStub}
         />
       </BadgeContainer>

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/settings/billing/components/PlanInfoCard.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/settings/billing/components/PlanInfoCard.tsx
@@ -17,10 +17,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@/components/ui/sheet";
-import {
-  type CancelPlan,
-  CancelPlanButton,
-} from "components/settings/Account/Billing/CancelPlanModal/CancelPlanModal";
+import { CancelPlanButton } from "components/settings/Account/Billing/CancelPlanModal/CancelPlanModal";
 import { BillingPricing } from "components/settings/Account/Billing/Pricing";
 import { differenceInDays, isAfter } from "date-fns";
 import { format } from "date-fns/format";
@@ -28,6 +25,7 @@ import { CreditCardIcon, FileTextIcon, SquarePenIcon } from "lucide-react";
 import { CircleAlertIcon } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
+import { RenewSubscriptionButton } from "../../../../../../../../../components/settings/Account/Billing/renew-subscription/renew-subscription-button";
 import { getValidTeamPlan } from "../../../../../../components/TeamHeader/getValidTeamPlan";
 
 export function PlanInfoCardUI(props: {
@@ -35,7 +33,6 @@ export function PlanInfoCardUI(props: {
   team: Team;
   getBillingPortalUrl: GetBillingPortalUrlAction;
   getBillingCheckoutUrl: GetBillingCheckoutUrlAction;
-  cancelPlan: CancelPlan;
   getTeam: () => Promise<Team>;
 }) {
   const { subscriptions, team } = props;
@@ -63,6 +60,7 @@ export function PlanInfoCardUI(props: {
         getBillingCheckoutUrl={props.getBillingCheckoutUrl}
         isOpen={isPlanSheetOpen}
         onOpenChange={setIsPlanSheetOpen}
+        getTeam={props.getTeam}
       />
 
       <div className="flex flex-col gap-4 p-4 lg:flex-row lg:items-center lg:justify-between lg:p-6">
@@ -102,6 +100,16 @@ export function PlanInfoCardUI(props: {
               Your trial ends in {trialEndsAfterDays} days
             </p>
           )}
+          {props.team.planCancellationDate && (
+            <Badge variant="destructive">
+              Scheduled to cancel in{" "}
+              {differenceInDays(
+                new Date(props.team.planCancellationDate),
+                new Date(),
+              )}{" "}
+              days
+            </Badge>
+          )}
         </div>
 
         {props.team.billingPlan !== "free" && (
@@ -118,13 +126,20 @@ export function PlanInfoCardUI(props: {
               Change Plan
             </Button>
 
-            <CancelPlanButton
-              teamSlug={props.team.slug}
-              billingStatus={props.team.billingStatus}
-              cancelPlan={props.cancelPlan}
-              currentPlan={props.team.billingPlan}
-              getTeam={props.getTeam}
-            />
+            {props.team.planCancellationDate ? (
+              <RenewSubscriptionButton
+                teamId={props.team.id}
+                getTeam={props.getTeam}
+              />
+            ) : (
+              <CancelPlanButton
+                teamId={props.team.id}
+                teamSlug={props.team.slug}
+                billingStatus={props.team.billingStatus}
+                currentPlan={props.team.billingPlan}
+                getTeam={props.getTeam}
+              />
+            )}
           </div>
         )}
       </div>
@@ -291,6 +306,7 @@ function ViewPlansSheet(props: {
   getBillingCheckoutUrl: GetBillingCheckoutUrlAction;
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
+  getTeam: () => Promise<Team>;
 }) {
   return (
     <Sheet open={props.isOpen} onOpenChange={props.onOpenChange}>
@@ -302,6 +318,7 @@ function ViewPlansSheet(props: {
           team={props.team}
           trialPeriodEndedAt={props.trialPeriodEndedAt}
           getBillingCheckoutUrl={props.getBillingCheckoutUrl}
+          getTeam={props.getTeam}
         />
       </SheetContent>
     </Sheet>

--- a/apps/dashboard/src/components/settings/Account/Billing/CancelPlanModal/CancelPlanModal.tsx
+++ b/apps/dashboard/src/components/settings/Account/Billing/CancelPlanModal/CancelPlanModal.tsx
@@ -1,23 +1,9 @@
 "use client";
 
+import { getPlanCancelUrl } from "@/actions/billing";
 import type { Team } from "@/api/team";
 import { Spinner } from "@/components/ui/Spinner/Spinner";
 import { Button } from "@/components/ui/button";
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@/components/ui/form";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import {
   Sheet,
   SheetContent,
@@ -25,70 +11,34 @@ import {
   SheetTitle,
   SheetTrigger,
 } from "@/components/ui/sheet";
-import { Textarea } from "@/components/ui/textarea";
 import { useDashboardRouter } from "@/lib/DashboardRouter";
-import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation } from "@tanstack/react-query";
 import { CircleXIcon, ExternalLinkIcon } from "lucide-react";
 import Link from "next/link";
 import { useState, useTransition } from "react";
-import { useForm } from "react-hook-form";
 import { toast } from "sonner";
-import { z } from "zod";
+import { useStripeRedirectEvent } from "../../../../../app/(app)/stripe-redirect/stripeRedirectChannel";
 import { PRO_CONTACT_US_URL } from "../../../../../constants/pro";
 import { pollWithTimeout } from "../../../../../utils/pollWithTimeout";
-
-const cancelPlanFormSchema = z
-  .object({
-    comment: z.string().optional(),
-    feedback: z.enum([
-      "customer_service",
-      "low_quality",
-      "missing_features",
-      "other",
-      "switched_service",
-      "too_complex",
-      "too_expensive",
-      "unused",
-    ]),
-  })
-  // if feedback is other, comment is required
-  .refine(
-    (data) =>
-      !(
-        data.feedback === "other" &&
-        (!data.comment || data.comment.trim() === "")
-      ),
-    {
-      message: "Required",
-      path: ["comment"],
-    },
-  );
-
-type CancelPlanParams = z.infer<typeof cancelPlanFormSchema>;
-export type CancelPlan = (params: CancelPlanParams) => Promise<void>;
-
-const cancelReasons: Array<{
-  value: CancelPlanParams["feedback"];
-  label: string;
-}> = [
-  { value: "too_expensive", label: "Too expensive" },
-  { value: "too_complex", label: "Too complex to use" },
-  { value: "missing_features", label: "Missing features I need" },
-  { value: "low_quality", label: "Quality doesn't meet expectations" },
-  { value: "unused", label: "Not using it enough" },
-  { value: "switched_service", label: "Switched to another service" },
-  { value: "customer_service", label: "Unhappy with customer service" },
-  { value: "other", label: "Other reason" },
-];
+import { tryCatch } from "../../../../../utils/try-catch";
 
 export function CancelPlanButton(props: {
+  teamId: string;
   teamSlug: string;
-  cancelPlan: CancelPlan;
   currentPlan: Team["billingPlan"];
   billingStatus: Team["billingStatus"];
   getTeam: () => Promise<Team>;
 }) {
+  // shortcut the sheet in case the user is in the default state
+  if (props.billingStatus !== "invalidPayment" && props.currentPlan !== "pro") {
+    return (
+      <ImmediateCancelPlanButton
+        teamId={props.teamId}
+        getTeam={props.getTeam}
+      />
+    );
+  }
+
   return (
     <Sheet>
       <SheetTrigger asChild>
@@ -108,12 +58,8 @@ export function CancelPlanButton(props: {
           <UnpaidInvoicesWarning teamSlug={props.teamSlug} />
         ) : props.currentPlan === "pro" ? (
           <ProPlanCancelPlanSheetContent />
-        ) : (
-          <CancelPlanSheetContent
-            cancelPlan={props.cancelPlan}
-            getTeam={props.getTeam}
-          />
-        )}
+        ) : // this should never happen
+        null}
       </SheetContent>
     </Sheet>
   );
@@ -160,121 +106,90 @@ function ProPlanCancelPlanSheetContent() {
   );
 }
 
-function CancelPlanSheetContent(props: {
-  cancelPlan: CancelPlan;
+function ImmediateCancelPlanButton(props: {
+  teamId: string;
   getTeam: () => Promise<Team>;
 }) {
-  const [_isPending, startTransition] = useTransition();
-  const [isPollingTeam, setIsPollingTeam] = useState(false);
   const router = useDashboardRouter();
-  const isPending = _isPending || isPollingTeam;
+  const [isRoutePending, startTransition] = useTransition();
+  const [isPollingTeam, setIsPollingTeam] = useState(false);
 
-  const form = useForm<z.infer<typeof cancelPlanFormSchema>>({
-    resolver: zodResolver(cancelPlanFormSchema),
-    defaultValues: {
-      comment: "",
-      feedback: undefined,
-    },
+  useStripeRedirectEvent(async () => {
+    setIsPollingTeam(true);
+    const verifyResult = await tryCatch(
+      pollWithTimeout({
+        shouldStop: async () => {
+          const team = await props.getTeam();
+          const isCancelled =
+            team.billingPlan === "free" || team.planCancellationDate !== null;
+          return isCancelled;
+        },
+        timeoutMs: 5000,
+      }),
+    );
+
+    if (verifyResult.error) {
+      return;
+    }
+
+    setIsPollingTeam(false);
+    toast.success("Plan cancelled successfully");
+    startTransition(() => {
+      router.refresh();
+    });
   });
 
   const cancelPlan = useMutation({
-    mutationFn: props.cancelPlan,
+    mutationFn: async (opts: { teamId: string }) => {
+      const { url, status } = await getPlanCancelUrl({
+        teamId: opts.teamId,
+        redirectUrl: getAbsoluteUrl("/stripe-redirect"),
+      });
+
+      if (!url) {
+        throw new Error("Failed to get cancel plan url");
+      }
+
+      if (status !== 200) {
+        throw new Error("Failed to get cancel plan url");
+      }
+
+      const tab = window.open(url, "_blank");
+      if (!tab) {
+        throw new Error("Failed to open cancel plan url");
+      }
+    },
   });
 
-  function onSubmit(values: z.infer<typeof cancelPlanFormSchema>) {
-    const promise = cancelPlan.mutateAsync(values);
-    toast.promise(promise, {
-      success: "Plan cancelled successfully",
-      error: "Failed to cancel plan",
-    });
-    promise.then(async () => {
-      setIsPollingTeam(true);
-      // keep polling until the team plan is free, then refresh the page
-      await pollWithTimeout({
-        shouldStop: async () => {
-          const team = await props.getTeam();
-          return team.billingPlan === "free";
-        },
-        timeoutMs: 7000,
-      });
-
-      setIsPollingTeam(false);
-
-      startTransition(() => {
-        router.refresh();
-      });
+  async function handleCancelPlan() {
+    cancelPlan.mutate({
+      teamId: props.teamId,
     });
   }
 
+  const showPlanSpinner =
+    isPollingTeam || isRoutePending || cancelPlan.isPending;
+
   return (
-    <div>
-      <div className="mb-1 flex items-center gap-2">
-        <h2 className="font-semibold text-2xl tracking-tight">Cancel Plan</h2>
-        {isPending && <Spinner className="size-5" />}
-      </div>
-      <p className="mb-4 text-muted-foreground text-sm">
-        Please let us know why you're cancelling your plan. Your feedback helps
-        us improve our service.
-      </p>
-
-      <Form {...form}>
-        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-5">
-          <FormField
-            control={form.control}
-            name="feedback"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Why are you cancelling?</FormLabel>
-                <Select
-                  onValueChange={field.onChange}
-                  defaultValue={field.value}
-                >
-                  <FormControl>
-                    <SelectTrigger className="bg-card">
-                      <SelectValue placeholder="Select a reason" />
-                    </SelectTrigger>
-                  </FormControl>
-                  <SelectContent>
-                    {cancelReasons.map((reason) => (
-                      <SelectItem key={reason.value} value={reason.value}>
-                        {reason.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-
-          <FormField
-            control={form.control}
-            name="comment"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Additional comments</FormLabel>
-                <FormControl>
-                  <Textarea
-                    placeholder="Tell us more about your experience"
-                    className="bg-card"
-                    {...field}
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-
-          <Button
-            type="submit"
-            className="w-full"
-            disabled={cancelPlan.isPending}
-          >
-            {cancelPlan.isPending ? <Spinner className="mr-2 h-4 w-4" /> : null}
-            Cancel plan
-          </Button>
-        </form>
-      </Form>
-    </div>
+    <Button
+      variant="outline"
+      size="sm"
+      className="gap-2 bg-background"
+      disabled={showPlanSpinner}
+      onClick={handleCancelPlan}
+    >
+      {showPlanSpinner ? (
+        <Spinner className="size-4 text-muted-foreground" />
+      ) : (
+        <CircleXIcon className="size-4 text-muted-foreground" />
+      )}
+      Cancel Plan
+    </Button>
   );
+}
+
+function getAbsoluteUrl(path: string) {
+  const url = new URL(window.location.origin);
+  url.pathname = path;
+  return url.toString();
 }

--- a/apps/dashboard/src/components/settings/Account/Billing/renew-subscription/renew-subscription-button.tsx
+++ b/apps/dashboard/src/components/settings/Account/Billing/renew-subscription/renew-subscription-button.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { reSubscribePlan } from "@/actions/billing";
+import type { Team } from "@/api/team";
+import { Spinner } from "@/components/ui/Spinner/Spinner";
+import { Button } from "@/components/ui/button";
+import { useDashboardRouter } from "@/lib/DashboardRouter";
+import { useMutation } from "@tanstack/react-query";
+import { RefreshCwIcon } from "lucide-react";
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import { pollWithTimeout } from "../../../../../utils/pollWithTimeout";
+import { tryCatch } from "../../../../../utils/try-catch";
+
+export function RenewSubscriptionButton(props: {
+  teamId: string;
+  getTeam: () => Promise<Team>;
+}) {
+  const router = useDashboardRouter();
+  const [isRoutePending, setTransition] = useTransition();
+  const [isPollingTeam, setIsPollingTeam] = useState(false);
+
+  const reSubscribePlanMutation = useMutation({
+    mutationFn: async () => {
+      const res = await reSubscribePlan({ teamId: props.teamId });
+      if (res.status !== 200) {
+        throw new Error("Failed to renew subscription");
+      }
+    },
+  });
+
+  const showSpinner =
+    isPollingTeam || isRoutePending || reSubscribePlanMutation.isPending;
+
+  async function handleRenewSubscription() {
+    const renewResult = await tryCatch(reSubscribePlanMutation.mutateAsync());
+
+    if (renewResult.error) {
+      toast.error("Failed to renew subscription");
+      return;
+    }
+
+    toast.success("Subscription renewed successfully");
+
+    setIsPollingTeam(true);
+
+    const verifyResult = await tryCatch(
+      pollWithTimeout({
+        shouldStop: async () => {
+          const team = await props.getTeam();
+          return team.planCancellationDate === null;
+        },
+        timeoutMs: 5000,
+      }),
+    );
+
+    setIsPollingTeam(false);
+
+    if (verifyResult.error) {
+      return;
+    }
+
+    setTransition(() => {
+      router.refresh();
+    });
+  }
+
+  return (
+    <Button
+      onClick={handleRenewSubscription}
+      variant="default"
+      size="sm"
+      className="gap-2"
+      disabled={showSpinner}
+    >
+      {showSpinner ? (
+        <Spinner className="size-4" />
+      ) : (
+        <RefreshCwIcon className="size-4" />
+      )}
+      Renew Subscription
+    </Button>
+  );
+}

--- a/apps/dashboard/src/stories/stubs.ts
+++ b/apps/dashboard/src/stories/stubs.ts
@@ -95,6 +95,7 @@ export function teamStub(id: string, billingPlan: Team["billingPlan"]): Team {
         mainnetEnabled: true,
       },
     },
+    planCancellationDate: null,
   };
 
   return team;

--- a/apps/dashboard/src/utils/try-catch.ts
+++ b/apps/dashboard/src/utils/try-catch.ts
@@ -1,0 +1,22 @@
+type Success<T> = {
+  data: T;
+  error: null;
+};
+
+type Failure<E> = {
+  data: null;
+  error: E;
+};
+
+type Result<T, E = Error> = Success<T> | Failure<E>;
+
+export async function tryCatch<T, E = Error>(
+  promise: Promise<T>,
+): Promise<Result<T, E>> {
+  try {
+    const data = await promise;
+    return { data, error: null };
+  } catch (error) {
+    return { data: null, error: error as E };
+  }
+}

--- a/packages/service-utils/src/core/api.ts
+++ b/packages/service-utils/src/core/api.ts
@@ -123,6 +123,7 @@ export type TeamResponse = {
   enabledScopes: ServiceName[];
   isOnboarded: boolean;
   capabilities: TeamCapabilities;
+  planCancellationDate: string | null;
 };
 
 export type ProjectSecretKey = {

--- a/packages/service-utils/src/mocks.ts
+++ b/packages/service-utils/src/mocks.ts
@@ -98,6 +98,7 @@ export const validTeamResponse: TeamResponse = {
       rateLimit: 100,
     },
   },
+  planCancellationDate: null,
 };
 
 export const validTeamAndProjectResponse: TeamAndProjectResponse = {


### PR DESCRIPTION
### TL;DR

Added functionality to cancel and renew subscriptions through Stripe, replacing the previous in-app cancellation flow.

### What changed?

- Added new API endpoints for cancellation and resubscription:
  - `getPlanCancelUrl`: Generates a Stripe URL for cancellation
  - `reSubscribePlan`: Reactivates a canceled subscription
- Created a new `RenewSubscriptionButton` component for reactivating canceled subscriptions
- Updated the `CancelPlanButton` to redirect to Stripe for cancellation instead of using the previous in-app form
- Added UI indicators to show when a plan is scheduled for cancellation
- Updated the pricing card component to support resubscription functionality
- Added `planCancellationDate` field to the Team model to track scheduled cancellations

### How to test?

1. Navigate to a team's billing settings
2. Test canceling a subscription by clicking "Cancel Plan" - you should be redirected to Stripe
3. After cancellation, verify the UI shows the plan is scheduled to cancel
4. Test resubscribing by clicking "Renew Subscription" 
5. Verify the cancellation status is removed after resubscription

### Why make this change?

This change improves the subscription management flow by:
- Leveraging Stripe's native cancellation UI instead of a custom form
- Providing users with a clear way to reactivate subscriptions before they expire
- Giving better visibility into subscription status with UI indicators for scheduled cancellations
- Simplifying the cancellation process while maintaining the ability to collect feedback through Stripe

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the billing and subscription management features in the application. It introduces new functionalities for plan cancellation and renewal, updates the data structure to manage cancellation dates, and refines the UI components related to billing.

### Detailed summary
- Added `planCancellationDate` to relevant data structures.
- Introduced `tryCatch` utility for improved error handling in async functions.
- Created `RenewSubscriptionButton` for renewing subscriptions.
- Added `getPlanCancelUrl` and `reSubscribePlan` actions in billing.
- Updated `PlanInfoCard` to display cancellation status and renewal options.
- Modified various components to utilize new billing functionalities and data.
- Removed deprecated `cancelPlan` methods and logic in favor of new implementations.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->