### PR TITLE
chore: update endpoint to rotate secret key

### DIFF
--- a/apps/dashboard/src/@3rdweb-sdk/react/hooks/useApi.ts
+++ b/apps/dashboard/src/@3rdweb-sdk/react/hooks/useApi.ts
@@ -322,13 +322,14 @@ export type RotateSecretKeyAPIReturnType = {
   };
 };
 
-export async function rotateSecretKeyClient(projectId: string) {
+export async function rotateSecretKeyClient(params: {
+  teamId: string;
+  projectId: string;
+}) {
   const res = await apiServerProxy<RotateSecretKeyAPIReturnType>({
-    pathname: "/v2/keys/rotate-secret-key",
+    pathname: `/v1/teams/${params.teamId}/projects/${params.projectId}/rotate-secret-key`,
     method: "POST",
-    body: JSON.stringify({
-      projectId,
-    }),
+    body: JSON.stringify({}),
     headers: {
       "Content-Type": "application/json",
     },

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/components/ProjectFTUX/ProjectFTUX.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/components/ProjectFTUX/ProjectFTUX.tsx
@@ -63,6 +63,7 @@ function IntegrateAPIKeySection({
           {secretKeyMasked && (
             <SecretKeySection
               secretKeyMasked={secretKeyMasked}
+              teamId={project.teamId}
               projectId={project.id}
             />
           )}

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/components/ProjectFTUX/SecretKeySection.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/components/ProjectFTUX/SecretKeySection.tsx
@@ -6,6 +6,7 @@ import { RotateSecretKeyButton } from "../../settings/ProjectGeneralSettingsPage
 
 export function SecretKeySection(props: {
   secretKeyMasked: string;
+  teamId: string;
   projectId: string;
 }) {
   const [secretKeyMasked, setSecretKeyMasked] = useState(props.secretKeyMasked);
@@ -26,7 +27,10 @@ export function SecretKeySection(props: {
 
         <RotateSecretKeyButton
           rotateSecretKey={async () => {
-            return rotateSecretKeyClient(props.projectId);
+            return rotateSecretKeyClient({
+              teamId: props.teamId,
+              projectId: props.projectId,
+            });
           }}
           onSuccess={(data) => {
             setSecretKeyMasked(data.data.secretMasked);

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/nebula/nebula-ftux.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/nebula/nebula-ftux.tsx
@@ -4,6 +4,7 @@ import { WaitingForIntegrationCard } from "../components/WaitingForIntegrationCa
 
 export function NebulaFTUX(props: {
   secretKeyMasked: string;
+  teamId: string;
   projectId: string;
 }) {
   return (
@@ -50,6 +51,7 @@ export function NebulaFTUX(props: {
     >
       <SecretKeySection
         secretKeyMasked={props.secretKeyMasked}
+        teamId={props.teamId}
         projectId={props.projectId}
       />
       <div className="h-4" />

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/nebula/page.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/nebula/page.tsx
@@ -60,6 +60,7 @@ export default async function Page(props: {
         <div className="container mt-6 max-w-7xl">
           <NebulaFTUX
             secretKeyMasked={project.secretKeys[0]?.masked || ""}
+            teamId={team.id}
             projectId={project.id}
           />
         </div>

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/settings/ProjectGeneralSettingsPage.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/settings/ProjectGeneralSettingsPage.tsx
@@ -165,7 +165,10 @@ export function ProjectGeneralSettingsPage(props: {
       }}
       showNebulaSettings={props.showNebulaSettings}
       rotateSecretKey={async () => {
-        return rotateSecretKeyClient(props.project.id);
+        return rotateSecretKeyClient({
+          teamId: props.project.teamId,
+          projectId: props.project.id,
+        });
       }}
       teamsWithRole={props.teamsWithRole}
       transferProject={async (newTeam) => {


### PR DESCRIPTION
## [Dashboard] Fix: Update Secret Key Rotation API Endpoint

## Notes for the reviewer

This PR updates the secret key rotation functionality to use the new team-based API endpoint structure. The `rotateSecretKeyClient` function now requires both `teamId` and `projectId` parameters, and the API endpoint has been updated to follow the `/v1/teams/{teamId}/projects/{projectId}/rotate-secret-key` pattern.

## How to test

Test the secret key rotation functionality in:
1. Project FTUX
2. Nebula FTUX
3. Project General Settings page

Verify that the secret key can be successfully rotated in all these locations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated secret key rotation to require both team and project identifiers for enhanced security and context.
  - Modified components to include team ID alongside project data, improving integration and user experience in project-related sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the handling of project and team identifiers in the `NebulaFTUX`, `ProjectFTUX`, and `SecretKeySection` components, as well as updating the `rotateSecretKeyClient` function to accept both `teamId` and `projectId` for better API interaction.

### Detailed summary
- Added `teamId` prop to `NebulaFTUX` and `ProjectFTUX`.
- Updated `NebulaFTUX` to pass `teamId` to `SecretKeySection`.
- Modified `rotateSecretKeyClient` to accept an object with `teamId` and `projectId`.
- Changed the API call in `rotateSecretKeyClient` to use the new parameters.
- Adjusted `SecretKeySection` to accept `teamId` and pass it to `rotateSecretKeyClient`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->