### PR TITLE
Add webhook API functions for insight dashboard

### DIFF
--- a/apps/dashboard/src/@/api/insight/webhooks.ts
+++ b/apps/dashboard/src/@/api/insight/webhooks.ts
@@ -1,0 +1,202 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+"use server";
+
+import { getAuthToken } from "app/(app)/api/lib/getAuthToken";
+import { THIRDWEB_INSIGHT_API_DOMAIN } from "constants/urls";
+
+interface WebhookResponse {
+  id: string;
+  name: string;
+  team_id: string;
+  project_id: string;
+  webhook_url: string;
+  webhook_secret: string;
+  filters: WebhookFilters;
+  suspended_at: string | null;
+  suspended_reason: string | null;
+  disabled: boolean;
+  created_at: string;
+  updated_at: string | null;
+}
+
+interface WebhookFilters {
+  "v1.events"?: {
+    chain_ids?: string[];
+    addresses?: string[];
+    signatures?: Array<{
+      sig_hash: string;
+      abi?: string;
+      params?: Record<string, unknown>;
+    }>;
+  };
+  "v1.transactions"?: {
+    chain_ids?: string[];
+    from_addresses?: string[];
+    to_addresses?: string[];
+    signatures?: Array<{
+      sig_hash: string;
+      abi?: string;
+      params?: Record<string, unknown>;
+    }>;
+  };
+}
+
+interface CreateWebhookPayload {
+  name: string;
+  webhook_url: string;
+  filters: WebhookFilters;
+}
+
+interface WebhooksListResponse {
+  data: WebhookResponse[];
+  error?: string;
+}
+
+interface WebhookSingleResponse {
+  data: WebhookResponse | null;
+  error?: string;
+}
+
+interface TestWebhookPayload {
+  webhook_url: string;
+  type?: "event" | "transaction";
+}
+
+interface TestWebhookResponse {
+  success: boolean;
+  error?: string;
+}
+
+// biome-ignore lint/correctness/noUnusedVariables: will be used in the next PR
+async function createWebhook(
+  payload: CreateWebhookPayload,
+  clientId: string,
+): Promise<WebhookSingleResponse> {
+  try {
+    const authToken = await getAuthToken();
+    const response = await fetch(`${THIRDWEB_INSIGHT_API_DOMAIN}/v1/webhooks`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-client-id": clientId,
+        Authorization: `Bearer ${authToken}`,
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return {
+        data: null,
+        error: `Failed to create webhook: ${errorText}`,
+      };
+    }
+
+    return (await response.json()) as WebhookSingleResponse;
+  } catch (error) {
+    return {
+      data: null,
+      error: `Network or parsing error: ${error instanceof Error ? error.message : "Unknown error"}`,
+    };
+  }
+}
+
+export async function getWebhooks(
+  clientId: string,
+): Promise<WebhooksListResponse> {
+  try {
+    const authToken = await getAuthToken();
+    const response = await fetch(`${THIRDWEB_INSIGHT_API_DOMAIN}/v1/webhooks`, {
+      method: "GET",
+      headers: {
+        "x-client-id": clientId,
+        Authorization: `Bearer ${authToken}`,
+      },
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return {
+        data: [],
+        error: `Failed to get webhooks: ${errorText}`,
+      };
+    }
+
+    return (await response.json()) as WebhooksListResponse;
+  } catch (error) {
+    return {
+      data: [],
+      error: `Network or parsing error: ${error instanceof Error ? error.message : "Unknown error"}`,
+    };
+  }
+}
+// biome-ignore lint/correctness/noUnusedVariables: will be used in the next PR
+async function deleteWebhook(
+  webhookId: string,
+  clientId: string,
+): Promise<WebhookSingleResponse> {
+  try {
+    const authToken = await getAuthToken();
+    const response = await fetch(
+      `${THIRDWEB_INSIGHT_API_DOMAIN}/v1/webhooks/${encodeURIComponent(webhookId)}`,
+      {
+        method: "DELETE",
+        headers: {
+          "x-client-id": clientId,
+          Authorization: `Bearer ${authToken}`,
+        },
+      },
+    );
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return {
+        data: null,
+        error: `Failed to delete webhook: ${errorText}`,
+      };
+    }
+
+    return (await response.json()) as WebhookSingleResponse;
+  } catch (error) {
+    return {
+      data: null,
+      error: `Network or parsing error: ${error instanceof Error ? error.message : "Unknown error"}`,
+    };
+  }
+}
+// biome-ignore lint/correctness/noUnusedVariables: will be used in the next PR
+async function testWebhook(
+  payload: TestWebhookPayload,
+  clientId: string,
+): Promise<TestWebhookResponse> {
+  try {
+    const authToken = await getAuthToken();
+    const response = await fetch(
+      `${THIRDWEB_INSIGHT_API_DOMAIN}/v1/webhooks/test`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-client-id": clientId,
+          Authorization: `Bearer ${authToken}`,
+        },
+        body: JSON.stringify(payload),
+      },
+    );
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return {
+        success: false,
+        error: `Failed to test webhook: ${errorText}`,
+      };
+    }
+
+    return (await response.json()) as TestWebhookResponse;
+  } catch (error) {
+    return {
+      success: false,
+      error: `Network or parsing error: ${error instanceof Error ? error.message : "Unknown error"}`,
+    };
+  }
+}

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/webhooks/page.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/webhooks/page.tsx
@@ -1,0 +1,8 @@
+// This is a temporary page to supress linting errors and will be implemented up in the stack
+import { getWebhooks } from "@/api/insight/webhooks";
+
+export default async function WebhooksPage() {
+  const { data: webhooks, error } = await getWebhooks("123");
+
+  return <div>{JSON.stringify({ webhooks, error })}</div>;
+}


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a temporary `WebhooksPage` component and expands the `webhooks` API with several interfaces and functions for managing webhooks, including creating, retrieving, deleting, and testing webhooks.

### Detailed summary
- Added `WebhooksPage` in `apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/webhooks/page.tsx`.
- Defined interfaces for webhook responses and payloads in `apps/dashboard/src/@/api/insight/webhooks.ts`.
- Implemented `createWebhook`, `getWebhooks`, `deleteWebhook`, and `testWebhook` functions for webhook management.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for managing webhooks, including viewing webhook data through the dashboard.
  - Introduced a new dashboard page that displays webhook information for improved monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->