### PR TITLE
Remove advancedEnabled field from Account interface

### DIFF
--- a/apps/dashboard/src/@3rdweb-sdk/react/hooks/useApi.ts
+++ b/apps/dashboard/src/@3rdweb-sdk/react/hooks/useApi.ts
@@ -32,7 +32,6 @@ export type Account = {
   image?: string | null;
   name?: string;
   email?: string;
-  advancedEnabled: boolean;
   emailConfirmedAt?: string;
   unconfirmedEmail?: string;
   emailConfirmationWalletAddress?: string;
@@ -41,7 +40,6 @@ export type Account = {
     billing: "email" | "none";
     updates: "email" | "none";
   };
-  // TODO - add image URL
 };
 
 interface UpdateAccountNotificationsInput {

--- a/apps/dashboard/src/stories/stubs.ts
+++ b/apps/dashboard/src/stories/stubs.ts
@@ -333,7 +333,6 @@ export function newAccountStub(overrides?: Partial<Account>): Account {
     name: undefined,
     id: "foo",
     isStaff: false,
-    advancedEnabled: false,
     creatorWalletAddress: "0x1F846F6DAE38E1C88D71EAA191760B15f38B7A37",
     ...overrides,
   };


### PR DESCRIPTION
### TL;DR

Removed the `advancedEnabled` property from the Account type and cleaned up a TODO comment.

### What changed?

- Removed the `advancedEnabled` boolean property from the Account type definition in `useApi.ts`
- Removed a TODO comment about adding image URL in the Account type
- Updated the `newAccountStub` function in `stubs.ts` to remove the `advancedEnabled` property from the default account stub

### How to test?

1. Verify that any components or functions using the Account type don't reference the removed `advancedEnabled` property
2. Check that the account stub is properly created without the `advancedEnabled` property
3. Ensure that any UI components that previously used this property are updated accordingly

### Why make this change?

The `advancedEnabled` property is no longer needed in the Account type, likely because this feature flag has been deprecated or the functionality has been restructured. Removing unused properties keeps the codebase clean and prevents confusion about which fields are actually used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the "advancedEnabled" property from account-related data. This change does not affect user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->