### PR TITLE
[PayEmbed] Always connect to destination chain if available

### DIFF
--- a/.changeset/violet-areas-jump.md
+++ b/.changeset/violet-areas-jump.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Always connect to destination chain if available in PayEmbed

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx
@@ -271,8 +271,8 @@ function BuyScreenContent(props: BuyScreenContentProps) {
       <WalletSwitcherConnectionScreen
         accountAbstraction={props.connectOptions?.accountAbstraction}
         appMetadata={props.connectOptions?.appMetadata}
-        chain={props.connectOptions?.chain}
-        chains={props.connectOptions?.chains}
+        chain={toChain || props.connectOptions?.chain}
+        chains={[toChain, ...(props.connectOptions?.chains || [])]}
         client={props.client}
         connectLocale={props.connectLocale}
         isEmbed={props.isEmbed}


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `PayEmbed` functionality by ensuring it always connects to the destination chain when available. It also refines the handling of `chain` and `chains` properties in the `BuyScreen` component.

### Detailed summary
- Updated `BuyScreen.tsx` to always connect to the destination chain if available.
- Changed `chain` assignment to use `toChain` or fallback to `props.connectOptions?.chain`.
- Modified `chains` to include `toChain` and existing chains from `props.connectOptions?.chains`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->