### PR TITLE
[TOOL-4373] Dashboard: replace /team/~/~ with /team/<team-slug>/~ wherever possible

### DIFF
--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/connect/account-abstraction/AccountAbstractionPage.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/connect/account-abstraction/AccountAbstractionPage.tsx
@@ -47,7 +47,9 @@ export function AccountAbstractionLayout(props: {
               </TrackedUnderlineLink>
             </p>
           </div>
-          {props.hasSmartWalletsWithoutBilling && <SmartWalletsBillingAlert />}
+          {props.hasSmartWalletsWithoutBilling && (
+            <SmartWalletsBillingAlert teamSlug={props.teamSlug} />
+          )}
           <GasCreditAlert
             teamSlug={props.teamSlug}
             projectId={props.projectId}

--- a/apps/dashboard/src/components/settings/Account/Billing/CreditsItem.tsx
+++ b/apps/dashboard/src/components/settings/Account/Billing/CreditsItem.tsx
@@ -17,6 +17,7 @@ interface CreditsItemProps {
   onClickApply?: () => void;
   twAccount: Account;
   client: ThirdwebClient;
+  teamSlug: string;
 }
 
 export const CreditsItem: React.FC<CreditsItemProps> = ({
@@ -25,6 +26,7 @@ export const CreditsItem: React.FC<CreditsItemProps> = ({
   onClickApply,
   twAccount,
   client,
+  teamSlug,
 }) => {
   const trackEvent = useTrack();
 
@@ -130,7 +132,7 @@ export const CreditsItem: React.FC<CreditsItemProps> = ({
         <div className="mt-2 flex justify-end border-t px-4 py-4 lg:px-6">
           <Button asChild size="sm" variant="outline">
             <Link
-              href="/team/~/~/settings/credits"
+              href={`/team/${teamSlug}/~/settings/credits`}
               onClick={() => {
                 trackEvent({
                   category: "op-sponsorship",

--- a/apps/dashboard/src/components/settings/Account/Billing/PlanCard.tsx
+++ b/apps/dashboard/src/components/settings/Account/Billing/PlanCard.tsx
@@ -12,6 +12,7 @@ import { CreditsItem } from "./CreditsItem";
 export const CreditsInfoCard = (props: {
   twAccount: Account;
   client: ThirdwebClient;
+  teamSlug: string;
 }) => {
   const { data: credits } = useAccountCredits();
 
@@ -29,6 +30,7 @@ export const CreditsInfoCard = (props: {
         isOpCreditDefault={true}
         twAccount={props.twAccount}
         client={props.client}
+        teamSlug={props.teamSlug}
       />
       {restCredits?.map((credit) => (
         <CreditsItem
@@ -36,6 +38,7 @@ export const CreditsInfoCard = (props: {
           credit={credit}
           twAccount={props.twAccount}
           client={props.client}
+          teamSlug={props.teamSlug}
         />
       ))}
     </section>

--- a/apps/dashboard/src/components/settings/Account/Billing/index.tsx
+++ b/apps/dashboard/src/components/settings/Account/Billing/index.tsx
@@ -30,7 +30,11 @@ export const Billing: React.FC<BillingProps> = ({
         <PlanInfoCardClient team={team} subscriptions={subscriptions} />
       </div>
 
-      <CreditsInfoCard twAccount={twAccount} client={client} />
+      <CreditsInfoCard
+        twAccount={twAccount}
+        client={client}
+        teamSlug={team.slug}
+      />
       <Coupons teamId={team.id} isPaymentSetup={validPayment} />
     </div>
   );

--- a/apps/dashboard/src/components/settings/ApiKeys/Alerts.tsx
+++ b/apps/dashboard/src/components/settings/ApiKeys/Alerts.tsx
@@ -2,7 +2,9 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { TrackedUnderlineLink } from "@/components/ui/tracked-link";
 import { CircleAlertIcon } from "lucide-react";
 
-export const SmartWalletsBillingAlert = () => {
+export const SmartWalletsBillingAlert = (props: {
+  teamSlug: string;
+}) => {
   return (
     <Alert variant="warning">
       <CircleAlertIcon className="size-5" />
@@ -10,7 +12,7 @@ export const SmartWalletsBillingAlert = () => {
       <AlertDescription>
         To enable AA on mainnet chains,{" "}
         <TrackedUnderlineLink
-          href="/team/~/~/settings/billing"
+          href={`/team/${props.teamSlug}/~/settings/billing`}
           category="api_keys"
           label="smart_wallets_missing_billing"
         >


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `CreditsInfoCard` and `SmartWalletsBillingAlert` components by adding a `teamSlug` prop for better team-specific functionality and updating relevant links throughout the application.

### Detailed summary
- Added `teamSlug` prop to `CreditsInfoCard` and `CreditsItem`.
- Updated `SmartWalletsBillingAlert` to accept `teamSlug`.
- Modified links in `CreditsItem` and `SmartWalletsBillingAlert` to include `teamSlug`. 
- Cleaned up JSX formatting for better readability.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->