### PR TITLE
Add webhooks capability to insight team capabilities

### DIFF
--- a/.changeset/smooth-ghosts-rhyme.md
+++ b/.changeset/smooth-ghosts-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+add insight.webhooks to capabilities

--- a/apps/dashboard/src/stories/stubs.ts
+++ b/apps/dashboard/src/stories/stubs.ts
@@ -79,6 +79,7 @@ export function teamStub(id: string, billingPlan: Team["billingPlan"]): Team {
       insight: {
         enabled: true,
         rateLimit: 1000,
+        webhooks: true,
       },
       embeddedWallets: {
         enabled: true,

--- a/packages/service-utils/src/core/api.ts
+++ b/packages/service-utils/src/core/api.ts
@@ -55,6 +55,7 @@ type TeamCapabilities = {
   insight: {
     enabled: boolean;
     rateLimit: number;
+    webhooks: boolean;
   };
   storage: {
     enabled: boolean;

--- a/packages/service-utils/src/mocks.ts
+++ b/packages/service-utils/src/mocks.ts
@@ -67,6 +67,7 @@ export const validTeamResponse: TeamResponse = {
     insight: {
       enabled: true,
       rateLimit: 1000,
+      webhooks: true,
     },
     storage: {
       enabled: true,


### PR DESCRIPTION
depends on: https://app.graphite.dev/github/pr/thirdweb-dev/api-server/1580/Add-webhooks-capability-to-team-plan-configurations

Added `webhooks` boolean field to the `insight` capability in the `TeamCapabilities` type. Also created a changeset to document this addition.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `webhooks` capability to the service utilities, enhancing the configuration options for both the `mocks.ts` and `api.ts` files.

### Detailed summary
- Added `webhooks: true` to the configuration in `packages/service-utils/src/mocks.ts`.
- Updated the `packages/service-utils/src/core/api.ts` to include `webhooks: boolean;` in the interface.
- Documented the addition of `webhooks` in the changeset file `changeset/smooth-ghosts-rhyme.md`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->