### PR TITLE
SDK: do not attempt autoconnect again if already successfull 

### DIFF
--- a/.changeset/odd-rooms-sleep.md
+++ b/.changeset/odd-rooms-sleep.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Only attempt autoconnect once

--- a/packages/thirdweb/src/wallets/connection/autoConnect.ts
+++ b/packages/thirdweb/src/wallets/connection/autoConnect.ts
@@ -32,6 +32,12 @@ import type { AutoConnectProps } from "./types.js";
 export async function autoConnect(
   props: AutoConnectProps & {
     wallets?: Wallet[];
+    /**
+     * If true, the auto connect will be forced even if autoConnect has already been attempted successfully earlier.
+     *
+     * @default `false`
+     */
+    force?: boolean;
   },
 ): Promise<boolean> {
   const wallets = props.wallets || getDefaultWallets(props);

--- a/packages/thirdweb/src/wallets/connection/autoConnectCore.test.ts
+++ b/packages/thirdweb/src/wallets/connection/autoConnectCore.test.ts
@@ -35,6 +35,7 @@ describe("useAutoConnectCore", () => {
 
     expect(
       await autoConnectCore({
+        force: true,
         storage: mockStorage,
         props: {
           wallets: [wallet],
@@ -68,6 +69,7 @@ describe("useAutoConnectCore", () => {
 
     expect(
       await autoConnectCore({
+        force: true,
         storage: mockStorage,
         props: {
           wallets: [wallet],
@@ -111,6 +113,7 @@ describe("useAutoConnectCore", () => {
       });
 
     await autoConnectCore({
+      force: true,
       storage: mockStorage,
       props: {
         wallets: [wallet],
@@ -155,6 +158,7 @@ describe("useAutoConnectCore", () => {
     });
 
     await autoConnectCore({
+      force: true,
       storage: mockStorage,
       props: {
         wallets: [wallet],
@@ -191,6 +195,7 @@ describe("useAutoConnectCore", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     await autoConnectCore({
+      force: true,
       storage: mockStorage,
       props: {
         wallets: [wallet1],
@@ -235,6 +240,7 @@ describe("useAutoConnectCore", () => {
     const addConnectedWalletSpy = vi.spyOn(manager, "addConnectedWallet");
 
     await autoConnectCore({
+      force: true,
       storage: mockStorage,
       props: {
         wallets: [wallet1, wallet2],
@@ -264,6 +270,7 @@ describe("useAutoConnectCore", () => {
       JSON.stringify([wallet.id]),
     );
     await autoConnectCore({
+      force: true,
       storage: mockStorage,
       props: {
         wallets: [wallet],
@@ -276,6 +283,7 @@ describe("useAutoConnectCore", () => {
 
     expect(mockOnConnect).toHaveBeenCalledWith(wallet);
   });
+
   it("should continue even if onConnect callback throws", async () => {
     const mockOnConnect = vi.fn();
     mockOnConnect.mockImplementation(() => {
@@ -296,6 +304,7 @@ describe("useAutoConnectCore", () => {
       JSON.stringify([wallet.id]),
     );
     await autoConnectCore({
+      force: true,
       storage: mockStorage,
       props: {
         wallets: [wallet],
@@ -308,6 +317,7 @@ describe("useAutoConnectCore", () => {
 
     expect(mockOnConnect).toHaveBeenCalledWith(wallet);
   });
+
   it("should call setLastAuthProvider if authProvider is present", async () => {
     const wallet = createWalletAdapter({
       adaptedAccount: TEST_ACCOUNT_A,
@@ -328,6 +338,7 @@ describe("useAutoConnectCore", () => {
       JSON.stringify([wallet.id]),
     );
     await autoConnectCore({
+      force: true,
       storage: mockStorage,
       props: {
         wallets: [wallet],
@@ -340,6 +351,7 @@ describe("useAutoConnectCore", () => {
 
     expect(mockSetLastAuthProvider).toHaveBeenCalledWith("email", mockStorage);
   });
+
   it("should set connection status to disconnect if no connectedWallet is returned", async () => {
     const wallet = createWalletAdapter({
       adaptedAccount: TEST_ACCOUNT_A,
@@ -360,6 +372,7 @@ describe("useAutoConnectCore", () => {
       .mockResolvedValueOnce(null as unknown as Wallet);
 
     await autoConnectCore({
+      force: true,
       storage: mockStorage,
       props: {
         wallets: [wallet],


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a `force` option for the auto-connect functionality in the `thirdweb` wallet connection logic, allowing users to bypass previous connection attempts and enforce a new connection.

### Detailed summary
- Added `force` property to `AutoConnectProps` for auto-connect functionality.
- Updated `autoConnectCore` to handle the `force` option, allowing repeated connection attempts.
- Modified tests to include the `force` parameter in various scenarios.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->