### PR TITLE
chore: remove Team from confirmEmail response

### DIFF
--- a/apps/dashboard/src/@3rdweb-sdk/react/hooks/useApi.ts
+++ b/apps/dashboard/src/@3rdweb-sdk/react/hooks/useApi.ts
@@ -1,6 +1,5 @@
 import { apiServerProxy } from "@/actions/proxies";
 import type { Project } from "@/api/projects";
-import type { Team } from "@/api/team";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useActiveAccount } from "thirdweb/react";
 import { accountKeys, authorizedWallets } from "../cache-keys";
@@ -188,7 +187,7 @@ export function useUpdateNotifications() {
 export const verifyEmailClient = async (input: ConfirmEmailInput) => {
   type Result = {
     error?: { message: string };
-    data: { team: Team; account: Account };
+    data: { account: Account };
   };
 
   const res = await apiServerProxy<Result>({

--- a/apps/dashboard/src/app/(app)/login/onboarding/VerifyEmail/VerifyEmail.stories.tsx
+++ b/apps/dashboard/src/app/(app)/login/onboarding/VerifyEmail/VerifyEmail.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { newAccountStub, teamStub } from "stories/stubs";
+import { newAccountStub } from "stories/stubs";
 import { storybookLog } from "stories/utils";
 import { AccountOnboardingLayout } from "../onboarding-layout";
 import { VerifyEmail } from "./VerifyEmail";
@@ -60,7 +60,6 @@ function Story(props: {
             throw new Error("Example error");
           }
           return {
-            team: teamStub("foo", "free"),
             account: newAccountStub(),
           };
         }}

--- a/apps/dashboard/src/app/(app)/login/onboarding/VerifyEmail/VerifyEmail.tsx
+++ b/apps/dashboard/src/app/(app)/login/onboarding/VerifyEmail/VerifyEmail.tsx
@@ -1,6 +1,4 @@
 "use client";
-
-import type { Team } from "@/api/team";
 import { Spinner } from "@/components/ui/Spinner/Spinner";
 import { Button } from "@/components/ui/button";
 import {
@@ -24,17 +22,11 @@ import {
 
 type VerifyEmailProps = {
   email: string;
-  onEmailConfirmed: (params: {
-    team: Team;
-    account: Account;
-  }) => void;
+  onEmailConfirmed: (params: { account: Account }) => void;
   onBack: () => void;
   verifyEmail: (params: {
     confirmationToken: string;
-  }) => Promise<{
-    team: Team;
-    account: Account;
-  }>;
+  }) => Promise<{ account: Account }>;
   resendConfirmationEmail: () => Promise<void>;
   trackEvent: (params: TrackingParams) => void;
   accountAddress: string;

--- a/apps/dashboard/src/app/(app)/login/onboarding/account-onboarding-ui.tsx
+++ b/apps/dashboard/src/app/(app)/login/onboarding/account-onboarding-ui.tsx
@@ -1,6 +1,4 @@
 "use client";
-
-import type { Team } from "@/api/team";
 import type { Account } from "@3rdweb-sdk/react/hooks/useApi";
 import type { TrackingParams } from "hooks/analytics/useTrack";
 import { useState } from "react";
@@ -27,18 +25,12 @@ type AccountOnboardingScreen =
     };
 
 type AccountOnboardingProps = {
-  onComplete: (param: {
-    team: Team;
-    account: Account;
-  }) => void;
+  onComplete: (param: { account: Account }) => void;
   accountAddress: string;
   trackEvent: (params: TrackingParams) => void;
   verifyEmail: (params: {
     confirmationToken: string;
-  }) => Promise<{
-    team: Team;
-    account: Account;
-  }>;
+  }) => Promise<{ account: Account }>;
   resendEmailConfirmation: () => Promise<void>;
   loginOrSignup: (input: {
     email: string;
@@ -106,12 +98,7 @@ export function AccountOnboardingUI(props: AccountOnboardingProps) {
           verifyEmail={props.verifyEmail}
           resendConfirmationEmail={props.resendEmailConfirmation}
           trackEvent={props.trackEvent}
-          onEmailConfirmed={(data) => {
-            props.onComplete({
-              team: data.team,
-              account: data.account,
-            });
-          }}
+          onEmailConfirmed={props.onComplete}
           onBack={() => setScreen(screen.backScreen)}
           email={screen.email}
         />


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on removing the dependency on the `Team` type across various components related to email verification, simplifying the data structures used in the onboarding process.

### Detailed summary
- Removed `teamStub` import in `VerifyEmail.stories.tsx`.
- Eliminated `Team` type usage in `useApi.ts`, `VerifyEmail.tsx`, and `account-onboarding-ui.tsx`.
- Updated `onEmailConfirmed` and `verifyEmail` props to only include `account` instead of both `account` and `team`. 
- Adjusted the `onComplete` callback in `AccountOnboardingUI` to directly use `props.onComplete`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified onboarding and email verification flows by removing the requirement for team-related data. All relevant callbacks and functions now operate solely with account information.
- **Type Updates**
  - Updated type signatures for onboarding and verification handlers to exclude the team property, streamlining integration for end-users and developers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->