### PR TITLE
fix: hide common extension name

### DIFF
--- a/apps/portal/src/app/references/components/TDoc/Function.tsx
+++ b/apps/portal/src/app/references/components/TDoc/Function.tsx
@@ -46,7 +46,9 @@ export function FunctionTDoc(props: {
     <>
       {props.showHeading !== false && (
         <Heading level={props.level} id={slugger.slug(doc.name)}>
-          {extensionName ? `${extensionName}.${doc.name}` : doc.name}
+          {extensionName && extensionName !== "Common"
+            ? `${extensionName}.${doc.name}`
+            : doc.name}
         </Heading>
       )}
 


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR modifies the rendering logic of a heading in the `Function` component of the `TDoc` module. It updates how the heading text is constructed based on the presence and value of `extensionName`.

### Detailed summary
- Changes the conditional rendering of the heading text in the `Heading` component.
- Updates the text to include `extensionName` only if it is defined and not equal to "Common".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->