### PR TITLE
[Docs] Update Engine Pricing

### DIFF
--- a/apps/portal/src/app/engine/v3/faq/page.mdx
+++ b/apps/portal/src/app/engine/v3/faq/page.mdx
@@ -3,11 +3,11 @@ import { Callout, Details } from "@doc";
 # Engine FAQs
 
 <Details summary="How is pricing calculated for Engine Cloud?">
-Pricing is calculated through the number of write requests (ex: /v1/write/contract) made through the Engine API. Requests cost $1 per 1,000 requests. Read requests made through Engine API are free, within the RPC limits/plan. 
+Pricing is calculated through the number of write requests (ex: /v1/write/contract) and sign requests (ex: /v1/sign/transaction) made through the Engine API. Write and sign requests cost $1 per 1,000 requests. Read requests made through Engine API are free, within the RPC limits/plan. 
 
 For transactions through server wallets paid through the user's thirdweb account, users will pay a 5% premium on the gas fee of each transaction completed on any mainnet as part of account abstraction fees. There are no gas charges for testnets.
 
-**Please note: Legacy pricing plans may be subject to the 10% fee instead of 5%. Please update your pricing plan to avoid being subject to the 10% fee.** 
+**Please note: Legacy pricing plans may be subject to the 10% fee specified when signed up instead of 5%. [See pricing page for updated plans and benefits](https://thirdweb.com/pricing)** 
 
 The breakdown for usage and transaction fees can be found in your usage dashboard under the team overview. 
 </Details>


### PR DESCRIPTION
CORE-0000

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the pricing information in the `page.mdx` file for Engine Cloud, clarifying the calculation of costs and modifying the legacy pricing note.

### Detailed summary
- Updated the pricing calculation to include `sign requests` alongside `write requests`.
- Clarified that both `write` and `sign requests` cost $1 per 1,000 requests.
- Revised the note about legacy pricing plans to specify a 10% fee when signed up instead of 5%, with a link to the pricing page.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->