### PR TITLE
Nebula: Fix wallet address not set in context when clicking example prompt on login page

### DIFF
--- a/apps/dashboard/src/app/nebula-app/(app)/chat/[session_id]/page.tsx
+++ b/apps/dashboard/src/app/nebula-app/(app)/chat/[session_id]/page.tsx
@@ -1,6 +1,9 @@
 import { redirect } from "next/navigation";
 import { loginRedirect } from "../../../../(app)/login/loginRedirect";
-import { getNebulaAuthToken } from "../../../_utils/authToken";
+import {
+  getNebulaAuthToken,
+  getNebulaAuthTokenWalletAddress,
+} from "../../../_utils/authToken";
 import { getSessionById } from "../../api/session";
 import { ChatPageContent } from "../../components/ChatPageContent";
 
@@ -12,8 +15,9 @@ export default async function Page(props: {
   const params = await props.params;
   const pagePath = `/chat/${params.session_id}`;
   const authToken = await getNebulaAuthToken();
+  const accountAddress = await getNebulaAuthTokenWalletAddress();
 
-  if (!authToken) {
+  if (!authToken || !accountAddress) {
     loginRedirect(pagePath);
   }
 
@@ -28,6 +32,7 @@ export default async function Page(props: {
 
   return (
     <ChatPageContent
+      accountAddress={accountAddress}
       authToken={authToken}
       session={session}
       type="new-chat"

--- a/apps/dashboard/src/app/nebula-app/(app)/chat/page.tsx
+++ b/apps/dashboard/src/app/nebula-app/(app)/chat/page.tsx
@@ -1,16 +1,23 @@
 import { loginRedirect } from "../../../(app)/login/loginRedirect";
-import { getNebulaAuthToken } from "../../_utils/authToken";
+import {
+  getNebulaAuthToken,
+  getNebulaAuthTokenWalletAddress,
+} from "../../_utils/authToken";
 import { ChatPageContent } from "../components/ChatPageContent";
 
 export default async function Page() {
-  const authToken = await getNebulaAuthToken();
+  const [authToken, accountAddress] = await Promise.all([
+    getNebulaAuthToken(),
+    getNebulaAuthTokenWalletAddress(),
+  ]);
 
-  if (!authToken) {
+  if (!authToken || !accountAddress) {
     loginRedirect();
   }
 
   return (
     <ChatPageContent
+      accountAddress={accountAddress}
       authToken={authToken}
       session={undefined}
       type="new-chat"

--- a/apps/dashboard/src/app/nebula-app/(app)/components/ChatPageContent.tsx
+++ b/apps/dashboard/src/app/nebula-app/(app)/components/ChatPageContent.tsx
@@ -29,6 +29,7 @@ import { EmptyStateChatPageContent } from "./EmptyStateChatPageContent";
 
 export function ChatPageContent(props: {
   session: SessionInfo | undefined;
+  accountAddress: string;
   authToken: string;
   type: "landing" | "new-chat";
   initialParams:
@@ -99,7 +100,7 @@ export function ChatPageContent(props: {
         contextRes?.chain_ids ||
         props.initialParams?.chainIds.map((x) => x.toString()) ||
         [],
-      walletAddress: contextRes?.wallet_address || null,
+      walletAddress: contextRes?.wallet_address || props.accountAddress || null,
     };
 
     return value;

--- a/apps/dashboard/src/app/nebula-app/(app)/page.tsx
+++ b/apps/dashboard/src/app/nebula-app/(app)/page.tsx
@@ -1,5 +1,8 @@
 import { loginRedirect } from "../../(app)/login/loginRedirect";
-import { getNebulaAuthToken } from "../_utils/authToken";
+import {
+  getNebulaAuthToken,
+  getNebulaAuthTokenWalletAddress,
+} from "../_utils/authToken";
 import { ChatPageContent } from "./components/ChatPageContent";
 import { getChains } from "./utils/getChainIds";
 
@@ -11,17 +14,19 @@ export default async function Page(props: {
 }) {
   const searchParams = await props.searchParams;
 
-  const [chains, authToken] = await Promise.all([
+  const [chains, authToken, accountAddress] = await Promise.all([
     getChains(searchParams.chain),
     getNebulaAuthToken(),
+    getNebulaAuthTokenWalletAddress(),
   ]);
 
-  if (!authToken) {
+  if (!authToken || !accountAddress) {
     loginRedirect();
   }
 
   return (
     <ChatPageContent
+      accountAddress={accountAddress}
       authToken={authToken}
       session={undefined}
       type="landing"


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the retrieval of `accountAddress` alongside `authToken` in multiple components, ensuring that the `ChatPageContent` receives this new prop. It enhances the login validation by checking both tokens before redirecting.

### Detailed summary
- Added `accountAddress` prop to `ChatPageContent` in `ChatPageContent.tsx`.
- Updated `Page` function in `page.tsx` to fetch `accountAddress` using `getNebulaAuthTokenWalletAddress`.
- Modified login validation in `page.tsx` to check both `authToken` and `accountAddress`.
- Updated `page.tsx` in the chat session to retrieve `accountAddress`.
- Adjusted imports in multiple files to include `getNebulaAuthTokenWalletAddress`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->