### PR TITLE
[Docs] Add Onramp extension to sidebar and typedoc

### DIFF
--- a/apps/portal/src/app/typescript/v5/sidebar.tsx
+++ b/apps/portal/src/app/typescript/v5/sidebar.tsx
@@ -284,6 +284,35 @@ export const sidebar: SideBar = {
                     };
                   }) || [],
             },
+            {
+              name: "Onramp",
+              links:
+                docs.functions
+                  ?.filter((f) => {
+                    const [tag] = getCustomTag(f) || [];
+                    if (tag !== "@bridge") return false;
+                    const blockTag = f.signatures?.[0]?.blockTags?.find(
+                      (b) => b.tag === "@bridge",
+                    );
+                    const extensionName = blockTag
+                      ? getExtensionName(blockTag) || "Common"
+                      : "Common";
+                    if (extensionName !== "Onramp") return false;
+                    return true;
+                  })
+                  .map((f) => {
+                    const blockTag = f.signatures?.[0]?.blockTags?.find(
+                      (b) => b.tag === "@bridge",
+                    );
+                    const extensionName = blockTag
+                      ? getExtensionName(blockTag) || "Common"
+                      : "Common";
+                    return {
+                      name: f.name,
+                      href: `${slug}/${extensionName.toLowerCase()}/${f.name}`,
+                    };
+                  }) || [],
+            },
             ...(docs.functions
               ?.filter((f) => {
                 const [tag] = getCustomTag(f) || [];

--- a/packages/thirdweb/scripts/typedoc.mjs
+++ b/packages/thirdweb/scripts/typedoc.mjs
@@ -13,6 +13,7 @@ const app = await Application.bootstrapWithPlugins({
     "src/bridge/index.ts",
     "src/bridge/Buy.ts",
     "src/bridge/Sell.ts",
+    "src/bridge/Onramp.ts",
     "src/insight/index.ts",
     "src/engine/index.ts",
   ],


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces support for an `Onramp` feature in the codebase, enhancing the documentation generation by filtering and mapping functions related to `Onramp`.

### Detailed summary
- Added `src/bridge/Onramp.ts` to the project.
- Introduced a new entry for `Onramp` in the sidebar of the documentation.
- Implemented filtering logic to include only functions tagged with `@bridge` and belonging to the `Onramp` extension.
- Mapped the filtered functions to create links in the documentation sidebar.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an "Onramp" subsection under "Bridge, Swap, and Onramp" in the sidebar, displaying relevant links dynamically.
- **Documentation**
  - Included "Onramp" functionality in the generated documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->