### PR TITLE
[NEB-229] Nebula: follow-up prompt improvements, preserve reasoning UI on error

### DIFF
--- a/apps/dashboard/src/app/nebula-app/(app)/components/ChatPageContent.tsx
+++ b/apps/dashboard/src/app/nebula-app/(app)/components/ChatPageContent.tsx
@@ -375,10 +375,6 @@ export function ChatPageContent(props: {
                     chatAbortController?.abort();
                     setChatAbortController(undefined);
                     setIsChatStreaming(false);
-                    // if last message is presence, remove it
-                    if (messages[messages.length - 1]?.type === "presence") {
-                      setMessages((prev) => prev.slice(0, -1));
-                    }
                   }}
                   context={contextFilters}
                   setContext={(v) => {

--- a/apps/dashboard/src/app/nebula-app/(app)/components/Chats.tsx
+++ b/apps/dashboard/src/app/nebula-app/(app)/components/Chats.tsx
@@ -173,6 +173,7 @@ export function Chats(props: {
                             isMessagePending={isMessagePending}
                             client={props.client}
                             sendMessage={props.sendMessage}
+                            nextMessage={props.messages[index + 1]}
                           />
                         </ScrollShadow>
 
@@ -207,8 +208,9 @@ function RenderMessage(props: {
   isMessagePending: boolean;
   client: ThirdwebClient;
   sendMessage: (message: string) => void;
+  nextMessage: ChatMessage | undefined;
 }) {
-  const { message, isMessagePending, client, sendMessage } = props;
+  const { message, isMessagePending, client, sendMessage, nextMessage } = props;
 
   switch (message.type) {
     case "assistant":
@@ -237,6 +239,11 @@ function RenderMessage(props: {
             txData={message.data}
             client={client}
             onTxSettled={(txHash) => {
+              // do not send automatic prompt if there is another transaction after this one
+              if (nextMessage?.type === "action") {
+                return;
+              }
+
               sendMessage(getTransactionSettledPrompt(txHash));
             }}
           />
@@ -254,8 +261,13 @@ function RenderMessage(props: {
           <SwapTransactionCard
             swapData={message.data}
             client={client}
-            onTxSettled={() => {
-              // no op
+            onTxSettled={(txHash) => {
+              // do not send automatic prompt if there is another transaction after this one
+              if (nextMessage?.type === "action") {
+                return;
+              }
+
+              sendMessage(getTransactionSettledPrompt(txHash));
             }}
           />
         );


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on enhancing the `ChatPageContent` and `RenderMessage` components by modifying how messages are processed and sent, particularly in relation to the presence of subsequent messages.

### Detailed summary
- Removed logic that removed the last message if it was of type `presence` in `ChatPageContent`.
- Added `nextMessage` prop to `RenderMessage` to reference the following message.
- Updated `onTxSettled` to prevent sending automatic prompts if the next message is of type `action`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->