### PR TITLE
[SDK] Fix: Add custom title & icon to wagmi connectors

### DIFF
--- a/.changeset/fuzzy-paws-fix.md
+++ b/.changeset/fuzzy-paws-fix.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/wagmi-adapter": patch
+---
+
+Respect inAppWallet metadata props

--- a/.changeset/solid-numbers-return.md
+++ b/.changeset/solid-numbers-return.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Add name and icon to inAppWallet metadata props to customize in-app wallets inside the connect modal

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/AllWalletsUI.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/AllWalletsUI.tsx
@@ -130,6 +130,7 @@ function AllWalletsUI(props: {
             >
               {walletInfosToShow.map((walletInfo, i) => {
                 const isLast = i === walletInfosToShow.length - 1;
+                const wallet = createWallet(walletInfo.id);
 
                 return (
                   <li
@@ -140,9 +141,8 @@ function AllWalletsUI(props: {
                     }}
                   >
                     <WalletEntryButton
-                      walletId={walletInfo.id}
+                      wallet={wallet}
                       selectWallet={() => {
-                        const wallet = createWallet(walletInfo.id);
                         props.onSelect(wallet);
                         if (!props.disableSelectionDataReset) {
                           setSelectionData({});

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/WalletEntryButton.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/WalletEntryButton.tsx
@@ -1,8 +1,8 @@
 "use client";
 import type { ThirdwebClient } from "../../../../client/client.js";
+import type { InAppWalletCreationOptions } from "../../../../wallets/in-app/core/wallet/types.js";
 import { getInstalledWalletProviders } from "../../../../wallets/injected/mipdStore.js";
 import type { Wallet } from "../../../../wallets/interfaces/wallet.js";
-import type { WalletId } from "../../../../wallets/wallet-types.js";
 import { useCustomTheme } from "../../../core/design-system/CustomThemeProvider.js";
 import {
   fontSize,
@@ -11,6 +11,7 @@ import {
   spacing,
 } from "../../../core/design-system/index.js";
 import { useWalletInfo } from "../../../core/utils/wallet.js";
+import { Img } from "../components/Img.js";
 import { Skeleton } from "../components/Skeleton.js";
 import { WalletImage } from "../components/WalletImage.js";
 import { Container } from "../components/basic.js";
@@ -22,7 +23,7 @@ import type { ConnectLocale } from "./locale/types.js";
  * @internal
  */
 export function WalletEntryButton(props: {
-  walletId: WalletId;
+  wallet: Wallet;
   selectWallet: () => void;
   connectLocale: ConnectLocale;
   recommendedWallets: Wallet[] | undefined;
@@ -30,7 +31,8 @@ export function WalletEntryButton(props: {
   isActive: boolean;
   badge: string | undefined;
 }) {
-  const { walletId, selectWallet } = props;
+  const { selectWallet, wallet } = props;
+  const walletId = wallet.id;
   const isRecommended = props.recommendedWallets?.find(
     (w) => w.id === walletId,
   );
@@ -45,23 +47,39 @@ export function WalletEntryButton(props: {
     (p) => p.info.rdns === walletId,
   );
 
+  const customMeta =
+    wallet && walletId === "inApp"
+      ? (wallet.getConfig() as InAppWalletCreationOptions)?.metadata
+      : undefined;
+  const nameOverride = customMeta?.name || walletName;
+  const iconOverride = customMeta?.icon;
+
   return (
     <WalletButtonEl
       type="button"
       onClick={selectWallet}
       data-active={props.isActive}
     >
-      <WalletImage id={walletId} size={iconSize.xl} client={props.client} />
+      {iconOverride ? (
+        <Img
+          client={props.client}
+          src={iconOverride}
+          alt={nameOverride}
+          width={`${iconSize.xl}`}
+          height={`${iconSize.xl}`}
+        />
+      ) : (
+        <WalletImage id={walletId} size={iconSize.xl} client={props.client} />
+      )}
 
       <Container flex="column" gap="xxs" expand>
-        {walletName ? (
+        {nameOverride ? (
           <Text color="primaryText" weight={600}>
-            {walletName}
+            {nameOverride}
           </Text>
         ) : (
           <Skeleton width="100px" height={fontSize.md} />
         )}
-
         {props.badge ? (
           <Text size="sm">{props.badge}</Text>
         ) : isRecommended ? (

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/WalletSelector.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/WalletSelector.tsx
@@ -218,9 +218,6 @@ const WalletSelectorInner: React.FC<WalletSelectorProps> = (props) => {
   );
 
   const handleSelect = async (wallet: Wallet) => {
-    // if (connectionStatus !== "disconnected") {
-    //   await disconnect();
-    // }
     props.selectWallet(wallet);
   };
 
@@ -640,7 +637,7 @@ const WalletSelection: React.FC<{
               </Suspense>
             ) : (
               <WalletEntryButton
-                walletId={wallet.id}
+                wallet={wallet}
                 selectWallet={() => {
                   if (!props.diableSelectionDataReset) {
                     setSelectionData({});

--- a/packages/thirdweb/src/react/web/wallets/in-app/InAppWalletSelectionUI.tsx
+++ b/packages/thirdweb/src/react/web/wallets/in-app/InAppWalletSelectionUI.tsx
@@ -41,7 +41,7 @@ function InAppWalletSelectionUI(props: {
   ) {
     return (
       <WalletEntryButton
-        walletId={props.wallet.id}
+        wallet={props.wallet}
         selectWallet={() => {
           setData({});
           props.select();

--- a/packages/thirdweb/src/wallets/in-app/core/wallet/types.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/wallet/types.ts
@@ -70,6 +70,7 @@ export type InAppWalletCreationOptions =
        */
       metadata?: {
         name?: string;
+        icon?: string;
         image?: {
           src: string;
           width?: number;

--- a/packages/thirdweb/src/wallets/in-app/core/wallet/types.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/wallet/types.ts
@@ -69,6 +69,7 @@ export type InAppWalletCreationOptions =
        * Metadata to display in the Connect Modal
        */
       metadata?: {
+        name?: string;
         image?: {
           src: string;
           width?: number;

--- a/packages/wagmi-adapter/src/connector.ts
+++ b/packages/wagmi-adapter/src/connector.ts
@@ -96,7 +96,7 @@ export function inAppWalletConnector(
     id: "in-app-wallet",
     name: args.metadata?.name || "In-App wallet",
     type: "in-app",
-    icon: args.metadata?.image?.src,
+    icon: args.metadata?.icon,
     connect: async (params) => {
       const rawStorage =
         typeof window !== "undefined" && window.localStorage

--- a/packages/wagmi-adapter/src/connector.ts
+++ b/packages/wagmi-adapter/src/connector.ts
@@ -94,8 +94,9 @@ export function inAppWalletConnector(
   const client = args.client;
   return createConnector<Provider, Properties, StorageItem>((config) => ({
     id: "in-app-wallet",
-    name: "In-App wallet",
+    name: args.metadata?.name || "In-App wallet",
     type: "in-app",
+    icon: args.metadata?.image?.src,
     connect: async (params) => {
       const rawStorage =
         typeof window !== "undefined" && window.localStorage


### PR DESCRIPTION
Hi!

I've been trying to use thirdweb's wagmi-adaptor with [ConnectKit](https://github.com/family/connectkit), but I'm having trouble setting an icon or title for my connectors. So they end up looking like this:

![Screenshot 2025-04-25 at 6 43 28 PM](https://github.com/user-attachments/assets/5a14d60e-e54f-4a44-a696-6fbe7e1009e0)

This is my code:

```ts
"use client";
import { createConfig, WagmiProvider, type Transport } from "wagmi";
import { mainnet } from "wagmi/chains";
import { ConnectKitProvider, getDefaultConfig, SIWEProvider } from "connectkit";
import {
  createThirdwebClient,
  defineChain as thirdwebDefineChain,
} from "thirdweb";
import { inAppWalletConnector } from "@thirdweb-dev/wagmi-adapter";
import { getTransportForChain } from "@/lib/utils";

const thirdwebClientId =
  process.env.NEXT_PUBLIC_THIRDWEB_CLIENT_ID

// Create Thirdweb Client
const client = createThirdwebClient({
  clientId: thirdwebClientId,
});

// Define the custom icon source
const unicornIconSrc =
  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAA...";

const unicornConnector = inAppWalletConnector({
  client,
  smartAccount: {
    sponsorGas: true,
    chain: thirdwebDefineChain(mainnet.id),
    factoryAddress: unicornFactoryAddress,
  },
  metadata: {
    image: {
      src: unicornIconSrc,
      alt: "Unicorn.eth",
      height: 100,
      width: 100,
    },
  },
});

const metadata = {
  name: "Agora Next",
  description: "The on-chain governance company",
  url: process.env.NEXT_PUBLIC_AGORA_BASE_URL!,
  icons: ["https://avatars.githubusercontent.com/u/37784886"],
};
const projectId = process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID!;
const { contracts, ui } = Tenant.current();
const shouldHideAgoraBranding = ui.hideAgoraBranding;

const baseConfig = getDefaultConfig({
  walletConnectProjectId: projectId,
  chains: [contracts.token.chain, mainnet],
  transports: {
    [mainnet.id]: getTransportForChain(mainnet.id)!,
    [contracts.token.chain.id]: getTransportForChain(contracts.token.chain.id)!,
  },
  appName: metadata.name,
  appDescription: metadata.description,
  appUrl: metadata.url,
});
export const config = createConfig({
  ...baseConfig,
  connectors: [unicornConnector, ...(baseConfig.connectors ?? [])],
});

```

The problem is, ConnectKit looks for the `icon` and `name` properties in a connector, but these properties are not set in the `inAppWalletConnector` function, so as a result, there's no icon to show, and the wallet's name is always "In-App wallet".

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `inAppWallet` metadata by adding customizable `name` and `icon` properties. This allows for better personalization of in-app wallets within the connect modal.

### Detailed summary
- Added `name` and `icon` properties to `inAppWallet` metadata in `types.ts`.
- Updated `InAppWalletSelectionUI.tsx` to use `wallet` object instead of `walletId`.
- Refactored `connector.ts` to retrieve `name` and `icon` from metadata.
- Modified `WalletEntryButton.tsx` to use `wallet` object and display custom metadata.
- Adjusted `AllWalletsUI.tsx` to create `wallet` from `walletInfo.id`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->