### PR TITLE
[TOOL-4354] Nebula: Configure erc20Value for swap prepared transaction

### DIFF
--- a/apps/dashboard/src/app/nebula-app/(app)/components/Swap/SwapCards.tsx
+++ b/apps/dashboard/src/app/nebula-app/(app)/components/Swap/SwapCards.tsx
@@ -2,8 +2,10 @@ import { TransactionButton } from "components/buttons/TransactionButton";
 import { useV5DashboardChain } from "lib/v5-adapter";
 import { ArrowRightLeftIcon, CheckIcon } from "lucide-react";
 import {
+  NATIVE_TOKEN_ADDRESS,
   type PreparedTransaction,
   type ThirdwebClient,
+  getAddress,
   prepareTransaction,
   toTokens,
 } from "thirdweb";
@@ -38,6 +40,9 @@ export function SwapTransactionCardLayout(props: {
 }) {
   const { swapData } = props;
   const txChain = useV5DashboardChain(swapData.transaction.chainId);
+
+  const isSellingNativeToken =
+    getAddress(swapData.from.address) === getAddress(NATIVE_TOKEN_ADDRESS);
 
   return (
     <div className="max-w-lg">
@@ -102,6 +107,12 @@ export function SwapTransactionCardLayout(props: {
                   client: props.client,
                   data: swapData.transaction.data,
                   to: swapData.transaction.to,
+                  erc20Value: isSellingNativeToken
+                    ? undefined
+                    : {
+                        amountWei: BigInt(swapData.from.amount),
+                        tokenAddress: swapData.from.address,
+                      },
                 });
 
                 props.sendTx(tx);


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces logic to handle transactions involving the native token in the `SwapTransactionCardLayout` component. It determines if the user is selling the native token and adjusts the transaction data accordingly.

### Detailed summary
- Added `NATIVE_TOKEN_ADDRESS` and `getAddress` imports from `thirdweb`.
- Defined `isSellingNativeToken` to check if the transaction involves the native token.
- Updated the `tx` object to conditionally set `erc20Value` based on whether the user is selling the native token.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->