### PR TITLE
[SDK] Only update isLoggedIn state on successful logins

### DIFF
--- a/.changeset/large-candies-cough.md
+++ b/.changeset/large-candies-cough.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Only update isLoggedIn state on successfull logins

--- a/packages/thirdweb/src/react/core/hooks/auth/useSiweAuth.ts
+++ b/packages/thirdweb/src/react/core/hooks/auth/useSiweAuth.ts
@@ -110,7 +110,7 @@ export function useSiweAuth(
 
       return await authOptions.doLogin(signedPayload);
     },
-    onSettled: () => {
+    onSuccess: () => {
       return queryClient.invalidateQueries({
         queryKey: ["siwe_auth", "isLoggedIn"],
       });
@@ -126,7 +126,7 @@ export function useSiweAuth(
 
       return await authOptions.doLogout();
     },
-    onSettled: () => {
+    onSuccess: () => {
       return queryClient.invalidateQueries({
         queryKey: ["siwe_auth", "isLoggedIn"],
       });


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the state management of the `isLoggedIn` status in the `useSiweAuth` hook by updating it only on successful login and logout actions.

### Detailed summary
- Changed the callback from `onSettled` to `onSuccess` for both login and logout actions in the `useSiweAuth` hook.
- Ensured `isLoggedIn` state is updated only after successful authentication actions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->