### PR TITLE
[SDK] Fix SIWE auth forcing unnecessary chain switch

### DIFF
--- a/.changeset/ten-parrots-poke.md
+++ b/.changeset/ten-parrots-poke.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix siwe auth always forcing a switch chain call

--- a/packages/thirdweb/src/react/core/hooks/auth/useSiweAuth.ts
+++ b/packages/thirdweb/src/react/core/hooks/auth/useSiweAuth.ts
@@ -97,7 +97,7 @@ export function useSiweAuth(
         import("../../../../auth/core/sign-login-payload.js"),
       ]);
 
-      if (payload.chain_id) {
+      if (payload.chain_id && Number(payload.chain_id) !== chain.id) {
         await activeWallet.switchChain(
           getCachedChain(Number(payload.chain_id)),
         );


### PR DESCRIPTION
Fixes TOOL-4554

<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing an issue in the `useSiweAuth` hook related to the authentication process by ensuring that a chain switch is only triggered when the `chain_id` in the payload is different from the current chain.

### Detailed summary
- Updated the condition in `useSiweAuth.ts` to check if `payload.chain_id` is both present and different from the current `chain.id` before calling `activeWallet.switchChain`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the SIWE (Sign-In with Ethereum) authentication process by preventing unnecessary chain switching, resulting in a smoother and more efficient authentication flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->