### PR TITLE
SDK: Signature screen loading state improvements

### DIFF
--- a/.changeset/fast-bushes-juggle.md
+++ b/.changeset/fast-bushes-juggle.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Signature Screen loading state improvements

--- a/packages/thirdweb/src/react/core/hooks/auth/useSiweAuth.ts
+++ b/packages/thirdweb/src/react/core/hooks/auth/useSiweAuth.ts
@@ -148,5 +148,6 @@ export function useSiweAuth(
     // checking if logged in
     isLoggedIn: isLoggedInQuery.data,
     isLoading: isLoggedInQuery.isFetching,
+    isPending: isLoggedInQuery.isPending,
   };
 }

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/ConnectButton.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/ConnectButton.tsx
@@ -479,7 +479,7 @@ function ConnectButtonInner(
   if (siweAuth.requiresAuth) {
     // loading state if loading
     // TODO: figure out a way to consolidate the loading states with the ones from locale loading
-    if (siweAuth.isLoading || siweAuth.isLoggingIn || siweAuth.isLoggingOut) {
+    if (siweAuth.isPending || siweAuth.isLoggingIn || siweAuth.isLoggingOut) {
       const combinedClassName = `${props.connectButton?.className || ""} ${TW_CONNECT_WALLET}`;
       return (
         <AnimatedButton

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/SignatureScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/SignatureScreen.tsx
@@ -71,7 +71,7 @@ export const SignatureScreen: React.FC<{
     }
   }, [onDone, siweAuth]);
 
-  if (!wallet || siweAuth.isLoading) {
+  if (!wallet || siweAuth.isPending) {
     return <LoadingScreen data-testid="loading-screen" />;
   }
 


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the loading state management in the `thirdweb` package, specifically in the authentication process using the `useSiweAuth` hook and the `SignatureScreen`.

### Detailed summary
- Added `isPending` to the state returned by `useSiweAuth`.
- Updated the condition in `SignatureScreen` to check for `siweAuth.isPending` instead of `siweAuth.isLoading`.
- Modified the condition in `ConnectButton` to use `siweAuth.isPending` instead of `siweAuth.isLoading`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->