### PR TITLE
[TOOL-4366] Redirect /team to last visited team

### DIFF
--- a/apps/dashboard/src/@/api/team.ts
+++ b/apps/dashboard/src/@/api/team.ts
@@ -1,7 +1,9 @@
 import "server-only";
 import { API_SERVER_URL, THIRDWEB_API_SECRET } from "@/constants/env";
 import type { TeamResponse } from "@thirdweb-dev/service-utils";
+import { cookies } from "next/headers";
 import { getAuthToken } from "../../app/(app)/api/lib/getAuthToken";
+import { LAST_USED_TEAM_ID } from "../../constants/cookies";
 
 export type Team = TeamResponse & { stripeCustomerId: string | null };
 
@@ -73,4 +75,23 @@ export async function getDefaultTeam() {
     return (await res.json())?.result as Team;
   }
   return null;
+}
+
+export async function getLastVisitedTeamOrDefaultTeam() {
+  const token = await getAuthToken();
+  if (!token) {
+    return null;
+  }
+
+  const cookiesStore = await cookies();
+  const lastVisitedTeamId = cookiesStore.get(LAST_USED_TEAM_ID)?.value;
+
+  if (lastVisitedTeamId) {
+    const team = await getTeamById(lastVisitedTeamId);
+    if (team) {
+      return team;
+    }
+  }
+
+  return getDefaultTeam();
 }

--- a/apps/dashboard/src/app/(app)/team/page.tsx
+++ b/apps/dashboard/src/app/(app)/team/page.tsx
@@ -1,10 +1,10 @@
-import { getDefaultTeam } from "@/api/team";
+import { getLastVisitedTeamOrDefaultTeam } from "@/api/team";
 import { notFound, redirect } from "next/navigation";
 
 export default async function TeamRootPage() {
-  const firstTeam = await getDefaultTeam();
-  if (!firstTeam) {
+  const team = await getLastVisitedTeamOrDefaultTeam();
+  if (!team) {
     notFound();
   }
-  redirect(`/team/${firstTeam.slug}`);
+  redirect(`/team/${team.slug}`);
 }


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `TeamRootPage` to retrieve the last visited team or a default team instead of just the default team. It introduces a new function to handle this logic, enhancing user experience by remembering the last visited team.

### Detailed summary
- Replaced `getDefaultTeam` with `getLastVisitedTeamOrDefaultTeam` in `TeamRootPage`.
- Updated the condition to check for the existence of `team` instead of `firstTeam`.
- Changed the redirect URL to use `team.slug` instead of `firstTeam.slug`.
- Added `getLastVisitedTeamOrDefaultTeam` function in `team.ts` to manage team retrieval logic.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->