### PR TITLE
[SDK] Fix: Apply accentButtonText theme key to the Spinner inside of PayEmbed Buttons

### DIFF
--- a/.changeset/slick-apes-do.md
+++ b/.changeset/slick-apes-do.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix loading spinner theme color in PayEmbed

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/fiat/FiatScreenContent.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/fiat/FiatScreenContent.tsx
@@ -291,7 +291,7 @@ export function FiatScreenContent(props: {
           {fiatQuoteQuery.isLoading ? (
             <>
               Getting price quote
-              <Spinner size="sm" color="accentText" />
+              <Spinner size="sm" color="accentButtonText" />
             </>
           ) : (
             "Continue"

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/SwapScreenContent.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/SwapScreenContent.tsx
@@ -389,7 +389,7 @@ export function SwapScreenContent(props: {
           {quoteQuery.isLoading ? (
             <>
               Getting price quote
-              <Spinner size="sm" color="accentText" />
+              <Spinner size="sm" color="accentButtonText" />
             </>
           ) : (
             "Continue"


### PR DESCRIPTION
Various components in the codebase were a spinner was rendered inside a button, the `accentButtonText` key was applied to the spinner. This seems to make a bit more sense compared to using `accentText` which will make it hard to give the button a light color while keeping the rest dark, since the spinner color is related to the accentText rather than the button text colour.

Attached is a situation I was running into:
<img width="474" alt="Screenshot 2025-05-21 at 12 25 59" src="https://github.com/user-attachments/assets/ea6429f7-2691-4864-b70c-ae18164031f0" />

Changing the theme key that's applied to be `accentTextButton` throughout all <Spinner> components rendered inside of a <Button> makes things nice and consistent, and resolves the above scenario.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the theme color of the loading spinner in the `PayEmbed` component to enhance visual consistency.

### Detailed summary
- Updated the `color` prop of the `<Spinner>` component in `FiatScreenContent.tsx` from `accentText` to `accentButtonText`.
- Updated the `color` prop of the `<Spinner>` component in `SwapScreenContent.tsx` from `accentText` to `accentButtonText`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated the loading spinner color on the fiat and swap screens for improved visual consistency.
  - Fixed the loading spinner color in the payment embed component for better theme alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->