### PR TITLE
[SDK] Show injected wallet icon when available

### DIFF
--- a/.changeset/tangy-bugs-feel.md
+++ b/.changeset/tangy-bugs-feel.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Show injected wallet icon when available

--- a/packages/thirdweb/src/react/core/utils/wallet.ts
+++ b/packages/thirdweb/src/react/core/utils/wallet.ts
@@ -194,9 +194,18 @@ export function useWalletInfo(id: WalletId | undefined) {
 export function useWalletImage(id: WalletId | undefined) {
   return useQuery({
     queryKey: ["wallet-image", id],
-    queryFn: () => {
+    queryFn: async () => {
       if (!id) {
         throw new Error("Wallet id is required");
+      }
+      const { getInstalledWalletProviders } = await import(
+        "../../../wallets/injected/mipdStore.js"
+      );
+      const mipdImage = getInstalledWalletProviders().find(
+        (x) => x.info.rdns === id,
+      )?.info.icon;
+      if (mipdImage) {
+        return mipdImage;
       }
       return getWalletInfo(id, true);
     },

--- a/packages/thirdweb/src/react/core/utils/walletIcon.ts
+++ b/packages/thirdweb/src/react/core/utils/walletIcon.ts
@@ -129,8 +129,15 @@ export function useWalletIcon(props: {
 /**
  * @internal Exported for tests only
  */
-export async function fetchWalletImage(props: {
-  id: WalletId;
-}) {
+export async function fetchWalletImage(props: { id: WalletId }) {
+  const { getInstalledWalletProviders } = await import(
+    "../../../wallets/injected/mipdStore.js"
+  );
+  const mipdImage = getInstalledWalletProviders().find(
+    (x) => x.info.rdns === props.id,
+  )?.info.icon;
+  if (mipdImage) {
+    return mipdImage;
+  }
   return getWalletInfo(props.id, true);
 }


### PR DESCRIPTION
Fixes TOOL-4213

<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces improvements to wallet image fetching by showing the injected wallet icon when available. It modifies the `queryFn` in the `useQuery` hook and updates the `fetchWalletImage` function to include dynamic imports for wallet providers.

### Detailed summary
- Updated `queryFn` in `useQuery` to be asynchronous and handle wallet ID validation.
- Imported `getInstalledWalletProviders` from `../../../wallets/injected/mipdStore.js`.
- Enhanced logic to retrieve the injected wallet icon based on the wallet ID.
- Updated `fetchWalletImage` to include similar changes for fetching wallet images.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->