### PR TITLE
[SDK] Handle fixed size arrays in solidity inputs

### DIFF
--- a/.changeset/grumpy-carpets-sniff.md
+++ b/.changeset/grumpy-carpets-sniff.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Handle fixed size arrays in solidity inputs

--- a/apps/dashboard/src/contract-ui/components/solidity-inputs/helpers.ts
+++ b/apps/dashboard/src/contract-ui/components/solidity-inputs/helpers.ts
@@ -159,7 +159,10 @@ export const validateAddress = (value: string) => {
 
 // all
 export const validateSolidityInput = (value: string, solidityType: string) => {
-  if (solidityType.startsWith("int") || solidityType.startsWith("uint")) {
+  if (
+    (solidityType.startsWith("int") || solidityType.startsWith("uint")) &&
+    !solidityType.endsWith("]")
+  ) {
     return validateInt(value, solidityType);
   }
   // TODO: bytes array not working right now

--- a/apps/dashboard/src/contract-ui/components/solidity-inputs/index.tsx
+++ b/apps/dashboard/src/contract-ui/components/solidity-inputs/index.tsx
@@ -60,7 +60,7 @@ export const SolidityInput = forwardRef<
     );
   }
 
-  if (solidityType?.endsWith("[]")) {
+  if (solidityType?.endsWith("]")) {
     return (
       <SolidityRawInput
         formContext={form}

--- a/packages/thirdweb/src/utils/contract/parse-abi-params.ts
+++ b/packages/thirdweb/src/utils/contract/parse-abi-params.ts
@@ -51,7 +51,7 @@ export function parseAbiParams(
   }
   return constructorParamTypes.map((type, index) => {
     const value = constructorParamValues[index];
-    if (type === "tuple" || type.endsWith("[]")) {
+    if (type === "tuple" || type.endsWith("]")) {
       if (typeof value === "string") {
         return JSON.parse(value);
       }


### PR DESCRIPTION
Fixes TOOL-4270

<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the handling of fixed-size arrays in Solidity inputs within the application, ensuring correct validation and parsing of Solidity types.

### Detailed summary
- Updated the condition for checking array types in `solidity-inputs/index.tsx` to end with `]`.
- Modified the type check for parameters in `parse-abi-params.ts` to also end with `]`.
- Adjusted validation logic in `helpers.ts` to ensure it only validates integers and unsigned integers if they do not end with `]`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->