### PR TITLE
Fix: Trend badge formatting

### DIFF
--- a/apps/dashboard/src/components/pay/PayAnalytics/components/PayNewCustomers.tsx
+++ b/apps/dashboard/src/components/pay/PayAnalytics/components/PayNewCustomers.tsx
@@ -49,10 +49,13 @@ export function PayNewCustomers(props: {
     }
     const lastPeriod = newUsersData[newUsersData.length - 2];
     const currentPeriod = newUsersData[newUsersData.length - 1];
+    // Calculate the percent change from last period to current period
     const trend =
       lastPeriod && currentPeriod && lastPeriod.value > 0
         ? (currentPeriod.value - lastPeriod.value) / lastPeriod.value
-        : 0;
+        : lastPeriod?.value === 0
+          ? 100
+          : 0;
     return { graphData: newUsersData, trend };
   }, [props.data, props.dateFormat]);
   const isEmpty = useMemo(

--- a/apps/dashboard/src/components/pay/PayAnalytics/components/Payouts.tsx
+++ b/apps/dashboard/src/components/pay/PayAnalytics/components/Payouts.tsx
@@ -54,7 +54,9 @@ export function Payouts(props: {
     const trend =
       lastPeriod && currentPeriod && lastPeriod.value > 0
         ? (currentPeriod.value - lastPeriod.value) / lastPeriod.value
-        : 0;
+        : lastPeriod?.value === 0
+          ? 100
+          : 0;
     return {
       graphData: cleanedData,
       totalPayoutsUSD: totalPayouts / 100,

--- a/apps/dashboard/src/components/pay/PayAnalytics/components/common.tsx
+++ b/apps/dashboard/src/components/pay/PayAnalytics/components/common.tsx
@@ -34,7 +34,13 @@ export function ChangeBadge(props: { percent: number }) {
           ) : (
             <ArrowDownIcon className="size-4" />
           )}
-          {percentValue}
+
+          {new Intl.NumberFormat("en-US", {
+            style: "percent",
+            minimumFractionDigits: 0,
+            maximumFractionDigits: 0,
+            signDisplay: "never",
+          }).format(props.percent)}
         </Badge>
       </div>
     </ToolTipLabel>


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the calculation of percentage changes and formatting for better clarity in the `Payouts`, `common`, and `PayNewCustomers` components.

### Detailed summary
- In `Payouts.tsx`, updated the trend calculation to handle cases where `lastPeriod.value` is `0`, returning `100` instead of performing division.
- In `common.tsx`, replaced the display of `percentValue` with a formatted string using `Intl.NumberFormat` to show percentage without decimal places.
- In `PayNewCustomers.tsx`, similar trend calculation adjustment as in `Payouts.tsx` to improve handling of zero values.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->