### PR TITLE
Remove SIWA feedback buttons from nebula

### DIFF
--- a/apps/dashboard/src/app/nebula-app/(app)/components/ChatPageContent.tsx
+++ b/apps/dashboard/src/app/nebula-app/(app)/components/ChatPageContent.tsx
@@ -339,7 +339,6 @@ export function ChatPageContent(props: {
 
               {messages.length > 0 && (
                 <Chats
-                  teamId={undefined}
                   messages={messages}
                   isChatStreaming={isChatStreaming}
                   authToken={props.authToken}

--- a/apps/dashboard/src/app/nebula-app/(app)/components/Chats.stories.tsx
+++ b/apps/dashboard/src/app/nebula-app/(app)/components/Chats.stories.tsx
@@ -227,7 +227,6 @@ function Variant(props: {
 }) {
   return (
     <Chats
-      teamId={undefined}
       enableAutoScroll={false}
       setEnableAutoScroll={() => {}}
       client={storybookThirdwebClient}

--- a/apps/dashboard/src/app/nebula-app/(app)/components/Chats.tsx
+++ b/apps/dashboard/src/app/nebula-app/(app)/components/Chats.tsx
@@ -1,11 +1,9 @@
 import { ScrollShadow } from "@/components/ui/ScrollShadow/ScrollShadow";
 import { cn } from "@/lib/utils";
 import { MarkdownRenderer } from "components/contract-components/published-contract/markdown-renderer";
-import { AlertCircleIcon, ThumbsDownIcon, ThumbsUpIcon } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { AlertCircleIcon } from "lucide-react";
+import { useEffect, useRef } from "react";
 import type { ThirdwebClient } from "thirdweb";
-import { Button } from "../../../../@/components/ui/button";
-import { useTrack } from "../../../../hooks/analytics/useTrack";
 import type { NebulaSwapData } from "../api/chat";
 import type { NebulaUserMessage, NebulaUserMessageContent } from "../api/types";
 import { NebulaIcon } from "../icons/NebulaIcon";
@@ -74,7 +72,6 @@ export function Chats(props: {
   enableAutoScroll: boolean;
   useSmallText?: boolean;
   sendMessage: (message: NebulaUserMessage) => void;
-  teamId: string | undefined;
 }) {
   const { messages, setEnableAutoScroll, enableAutoScroll } = props;
   const scrollAnchorRef = useRef<HTMLDivElement>(null);
@@ -156,7 +153,6 @@ export function Chats(props: {
                     nextMessage={props.messages[index + 1]}
                     authToken={props.authToken}
                     sessionId={props.sessionId}
-                    teamId={props.teamId}
                   />
                 </div>
               );
@@ -176,7 +172,6 @@ function RenderMessage(props: {
   sendMessage: (message: NebulaUserMessage) => void;
   nextMessage: ChatMessage | undefined;
   authToken: string;
-  teamId: string | undefined;
   sessionId: string | undefined;
 }) {
   const { message } = props;
@@ -225,41 +220,6 @@ function RenderMessage(props: {
 
           return null;
         })}
-      </div>
-    );
-  }
-
-  // Feedback for assistant messages
-  if (props.message.type === "assistant") {
-    return (
-      <div className="flex flex-col gap-2">
-        <div className="flex gap-3">
-          {/* Left Icon */}
-          <div className="-translate-y-[2px] relative shrink-0">
-            <div className="flex size-9 items-center justify-center rounded-full border bg-card">
-              <NebulaIcon className="size-5 text-muted-foreground" />
-            </div>
-          </div>
-          {/* Right Message */}
-          <div className="min-w-0 grow">
-            <ScrollShadow className="rounded-lg">
-              <RenderResponse
-                message={message}
-                isMessagePending={props.isMessagePending}
-                client={props.client}
-                sendMessage={props.sendMessage}
-                nextMessage={props.nextMessage}
-                sessionId={props.sessionId}
-                authToken={props.authToken}
-              />
-            </ScrollShadow>
-            <FeedbackButtons
-              sessionId={props.sessionId}
-              authToken={props.authToken}
-              teamId={props.teamId}
-            />
-          </div>
-        </div>
       </div>
     );
   }
@@ -460,83 +420,5 @@ function StyledMarkdownRenderer(props: {
       li={{ className: "text-foreground" }}
       inlineCode={{ className: "border-none" }}
     />
-  );
-}
-
-function FeedbackButtons({
-  sessionId,
-  authToken,
-  teamId,
-}: {
-  sessionId: string | undefined;
-  authToken: string;
-  teamId: string | undefined;
-}) {
-  const [, setFeedback] = useState<1 | -1 | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [thankYou, setThankYou] = useState(false);
-  const trackEvent = useTrack();
-
-  async function sendFeedback(rating: 1 | -1) {
-    setLoading(true);
-    try {
-      trackEvent({
-        category: "siwa",
-        action: "submit-feedback",
-        rating: rating === 1 ? "good" : "bad",
-        sessionId,
-        teamId,
-      });
-      const apiUrl = process.env.NEXT_PUBLIC_SIWA_URL;
-      await fetch(`${apiUrl}/v1/chat/feedback`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${authToken}`,
-          ...(teamId ? { "x-team-id": teamId } : {}),
-        },
-        body: JSON.stringify({
-          conversationId: sessionId,
-          feedbackRating: rating,
-        }),
-      });
-      setFeedback(rating);
-      setThankYou(true);
-    } catch {
-      // TODO handle error
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  if (thankYou) {
-    return (
-      <div className="mt-2 text-muted-foreground text-xs">
-        Thank you for your feedback!
-      </div>
-    );
-  }
-
-  return (
-    <div className="mt-2 flex gap-2">
-      <Button
-        className="rounded-full border p-2 hover:bg-muted-foreground/10"
-        variant="ghost"
-        onClick={() => sendFeedback(-1)}
-        disabled={loading}
-        aria-label="Thumbs down"
-      >
-        <ThumbsDownIcon className="size-4 text-red-500" />
-      </Button>
-      <Button
-        className="rounded-full border p-2 hover:bg-muted-foreground/10"
-        variant="ghost"
-        onClick={() => sendFeedback(1)}
-        disabled={loading}
-        aria-label="Thumbs up"
-      >
-        <ThumbsUpIcon className="size-4 text-green-500" />
-      </Button>
-    </div>
   );
 }

--- a/apps/dashboard/src/app/nebula-app/(app)/components/CustomChat/CustomChatContent.tsx
+++ b/apps/dashboard/src/app/nebula-app/(app)/components/CustomChat/CustomChatContent.tsx
@@ -158,7 +158,6 @@ function CustomChatContentLoggedIn(props: {
         />
       ) : (
         <Chats
-          teamId={props.teamId}
           messages={messages}
           isChatStreaming={isChatStreaming}
           authToken={props.authToken}

--- a/apps/dashboard/src/app/nebula-app/(app)/components/FloatingChat/FloatingChatContent.tsx
+++ b/apps/dashboard/src/app/nebula-app/(app)/components/FloatingChat/FloatingChatContent.tsx
@@ -202,7 +202,6 @@ function FloatingChatContentLoggedIn(props: {
         />
       ) : (
         <Chats
-          teamId={undefined}
           messages={messages}
           isChatStreaming={isChatStreaming}
           authToken={props.authToken}


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on refactoring the `Chats` component by removing the `teamId` prop from various instances and eliminating the feedback functionality. It simplifies the component's structure and reduces unnecessary complexity.

### Detailed summary
- Removed `teamId` prop from multiple instances of `Chats`.
- Deleted the entire `FeedbackButtons` component and its associated logic.
- Updated imports in `Chats.tsx`, removing unused imports.
- Simplified the `RenderMessage` function by removing feedback-related code.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- None.

- **Bug Fixes**
	- None.

- **Refactor**
	- Removed the feedback feature, including thumbs up/down buttons and related tracking, from chat components.
	- Simplified chat components by removing the unused or redundant team selection prop.

- **Chores**
	- Cleaned up code by deleting unnecessary feedback-related imports and props.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->