### PR TITLE
[SDK] Refactor: Switch PayEmbed Swap Quotes to use UB

### DIFF
--- a/.changeset/stale-yaks-bathe.md
+++ b/.changeset/stale-yaks-bathe.md
@@ -1,0 +1,154 @@
+---
+"thirdweb": minor
+---
+
+Adds Bridge.Transfer module for direct token transfers:
+
+```typescript
+import { Bridge, NATIVE_TOKEN_ADDRESS } from "thirdweb";
+
+const quote = await Bridge.Transfer.prepare({
+  chainId: 1,
+  tokenAddress: NATIVE_TOKEN_ADDRESS,
+  amount: toWei("0.01"),
+  sender: "0x...",
+  receiver: "0x...",
+  client: thirdwebClient,
+});
+```
+
+This will return a quote that might look like:
+```typescript
+{
+  originAmount: 10000026098875381n,
+  destinationAmount: 10000000000000000n,
+  blockNumber: 22026509n,
+  timestamp: 1741730936680,
+  estimatedExecutionTimeMs: 1000
+  steps: [
+    {
+      originToken: {
+        chainId: 1,
+        address: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+        symbol: "ETH",
+        name: "Ethereum",
+        decimals: 18,
+        priceUsd: 2000,
+        iconUri: "https://..."
+      },
+      destinationToken: {
+        chainId: 1,
+        address: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+        symbol: "ETH",
+        name: "Ethereum",
+        decimals: 18,
+        priceUsd: 2000,
+        iconUri: "https://..."
+      },
+      originAmount: 10000026098875381n,
+      destinationAmount: 10000000000000000n,
+      estimatedExecutionTimeMs: 1000
+      transactions: [
+        {
+          action: "approval",
+          id: "0x",
+          to: "0x...",
+          data: "0x...",
+          chainId: 1,
+          type: "eip1559"
+        },
+        {
+          action: "transfer",
+          to: "0x...",
+          value: 10000026098875381n,
+          data: "0x...",
+          chainId: 1,
+          type: "eip1559"
+        }
+      ]
+    }
+  ],
+  expiration: 1741730936680,
+  intent: {
+    chainId: 1,
+    tokenAddress: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+    amount: 10000000000000000n,
+    sender: "0x...",
+    receiver: "0x..."
+  }
+}
+```
+
+## Sending the transactions
+The `transactions` array is a series of [ox](https://oxlib.sh) EIP-1559 transactions that must be executed one after the other in order to fulfill the complete route. There are a few things to keep in mind when executing these transactions:
+ - Approvals will have the `approval` action specified. You can perform approvals with `sendAndConfirmTransaction`, then proceed to the next transaction.
+ - All transactions are assumed to be executed by the `sender` address, regardless of which chain they are on. The final transaction will use the `receiver` as the recipient address.
+ - If an `expiration` timestamp is provided, all transactions must be executed before that time to guarantee successful execution at the specified price.
+
+NOTE: To get the status of each non-approval transaction, use `Bridge.status` rather than checking for transaction inclusion. This function will ensure full completion of the transfer.
+
+You can include arbitrary data to be included on any webhooks and status responses with the `purchaseData` option:
+
+```ts
+const quote = await Bridge.Transfer.prepare({
+  chainId: 1,
+  tokenAddress: NATIVE_TOKEN_ADDRESS,
+  amount: toWei("0.01"),
+  sender: "0x...",
+  receiver: "0x...",
+  purchaseData: {
+    reference: "payment-123",
+    metadata: {
+      note: "Transfer to Alice"
+    }
+  },
+  client: thirdwebClient,
+});
+```
+
+## Fees
+There may be fees associated with the transfer. These fees are paid by the `feePayer` address, which defaults to the `sender` address. You can specify a different address with the `feePayer` option. If you do not specify an option or explicitly specify `sender`, the fees will be added to the input amount. If you specify the `receiver` as the fee payer the fees will be subtracted from the destination amount.
+
+For example, if you were to request a transfer with `feePayer` set to `receiver`:
+```typescript
+const quote = await Bridge.Transfer.prepare({
+  chainId: 1,
+  tokenAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // USDC
+  amount: 100_000_000n, // 100 USDC
+  sender: "0x...",
+  receiver: "0x...",
+  feePayer: "receiver",
+  client: thirdwebClient,
+});
+```
+
+The returned quote might look like:
+```typescript
+{
+  originAmount: 100_000_000n, // 100 USDC
+  destinationAmount: 99_970_000n, // 99.97 USDC
+  ...
+}
+```
+
+If you were to request a transfer with `feePayer` set to `sender`:
+```typescript
+const quote = await Bridge.Transfer.prepare({
+  chainId: 1,
+  tokenAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // USDC
+  amount: 100_000_000n, // 100 USDC
+  sender: "0x...",
+  receiver: "0x...",
+  feePayer: "sender",
+  client: thirdwebClient,
+});
+```
+
+The returned quote might look like:
+```typescript
+{
+  originAmount: 100_030_000n, // 100.03 USDC
+  destinationAmount: 100_000_000n, // 100 USDC
+  ...
+}
+```

--- a/packages/thirdweb/src/bridge/Buy.ts
+++ b/packages/thirdweb/src/bridge/Buy.ts
@@ -119,6 +119,7 @@ export async function quote(options: quote.Options): Promise<quote.Result> {
   url.searchParams.set("destinationChainId", destinationChainId.toString());
   url.searchParams.set("destinationTokenAddress", destinationTokenAddress);
   url.searchParams.set("buyAmountWei", amount.toString());
+  url.searchParams.set("amount", amount.toString());
   if (maxSteps) {
     url.searchParams.set("maxSteps", maxSteps.toString());
   }
@@ -199,7 +200,7 @@ export declare namespace quote {
  * This will return a quote that might look like:
  * ```typescript
  * {
- *   originAmount: 10000026098875381n,
+ *   originAmount: 2000030000n,
  *   destinationAmount: 1000000000000000000n,
  *   blockNumber: 22026509n,
  *   timestamp: 1741730936680,
@@ -208,11 +209,11 @@ export declare namespace quote {
  *     {
  *       originToken: {
  *         chainId: 1,
- *         address: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
- *         symbol: "ETH",
- *         name: "Ethereum",
- *         decimals: 18,
- *         priceUsd: 2000,
+ *         address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+ *         symbol: "USDC",
+ *         name: "USDC",
+ *         decimals: 6,
+ *         priceUsd: 1,
  *         iconUri: "https://..."
  *       },
  *       destinationToken: {
@@ -224,7 +225,7 @@ export declare namespace quote {
  *         priceUsd: 2000,
  *         iconUri: "https://..."
  *       },
- *       originAmount: 10000026098875381n,
+ *       originAmount: 2000030000n,
  *       destinationAmount: 1000000000000000000n,
  *       estimatedExecutionTimeMs: 1000
  *       transactions: [
@@ -250,7 +251,7 @@ export declare namespace quote {
  *   expiration: 1741730936680,
  *   intent: {
  *     originChainId: 1,
- *     originTokenAddress: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+ *     originTokenAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
  *     destinationChainId: 10,
  *     destinationTokenAddress: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
  *     amount: 1000000000000000000n
@@ -342,7 +343,8 @@ export async function prepare(
       "Content-Type": "application/json",
     },
     body: stringify({
-      buyAmountWei: amount.toString(),
+      buyAmountWei: amount.toString(), // legacy
+      amount: amount.toString(),
       originChainId: originChainId.toString(),
       originTokenAddress,
       destinationChainId: destinationChainId.toString(),
@@ -382,6 +384,8 @@ export async function prepare(
       destinationChainId,
       destinationTokenAddress,
       amount,
+      sender,
+      receiver,
     },
   };
 }
@@ -407,6 +411,8 @@ export declare namespace prepare {
       destinationChainId: number;
       destinationTokenAddress: ox__Address.Address;
       amount: bigint;
+      sender: ox__Address.Address;
+      receiver: ox__Address.Address;
       purchaseData?: unknown;
     };
   };

--- a/packages/thirdweb/src/bridge/Sell.ts
+++ b/packages/thirdweb/src/bridge/Sell.ts
@@ -118,6 +118,7 @@ export async function quote(options: quote.Options): Promise<quote.Result> {
   url.searchParams.set("destinationChainId", destinationChainId.toString());
   url.searchParams.set("destinationTokenAddress", destinationTokenAddress);
   url.searchParams.set("sellAmountWei", amount.toString());
+  url.searchParams.set("amount", amount.toString());
   if (typeof maxSteps !== "undefined") {
     url.searchParams.set("maxSteps", maxSteps.toString());
   }
@@ -190,7 +191,7 @@ export declare namespace quote {
  * This will return a quote that might look like:
  * ```typescript
  * {
- *   originAmount: 1000000000000000000n,
+ *   originAmount: 2000000000n,
  *   destinationAmount:  9980000000000000000n,
  *   blockNumber: 22026509n,
  *   timestamp: 1741730936680,
@@ -199,11 +200,11 @@ export declare namespace quote {
  *     {
  *       originToken: {
  *         chainId: 1,
- *         address: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
- *         symbol: "ETH",
- *         name: "Ethereum",
- *         decimals: 18,
- *         priceUsd: 2000,
+ *         address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+ *         symbol: "USDC",
+ *         name: "USDC",
+ *         decimals: 6,
+ *         priceUsd: 1,
  *         iconUri: "https://..."
  *       },
  *       destinationToken: {
@@ -215,7 +216,7 @@ export declare namespace quote {
  *         priceUsd: 2000,
  *         iconUri: "https://..."
  *       },
- *       originAmount: 1000000000000000000n,
+ *       originAmount: 2000000000n,
  *       destinationAmount:  9980000000000000000n,
  *       estimatedExecutionTimeMs: 1000
  *     }
@@ -241,10 +242,10 @@ export declare namespace quote {
  *   expiration: 1741730936680,
  *   intent: {
  *     originChainId: 1,
- *     originTokenAddress: NATIVE_TOKEN_ADDRESS,
+ *     originTokenAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
  *     destinationChainId: 10,
- *     destinationTokenAddress: NATIVE_TOKEN_ADDRESS,
- *     amount: 1000000000000000000n
+ *     destinationTokenAddress: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+ *     amount: 2000000000n
  *   }
  * }
  * ```
@@ -334,6 +335,7 @@ export async function prepare(
     },
     body: stringify({
       sellAmountWei: amount.toString(),
+      amount: amount.toString(),
       originChainId: originChainId.toString(),
       originTokenAddress,
       destinationChainId: destinationChainId.toString(),
@@ -374,6 +376,8 @@ export async function prepare(
       destinationChainId,
       destinationTokenAddress,
       amount,
+      sender,
+      receiver,
       purchaseData,
     },
   };
@@ -400,6 +404,8 @@ export declare namespace prepare {
       destinationChainId: number;
       destinationTokenAddress: ox__Address.Address;
       amount: bigint;
+      sender: ox__Address.Address;
+      receiver: ox__Address.Address;
       purchaseData?: unknown;
     };
   };

--- a/packages/thirdweb/src/bridge/Transfer.test.ts
+++ b/packages/thirdweb/src/bridge/Transfer.test.ts
@@ -1,0 +1,76 @@
+import { toWei } from "src/utils/units.js";
+import { describe, expect, it } from "vitest";
+import { TEST_CLIENT } from "~test/test-clients.js";
+import * as Transfer from "./Transfer.js";
+
+describe.runIf(process.env.TW_SECRET_KEY)("Bridge.Transfer.prepare", () => {
+  it("should get a valid prepared quote", async () => {
+    const quote = await Transfer.prepare({
+      chainId: 1,
+      tokenAddress: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+      amount: toWei("0.01"),
+      sender: "0x2a4f24F935Eb178e3e7BA9B53A5Ee6d8407C0709",
+      receiver: "0x2a4f24F935Eb178e3e7BA9B53A5Ee6d8407C0709",
+      client: TEST_CLIENT,
+      purchaseData: {
+        reference: "test-transfer",
+      },
+    });
+
+    expect(quote).toBeDefined();
+    expect(quote.intent.amount).toEqual(toWei("0.01"));
+    for (const step of quote.steps) {
+      expect(step.transactions.length).toBeGreaterThan(0);
+    }
+    expect(quote.intent).toBeDefined();
+  });
+
+  it("should surface any errors", async () => {
+    await expect(
+      Transfer.prepare({
+        chainId: 444, // Invalid chain ID
+        tokenAddress: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+        amount: toWei("1000000000"),
+        sender: "0x2a4f24F935Eb178e3e7BA9B53A5Ee6d8407C0709",
+        receiver: "0x2a4f24F935Eb178e3e7BA9B53A5Ee6d8407C0709",
+        client: TEST_CLIENT,
+      }),
+    ).rejects.toThrowError();
+  });
+
+  it("should support the feePayer option", async () => {
+    const senderQuote = await Transfer.prepare({
+      chainId: 1,
+      tokenAddress: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+      amount: toWei("0.01"),
+      sender: "0x2a4f24F935Eb178e3e7BA9B53A5Ee6d8407C0709",
+      receiver: "0x2a4f24F935Eb178e3e7BA9B53A5Ee6d8407C0709",
+      feePayer: "sender",
+      client: TEST_CLIENT,
+    });
+
+    expect(senderQuote).toBeDefined();
+    expect(senderQuote.intent.feePayer).toBe("sender");
+
+    const receiverQuote = await Transfer.prepare({
+      chainId: 1,
+      tokenAddress: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+      amount: toWei("0.01"),
+      sender: "0x2a4f24F935Eb178e3e7BA9B53A5Ee6d8407C0709",
+      receiver: "0x2a4f24F935Eb178e3e7BA9B53A5Ee6d8407C0709",
+      feePayer: "receiver",
+      client: TEST_CLIENT,
+    });
+
+    expect(receiverQuote).toBeDefined();
+    expect(receiverQuote.intent.feePayer).toBe("receiver");
+
+    // When receiver pays fees, the destination amount should be less than the requested amount
+    expect(receiverQuote.destinationAmount).toBeLessThan(toWei("0.01"));
+
+    // When sender pays fees, the origin amount should be more than the requested amount
+    // and the destination amount should equal the requested amount
+    expect(senderQuote.originAmount).toBeGreaterThan(toWei("0.01"));
+    expect(senderQuote.destinationAmount).toEqual(toWei("0.01"));
+  });
+});

--- a/packages/thirdweb/src/bridge/Transfer.ts
+++ b/packages/thirdweb/src/bridge/Transfer.ts
@@ -1,0 +1,270 @@
+import type { Address as ox__Address } from "ox";
+import { defineChain } from "../chains/utils.js";
+import type { ThirdwebClient } from "../client/client.js";
+import { getClientFetch } from "../utils/fetch.js";
+import { stringify } from "../utils/json.js";
+import { UNIVERSAL_BRIDGE_URL } from "./constants.js";
+import type { PreparedQuote } from "./types/Quote.js";
+
+/**
+ * Prepares a **finalized** Universal Bridge quote for the provided transfer request with transaction data.
+ *
+ * @example
+ * ```typescript
+ * import { Bridge, NATIVE_TOKEN_ADDRESS } from "thirdweb";
+ *
+ * const quote = await Bridge.Transfer.prepare({
+ *   chainId: 1,
+ *   tokenAddress: NATIVE_TOKEN_ADDRESS,
+ *   amount: toWei("0.01"),
+ *   sender: "0x...",
+ *   receiver: "0x...",
+ *   client: thirdwebClient,
+ * });
+ * ```
+ *
+ * This will return a quote that might look like:
+ * ```typescript
+ * {
+ *   originAmount: 10000026098875381n,
+ *   destinationAmount: 10000000000000000n,
+ *   blockNumber: 22026509n,
+ *   timestamp: 1741730936680,
+ *   estimatedExecutionTimeMs: 1000
+ *   steps: [
+ *     {
+ *       originToken: {
+ *         chainId: 1,
+ *         address: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+ *         symbol: "ETH",
+ *         name: "Ethereum",
+ *         decimals: 18,
+ *         priceUsd: 2000,
+ *         iconUri: "https://..."
+ *       },
+ *       destinationToken: {
+ *         chainId: 1,
+ *         address: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+ *         symbol: "ETH",
+ *         name: "Ethereum",
+ *         decimals: 18,
+ *         priceUsd: 2000,
+ *         iconUri: "https://..."
+ *       },
+ *       originAmount: 10000026098875381n,
+ *       destinationAmount: 10000000000000000n,
+ *       estimatedExecutionTimeMs: 1000
+ *       transactions: [
+ *         {
+ *           action: "approval",
+ *           id: "0x",
+ *           to: "0x...",
+ *           data: "0x...",
+ *           chainId: 1,
+ *           type: "eip1559"
+ *         },
+ *         {
+ *           action: "transfer",
+ *           to: "0x...",
+ *           value: 10000026098875381n,
+ *           data: "0x...",
+ *           chainId: 1,
+ *           type: "eip1559"
+ *         }
+ *       ]
+ *     }
+ *   ],
+ *   expiration: 1741730936680,
+ *   intent: {
+ *     chainId: 1,
+ *     tokenAddress: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+ *     amount: 10000000000000000n,
+ *     sender: "0x...",
+ *     receiver: "0x..."
+ *   }
+ * }
+ * ```
+ *
+ * ## Sending the transactions
+ * The `transactions` array is a series of [ox](https://oxlib.sh) EIP-1559 transactions that must be executed one after the other in order to fulfill the complete route. There are a few things to keep in mind when executing these transactions:
+ *  - Approvals will have the `approval` action specified. You can perform approvals with `sendAndConfirmTransaction`, then proceed to the next transaction.
+ *  - All transactions are assumed to be executed by the `sender` address, regardless of which chain they are on. The final transaction will use the `receiver` as the recipient address.
+ *  - If an `expiration` timestamp is provided, all transactions must be executed before that time to guarantee successful execution at the specified price.
+ *
+ * NOTE: To get the status of each non-approval transaction, use `Bridge.status` rather than checking for transaction inclusion. This function will ensure full completion of the transfer.
+ *
+ * You can access this functions input and output types with `Transfer.prepare.Options` and `Transfer.prepare.Result`, respectively.
+ *
+ * You can include arbitrary data to be included on any webhooks and status responses with the `purchaseData` option.
+ *
+ * ```ts
+ * const quote = await Bridge.Transfer.prepare({
+ *   chainId: 1,
+ *   tokenAddress: NATIVE_TOKEN_ADDRESS,
+ *   amount: toWei("0.01"),
+ *   sender: "0x...",
+ *   receiver: "0x...",
+ *   purchaseData: {
+ *     reference: "payment-123",
+ *     metadata: {
+ *       note: "Transfer to Alice"
+ *     }
+ *   },
+ *   client: thirdwebClient,
+ * });
+ * ```
+ *
+ * ## Fees
+ * There may be fees associated with the transfer. These fees are paid by the `feePayer` address, which defaults to the `sender` address. You can specify a different address with the `feePayer` option. If you do not specify an option or explicitly specify `sender`, the fees will be added to the input amount. If you specify the `receiver` as the fee payer the fees will be subtracted from the destination amount.
+ *
+ * For example, if you were to request a transfer with `feePayer` set to `receiver`:
+ * ```typescript
+ * const quote = await Bridge.Transfer.prepare({
+ *   chainId: 1,
+ *   tokenAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // USDC
+ *   amount: 100_000_000n, // 100 USDC
+ *   sender: "0x...",
+ *   receiver: "0x...",
+ *   feePayer: "receiver",
+ *   client: thirdwebClient,
+ * });
+ * ```
+ *
+ * The returned quote might look like:
+ * ```typescript
+ * {
+ *   originAmount: 100_000_000n, // 100 USDC
+ *   destinationAmount: 99_970_000n, // 99.97 USDC
+ *   ...
+ * }
+ * ```
+ *
+ * If you were to request a transfer with `feePayer` set to `sender`:
+ * ```typescript
+ * const quote = await Bridge.Transfer.prepare({
+ *   chainId: 1,
+ *   tokenAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // USDC
+ *   amount: 100_000_000n, // 100 USDC
+ *   sender: "0x...",
+ *   receiver: "0x...",
+ *   feePayer: "sender",
+ *   client: thirdwebClient,
+ * });
+ * ```
+ *
+ * The returned quote might look like:
+ * ```typescript
+ * {
+ *   originAmount: 100_030_000n, // 100.03 USDC
+ *   destinationAmount: 100_000_000n, // 100 USDC
+ *   ...
+ * }
+ * ```
+ *
+ * @param options - The options for the quote.
+ * @param options.chainId - The chain ID of the token.
+ * @param options.tokenAddress - The address of the token.
+ * @param options.amount - The amount of the token to transfer.
+ * @param options.sender - The address of the sender.
+ * @param options.receiver - The address of the recipient.
+ * @param options.purchaseData - Arbitrary data to be passed to the transfer function and included with any webhooks or status calls.
+ * @param options.client - Your thirdweb client.
+ * @param [options.feePayer] - The address that will pay the fees for the transfer. If not specified, the sender will be used. Values can be "sender" or "receiver".
+ *
+ * @returns A promise that resolves to a finalized quote and transactions for the requested transfer.
+ *
+ * @throws Will throw an error if there is an issue fetching the quote.
+ * @bridge Transfer
+ * @beta
+ */
+export async function prepare(
+  options: prepare.Options,
+): Promise<prepare.Result> {
+  const {
+    chainId,
+    tokenAddress,
+    sender,
+    receiver,
+    client,
+    amount,
+    purchaseData,
+    feePayer,
+  } = options;
+
+  const clientFetch = getClientFetch(client);
+  const url = new URL(`${UNIVERSAL_BRIDGE_URL}/transfer/prepare`);
+
+  const response = await clientFetch(url.toString(), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: stringify({
+      transferAmountWei: amount.toString(), // legacy
+      amount: amount.toString(),
+      chainId: chainId.toString(),
+      tokenAddress,
+      sender,
+      receiver,
+      purchaseData,
+      feePayer,
+    }),
+  });
+  if (!response.ok) {
+    const errorJson = await response.json();
+    throw new Error(
+      `${errorJson.code} | ${errorJson.message} - ${errorJson.correlationId}`,
+    );
+  }
+
+  const { data }: { data: PreparedQuote } = await response.json();
+  return {
+    originAmount: BigInt(data.originAmount),
+    destinationAmount: BigInt(data.destinationAmount),
+    blockNumber: data.blockNumber ? BigInt(data.blockNumber) : undefined,
+    timestamp: data.timestamp,
+    estimatedExecutionTimeMs: data.estimatedExecutionTimeMs,
+    steps: data.steps.map((step) => ({
+      ...step,
+      transactions: step.transactions.map((transaction) => ({
+        ...transaction,
+        value: transaction.value ? BigInt(transaction.value) : undefined,
+        client,
+        chain: defineChain(transaction.chainId),
+      })),
+    })),
+    intent: {
+      chainId,
+      tokenAddress,
+      amount,
+      sender,
+      receiver,
+      feePayer,
+    },
+  };
+}
+
+export declare namespace prepare {
+  type Options = {
+    chainId: number;
+    tokenAddress: ox__Address.Address;
+    sender: ox__Address.Address;
+    receiver: ox__Address.Address;
+    amount: bigint;
+    client: ThirdwebClient;
+    purchaseData?: unknown;
+    feePayer?: "sender" | "receiver";
+  };
+
+  type Result = PreparedQuote & {
+    intent: {
+      chainId: number;
+      tokenAddress: ox__Address.Address;
+      amount: bigint;
+      sender: ox__Address.Address;
+      receiver: ox__Address.Address;
+      purchaseData?: unknown;
+      feePayer?: "sender" | "receiver";
+    };
+  };
+}

--- a/packages/thirdweb/src/bridge/index.ts
+++ b/packages/thirdweb/src/bridge/index.ts
@@ -1,5 +1,6 @@
 export * as Buy from "./Buy.js";
 export * as Sell from "./Sell.js";
+export * as Transfer from "./Transfer.js";
 export { status } from "./Status.js";
 export { routes } from "./Routes.js";
 export { chains } from "./Chains.js";

--- a/packages/thirdweb/src/pay/buyWithCrypto/commonTypes.ts
+++ b/packages/thirdweb/src/pay/buyWithCrypto/commonTypes.ts
@@ -10,16 +10,6 @@ export type QuoteTokenInfo = {
   symbol?: string;
 };
 
-export type QuoteTransactionRequest = {
-  data: string;
-  to: string;
-  value: string;
-  from: string;
-  chainId: number;
-  gasPrice: string;
-  gasLimit: string;
-};
-
 export type QuoteApprovalInfo = {
   chainId: number;
   tokenAddress: string;

--- a/packages/thirdweb/src/pay/buyWithCrypto/getQuote.ts
+++ b/packages/thirdweb/src/pay/buyWithCrypto/getQuote.ts
@@ -1,15 +1,15 @@
-import type { Hash } from "viem";
+import { Value } from "ox";
+import * as Bridge from "../../bridge/index.js";
 import { getCachedChain } from "../../chains/utils.js";
 import type { ThirdwebClient } from "../../client/client.js";
+import { NATIVE_TOKEN_ADDRESS } from "../../constants/addresses.js";
+import { getContract } from "../../contract/contract.js";
+import { decimals } from "../../extensions/erc20/read/decimals.js";
 import type { PrepareTransactionOptions } from "../../transaction/prepare-transaction.js";
-import { getClientFetch } from "../../utils/fetch.js";
-import { stringify } from "../../utils/json.js";
-import { getPayBuyWithCryptoQuoteEndpoint } from "../utils/definitions.js";
 import type {
   QuoteApprovalInfo,
   QuotePaymentToken,
   QuoteTokenInfo,
-  QuoteTransactionRequest,
 } from "./commonTypes.js";
 
 /**
@@ -108,44 +108,6 @@ export type GetBuyWithCryptoQuoteParams = {
 /**
  * @buyCrypto
  */
-type BuyWithCryptoQuoteRouteResponse = {
-  transactionRequest: QuoteTransactionRequest;
-  approval?: QuoteApprovalInfo;
-
-  fromAddress: string;
-  toAddress: string;
-
-  fromToken: QuoteTokenInfo;
-  toToken: QuoteTokenInfo;
-
-  fromAmountWei: string;
-  fromAmount: string;
-
-  toAmountMinWei: string;
-  toAmountMin: string;
-  toAmountWei: string;
-  toAmount: string;
-
-  paymentTokens: QuotePaymentToken[];
-  processingFees: QuotePaymentToken[];
-
-  estimated: {
-    fromAmountUSDCents: number;
-    toAmountMinUSDCents: number;
-    toAmountUSDCents: number;
-    slippageBPS: number;
-    feesUSDCents: number;
-    gasCostUSDCents?: number;
-    durationSeconds?: number;
-  };
-
-  maxSlippageBPS: number;
-  bridge?: string;
-};
-
-/**
- * @buyCrypto
- */
 export type BuyWithCryptoQuote = {
   transactionRequest: PrepareTransactionOptions;
   approvalData?: QuoteApprovalInfo;
@@ -215,76 +177,200 @@ export async function getBuyWithCryptoQuote(
   params: GetBuyWithCryptoQuoteParams,
 ): Promise<BuyWithCryptoQuote> {
   try {
-    const clientFetch = getClientFetch(params.client);
-
-    const response = await clientFetch(getPayBuyWithCryptoQuoteEndpoint(), {
-      method: "POST",
-      headers: {
-        Accept: "application/json",
-        "Content-Type": "application/json",
-      },
-      body: stringify({
-        fromAddress: params.fromAddress,
-        toAddress: params.toAddress,
-        fromChainId: params.fromChainId.toString(),
-        fromTokenAddress: params.fromTokenAddress,
-        toChainId: params.toChainId.toString(),
-        toTokenAddress: params.toTokenAddress,
-        fromAmount: params.fromAmount,
-        toAmount: params.toAmount,
-        maxSlippageBPS: params.maxSlippageBPS,
-        intentId: params.intentId,
-        purchaseData: params.purchaseData,
-      }),
-    });
-
-    // Assuming the response directly matches the SwapResponse interface
-    if (!response.ok) {
-      const errorObj = await response.json();
-      if (errorObj && "error" in errorObj) {
-        throw errorObj;
+    const quote = await (async () => {
+      if (params.toAmount) {
+        const destinationTokenContract = getContract({
+          address: params.toTokenAddress,
+          chain: getCachedChain(params.toChainId),
+          client: params.client,
+        });
+        const tokenDecimals =
+          destinationTokenContract.address.toLowerCase() ===
+          NATIVE_TOKEN_ADDRESS
+            ? 18
+            : await decimals({
+                contract: destinationTokenContract,
+              });
+        const amount = Value.from(params.toAmount, tokenDecimals);
+        return Bridge.Buy.prepare({
+          sender: params.fromAddress,
+          receiver: params.toAddress,
+          originChainId: params.fromChainId,
+          originTokenAddress: params.fromTokenAddress,
+          destinationChainId: params.toChainId,
+          destinationTokenAddress: params.toTokenAddress,
+          amount: amount,
+          purchaseData: params.purchaseData,
+          client: params.client,
+        });
+      } else if (params.fromAmount) {
+        const originTokenContract = getContract({
+          address: params.fromTokenAddress,
+          chain: getCachedChain(params.fromChainId),
+          client: params.client,
+        });
+        const tokenDecimals = await decimals({
+          contract: originTokenContract,
+        });
+        const amount = Value.from(params.fromAmount, tokenDecimals);
+        return Bridge.Sell.prepare({
+          sender: params.fromAddress,
+          receiver: params.toAddress,
+          originChainId: params.fromChainId,
+          originTokenAddress: params.fromTokenAddress,
+          destinationChainId: params.toChainId,
+          destinationTokenAddress: params.toTokenAddress,
+          amount: amount,
+          purchaseData: params.purchaseData,
+          client: params.client,
+        });
       }
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
-
-    const data: BuyWithCryptoQuoteRouteResponse = (await response.json())
-      .result;
+      throw new Error(
+        "Invalid quote request, must provide either `fromAmount` or `toAmount`",
+      );
+    })();
 
     // check if the fromAddress already has approval for the given amount
-    const approvalData = data.approval;
+    const firstStep = quote.steps[0];
+    if (!firstStep) {
+      throw new Error(
+        "This quote is incompatible with getBuyWithCryptoQuote. Please use Bridge.Buy.prepare instead.",
+      );
+    }
+    const approvalTxs = firstStep.transactions.filter(
+      (tx) => tx.action === "approval",
+    );
+    if (approvalTxs.length > 1) {
+      throw new Error(
+        "This quote is incompatible with getBuyWithCryptoQuote. Please use Bridge.Buy.prepare instead.",
+      );
+    }
+    const approvalTx = approvalTxs[0];
+
+    const txs = firstStep.transactions.filter((tx) => tx.action !== "approval");
+    if (txs.length > 1) {
+      throw new Error(
+        "This quote is incompatible with getBuyWithCryptoQuote. Please use Bridge.Buy.prepare instead.",
+      );
+    }
+    const tx = txs[0];
+    if (!tx) {
+      throw new Error(
+        "This quote is incompatible with getBuyWithCryptoQuote. Please use Bridge.Buy.prepare instead.",
+      );
+    }
+
+    const approvalData: QuoteApprovalInfo | undefined = approvalTx
+      ? {
+          chainId: firstStep.originToken.chainId,
+          tokenAddress: firstStep.originToken.address,
+          spenderAddress: approvalTx.to,
+          amountWei: quote.originAmount.toString(),
+        }
+      : undefined;
 
     const swapRoute: BuyWithCryptoQuote = {
       transactionRequest: {
-        chain: getCachedChain(data.transactionRequest.chainId),
-        client: params.client,
-        data: data.transactionRequest.data as Hash,
-        to: data.transactionRequest.to,
-        value: BigInt(data.transactionRequest.value),
+        ...tx,
         extraGas: 50000n, // extra gas buffer
       },
       approvalData,
       swapDetails: {
-        fromAddress: data.fromAddress,
-        toAddress: data.toAddress,
+        fromAddress: quote.intent.sender,
+        toAddress: quote.intent.receiver,
 
-        fromToken: data.fromToken,
-        toToken: data.toToken,
+        fromToken: {
+          tokenAddress: firstStep.originToken.address,
+          chainId: firstStep.originToken.chainId,
+          decimals: firstStep.originToken.decimals,
+          symbol: firstStep.originToken.symbol,
+          name: firstStep.originToken.name,
+          priceUSDCents: firstStep.originToken.priceUsd * 100,
+        },
+        toToken: {
+          tokenAddress: firstStep.destinationToken.address,
+          chainId: firstStep.destinationToken.chainId,
+          decimals: firstStep.destinationToken.decimals,
+          symbol: firstStep.destinationToken.symbol,
+          name: firstStep.destinationToken.name,
+          priceUSDCents: firstStep.destinationToken.priceUsd * 100,
+        },
 
-        fromAmount: data.fromAmount,
-        fromAmountWei: data.fromAmountWei,
+        fromAmount: Value.format(
+          quote.originAmount,
+          firstStep.originToken.decimals,
+        ).toString(),
+        fromAmountWei: quote.originAmount.toString(),
 
-        toAmountMinWei: data.toAmountMinWei,
-        toAmountMin: data.toAmountMin,
+        toAmountMinWei: quote.destinationAmount.toString(),
+        toAmountMin: Value.format(
+          quote.destinationAmount,
+          firstStep.destinationToken.decimals,
+        ).toString(),
 
-        toAmountWei: data.toAmountWei,
-        toAmount: data.toAmount,
-        estimated: data.estimated,
+        toAmountWei: quote.destinationAmount.toString(),
+        toAmount: Value.format(
+          quote.destinationAmount,
+          firstStep.destinationToken.decimals,
+        ).toString(),
+        estimated: {
+          fromAmountUSDCents:
+            Number(
+              Value.format(quote.originAmount, firstStep.originToken.decimals),
+            ) *
+            firstStep.originToken.priceUsd *
+            100,
+          toAmountMinUSDCents:
+            Number(
+              Value.format(
+                quote.destinationAmount,
+                firstStep.destinationToken.decimals,
+              ),
+            ) *
+            firstStep.destinationToken.priceUsd *
+            100,
+          toAmountUSDCents:
+            Number(
+              Value.format(
+                quote.destinationAmount,
+                firstStep.destinationToken.decimals,
+              ),
+            ) *
+            firstStep.destinationToken.priceUsd *
+            100,
+          slippageBPS: 0,
+          feesUSDCents: 0,
+          gasCostUSDCents: 0,
+          durationSeconds: 0,
+        },
 
-        maxSlippageBPS: data.maxSlippageBPS,
+        maxSlippageBPS: 0,
       },
 
-      paymentTokens: data.paymentTokens,
-      processingFees: data.processingFees,
+      paymentTokens: [
+        {
+          token: {
+            tokenAddress: firstStep.originToken.address,
+            chainId: firstStep.originToken.chainId,
+            decimals: firstStep.originToken.decimals,
+            symbol: firstStep.originToken.symbol,
+            name: firstStep.originToken.name,
+            priceUSDCents: firstStep.originToken.priceUsd * 100,
+          },
+          amountWei: quote.originAmount.toString(),
+          amount: Value.format(
+            quote.originAmount,
+            firstStep.originToken.decimals,
+          ).toString(),
+          amountUSDCents:
+            Number(
+              Value.format(quote.originAmount, firstStep.originToken.decimals),
+            ) *
+            firstStep.originToken.priceUsd *
+            100,
+        },
+      ],
+      processingFees: [],
       client: params.client,
     };
 

--- a/packages/thirdweb/src/pay/utils/definitions.ts
+++ b/packages/thirdweb/src/pay/utils/definitions.ts
@@ -13,19 +13,6 @@ const getPayBaseUrl = () => {
  */
 export const getPayBuyWithCryptoStatusUrl = () =>
   `${getPayBaseUrl()}/buy-with-crypto/status/v1`;
-/**
- * Endpoint to get "Buy with Crypto" quote.
- * @internal
- */
-export const getPayBuyWithCryptoQuoteEndpoint = () =>
-  `${getPayBaseUrl()}/buy-with-crypto/quote/v1`;
-
-/**
- * Endpoint to get "Buy with Crypto" transfer.
- * @internal
- */
-export const getPayBuyWithCryptoTransferEndpoint = () =>
-  `${getPayBaseUrl()}/buy-with-crypto/transfer/v1`;
 
 /**
  * Endpoint to get a "Buy with Fiat" quote.

--- a/packages/thirdweb/src/utils/any-evm/zksync/constants.ts
+++ b/packages/thirdweb/src/utils/any-evm/zksync/constants.ts
@@ -3,6 +3,7 @@ export const ZKSYNC_SINGLETON_FACTORY =
 export const CONTRACT_DEPLOYER_ADDRESS =
   "0x0000000000000000000000000000000000008006" as const;
 export const KNOWN_CODES_STORAGE = "0x0000000000000000000000000000000000008004";
+// biome-ignore lint/nursery/noProcessEnv: Used for testing
 export const PUBLISHED_PRIVATE_KEY = process.env.ZKSYNC_PUBLISHED_PRIVATE_KEY;
 
 export const singletonFactoryAbi = [


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `Transfer` module for direct token transfers within the `thirdweb` SDK, enhancing the bridge functionality. It includes new methods for preparing transfer quotes and adds testing for the transfer functionality.

### Detailed summary
- Added `Transfer` export in `packages/thirdweb/src/bridge/index.ts`.
- Created `Transfer` module with the `prepare` method for token transfers.
- Updated `Buy` and `Sell` modules to include `amount` in transaction requests.
- Modified `getBuyWithCryptoTransfer` and `getBuyWithCryptoQuote` to utilize the new `Transfer` module.
- Added tests for the `Transfer` functionality in `packages/thirdweb/src/bridge/Transfer.test.ts`.
- Removed deprecated quote endpoint methods in `packages/thirdweb/src/pay/utils/definitions.ts`.
- Updated transaction data handling in `getTransfer.ts` and `getQuote.ts` to reflect changes in the transfer logic.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->