### PR TITLE
[NEB-238] Show ENS name in selected account badge

### DIFF
--- a/apps/dashboard/src/app/nebula-app/(app)/components/ChatBar.tsx
+++ b/apps/dashboard/src/app/nebula-app/(app)/components/ChatBar.tsx
@@ -484,7 +484,19 @@ function WalletSelector(props: {
                 <AccountBlobbie className="size-3 rounded-full" />
               }
             />
-            {shortenAddress(props.selectedAddress)}
+            <AccountName
+              className="text-xs"
+              loadingComponent={
+                <span className="text-xs">
+                  {shortenAddress(props.selectedAddress)}
+                </span>
+              }
+              fallbackComponent={
+                <span className="text-xs">
+                  {shortenAddress(props.selectedAddress)}
+                </span>
+              }
+            />
             <ChevronDownIcon className="size-3 text-muted-foreground/70" />
           </AccountProvider>
         </Button>
@@ -533,12 +545,12 @@ function WalletSelector(props: {
                           <AccountName
                             className="text-sm"
                             loadingComponent={
-                              <span className="font-mono text-sm">
+                              <span className="text-sm">
                                 {shortenAddress(wallet.address)}
                               </span>
                             }
                             fallbackComponent={
-                              <span className="font-mono text-sm">
+                              <span className="text-sm">
                                 {shortenAddress(wallet.address)}
                               </span>
                             }


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `ChatBar.tsx` component to improve the rendering of account names by modifying the `AccountName` component's `loadingComponent` and `fallbackComponent` properties to use consistent styling.

### Detailed summary
- Updated `loadingComponent` in `AccountName` to use a `span` with class `text-xs`.
- Updated `fallbackComponent` in `AccountName` to use a `span` with class `text-xs`.
- Changed the `span` class for the `loadingComponent` and `fallbackComponent` in `WalletSelector` from `font-mono text-sm` to `text-sm`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->