### PR TITLE
chore: Support Engine Core and Webhook usage events

### DIFF
--- a/.changeset/whole-women-divide.md
+++ b/.changeset/whole-women-divide.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+chore: Support Engine Core and Webhook usage events

--- a/packages/service-utils/src/core/usageV2.ts
+++ b/packages/service-utils/src/core/usageV2.ts
@@ -1,6 +1,7 @@
 export const USAGE_V2_SOURCES = [
   "bundler",
-  "engine",
+  "engine", // Engine Core -- treat as a client-side event
+  "engine-cloud", // Engine Cloud
   "insight",
   "nebula",
   "rpc",
@@ -8,14 +9,18 @@ export const USAGE_V2_SOURCES = [
   "storage",
   "wallet",
   "pay",
+  "webhook",
 ] as const;
 export type UsageV2Source = (typeof USAGE_V2_SOURCES)[number];
+
 export function getTopicName(source: UsageV2Source) {
   switch (source) {
     // Some sources are sent from clients and are written to an "untrusted" table.
     case "sdk":
     case "engine":
       return `usage_v2.untrusted_raw_${source}`;
+    case "engine-cloud":
+      return "usage_v2.raw_engine";
     default:
       return `usage_v2.raw_${source}`;
   }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR enhances the `@thirdweb-dev/service-utils` package by adding support for Engine Core and Webhook usage events in the `usageV2` module.

### Detailed summary
- Updated `USAGE_V2_SOURCES` to include `engine-cloud` and `webhook`.
- Modified `getTopicName` function to handle `engine-cloud` and return `usage_v2.raw_engine`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->