### PR TITLE
[TOOL-4374] Dashboard: Update Team name and slug validation

### DIFF
--- a/apps/dashboard/src/app/(app)/login/onboarding/team-onboarding/TeamInfoForm.tsx
+++ b/apps/dashboard/src/app/(app)/login/onboarding/team-onboarding/TeamInfoForm.tsx
@@ -20,7 +20,12 @@ import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { useDebounce } from "use-debounce";
 import { z } from "zod";
-import { teamSlugRegex } from "../../../team/[team_slug]/(team)/~/settings/general/common";
+import {
+  maxTeamNameLength,
+  maxTeamSlugLength,
+  teamNameSchema,
+  teamSlugSchema,
+} from "../../../team/[team_slug]/(team)/~/settings/general/common";
 
 type TeamData = {
   name?: string;
@@ -28,27 +33,8 @@ type TeamData = {
   image?: File;
 };
 
-const teamSlugSchema = z
-  .string()
-  .min(3, {
-    message: "URL must be at least 3 characters",
-  })
-  .max(48, {
-    message: "URL must be at most 48 characters",
-  })
-  .refine((slug) => !teamSlugRegex.test(slug), {
-    message: "URL can only contain lowercase letters, numbers and hyphens",
-  });
-
 const formSchema = z.object({
-  name: z
-    .string()
-    .min(3, {
-      message: "Name must be at least 3 characters",
-    })
-    .max(32, {
-      message: "Name must be at most 32 characters",
-    }),
+  name: teamNameSchema,
   slug: teamSlugSchema,
   image: z.instanceof(File).optional(),
 });
@@ -155,8 +141,6 @@ export function TeamInfoFormUI(props: {
     });
   }
 
-  const maxTeamNameLength = 32;
-
   return (
     <div className="rounded-lg border bg-card ">
       <Form {...form}>
@@ -234,6 +218,7 @@ export function TeamInfoFormUI(props: {
                         }}
                         className="truncate border-0 font-mono"
                         placeholder="my-team"
+                        maxLength={maxTeamSlugLength}
                       />
                       {(isCheckingSlug || isCalculatingSlug) && (
                         <div className="-translate-y-1/2 fade-in-0 absolute top-1/2 right-3 duration-300">

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/settings/general/common.ts
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/settings/general/common.ts
@@ -1,1 +1,40 @@
-export const teamSlugRegex = /[^a-zA-Z0-9-]/;
+import { z } from "zod";
+
+const teamSlugRegex = /^[a-z0-9]+(?:[-][a-z0-9]+)*$/;
+const teamNameRegex = /^[A-Za-z0-9]+(?:[ -][A-Za-z0-9]+)*$/;
+
+export const maxTeamSlugLength = 48;
+const minTeamSlugLength = 3;
+
+export const teamSlugSchema = z
+  .string()
+  .min(minTeamSlugLength, {
+    message: `Team slug must be at least ${minTeamSlugLength} characters`,
+  })
+  .max(maxTeamSlugLength, {
+    message: `Team slug must be at most ${maxTeamSlugLength} characters`,
+  })
+  .refine((slug) => !slug.includes(" "), {
+    message: "Team URL cannot contain spaces",
+  })
+  .refine((slug) => teamSlugRegex.test(slug), {
+    message: "Team URL can only contain lowercase letters, numbers and hyphens",
+  });
+
+export const maxTeamNameLength = 32;
+const minTeamNameLength = 3;
+
+export const teamNameSchema = z
+  .string()
+  .min(minTeamNameLength, {
+    message: `Team name must be at least ${minTeamNameLength} characters`,
+  })
+  .max(maxTeamNameLength, {
+    message: `Team name must be at most ${maxTeamNameLength} characters`,
+  })
+  .refine((name) => name.trim() === name, {
+    message: "Team name cannot contain leading or trailing spaces",
+  })
+  .refine((name) => teamNameRegex.test(name), {
+    message: "Team name can only contain letters, numbers, spaces and hyphens",
+  });


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces validation schemas for team slugs and names using `zod`. It refactors the `TeamInfoForm` and `TeamGeneralSettingsPageUI` components to utilize these schemas, enhancing form validation and improving user feedback.

### Detailed summary
- Added `teamSlugSchema` and `teamNameSchema` in `common.ts` for validation.
- Refactored `TeamInfoForm` to use `teamNameSchema` and `teamSlugSchema`.
- Updated `TeamGeneralSettingsPageUI` to incorporate new validation schemas.
- Removed redundant validation logic from `TeamInfoForm`.
- Improved error handling and user feedback in form submissions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->