### PR TITLE
[Dashboard]: Adding new assets forPlume chains

### DIFF
--- a/apps/dashboard/src/app/(app)/(dashboard)/(chain)/utils.ts
+++ b/apps/dashboard/src/app/(app)/(dashboard)/(chain)/utils.ts
@@ -578,6 +578,30 @@ const chainMetaRecord = {
       buttonText: "Learn more",
     },
   },
+  //Plume Mainnet
+  98866: {
+    headerImgUrl: plumeBanner.src,
+    about:
+      "Plume Network is the first full-stack L1 RWA Chain and ecosystem purpose-built for RWAfi, enabling the rapid adoption and demand-driven integration of real world assets. With 180+ projects building on the network, Plume offers a composable, EVM-compatible environment for onboarding and managing diverse real world assets. Coupled with an end-to-end tokenization engine and a network of financial infrastructure partners, Plume simplifies asset onboarding and enables seamless DeFi integration for RWAs so anyone can tokenize real world assets, distribute them globally, and make them useful for native crypto users.",
+    cta: {
+      backgroundImageUrl: plumeCTA.src,
+      title: "Bringing the Real World Onchain",
+      buttonLink: "https://miles.plumenetwork.xyz/",
+      buttonText: "Learn more",
+    },
+  },
+  //Plume Mainnet
+  98867: {
+    headerImgUrl: plumeBanner.src,
+    about:
+      "Plume Network is the first full-stack L1 RWA Chain and ecosystem purpose-built for RWAfi, enabling the rapid adoption and demand-driven integration of real world assets. With 180+ projects building on the network, Plume offers a composable, EVM-compatible environment for onboarding and managing diverse real world assets. Coupled with an end-to-end tokenization engine and a network of financial infrastructure partners, Plume simplifies asset onboarding and enables seamless DeFi integration for RWAs so anyone can tokenize real world assets, distribute them globally, and make them useful for native crypto users.",
+    cta: {
+      backgroundImageUrl: plumeCTA.src,
+      title: "Bringing the Real World Onchain",
+      buttonLink: "https://miles.plumenetwork.xyz/",
+      buttonText: "Learn more",
+    },
+  },
   //Rivalz Mainnet
   753: {
     headerImgUrl: rivalzBanner.src,


### PR DESCRIPTION
SOL2-150

Added the custom banner and chain information for: 
- 98866
- 98867

Test 
1) Verify Chainlist page fro chain 98866
2) Verify banner and about 
![image](https://github.com/user-attachments/assets/5ecfa1ed-ded1-4cf2-9b28-d95e7addabd1)

3) Visit Chainlist page for 98867
4) Verify banner and about section 
![image](https://github.com/user-attachments/assets/d915bdad-33c4-459a-abfa-867a2a65af50)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds details for the `Plume Mainnet` section in the `utils.ts` file, including header images, descriptions, and call-to-action buttons.

### Detailed summary
- Added `Plume Mainnet` entry with ID `98866`:
  - `headerImgUrl`: `plumeBanner.src`
  - `about`: Description of `Plume Network`
  - `cta`: Includes `backgroundImageUrl`, `title`, `buttonLink`, and `buttonText`
  
- Added another `Plume Mainnet` entry with ID `98867` with the same content as above.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->