### PR TITLE
Fix requests to thirdwebstorage-dev.com not set with secret-key

### DIFF
--- a/packages/thirdweb/src/utils/fetch.ts
+++ b/packages/thirdweb/src/utils/fetch.ts
@@ -127,6 +127,7 @@ const THIRDWEB_DOMAINS = [
   // dev domains
   ".thirdweb.dev",
   ".thirdweb-dev.com",
+  ".thirdwebstorage-dev.com",
 ] as const;
 
 export const IS_THIRDWEB_URL_CACHE = new LruMap<boolean>(4096);


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new URL to the list of constants in the `fetch.ts` file, which likely pertains to thirdweb's storage capabilities.

### Detailed summary
- Added `".thirdwebstorage-dev.com"` to the array of constants.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the list of recognized thirdweb service domains to include ".thirdwebstorage-dev.com".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->