### PR TITLE
[Vault] default to engine-cloud vault proxy

### DIFF
--- a/.changeset/all-bears-visit.md
+++ b/.changeset/all-bears-visit.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/vault-sdk": patch
+---
+
+added secret key and default vault url


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces enhancements to the `createVaultClient` function in the `vault-sdk` package by adding support for an optional `secretKey` and updating the default `baseUrl`. It also modifies the request headers to include the `secretKey` when provided.

### Detailed summary
- Updated `createVaultClient` function to accept an optional `secretKey`.
- Set default `baseUrl` to "https://engine.thirdweb.com" if not provided.
- Constructed headers to include `x-secret-key` if `secretKey` is supplied.
- Simplified the headers assignment in the fetch request.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->