### PR TITLE
Fix: `useWalletBalance` and the `useActiveAccount` to work with `0x{string}` addresses instead of strings.

### DIFF
--- a/packages/thirdweb/src/adapters/viem.ts
+++ b/packages/thirdweb/src/adapters/viem.ts
@@ -394,7 +394,7 @@ function fromViemWalletClient(options: {
     );
   }
   return {
-    address: viemAccount.address,
+    address: viemAccount.address as `0x${string}`,
     signMessage: async (msg) => {
       return options.walletClient.signMessage({
         account: viemAccount,

--- a/packages/thirdweb/src/react/core/hooks/others/useWalletBalance.ts
+++ b/packages/thirdweb/src/react/core/hooks/others/useWalletBalance.ts
@@ -13,7 +13,7 @@ import {
 
 type UseWalletBalanceOptions = Prettify<
   Omit<GetWalletBalanceOptions, "address" | "chain"> & {
-    address: string | undefined;
+    address: `0x${string}` | undefined;
     chain: Chain | undefined;
   }
 >;

--- a/packages/thirdweb/src/react/native/ui/connect/TokenListScreen.tsx
+++ b/packages/thirdweb/src/react/native/ui/connect/TokenListScreen.tsx
@@ -64,7 +64,7 @@ export const TokenRow = (props: {
   theme: Theme;
   client: ThirdwebClient;
   chain?: Chain;
-  address?: string;
+  address?: `0x${string}`;
   onTokenSelected?: (token?: TokenInfo) => void;
 }) => {
   const { token, theme, address, chain, client, onTokenSelected } = props;

--- a/packages/thirdweb/src/wallets/engine/index.ts
+++ b/packages/thirdweb/src/wallets/engine/index.ts
@@ -19,7 +19,7 @@ export type EngineAccountOptions = {
   /**
    * The backend wallet to use for sending transactions inside engine.
    */
-  walletAddress: string;
+  walletAddress: `0x${string}`;
   overrides?: {
     /**
      * The address of the smart account to act on behalf of. Requires your backend wallet to be a valid signer on that smart account.

--- a/packages/thirdweb/src/wallets/interfaces/wallet.ts
+++ b/packages/thirdweb/src/wallets/interfaces/wallet.ts
@@ -164,7 +164,7 @@ export type Account = {
   /**
    * address of the account
    */
-  address: Address;
+  address: `0x${string}`;
   /**
    * Send the given transaction to the blockchain
    * @example


### PR DESCRIPTION
- Updated type annotations for wallet/account addresses from generic string types to the more specific `0x${string}` type across several files.
- This change addresses the issue where users would see a plain string instead of the expected `0x{string}` type for addresses, improving type safety and developer experience.
- Ensured that this fix applies to both useActiveAccount and useWalletBalance hooks, so address types are now consistent and accurate in these commonly used hooks.
- Only performed a type coercion (using as `0x${string}`) in a single location, specifically in the deprecated fromViemWalletClient function, to maintain backward compatibility without introducing unnecessary changes elsewhere.
- No functional logic was altered; only type definitions were updated for clarity and correctness.

solves issue #6810 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing type safety by changing the type of various `address` properties across multiple files to a more specific format, ensuring they conform to the Ethereum address pattern.

### Detailed summary
- Changed `address` type from `Address` to `0x${string}` in `wallet.ts`.
- Cast `viemAccount.address` to `0x${string}` in `viem.ts`.
- Updated `address` type to `0x${string} | undefined` in `useWalletBalance.ts`.
- Modified optional `address` type to `0x${string}` in `TokenListScreen.tsx`.
- Changed `walletAddress` type from `string` to `0x${string}` in `index.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->