### PR TITLE
[SDK] Handle Hedera native currency decimals for smart wallet calls

### DIFF
--- a/.changeset/chubby-aliens-film.md
+++ b/.changeset/chubby-aliens-film.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Handle hedera native currency decimal values for smart wallet calls

--- a/packages/thirdweb/src/extensions/erc721/read/getNFT.test.ts
+++ b/packages/thirdweb/src/extensions/erc721/read/getNFT.test.ts
@@ -58,7 +58,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("erc721.getNFT", () => {
       includeOwner: true,
     });
     expect(nft.metadata.name).toBe("Doodle #1");
-    expect(nft.owner).toBe("0xbE9936FCFC50666f5425FDE4A9decC59cEF73b24");
+    expect(nft.owner).toBeDefined();
     expect(nft).toMatchInlineSnapshot(`
       {
         "chainId": 1,
@@ -92,7 +92,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("erc721.getNFT", () => {
           "name": "Doodle #1",
           "uri": "ipfs://QmPMc4tcBsMqLRuCQtPmPe84bpSjrC3Ky7t3JWuHXYB4aS/1",
         },
-        "owner": "0xbE9936FCFC50666f5425FDE4A9decC59cEF73b24",
+        "owner": "0x620b70123fB810F6C653DA7644b5dD0b6312e4D8",
         "tokenAddress": "0x8a90cab2b38dba80c64b7734e58ee1db38b8992e",
         "tokenURI": "ipfs://QmPMc4tcBsMqLRuCQtPmPe84bpSjrC3Ky7t3JWuHXYB4aS/1",
         "type": "ERC721",

--- a/packages/thirdweb/src/wallets/smart/lib/calls.ts
+++ b/packages/thirdweb/src/wallets/smart/lib/calls.ts
@@ -181,14 +181,15 @@ export function prepareExecute(args: {
   if (execute) {
     return execute(accountContract, transaction);
   }
+  let value = transaction.value || 0n;
+  // special handling of hedera chains, decimals for native value is 8 instead of 18 when passed as contract params
+  if (transaction.chainId === 295 || transaction.chainId === 296) {
+    value = value / BigInt(10 ** 10);
+  }
   return prepareContractCall({
     contract: accountContract,
     method: "function execute(address, uint256, bytes)",
-    params: [
-      transaction.to || "",
-      transaction.value || 0n,
-      transaction.data || "0x",
-    ],
+    params: [transaction.to || "", value, transaction.data || "0x"],
     // if gas is specified for the inner tx, use that and add 21k for the execute call on the account contract
     // this avoids another estimateGas call when bundling the userOp
     // and also allows for passing custom gas limits for the inner tx
@@ -215,12 +216,18 @@ export function prepareBatchExecute(args: {
   if (executeBatch) {
     return executeBatch(accountContract, transactions);
   }
+  let values = transactions.map((tx) => tx.value || 0n);
+  const chainId = transactions[0]?.chainId;
+  // special handling of hedera chains, decimals for native value is 8 instead of 18 when passed as contract params
+  if (chainId === 295 || chainId === 296) {
+    values = values.map((value) => value / BigInt(10 ** 10));
+  }
   return prepareContractCall({
     contract: accountContract,
     method: "function executeBatch(address[], uint256[], bytes[])",
     params: [
       transactions.map((tx) => tx.to || ""),
-      transactions.map((tx) => tx.value || 0n),
+      values,
       transactions.map((tx) => tx.data || "0x"),
     ],
   });


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces adjustments to handle the decimal values of native currency for smart wallet calls specifically for hedera chains, ensuring compatibility in contract transactions.

### Detailed summary
- Updated `expect` statement to check if `nft.owner` is defined instead of a specific address.
- Changed the `nft.owner` value in the inline snapshot.
- Added special handling for hedera chains in `packages/thirdweb/src/wallets/smart/lib/calls.ts`:
  - Adjusted `transaction.value` by dividing it for specific chain IDs (295 and 296).
  - Implemented similar handling for batch transactions, modifying the values accordingly.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->