### PR TITLE
postfix slash to engine url

### DIFF
--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/engine/dedicated/_utils/getEngineInstance.ts
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/engine/dedicated/_utils/getEngineInstance.ts
@@ -45,5 +45,9 @@ export async function getEngineInstance(params: {
     result: EngineInstance;
   };
 
+  if (!json.result.url.endsWith("/")) {
+    json.result.url += "/";
+  }
+
   return json.result;
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a check to ensure that the `url` property of the `json.result` object ends with a trailing slash. If it does not, the slash is appended.

### Detailed summary
- Added a conditional check to verify if `json.result.url` ends with a `/`.
- If it doesn't, a trailing slash is appended to `json.result.url`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->