### PR TITLE
[TOOL-4248] Dashboard: Fix explore category page not showing contract cards

### DIFF
--- a/apps/dashboard/src/app/(app)/(dashboard)/explore/[category]/page.tsx
+++ b/apps/dashboard/src/app/(app)/(dashboard)/explore/[category]/page.tsx
@@ -6,6 +6,7 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
+import { getThirdwebClient } from "@/constants/thirdweb.server";
 import {
   ContractCard,
   ContractCardSkeleton,
@@ -16,13 +17,11 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { Suspense } from "react";
-import type { ThirdwebClient } from "thirdweb";
 
 type ExploreCategoryPageProps = {
   params: Promise<{
     category: string;
   }>;
-  client: ThirdwebClient;
 };
 
 export async function generateMetadata(
@@ -47,6 +46,7 @@ export default async function ExploreCategoryPage(
   if (!category) {
     notFound();
   }
+  const client = getThirdwebClient(undefined);
 
   return (
     <div className="flex flex-col">
@@ -94,6 +94,7 @@ export default async function ExploreCategoryPage(
             const overrides = Array.isArray(publishedContractId)
               ? publishedContractId[2]
               : undefined;
+
             if (!publisher || !contractId) {
               return null;
             }
@@ -104,7 +105,7 @@ export default async function ExploreCategoryPage(
                 key={publisher + contractId + overrides?.title}
               >
                 <ContractCard
-                  client={props.client}
+                  client={client}
                   publisher={publisher}
                   contractId={contractId}
                   titleOverride={overrides?.title}


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `ExploreCategoryPage` component by removing the dependency on the `ThirdwebClient` type and instead utilizing a `getThirdwebClient` function to obtain a client instance directly.

### Detailed summary
- Removed `client: ThirdwebClient;` from `ExploreCategoryPageProps`.
- Added `const client = getThirdwebClient(undefined);` to retrieve the client.
- Updated the `client` prop in the `ContractCard` component to use the new `client` variable.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->