### PR TITLE
Only set secret key or client ID when not using auth token

### DIFF
--- a/packages/thirdweb/src/utils/fetch.ts
+++ b/packages/thirdweb/src/utils/fetch.ts
@@ -70,14 +70,15 @@ export function getClientFetch(client: ThirdwebClient, ecosystem?: Ecosystem) {
         if (client.teamId) {
           headers.set("x-team-id", client.teamId);
         }
-      }
+      } else {
+        // only set secret key or client id if we are NOT using the auth token!
+        if (secretKey) {
+          headers.set("x-secret-key", secretKey);
+        }
 
-      if (secretKey) {
-        headers.set("x-secret-key", secretKey);
-      }
-
-      if (clientId) {
-        headers.set("x-client-id", clientId);
+        if (clientId) {
+          headers.set("x-client-id", clientId);
+        }
       }
 
       if (ecosystem) {


### PR DESCRIPTION
This PR modifies the header setting logic in `getClientFetch` to ensure that secret keys and client IDs are only set when not using an auth token. This prevents potential conflicts between different authentication methods by making the header setting logic mutually exclusive.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR modifies the logic for setting HTTP headers in the `fetch.ts` file. It ensures that the `x-secret-key` and `x-client-id` headers are only set when an authentication token is not being used, improving the conditional handling of these headers.

### Detailed summary
- Changed the logic for setting `x-secret-key` to only occur if an authentication token is not used.
- Adjusted the placement of the `if (clientId)` condition to maintain clarity in header setting.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->