### PR TITLE
[NEB-245] Limit image format types for upload

### DIFF
--- a/apps/dashboard/src/@/components/ui/image-upload-button.tsx
+++ b/apps/dashboard/src/@/components/ui/image-upload-button.tsx
@@ -11,6 +11,7 @@ interface ImageUploadProps {
   variant?: React.ComponentProps<typeof Button>["variant"];
   className?: string;
   multiple?: boolean;
+  accept: string;
 }
 
 export function ImageUploadButton(props: ImageUploadProps) {
@@ -34,7 +35,7 @@ export function ImageUploadButton(props: ImageUploadProps) {
         ref={fileInputRef}
         type="file"
         multiple={props.multiple}
-        accept="image/*"
+        accept={props.accept}
         onChange={handleFileChange}
         className="hidden"
         aria-label="Upload image"

--- a/apps/dashboard/src/app/nebula-app/(app)/components/ChatBar.tsx
+++ b/apps/dashboard/src/app/nebula-app/(app)/components/ChatBar.tsx
@@ -254,6 +254,7 @@ export function ChatBar(props: {
                 <ImageUploadButton
                   multiple
                   value={undefined}
+                  accept="image/jpeg,image/png,image/webp"
                   onChange={(files) => {
                     const totalFiles = files.length + images.length;
 


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `ImageUploadButton` component to allow for more specific file type acceptance by adding an `accept` prop, which is used in the file input element.

### Detailed summary
- In `ChatBar.tsx`, added `accept="image/jpeg,image/png,image/webp"` to the file input.
- In `image-upload-button.tsx`, added `accept: string;` to the `ImageUploadProps` interface.
- Updated the `accept` attribute of the file input to use `props.accept` instead of a hardcoded value.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->