### PR TITLE
[SDK] Lazy import native dependencies in React Native

### DIFF
--- a/.changeset/quiet-bats-tickle.md
+++ b/.changeset/quiet-bats-tickle.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Lazy import native dependencies in React Native


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on implementing lazy loading for native dependencies in the `InAppNativeConnector` class, optimizing performance by importing modules only when needed.

### Detailed summary
- Added lazy imports for various modules in `packages/thirdweb/src/wallets/in-app/native/native-connector.ts`.
- Converted several function imports to use `await import()` syntax for on-demand loading.
- Updated `preAuthenticate`, `logout`, and other methods to support new import structure.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->