### PR TITLE
Fix: Transfer purchase data

### DIFF
--- a/.changeset/upset-views-show.md
+++ b/.changeset/upset-views-show.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fixes a bug with purchaseData not being included on PayEmbed transfers

--- a/packages/thirdweb/src/pay/buyWithCrypto/getTransfer.ts
+++ b/packages/thirdweb/src/pay/buyWithCrypto/getTransfer.ts
@@ -133,6 +133,7 @@ export async function getBuyWithCryptoTransfer(
       client: params.client,
       feePayer: params.feePayer,
       paymentLinkId: params.paymentLinkId,
+      purchaseData: params.purchaseData,
     });
 
     const firstStep = quote.steps[0];


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing a bug related to the inclusion of `purchaseData` in `PayEmbed` transfers within the `thirdweb` package.

### Detailed summary
- Added `purchaseData: params.purchaseData` to the transfer parameters in the `getTransfer.ts` file.
- This change ensures that `purchaseData` is included during `PayEmbed` transfers, addressing the identified bug.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Fixed an issue where purchase details were not included in PayEmbed transfers, ensuring all relevant purchase data is now properly transferred.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->