### PR TITLE
Add domain verification functionality for teams

### DIFF
--- a/apps/dashboard/src/@/api/verified-domain.ts
+++ b/apps/dashboard/src/@/api/verified-domain.ts
@@ -1,0 +1,94 @@
+"use server";
+import "server-only";
+
+import { getAuthToken } from "../../app/(app)/api/lib/getAuthToken";
+import { API_SERVER_URL } from "../constants/env";
+
+export type VerifiedDomainResponse =
+  | {
+      status: "pending";
+      domain: string;
+      dnsSublabel: string;
+      dnsValue: string;
+    }
+  | {
+      status: "verified";
+      domain: string;
+      verifiedAt: Date;
+    };
+
+export async function checkDomainVerification(
+  teamIdOrSlug: string,
+): Promise<VerifiedDomainResponse | null> {
+  const token = await getAuthToken();
+
+  if (!token) {
+    return null;
+  }
+
+  const res = await fetch(
+    `${API_SERVER_URL}/v1/teams/${teamIdOrSlug}/verified-domain`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  );
+  if (res.ok) {
+    return (await res.json())?.result as VerifiedDomainResponse;
+  }
+
+  return null;
+}
+
+export async function createDomainVerification(
+  teamIdOrSlug: string,
+  domain: string,
+): Promise<VerifiedDomainResponse | { error: string }> {
+  const token = await getAuthToken();
+
+  if (!token) {
+    return {
+      error: "Unauthorized",
+    };
+  }
+
+  const res = await fetch(
+    `${API_SERVER_URL}/v1/teams/${teamIdOrSlug}/verified-domain`,
+    {
+      method: "POST",
+      body: JSON.stringify({ domain }),
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  );
+
+  if (res.ok) {
+    return (await res.json())?.result as VerifiedDomainResponse;
+  }
+
+  const resJson = (await res.json()) as {
+    error: {
+      code: string;
+      message: string;
+      statusCode: number;
+    };
+  };
+
+  switch (resJson?.error?.statusCode) {
+    case 400:
+      return {
+        error: "The domain you provided is not valid.",
+      };
+    case 409:
+      return {
+        error: "This domain is already verified by another team.",
+      };
+    default:
+      return {
+        error: resJson?.error?.message ?? "Failed to verify domain",
+      };
+  }
+}

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/settings/_components/settings-cards/domain-verification.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/settings/_components/settings-cards/domain-verification.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import {
+  type VerifiedDomainResponse,
+  checkDomainVerification,
+  createDomainVerification,
+} from "@/api/verified-domain";
+import { SettingsCard } from "@/components/blocks/SettingsCard";
+import { CopyButton } from "@/components/ui/CopyButton";
+import { Spinner } from "@/components/ui/Spinner/Spinner";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { AlertCircle, CheckCircle } from "lucide-react";
+import { useState } from "react";
+
+interface DomainVerificationFormProps {
+  teamId: string;
+  initialVerification: VerifiedDomainResponse | null;
+  isOwnerAccount: boolean;
+}
+
+export function TeamDomainVerificationCard({
+  initialVerification,
+  isOwnerAccount,
+  teamId,
+}: DomainVerificationFormProps) {
+  const [domain, setDomain] = useState("");
+  const queryClient = useQueryClient();
+
+  const domainQuery = useQuery({
+    queryKey: ["domain-verification", teamId],
+    queryFn: () => checkDomainVerification(teamId),
+    initialData: initialVerification,
+    refetchInterval: (query) => {
+      // if the data is pending, refetch every 10 seconds
+      if (query.state.data?.status === "pending") {
+        return 10000;
+      }
+      // if the data is verified, don't refetch ever
+      return false;
+    },
+  });
+
+  const verificationMutation = useMutation({
+    mutationFn: async (params: { teamId: string; domain: string }) => {
+      const res = await createDomainVerification(params.teamId, params.domain);
+      if ("error" in res) {
+        throw new Error(res.error);
+      }
+      return res;
+    },
+    onSuccess: (data) => {
+      queryClient.setQueryData(["domain-verification", teamId], data);
+    },
+  });
+
+  // Get the appropriate bottom text based on verification status
+  const getBottomText = () => {
+    if (!domainQuery.data) {
+      return "Domains must be verified before use.";
+    }
+
+    if (domainQuery.data.status === "pending") {
+      return "Your domain verification is pending. Please add the DNS record to complete verification.";
+    }
+
+    return `Domain ${domainQuery.data.domain} has been successfully verified.`;
+  };
+
+  // Render the content for the settings card
+  const renderContent = () => {
+    // Initial state - show domain input form
+    if (!domainQuery.data) {
+      return (
+        <div>
+          <Input
+            id="domain"
+            placeholder="example.com"
+            value={domain}
+            onChange={(e) => setDomain(e.target.value)}
+            disabled={!isOwnerAccount || verificationMutation.isPending}
+            // is the max length for a domain
+            maxLength={253}
+            className="md:w-[450px]"
+          />
+          <p className="mt-2 text-muted-foreground text-sm">
+            Enter the domain you want to verify. Do not include http(s):// or
+            www.
+          </p>
+        </div>
+      );
+    }
+
+    // Pending verification state
+    if (domainQuery.data.status === "pending") {
+      return (
+        <div className="space-y-6">
+          <div>
+            <div className="flex items-center justify-between">
+              <h3 className="font-medium text-sm">Domain</h3>
+              <span className="inline-flex items-center rounded-full bg-yellow-100 px-2.5 py-0.5 font-medium text-xs text-yellow-800">
+                Pending
+              </span>
+            </div>
+            <p className="mt-1 font-medium">{domainQuery.data.domain}</p>
+          </div>
+
+          <div className="space-y-4">
+            <p>
+              Before we can verify <b>{domainQuery.data.domain}</b>, you need to
+              add the following DNS TXT record:
+            </p>
+
+            <div className="grid gap-4">
+              <div>
+                <h4 className="mb-1 text-muted-foreground text-xs">
+                  Name / Host / Alias
+                </h4>
+
+                <div className="flex items-center gap-2 break-all font-mono text-sm">
+                  <span className="flex items-center gap-2 rounded-md bg-muted p-2">
+                    {domainQuery.data.dnsSublabel}{" "}
+                    <CopyButton text={domainQuery.data.dnsSublabel} />
+                  </span>
+                  <span>.{domainQuery.data.domain}</span>
+                </div>
+              </div>
+
+              <div>
+                <h4 className="mb-1 text-muted-foreground text-xs">
+                  Value / Content
+                </h4>
+                <div className="flex items-center gap-2 break-all font-mono text-sm">
+                  <span className="flex items-center gap-2 rounded-md bg-muted p-2">
+                    {domainQuery.data.dnsValue}{" "}
+                    <CopyButton text={domainQuery.data.dnsValue} />
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            <Alert variant="info">
+              <AlertCircle className="size-4" />
+              <AlertTitle>
+                DNS changes can take up to 48 hours to propagate.
+              </AlertTitle>
+              <AlertDescription>
+                We'll automatically check the status periodically. You can
+                manually check the status by clicking the button below.
+              </AlertDescription>
+            </Alert>
+
+            <Button
+              onClick={() => domainQuery.refetch()}
+              disabled={domainQuery.isFetching}
+              variant="outline"
+              size="sm"
+              className="flex items-center gap-2"
+            >
+              {domainQuery.isFetching && <Spinner className="size-4" />}
+              {domainQuery.isFetching
+                ? "Checking Status..."
+                : "Check Status Now"}
+            </Button>
+          </div>
+        </div>
+      );
+    }
+
+    // Verified state
+    return (
+      <div>
+        <div className="flex items-center justify-between">
+          <div className="mt-2 flex items-start space-x-3">
+            <CheckCircle className="mt-0.5 h-5 w-5 text-green-500" />
+            <div>
+              <p className="font-medium">{domainQuery.data.domain}</p>
+              <p className="text-muted-foreground text-sm">
+                Verified on{" "}
+                {new Date(domainQuery.data.verifiedAt).toLocaleDateString()}
+              </p>
+            </div>
+          </div>
+          <span className="inline-flex items-center rounded-full bg-green-100 px-2.5 py-0.5 font-medium text-green-800 text-xs">
+            Verified
+          </span>
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <SettingsCard
+      header={{
+        title: "Domain Verification",
+        description: "Verify your domain to enable advanced features.",
+      }}
+      errorText={
+        verificationMutation.error?.message || domainQuery.error?.message
+      }
+      noPermissionText={
+        domainQuery.data?.status === "pending"
+          ? !isOwnerAccount
+            ? "Only team owners can verify domains"
+            : undefined
+          : undefined
+      }
+      bottomText={getBottomText()}
+      saveButton={
+        !domainQuery.data
+          ? {
+              onClick: () =>
+                verificationMutation.mutate({
+                  teamId,
+                  domain,
+                }),
+              disabled: !domain || verificationMutation.isPending,
+              isPending: verificationMutation.isPending,
+              label: "Verify Domain",
+            }
+          : undefined
+      }
+    >
+      {renderContent()}
+    </SettingsCard>
+  );
+}

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/settings/general/GeneralSettingsPage.stories.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/settings/general/GeneralSettingsPage.stories.tsx
@@ -42,6 +42,8 @@ function Story() {
         leaveTeam={async () => {
           await new Promise((resolve) => setTimeout(resolve, 1000));
         }}
+        initialVerification={null}
+        isOwnerAccount={true}
       />
       <ComponentVariants />
     </div>

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/settings/general/TeamGeneralSettingsPage.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/settings/general/TeamGeneralSettingsPage.tsx
@@ -2,6 +2,7 @@
 
 import { apiServerProxy } from "@/actions/proxies";
 import type { Team } from "@/api/team";
+import type { VerifiedDomainResponse } from "@/api/verified-domain";
 import { useDashboardRouter } from "@/lib/DashboardRouter";
 import type { ThirdwebClient } from "thirdweb";
 import { upload } from "thirdweb/storage";
@@ -10,6 +11,8 @@ import { updateTeam } from "./updateTeam";
 
 export function TeamGeneralSettingsPage(props: {
   team: Team;
+  initialVerification: VerifiedDomainResponse | null;
+  isOwnerAccount: boolean;
   client: ThirdwebClient;
   accountId: string;
 }) {
@@ -72,6 +75,8 @@ export function TeamGeneralSettingsPage(props: {
 
         router.refresh();
       }}
+      initialVerification={props.initialVerification}
+      isOwnerAccount={props.isOwnerAccount}
     />
   );
 }

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/settings/general/TeamGeneralSettingsPageUI.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/settings/general/TeamGeneralSettingsPageUI.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { Team } from "@/api/team";
+import type { VerifiedDomainResponse } from "@/api/verified-domain";
 import { DangerSettingCard } from "@/components/blocks/DangerSettingCard";
 import { SettingsCard } from "@/components/blocks/SettingsCard";
 import { CopyTextButton } from "@/components/ui/CopyTextButton";
@@ -12,12 +13,15 @@ import { FileInput } from "components/shared/FileInput";
 import { useState } from "react";
 import { toast } from "sonner";
 import type { ThirdwebClient } from "thirdweb";
+import { TeamDomainVerificationCard } from "../_components/settings-cards/domain-verification";
 import { teamSlugRegex } from "./common";
 
 type UpdateTeamField = (team: Partial<Team>) => Promise<void>;
 
 export function TeamGeneralSettingsPageUI(props: {
   team: Team;
+  initialVerification: VerifiedDomainResponse | null;
+  isOwnerAccount: boolean;
   updateTeamImage: (file: File | undefined) => Promise<void>;
   updateTeamField: UpdateTeamField;
   client: ThirdwebClient;
@@ -40,6 +44,12 @@ export function TeamGeneralSettingsPageUI(props: {
         client={props.client}
       />
       <TeamIdCard team={props.team} />
+      <TeamDomainVerificationCard
+        teamId={props.team.id}
+        initialVerification={props.initialVerification}
+        isOwnerAccount={props.isOwnerAccount}
+      />
+
       <LeaveTeamCard teamName={props.team.name} leaveTeam={props.leaveTeam} />
       <DeleteTeamCard
         enabled={hasPermissionToDelete}

--- a/apps/dashboard/src/app/(app)/team/components/TeamHeader/TeamHeaderUI.tsx
+++ b/apps/dashboard/src/app/(app)/team/components/TeamHeader/TeamHeaderUI.tsx
@@ -18,6 +18,7 @@ import { ProjectSelectorMobileMenuButton } from "./ProjectSelectorMobileMenuButt
 import { TeamAndProjectSelectorPopoverButton } from "./TeamAndProjectSelectorPopoverButton";
 import { TeamSelectorMobileMenuButton } from "./TeamSelectorMobileMenuButton";
 import { getValidTeamPlan } from "./getValidTeamPlan";
+import { TeamVerifiedIcon } from "./team-verified-icon";
 
 export type TeamHeaderCompProps = {
   currentTeam: Team;
@@ -65,6 +66,7 @@ export function TeamHeaderDesktopUI(props: TeamHeaderCompProps) {
               client={props.client}
             />
             <span> {currentTeam.name} </span>
+            <TeamVerifiedIcon domain={currentTeam.verifiedDomain} />
             <TeamPlanBadge plan={teamPlan} />
           </Link>
 
@@ -156,7 +158,10 @@ export function TeamHeaderMobileUI(props: TeamHeaderCompProps) {
             />
 
             {!props.currentProject && (
-              <span className="font-semibold">{currentTeam.name}</span>
+              <div className="flex items-center gap-2">
+                <span className="font-semibold">{currentTeam.name}</span>
+                <TeamVerifiedIcon domain={currentTeam.verifiedDomain} />
+              </div>
             )}
           </Link>
 

--- a/apps/dashboard/src/app/(app)/team/components/TeamHeader/TeamSelectionUI.tsx
+++ b/apps/dashboard/src/app/(app)/team/components/TeamHeader/TeamSelectionUI.tsx
@@ -7,12 +7,14 @@ import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { cn } from "@/lib/utils";
 import type { Account } from "@3rdweb-sdk/react/hooks/useApi";
-import { CheckIcon, CirclePlusIcon } from "lucide-react";
+import { CirclePlusIcon } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
 import type { ThirdwebClient } from "thirdweb";
+import { TeamPlanBadge } from "../../../components/TeamPlanBadge";
 import { SearchInput } from "./SearchInput";
 import { getValidTeamPlan } from "./getValidTeamPlan";
+import { TeamVerifiedIcon } from "./team-verified-icon";
 
 export function TeamSelectionUI(props: {
   setHoveredTeam: (team: Team | undefined) => void;
@@ -68,11 +70,11 @@ export function TeamSelectionUI(props: {
 
           <ul>
             {filteredTeams.map((team) => {
-              const isSelected = team.slug === currentTeam?.slug;
+              const isSelected = team.id === currentTeam?.id;
               return (
                 // biome-ignore lint/a11y/useKeyWithMouseEvents: <explanation>
                 <li
-                  key={team.slug}
+                  key={team.id}
                   className="py-0.5"
                   onMouseOver={() => {
                     setHoveredTeam(team);
@@ -96,10 +98,10 @@ export function TeamSelectionUI(props: {
                         />
 
                         <span className="truncate"> {team.name} </span>
+                        <TeamVerifiedIcon domain={team.verifiedDomain} />
                       </div>
-                      {isSelected && (
-                        <CheckIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
-                      )}
+
+                      <TeamPlanBadge plan={team.billingPlan} />
                     </Link>
                   </Button>
                 </li>

--- a/apps/dashboard/src/app/(app)/team/components/TeamHeader/team-verified-icon.tsx
+++ b/apps/dashboard/src/app/(app)/team/components/TeamHeader/team-verified-icon.tsx
@@ -1,0 +1,22 @@
+import { ToolTipLabel } from "@/components/ui/tooltip";
+import { VerifiedIcon } from "lucide-react";
+
+export function TeamVerifiedIcon(props: {
+  domain: string | null;
+}) {
+  if (!props.domain) {
+    return null;
+  }
+
+  return (
+    <ToolTipLabel
+      label={
+        <>
+          <b className="font-mono">{props.domain}</b> is verified
+        </>
+      }
+    >
+      <VerifiedIcon className="size-4 text-blue-500" />
+    </ToolTipLabel>
+  );
+}

--- a/apps/dashboard/src/stories/stubs.ts
+++ b/apps/dashboard/src/stories/stubs.ts
@@ -98,6 +98,7 @@ export function teamStub(id: string, billingPlan: Team["billingPlan"]): Team {
     },
     planCancellationDate: null,
     unthreadCustomerId: null,
+    verifiedDomain: null,
   };
 
   return team;

--- a/packages/service-utils/src/core/api.ts
+++ b/packages/service-utils/src/core/api.ts
@@ -126,6 +126,7 @@ export type TeamResponse = {
   capabilities: TeamCapabilities;
   unthreadCustomerId: string | null;
   planCancellationDate: string | null;
+  verifiedDomain: string | null;
 };
 
 export type ProjectSecretKey = {

--- a/packages/service-utils/src/mocks.ts
+++ b/packages/service-utils/src/mocks.ts
@@ -59,6 +59,7 @@ export const validTeamResponse: TeamResponse = {
   canCreatePublicChains: false,
   enabledScopes: ["storage", "rpc", "bundler"],
   isOnboarded: true,
+  verifiedDomain: null,
   capabilities: {
     rpc: {
       enabled: true,


### PR DESCRIPTION
# Domain Verification for Teams

This PR adds domain verification functionality for teams, allowing team owners to verify domain ownership through DNS TXT records.

## Features

- Added server-side API functions to check and create domain verifications
- Created a new domain verification settings card component for the team settings page
- Added verification status display in team headers with a verified badge
- Implemented automatic status checking for pending verifications

## Implementation Details

- The verification process uses DNS TXT records for domain ownership validation
- Verification states include "pending" and "verified" with appropriate UI for each
- Added error handling for invalid domains and already verified domains
- Automatic polling checks verification status every 10 seconds when pending

The feature enhances team identity by allowing teams to prove domain ownership, which will enable additional features in the future.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding domain verification functionality to the team settings, allowing teams to verify their domains and display verification status within the app.

### Detailed summary
- Added `verifiedDomain` fields in various types and components.
- Introduced `TeamVerifiedIcon` to show verification status.
- Enhanced `TeamGeneralSettingsPage` to accept `initialVerification` and `isOwnerAccount`.
- Implemented domain verification logic in `TeamDomainVerificationCard`.
- Created API functions for checking and creating domain verification.
- Updated UI components to reflect domain verification status and provide user feedback.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->