### PR TITLE
chore: annotate getBuyWithFiatQuote as deprecated

### DIFF
--- a/packages/thirdweb/src/pay/buyWithFiat/getQuote.ts
+++ b/packages/thirdweb/src/pay/buyWithFiat/getQuote.ts
@@ -276,6 +276,7 @@ export type BuyWithFiatQuote = {
  *
  * window.open(quote.onRampLink, "_blank");
  * ```
+ * @deprecated
  * @buyCrypto
  */
 export async function getBuyWithFiatQuote(


### PR DESCRIPTION
Since the param type `GetBuyWithFiatQuoteParams` and wrapping hook `useBuyWithFiatQuote` are marked as deprecated, and we were explicitly advised to use the `Bridge.Onramp.prepare`, I think `getBuyWithFiatQuote` should be marked as deprecated too. Unless there's very specific purpose for it not being marked as such already, in that case please ignore!

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a deprecation notice for the `getBuyWithFiatQuote` function and adds an annotation for its usage.

### Detailed summary
- Added `@deprecated` annotation to the `getBuyWithFiatQuote` function.
- Included `@buyCrypto` annotation for further context on the function's purpose.
- No functional changes were made to the code logic.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Marked the buy with fiat quote function as deprecated in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->