### PR TITLE
Temporarily remove webhooks sidebar link until scrolling issue is fixed

### DIFF
--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/components/ProjectSidebarLayout.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/components/ProjectSidebarLayout.tsx
@@ -2,7 +2,6 @@
 import { FullWidthSidebarLayout } from "@/components/blocks/SidebarLayout";
 import { Badge } from "@/components/ui/badge";
 import {
-  BellIcon,
   BookTextIcon,
   BoxIcon,
   CoinsIcon,
@@ -95,16 +94,17 @@ export function ProjectSidebarLayout(props: {
           icon: NebulaIcon,
           tracking: tracking("nebula"),
         },
-        {
-          href: `${layoutPath}/webhooks`,
-          label: (
-            <span className="flex items-center gap-2">
-              Webhooks <Badge>New</Badge>
-            </span>
-          ),
-          icon: BellIcon,
-          tracking: tracking("webhooks"),
-        },
+        // Commented until we solve the scrolling issue
+        // {
+        //   href: `${layoutPath}/webhooks`,
+        //   label: (
+        //     <span className="flex items-center gap-2">
+        //       Webhooks <Badge>New</Badge>
+        //     </span>
+        //   ),
+        //   icon: BellIcon,
+        //   tracking: tracking("webhooks"),
+        // },
       ]}
       footerSidebarLinks={[
         {


### PR DESCRIPTION
## [Dashboard] Fix: Temporarily remove Webhooks from sidebar

## Notes for the reviewer

Commented out the Webhooks section in the project sidebar until we resolve a scrolling issue. Also removed the unused BellIcon import.

## How to test

Verify that the Webhooks option no longer appears in the project sidebar navigation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Temporarily removed the "Webhooks" link and its "New" badge from the project sidebar to resolve a scrolling issue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on temporarily commenting out the `webhooks` sidebar link in the `ProjectSidebarLayout` component to address a scrolling issue.

### Detailed summary
- Commented out the `webhooks` sidebar link object in the array.
- Removed the `href`, `label`, `icon`, and `tracking` properties related to the `webhooks` link.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->