### PR TITLE
Fix: Bridge jsdoc to not mention ox

### DIFF
--- a/apps/dashboard/src/app/(app)/(dashboard)/(bridge)/routes/components/server/routes-table.tsx
+++ b/apps/dashboard/src/app/(app)/(dashboard)/(bridge)/routes/components/server/routes-table.tsx
@@ -57,7 +57,7 @@ async function getRoutesToRender(params: SearchParams) {
     }
   }
   // Temporary, will update this after the /routes endpoint
-  let routes = await getRoutes({ limit: 100_000 });
+  let routes = await getRoutes({ limit: 500_000 });
 
   const totalCount = routes.length;
 

--- a/packages/thirdweb/src/bridge/Buy.ts
+++ b/packages/thirdweb/src/bridge/Buy.ts
@@ -260,7 +260,7 @@ export declare namespace quote {
  * ```
  *
  * ## Sending the transactions
- * The `transactions` array is a series of [ox](https://oxlib.sh) EIP-1559 transactions that must be executed one after the other in order to fulfill the complete route. There are a few things to keep in mind when executing these transactions:
+ * The `transactions` array is a series of transactions ready to be executed (with `sendTransaction`) one after the other in order to fulfill the complete route. There are a few things to keep in mind when executing these transactions:
  *  - Approvals will have the `approval` action specified. You can perform approvals with `sendAndConfirmTransaction`, then proceed to the next transaction.
  *  - All transactions are assumed to be executed by the `sender` address, regardless of which chain they are on. The final transaction will use the `receiver` as the recipient address.
  *  - If an `expiration` timestamp is provided, all transactions must be executed before that time to guarantee successful execution at the specified price.

--- a/packages/thirdweb/src/bridge/Sell.ts
+++ b/packages/thirdweb/src/bridge/Sell.ts
@@ -251,7 +251,7 @@ export declare namespace quote {
  * ```
  *
  * ## Sending the transactions
- * The `transactions` array is a series of [ox](https://oxlib.sh) EIP-1559 transactions that must be executed one after the other in order to fulfill the complete route. There are a few things to keep in mind when executing these transactions:
+ * The `transactions` array is a series of transactions ready to be executed (with `sendTransaction`) must be executed one after the other in order to fulfill the complete route. There are a few things to keep in mind when executing these transactions:
  *  - Approvals will have the `approval` action specified. You can perform approvals with `sendAndConfirmTransaction`, then proceed to the next transaction.
  *  - All transactions are assumed to be executed by the `sender` address, regardless of which chain they are on. The final transaction will use the `receiver` as the recipient address.
  *  - If an `expiration` timestamp is provided, all transactions must be executed before that time to guarantee successful execution at the specified price.


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on increasing the limit for fetching routes and clarifying documentation regarding transaction execution in the `Buy` and `Sell` components.

### Detailed summary
- In `routes-table.tsx`, the route fetching limit is increased from `100,000` to `500,000`.
- In `Buy.ts`, the description of the `transactions` array is updated to emphasize readiness for execution with `sendTransaction`.
- In `Sell.ts`, similar updates are made to the `transactions` array description for clarity.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Increased the maximum number of routes fetched in the dashboard from 100,000 to 500,000, allowing users to view more routes initially.

- **Documentation**
  - Improved descriptions for transaction arrays in the Buy and Sell bridge features to provide clearer guidance on execution and usage. No changes to functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->