### PR TITLE
Nebula: Save auth token for 14d

### DIFF
--- a/apps/dashboard/src/app/nebula-app/login/auth-actions.ts
+++ b/apps/dashboard/src/app/nebula-app/login/auth-actions.ts
@@ -16,6 +16,8 @@ import {
   NEBULA_COOKIE_PREFIX_TOKEN,
 } from "../_utils/constants";
 
+const FOURTEEN_DAYS_IN_SECONDS = 14 * 24 * 60 * 60;
+
 export async function getNebulaLoginPayload(
   params: GenerateLoginPayloadParams,
 ): Promise<LoginPayload> {
@@ -131,8 +133,7 @@ export async function doNebulaLogin(
       httpOnly: true,
       secure: true,
       sameSite: "strict",
-      // 3 days
-      maxAge: 3 * 24 * 60 * 60,
+      maxAge: FOURTEEN_DAYS_IN_SECONDS,
     },
   );
 
@@ -144,8 +145,7 @@ export async function doNebulaLogin(
       httpOnly: true,
       secure: true,
       sameSite: "strict",
-      // 3 days
-      maxAge: 3 * 24 * 60 * 60,
+      maxAge: FOURTEEN_DAYS_IN_SECONDS,
     },
   );
 
@@ -209,8 +209,7 @@ export async function isNebulaLoggedIn(address: string) {
     httpOnly: false,
     secure: true,
     sameSite: "strict",
-    // 3 days
-    maxAge: 3 * 24 * 60 * 60,
+    maxAge: FOURTEEN_DAYS_IN_SECONDS,
   });
   return true;
 }


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `maxAge` configuration for cookies in the `doNebulaLogin` and `isNebulaLoggedIn` functions to use a constant value representing fourteen days instead of a hardcoded value.

### Detailed summary
- Added a constant `FOURTEEN_DAYS_IN_SECONDS` set to 14 days in seconds.
- Updated `maxAge` in `doNebulaLogin` from 3 days to `FOURTEEN_DAYS_IN_SECONDS`.
- Updated `maxAge` in `isNebulaLoggedIn` from 3 days to `FOURTEEN_DAYS_IN_SECONDS`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->