### PR TITLE
Update plan tier hierarchy for sponsorship policies

### DIFF
--- a/apps/dashboard/src/components/settings/Account/Billing/planToTierRecord.ts
+++ b/apps/dashboard/src/components/settings/Account/Billing/planToTierRecord.ts
@@ -3,8 +3,8 @@ import type { Team } from "@/api/team";
 // Note: Growth legacy is considered higher tier in this hierarchy
 export const planToTierRecordForGating: Record<Team["billingPlan"], number> = {
   free: 0,
-  starter_legacy: 1,
-  starter: 2,
+  starter: 1,
+  starter_legacy: 2,
   growth: 3,
   accelerate: 4,
   growth_legacy: 5,

--- a/apps/dashboard/src/components/smart-wallets/SponsorshipPolicies/index.tsx
+++ b/apps/dashboard/src/components/smart-wallets/SponsorshipPolicies/index.tsx
@@ -572,7 +572,7 @@ export function AccountAbstractionSettingsPage(
               </div>
 
               <GatedSwitch
-                requiredPlan="accelerate"
+                requiredPlan="starter"
                 currentPlan={props.validTeamPlan}
                 teamSlug={props.teamSlug}
                 switchProps={{


### PR DESCRIPTION
### TL;DR

Updated plan tier hierarchy by swapping `starter` and `starter_legacy` positions, and lowered the required plan for sponsorship policies from `accelerate` to `starter`.

### What changed?

- Modified the plan tier hierarchy in `planToTierRecordForGating` by changing:
  - `starter_legacy` from tier 1 to tier 2
  - `starter` from tier 2 to tier 1
- Reduced the required plan for the sponsorship policies feature from `accelerate` to `starter` in the `GatedSwitch` component

### How to test?

1. Verify that users on the `starter` plan can now access sponsorship policies
2. Confirm that the plan hierarchy works correctly in all gated features
3. Test that users on `starter_legacy` plans maintain their expected access levels

### Why make this change?

This change makes sponsorship policies available to more users by lowering the tier requirement. The plan hierarchy adjustment ensures that the `starter` plan is positioned correctly in the tier structure, making it more accessible than the legacy version while maintaining the proper feature gating across the platform.