### PR TITLE
[SDK] Fix buyWithCrypto false not respected when returning from quote

### DIFF
--- a/.changeset/rich-peaches-cheer.md
+++ b/.changeset/rich-peaches-cheer.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix buyWithCrypto false not respected when going back from quote

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/BuyScreen.tsx
@@ -510,8 +510,9 @@ function BuyScreenContent(props: BuyScreenContentProps) {
               client={client}
               onBack={() => {
                 if (
-                  screen.id === "buy-with-crypto" ||
-                  screen.id === "buy-with-fiat"
+                  (screen.id === "buy-with-crypto" ||
+                    screen.id === "buy-with-fiat") &&
+                  enabledPaymentMethods.buyWithCryptoEnabled
                 ) {
                   setScreen({
                     id: "select-from-token",


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR addresses an issue where the `buyWithCrypto` option was not being respected when navigating back from the quote screen. It ensures that the correct payment method is enabled based on the current screen.

### Detailed summary
- Updated the condition in the `onBack` function to check if `enabledPaymentMethods.buyWithCryptoEnabled` is true.
- Ensured that the `screen.id` checks for `buy-with-crypto` and `buy-with-fiat` are properly combined with the new condition.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->