### PR TITLE
Separate authToken from secretKey in ThirdwebClient

### DIFF
--- a/apps/dashboard/src/@/constants/thirdweb.server.ts
+++ b/apps/dashboard/src/@/constants/thirdweb.server.ts
@@ -79,7 +79,8 @@ export function getThirdwebClient(
 
   return createThirdwebClient({
     teamId: options?.teamId,
-    secretKey: options?.jwt ? options.jwt : DASHBOARD_THIRDWEB_SECRET_KEY,
+    secretKey: DASHBOARD_THIRDWEB_SECRET_KEY,
+    authToken: options?.jwt ?? undefined,
     clientId: DASHBOARD_THIRDWEB_CLIENT_ID,
     config: {
       storage: {

--- a/packages/thirdweb/src/client/client.test.ts
+++ b/packages/thirdweb/src/client/client.test.ts
@@ -29,15 +29,23 @@ describe("client", () => {
     it("should accept a jwt being passed", () => {
       const client = createThirdwebClient({
         clientId: "foo",
-        secretKey: "bar.baz.qux",
+        authToken: "bar.baz.qux",
       });
       expect(client.clientId).toBe("foo");
-      expect(client.secretKey).toBe("bar.baz.qux");
+      expect(client.authToken).toBe("bar.baz.qux");
+      expect(client.secretKey).toBeUndefined();
     });
-    it("should throw if clientId is missing with JWT input", () => {
+
+    it("should throw an error if authToken is passed as secretKey", () => {
       expect(() =>
         createThirdwebClient({ secretKey: "bar.baz.qux" }),
-      ).toThrowError(/clientId must be provided when using a JWT secretKey/);
+      ).toThrowError(/have to pass authToken directly/);
+    });
+
+    it("should throw if clientId is missing with JWT input", () => {
+      expect(() =>
+        createThirdwebClient({ authToken: "bar.baz.qux", secretKey: "foo" }),
+      ).toThrowError(/have to pass clientId when passing authToken/);
     });
   });
 });


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on refactoring the `createThirdwebClient` function to replace the use of `secretKey` with `authToken`, enhancing how authentication is managed and improving error handling related to client creation.

### Detailed summary
- Replaced `secretKey` with `authToken` in `createThirdwebClient` options.
- Updated tests to reflect changes in authentication method.
- Added error handling for cases where `clientId` must accompany `authToken`.
- Modified type definitions to include `authToken`.
- Adjusted fetch logic to prioritize `authToken` over `secretKey`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->