### PR TITLE
[Docs] Chore: Remove Kado references

### DIFF
--- a/apps/portal/src/app/pay/testing-pay/page.mdx
+++ b/apps/portal/src/app/pay/testing-pay/page.mdx
@@ -82,8 +82,6 @@ For other providers, you can use the following information when using any provid
 
 | Provider | Card Type    | Name        | Number              | Expiration Date | CVV          | Other Info                                                       |
 | -------- | ------------ | ----------- | ------------------- | --------------- | ------------ | ---------------------------------------------------------------- |
-| Kado     | Credit Card  | Test Credit | 4242 4242 4242 4242 | 01/25           | 123          | Test Phone Number: (234) 567-8909                                |
-| Kado     | Debit Card   | Test Debit  | 4659 1055 6905 1157 | 01/25           | 123          | Test Phone Number: (234) 567-8909                                |
 | Stripe   | Visa         | Any Name    | 4242 4242 4242 4242 | Any Future Date | Any 3 Digits | SSN: 000000000, Address line 1: address_full_match, OTP : 000000 |
 | Stripe   | Visa (Debit) | Any Name    | 4000 0566 5566 5556 | Any Future Date | Any 3 Digits | SSN: 000000000, Address line 1: address_full_match, OTP : 000000 |
 | Transak  | Visa         | Any Name    | 4111 1111 1111 1111 | 10/33           | 123          | Payment Authorization 3Ds screen password: **Checkout1!**        |
@@ -91,8 +89,6 @@ For other providers, you can use the following information when using any provid
 For Stripe testing, you can view more test cards [here](https://docs.stripe.com/testing).
 
 For Transak testing, you can view detailed information [here](https://docs.transak.com/docs/test-credentials#card-payments).
-
-For Kado testing, you can view detailed information [here](https://docs.kado.money/integrations/integrate-kado/sandbox).
 
 ## Buy With Crypto
 


### PR DESCRIPTION
As Kado was deprecated as an Onramp provider, here's a small PR to clean up the docs references

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the testing payment options by removing Kado entries and providing additional information for Transak testing.

### Detailed summary
- Removed Kado entries for `Credit Card` and `Debit Card` from the table.
- Kept entries for `Stripe` and `Transak`.
- Removed the link for Kado testing information.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Removed test card information and related references for the "Kado" provider from the documentation. Other provider details remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->