### PR TITLE
Rename "Secret Key" to "Webhook Secret" for consistency

### DIFF
--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/connect/universal-bridge/webhooks/components/webhooks.client.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/connect/universal-bridge/webhooks/components/webhooks.client.tsx
@@ -273,14 +273,14 @@ function CreateWebhookButton(props: PropsWithChildren<PayWebhooksPageProps>) {
             />
 
             <section>
-              <FormLabel>Secret Key</FormLabel>
+              <FormLabel>Webhook Secret</FormLabel>
 
               <CopyTextButton
                 textToCopy={secret}
                 className="!h-auto my-1 w-full justify-between truncate bg-card px-3 py-3 font-mono"
                 textToShow={shortenString(secret)}
                 copyIconPosition="right"
-                tooltip="Copy Secret Key"
+                tooltip="Copy Webhook Secret"
               />
               <FormDescription>
                 Passed as a bearer token in all webhook requests to verify the
@@ -293,7 +293,7 @@ function CreateWebhookButton(props: PropsWithChildren<PayWebhooksPageProps>) {
                     setSecretStored(!!v);
                   }}
                 />
-                I confirm that I've securely stored my secret key
+                I confirm that I've securely stored my webhook secret
               </CheckboxWithLabel>
             </section>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated labels and tooltips to use "Webhook Secret" instead of "Secret Key" for improved clarity in the webhook creation interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on renaming references to "Secret Key" to "Webhook Secret" throughout the `webhooks.client.tsx` file for clarity and consistency in terminology.

### Detailed summary
- Changed `<FormLabel>` text from `Secret Key` to `Webhook Secret`.
- Updated `tooltip` property in `CopyTextButton` from `Copy Secret Key` to `Copy Webhook Secret`.
- Modified confirmation text in `CheckboxWithLabel` from `I've securely stored my secret key` to `I've securely stored my webhook secret`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->