### PR TITLE
[SDK] Engine search transactions and batch transaction support

### DIFF
--- a/.changeset/engine-enhancements.md
+++ b/.changeset/engine-enhancements.md
@@ -1,0 +1,95 @@
+---
+"thirdweb": minor
+---
+
+Enhanced Engine functionality with server wallet management, search transactions and batch transaction support:
+
+- Added `Engine.createServerWallet()` to create a new server wallet with a custom label
+
+  ```ts
+  import { Engine } from "thirdweb";
+
+  const serverWallet = await Engine.createServerWallet({
+    client,
+    label: "My Server Wallet",
+  });
+  console.log(serverWallet.address);
+  console.log(serverWallet.smartAccountAddress);
+  ```
+
+- Added `Engine.getServerWallets()` to list all existing server wallets
+
+  ```ts
+  import { Engine } from "thirdweb";
+
+  const serverWallets = await Engine.getServerWallets({
+    client,
+  });
+  console.log(serverWallets);
+  ```
+
+- Added `Engine.searchTransactions()` to search for transactions by various filters (id, chainId, from address, etc.)
+
+  ```ts
+  // Search by transaction IDs
+  const transactions = await Engine.searchTransactions({
+    client,
+    filters: [
+      {
+        field: "id",
+        values: ["1", "2", "3"],
+      },
+    ],
+  });
+
+  // Search by chain ID and sender address
+  const transactions = await Engine.searchTransactions({
+    client,
+    filters: [
+      {
+        filters: [
+          {
+            field: "from",
+            values: ["0x1234567890123456789012345678901234567890"],
+          },
+          {
+            field: "chainId",
+            values: ["8453"],
+          },
+        ],
+        operation: "AND",
+      },
+    ],
+    pageSize: 100,
+    page: 0,
+  });
+  ```
+
+- Added `serverWallet.enqueueBatchTransaction()` to enqueue multiple transactions in a single batch
+
+  ```ts
+  // Prepare multiple transactions
+  const transaction1 = claimTo({
+    contract,
+    to: firstRecipient,
+    quantity: 1n,
+  });
+  const transaction2 = claimTo({
+    contract,
+    to: secondRecipient,
+    quantity: 1n,
+  });
+
+  // Enqueue as a batch
+  const { transactionId } = await serverWallet.enqueueBatchTransaction({
+    transactions: [transaction1, transaction2],
+  });
+
+  // Wait for batch completion
+  const { transactionHash } = await Engine.waitForTransactionHash({
+    client,
+    transactionId,
+  });
+  ```
+
+- Improved server wallet transaction handling with better error reporting

--- a/.changeset/stupid-adults-flow.md
+++ b/.changeset/stupid-adults-flow.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/engine": patch
+---
+
+Updated to latest API

--- a/packages/engine/src/client/sdk.gen.ts
+++ b/packages/engine/src/client/sdk.gen.ts
@@ -7,6 +7,8 @@ import type {
 } from "@hey-api/client-fetch";
 import { client as _heyApiClient } from "./client.gen.js";
 import type {
+  CreateAccountData,
+  CreateAccountResponse,
   EncodeFunctionDataData,
   EncodeFunctionDataResponse,
   GetNativeBalanceData,
@@ -15,6 +17,8 @@ import type {
   GetTransactionAnalyticsResponse,
   GetTransactionAnalyticsSummaryData,
   GetTransactionAnalyticsSummaryResponse,
+  ListAccountsData,
+  ListAccountsResponse,
   ReadContractData,
   ReadContractResponse,
   SearchTransactionsData,
@@ -46,6 +50,56 @@ export type Options<
    * used to access values that aren't defined as part of the SDK function.
    */
   meta?: Record<string, unknown>;
+};
+
+/**
+ * List Server Wallets
+ * List all engine server wallets for the current project. Returns an array of EOA addresses with their corresponding predicted smart account addresses.
+ */
+export const listAccounts = <ThrowOnError extends boolean = false>(
+  options?: Options<ListAccountsData, ThrowOnError>,
+) => {
+  return (options?.client ?? _heyApiClient).get<
+    ListAccountsResponse,
+    unknown,
+    ThrowOnError
+  >({
+    security: [
+      {
+        name: "x-secret-key",
+        type: "apiKey",
+      },
+    ],
+    url: "/v1/accounts",
+    ...options,
+  });
+};
+
+/**
+ * Create Server Wallet
+ * Create a new engine server wallet. This is a helper route for creating a new EOA with your KMS provider, provided as a convenient alternative to creating an EOA directly with your KMS provider. Your KMS credentials are not stored, and usage of created accounts require your KMS credentials to be sent with requests.
+ */
+export const createAccount = <ThrowOnError extends boolean = false>(
+  options?: Options<CreateAccountData, ThrowOnError>,
+) => {
+  return (options?.client ?? _heyApiClient).post<
+    CreateAccountResponse,
+    unknown,
+    ThrowOnError
+  >({
+    security: [
+      {
+        name: "x-secret-key",
+        type: "apiKey",
+      },
+    ],
+    url: "/v1/accounts",
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      ...options?.headers,
+    },
+  });
 };
 
 /**

--- a/packages/engine/src/client/types.gen.ts
+++ b/packages/engine/src/client/types.gen.ts
@@ -9,7 +9,7 @@ export type TransactionsFilterValue = {
     | "smartAccountAddress"
     | "chainId";
   values: Array<string>;
-  operation: "AND" | "OR";
+  operation?: "AND" | "OR";
 };
 
 export type TransactionsFilterNested = {
@@ -91,6 +91,70 @@ export type AaZksyncExecutionOptions = {
    */
   chainId: string;
 };
+
+export type ListAccountsData = {
+  body?: never;
+  path?: never;
+  query?: never;
+  url: "/v1/accounts";
+};
+
+export type ListAccountsResponses = {
+  /**
+   * Accounts retrieved successfully
+   */
+  200: {
+    result: Array<{
+      /**
+       * EVM address in hex format
+       */
+      address: string;
+      /**
+       * The predicted smart account address for use with the default thirdweb v0.7 AccountFactory
+       */
+      smartAccountAddress?: string;
+    }>;
+  };
+};
+
+export type ListAccountsResponse =
+  ListAccountsResponses[keyof ListAccountsResponses];
+
+export type CreateAccountData = {
+  body?: {
+    label: string;
+  };
+  headers?: {
+    /**
+     * Vault Access Token used to access your EOA
+     */
+    "x-vault-access-token"?: string;
+  };
+  path?: never;
+  query?: never;
+  url: "/v1/accounts";
+};
+
+export type CreateAccountResponses = {
+  /**
+   * Account created successfully
+   */
+  201: {
+    result: {
+      /**
+       * EVM address in hex format
+       */
+      address: string;
+      /**
+       * The predicted smart account address for use with the default thirdweb v0.7 AccountFactory
+       */
+      smartAccountAddress?: string;
+    };
+  };
+};
+
+export type CreateAccountResponse =
+  CreateAccountResponses[keyof CreateAccountResponses];
 
 export type WriteContractData = {
   body?: {

--- a/packages/thirdweb/src/bridge/Chains.test.ts
+++ b/packages/thirdweb/src/bridge/Chains.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { TEST_CLIENT } from "~test/test-clients.js";
 import { chains } from "./Chains.js";
 
-describe("chains", () => {
+describe.runIf(process.env.TW_SECRET_KEY)("chains", () => {
   it("should fetch chains", async () => {
     // Setup
     const client = TEST_CLIENT;

--- a/packages/thirdweb/src/engine/create-server-wallet.ts
+++ b/packages/thirdweb/src/engine/create-server-wallet.ts
@@ -1,0 +1,57 @@
+import { createAccount } from "@thirdweb-dev/engine";
+import { stringify } from "viem";
+import type { ThirdwebClient } from "../client/client.js";
+import { getThirdwebBaseUrl } from "../utils/domains.js";
+import { getClientFetch } from "../utils/fetch.js";
+
+export type CreateServerWalletArgs = {
+  client: ThirdwebClient;
+  label: string;
+};
+
+/**
+ * Create a server wallet.
+ * @param params - The parameters for the server wallet.
+ * @param params.client - The thirdweb client to use.
+ * @param params.label - The label for the server wallet.
+ * @returns The server wallet signer address and the predicted smart account address.
+ * @engine
+ * @example
+ * ```ts
+ * import { Engine } from "thirdweb";
+ *
+ * const serverWallet = await Engine.createServerWallet({
+ *   client,
+ *   label: "My Server Wallet",
+ * });
+ * console.log(serverWallet.address);
+ * console.log(serverWallet.smartAccountAddress);
+ * ```
+ */
+export async function createServerWallet(params: CreateServerWalletArgs) {
+  const { client, label } = params;
+  const result = await createAccount({
+    baseUrl: getThirdwebBaseUrl("engineCloud"),
+    bodySerializer: stringify,
+    fetch: getClientFetch(client),
+    body: {
+      label,
+    },
+  });
+
+  if (result.error) {
+    throw new Error(
+      `Error creating server wallet with label ${label}: ${stringify(
+        result.error,
+      )}`,
+    );
+  }
+
+  const data = result.data?.result;
+
+  if (!data) {
+    throw new Error(`No server wallet created with label ${label}`);
+  }
+
+  return data;
+}

--- a/packages/thirdweb/src/engine/get-status.ts
+++ b/packages/thirdweb/src/engine/get-status.ts
@@ -2,7 +2,6 @@ import { searchTransactions } from "@thirdweb-dev/engine";
 import type { Chain } from "../chains/types.js";
 import { getCachedChain } from "../chains/utils.js";
 import type { ThirdwebClient } from "../client/client.js";
-import type { WaitForReceiptOptions } from "../transaction/actions/wait-for-tx-receipt.js";
 import { getThirdwebBaseUrl } from "../utils/domains.js";
 import type { Hex } from "../utils/encoding/hex.js";
 import { getClientFetch } from "../utils/fetch.js";
@@ -116,72 +115,4 @@ export async function getTransactionStatus(args: {
     from: data.from ?? undefined,
     id: data.id,
   };
-}
-
-/**
- * Wait for a transaction to be submitted onchain and return the transaction hash.
- * @param args - The arguments for the transaction.
- * @param args.client - The thirdweb client to use.
- * @param args.transactionId - The id of the transaction to wait for.
- * @param args.timeoutInSeconds - The timeout in seconds.
- * @engine
- * @example
- * ```ts
- * import { Engine } from "thirdweb";
- *
- * const { transactionHash } = await Engine.waitForTransactionHash({
- *   client,
- *   transactionId, // the transaction id returned from enqueueTransaction
- * });
- * ```
- */
-export async function waitForTransactionHash(args: {
-  client: ThirdwebClient;
-  transactionId: string;
-  timeoutInSeconds?: number;
-}): Promise<WaitForReceiptOptions> {
-  const startTime = Date.now();
-  const TIMEOUT_IN_MS = args.timeoutInSeconds
-    ? args.timeoutInSeconds * 1000
-    : 5 * 60 * 1000; // 5 minutes in milliseconds
-
-  while (Date.now() - startTime < TIMEOUT_IN_MS) {
-    const executionResult = await getTransactionStatus(args);
-    const status = executionResult.status;
-
-    switch (status) {
-      case "FAILED": {
-        throw new Error(
-          `Transaction failed: ${executionResult.error || "Unknown error"}`,
-        );
-      }
-      case "CONFIRMED": {
-        const onchainStatus =
-          executionResult && "onchainStatus" in executionResult
-            ? executionResult.onchainStatus
-            : null;
-        if (onchainStatus === "REVERTED") {
-          const revertData =
-            "revertData" in executionResult
-              ? executionResult.revertData
-              : undefined;
-          throw new Error(
-            `Transaction reverted: ${revertData?.errorName || ""} ${revertData?.errorArgs ? stringify(revertData.errorArgs) : ""}`,
-          );
-        }
-        return {
-          transactionHash: executionResult.transactionHash as Hex,
-          client: args.client,
-          chain: executionResult.chain,
-        };
-      }
-      default: {
-        // wait for the transaction to be confirmed
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-      }
-    }
-  }
-  throw new Error(
-    `Transaction timed out after ${TIMEOUT_IN_MS / 1000} seconds`,
-  );
 }

--- a/packages/thirdweb/src/engine/index.ts
+++ b/packages/thirdweb/src/engine/index.ts
@@ -5,7 +5,19 @@ export {
 } from "./server-wallet.js";
 export {
   getTransactionStatus,
-  waitForTransactionHash,
   type ExecutionResult,
   type RevertData,
 } from "./get-status.js";
+export { waitForTransactionHash } from "./wait-for-tx-hash.js";
+export {
+  searchTransactions,
+  type SearchTransactionsArgs,
+} from "./search-transactions.js";
+export {
+  createServerWallet,
+  type CreateServerWalletArgs,
+} from "./create-server-wallet.js";
+export {
+  getServerWallets,
+  type GetServerWalletsArgs,
+} from "./list-server-wallets.js";

--- a/packages/thirdweb/src/engine/list-server-wallets.ts
+++ b/packages/thirdweb/src/engine/list-server-wallets.ts
@@ -1,0 +1,46 @@
+import { listAccounts } from "@thirdweb-dev/engine";
+import { stringify } from "viem";
+import type { ThirdwebClient } from "../client/client.js";
+import { getThirdwebBaseUrl } from "../utils/domains.js";
+import { getClientFetch } from "../utils/fetch.js";
+
+export type GetServerWalletsArgs = {
+  client: ThirdwebClient;
+};
+
+/**
+ * List all server wallets.
+ * @param params - The parameters for the server wallet.
+ * @param params.client - The thirdweb client to use.
+ * @returns an array of server wallets with their signer address and predicted smart account address.
+ * @engine
+ * @example
+ * ```ts
+ * import { Engine } from "thirdweb";
+ *
+ * const serverWallets = await Engine.getServerWallets({
+ *   client,
+ * });
+ * console.log(serverWallets);
+ * ```
+ */
+export async function getServerWallets(params: GetServerWalletsArgs) {
+  const { client } = params;
+  const result = await listAccounts({
+    baseUrl: getThirdwebBaseUrl("engineCloud"),
+    bodySerializer: stringify,
+    fetch: getClientFetch(client),
+  });
+
+  if (result.error) {
+    throw new Error(`Error listing server wallets: ${stringify(result.error)}`);
+  }
+
+  const data = result.data?.result;
+
+  if (!data) {
+    throw new Error("No server wallets found");
+  }
+
+  return data;
+}

--- a/packages/thirdweb/src/engine/search-transactions.ts
+++ b/packages/thirdweb/src/engine/search-transactions.ts
@@ -1,0 +1,132 @@
+import {
+  type TransactionsFilterNested,
+  type TransactionsFilterValue,
+  searchTransactions as engineSearchTransactions,
+} from "@thirdweb-dev/engine";
+import type { ThirdwebClient } from "../client/client.js";
+import { getThirdwebBaseUrl } from "../utils/domains.js";
+import { getClientFetch } from "../utils/fetch.js";
+import { stringify } from "../utils/json.js";
+
+export type SearchTransactionsArgs = {
+  client: ThirdwebClient;
+  filters?: (TransactionsFilterValue | TransactionsFilterNested)[];
+  pageSize?: number;
+  page?: number;
+};
+
+/**
+ * Search for transactions by their ids.
+ * @param args - The arguments for the search.
+ * @param args.client - The thirdweb client to use.
+ * @param args.transactionIds - The ids of the transactions to search for.
+ * @engine
+ * @example
+ * ## Search for transactions by their ids
+ *
+ * ```ts
+ * import { Engine } from "thirdweb";
+ *
+ * const transactions = await Engine.searchTransactions({
+ *   client,
+ *   filters: [
+ *     {
+ *       field: "id",
+ *       values: ["1", "2", "3"],
+ *     },
+ *   ],
+ * });
+ * console.log(transactions);
+ * ```
+ *
+ * ## Search for transactions by chain id
+ *
+ * ```ts
+ * import { Engine } from "thirdweb";
+ *
+ * const transactions = await Engine.searchTransactions({
+ *   client,
+ *   filters: [
+ *     {
+ *       field: "chainId",
+ *       values: ["1", "137"],
+ *     },
+ *   ],
+ * });
+ * console.log(transactions);
+ * ```
+ *
+ * ## Search for transactions by sender wallet address
+ *
+ * ```ts
+ * import { Engine } from "thirdweb";
+ *
+ * const transactions = await Engine.searchTransactions({
+ *   client,
+ *   filters: [
+ *     {
+ *       field: "from",
+ *       values: ["0x1234567890123456789012345678901234567890"],
+ *     },
+ *   ],
+ * });
+ * console.log(transactions);
+ * ```
+ *
+ * ## Combined search
+ *
+ * ```ts
+ * import { Engine } from "thirdweb";
+ *
+ * const transactions = await Engine.searchTransactions({
+ *   client,
+ *   filters: [
+ *     {
+ *       filters: [
+ *         {
+ *          field: "from",
+ *          values: ["0x1234567890123456789012345678901234567890"],
+ *        },
+ *        {
+ *          field: "chainId",
+ *          values: ["8453"],
+ *        },
+ *      ],
+ *      operation: "AND",
+ *    },
+ *  ],
+ *  pageSize: 100,
+ *  page: 0,
+ * });
+ * console.log(transactions);
+ * ```
+ */
+export async function searchTransactions(args: SearchTransactionsArgs) {
+  const { client, filters, pageSize = 100, page = 1 } = args;
+  const searchResult = await engineSearchTransactions({
+    baseUrl: getThirdwebBaseUrl("engineCloud"),
+    bodySerializer: stringify,
+    fetch: getClientFetch(client),
+    body: {
+      filters,
+      limit: pageSize,
+      page,
+    },
+  });
+
+  if (searchResult.error) {
+    throw new Error(
+      `Error searching for transaction with filters ${stringify(filters)}: ${stringify(
+        searchResult.error,
+      )}`,
+    );
+  }
+
+  const data = searchResult.data?.result;
+
+  if (!data) {
+    throw new Error(`No transactions found with filters ${stringify(filters)}`);
+  }
+
+  return data;
+}

--- a/packages/thirdweb/src/engine/wait-for-tx-hash.ts
+++ b/packages/thirdweb/src/engine/wait-for-tx-hash.ts
@@ -1,0 +1,75 @@
+import { stringify } from "viem";
+
+import type { Hex } from "../utils/encoding/hex.js";
+
+import type { ThirdwebClient } from "../client/client.js";
+import type { WaitForReceiptOptions } from "../transaction/actions/wait-for-tx-receipt.js";
+import { getTransactionStatus } from "./get-status.js";
+
+/**
+ * Wait for a transaction to be submitted onchain and return the transaction hash.
+ * @param args - The arguments for the transaction.
+ * @param args.client - The thirdweb client to use.
+ * @param args.transactionId - The id of the transaction to wait for.
+ * @param args.timeoutInSeconds - The timeout in seconds.
+ * @engine
+ * @example
+ * ```ts
+ * import { Engine } from "thirdweb";
+ *
+ * const { transactionHash } = await Engine.waitForTransactionHash({
+ *   client,
+ *   transactionId, // the transaction id returned from enqueueTransaction
+ * });
+ * ```
+ */
+export async function waitForTransactionHash(args: {
+  client: ThirdwebClient;
+  transactionId: string;
+  timeoutInSeconds?: number;
+}): Promise<WaitForReceiptOptions> {
+  const startTime = Date.now();
+  const TIMEOUT_IN_MS = args.timeoutInSeconds
+    ? args.timeoutInSeconds * 1000
+    : 5 * 60 * 1000; // 5 minutes in milliseconds
+
+  while (Date.now() - startTime < TIMEOUT_IN_MS) {
+    const executionResult = await getTransactionStatus(args);
+    const status = executionResult.status;
+
+    switch (status) {
+      case "FAILED": {
+        throw new Error(
+          `Transaction failed: ${executionResult.error || "Unknown error"}`,
+        );
+      }
+      case "CONFIRMED": {
+        const onchainStatus =
+          executionResult && "onchainStatus" in executionResult
+            ? executionResult.onchainStatus
+            : null;
+        if (onchainStatus === "REVERTED") {
+          const revertData =
+            "revertData" in executionResult
+              ? executionResult.revertData
+              : undefined;
+          throw new Error(
+            `Transaction reverted: ${revertData?.errorName || "unknown error"} ${revertData?.errorArgs ? stringify(revertData.errorArgs) : ""} - ${executionResult.transactionHash ? executionResult.transactionHash : ""}`,
+          );
+        }
+        return {
+          transactionHash: executionResult.transactionHash as Hex,
+          client: args.client,
+          chain: executionResult.chain,
+        };
+      }
+      default: {
+        // wait for the transaction to be confirmed
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+      }
+    }
+  }
+  throw new Error(
+    `Transaction timed out after ${TIMEOUT_IN_MS / 1000} seconds`,
+  );
+}

--- a/packages/thirdweb/src/extensions/erc1155/read/getOwnedNFTs.test.ts
+++ b/packages/thirdweb/src/extensions/erc1155/read/getOwnedNFTs.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { DROP1155_CONTRACT } from "~test/test-contracts.js";
+import { getOwnedNFTs } from "./getOwnedNFTs.js";
+
+describe.runIf(process.env.TW_SECRET_KEY)("erc1155.getOwnedNFTs", () => {
+  it("with indexer", async () => {
+    const nfts = await getOwnedNFTs({
+      contract: DROP1155_CONTRACT,
+      address: "0x00d4da27dedce60f859471d8f595fdb4ae861557",
+    });
+    expect(nfts.length).toBe(3);
+    expect(nfts.find((nft) => nft.id === 4n)?.quantityOwned).toBe(411n);
+  });
+
+  it("without indexer", async () => {
+    const nfts = await getOwnedNFTs({
+      contract: DROP1155_CONTRACT,
+      address: "0x00d4da27dedce60f859471d8f595fdb4ae861557",
+      useIndexer: false,
+    });
+    expect(nfts.length).toBe(3);
+    expect(nfts.find((nft) => nft.id === 4n)?.quantityOwned).toBe(411n);
+  });
+});

--- a/packages/thirdweb/src/insight/get-nfts.ts
+++ b/packages/thirdweb/src/insight/get-nfts.ts
@@ -319,7 +319,12 @@ async function transformNFTModel(
         });
       }
 
-      return parsedNft;
+      return {
+        ...parsedNft,
+        ...(contract?.type === "erc1155"
+          ? { quantityOwned: balance ? BigInt(balance) : undefined }
+          : {}),
+      };
     }),
   );
 }


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `Engine` functionality by introducing server wallet management, transaction searching, and batch transaction support.

### Detailed summary
- Added `Engine.createServerWallet()` for creating server wallets.
- Added `Engine.getServerWallets()` to list existing server wallets.
- Introduced `Engine.searchTransactions()` for searching transactions.
- Implemented `serverWallet.enqueueBatchTransaction()` for batch transactions.
- Improved error handling in server wallet transactions.
- Updated the `waitForTransactionHash` function to include detailed error reporting.
- Modified tests to cover new server wallet and transaction functionalities.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added transaction search functionality with flexible filters and pagination.
  - Introduced batch transaction support for enqueuing and sending multiple transactions together.
  - Added server wallet creation and listing capabilities.
  - Enhanced transaction confirmation waiting with improved error handling.

- **Bug Fixes**
  - Improved error reporting during server wallet transaction handling.

- **Tests**
  - Added tests for transaction searching, batch transactions, and server wallet creation.
  - Added test for claiming tokens priced in ERC20 tokens in DropERC20 contracts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->