### PR TITLE
[Dashboard] Fix: Display latest value in PayNewCustomers component

### DIFF
--- a/apps/dashboard/src/components/pay/PayAnalytics/components/PayNewCustomers.tsx
+++ b/apps/dashboard/src/components/pay/PayAnalytics/components/PayNewCustomers.tsx
@@ -74,9 +74,7 @@ export function PayNewCustomers(props: {
           <div className="mb-5 flex items-center gap-3">
             <SkeletonContainer
               loadedData={
-                isEmpty
-                  ? "NA"
-                  : graphData.reduce((acc, curr) => acc + curr.value, 0)
+                isEmpty ? "NA" : graphData[graphData.length - 1]?.value || 0
               }
               skeletonData={100}
               render={(v) => {


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.ai/code)

<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the logic for displaying the total value of new customers in the `PayNewCustomers` component. It changes how the value is computed when the `graphData` is empty or when accessing the latest value.

### Detailed summary
- Modified the `loadedData` prop in the `SkeletonContainer`.
- Changed the logic from summing all `curr.value` to retrieving the last value in `graphData` or returning `0` if not available.
- Handled the case where `graphData` is empty by displaying "NA".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->