### PR TITLE
[TOOL-4277] Dashboard: Update gated features

### DIFF
--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/connect/account-abstraction/settings/page.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/connect/account-abstraction/settings/page.tsx
@@ -60,6 +60,7 @@ export default async function Page(props: {
         trackingCategory="account-abstraction-project-settings"
         project={project}
         teamId={team.id}
+        teamSlug={team.slug}
         validTeamPlan={getValidTeamPlan(team)}
       />
     </ChakraProviderSetup>

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/connect/in-app-wallets/settings/page.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/connect/in-app-wallets/settings/page.tsx
@@ -30,7 +30,7 @@ export default async function Page(props: {
       teamId={team.id}
       trackingCategory="in-app-wallet-project-settings"
       teamSlug={team_slug}
-      validTeamPlan={getValidTeamPlan(team)}
+      teamPlan={getValidTeamPlan(team)}
       smsCountryTiers={smsCountryTiers}
     />
   );

--- a/apps/dashboard/src/components/embedded-wallets/Configure/InAppWalletSettingsUI.stories.tsx
+++ b/apps/dashboard/src/components/embedded-wallets/Configure/InAppWalletSettingsUI.stories.tsx
@@ -1,6 +1,6 @@
+import type { Team } from "@/api/team";
 import type { Meta, StoryObj } from "@storybook/react";
 import { projectStub } from "../../../stories/stubs";
-import { mobileViewport } from "../../../stories/utils";
 import { InAppWalletSettingsUI } from "./index";
 
 const meta = {
@@ -16,44 +16,44 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const GrowthPlan: Story = {
-  args: {
-    canEditAdvancedFeatures: true,
-  },
-};
-
 export const FreePlan: Story = {
   args: {
-    canEditAdvancedFeatures: false,
+    currentPlan: "free",
   },
 };
 
-export const GrowthPlanMobile: Story = {
+export const GrowthPlan: Story = {
   args: {
-    canEditAdvancedFeatures: true,
-  },
-  parameters: {
-    viewport: mobileViewport("iphone14"),
+    currentPlan: "growth",
   },
 };
 
-export const FreePlanMobile: Story = {
+export const AcceleratePlan: Story = {
   args: {
-    canEditAdvancedFeatures: false,
+    currentPlan: "accelerate",
   },
-  parameters: {
-    viewport: mobileViewport("iphone14"),
+};
+
+export const GrowthLegacyPlan: Story = {
+  args: {
+    currentPlan: "growth_legacy",
+  },
+};
+
+export const ProPlan: Story = {
+  args: {
+    currentPlan: "pro",
   },
 };
 
 function Variants(props: {
-  canEditAdvancedFeatures: boolean;
+  currentPlan: Team["billingPlan"];
 }) {
   return (
     <div className="mx-auto w-full max-w-[1140px] px-4 py-6">
       <div className="flex flex-col gap-10">
         <InAppWalletSettingsUI
-          canEditAdvancedFeatures={props.canEditAdvancedFeatures}
+          teamPlan={props.currentPlan}
           project={projectStub("foo", "bar")}
           teamId="bar"
           embeddedWalletService={{

--- a/apps/dashboard/src/components/settings/Account/Billing/GatedSwitch.stories.tsx
+++ b/apps/dashboard/src/components/settings/Account/Billing/GatedSwitch.stories.tsx
@@ -1,5 +1,14 @@
-import { Separator } from "@/components/ui/separator";
+import type { Team } from "@/api/team";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
 import { BadgeContainer } from "../../../../stories/utils";
 import { GatedSwitch } from "./GatedSwitch";
 
@@ -18,41 +27,52 @@ export const AllVariants: Story = {
 };
 
 function Variants() {
+  const [requiredPlan, setRequiredPlan] = useState<
+    "free" | "growth" | "accelerate" | "pro"
+  >("accelerate");
+
+  const plans: Team["billingPlan"][] = [
+    "free",
+    "starter_legacy",
+    "starter",
+    "growth_legacy",
+    "growth",
+    "accelerate",
+    "pro",
+  ];
+
   return (
-    <div className="min-h-dvh bg-background p-7 text-foreground">
-      <div className="mx-auto flex max-w-[500px] flex-col gap-8">
-        <BadgeContainer label="upgradeRequired">
-          <GatedSwitch upgradeRequired />
-        </BadgeContainer>
-
-        <BadgeContainer label="No upgradeRequired">
-          <GatedSwitch upgradeRequired={false} />
-        </BadgeContainer>
-
-        <BadgeContainer label="No upgradeRequired, disabled">
-          <GatedSwitch upgradeRequired={false} disabled />
-        </BadgeContainer>
-
-        <Separator />
-
-        <BadgeContainer label="upgradeRequired, Checked">
-          <GatedSwitch upgradeRequired checked />
-        </BadgeContainer>
-
-        <BadgeContainer label="upgradeRequired, unchecked">
-          <GatedSwitch upgradeRequired checked={false} />
-        </BadgeContainer>
-
-        <Separator />
-
-        <BadgeContainer label="No upgradeRequired, Checked">
-          <GatedSwitch upgradeRequired={false} checked />
-        </BadgeContainer>
-
-        <BadgeContainer label="No upgradeRequired, unchecked">
-          <GatedSwitch upgradeRequired={false} checked={false} />
-        </BadgeContainer>
+    <div className="container flex max-w-5xl flex-col gap-10 py-10">
+      <div className="flex items-center gap-2">
+        <Label>Required Plan</Label>
+        <Select
+          value={requiredPlan}
+          onValueChange={(value) =>
+            setRequiredPlan(value as typeof requiredPlan)
+          }
+        >
+          <SelectTrigger className="w-[180px]">
+            <SelectValue placeholder="Select plan" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="free">Free</SelectItem>
+            <SelectItem value="growth">Growth</SelectItem>
+            <SelectItem value="accelerate">Accelerate</SelectItem>
+            <SelectItem value="pro">Pro</SelectItem>
+          </SelectContent>
+        </Select>
       </div>
+
+      {plans.map((currentPlan) => (
+        <BadgeContainer key={currentPlan} label={`plan: ${currentPlan}`}>
+          <GatedSwitch
+            key={currentPlan}
+            currentPlan={currentPlan}
+            requiredPlan={requiredPlan}
+            teamSlug="foo"
+          />
+        </BadgeContainer>
+      ))}
     </div>
   );
 }

--- a/apps/dashboard/src/components/settings/Account/Billing/GatedSwitch.tsx
+++ b/apps/dashboard/src/components/settings/Account/Billing/GatedSwitch.tsx
@@ -1,47 +1,56 @@
-import { Badge } from "@/components/ui/badge";
+import type { Team } from "@/api/team";
 import { Switch } from "@/components/ui/switch";
 import { ToolTipLabel } from "@/components/ui/tooltip";
 import { TrackedLinkTW } from "@/components/ui/tracked-link";
+import { cn } from "@/lib/utils";
+import { TeamPlanBadge } from "../../../../app/(app)/components/TeamPlanBadge";
+import { planToTierRecordForGating } from "./planToTierRecord";
 
 type SwitchProps = React.ComponentProps<typeof Switch>;
 
-interface GatedSwitchProps extends SwitchProps {
+type GatedSwitchProps = {
   trackingLabel?: string;
-  upgradeRequired: boolean;
-}
+  currentPlan: Team["billingPlan"];
+  requiredPlan: Team["billingPlan"];
+  teamSlug: string;
+  switchProps?: SwitchProps;
+};
 
 export const GatedSwitch: React.FC<GatedSwitchProps> = (
-  allProps: GatedSwitchProps,
+  props: GatedSwitchProps,
 ) => {
-  const { upgradeRequired, trackingLabel, checked, ...props } = allProps;
+  const isUpgradeRequired =
+    planToTierRecordForGating[props.currentPlan] <
+    planToTierRecordForGating[props.requiredPlan];
 
   return (
     <ToolTipLabel
       hoverable
+      contentClassName="max-w-[300px]"
       label={
-        upgradeRequired ? (
-          <div className="w-[220px]">
-            To access this feature, you need to upgrade to the{" "}
+        isUpgradeRequired ? (
+          <span>
+            To access this feature, <br /> Upgrade to the{" "}
             <TrackedLinkTW
               target="_blank"
-              href="/team/~/~/settings/billing"
+              href={`/team/${props.teamSlug}/~/settings/billing`}
               category="advancedFeature"
-              label={trackingLabel}
-              className="text-link-foreground hover:text-foreground"
+              label={props.trackingLabel}
+              className="text-link-foreground capitalize hover:text-foreground"
             >
-              Growth plan
+              {props.requiredPlan} plan
             </TrackedLinkTW>
-            .
-          </div>
+          </span>
         ) : undefined
       }
     >
       <div className="inline-flex items-center gap-2">
-        {upgradeRequired && <Badge>Growth</Badge>}
+        {isUpgradeRequired && <TeamPlanBadge plan={props.requiredPlan} />}
         <Switch
-          checked={checked}
-          disabled={upgradeRequired || props.disabled}
-          {...props}
+          {...props.switchProps}
+          checked={props.switchProps?.checked && !isUpgradeRequired}
+          disabled={props.switchProps?.disabled || isUpgradeRequired}
+          className={cn("disabled:opacity-100", props.switchProps?.className)}
         />
       </div>
     </ToolTipLabel>

--- a/apps/dashboard/src/components/settings/Account/Billing/planToTierRecord.ts
+++ b/apps/dashboard/src/components/settings/Account/Billing/planToTierRecord.ts
@@ -1,0 +1,13 @@
+import type { Team } from "@/api/team";
+
+// Note: Growth legacy is considered higher tier in this hierarchy
+export const planToTierRecordForGating: Record<Team["billingPlan"], number> = {
+  free: 0,
+  starter_legacy: 1,
+  starter: 2,
+  growth: 3,
+  accelerate: 4,
+  growth_legacy: 5,
+  scale: 6,
+  pro: 7,
+};

--- a/apps/dashboard/src/components/settings/ApiKeys/Create/index.tsx
+++ b/apps/dashboard/src/components/settings/ApiKeys/Create/index.tsx
@@ -32,7 +32,7 @@ import { useMutation } from "@tanstack/react-query";
 import type { ProjectService } from "@thirdweb-dev/service-utils";
 import { SERVICES } from "@thirdweb-dev/service-utils";
 import { useTrack } from "hooks/analytics/useTrack";
-import { ArrowLeftIcon, ExternalLinkIcon } from "lucide-react";
+import { ArrowLeftIcon, ArrowRightIcon } from "lucide-react";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
@@ -529,7 +529,7 @@ function CreatedProjectDetails(props: {
             className="min-w-28 gap-2"
           >
             View Project
-            <ExternalLinkIcon className="size-4" />
+            <ArrowRightIcon className="size-4" />
           </Button>
         )}
       </DialogFooter>

--- a/apps/dashboard/src/components/smart-wallets/SponsorshipPolicies/index.tsx
+++ b/apps/dashboard/src/components/smart-wallets/SponsorshipPolicies/index.tsx
@@ -41,6 +41,7 @@ type AccountAbstractionSettingsPageProps = {
   project: Project;
   trackingCategory: string;
   teamId: string;
+  teamSlug: string;
   validTeamPlan: Team["billingPlan"];
   client: ThirdwebClient;
 };
@@ -548,7 +549,12 @@ export function AccountAbstractionSettingsPage(
           <Flex flexDir="column" gap={4}>
             <div className="flex flex-row items-center justify-between gap-6 lg:gap-12">
               <div>
-                <FormLabel pointerEvents="none">Server verifier</FormLabel>
+                <FormLabel
+                  pointerEvents="none"
+                  htmlFor="server-verifier-switch"
+                >
+                  Server verifier
+                </FormLabel>
                 <Text>
                   Specify your own endpoint that will verify each transaction
                   and decide whether it should be sponsored or not. <br /> This
@@ -566,18 +572,20 @@ export function AccountAbstractionSettingsPage(
               </div>
 
               <GatedSwitch
-                upgradeRequired={props.validTeamPlan === "free"}
-                checked={
-                  form.watch("serverVerifier").enabled &&
-                  props.validTeamPlan !== "free"
-                }
-                onCheckedChange={(checked) => {
-                  form.setValue(
-                    "serverVerifier",
-                    !checked
-                      ? { enabled: false, url: null, headers: null }
-                      : { enabled: true, url: "", headers: [] },
-                  );
+                requiredPlan="accelerate"
+                currentPlan={props.validTeamPlan}
+                teamSlug={props.teamSlug}
+                switchProps={{
+                  id: "server-verifier-switch",
+                  checked: form.watch("serverVerifier").enabled,
+                  onCheckedChange: (checked) => {
+                    form.setValue(
+                      "serverVerifier",
+                      !checked
+                        ? { enabled: false, url: null, headers: null }
+                        : { enabled: true, url: "", headers: [] },
+                    );
+                  },
                 }}
               />
             </div>


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the handling of team plans and billing in various components, enhancing the user interface, and ensuring that features are gated based on the current plan of the team.

### Detailed summary
- Added `teamSlug` prop in `page.tsx` files.
- Changed `validTeamPlan` to `teamPlan` in `in-app-wallets` settings.
- Introduced `planToTierRecordForGating` for billing plans.
- Updated `GatedSwitch` to use `currentPlan` and `requiredPlan`.
- Enhanced UI components with better accessibility features.
- Renamed story variants for clarity in `GatedSwitch` stories.
- Refactored settings UI to incorporate plan checks for SMS and JWT features.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->