### PR TITLE
[SDK] Fix hex value handling for smart wallet execution

### DIFF
--- a/.changeset/short-feet-check.md
+++ b/.changeset/short-feet-check.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Handle hex value format for smart wallet execution

--- a/packages/thirdweb/src/react/web/ui/prebuilt/NFT/utils.ts
+++ b/packages/thirdweb/src/react/web/ui/prebuilt/NFT/utils.ts
@@ -17,6 +17,7 @@ export async function getNFTInfo(options: NFTProviderProps): Promise<NFT> {
         }),
         getNFT1155({
           ...options,
+          useIndexer: false, // TODO (insight): switch this call to only call insight once
         }),
       ]).then(([possibleNFT721, possibleNFT1155]) => {
         // getNFT extension always return an NFT object

--- a/packages/thirdweb/src/wallets/smart/lib/calls.ts
+++ b/packages/thirdweb/src/wallets/smart/lib/calls.ts
@@ -184,7 +184,7 @@ export function prepareExecute(args: {
   let value = transaction.value || 0n;
   // special handling of hedera chains, decimals for native value is 8 instead of 18 when passed as contract params
   if (transaction.chainId === 295 || transaction.chainId === 296) {
-    value = value / BigInt(10 ** 10);
+    value = BigInt(value) / BigInt(10 ** 10);
   }
   return prepareContractCall({
     contract: accountContract,
@@ -220,7 +220,7 @@ export function prepareBatchExecute(args: {
   const chainId = transactions[0]?.chainId;
   // special handling of hedera chains, decimals for native value is 8 instead of 18 when passed as contract params
   if (chainId === 295 || chainId === 296) {
-    values = values.map((value) => value / BigInt(10 ** 10));
+    values = values.map((value) => BigInt(value) / BigInt(10 ** 10));
   }
   return prepareContractCall({
     contract: accountContract,


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on handling hex value formats for smart wallet execution and includes adjustments for value calculations specific to hedera chains.

### Detailed summary
- Updated `getNFT1155` to set `useIndexer` to `false`.
- Changed value calculation for hedera chains from `value / BigInt(10 ** 10)` to `BigInt(value) / BigInt(10 ** 10)` in `packages/thirdweb/src/wallets/smart/lib/calls.ts`.
- Updated batch value calculations similarly in `prepareBatchExecute`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->