### PR TITLE
Nebula: Update Reasoning UI: show only latest presence in pending state

### DIFF
--- a/apps/dashboard/src/app/nebula-app/(app)/components/Reasoning/Reasoning.tsx
+++ b/apps/dashboard/src/app/nebula-app/(app)/components/Reasoning/Reasoning.tsx
@@ -11,6 +11,8 @@ export function Reasoning(props: {
 }) {
   const [_isOpen, setIsOpen] = useState(false);
   const isOpen = props.isPending ? true : _isOpen;
+  const showAll = !props.isPending;
+  const lastText = props.texts[props.texts.length - 1];
 
   return (
     <DynamicHeight>
@@ -23,7 +25,7 @@ export function Reasoning(props: {
         {props.isPending ? (
           <TextShimmer text="Reasoning..." />
         ) : (
-          <span>Reasoning</span>
+          <span className="text-foreground">Reasoning</span>
         )}
 
         {!props.isPending && (
@@ -36,17 +38,27 @@ export function Reasoning(props: {
         )}
       </Button>
 
-      {isOpen && props.texts.length > 0 && (
-        <ul className="list-none space-y-1.5">
-          {props.texts.map((text) => (
-            <li
-              key={text}
-              className="fade-in-0 animate-in text-muted-foreground text-sm leading-relaxed duration-300"
-            >
-              {text.trim()}
-            </li>
-          ))}
-        </ul>
+      {isOpen && (
+        <>
+          {showAll && props.texts.length > 0 && (
+            <ul className="list-none space-y-1.5">
+              {props.texts.map((text) => (
+                <li
+                  key={text}
+                  className="fade-in-0 animate-in text-muted-foreground text-sm leading-relaxed duration-300"
+                >
+                  {text.trim()}
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {!showAll && lastText && (
+            <div className="text-muted-foreground text-sm leading-relaxed">
+              {lastText.trim()}
+            </div>
+          )}
+        </>
       )}
     </DynamicHeight>
   );


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `Reasoning` component by modifying how text is displayed based on the `isPending` prop. It introduces a new variable to determine if all texts should be shown and updates the rendering logic accordingly.

### Detailed summary
- Added `showAll` variable to determine text visibility.
- Introduced `lastText` to capture the last element in `props.texts`.
- Updated the rendering logic to conditionally display either all texts or just the last text based on `showAll`.
- Changed the class name of the `<span>` from default to `text-foreground`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->