### PR TITLE
[Dashboard] Add teamId to fee management API calls

### DIFF
--- a/apps/dashboard/src/@/api/universal-bridge/developer.ts
+++ b/apps/dashboard/src/@/api/universal-bridge/developer.ts
@@ -100,12 +100,14 @@ export type Fee = {
 
 export async function getFees(props: {
   clientId: string;
+  teamId: string;
 }) {
   const authToken = await getAuthToken();
   const res = await fetch(`${UB_BASE_URL}/v1/developer/fees`, {
     method: "GET",
     headers: {
       "Content-Type": "application/json",
+      "x-team-id": props.teamId,
       "x-client-id-override": props.clientId,
       Authorization: `Bearer ${authToken}`,
     },
@@ -122,6 +124,7 @@ export async function getFees(props: {
 
 export async function updateFee(props: {
   clientId: string;
+  teamId: string;
   feeRecipient: string;
   feeBps: number;
 }) {
@@ -131,6 +134,7 @@ export async function updateFee(props: {
     headers: {
       "Content-Type": "application/json",
       "x-client-id-override": props.clientId,
+      "x-team-id": props.teamId,
       Authorization: `Bearer ${authToken}`,
     },
     body: JSON.stringify({

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/connect/universal-bridge/settings/page.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/connect/universal-bridge/settings/page.tsx
@@ -27,6 +27,7 @@ export default async function Page(props: {
 
   let fees = await getFees({
     clientId: project.publishableKey,
+    teamId: team.id,
   }).catch(() => {
     return {
       feeRecipient: "",

--- a/apps/dashboard/src/components/pay/PayConfig.tsx
+++ b/apps/dashboard/src/components/pay/PayConfig.tsx
@@ -49,6 +49,7 @@ export const PayConfig: React.FC<PayConfigProps> = (props) => {
     }) => {
       await updateFee({
         clientId: props.project.publishableKey,
+        teamId: props.teamId,
         feeRecipient: values.payoutAddress,
         feeBps: values.developerFeeBPS,
       });


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the fee management system by adding a `teamId` parameter to the `updateFee` and `getFees` functions, allowing for better team-specific fee handling.

### Detailed summary
- Added `teamId` parameter to `updateFee` function in `PayConfig.tsx`.
- Added `teamId` parameter to `getFees` function in `developer.ts`.
- Included `teamId` in the request headers for both `getFees` and `updateFee` functions.
- Updated the call to `getFees` in `page.tsx` to include `teamId`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->