### PR TITLE
Fix module deployment

### DIFF
--- a/.changeset/fruity-suits-relax.md
+++ b/.changeset/fruity-suits-relax.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix module deployment with refs and zk

--- a/apps/dashboard/src/components/contract-components/fetchPublishedContractsFromDeploy.ts
+++ b/apps/dashboard/src/components/contract-components/fetchPublishedContractsFromDeploy.ts
@@ -1,10 +1,21 @@
+import { THIRDWEB_DEPLOYER_ADDRESS } from "constants/addresses";
 import type { ThirdwebClient, ThirdwebContract } from "thirdweb";
+import { fetchPublishedContract } from "thirdweb/contract";
 import {
   getContractPublisher,
   getPublishedUriFromCompilerUri,
 } from "thirdweb/extensions/thirdweb";
-import { extractIPFSUri, resolveImplementation } from "thirdweb/utils";
+import { download } from "thirdweb/storage";
+import {
+  extractIPFSUri,
+  isZkSyncChain,
+  resolveImplementation,
+} from "thirdweb/utils";
 import { fetchDeployMetadata } from "./fetchDeployMetadata";
+
+type ZkSolcMetadata = {
+  source_metadata: { settings: { compilationTarget: Record<string, string> } };
+};
 
 export async function fetchPublishedContractsFromDeploy(options: {
   contract: ThirdwebContract;
@@ -17,10 +28,36 @@ export async function fetchPublishedContractsFromDeploy(options: {
     throw new Error("No IPFS URI found in bytecode");
   }
 
-  const publishURIs = await getPublishedUriFromCompilerUri({
+  let publishURIs = await getPublishedUriFromCompilerUri({
     contract: getContractPublisher(client),
     compilerMetadataUri: contractUri,
   });
+
+  // Try fetching using contract name from compiler metadata for zksolc variants
+  // TODO: ContractPublisher should handle multiple metadata uri for a published version
+  if (publishURIs.length === 0 && (await isZkSyncChain(contract.chain))) {
+    try {
+      const res = await download({
+        uri: contractUri,
+        client,
+      });
+
+      const deployMetadata = (await res.json()) as ZkSolcMetadata;
+
+      const contractId = Object.values(
+        deployMetadata.source_metadata.settings.compilationTarget,
+      );
+
+      if (contractId[0]) {
+        const published = await fetchPublishedContract({
+          client,
+          contractId: contractId[0],
+          publisherAddress: THIRDWEB_DEPLOYER_ADDRESS,
+        });
+        publishURIs = [published.publishMetadataUri];
+      }
+    } catch {}
+  }
 
   return await Promise.all(
     publishURIs.map((uri) => fetchDeployMetadata(uri, client)),

--- a/packages/thirdweb/src/contract/deployment/utils/bootstrap.ts
+++ b/packages/thirdweb/src/contract/deployment/utils/bootstrap.ts
@@ -236,7 +236,7 @@ export async function getOrDeployInfraContract(
   });
 }
 
-export async function getOrDeployInfraContractFromMetadata(
+async function getOrDeployInfraContractFromMetadata(
   options: ClientAndChainAndAccount & {
     contractMetadata: FetchDeployMetadataResult;
     constructorParams?: Record<string, unknown>;


### PR DESCRIPTION
- Handle refs and metadata format (solc vs zksolc) for modules

<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing module deployment issues related to references and zero-knowledge (zk) technology in the `thirdweb` package.

### Detailed summary
- Updated the function `getOrDeployInfraContractFromMetadata` to improve deployment logic.
- Changed the way contracts are deployed, using `deployContractfromDeployMetadata`.
- Enhanced `fetchPublishedContractsFromDeploy` to handle zkSync chain variants and fetch metadata correctly.
- Added error handling for fetching contract URIs.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->