### PR TITLE
Dashboard: Fix team links in header on pages outside /team layout

### DIFF
--- a/apps/dashboard/src/app/(app)/team/components/TeamHeader/TeamSelectionUI.tsx
+++ b/apps/dashboard/src/app/(app)/team/components/TeamHeader/TeamSelectionUI.tsx
@@ -93,8 +93,13 @@ export function TeamSelectionUI(props: {
                   >
                     <Link
                       href={
-                        currentTeam && !props.isOnProjectPage
-                          ? pathname.replace(currentTeam.slug, team.slug)
+                        currentTeam &&
+                        !props.isOnProjectPage &&
+                        pathname.startsWith("/team")
+                          ? pathname.replace(
+                              `/team/${currentTeam.slug}`,
+                              `/team/${team.slug}`,
+                            )
                           : `/team/${team.slug}`
                       }
                     >


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `href` property of the `Link` component in the `TeamSelectionUI.tsx` file to ensure it correctly replaces the team slug in the URL only when certain conditions are met.

### Detailed summary
- Modified the conditional logic for the `href` property of the `Link` component.
- Added a check to ensure `pathname` starts with `/team` before replacing the current team slug.
- Updated the replacement logic to use template literals for constructing URLs.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->