### PR TITLE
[SDK] ensure that the default spinner stroke color gets inherited from the parentnode

### DIFF
--- a/.changeset/fast-onions-obey.md
+++ b/.changeset/fast-onions-obey.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+default the spinner stroke color to currentColor and make the color prop optional

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/fiat/FiatScreenContent.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/fiat/FiatScreenContent.tsx
@@ -230,7 +230,7 @@ export function FiatScreenContent(props: {
       </Container>
 
       <Button
-        variant={disableSubmit ? "outline" : "accent"}
+        variant="accent"
         data-disabled={disableSubmit}
         disabled={disableSubmit}
         fullWidth
@@ -250,7 +250,7 @@ export function FiatScreenContent(props: {
         {fiatQuoteQuery.isLoading ? (
           <>
             Getting price quote
-            <Spinner size="sm" color="accentButtonText" />
+            <Spinner size="sm" />
           </>
         ) : (
           "Continue"

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/fiat/FiatScreenContent.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/fiat/FiatScreenContent.tsx
@@ -230,7 +230,7 @@ export function FiatScreenContent(props: {
       </Container>
 
       <Button
-        variant="accent"
+        variant={disableSubmit ? "outline" : "accent"}
         data-disabled={disableSubmit}
         disabled={disableSubmit}
         fullWidth

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/SwapScreenContent.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/SwapScreenContent.tsx
@@ -334,7 +334,7 @@ export function SwapScreenContent(props: {
         />
       ) : (
         <Button
-          variant={disableContinue ? "outline" : "accent"}
+          variant="accent"
           fullWidth
           data-disabled={disableContinue}
           disabled={disableContinue}
@@ -360,7 +360,7 @@ export function SwapScreenContent(props: {
           {quoteQuery.isLoading ? (
             <>
               Getting price quote
-              <Spinner size="sm" color="accentButtonText" />
+              <Spinner size="sm" />
             </>
           ) : (
             "Continue"

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/SwapScreenContent.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/SwapScreenContent.tsx
@@ -334,7 +334,7 @@ export function SwapScreenContent(props: {
         />
       ) : (
         <Button
-          variant="accent"
+          variant={disableContinue ? "outline" : "accent"}
           fullWidth
           data-disabled={disableContinue}
           disabled={disableContinue}

--- a/packages/thirdweb/src/react/web/ui/components/Spinner.tsx
+++ b/packages/thirdweb/src/react/web/ui/components/Spinner.tsx
@@ -9,8 +9,8 @@ import { StyledCircle, StyledSvg } from "../design-system/elements.js";
  * @internal
  */
 export const Spinner: React.FC<{
-  color: keyof Theme["colors"];
   size: keyof typeof iconSize;
+  color?: keyof Theme["colors"];
 }> = (props) => {
   const theme = useCustomTheme();
   return (
@@ -26,7 +26,7 @@ export const Spinner: React.FC<{
         cy="25"
         r="20"
         fill="none"
-        stroke={theme.colors[props.color]}
+        stroke={props.color ? theme.colors[props.color] : "currentColor"}
         strokeWidth={Number(iconSize[props.size]) > 64 ? "2" : "4"}
       />
     </Svg>


### PR DESCRIPTION
In a few cases the <Spinner> got an explicit color passed, eg `accentButtonText`, but this isn't great if the element in which is rendered has a variant or style prop that affects the color property of said element, as the Spinner will simply keep rendering in the color you passed it, unless you also dynamically switch the color property of the Spinner in similar fashion to the parent.

In the case of the FiatScreenContent and SwapScreenContent, the Button component that's rendered switches between the 'accent' and 'outline' variant when the buttons are disabled, which causes the Spinner to render the 'accentButtonText' color even though the 'outline' variant of the Button was active.

I considered two ways of fixing this

1 Removing the variant switching
2 Simply allowing the Spinner to inherit the color of the parent node

The latter seemed like the most flexible solution. The current color property on the Spinner is required so there's no risk in breaking any existing instance of the Spinner component, and it allows for simpler usage without explicit color passing.

Let me know if you prefer option 1 here, or whenever you see a different solution, happy to adjust where needed.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `Spinner` component by making the `color` prop optional and setting its default stroke color to `currentColor`. This change simplifies the usage of the `Spinner` in different contexts, particularly in the `FiatScreenContent` and `SwapScreenContent` components.

### Detailed summary
- Updated the `Spinner` component to make the `color` prop optional.
- Set the default stroke color of the `Spinner` to `currentColor`.
- Removed the `color` prop from `Spinner` instances in `FiatScreenContent.tsx` and `SwapScreenContent.tsx`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated spinner appearance in wallet screens by removing explicit color styling, enabling it to inherit default or theme-based colors.  
- **Refactor**
  - Enhanced spinner component flexibility by making the color optional and defaulting to the current text color when unspecified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->