### PR TITLE
[SDK] Add required email verification for in-app wallet

### DIFF
--- a/apps/playground-web/src/components/in-app-wallet/connect-button.tsx
+++ b/apps/playground-web/src/components/in-app-wallet/connect-button.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { inAppWallet } from "thirdweb/wallets/in-app";
-import { StyledConnectEmbed } from "../styled-connect-embed";
+import { StyledConnectButton } from "../styled-connect-button";
 
 export function InAppConnectEmbed() {
   return (
-    <StyledConnectEmbed
+    <StyledConnectButton
       wallets={[
         inAppWallet({
           auth: {
@@ -24,6 +24,7 @@ export function InAppConnectEmbed() {
               "passkey",
               "guest",
             ],
+            required: ["email"],
           },
         }),
       ]}

--- a/apps/playground-web/src/components/in-app-wallet/sponsored-tx.tsx
+++ b/apps/playground-web/src/components/in-app-wallet/sponsored-tx.tsx
@@ -43,6 +43,7 @@ export function SponsoredInAppTxPreview() {
                   "passkey",
                   "guest",
                 ],
+                required: ["email"],
               },
               // TODO (7702): update to 7702 once pectra is out
               executionMode: {

--- a/apps/playground-web/src/lib/constants.ts
+++ b/apps/playground-web/src/lib/constants.ts
@@ -27,6 +27,7 @@ export const WALLETS = [
         "farcaster",
         "line",
       ],
+      required: ["email"],
       mode: "redirect",
       passkeyDomain: getDomain(),
     },

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/constants.ts
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/constants.ts
@@ -3,6 +3,7 @@ export const reservedScreens = {
   getStarted: "getStarted",
   signIn: "signIn",
   showAll: "showAll",
+  linkProfile: "linkProfile",
 };
 
 export const modalMaxWidthCompact = "360px";

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/LinkProfileScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/LinkProfileScreen.tsx
@@ -28,13 +28,14 @@ export function LinkProfileScreen(props: {
   locale: ConnectLocale;
   client: ThirdwebClient;
   walletConnect: { projectId?: string } | undefined;
+  wallet?: Wallet;
 }) {
   const adminWallet = useAdminWallet();
   const activeWallet = useActiveWallet();
   const chain = useActiveWalletChain();
   const queryClient = useQueryClient();
 
-  const wallet = adminWallet || activeWallet;
+  const wallet = props.wallet || adminWallet || activeWallet;
 
   if (!wallet) {
     return <LoadingScreen />;

--- a/packages/thirdweb/src/wallets/in-app/core/wallet/types.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/wallet/types.ts
@@ -60,6 +60,8 @@ export type ExecutionModeOptions =
       mode: "EOA";
     };
 
+export type InAppWalletRequired = "email";
+
 export type InAppWalletCreationOptions =
   | {
       auth?: {
@@ -67,6 +69,7 @@ export type InAppWalletCreationOptions =
          * List of authentication options to display in the Connect Modal
          */
         options: InAppWalletAuth[];
+        required?: InAppWalletRequired[];
         /**
          * Whether to display the social auth prompt in a popup or redirect
          */


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing wallet connection functionality by adding email linking requirements for certain wallets, introducing a new `VerifyEmailPrompt` component, and updating various components to manage email linking more effectively.

### Detailed summary
- Added `required: ["email"]` to wallet configurations.
- Introduced `InAppWalletRequired` type to specify required fields.
- Implemented `VerifyEmailPrompt` component to handle email verification.
- Updated `ConnectEmbed` and `ConnectModalContent` to manage email linking.
- Enhanced `ConnectWalletSocialOptions` to restrict options based on email requirements.
- Modified logic to defer wallet activation until email is linked.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added enforcement of email as a required authentication method for in-app wallets where applicable.
  - Introduced a new flow that prompts users to link their email before completing wallet connection if required by the wallet.
  - Enhanced the wallet connection process with a dedicated email verification prompt and screen when email linking is mandatory.

- **User Interface**
  - Updated connection screens to guide users through required email linking and verification.
  - Improved prompts and validation for entering and verifying email addresses during wallet setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->