### PR TITLE
[SDK] Feature: Remove Switch Network button

### DIFF
--- a/.changeset/tricky-points-tease.md
+++ b/.changeset/tricky-points-tease.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Remove unnecessary Switch Network button in PayEmbed

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/SwapScreenContent.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/SwapScreenContent.tsx
@@ -21,7 +21,6 @@ import {
 } from "../../../../components/Drawer.js";
 import { Spacer } from "../../../../components/Spacer.js";
 import { Spinner } from "../../../../components/Spinner.js";
-import { SwitchNetworkButton } from "../../../../components/SwitchNetwork.js";
 import { Container } from "../../../../components/basic.js";
 import { Button } from "../../../../components/buttons.js";
 import { Text } from "../../../../components/text.js";
@@ -171,8 +170,6 @@ export function SwapScreenContent(props: {
     (swapRequired && !quoteQuery.data) ||
     isNotEnoughBalance ||
     allowanceQuery.isLoading;
-  const switchChainRequired =
-    props.payer.wallet.getChain()?.id !== fromChain?.id;
 
   const errorMsg =
     !quoteQuery.isLoading && quoteQuery.error
@@ -319,19 +316,6 @@ export function SwapScreenContent(props: {
         >
           Pay with another token
         </Button>
-      ) : switchChainRequired &&
-        fromChain &&
-        !quoteQuery.isLoading &&
-        !allowanceQuery.isLoading &&
-        !isNotEnoughBalance &&
-        !quoteQuery.error ? (
-        <SwitchNetworkButton
-          variant="accent"
-          fullWidth
-          switchChain={async () => {
-            await props.payer.wallet.switchChain(fromChain);
-          }}
-        />
       ) : (
         <Button
           variant={disableContinue ? "outline" : "accent"}
@@ -340,6 +324,9 @@ export function SwapScreenContent(props: {
           disabled={disableContinue}
           onClick={async () => {
             if (!disableContinue) {
+              if (props.payer.wallet.getChain()?.id !== fromChain?.id) {
+                await props.payer.wallet.switchChain(fromChain);
+              }
               showSwapFlow();
               trackPayEvent({
                 event: "confirm_swap_quote",


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the `SwapScreenContent` component by removing the unnecessary `SwitchNetworkButton`, streamlining the code and enhancing the user experience during the token swap process.

### Detailed summary
- Removed the import of `SwitchNetworkButton` from the component.
- Eliminated the conditional rendering of `SwitchNetworkButton`.
- Added a check for the current chain before invoking `switchChain` within the button click handler.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved the swap flow by automatically switching networks when needed, streamlining the process for users.

- **Refactor**
  - Removed the redundant "Switch Network" button from the payment and swap interfaces, resulting in a cleaner and simpler user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->