### PR TITLE
chore: Add support CRUD endpoints

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/support/add-message-to-ticket/components/add-message-to-ticket.action.ts
+++ b/apps/dashboard/src/app/(dashboard)/support/add-message-to-ticket/components/add-message-to-ticket.action.ts
@@ -1,0 +1,105 @@
+"use server";
+import "server-only";
+
+import { getTeamById } from "@/api/team";
+import { getUnthreadConversation } from "lib/unthread/get-conversation";
+import { getRawAccount } from "../../../../account/settings/getAccount";
+import { loginRedirect } from "../../../../login/loginRedirect";
+
+type AddMessageToTicketResponse =
+  | {
+      success: false;
+      message: string;
+    }
+  | {
+      success: true;
+    };
+
+export async function addMessageToTicketAction(args: {
+  teamId: string;
+  conversationId: string;
+  messageMarkdown: string;
+}): Promise<AddMessageToTicketResponse> {
+  const { teamId, conversationId, messageMarkdown } = args;
+  if (!teamId || !conversationId || !messageMarkdown) {
+    return {
+      success: false,
+      message: "Missing required arguments.",
+    };
+  }
+
+  const account = await getRawAccount();
+  if (!account) {
+    // User is not logged in.
+    loginRedirect("/support");
+  }
+
+  const team = await getTeamById(teamId);
+  const customerId = team?.unthreadCustomerId;
+  if (!customerId) {
+    return {
+      success: false,
+      message: `Support customer for team ${teamId} not found.`,
+    };
+  }
+
+  if (
+    [
+      process.env.UNTHREAD_FREE_TIER_ID,
+      process.env.UNTHREAD_GROWTH_TIER_ID,
+      process.env.UNTHREAD_PRO_TIER_ID,
+    ].includes(customerId)
+  ) {
+    // Disallow "shared" legacy customer IDs because this endpoint returns customer-specific data.
+    return {
+      success: false,
+      message: `This endpoint is not supported for legacy customer ID ${customerId}`,
+    };
+  }
+
+  // Get the conversation first to confirm the user has permissions to update this ticket.
+  const conversation = await getUnthreadConversation(conversationId);
+  if (!conversation || conversation.customerId !== customerId) {
+    return {
+      success: false,
+      message: "Ticket not found.",
+    };
+  }
+
+  // Get the conversation and messages.
+  const res = await fetch(
+    `https://api.unthread.io/api/conversations/${conversationId}/messages`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Api-Key": process.env.UNTHREAD_API_KEY ?? "",
+      },
+      body: JSON.stringify({
+        body: {
+          type: "markdown",
+          value: messageMarkdown,
+        },
+        onBehalfOf: {
+          email: account.email,
+          name: account.name,
+          id: customerId,
+        },
+      }),
+    },
+  );
+  if (!res.ok) {
+    console.error(
+      "Error adding message to the ticket:",
+      res.status,
+      res.statusText,
+      await res.text(),
+    );
+    return {
+      success: false,
+      message: "Error adding message to the ticket. Please try again later.",
+    };
+  }
+
+  return { success: true };
+}

--- a/apps/dashboard/src/app/(dashboard)/support/create-ticket/components/create-ticket.action.ts
+++ b/apps/dashboard/src/app/(dashboard)/support/create-ticket/components/create-ticket.action.ts
@@ -99,14 +99,10 @@ export async function createTicketAction(
   }
 
   // @TODO: This needs to be updated to use team.unthreadCustomerId after all users are migrated.
-  let customerId = isValidPlan(team.supportPlan)
+  const customerId = isValidPlan(team.supportPlan)
     ? planToCustomerId[team.supportPlan]
     : // fallback to "free" tier
       planToCustomerId.free;
-  // @TODO: Test accounts. Remove when released.
-  if (teamId === "clku79c5k0188520uyn729f7v") {
-    customerId = team.unthreadCustomerId;
-  }
 
   const product = formData.get("product")?.toString() || "";
   const problemArea = formData.get("extraInfo_Problem_Area")?.toString() || "";

--- a/apps/dashboard/src/app/(dashboard)/support/create-ticket/components/create-ticket.action.ts
+++ b/apps/dashboard/src/app/(dashboard)/support/create-ticket/components/create-ticket.action.ts
@@ -98,10 +98,15 @@ export async function createTicketAction(
     loginRedirect("/support");
   }
 
-  const customerId = isValidPlan(team.supportPlan)
+  // @TODO: This needs to be updated to use team.unthreadCustomerId after all users are migrated.
+  let customerId = isValidPlan(team.supportPlan)
     ? planToCustomerId[team.supportPlan]
     : // fallback to "free" tier
       planToCustomerId.free;
+  // @TODO: Test accounts. Remove when released.
+  if (teamId === "clku79c5k0188520uyn729f7v") {
+    customerId = team.unthreadCustomerId;
+  }
 
   const product = formData.get("product")?.toString() || "";
   const problemArea = formData.get("extraInfo_Problem_Area")?.toString() || "";

--- a/apps/dashboard/src/app/(dashboard)/support/get-ticket/components/get-ticket.action.ts
+++ b/apps/dashboard/src/app/(dashboard)/support/get-ticket/components/get-ticket.action.ts
@@ -1,0 +1,159 @@
+"use server";
+import "server-only";
+
+import { getTeamById } from "@/api/team";
+import { getUnthreadConversation } from "lib/unthread/get-conversation";
+import { getRawAccount } from "../../../../account/settings/getAccount";
+import { loginRedirect } from "../../../../login/loginRedirect";
+
+type GetTicketResponse =
+  | {
+      success: false;
+      message: string;
+    }
+  | {
+      success: true;
+      result: UnthreadMessagesResponse;
+    };
+
+interface UnthreadMessage {
+  ts: string;
+  botId: string;
+  botName: string;
+  timestamp: string;
+  threadTs: string;
+  id: string;
+  user: {
+    id: string;
+    name: string;
+    email: string;
+    photo?: string;
+  } | null;
+  conversation: {
+    customerId: string;
+  };
+  resolvedContent: (
+    | string
+    | {
+        type: "link";
+        id: string;
+        name: string;
+      }
+  )[];
+  text: string;
+  htmlContent: string;
+}
+
+interface UnthreadMessagesResponse {
+  data: UnthreadMessage[];
+  totalCount: number;
+  cursors: {
+    hasNext: boolean;
+    hasPrevious: boolean;
+    next?: string;
+    previous?: string;
+  };
+}
+
+export async function getTicketAction(args: {
+  teamId: string;
+  conversationId: string;
+  cursor?: string;
+}): Promise<GetTicketResponse> {
+  const { teamId, conversationId, cursor = "" } = args;
+  if (!teamId || !conversationId) {
+    return {
+      success: false,
+      message: "Missing required arguments.",
+    };
+  }
+
+  const account = await getRawAccount();
+  if (!account) {
+    // User is not logged in.
+    loginRedirect("/support");
+  }
+
+  const team = await getTeamById(teamId);
+  const customerId = team?.unthreadCustomerId;
+  if (!customerId) {
+    return {
+      success: false,
+      message: `Support customer for team ${teamId} not found.`,
+    };
+  }
+
+  if (
+    [
+      process.env.UNTHREAD_FREE_TIER_ID,
+      process.env.UNTHREAD_GROWTH_TIER_ID,
+      process.env.UNTHREAD_PRO_TIER_ID,
+    ].includes(customerId)
+  ) {
+    // Disallow "shared" legacy customer IDs because this endpoint returns customer-specific data.
+    return {
+      success: false,
+      message: `This endpoint is not supported for legacy customer ID ${customerId}`,
+    };
+  }
+
+  // Get the conversation first to confirm the user has permissions to update this ticket.
+  const conversation = await getUnthreadConversation(conversationId);
+  if (!conversation || conversation.customerId !== customerId) {
+    return {
+      success: false,
+      message: "Ticket not found.",
+    };
+  }
+
+  // Get the conversation and messages.
+  const res = await fetch(
+    `https://api.unthread.io/api/conversations/${conversationId}/messages/list`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Api-Key": process.env.UNTHREAD_API_KEY ?? "",
+      },
+      body: JSON.stringify({
+        select: [
+          "ts",
+          "botId",
+          "botName",
+          "text",
+          "timestamp",
+          "threadTs",
+          "metadata",
+          "user.id",
+          "user.name",
+          "user.email",
+          "user.slackId",
+          "user.photo",
+        ],
+        order: ["ts"],
+        descending: true,
+        limit: 100,
+        cursor,
+      }),
+    },
+  );
+  if (!res.ok) {
+    console.error(
+      "Error retrieving ticket:",
+      res.status,
+      res.statusText,
+      await res.text(),
+    );
+    return {
+      success: false,
+      message: "Error retrieving ticket. Please try again later.",
+    };
+  }
+
+  const json = (await res.json()) as UnthreadMessagesResponse;
+
+  return {
+    success: true,
+    result: json,
+  };
+}

--- a/apps/dashboard/src/app/(dashboard)/support/list-tickets/components/list-tickets.action.ts
+++ b/apps/dashboard/src/app/(dashboard)/support/list-tickets/components/list-tickets.action.ts
@@ -1,0 +1,131 @@
+"use server";
+import "server-only";
+
+import { getTeamById } from "@/api/team";
+import { getRawAccount } from "../../../../account/settings/getAccount";
+import { loginRedirect } from "../../../../login/loginRedirect";
+
+type ListTicketsResponse =
+  | {
+      success: false;
+      message: string;
+    }
+  | {
+      success: true;
+      result: UnthreadConversationsResponse;
+    };
+
+interface UnthreadConversation {
+  title: string;
+  createdAt: string;
+  id: string;
+  initialMessage: {
+    ts: string;
+    text: string;
+  };
+  tags: { name: string }[];
+  customerId: string;
+  titleOverwritten: boolean;
+  resolvedTitle: string[];
+}
+
+interface UnthreadConversationsResponse {
+  data: UnthreadConversation[];
+  totalCount: number;
+  cursors: {
+    hasNext: boolean;
+    hasPrevious: boolean;
+    next?: string;
+    previous?: string;
+  };
+}
+
+export async function listTicketsAction(args: {
+  teamId: string;
+  cursor?: string;
+}): Promise<ListTicketsResponse> {
+  const { teamId, cursor = "" } = args;
+  if (!teamId) {
+    return {
+      success: false,
+      message: "Missing required arguments.",
+    };
+  }
+
+  const account = await getRawAccount();
+  if (!account) {
+    // User is not logged in.
+    loginRedirect("/support");
+  }
+
+  const team = await getTeamById(teamId);
+  const customerId = team?.unthreadCustomerId;
+  if (!customerId) {
+    return {
+      success: false,
+      message: `Support customer for team ${teamId} not found.`,
+    };
+  }
+
+  if (
+    [
+      process.env.UNTHREAD_FREE_TIER_ID,
+      process.env.UNTHREAD_GROWTH_TIER_ID,
+      process.env.UNTHREAD_PRO_TIER_ID,
+    ].includes(customerId)
+  ) {
+    // Disallow "shared" legacy customer IDs because this endpoint returns customer-specific data.
+    return {
+      success: false,
+      message: `This endpoint is not supported for legacy customer ID ${customerId}`,
+    };
+  }
+
+  // Get the conversation and messages.
+  const res = await fetch("https://api.unthread.io/api/conversations/list", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Api-Key": process.env.UNTHREAD_API_KEY ?? "",
+    },
+    body: JSON.stringify({
+      select: [
+        "id",
+        "title",
+        "initialMessage.ts",
+        "initialMessage.text",
+        "tags.name",
+        "customerId",
+      ],
+      order: ["createdAt"],
+      where: [
+        {
+          field: "customerId",
+          operator: "==",
+          value: customerId,
+        },
+      ],
+      descending: true,
+      limit: 100,
+      cursor,
+    }),
+  });
+  if (!res.ok) {
+    console.error(
+      "Error listing tickets:",
+      res.status,
+      res.statusText,
+      await res.text(),
+    );
+    return {
+      success: false,
+      message: "Error listing tickets. Please try again later.",
+    };
+  }
+
+  const json = (await res.json()) as UnthreadConversationsResponse;
+  return {
+    success: true,
+    result: json,
+  };
+}

--- a/apps/dashboard/src/app/(dashboard)/support/update-ticket/components/update-ticket.action.ts
+++ b/apps/dashboard/src/app/(dashboard)/support/update-ticket/components/update-ticket.action.ts
@@ -1,0 +1,107 @@
+"use server";
+import "server-only";
+
+import { getTeamById } from "@/api/team";
+import { getUnthreadConversation } from "lib/unthread/get-conversation";
+import { getRawAccount } from "../../../../account/settings/getAccount";
+import { loginRedirect } from "../../../../login/loginRedirect";
+
+type UpdateTicketResponse =
+  | {
+      success: false;
+      message: string;
+    }
+  | {
+      success: true;
+    };
+
+export async function updateTicketAction(args: {
+  teamId: string;
+  conversationId: string;
+  updateData: Partial<{
+    status: "closed";
+  }>;
+}): Promise<UpdateTicketResponse> {
+  const { teamId, conversationId, updateData } = args;
+  if (!teamId || !conversationId) {
+    return {
+      success: false,
+      message: "Missing required arguments.",
+    };
+  }
+
+  if (updateData.status) {
+    // Only allow closing a ticket.
+    if (updateData.status !== "closed") {
+      return {
+        success: false,
+        message: 'Invalid "status".',
+      };
+    }
+  }
+
+  const account = await getRawAccount();
+  if (!account) {
+    // User is not logged in.
+    loginRedirect("/support");
+  }
+
+  const team = await getTeamById(teamId);
+  const customerId = team?.unthreadCustomerId;
+  if (!customerId) {
+    return {
+      success: false,
+      message: `Support customer for team ${teamId} not found.`,
+    };
+  }
+
+  if (
+    [
+      process.env.UNTHREAD_FREE_TIER_ID,
+      process.env.UNTHREAD_GROWTH_TIER_ID,
+      process.env.UNTHREAD_PRO_TIER_ID,
+    ].includes(customerId)
+  ) {
+    // Disallow "shared" legacy customer IDs because this endpoint returns customer-specific data.
+    return {
+      success: false,
+      message: `This endpoint is not supported for legacy customer ID ${customerId}`,
+    };
+  }
+
+  // Get the conversation first to confirm the user has permissions to update this ticket.
+  const conversation = await getUnthreadConversation(conversationId);
+  if (!conversation || conversation.customerId !== customerId) {
+    return {
+      success: false,
+      message: "Ticket not found.",
+    };
+  }
+
+  // Get the conversation and messages.
+  const res = await fetch(
+    `https://api.unthread.io/api/conversations/${conversationId}`,
+    {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Api-Key": process.env.UNTHREAD_API_KEY ?? "",
+      },
+      body: JSON.stringify(updateData),
+    },
+  );
+  if (!res.ok) {
+    console.error(
+      "Error updating ticket:",
+      res.status,
+      res.statusText,
+      await res.text(),
+    );
+    return {
+      success: false,
+      message: "Error updating tickets. Please try again later.",
+    };
+  }
+
+  return { success: true };
+}

--- a/apps/dashboard/src/lib/unthread/get-conversation.ts
+++ b/apps/dashboard/src/lib/unthread/get-conversation.ts
@@ -1,0 +1,123 @@
+"use server";
+import "server-only";
+
+interface UnthreadUser {
+  id: string;
+  name: string;
+  email: string;
+  slackId: string;
+  photo: string;
+}
+
+interface UnthreadMessage {
+  ts: string;
+  userId: string;
+  userTeamId: string;
+  botId: string;
+  botName: string;
+  text: string;
+  subtype: string | null;
+  conversationId: string;
+  timestamp: string;
+  threadTs: string | null;
+  conversation: UnthreadConversation;
+  user: UnthreadUser | null;
+  metadata?: {
+    eventType?:
+      | "autoresponder_replied"
+      | "email_received"
+      | "email_explanation_sent"
+      | "widget_message_received"
+      | "microsoft_teams_message_received"
+      | "unthread_outbound"
+      | "post_close_template_sent"
+      | "customer_view_button"
+      | "slack_bot_dm_received";
+  };
+}
+
+interface UnthreadTag {
+  id: string;
+  name: string;
+}
+
+interface UnthreadCustomer {
+  name: string;
+  primarySupportAssigneeId: string | null;
+  primarySupportAssigneeType: "user" | "team" | null;
+  secondarySupportAssigneeId: string | null;
+  secondarySupportAssigneeType: "user" | "team" | null;
+  replyTimeoutMinutes: number | null;
+  defaultTriageChannelId: string | null;
+  disableAutomatedTicketing: boolean | null;
+  botHandling: "off" | "all" | null;
+  // autoresponder: AutoresponderOptions | null;
+  // supportSteps: Array<SupportStep> | null;
+  slackTeamId: string | null;
+  assignToTaggedUserEnabled: boolean | null;
+  slackChannelId: string | null;
+  createdAt: string;
+  updatedAt: string;
+  tags: Array<UnthreadTag>;
+  // slackChannel: SlackChannel | null;
+}
+
+interface UnthreadConversation {
+  id: string;
+  status: "open" | "in_progress" | "on_hold" | "closed";
+  customerId: string | null;
+  channelId: string;
+  wasManuallyCreated: boolean;
+  friendlyId: number;
+  createdAt: string;
+  updatedAt: string;
+  closedAt: string | null;
+  statusUpdatedAt: string | null;
+  responseTime: number | null;
+  responseTimeWorking: number | null;
+  resolutionTime: number | null;
+  resolutionTimeWorking: number | null;
+  title: string | null;
+  priority: number | null;
+  initialMessage: UnthreadMessage;
+  assignedToUserId: UnthreadUser | null;
+  tags: Array<UnthreadTag>;
+  customer: UnthreadCustomer | null;
+  wakeUpAt: string | null;
+  summary: string | null;
+  snoozedAt: string | null;
+  lockedAt: string | null;
+  ticketTypeId: string | null;
+  ticketTypeFields: Record<string, string>;
+  metadata?: Record<string, string>;
+  followers?: {
+    userId?: string;
+    groupId?: string;
+    entityId: string;
+  }[];
+  collaborators?: {
+    collaboratorTypeId: string;
+    userId?: string;
+    groupId?: string;
+    entityId: string;
+  }[];
+}
+
+export async function getUnthreadConversation(
+  conversationId: string,
+): Promise<UnthreadConversation | null> {
+  const res = await fetch(
+    `https://api.unthread.io/api/conversations/${conversationId}`,
+    {
+      headers: {
+        "X-Api-Key": process.env.UNTHREAD_API_KEY ?? "",
+      },
+    },
+  );
+  if (!res.ok) {
+    throw new Error(
+      `Error getting conversation: ${res.status} - ${await res.text()}`,
+    );
+  }
+  return (await res.json()) as UnthreadConversation;
+}

--- a/packages/service-utils/src/core/api.ts
+++ b/packages/service-utils/src/core/api.ts
@@ -108,6 +108,7 @@ export type TeamResponse = {
   enabledScopes: ServiceName[];
   isOnboarded: boolean;
   capabilities: TeamCapabilities;
+  unthreadCustomerId: string | null;
 };
 
 export type ProjectSecretKey = {


### PR DESCRIPTION
Adds CRUD server actions to list, create, and update support tickets

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the ticketing system by introducing new functionalities for creating, updating, and retrieving tickets. It includes updates to type definitions and improvements in error handling and validation throughout the ticket management process.

### Detailed summary
- Added `engineCloud` configuration to `packages/service-utils/src/core/api.ts`.
- Introduced `TeamPlan` type to manage billing and support plans in `TeamResponse`.
- Updated `fetchTeamAndProject` to use `incomingServiceApiKey`.
- Implemented `updateTicketAction` for ticket updates with error handling.
- Created `addMessageToTicketAction` for adding messages to tickets.
- Developed `listTicketsAction` for retrieving a list of tickets.
- Enhanced `getTicketAction` for fetching ticket details and messages.
- Introduced `getUnthreadConversation` for conversation retrieval.
- Added validation for customer IDs and user permissions across actions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->