### PR TITLE
[SDK] Expose inMemoryStorage for inAppWallet backend usage

### DIFF
--- a/.changeset/loud-points-count.md
+++ b/.changeset/loud-points-count.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Expose inMemoryStorage for inAppWallet backend usage

--- a/packages/thirdweb/src/exports/storage.ts
+++ b/packages/thirdweb/src/exports/storage.ts
@@ -11,3 +11,4 @@ export {
   type ResolveArweaveSchemeOptions,
 } from "../utils/arweave.js";
 export type { AsyncStorage } from "../utils/storage/AsyncStorage.js";
+export { inMemoryStorage } from "../utils/storage/inMemoryStorage.js";

--- a/packages/thirdweb/src/utils/storage/inMemoryStorage.ts
+++ b/packages/thirdweb/src/utils/storage/inMemoryStorage.ts
@@ -1,0 +1,15 @@
+import type { AsyncStorage } from "./AsyncStorage.js";
+
+const store = new Map<string, string>();
+
+export const inMemoryStorage: AsyncStorage = {
+  getItem: async (key: string) => {
+    return store.get(key) ?? null;
+  },
+  setItem: async (key: string, value: string) => {
+    store.set(key, value);
+  },
+  removeItem: async (key: string) => {
+    store.delete(key);
+  },
+};

--- a/packages/thirdweb/src/wallets/in-app/web/in-app.ts
+++ b/packages/thirdweb/src/wallets/in-app/web/in-app.ts
@@ -141,10 +141,14 @@ import type { InAppWalletCreationOptions } from "../core/wallet/types.js";
  *
  * ### Connect to a backend account
  *
+ * for usage in backends, you might also need to provide a 'storage' to store auth tokens. In-memory usually works for most purposes.
+ *
  * ```ts
  * import { inAppWallet } from "thirdweb/wallets";
  *
- * const wallet = inAppWallet();
+ * const wallet = inAppWallet({
+ *   storage: inMemoryStorage, // for usage in backends/scripts
+ * });
  *
  * const account = await wallet.connect({
  *   client,

--- a/packages/thirdweb/src/wallets/in-app/web/lib/in-app-backend.test.ts
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/in-app-backend.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { TEST_CLIENT } from "~test/test-clients.js";
+import { sepolia } from "../../../../chains/chain-definitions/sepolia.js";
+import { inMemoryStorage } from "../../../../utils/storage/inMemoryStorage.js";
+import { inAppWallet } from "../in-app.js";
+
+describe("InAppWallet", () => {
+  it("should sign a message with backend strategy", async () => {
+    const wallet = inAppWallet({
+      smartAccount: {
+        chain: sepolia,
+        sponsorGas: true,
+      },
+      storage: inMemoryStorage,
+    });
+    const account = await wallet.connect({
+      client: TEST_CLIENT,
+      strategy: "backend",
+      walletSecret: "test-secret",
+    });
+    expect(account.address).toBeDefined();
+    const message = await account.signMessage({
+      message: "Hello, world!",
+    });
+    expect(message).toBeDefined();
+  });
+});


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on exposing the `inMemoryStorage` for the `inAppWallet` backend, allowing for the storage of authentication tokens. It also includes tests for the `inAppWallet` using this new storage mechanism.

### Detailed summary
- Added export of `inMemoryStorage` in `packages/thirdweb/src/exports/storage.ts`.
- Implemented `inMemoryStorage` in `packages/thirdweb/src/utils/storage/inMemoryStorage.ts` with methods: `getItem`, `setItem`, and `removeItem`.
- Updated documentation in `packages/thirdweb/src/wallets/in-app/web/in-app.ts` to include usage of `inMemoryStorage`.
- Created a test for `inAppWallet` in `packages/thirdweb/src/wallets/in-app/web/lib/in-app-backend.test.ts` that verifies signing a message with backend strategy using `inMemoryStorage`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->