### PR TITLE
[Dashboard] Remove taint for THIRDWEB_ENGINE_URL

### DIFF
--- a/apps/dashboard/src/@/constants/server-envs.ts
+++ b/apps/dashboard/src/@/constants/server-envs.ts
@@ -36,14 +36,6 @@ if (API_SERVER_SECRET) {
 
 export const THIRDWEB_ENGINE_URL = process.env.THIRDWEB_ENGINE_URL || "";
 
-if (THIRDWEB_ENGINE_URL) {
-  experimental_taintUniqueValue(
-    "Do not pass THIRDWEB_ENGINE_URL to the client",
-    process,
-    THIRDWEB_ENGINE_URL,
-  );
-}
-
 export const THIRDWEB_ACCESS_TOKEN = process.env.THIRDWEB_ACCESS_TOKEN || "";
 
 if (THIRDWEB_ACCESS_TOKEN) {


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes a conditional block that was checking if the `THIRDWEB_ENGINE_URL` is set, along with a call to `experimental_taintUniqueValue`. This change simplifies the handling of the `THIRDWEB_ENGINE_URL` constant.

### Detailed summary
- Removed the conditional check for `THIRDWEB_ENGINE_URL`.
- Deleted the call to `experimental_taintUniqueValue` related to `THIRDWEB_ENGINE_URL`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->