### PR TITLE
show block gas limit on the chain page

### DIFF
--- a/apps/dashboard/src/app/(app)/(dashboard)/(chain)/[chain_id]/(chainPage)/components/client/live-stats.tsx
+++ b/apps/dashboard/src/app/(app)/(dashboard)/(chain)/[chain_id]/(chainPage)/components/client/live-stats.tsx
@@ -32,8 +32,8 @@ function useChainStatswithRPC(_rpcUrl: string) {
         method: "POST",
         body: JSON.stringify({
           jsonrpc: "2.0",
-          method: "eth_blockNumber",
-          params: [],
+          method: "eth_getBlockByNumber",
+          params: ["latest", false],
           id: 1,
         }),
       });
@@ -41,9 +41,12 @@ function useChainStatswithRPC(_rpcUrl: string) {
       const json = await res.json();
       const latency = (performance.now() - startTimeStamp).toFixed(0);
 
+      const blockNumber = Number.parseInt(json.result.number, 16);
+      const blockGasLimit = Number.parseInt(json.result.gasLimit, 16);
       return {
         latency,
-        blockNumber: Number.parseInt(json.result, 16),
+        blockNumber,
+        blockGasLimit,
       };
     },
     refetchInterval: (query) => {
@@ -109,6 +112,21 @@ export function ChainLiveStats(props: { rpc: string }) {
           <p className="fade-in-0 animate-in text-destructive-text">N/A</p>
         ) : stats.data ? (
           <p className="fade-in-0 animate-in">{stats.data.blockNumber}</p>
+        ) : (
+          <div className="flex h-[28px] w-[140px] py-1">
+            <Skeleton className="h-full w-full" />
+          </div>
+        )}
+      </PrimaryInfoItem>
+
+      {/* Block Gas Limit */}
+      <PrimaryInfoItem title="Block Gas Limit" titleIcon={<PulseDot />}>
+        {stats.isError ? (
+          <p className="fade-in-0 animate-in text-destructive-text">N/A</p>
+        ) : stats.data ? (
+          <p className="fade-in-0 animate-in">
+            {stats.data.blockGasLimit ?? "N/A"}
+          </p>
         ) : (
           <div className="flex h-[28px] w-[140px] py-1">
             <Skeleton className="h-full w-full" />


### PR DESCRIPTION
## [Dashboard] Feature: Add Block Gas Limit to Chain Live Stats

## Notes for the reviewer

as requested by @0xFirekeeper 

This PR enhances the chain live stats component by adding the block gas limit information. The RPC method has been updated from `eth_blockNumber` to `eth_getBlockByNumber` to fetch additional block data including the gas limit.

## How to test

The block gas limit should now be displayed alongside other chain statistics in the dashboard. The component handles loading and error states appropriately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added display of the latest block's gas limit in the live stats section, including proper handling of loading, error, and unavailable states.

- **Enhancements**
  - Improved the accuracy of live stats by retrieving and displaying more detailed block information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `live-stats.tsx` component to fetch and display the latest block number and gas limit from the blockchain. It changes the RPC method used for fetching data and introduces new UI elements to present the block gas limit.

### Detailed summary
- Changed the RPC method from `eth_blockNumber` to `eth_getBlockByNumber`.
- Updated parameters to fetch the latest block and its details.
- Parsed and included `blockGasLimit` in the returned data.
- Added a new UI section to display the block gas limit in the component.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->