### PR TITLE
[SDK] Fix MetaMask deeplink parsing

### DIFF
--- a/.changeset/angry-hats-start.md
+++ b/.changeset/angry-hats-start.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix metamask deeplink parsing

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/DeepLinkConnectUI.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/DeepLinkConnectUI.tsx
@@ -25,7 +25,12 @@ export const DeepLinkConnectUI = (props: {
   onBack?: () => void;
   client: ThirdwebClient;
 }) => {
-  const link = encodeURIComponent(window.location.toString());
+  let link = window.location.toString();
+  if (props.wallet.id === "io.metamask") {
+    link = link.replace("https://", "");
+  } else {
+    link = encodeURIComponent(link);
+  }
   const deeplink = `${props.deepLinkPrefix}${link}?ref=${link}`;
   return (
     <Container animate="fadein">


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the parsing of the MetaMask deep link in the `thirdweb` package, ensuring that the link is correctly formatted based on the wallet being used.

### Detailed summary
- Updated the link generation logic in the `DeepLinkConnectUI.tsx` file.
- Changed `const link` to `let link` for reassignment.
- Added a conditional check for `props.wallet.id` to modify the link format for MetaMask.
- Ensured that the link is encoded only for non-MetaMask wallets.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->