### PR TITLE
[SDK] Improve error handling in PayEmbed

### DIFF
--- a/.changeset/blue-comics-doubt.md
+++ b/.changeset/blue-comics-doubt.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Better error messages in PayEmbed

--- a/packages/thirdweb/src/bridge/Buy.ts
+++ b/packages/thirdweb/src/bridge/Buy.ts
@@ -4,6 +4,7 @@ import type { ThirdwebClient } from "../client/client.js";
 import { getThirdwebBaseUrl } from "../utils/domains.js";
 import { getClientFetch } from "../utils/fetch.js";
 import { stringify } from "../utils/json.js";
+import { ApiError } from "./types/Errors.js";
 import type { PreparedQuote, Quote } from "./types/Quote.js";
 
 /**
@@ -127,9 +128,12 @@ export async function quote(options: quote.Options): Promise<quote.Result> {
   const response = await clientFetch(url.toString());
   if (!response.ok) {
     const errorJson = await response.json();
-    throw new Error(
-      `${errorJson.code} | ${errorJson.message} - ${errorJson.correlationId}`,
-    );
+    throw new ApiError({
+      code: errorJson.code || "UNKNOWN_ERROR",
+      message: errorJson.message || response.statusText,
+      correlationId: errorJson.correlationId || undefined,
+      statusCode: response.status,
+    });
   }
 
   const { data }: { data: Quote } = await response.json();
@@ -357,9 +361,12 @@ export async function prepare(
   });
   if (!response.ok) {
     const errorJson = await response.json();
-    throw new Error(
-      `${errorJson.code} | ${errorJson.message} - ${errorJson.correlationId}`,
-    );
+    throw new ApiError({
+      code: errorJson.code || "UNKNOWN_ERROR",
+      message: errorJson.message || response.statusText,
+      correlationId: errorJson.correlationId || undefined,
+      statusCode: response.status,
+    });
   }
 
   const { data }: { data: PreparedQuote } = await response.json();

--- a/packages/thirdweb/src/bridge/Chains.ts
+++ b/packages/thirdweb/src/bridge/Chains.ts
@@ -2,6 +2,7 @@ import type { ThirdwebClient } from "../client/client.js";
 import { getThirdwebBaseUrl } from "../utils/domains.js";
 import { getClientFetch } from "../utils/fetch.js";
 import type { Chain } from "./types/Chain.js";
+import { ApiError } from "./types/Errors.js";
 
 /**
  * Retrieves supported Universal Bridge chains.
@@ -59,7 +60,12 @@ export async function chains(options: chains.Options): Promise<chains.Result> {
   const response = await clientFetch(url.toString());
   if (!response.ok) {
     const errorJson = await response.json();
-    throw new Error(`${errorJson.code} | ${errorJson.message}`);
+    throw new ApiError({
+      code: errorJson.code || "UNKNOWN_ERROR",
+      message: errorJson.message || response.statusText,
+      correlationId: errorJson.correlationId || undefined,
+      statusCode: response.status,
+    });
   }
 
   const { data }: { data: Chain[] } = await response.json();

--- a/packages/thirdweb/src/bridge/Onramp.ts
+++ b/packages/thirdweb/src/bridge/Onramp.ts
@@ -3,6 +3,7 @@ import type { ThirdwebClient } from "../client/client.js";
 import { getThirdwebBaseUrl } from "../utils/domains.js";
 import { getClientFetch } from "../utils/fetch.js";
 import { stringify } from "../utils/json.js";
+import { ApiError } from "./types/Errors.js";
 import type { RouteStep } from "./types/Route.js";
 import type { Token } from "./types/Token.js";
 
@@ -191,9 +192,12 @@ export async function prepare(
 
   if (!response.ok) {
     const errorJson = await response.json();
-    throw new Error(
-      `${errorJson.code || response.status} | ${errorJson.message || response.statusText} - ${errorJson.correlationId || "N/A"}`,
-    );
+    throw new ApiError({
+      code: errorJson.code || "UNKNOWN_ERROR",
+      message: errorJson.message || response.statusText,
+      correlationId: errorJson.correlationId || undefined,
+      statusCode: response.status,
+    });
   }
 
   const { data }: { data: OnrampPrepareQuoteResponseData } =

--- a/packages/thirdweb/src/bridge/OnrampStatus.ts
+++ b/packages/thirdweb/src/bridge/OnrampStatus.ts
@@ -2,6 +2,7 @@ import type { Hex as ox__Hex } from "ox";
 import type { ThirdwebClient } from "../client/client.js";
 import { getThirdwebBaseUrl } from "../utils/domains.js";
 import { getClientFetch } from "../utils/fetch.js";
+import { ApiError } from "./types/Errors.js";
 
 /**
  * Retrieves the status of an Onramp session created via {@link Bridge.Onramp.prepare}. The
@@ -72,9 +73,12 @@ export async function status(options: status.Options): Promise<status.Result> {
   const response = await clientFetch(url.toString());
   if (!response.ok) {
     const errorJson = await response.json();
-    throw new Error(
-      `${errorJson.code || response.status} | ${errorJson.message || response.statusText} - ${errorJson.correlationId || "N/A"}`,
-    );
+    throw new ApiError({
+      code: errorJson.code || "UNKNOWN_ERROR",
+      message: errorJson.message || response.statusText,
+      correlationId: errorJson.correlationId || undefined,
+      statusCode: response.status,
+    });
   }
 
   const { data }: { data: status.Result } = await response.json();

--- a/packages/thirdweb/src/bridge/Routes.test.ts
+++ b/packages/thirdweb/src/bridge/Routes.test.ts
@@ -155,7 +155,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("Bridge.routes", () => {
         offset: 1000,
       }),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `[Error: InvalidRoutesRequest | The provided request is invalid.]`,
+      "[Error: The provided request is invalid.]",
     );
   });
 });

--- a/packages/thirdweb/src/bridge/Routes.ts
+++ b/packages/thirdweb/src/bridge/Routes.ts
@@ -2,6 +2,7 @@ import type { Address as ox__Address, Hex as ox__Hex } from "ox";
 import type { ThirdwebClient } from "../client/client.js";
 import { getThirdwebBaseUrl } from "../utils/domains.js";
 import { getClientFetch } from "../utils/fetch.js";
+import { ApiError } from "./types/Errors.js";
 import type { Route } from "./types/Route.js";
 
 /**
@@ -162,7 +163,12 @@ export async function routes(options: routes.Options): Promise<routes.Result> {
   const response = await clientFetch(url.toString());
   if (!response.ok) {
     const errorJson = await response.json();
-    throw new Error(`${errorJson.code} | ${errorJson.message}`);
+    throw new ApiError({
+      code: errorJson.code || "UNKNOWN_ERROR",
+      message: errorJson.message || response.statusText,
+      correlationId: errorJson.correlationId || undefined,
+      statusCode: response.status,
+    });
   }
 
   const { data }: { data: Route[] } = await response.json();

--- a/packages/thirdweb/src/bridge/Sell.ts
+++ b/packages/thirdweb/src/bridge/Sell.ts
@@ -4,6 +4,7 @@ import type { ThirdwebClient } from "../client/client.js";
 import { getThirdwebBaseUrl } from "../utils/domains.js";
 import { getClientFetch } from "../utils/fetch.js";
 import { stringify } from "../utils/json.js";
+import { ApiError } from "./types/Errors.js";
 import type { PreparedQuote, Quote } from "./types/Quote.js";
 
 /**
@@ -126,9 +127,12 @@ export async function quote(options: quote.Options): Promise<quote.Result> {
   const response = await clientFetch(url.toString());
   if (!response.ok) {
     const errorJson = await response.json();
-    throw new Error(
-      `${errorJson.code} | ${errorJson.message} - ${errorJson.correlationId}`,
-    );
+    throw new ApiError({
+      code: errorJson.code || "UNKNOWN_ERROR",
+      message: errorJson.message || response.statusText,
+      correlationId: errorJson.correlationId || undefined,
+      statusCode: response.status,
+    });
   }
 
   const { data }: { data: Quote } = await response.json();
@@ -348,9 +352,12 @@ export async function prepare(
   });
   if (!response.ok) {
     const errorJson = await response.json();
-    throw new Error(
-      `${errorJson.code} | ${errorJson.message} - ${errorJson.correlationId}`,
-    );
+    throw new ApiError({
+      code: errorJson.code || "UNKNOWN_ERROR",
+      message: errorJson.message || response.statusText,
+      correlationId: errorJson.correlationId || undefined,
+      statusCode: response.status,
+    });
   }
 
   const { data }: { data: PreparedQuote } = await response.json();

--- a/packages/thirdweb/src/bridge/Status.ts
+++ b/packages/thirdweb/src/bridge/Status.ts
@@ -3,6 +3,7 @@ import type { Chain } from "../chains/types.js";
 import type { ThirdwebClient } from "../client/client.js";
 import { getThirdwebBaseUrl } from "../utils/domains.js";
 import { getClientFetch } from "../utils/fetch.js";
+import { ApiError } from "./types/Errors.js";
 import type { Status } from "./types/Status.js";
 
 /**
@@ -115,9 +116,12 @@ export async function status(options: status.Options): Promise<status.Result> {
   const response = await clientFetch(url.toString());
   if (!response.ok) {
     const errorJson = await response.json();
-    throw new Error(
-      `${errorJson.code} | ${errorJson.message} - ${errorJson.correlationId}`,
-    );
+    throw new ApiError({
+      code: errorJson.code || "UNKNOWN_ERROR",
+      message: errorJson.message || response.statusText,
+      correlationId: errorJson.correlationId || undefined,
+      statusCode: response.status,
+    });
   }
 
   const { data }: { data: Status } = await response.json();

--- a/packages/thirdweb/src/bridge/Transfer.ts
+++ b/packages/thirdweb/src/bridge/Transfer.ts
@@ -4,6 +4,7 @@ import type { ThirdwebClient } from "../client/client.js";
 import { getThirdwebBaseUrl } from "../utils/domains.js";
 import { getClientFetch } from "../utils/fetch.js";
 import { stringify } from "../utils/json.js";
+import { ApiError } from "./types/Errors.js";
 import type { PreparedQuote } from "./types/Quote.js";
 
 /**
@@ -212,9 +213,12 @@ export async function prepare(
   });
   if (!response.ok) {
     const errorJson = await response.json();
-    throw new Error(
-      `${errorJson.code} | ${errorJson.message} - ${errorJson.correlationId}`,
-    );
+    throw new ApiError({
+      code: errorJson.code || "UNKNOWN_ERROR",
+      message: errorJson.message || response.statusText,
+      correlationId: errorJson.correlationId || undefined,
+      statusCode: response.status,
+    });
   }
 
   const { data }: { data: PreparedQuote } = await response.json();

--- a/packages/thirdweb/src/bridge/index.ts
+++ b/packages/thirdweb/src/bridge/index.ts
@@ -16,4 +16,5 @@ export type {
 } from "./types/Route.js";
 export type { Status } from "./types/Status.js";
 export type { Token } from "./types/Token.js";
-export type { BridgeAction } from "./types/BridgeAction.js";
+export type { Action } from "./types/BridgeAction.js";
+export type { ApiError } from "./types/Errors.js";

--- a/packages/thirdweb/src/bridge/types/BridgeAction.ts
+++ b/packages/thirdweb/src/bridge/types/BridgeAction.ts
@@ -1,1 +1,1 @@
-export type BridgeAction = "approval" | "transfer" | "buy" | "sell";
+export type Action = "approval" | "transfer" | "buy" | "sell";

--- a/packages/thirdweb/src/bridge/types/Errors.ts
+++ b/packages/thirdweb/src/bridge/types/Errors.ts
@@ -1,0 +1,24 @@
+type ErrorCode =
+  | "INVALID_INPUT"
+  | "ROUTE_NOT_FOUND"
+  | "AMOUNT_TOO_LOW"
+  | "AMOUNT_TOO_HIGH"
+  | "UNKNOWN_ERROR";
+
+export class ApiError extends Error {
+  code: ErrorCode;
+  correlationId?: string;
+  statusCode: number;
+
+  constructor(args: {
+    code: ErrorCode;
+    message: string;
+    statusCode: number;
+    correlationId?: string;
+  }) {
+    super(args.message);
+    this.code = args.code;
+    this.correlationId = args.correlationId;
+    this.statusCode = args.statusCode;
+  }
+}

--- a/packages/thirdweb/src/bridge/types/Route.ts
+++ b/packages/thirdweb/src/bridge/types/Route.ts
@@ -1,7 +1,7 @@
 import type { Hex as ox__Hex } from "ox";
 import type { Chain } from "../../chains/types.js";
 import type { ThirdwebClient } from "../../client/client.js";
-import type { BridgeAction } from "./BridgeAction.js";
+import type { Action } from "./BridgeAction.js";
 import type { Token } from "./Token.js";
 
 export type Route = {
@@ -35,7 +35,7 @@ export type RouteTransaction = {
   /**
    * The action this transaction performs. This can be "approval", "transfer", "buy", or "sell".
    */
-  action: BridgeAction;
+  action: Action;
   /**
    * The transaction ID, used for tracking purposes.
    */

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/PayWIthCreditCard.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/PayWIthCreditCard.tsx
@@ -85,7 +85,7 @@ export function PayWithCreditCard(props: {
             {props.value
               ? `${props.currency.symbol}${formatNumber(
                   Number(props.value),
-                  6,
+                  2,
                 )}`
               : "--"}
           </Text>

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/fiat/FiatScreenContent.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/fiat/FiatScreenContent.tsx
@@ -5,7 +5,6 @@ import type { Chain } from "../../../../../../../chains/types.js";
 import type { ThirdwebClient } from "../../../../../../../client/client.js";
 import { NATIVE_TOKEN_ADDRESS } from "../../../../../../../constants/addresses.js";
 import type { FiatProvider } from "../../../../../../../pay/utils/commonTypes.js";
-import { formatNumber } from "../../../../../../../utils/formatNumber.js";
 import {
   type Theme,
   iconSize,
@@ -25,7 +24,6 @@ import { Spinner } from "../../../../components/Spinner.js";
 import { Container } from "../../../../components/basic.js";
 import { Button } from "../../../../components/buttons.js";
 import { Text } from "../../../../components/text.js";
-import { TokenSymbol } from "../../../../components/token/TokenSymbol.js";
 import { type ERC20OrNativeToken, isNativeToken } from "../../nativeToken.js";
 import { EstimatedTimeAndFees } from "../EstimatedTimeAndFees.js";
 import { PayWithCreditCard } from "../PayWIthCreditCard.js";
@@ -227,77 +225,43 @@ export function FiatScreenContent(props: {
         {/* Error message */}
         {errorMsg && (
           <div>
-            {errorMsg.data?.minimumAmountEth ? (
-              <Text color="danger" size="sm" center multiline>
-                Minimum amount is{" "}
-                {formatNumber(Number(errorMsg.data.minimumAmountEth), 6)}{" "}
-                <TokenSymbol
-                  token={toToken}
-                  chain={toChain}
-                  size="sm"
-                  inline
-                  color="danger"
-                />
-              </Text>
-            ) : (
-              <div>
-                <Text color="danger" size="xs" center multiline>
-                  {errorMsg.title}
-                </Text>
-                <Text size="xs" center multiline>
-                  {errorMsg.message}
-                </Text>
-              </div>
-            )}
+            <Text color="danger" size="xs" center multiline>
+              {errorMsg.title}
+            </Text>
+            <Text size="xs" center multiline>
+              {errorMsg.message}
+            </Text>
           </div>
         )}
       </Container>
 
-      {errorMsg?.data?.minimumAmountEth ? (
-        <Button
-          variant="accent"
-          fullWidth
-          onClick={() => {
-            props.setTokenAmount(
-              formatNumber(
-                Number(errorMsg.data?.minimumAmountEth),
-                6,
-              ).toString(),
-            );
-            props.setHasEditedAmount(true);
-          }}
-        >
-          Set Minimum
-        </Button>
-      ) : (
-        <Button
-          variant={disableSubmit ? "outline" : "accent"}
-          data-disabled={disableSubmit}
-          disabled={disableSubmit}
-          fullWidth
-          onClick={() => {
-            trackPayEvent({
-              event: "confirm_onramp_quote",
-              client: client,
-              walletAddress: payer.account.address,
-              walletType: payer.wallet.id,
-              toChainId: toChain.id,
-              toToken: isNativeToken(toToken) ? undefined : toToken.address,
-            });
-            handleSubmit();
-          }}
-          gap="xs"
-        >
-          {fiatQuoteQuery.isLoading ? (
-            <>
-              Getting price quote
-              <Spinner size="sm" color="accentButtonText" />
-            </>
-          ) : (
-            "Continue"
-          )}
-        </Button>
-      )}
+      <Button
+        variant={disableSubmit ? "outline" : "accent"}
+        data-disabled={disableSubmit}
+        disabled={disableSubmit}
+        fullWidth
+        onClick={() => {
+          trackPayEvent({
+            event: "confirm_onramp_quote",
+            client: client,
+            walletAddress: payer.account.address,
+            walletType: payer.wallet.id,
+            toChainId: toChain.id,
+            toToken: isNativeToken(toToken) ? undefined : toToken.address,
+          });
+          handleSubmit();
+        }}
+        gap="xs"
+      >
+        {fiatQuoteQuery.isLoading ? (
+          <>
+            Getting price quote
+            <Spinner size="sm" color="accentButtonText" />
+          </>
+        ) : (
+          "Continue"
+        )}
+      </Button>
     </Container>
   );
 }

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/SwapScreenContent.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/SwapScreenContent.tsx
@@ -8,7 +8,6 @@ import { NATIVE_TOKEN_ADDRESS } from "../../../../../../../constants/addresses.j
 import { getContract } from "../../../../../../../contract/contract.js";
 import { allowance } from "../../../../../../../extensions/erc20/__generated__/IERC20/read/allowance.js";
 import type { GetBuyWithCryptoQuoteParams } from "../../../../../../../pay/buyWithCrypto/getQuote.js";
-import { formatNumber } from "../../../../../../../utils/formatNumber.js";
 import type { Account } from "../../../../../../../wallets/interfaces/wallet.js";
 import type { PayUIOptions } from "../../../../../../core/hooks/connection/ConnectButtonProps.js";
 import { useWalletBalance } from "../../../../../../core/hooks/others/useWalletBalance.js";
@@ -286,28 +285,14 @@ export function SwapScreenContent(props: {
         {/* Error message */}
         {errorMsg && (
           <div>
-            {errorMsg.data?.minimumAmountEth ? (
+            <div>
               <Text color="danger" size="xs" center multiline>
-                Minimum amount is{" "}
-                {formatNumber(Number(errorMsg.data.minimumAmountEth), 6)}{" "}
-                <TokenSymbol
-                  token={toToken}
-                  chain={toChain}
-                  size="sm"
-                  inline
-                  color="danger"
-                />
+                {errorMsg.title}
               </Text>
-            ) : (
-              <div>
-                <Text color="danger" size="xs" center multiline>
-                  {errorMsg.title}
-                </Text>
-                <Text size="xs" center multiline>
-                  {errorMsg.message}
-                </Text>
-              </div>
-            )}
+              <Text size="xs" center multiline>
+                {errorMsg.message}
+              </Text>
+            </div>
           </div>
         )}
 
@@ -324,23 +309,7 @@ export function SwapScreenContent(props: {
       </Container>
 
       {/* Button */}
-      {errorMsg?.data?.minimumAmountEth ? (
-        <Button
-          variant="accent"
-          fullWidth
-          onClick={() => {
-            props.setTokenAmount(
-              formatNumber(
-                Number(errorMsg.data?.minimumAmountEth),
-                6,
-              ).toString(),
-            );
-            props.setHasEditedAmount(true);
-          }}
-        >
-          Set Minimum
-        </Button>
-      ) : isNotEnoughBalance || errorMsg ? (
+      {isNotEnoughBalance || errorMsg ? (
         <Button
           variant="accent"
           fullWidth

--- a/packages/thirdweb/src/react/web/utils/errors.ts
+++ b/packages/thirdweb/src/react/web/utils/errors.ts
@@ -1,17 +1,21 @@
-type ApiError = {
+import { ApiError } from "../../../bridge/types/Errors.js";
+
+type UiError = {
   code: string;
   title: string;
   message: string;
-  data?: {
-    minimumAmountUSDCents?: string;
-    requestedAmountUSDCents?: string;
-    minimumAmountWei?: string;
-    minimumAmountEth?: string;
-  };
 };
 
 // biome-ignore lint/suspicious/noExplicitAny: <explanation>
-export function getErrorMessage(err: any): ApiError {
+export function getErrorMessage(err: any): UiError {
+  if (err instanceof ApiError) {
+    return {
+      code: err.code,
+      title: "Failed to Find Quote",
+      message: getErrorMessageFromBridgeApiError(err),
+    };
+  }
+
   if (typeof err.error === "object" && err.error.code) {
     if (err.error.code === "MINIMUM_PURCHASE_AMOUNT") {
       return {
@@ -29,6 +33,18 @@ export function getErrorMessage(err: any): ApiError {
     code: "UNABLE_TO_GET_PRICE_QUOTE",
     title: "Failed to Find Quote",
     message:
+      err.message ||
       "We couldn't get a quote for this token pair. Select another token or pay with card.",
   };
+}
+
+function getErrorMessageFromBridgeApiError(err: ApiError) {
+  let msg = err.message;
+  if (msg.includes("Details")) {
+    msg = msg.substring(0, msg.indexOf("Details"));
+  }
+  if (msg.includes("{")) {
+    msg = msg.substring(0, msg.indexOf("{"));
+  }
+  return msg;
 }


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving error handling and messages within the `thirdweb` package, particularly in the `PayEmbed` component and throughout the bridge-related functionalities. It introduces a new `ApiError` class for more structured error management.

### Detailed summary
- Added better error messages in `PayEmbed`.
- Introduced `ApiError` class in `packages/thirdweb/src/bridge/types/Errors.ts`.
- Updated error handling to use `ApiError` in various files.
- Renamed `BridgeAction` to `Action` in type definitions.
- Enhanced error message formatting in `SwapScreenContent` and `FiatScreenContent`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error messages in PayEmbed and related wallet features with clearer, more detailed reporting.
  - Numeric values in the Pay With Credit Card screen now display with two decimal places for better readability.
  - Simplified error messages and UI in Fiat and Swap screens by removing minimum amount details and related controls.
- **New Features**
  - Introduced structured error handling with detailed error codes and correlation IDs for enhanced troubleshooting across multiple wallet operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->