### PR TITLE
Fix testnet filtering in NetworkSelectors

### DIFF
--- a/apps/dashboard/src/@/components/blocks/NetworkSelectors.tsx
+++ b/apps/dashboard/src/@/components/blocks/NetworkSelectors.tsx
@@ -151,15 +151,18 @@ export function SingleNetworkSelector(props: {
   const { allChains, idToChain } = useAllChainsData();
 
   const chainsToShow = useMemo(() => {
-    if (!props.chainIds) {
-      return allChains;
+    let chains = allChains;
+
+    if (props.disableTestnets) {
+      chains = chains.filter((chain) => !chain.testnet);
     }
-    const chainIdSet = new Set(props.chainIds);
-    return allChains.filter(
-      (chain) =>
-        chainIdSet.has(chain.chainId) &&
-        (!props.disableTestnets || !chain.testnet),
-    );
+
+    if (props.chainIds) {
+      const chainIdSet = new Set(props.chainIds);
+      chains = chains.filter((chain) => chainIdSet.has(chain.chainId));
+    }
+
+    return chains;
   }, [allChains, props.chainIds, props.disableTestnets]);
 
   const options = useMemo(() => {


### PR DESCRIPTION
Fixed issue with the disableTestnets filter in SingleNetworkSelector to properly filter out testnets regardless of chainIds being provided.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR refactors the logic in the `chainsToShow` computation within the `NetworkSelectors.tsx` component to improve readability and efficiency by using a `chains` variable that is filtered based on `props.disableTestnets` and `props.chainIds`.

### Detailed summary
- Introduced a `chains` variable to hold `allChains`.
- Added a filter for `chains` to exclude testnets if `props.disableTestnets` is true.
- Simplified the filtering of `chains` based on `props.chainIds` using a `Set`.
- Removed redundant filtering logic that combined testnet and chain ID checks into a single return statement.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->