### PR TITLE
Dashboard: Fix Nebula floating chat authToken query cache key

### DIFF
--- a/apps/dashboard/src/app/(app)/(dashboard)/(chain)/[chain_id]/(chainPage)/layout.tsx
+++ b/apps/dashboard/src/app/(app)/(dashboard)/(chain)/[chain_id]/(chainPage)/layout.tsx
@@ -100,6 +100,7 @@ The following is the user's message:
   return (
     <>
       <NebulaChatButton
+        isLoggedIn={!!authToken}
         networks={chain.testnet ? "testnet" : "mainnet"}
         isFloating={true}
         pageType="chain"

--- a/apps/dashboard/src/app/(app)/(dashboard)/(chain)/[chain_id]/[contractAddress]/layout.tsx
+++ b/apps/dashboard/src/app/(app)/(dashboard)/(chain)/[chain_id]/[contractAddress]/layout.tsx
@@ -111,6 +111,7 @@ The following is the user's message:`;
       client={client}
     >
       <NebulaChatButton
+        isLoggedIn={!!accountAddress}
         networks={info.chainMetadata.testnet ? "testnet" : "mainnet"}
         isFloating={true}
         pageType="contract"

--- a/apps/dashboard/src/app/(app)/(dashboard)/support/page.tsx
+++ b/apps/dashboard/src/app/(app)/(dashboard)/support/page.tsx
@@ -158,6 +158,7 @@ export default async function SupportPage() {
             </p>
             <div className="mt-6 flex w-full flex-col items-center gap-3">
               <NebulaChatButton
+                isLoggedIn={!!accountAddress}
                 networks="all"
                 isFloating={false}
                 pageType="support"

--- a/apps/dashboard/src/app/nebula-app/(app)/components/FloatingChat/FloatingChat.tsx
+++ b/apps/dashboard/src/app/nebula-app/(app)/components/FloatingChat/FloatingChat.tsx
@@ -28,6 +28,7 @@ export function NebulaChatButton(props: {
   pageType: "chain" | "contract" | "support";
   examplePrompts: ExamplePrompt[];
   networks: NebulaContext["networks"];
+  isLoggedIn: boolean;
   label: string;
   client: ThirdwebClient;
   isFloating: boolean;
@@ -94,6 +95,7 @@ export function NebulaChatButton(props: {
       </div>
 
       <NebulaChatUIContainer
+        isLoggedIn={props.isLoggedIn}
         networks={props.networks}
         onClose={closeModal}
         isOpen={isOpen}
@@ -114,6 +116,7 @@ function NebulaChatUIContainer(props: {
   examplePrompts: ExamplePrompt[];
   pageType: "chain" | "contract" | "support";
   client: ThirdwebClient;
+  isLoggedIn: boolean;
   networks: NebulaContext["networks"];
   nebulaParams:
     | {
@@ -183,6 +186,7 @@ function NebulaChatUIContainer(props: {
       <div className="relative flex grow flex-col overflow-hidden">
         {shouldRenderChat && (
           <ChatContent
+            isLoggedIn={props.isLoggedIn}
             sessionKey={nebulaSessionKey}
             networks={props.networks}
             client={props.client}
@@ -202,12 +206,13 @@ function ChatContent(
     "authToken"
   > & {
     sessionKey: number;
+    isLoggedIn: boolean;
   },
 ) {
-  const { sessionKey, ...restProps } = props;
-  const nebulaAuthTokenQuery = useNebulaAuthToken();
+  const { sessionKey, isLoggedIn, ...restProps } = props;
+  const nebulaAuthTokenQuery = useNebulaAuthToken(isLoggedIn);
 
-  if (nebulaAuthTokenQuery.isPending) {
+  if (nebulaAuthTokenQuery.isFetching) {
     return <LoadingScreen />;
   }
 
@@ -259,16 +264,16 @@ function useOutsideClick(onOutsideClick: () => void) {
   return ref;
 }
 
-function useNebulaAuthToken() {
+function useNebulaAuthToken(isLoggedInToDashboard: boolean) {
   return useQuery({
-    queryKey: ["nebula-auth-token"],
+    queryKey: ["nebula-auth-token", isLoggedInToDashboard],
     queryFn: async () => {
       const jwt = await getNebulaAuthToken();
       return jwt || null;
     },
     retry: false,
     refetchOnWindowFocus: false,
-    refetchOnMount: false,
+    refetchOnMount: "always",
     refetchOnReconnect: false,
   });
 }


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `NebulaChatButton` component by adding an `isLoggedIn` prop across various pages and updates the `useNebulaAuthToken` hook to accept a parameter indicating the login status. This improves the chat functionality based on user authentication.

### Detailed summary
- Added `isLoggedIn` prop to `NebulaChatButton` in:
  - `layout.tsx` for chain page
  - `page.tsx` for support page
  - `layout.tsx` for contract page
- Updated `NebulaChatButton` props in `FloatingChat.tsx` to include `isLoggedIn`.
- Modified `useNebulaAuthToken` to accept `isLoggedInToDashboard` parameter.
- Changed query key in `useNebulaAuthToken` to include login status.
- Updated conditional check for loading state from `isPending` to `isFetching`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->