### PR TITLE
[SDK] Fix: Automatically trigger login for connected wallets whe…

### DIFF
--- a/.changeset/every-sides-invent.md
+++ b/.changeset/every-sides-invent.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Automatically trigger SIWE sign in when a wallet is connected

--- a/apps/playground-web/src/components/auth/auth-button.tsx
+++ b/apps/playground-web/src/components/auth/auth-button.tsx
@@ -8,11 +8,25 @@ import {
 } from "@/app/connect/auth/server/actions/auth";
 import { THIRDWEB_CLIENT } from "@/lib/client";
 import { ConnectButton } from "thirdweb/react";
+import { createWallet, inAppWallet } from "thirdweb/wallets";
 
 export function AuthButton() {
   return (
     <ConnectButton
       client={THIRDWEB_CLIENT}
+      wallets={[
+        inAppWallet({
+          auth: {
+            options: ["google", "telegram", "github"],
+            mode: "redirect",
+          },
+        }),
+        createWallet("io.metamask"),
+        createWallet("com.coinbase.wallet"),
+        createWallet("me.rainbow"),
+        createWallet("io.rabby"),
+        createWallet("io.zerion.wallet"),
+      ]}
       auth={{
         isLoggedIn: (address) => isLoggedIn(address),
         doLogin: (params) => login(params),

--- a/packages/thirdweb/src/react/core/hooks/connection/ConnectEmbedProps.ts
+++ b/packages/thirdweb/src/react/core/hooks/connection/ConnectEmbedProps.ts
@@ -290,6 +290,11 @@ export type ConnectEmbedProps = {
   auth?: SiweAuthOptions;
 
   /**
+   * @hidden
+   */
+  siweLogin?: () => Promise<void>;
+
+  /**
    * Customize the welcome screen. This prop is only applicable when modalSize prop is set to "wide". On "wide" Modal size, a welcome screen is shown on the right side of the modal.
    *
    * This screen can be customized in two ways

--- a/packages/thirdweb/src/react/core/hooks/connection/ConnectEmbedProps.ts
+++ b/packages/thirdweb/src/react/core/hooks/connection/ConnectEmbedProps.ts
@@ -290,11 +290,6 @@ export type ConnectEmbedProps = {
   auth?: SiweAuthOptions;
 
   /**
-   * @hidden
-   */
-  siweLogin?: () => Promise<void>;
-
-  /**
    * Customize the welcome screen. This prop is only applicable when modalSize prop is set to "wide". On "wide" Modal size, a welcome screen is shown on the right side of the modal.
    *
    * This screen can be customized in two ways

--- a/packages/thirdweb/src/react/native/ui/connect/ConnectButton.tsx
+++ b/packages/thirdweb/src/react/native/ui/connect/ConnectButton.tsx
@@ -122,9 +122,9 @@ export function ConnectButton(props: ConnectButtonProps) {
       ) : (
         <ThemedButton theme={theme} onPress={() => openModal()}>
           {status === "connecting" ||
-            siweAuth.isLoggingIn ||
-            siweAuth.isLoading ||
-            siweAuth.isLoggingOut ? (
+          siweAuth.isLoggingIn ||
+          siweAuth.isLoading ||
+          siweAuth.isLoggingOut ? (
             <>
               <ThemedSpinner color={theme.colors.primaryButtonText} />
             </>

--- a/packages/thirdweb/src/react/native/ui/connect/ConnectButton.tsx
+++ b/packages/thirdweb/src/react/native/ui/connect/ConnectButton.tsx
@@ -47,7 +47,10 @@ export function ConnectButton(props: ConnectButtonProps) {
   const status = useActiveWalletConnectionStatus();
   const connectionManager = useConnectionManager();
   const siweAuth = useSiweAuth(wallet, account, props.auth);
-  useAutoConnect(props);
+  useAutoConnect({
+    ...props,
+    siweLogin: siweAuth.doLogin,
+  });
 
   const fadeAnim = useRef(new Animated.Value(0)); // For background opacity
   const slideAnim = useRef(new Animated.Value(screenHeight)); // For bottom sheet position

--- a/packages/thirdweb/src/react/native/ui/connect/ConnectButton.tsx
+++ b/packages/thirdweb/src/react/native/ui/connect/ConnectButton.tsx
@@ -49,7 +49,7 @@ export function ConnectButton(props: ConnectButtonProps) {
   const siweAuth = useSiweAuth(wallet, account, props.auth);
   useAutoConnect({
     ...props,
-    siweLogin: siweAuth.doLogin,
+    siweAuth: siweAuth,
   });
 
   const fadeAnim = useRef(new Animated.Value(0)); // For background opacity
@@ -122,9 +122,9 @@ export function ConnectButton(props: ConnectButtonProps) {
       ) : (
         <ThemedButton theme={theme} onPress={() => openModal()}>
           {status === "connecting" ||
-          siweAuth.isLoggingIn ||
-          siweAuth.isLoading ||
-          siweAuth.isLoggingOut ? (
+            siweAuth.isLoggingIn ||
+            siweAuth.isLoading ||
+            siweAuth.isLoggingOut ? (
             <>
               <ThemedSpinner color={theme.colors.primaryButtonText} />
             </>

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/ConnectButton.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/ConnectButton.tsx
@@ -30,6 +30,7 @@ import { LockIcon } from "./icons/LockIcon.js";
 import { useConnectLocale } from "./locale/getConnectLocale.js";
 import type { ConnectLocale } from "./locale/types.js";
 import { SignatureScreen } from "./screens/SignatureScreen.js";
+import { useAdminWallet } from "src/exports/react.native.js";
 
 const TW_CONNECT_WALLET = "tw-connect-wallet";
 
@@ -400,6 +401,7 @@ function ConnectButtonInner(
 ) {
   const activeWallet = useActiveWallet();
   const activeAccount = useActiveAccount();
+  const adminWallet = useAdminWallet();
   const siweAuth = useSiweAuth(activeWallet, activeAccount, props.auth);
   const [showSignatureModal, setShowSignatureModal] = useState(false);
 
@@ -410,13 +412,15 @@ function ConnectButtonInner(
     }
   }, [activeAccount]);
 
-  // if the wallet is connected and auth is required, trigger a login attempt automatically
+  // if an IAW wallet is connected and auth is required, trigger a login attempt automatically
   useEffect(() => {
+    const isIAW = activeWallet?.id === "inApp" || adminWallet?.id === "inApp";
     if (
       activeAccount &&
       siweAuth.requiresAuth &&
       !siweAuth.isLoggedIn &&
-      !siweAuth.isLoggingIn
+      !siweAuth.isLoggingIn &&
+      isIAW
     ) {
       siweAuth.doLogin();
     }
@@ -426,6 +430,8 @@ function ConnectButtonInner(
     siweAuth.doLogin,
     siweAuth.isLoggedIn,
     siweAuth.isLoggingIn,
+    activeWallet,
+    adminWallet,
   ]);
 
   const theme = props.theme || "dark";

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/ConnectButton.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/ConnectButton.tsx
@@ -410,6 +410,24 @@ function ConnectButtonInner(
     }
   }, [activeAccount]);
 
+  // if the wallet is connected and auth is required, trigger a login attempt automatically
+  useEffect(() => {
+    if (
+      activeAccount &&
+      siweAuth.requiresAuth &&
+      !siweAuth.isLoggedIn &&
+      !siweAuth.isLoggingIn
+    ) {
+      siweAuth.doLogin();
+    }
+  }, [
+    activeAccount,
+    siweAuth.requiresAuth,
+    siweAuth.doLogin,
+    siweAuth.isLoggedIn,
+    siweAuth.isLoggingIn,
+  ]);
+
   const theme = props.theme || "dark";
   const connectionStatus = useActiveWalletConnectionStatus();
   const locale = props.connectLocale;

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/ConnectButton.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/ConnectButton.tsx
@@ -340,7 +340,7 @@ export function ConnectButton(props: ConnectButtonProps) {
       }
       accountAbstraction={props.accountAbstraction}
       onConnect={props.onConnect}
-      siweLogin={siweAuth.doLogin}
+      siweAuth={siweAuth}
     />
   );
 

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/ConnectEmbed.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/ConnectEmbed.tsx
@@ -247,7 +247,7 @@ export function ConnectEmbed(props: ConnectEmbedProps) {
       chain={preferredChain}
       appMetadata={props.appMetadata}
       client={props.client}
-      siweLogin={siweAuth.doLogin}
+      siweAuth={siweAuth}
       wallets={wallets}
       accountAbstraction={props.accountAbstraction}
       timeout={

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/ConnectEmbed.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/ConnectEmbed.tsx
@@ -11,8 +11,8 @@ import {
 } from "../../../../core/design-system/CustomThemeProvider.js";
 import { radius } from "../../../../core/design-system/index.js";
 import {
-  useSiweAuth,
   type SiweAuthOptions,
+  useSiweAuth,
 } from "../../../../core/hooks/auth/useSiweAuth.js";
 import type { ConnectEmbedProps } from "../../../../core/hooks/connection/ConnectEmbedProps.js";
 import { useActiveAccount } from "../../../../core/hooks/wallets/useActiveAccount.js";
@@ -327,21 +327,21 @@ const ConnectEmbedContent = (props: {
   };
   size: "compact" | "wide";
   header:
-  | {
-    title?: string;
-    titleIcon?: string;
-  }
-  | true
-  | undefined;
+    | {
+        title?: string;
+        titleIcon?: string;
+      }
+    | true
+    | undefined;
   localeId: LocaleId;
   onConnect: ((wallet: Wallet) => void) | undefined;
   recommendedWallets: Wallet[] | undefined;
   showAllWallets: boolean | undefined;
   walletConnect:
-  | {
-    projectId?: string;
-  }
-  | undefined;
+    | {
+        projectId?: string;
+      }
+    | undefined;
   wallets: Wallet[];
   welcomeScreen: WelcomeScreen | undefined;
 }) => {

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/ConnectEmbed.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/ConnectEmbed.tsx
@@ -11,8 +11,8 @@ import {
 } from "../../../../core/design-system/CustomThemeProvider.js";
 import { radius } from "../../../../core/design-system/index.js";
 import {
-  type SiweAuthOptions,
   useSiweAuth,
+  type SiweAuthOptions,
 } from "../../../../core/hooks/auth/useSiweAuth.js";
 import type { ConnectEmbedProps } from "../../../../core/hooks/connection/ConnectEmbedProps.js";
 import { useActiveAccount } from "../../../../core/hooks/wallets/useActiveAccount.js";
@@ -247,6 +247,7 @@ export function ConnectEmbed(props: ConnectEmbedProps) {
       chain={preferredChain}
       appMetadata={props.appMetadata}
       client={props.client}
+      siweLogin={siweAuth.doLogin}
       wallets={wallets}
       accountAbstraction={props.accountAbstraction}
       timeout={
@@ -326,21 +327,21 @@ const ConnectEmbedContent = (props: {
   };
   size: "compact" | "wide";
   header:
-    | {
-        title?: string;
-        titleIcon?: string;
-      }
-    | true
-    | undefined;
+  | {
+    title?: string;
+    titleIcon?: string;
+  }
+  | true
+  | undefined;
   localeId: LocaleId;
   onConnect: ((wallet: Wallet) => void) | undefined;
   recommendedWallets: Wallet[] | undefined;
   showAllWallets: boolean | undefined;
   walletConnect:
-    | {
-        projectId?: string;
-      }
-    | undefined;
+  | {
+    projectId?: string;
+  }
+  | undefined;
   wallets: Wallet[];
   welcomeScreen: WelcomeScreen | undefined;
 }) => {

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/fiat/OnRampScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/fiat/OnRampScreen.tsx
@@ -23,10 +23,7 @@ import { sendTransaction } from "../../../../../../../transaction/actions/send-t
 import type { WaitForReceiptOptions } from "../../../../../../../transaction/actions/wait-for-tx-receipt.js";
 import { waitForReceipt } from "../../../../../../../transaction/actions/wait-for-tx-receipt.js";
 import { formatNumber } from "../../../../../../../utils/formatNumber.js";
-import { isEcosystemWallet } from "../../../../../../../wallets/ecosystem/is-ecosystem-wallet.js";
-import { isInAppWallet } from "../../../../../../../wallets/in-app/core/wallet/index.js";
-import type { Wallet } from "../../../../../../../wallets/interfaces/wallet.js";
-import { isSmartWallet } from "../../../../../../../wallets/smart/is-smart-wallet.js";
+import { isInAppSigner } from "../../../../../../../wallets/in-app/core/wallet/is-in-app-signer.js";
 import { spacing } from "../../../../../../core/design-system/index.js";
 import { useChainName } from "../../../../../../core/hooks/others/useChainQuery.js";
 import { useBuyWithCryptoStatus } from "../../../../../../core/hooks/pay/useBuyWithCryptoStatus.js";
@@ -778,21 +775,4 @@ function useSwapMutation(props: {
       invalidateWalletBalance(queryClient);
     },
   });
-}
-
-function isInAppSigner(options: {
-  wallet: Wallet;
-  connectedWallets: Wallet[];
-}) {
-  const isInAppOrEcosystem = (w: Wallet) =>
-    isInAppWallet(w) || isEcosystemWallet(w);
-  const isSmartWalletWithAdmin =
-    isSmartWallet(options.wallet) &&
-    options.connectedWallets.some(
-      (w) =>
-        isInAppOrEcosystem(w) &&
-        w.getAccount()?.address?.toLowerCase() ===
-          options.wallet.getAdminAccount?.()?.address?.toLowerCase(),
-    );
-  return isInAppOrEcosystem(options.wallet) || isSmartWalletWithAdmin;
 }

--- a/packages/thirdweb/src/react/web/ui/PayEmbed.tsx
+++ b/packages/thirdweb/src/react/web/ui/PayEmbed.tsx
@@ -9,7 +9,10 @@ import type { AppMetadata } from "../../../wallets/types.js";
 import type { WalletId } from "../../../wallets/wallet-types.js";
 import { CustomThemeProvider } from "../../core/design-system/CustomThemeProvider.js";
 import type { Theme } from "../../core/design-system/index.js";
-import type { SiweAuthOptions } from "../../core/hooks/auth/useSiweAuth.js";
+import {
+  useSiweAuth,
+  type SiweAuthOptions,
+} from "../../core/hooks/auth/useSiweAuth.js";
 import type {
   ConnectButton_connectModalOptions,
   PayUIOptions,
@@ -23,6 +26,9 @@ import { ExecutingTxScreen } from "./TransactionButton/ExecutingScreen.js";
 import { DynamicHeight } from "./components/DynamicHeight.js";
 import { Spinner } from "./components/Spinner.js";
 import type { LocaleId } from "./types.js";
+import { useActiveAccount } from "../../core/hooks/wallets/useActiveAccount.js";
+import { useActiveWallet } from "../../core/hooks/wallets/useActiveWallet.js";
+import { AutoConnect } from "../../web/ui/AutoConnect/AutoConnect.js";
 
 /**
  * Props of [`PayEmbed`](https://portal.thirdweb.com/references/typescript/v5/PayEmbed) component
@@ -300,6 +306,13 @@ export function PayEmbed(props: PayEmbedProps) {
   const [screen, setScreen] = useState<"buy" | "execute-tx">("buy");
   const theme = props.theme || "dark";
   const connectionManager = useConnectionManager();
+  const activeAccount = useActiveAccount();
+  const activeWallet = useActiveWallet();
+  const siweAuth = useSiweAuth(
+    activeWallet,
+    activeAccount,
+    props.connectOptions?.auth,
+  );
 
   // Add props.chain and props.chains to defined chains store
   useEffect(() => {
@@ -342,6 +355,7 @@ export function PayEmbed(props: PayEmbedProps) {
   } else {
     content = (
       <>
+        <AutoConnect client={props.client} siweLogin={siweAuth.doLogin} />
         {screen === "buy" && (
           <BuyScreen
             title={metadata?.name || "Buy"}
@@ -459,10 +473,10 @@ export type PayEmbedConnectOptions = {
    * ```
    */
   autoConnect?:
-    | {
-        timeout: number;
-      }
-    | boolean;
+  | {
+    timeout: number;
+  }
+  | boolean;
 
   /**
    * Metadata of the app that will be passed to connected wallet. Setting this is highly recommended.

--- a/packages/thirdweb/src/react/web/ui/PayEmbed.tsx
+++ b/packages/thirdweb/src/react/web/ui/PayEmbed.tsx
@@ -10,15 +10,18 @@ import type { WalletId } from "../../../wallets/wallet-types.js";
 import { CustomThemeProvider } from "../../core/design-system/CustomThemeProvider.js";
 import type { Theme } from "../../core/design-system/index.js";
 import {
-  useSiweAuth,
   type SiweAuthOptions,
+  useSiweAuth,
 } from "../../core/hooks/auth/useSiweAuth.js";
 import type {
   ConnectButton_connectModalOptions,
   PayUIOptions,
 } from "../../core/hooks/connection/ConnectButtonProps.js";
+import { useActiveAccount } from "../../core/hooks/wallets/useActiveAccount.js";
+import { useActiveWallet } from "../../core/hooks/wallets/useActiveWallet.js";
 import { useConnectionManager } from "../../core/providers/connection-manager.js";
 import type { SupportedTokens } from "../../core/utils/defaultTokens.js";
+import { AutoConnect } from "../../web/ui/AutoConnect/AutoConnect.js";
 import { EmbedContainer } from "./ConnectWallet/Modal/ConnectEmbed.js";
 import { useConnectLocale } from "./ConnectWallet/locale/getConnectLocale.js";
 import BuyScreen from "./ConnectWallet/screens/Buy/BuyScreen.js";
@@ -26,9 +29,6 @@ import { ExecutingTxScreen } from "./TransactionButton/ExecutingScreen.js";
 import { DynamicHeight } from "./components/DynamicHeight.js";
 import { Spinner } from "./components/Spinner.js";
 import type { LocaleId } from "./types.js";
-import { useActiveAccount } from "../../core/hooks/wallets/useActiveAccount.js";
-import { useActiveWallet } from "../../core/hooks/wallets/useActiveWallet.js";
-import { AutoConnect } from "../../web/ui/AutoConnect/AutoConnect.js";
 
 /**
  * Props of [`PayEmbed`](https://portal.thirdweb.com/references/typescript/v5/PayEmbed) component
@@ -473,10 +473,10 @@ export type PayEmbedConnectOptions = {
    * ```
    */
   autoConnect?:
-  | {
-    timeout: number;
-  }
-  | boolean;
+    | {
+        timeout: number;
+      }
+    | boolean;
 
   /**
    * Metadata of the app that will be passed to connected wallet. Setting this is highly recommended.

--- a/packages/thirdweb/src/react/web/ui/PayEmbed.tsx
+++ b/packages/thirdweb/src/react/web/ui/PayEmbed.tsx
@@ -355,7 +355,7 @@ export function PayEmbed(props: PayEmbedProps) {
   } else {
     content = (
       <>
-        <AutoConnect client={props.client} siweLogin={siweAuth.doLogin} />
+        <AutoConnect client={props.client} siweAuth={siweAuth} />
         {screen === "buy" && (
           <BuyScreen
             title={metadata?.name || "Buy"}

--- a/packages/thirdweb/src/wallets/connection/autoConnectCore.ts
+++ b/packages/thirdweb/src/wallets/connection/autoConnectCore.ts
@@ -92,9 +92,9 @@ const _autoConnectCore = async ({
       clientId: props.client.clientId,
       ecosystem: isEcosystemWallet(wallet)
         ? {
-          id: wallet.id,
-          partnerId: wallet.getConfig()?.partnerId,
-        }
+            id: wallet.id,
+            partnerId: wallet.getConfig()?.partnerId,
+          }
         : undefined,
     });
     await clientStorage.saveAuthCookie(urlToken.authCookie);
@@ -150,9 +150,9 @@ const _autoConnectCore = async ({
       const connectedWallet = await (connectOverride
         ? connectOverride(activeWallet)
         : manager.connect(activeWallet, {
-          client: props.client,
-          accountAbstraction: props.accountAbstraction,
-        }));
+            client: props.client,
+            accountAbstraction: props.accountAbstraction,
+          }));
       if (connectedWallet) {
         autoConnected = true;
         try {

--- a/packages/thirdweb/src/wallets/connection/autoConnectCore.ts
+++ b/packages/thirdweb/src/wallets/connection/autoConnectCore.ts
@@ -192,8 +192,8 @@ const _autoConnectCore = async ({
   }
 
   // Auto-login with SIWE
-  if (urlToken && activeWallet && props.siweLogin) {
-    await props.siweLogin();
+  if (urlToken && activeWallet && props.siweAuth?.requiresAuth) {
+    await props.siweAuth?.doLogin();
   }
   manager.isAutoConnecting.setValue(false);
   return autoConnected; // useQuery needs a return value

--- a/packages/thirdweb/src/wallets/connection/types.ts
+++ b/packages/thirdweb/src/wallets/connection/types.ts
@@ -122,5 +122,8 @@ export type AutoConnectProps = {
   /**
    * @hidden
    */
-  siweLogin?: () => Promise<void>;
+  siweAuth?: {
+    requiresAuth: boolean;
+    doLogin: () => Promise<void>;
+  };
 };

--- a/packages/thirdweb/src/wallets/connection/types.ts
+++ b/packages/thirdweb/src/wallets/connection/types.ts
@@ -118,4 +118,9 @@ export type AutoConnectProps = {
    * Callback to be called when the connection is timeout-ed
    */
   onTimeout?: () => void;
+
+  /**
+   * @hidden
+   */
+  siweLogin?: () => Promise<void>;
 };

--- a/packages/thirdweb/src/wallets/in-app/core/wallet/is-in-app-signer.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/wallet/is-in-app-signer.ts
@@ -1,0 +1,21 @@
+import { isEcosystemWallet } from "../../../../wallets/ecosystem/is-ecosystem-wallet.js";
+import type { Wallet } from "../../../interfaces/wallet.js";
+import { isSmartWallet } from "../../../smart/index.js";
+import { isInAppWallet } from "./index.js";
+
+export function isInAppSigner(options: {
+  wallet: Wallet;
+  connectedWallets: Wallet[];
+}) {
+  const isInAppOrEcosystem = (w: Wallet) =>
+    isInAppWallet(w) || isEcosystemWallet(w);
+  const isSmartWalletWithAdmin =
+    isSmartWallet(options.wallet) &&
+    options.connectedWallets.some(
+      (w) =>
+        isInAppOrEcosystem(w) &&
+        w.getAccount()?.address?.toLowerCase() ===
+          options.wallet.getAdminAccount?.()?.address?.toLowerCase(),
+    );
+  return isInAppOrEcosystem(options.wallet) || isSmartWalletWithAdmin;
+}


### PR DESCRIPTION
…n auth is required

🤖 Generated with [Claude Code](https://claude.ai/code)

<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces automatic SIWE (Sign-In with Ethereum) authentication when a wallet is connected, enhancing user experience by streamlining the login process.

### Detailed summary
- Added `siweAuth` options to various components for handling SIWE authentication.
- Updated `ConnectButton` and `ConnectEmbed` to utilize `siweAuth`.
- Introduced `isInAppSigner` function to determine in-app wallet status.
- Modified `autoConnectCore` to support SIWE login logic.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->