### PR TITLE
[thirdweb] Ensure bigints are stringified before usage with server wallets

### DIFF
--- a/.changeset/whole-pears-stay.md
+++ b/.changeset/whole-pears-stay.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Ensure bigints are stringified before usage with server wallets

--- a/packages/engine/src/configure.ts
+++ b/packages/engine/src/configure.ts
@@ -14,6 +14,25 @@ export function configure(
       ...(options.clientId && { "x-client-id": options.clientId }),
       ...(options.secretKey && { "x-secret-key": options.secretKey }),
     },
+    bodySerializer: stringify,
     ...(options.override ?? {}),
   });
+}
+
+function stringify(
+  // biome-ignore lint/suspicious/noExplicitAny: JSON.stringify signature
+  value: any,
+  // biome-ignore lint/suspicious/noExplicitAny: JSON.stringify signature
+  replacer?: ((this: any, key: string, value: any) => any) | null,
+  space?: string | number,
+) {
+  const res = JSON.stringify(
+    value,
+    (key, value_) => {
+      const value__ = typeof value_ === "bigint" ? value_.toString() : value_;
+      return typeof replacer === "function" ? replacer(key, value__) : value__;
+    },
+    space,
+  );
+  return res;
 }

--- a/packages/thirdweb/src/engine/get-status.ts
+++ b/packages/thirdweb/src/engine/get-status.ts
@@ -79,6 +79,7 @@ export async function getTransactionStatus(args: {
   const { client, transactionId } = args;
   const searchResult = await searchTransactions({
     baseUrl: getThirdwebBaseUrl("engineCloud"),
+    bodySerializer: stringify,
     fetch: getClientFetch(client),
     body: {
       filters: [

--- a/packages/thirdweb/src/engine/server-wallet.test.ts
+++ b/packages/thirdweb/src/engine/server-wallet.test.ts
@@ -3,13 +3,14 @@ import { TEST_CLIENT } from "../../test/src/test-clients.js";
 import { TEST_ACCOUNT_B } from "../../test/src/test-wallets.js";
 import { typedData } from "../../test/src/typed-data.js";
 import { arbitrumSepolia } from "../chains/chain-definitions/arbitrum-sepolia.js";
+import { baseSepolia } from "../chains/chain-definitions/base-sepolia.js";
 import { sepolia } from "../chains/chain-definitions/sepolia.js";
 import { getContract } from "../contract/contract.js";
 import { setContractURI } from "../extensions/common/__generated__/IContractMetadata/write/setContractURI.js";
+import { mintTo } from "../extensions/erc20/write/mintTo.js";
 import { claimTo } from "../extensions/erc1155/drops/write/claimTo.js";
 import { getAllActiveSigners } from "../extensions/erc4337/__generated__/IAccountPermissions/read/getAllActiveSigners.js";
 import { sendTransaction } from "../transaction/actions/send-transaction.js";
-import { setThirdwebDomains } from "../utils/domains.js";
 import {
   DEFAULT_ACCOUNT_FACTORY_V0_6,
   ENTRYPOINT_ADDRESS_v0_6,
@@ -32,12 +33,12 @@ describe.runIf(
     let serverWallet: Engine.ServerWallet;
 
     beforeAll(async () => {
-      setThirdwebDomains({
-        rpc: "rpc.thirdweb-dev.com",
-        storage: "storage.thirdweb-dev.com",
-        bundler: "bundler.thirdweb-dev.com",
-        engineCloud: "engine.thirdweb-dev.com",
-      });
+      // setThirdwebDomains({
+      //   rpc: "rpc.thirdweb-dev.com",
+      //   storage: "storage.thirdweb-dev.com",
+      //   bundler: "bundler.thirdweb-dev.com",
+      //   engineCloud: "engine.thirdweb-dev.com",
+      // });
       serverWallet = Engine.serverWallet({
         client: TEST_CLIENT,
         vaultAccessToken: process.env.VAULT_TOKEN as string,
@@ -81,7 +82,7 @@ describe.runIf(
       });
       const claimTx = claimTo({
         contract: nftContract,
-        to: TEST_ACCOUNT_B.address,
+        to: serverWallet.address,
         tokenId: 0n,
         quantity: 1n,
       });
@@ -97,16 +98,15 @@ describe.runIf(
     });
 
     it("should send a extension tx", async () => {
-      const nftContract = getContract({
+      const tokenContract = getContract({
         client: TEST_CLIENT,
-        chain: sepolia,
-        address: "0xe2cb0eb5147b42095c2FfA6F7ec953bb0bE347D8",
+        chain: baseSepolia,
+        address: "0x87C52295891f208459F334975a3beE198fE75244",
       });
-      const claimTx = claimTo({
-        contract: nftContract,
-        to: TEST_ACCOUNT_B.address,
-        tokenId: 0n,
-        quantity: 1n,
+      const claimTx = mintTo({
+        contract: tokenContract,
+        to: serverWallet.address,
+        amount: "0.001",
       });
       const tx = await sendTransaction({
         account: serverWallet,

--- a/packages/thirdweb/src/engine/server-wallet.ts
+++ b/packages/thirdweb/src/engine/server-wallet.ts
@@ -144,13 +144,14 @@ export function serverWallet(options: ServerWalletOptions): ServerWallet {
 
     const result = await sendTransaction({
       baseUrl: getThirdwebBaseUrl("engineCloud"),
+      bodySerializer: stringify,
       fetch: getClientFetch(client),
       headers,
       body,
     });
 
     if (result.error) {
-      throw new Error(`Error sending transaction: ${result.error}`);
+      throw new Error(`Error sending transaction: ${stringify(result.error)}`);
     }
 
     const data = result.data?.result;
@@ -220,6 +221,7 @@ export function serverWallet(options: ServerWalletOptions): ServerWallet {
 
       const signResult = await signMessage({
         baseUrl: getThirdwebBaseUrl("engineCloud"),
+        bodySerializer: stringify,
         fetch: getClientFetch(client),
         headers,
         body: {
@@ -256,6 +258,7 @@ export function serverWallet(options: ServerWalletOptions): ServerWallet {
 
       const signResult = await signTypedData({
         baseUrl: getThirdwebBaseUrl("engineCloud"),
+        bodySerializer: stringify,
         fetch: getClientFetch(client),
         headers,
         body: {


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the handling of `bigint` values in the `thirdweb` package by ensuring they are stringified before being used with server wallets, along with various updates to transaction handling and test cases.

### Detailed summary
- Added `bodySerializer: stringify` to several transaction functions.
- Introduced `stringify` function to handle `bigint` values.
- Updated error handling to stringify errors before throwing.
- Adjusted tests to use `serverWallet.address` instead of a test account.
- Changed contract address and type in test cases.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved compatibility when handling large numbers by ensuring all bigint values are converted to strings before being sent with server wallet operations.
	- Enhanced error messages for server wallet transactions by providing clearer, stringified error details.

- **Tests**
	- Updated server wallet tests to use new contract addresses, transaction types, and to disable custom domain configuration for endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->