### PR TITLE
[SDK] Always checksum Account.address

### DIFF
--- a/.changeset/shiny-pants-shout.md
+++ b/.changeset/shiny-pants-shout.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Always checksum Account.address

--- a/packages/thirdweb/src/adapters/ethers5.ts
+++ b/packages/thirdweb/src/adapters/ethers5.ts
@@ -14,6 +14,7 @@ import {
   TransactionTypeMap,
 } from "../transaction/prepare-transaction.js";
 import type { SerializableTransaction } from "../transaction/serialize-transaction.js";
+import { getAddress } from "../utils/address.js";
 import { toHex } from "../utils/encoding/hex.js";
 import type { Account } from "../wallets/interfaces/wallet.js";
 
@@ -364,7 +365,7 @@ export async function fromEthersSigner(
 ): Promise<Account> {
   const address = await signer.getAddress();
   const account: Account = {
-    address,
+    address: getAddress(address),
     signMessage: async ({ message }) => {
       return signer.signMessage(
         typeof message === "string" ? message : message.raw,

--- a/packages/thirdweb/src/adapters/ethers6.ts
+++ b/packages/thirdweb/src/adapters/ethers6.ts
@@ -10,6 +10,7 @@ import { type ThirdwebContract, getContract } from "../contract/contract.js";
 import { toSerializableTransaction } from "../transaction/actions/to-serializable-transaction.js";
 import type { PreparedTransaction } from "../transaction/prepare-transaction.js";
 import type { SerializableTransaction } from "../transaction/serialize-transaction.js";
+import { getAddress } from "../utils/address.js";
 import { toHex } from "../utils/encoding/hex.js";
 import { resolvePromisedValue } from "../utils/promise/resolve-promised-value.js";
 import type { Account } from "../wallets/interfaces/wallet.js";
@@ -327,7 +328,7 @@ export async function fromEthersSigner(
 ): Promise<Account> {
   const address = await signer.getAddress();
   const account: Account = {
-    address,
+    address: getAddress(address),
     signMessage: async ({ message }) => {
       return signer.signMessage(
         typeof message === "string" ? message : message.raw,

--- a/packages/thirdweb/src/wallets/coinbase/coinbase-web.ts
+++ b/packages/thirdweb/src/wallets/coinbase/coinbase-web.ts
@@ -284,7 +284,7 @@ function createAccount({
   client: ThirdwebClient;
 }) {
   const account: Account = {
-    address,
+    address: getAddress(address),
     async sendTransaction(tx: SendTransactionOption) {
       const transactionHash = (await provider.request({
         method: "eth_sendTransaction",

--- a/packages/thirdweb/src/wallets/private-key.ts
+++ b/packages/thirdweb/src/wallets/private-key.ts
@@ -10,6 +10,7 @@ import { getRpcClient } from "../rpc/rpc.js";
 import type { AuthorizationRequest } from "../transaction/actions/eip7702/authorization.js";
 import { signTransaction } from "../transaction/actions/sign-transaction.js";
 import type { SerializableTransaction } from "../transaction/serialize-transaction.js";
+import { getAddress } from "../utils/address.js";
 import { type Hex, toHex } from "../utils/encoding/hex.js";
 import { signMessage } from "../utils/signatures/sign-message.js";
 import { signTypedData } from "../utils/signatures/sign-typed-data.js";
@@ -79,7 +80,7 @@ export function privateKeyToAccount(
   const address = publicKeyToAddress(publicKey);
 
   const account = {
-    address,
+    address: getAddress(address),
     sendTransaction: async (
       tx: SerializableTransaction & { chainId: number },
     ) => {

--- a/packages/thirdweb/src/wallets/smart/index.ts
+++ b/packages/thirdweb/src/wallets/smart/index.ts
@@ -421,7 +421,7 @@ function createZkSyncAccount(args: {
 }): Account {
   const { creationOptions, connectionOptions, chain } = args;
   const account: Account = {
-    address: connectionOptions.personalAccount.address,
+    address: getAddress(connectionOptions.personalAccount.address),
     async sendTransaction(transaction: SendTransactionOption) {
       // override passed tx, we have to refetch gas and fees always
       const prepTx = {

--- a/packages/thirdweb/src/wallets/wallet-connect/controller.ts
+++ b/packages/thirdweb/src/wallets/wallet-connect/controller.ts
@@ -333,7 +333,7 @@ function createAccount({
   client: ThirdwebClient;
 }) {
   const account: Account = {
-    address: address,
+    address: getAddress(address),
     async sendTransaction(tx: SendTransactionOption) {
       const transactionHash = (await provider.request({
         method: "eth_sendTransaction",


### PR DESCRIPTION
Fixes TOOL-4242

<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on ensuring that the `address` property of the `Account` object is consistently processed through the `getAddress` function across various files in the `thirdweb` package.

### Detailed summary
- Updated `address` assignment to use `getAddress(address)` in:
  - `packages/thirdweb/src/wallets/coinbase/coinbase-web.ts`
  - `packages/thirdweb/src/wallets/wallet-connect/controller.ts`
  - `packages/thirdweb/src/wallets/smart/index.ts`
  - `packages/thirdweb/src/wallets/private-key.ts`
  - `packages/thirdweb/src/adapters/ethers5.ts`
  - `packages/thirdweb/src/adapters/ethers6.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->