### PR TITLE
fixing code snippets

### DIFF
--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/engine/cloud/server-wallets/components/try-it-out.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/engine/cloud/server-wallets/components/try-it-out.tsx
@@ -184,12 +184,7 @@ export function TryItOut() {
 }
 
 const sdkExample = () => `\
-import {
-  createThirdwebClient,
-  sendTransaction,
-  getContract,
-  Engine,
-} from "thirdweb";
+import {createThirdwebClient, sendTransaction, getContract, Engine} from "thirdweb";
 import { baseSepolia } from "thirdweb/chains";
 import { claimTo } from "thirdweb/extensions/erc1155";
 

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/engine/cloud/server-wallets/components/try-it-out.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/engine/cloud/server-wallets/components/try-it-out.tsx
@@ -184,9 +184,14 @@ export function TryItOut() {
 }
 
 const sdkExample = () => `\
-import { createThirdwebClient, sendTransaction, getContract, Engine } from "thirdweb";
+import {
+  createThirdwebClient,
+  sendTransaction,
+  getContract,
+  Engine,
+} from "thirdweb";
 import { baseSepolia } from "thirdweb/chains";
-import { claimTo } from "thirdweb/extensions/1155";
+import { claimTo } from "thirdweb/extensions/erc1155";
 
 // Create a thirdweb client
 const client = createThirdwebClient({
@@ -228,7 +233,7 @@ const txHash = await Engine.waitForTransactionHash({
   client,
   transactionId,
 });
-console.log("Transaction hash:", result.transactionHash);
+console.log("Transaction hash:", txHash);
 `;
 
 const curlExample = () => `\

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/engine/cloud/server-wallets/components/try-it-out.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/engine/cloud/server-wallets/components/try-it-out.tsx
@@ -184,7 +184,7 @@ export function TryItOut() {
 }
 
 const sdkExample = () => `\
-import {createThirdwebClient, sendTransaction, getContract, Engine} from "thirdweb";
+import { createThirdwebClient, sendTransaction, getContract, Engine } from "thirdweb";
 import { baseSepolia } from "thirdweb/chains";
 import { claimTo } from "thirdweb/extensions/erc1155";
 


### PR DESCRIPTION
fixing the code snippets for engine cloud docs

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the import path for the `claimTo` function from `thirdweb/extensions/1155` to `thirdweb/extensions/erc1155` and modifies a variable used in a console log statement to correctly reflect the transaction hash.

### Detailed summary
- Changed import path for `claimTo` from `thirdweb/extensions/1155` to `thirdweb/extensions/erc1155`.
- Updated the console log statement to use `txHash` instead of `result.transactionHash`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->