### PR TITLE
[Dashboard] Replace serverThirdwebClient with getUserThirdwebClient

### DIFF
--- a/apps/dashboard/src/app/(app)/(dashboard)/(chain)/[chain_id]/[contractAddress]/_utils/getContractFromParams.ts
+++ b/apps/dashboard/src/app/(app)/(dashboard)/(chain)/[chain_id]/[contractAddress]/_utils/getContractFromParams.ts
@@ -1,7 +1,7 @@
-import { serverThirdwebClient } from "@/constants/thirdweb-client.server";
 import { mapV4ChainToV5Chain } from "contexts/map-chains";
 import { getAddress, getContract, isAddress } from "thirdweb";
 import { fetchChainWithLocalOverrides } from "../../../../../../../utils/fetchChainWithLocalOverrides";
+import { getUserThirdwebClient } from "../../../../../api/lib/getAuthToken";
 
 export async function getContractPageParamsInfo(params: {
   contractAddress: string;
@@ -22,7 +22,7 @@ export async function getContractPageParamsInfo(params: {
     // eslint-disable-next-line no-restricted-syntax
     chain: mapV4ChainToV5Chain(chainMetadata),
     // if we have the auth token pass it into the client
-    client: serverThirdwebClient,
+    client: await getUserThirdwebClient(),
   });
 
   return {


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `getContractPageParamsInfo` function to utilize an authenticated Thirdweb client, enhancing the ability to interact with contracts securely.

### Detailed summary
- Added an import statement for `getUserThirdwebClient` from the `../../../../../api/lib/getAuthToken`.
- Modified the `client` parameter in the `getContractPageParamsInfo` function to be assigned the result of `await getUserThirdwebClient()`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->