### PR TITLE
Update PostHog import to use React hook

### DIFF
--- a/apps/dashboard/src/hooks/analytics/useTrack.ts
+++ b/apps/dashboard/src/hooks/analytics/useTrack.ts
@@ -1,5 +1,5 @@
 import { flatten } from "flat";
-import posthog from "posthog-js";
+import { usePostHog } from "posthog-js/react";
 import { useCallback } from "react";
 
 export type TrackingParams = {
@@ -11,31 +11,35 @@ export type TrackingParams = {
 };
 
 export function useTrack() {
-  return useCallback((trackingData: TrackingParams) => {
-    const { category, action, label, ...restData } = trackingData;
-    const catActLab = label
-      ? `${category}.${action}.${label}`
-      : `${category}.${action}`;
-    if (process.env.NODE_ENV !== "production") {
-      console.debug(`[PH.capture]:${catActLab}`, restData);
-    }
+  const posthog = usePostHog();
+  return useCallback(
+    (trackingData: TrackingParams) => {
+      const { category, action, label, ...restData } = trackingData;
+      const catActLab = label
+        ? `${category}.${action}.${label}`
+        : `${category}.${action}`;
+      if (process.env.NODE_ENV !== "production") {
+        console.debug(`[PH.capture]:${catActLab}`, restData);
+      }
 
-    const restDataSafe = Object.fromEntries(
-      Object.entries(restData).map(([key, value]) => {
-        if (value instanceof Error) {
-          return [
-            key,
-            { message: value.message, stack: value.stack?.toString() },
-          ];
-        }
-        return [key, value];
-      }),
-    );
+      const restDataSafe = Object.fromEntries(
+        Object.entries(restData).map(([key, value]) => {
+          if (value instanceof Error) {
+            return [
+              key,
+              { message: value.message, stack: value.stack?.toString() },
+            ];
+          }
+          return [key, value];
+        }),
+      );
 
-    try {
-      posthog.capture(catActLab, flatten(restDataSafe));
-    } catch {
-      // ignore - we just don't want to trigger an error in the app if posthog fails
-    }
-  }, []);
+      try {
+        posthog?.capture(catActLab, flatten(restDataSafe));
+      } catch {
+        // ignore - we just don't want to trigger an error in the app if posthog fails
+      }
+    },
+    [posthog],
+  );
 }


### PR DESCRIPTION
# Update PostHog import to use React hook

This PR updates the PostHog implementation in the `useTrack` hook to use the React-specific hook from PostHog instead of the direct import. The changes include:

- Replaced the direct import of `posthog` with `usePostHog` from `posthog-js/react`
- Added the PostHog instance as a dependency to the `useCallback` hook
- Added a null check before calling `posthog.capture()` to handle cases where PostHog might not be initialized

These changes ensure proper React integration with PostHog and prevent potential issues with the hook's dependency array.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `useTrack` hook to use the `usePostHog` hook from `posthog-js/react` instead of directly importing `posthog`. It also modifies the dependency array for the `useCallback` hook to include `posthog`.

### Detailed summary
- Replaced direct import of `posthog` with `usePostHog` from `posthog-js/react`.
- Updated the `useCallback` hook to include `posthog` in its dependency array.
- Ensured the `capture` method is called on `posthog` if it exists.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal tracking logic to enhance stability and reliability of analytics event capture. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->