### PR TITLE
[SDK] Propagate 401 errors when connecting in-app wallet

### DIFF
--- a/.changeset/six-dryers-sing.md
+++ b/.changeset/six-dryers-sing.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Propagate 401 errors when connecting in-app wallet

--- a/packages/thirdweb/src/wallets/in-app/core/actions/get-enclave-user-status.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/actions/get-enclave-user-status.ts
@@ -17,7 +17,7 @@ export async function getUserStatus({
   authToken: string;
   client: ThirdwebClient;
   ecosystem?: Ecosystem;
-}): Promise<UserStatus | undefined> {
+}): Promise<UserStatus> {
   const clientFetch = getClientFetch(client, ecosystem);
   const response = await clientFetch(
     `${getThirdwebBaseUrl("inAppWallet")}/api/2024-05-05/accounts`,
@@ -32,12 +32,10 @@ export async function getUserStatus({
   );
 
   if (!response.ok) {
-    if (response.status === 401) {
-      // 401 response indicates there is no user logged in, so we return undefined
-      return undefined;
-    }
-    const result = await response.json();
-    throw new Error(`Failed to get user status: ${result.message}`);
+    const result = await response.text().catch(() => {
+      return "Unknown error";
+    });
+    throw new Error(`Failed to get user info: ${result}`);
   }
 
   return (await response.json()) as UserStatus;


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving error handling in the `getUserStatus` function within the `get-enclave-user-status.ts` file. It changes the way 401 errors are handled and modifies the return type of the function.

### Detailed summary
- Changed the return type of `getUserStatus` from `Promise<UserStatus | undefined>` to `Promise<UserStatus>`.
- Removed the handling of 401 errors that returned `undefined` when no user was logged in.
- Updated error handling to return a more descriptive error message using `response.text()` instead of `response.json()`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->