### PR TITLE
chore: redirect /team to /team/~ to select a team

### DIFF
--- a/apps/dashboard/src/@/api/team.ts
+++ b/apps/dashboard/src/@/api/team.ts
@@ -84,7 +84,7 @@ export async function getDefaultTeam() {
   return null;
 }
 
-export async function getLastVisitedTeamOrDefaultTeam() {
+export async function getLastVisitedTeam() {
   const token = await getAuthToken();
   if (!token) {
     return null;
@@ -100,5 +100,5 @@ export async function getLastVisitedTeamOrDefaultTeam() {
     }
   }
 
-  return getDefaultTeam();
+  return null;
 }

--- a/apps/dashboard/src/app/(app)/team/page.tsx
+++ b/apps/dashboard/src/app/(app)/team/page.tsx
@@ -1,10 +1,7 @@
-import { getLastVisitedTeamOrDefaultTeam } from "@/api/team";
-import { notFound, redirect } from "next/navigation";
+import { getLastVisitedTeam } from "@/api/team";
+import { redirect } from "next/navigation";
 
 export default async function TeamRootPage() {
-  const team = await getLastVisitedTeamOrDefaultTeam();
-  if (!team) {
-    notFound();
-  }
-  redirect(`/team/${team.slug}`);
+  const team = await getLastVisitedTeam();
+  redirect(team ? `/team/${team.slug}` : "/team/~");
 }


### PR DESCRIPTION
## [Dashboard] Fix: Simplify team redirection logic

## Notes for the reviewer
This PR modifies the team redirection logic by:
1. Renaming `getLastVisitedTeamOrDefaultTeam()` to `getLastVisitedTeam()`
2. Removing the fallback to `getDefaultTeam()` when no last visited team is found
3. Updating the team root page to redirect to `/team/~` when no team is found instead of showing a 404

## How to test
Verify that users are properly redirected to their last visited team when available, and to `/team/~` when no team history exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling when no last visited team is found by redirecting users to a fallback page instead of showing a not found error.

- **Refactor**
	- Updated team selection logic to remove fallback to a default team and streamline user redirection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR refactors the team retrieval logic in the dashboard application. It renames the `getLastVisitedTeamOrDefaultTeam` function to `getLastVisitedTeam` and modifies its behavior. The `TeamRootPage` component is updated to handle the new function and its return value.

### Detailed summary
- Renamed function `getLastVisitedTeamOrDefaultTeam` to `getLastVisitedTeam`.
- Changed the return value of `getLastVisitedTeam` from `getDefaultTeam()` to `null`.
- Updated `TeamRootPage` to call `getLastVisitedTeam` instead.
- Adjusted the redirect logic to handle the case when `team` is `null`, redirecting to `/team/~`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->