### PR TITLE
[SDK] Preload wallet balances on pay embed

### DIFF
--- a/.changeset/sour-flies-post.md
+++ b/.changeset/sour-flies-post.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Preload wallet balances on pay embed

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx
@@ -63,6 +63,7 @@ import { SwapFlow } from "./swap/SwapFlow.js";
 import { SwapScreenContent } from "./swap/SwapScreenContent.js";
 import { TokenSelectorScreen } from "./swap/TokenSelectorScreen.js";
 import { TransferFlow } from "./swap/TransferFlow.js";
+import { useWalletsAndBalances } from "./swap/fetchBalancesForWallet.js";
 import {
   type SupportedChainAndTokens,
   useBuySupportedDestinations,
@@ -217,6 +218,15 @@ function BuyScreenContent(props: BuyScreenContentProps) {
       props.supportedTokens,
     );
   }, [props.supportedTokens, supportedSourcesQuery.data, payOptions]);
+
+  // preload wallets and balances
+  useWalletsAndBalances({
+    client: props.client,
+    sourceSupportedTokens: sourceSupportedTokens || [],
+    toChain: toChain,
+    toToken: toToken,
+    mode: payOptions.mode,
+  });
 
   const { fromChain, setFromChain, fromToken, setFromToken } =
     useFromTokenSelectionStates({


### PR DESCRIPTION
Fixes TOOL-4477

<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on preloading wallet balances in the `BuyScreen` component by introducing a new hook, `useWalletsAndBalances`, which enhances the user experience by fetching wallet balances more efficiently.

### Detailed summary
- Added `useWalletsAndBalances` hook in `fetchBalancesForWallet.tsx`.
- Replaced the previous balance fetching logic in `TokenSelectorScreen.tsx` with the new hook.
- Preloaded wallet balances in `BuyScreenContent` using `useWalletsAndBalances`.
- Removed the old balance fetching code and related imports.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->