### PR TITLE
remove otp from insight docs

### DIFF
--- a/apps/portal/src/app/insight/webhooks/managing-webhooks/page.mdx
+++ b/apps/portal/src/app/insight/webhooks/managing-webhooks/page.mdx
@@ -24,42 +24,17 @@ Retrieve all webhooks for your project or get details for a specific webhook by 
 Creates a new webhook subscription.  
 It may take up to a minute to start working.
 
-### Verifying the created webhook
-- The webhook starts in a suspended state
-- An OTP (One-Time Password) is sent to your webhook URL for verification
-- You must verify the webhook within 15 minutes using the OTP
-- Once verified, it may take up to a minute for the webhook to become fully active
-- You can request a new OTP if you can't retrieve the initial OTP
-
 ## Update Webhook
 `PATCH /v1/webhooks/:webhook_id`
 
 You can modify the URL or filters of a webhook. Additionally you can enable and disable the webhook.  
 Changes may take up to a minute to take effect.
 
-### Updating webhook URL
-- If you update the webhook URL, you'll need to verify it again with a new OTP
-- Other fields can be updated without requiring re-verification
 
 ## Delete Webhook
 `DELETE /v1/webhooks/:webhook_id`
 
 Permanently removes a webhook subscription. This action cannot be undone.
-
-## Verify Webhook
-`POST /v1/webhooks/:webhook_id/verify`
-
-Activates a webhook using the OTP code that was sent to your webhook URL. Required for:
-- New webhook creation
-- After updating a webhook URL
-
-## Resend OTP
-`POST /v1/webhooks/:webhook_id/resend-otp`
-
-Request a new OTP code if the original expires or is lost:
-- Invalidates the previous OTP
-- New OTP expires after 15 minutes
-- Only works for webhooks pending verification
 
 ## Test Webhook
 `POST /v1/webhooks/test`


### PR DESCRIPTION
## [Portal] Fix: Remove webhook verification details from documentation

## Notes for the reviewer

This PR simplifies the webhooks documentation by removing detailed information about the webhook verification process, including OTP verification steps, URL updating requirements, and the API endpoints for verification and OTP resending.

## How to test

Review the updated documentation page to ensure it still provides clear information about the core webhook management functionality without the removed verification details.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the documentation for managing webhooks, specifically clarifying the verification process, updating webhook URLs, and the OTP (One-Time Password) functionality.

### Detailed summary
- Removed details about verifying the created webhook, including OTP verification and timing.
- Clarified that updating the webhook URL requires re-verification with a new OTP.
- Added a section for verifying webhooks and resending OTPs, with specific requirements and expiry information.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->