### PR TITLE
token owners endpoint in insight playground

### DIFF
--- a/apps/playground-web/src/app/insight/insightBlueprints.ts
+++ b/apps/playground-web/src/app/insight/insightBlueprints.ts
@@ -60,6 +60,11 @@ export const insightBlueprints: MinimalBlueprintSpec[] = [
     name: "Tokens",
     paths: [
       {
+        name: "Get token owners by contract",
+        path: "/v1/tokens/owners",
+        deprecated: false,
+      },
+      {
         name: "Get token transfers by transaction",
         path: "/v1/tokens/transfers/transaction/{transaction_hash}",
         deprecated: false,
@@ -126,7 +131,7 @@ export const insightBlueprints: MinimalBlueprintSpec[] = [
         deprecated: false,
       },
       {
-        name: "Get NFTs by owner",
+        name: "Get NFTs",
         path: "/v1/nfts",
         deprecated: false,
       },


### PR DESCRIPTION
## [Dashboard] Feature: Update Token and NFT API Endpoints

## Notes for the reviewer

This PR adds a new token endpoint and updates the name of an existing NFT endpoint:

1. Added a new endpoint for getting token owners by contract: `/v1/tokens/owners`
2. Renamed the "Get NFTs by owner" endpoint to simply "Get NFTs" to better reflect its functionality

## How to test

Verify the updated endpoint names appear correctly in the Insight section of the playground.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new API endpoint for retrieving token owners by contract.

- **Refactor**
  - Renamed the "Get NFTs by owner" endpoint to "Get NFTs" for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `insightBlueprints` in the `insightBlueprints.ts` file by adding a new API endpoint for retrieving token owners and renaming an existing endpoint for NFTs.

### Detailed summary
- Added a new API endpoint:
  - Name: `Get token owners by contract`
  - Path: `/v1/tokens/owners`
  - Deprecated: `false`
- Renamed existing API endpoint:
  - From: `Get NFTs by owner`
  - To: `Get NFTs`
  - Path remains: `/v1/nfts`
  - Deprecated: `false`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->