### PR TITLE
[Dashboard] add wallet user search

### DIFF
--- a/apps/dashboard/src/components/embedded-wallets/Users/SearchInput.tsx
+++ b/apps/dashboard/src/components/embedded-wallets/Users/SearchInput.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import { SearchIcon } from "lucide-react";
+
+export function SearchInput(props: {
+  placeholder: string;
+  value: string;
+  onValueChange: (value: string) => void;
+}) {
+  return (
+    <div className="relative">
+      <Input
+        placeholder={props.placeholder}
+        value={props.value}
+        onChange={(e) => props.onValueChange(e.target.value)}
+        className="bg-card pl-9"
+      />
+      <SearchIcon className="-translate-y-1/2 absolute top-1/2 left-3 size-4 text-muted-foreground" />
+    </div>
+  );
+}


### PR DESCRIPTION
Fixes TOOL-4581

## Summary
- add a `SearchInput` component for the embedded wallet users page
- filter wallet users table by id, address or linked account details

## Testing
- `npx biome check apps/dashboard/src/components/embedded-wallets/Users/SearchInput.tsx apps/dashboard/src/components/embedded-wallets/Users/index.tsx`
- `pnpm lint` *(fails: EHOSTUNREACH)*
- `pnpm test` *(fails: spawn anvil ENOENT)*

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a `SearchInput` component to enhance user experience by allowing users to filter wallet users based on search criteria. It integrates the search functionality into the existing `InAppWalletUsersPageContent` component.

### Detailed summary
- Added a new `SearchInput` component in `SearchInput.tsx`.
- Integrated `SearchInput` into `InAppWalletUsersPageContent` in `index.tsx`.
- Introduced `searchValue` state to manage input value.
- Implemented filtering logic for wallets based on `searchValue`.
- Updated the displayed wallet data to show filtered results instead of all wallets.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a search bar to the wallet users page, allowing users to filter wallet users by ID, wallet address, or linked account details.
- **Style**
  - Introduced a visually styled input field with a search icon for improved user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->