### PR TITLE
[SDK] Add account deletion support when unlinking profiles

### DIFF
--- a/.changeset/account-deletion-unlink.md
+++ b/.changeset/account-deletion-unlink.md
@@ -1,0 +1,35 @@
+---
+"thirdweb": patch
+---
+
+**Add account deletion support when unlinking profiles**
+
+Added optional `allowAccountDeletion` parameter to `useUnlinkProfile` hook and `unlinkProfile` function. When set to `true`, this allows deleting the entire account when unlinking the last profile associated with it.
+
+**React Hook Example:**
+
+```tsx
+import { useUnlinkProfile } from "thirdweb/react";
+
+const { mutate: unlinkProfile } = useUnlinkProfile();
+
+const handleUnlink = () => {
+  unlinkProfile({
+    client,
+    profileToUnlink: connectedProfiles[0],
+    allowAccountDeletion: true, // Delete account if last profile
+  });
+};
+```
+
+**Direct Function Example:**
+
+```ts
+import { unlinkProfile } from "thirdweb/wallets/in-app";
+
+const updatedProfiles = await unlinkProfile({
+  client,
+  profileToUnlink: profiles[0],
+  allowAccountDeletion: true, // Delete account if last profile
+});
+```

--- a/packages/thirdweb/src/react/native/hooks/wallets/useUnlinkProfile.test.tsx
+++ b/packages/thirdweb/src/react/native/hooks/wallets/useUnlinkProfile.test.tsx
@@ -40,6 +40,32 @@ describe("useUnlinkProfile", () => {
       client: TEST_CLIENT,
       ecosystem: undefined,
       profileToUnlink: mockProfile,
+      allowAccountDeletion: false,
+    });
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["profiles"],
+    });
+  });
+
+  it("should call unlinkProfile with allowAccountDeletion if true", async () => {
+    const { result } = renderHook(() => useUnlinkProfile(), {
+      wrapper,
+    });
+    const mutationFn = result.current.mutateAsync;
+
+    await act(async () => {
+      await mutationFn({
+        client: TEST_CLIENT,
+        profileToUnlink: mockProfile,
+        allowAccountDeletion: true,
+      });
+    });
+
+    expect(unlinkProfile).toHaveBeenCalledWith({
+      client: TEST_CLIENT,
+      ecosystem: undefined,
+      profileToUnlink: mockProfile,
+      allowAccountDeletion: true,
     });
     expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
       queryKey: ["profiles"],
@@ -70,6 +96,7 @@ describe("useUnlinkProfile", () => {
           ?.partnerId,
       },
       profileToUnlink: mockProfile,
+      allowAccountDeletion: false,
     });
   });
 });

--- a/packages/thirdweb/src/react/native/hooks/wallets/useUnlinkProfile.ts
+++ b/packages/thirdweb/src/react/native/hooks/wallets/useUnlinkProfile.ts
@@ -31,6 +31,23 @@ import { useConnectedWallets } from "../../../core/hooks/wallets/useConnectedWal
  * };
  * ```
  *
+ * ### Unlinking an email account with account deletion
+ *
+ * ```jsx
+ * import { useUnlinkProfile } from "thirdweb/react";
+ *
+ * const { mutate: unlinkProfile } = useUnlinkProfile();
+ *
+ * const onClick = () => {
+ *   unlinkProfile({
+ *     client,
+ *      // Select the profile you want to unlink
+ *     profileToUnlink: connectedProfiles[0],
+ *     allowAccountDeletion: true, // This will delete the account if it's the last profile linked to the account
+ *   });
+ * };
+ * ```
+ *
  * @wallet
  */
 export function useUnlinkProfile() {
@@ -40,7 +57,12 @@ export function useUnlinkProfile() {
     mutationFn: async ({
       client,
       profileToUnlink,
-    }: { client: ThirdwebClient; profileToUnlink: Profile }) => {
+      allowAccountDeletion = false,
+    }: {
+      client: ThirdwebClient;
+      profileToUnlink: Profile;
+      allowAccountDeletion?: boolean;
+    }) => {
       const ecosystemWallet = wallets.find((w) => isEcosystemWallet(w));
       const ecosystem: Ecosystem | undefined = ecosystemWallet
         ? {
@@ -53,6 +75,7 @@ export function useUnlinkProfile() {
         client,
         ecosystem,
         profileToUnlink,
+        allowAccountDeletion,
       });
     },
     onSuccess: () => {

--- a/packages/thirdweb/src/react/web/hooks/wallets/useUnlinkProfile.test.tsx
+++ b/packages/thirdweb/src/react/web/hooks/wallets/useUnlinkProfile.test.tsx
@@ -40,6 +40,7 @@ describe("useUnlinkProfile", () => {
       client: TEST_CLIENT,
       ecosystem: undefined,
       profileToUnlink: mockProfile,
+      allowAccountDeletion: false,
     });
     expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
       queryKey: ["profiles"],
@@ -70,6 +71,7 @@ describe("useUnlinkProfile", () => {
           ?.partnerId,
       },
       profileToUnlink: mockProfile,
+      allowAccountDeletion: false,
     });
   });
 });

--- a/packages/thirdweb/src/react/web/hooks/wallets/useUnlinkProfile.ts
+++ b/packages/thirdweb/src/react/web/hooks/wallets/useUnlinkProfile.ts
@@ -31,6 +31,23 @@ import { useConnectedWallets } from "../../../core/hooks/wallets/useConnectedWal
  * };
  * ```
  *
+ * ### Unlinking an email account with account deletion
+ *
+ * ```jsx
+ * import { useUnlinkProfile } from "thirdweb/react";
+ *
+ * const { mutate: unlinkProfile } = useUnlinkProfile();
+ *
+ * const onClick = () => {
+ *   unlinkProfile({
+ *     client,
+ *      // Select the profile you want to unlink
+ *     profileToUnlink: connectedProfiles[0],
+ *     allowAccountDeletion: true, // This will delete the account if it's the last profile linked to the account
+ *   });
+ * };
+ * ```
+ *
  * @wallet
  */
 export function useUnlinkProfile() {
@@ -40,7 +57,12 @@ export function useUnlinkProfile() {
     mutationFn: async ({
       client,
       profileToUnlink,
-    }: { client: ThirdwebClient; profileToUnlink: Profile }) => {
+      allowAccountDeletion = false,
+    }: {
+      client: ThirdwebClient;
+      profileToUnlink: Profile;
+      allowAccountDeletion?: boolean;
+    }) => {
       const ecosystemWallet = wallets.find((w) => isEcosystemWallet(w));
       const ecosystem: Ecosystem | undefined = ecosystemWallet
         ? {
@@ -53,6 +75,7 @@ export function useUnlinkProfile() {
         client,
         ecosystem,
         profileToUnlink,
+        allowAccountDeletion,
       });
     },
     onSuccess: () => {

--- a/packages/thirdweb/src/wallets/in-app/core/authentication/linkAccount.test.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/authentication/linkAccount.test.ts
@@ -90,7 +90,37 @@ describe("Account linking functions", () => {
             Authorization: "Bearer iaw-auth-token:mock-token",
             "Content-Type": "application/json",
           },
-          body: JSON.stringify(profileToUnlink),
+          body: JSON.stringify({
+            type: profileToUnlink.type,
+            details: profileToUnlink.details,
+            allowAccountDeletion: false,
+          }),
+        },
+      );
+      expect(result).toEqual(mockLinkedAccounts);
+    });
+
+    it("should successfully unlink an account with allowAccountDeletion", async () => {
+      const result = await unlinkAccount({
+        client: mockClient,
+        profileToUnlink,
+        storage: mockStorage,
+        allowAccountDeletion: true,
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://embedded-wallet.thirdweb.com/api/2024-05-05/account/disconnect",
+        {
+          method: "POST",
+          headers: {
+            Authorization: "Bearer iaw-auth-token:mock-token",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            type: profileToUnlink.type,
+            details: profileToUnlink.details,
+            allowAccountDeletion: true,
+          }),
         },
       );
       expect(result).toEqual(mockLinkedAccounts);

--- a/packages/thirdweb/src/wallets/in-app/core/authentication/linkAccount.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/authentication/linkAccount.ts
@@ -66,11 +66,13 @@ export async function unlinkAccount({
   client,
   ecosystem,
   profileToUnlink,
+  allowAccountDeletion = false,
   storage,
 }: {
   client: ThirdwebClient;
   ecosystem?: Ecosystem;
   profileToUnlink: Profile;
+  allowAccountDeletion?: boolean;
   storage: ClientScopedStorage;
 }): Promise<Profile[]> {
   const clientFetch = getClientFetch(client, ecosystem);
@@ -90,7 +92,11 @@ export async function unlinkAccount({
     {
       method: "POST",
       headers,
-      body: stringify(profileToUnlink),
+      body: stringify({
+        type: profileToUnlink.type,
+        details: profileToUnlink.details,
+        allowAccountDeletion,
+      }),
     },
   );
 

--- a/packages/thirdweb/src/wallets/in-app/core/authentication/types.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/authentication/types.ts
@@ -259,4 +259,5 @@ export type UnlinkParams = {
   client: ThirdwebClient;
   ecosystem?: Ecosystem;
   profileToUnlink: Profile;
+  allowAccountDeletion?: boolean;
 };

--- a/packages/thirdweb/src/wallets/in-app/core/interfaces/connector.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/interfaces/connector.ts
@@ -37,7 +37,10 @@ export interface InAppConnector {
   ): Promise<AuthLoginReturnType>;
   logout(): Promise<LogoutReturnType>;
   linkProfile(args: AuthArgsType): Promise<Profile[]>;
-  unlinkProfile(args: Profile): Promise<Profile[]>;
+  unlinkProfile(
+    args: Profile,
+    allowAccountDeletion?: boolean,
+  ): Promise<Profile[]>;
   getProfiles(): Promise<Profile[]>;
   storage: ClientScopedStorage;
 }

--- a/packages/thirdweb/src/wallets/in-app/native/auth/index.ts
+++ b/packages/thirdweb/src/wallets/in-app/native/auth/index.ts
@@ -203,7 +203,10 @@ export async function linkProfile(args: AuthArgsType) {
  */
 export async function unlinkProfile(args: UnlinkParams) {
   const connector = await getInAppWalletConnector(args.client, args.ecosystem);
-  return await connector.unlinkProfile(args.profileToUnlink);
+  return await connector.unlinkProfile(
+    args.profileToUnlink,
+    args.allowAccountDeletion,
+  );
 }
 
 /**

--- a/packages/thirdweb/src/wallets/in-app/native/native-connector.ts
+++ b/packages/thirdweb/src/wallets/in-app/native/native-connector.ts
@@ -367,7 +367,7 @@ export class InAppNativeConnector implements InAppConnector {
     });
   }
 
-  async unlinkProfile(profile: Profile) {
+  async unlinkProfile(profile: Profile, allowAccountDeletion?: boolean) {
     const { unlinkAccount } = await import(
       "../core/authentication/linkAccount.js"
     );
@@ -376,6 +376,7 @@ export class InAppNativeConnector implements InAppConnector {
       ecosystem: this.ecosystem,
       storage: this.storage,
       profileToUnlink: profile,
+      allowAccountDeletion,
     });
   }
 

--- a/packages/thirdweb/src/wallets/in-app/web/lib/auth/index.ts
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/auth/index.ts
@@ -224,6 +224,8 @@ export async function linkProfile(args: AuthArgsType) {
  * @throws If the unlinking fails. This can happen if the account has no other associated profiles or if the profile that is being unlinked doesn't exists for the current logged in user.
  *
  * @example
+ * ### Unlinking an authentication method
+ *
  * ```ts
  * import { inAppWallet } from "thirdweb/wallets";
  *
@@ -239,11 +241,41 @@ export async function linkProfile(args: AuthArgsType) {
  *  profileToUnlink: profiles[0],
  * });
  * ```
+ *
+ * ### Unlinking an authentication for ecosystems
+ *
+ * ```ts
+ * import { unlinkProfile } from "thirdweb/wallets/in-app";
+ *
+ * const updatedProfiles = await unlinkProfile({
+ *  client,
+ *  ecosystem: {
+ *    id: "ecosystem.your-ecosystem-id",
+ *  },
+ *  profileToUnlink: profiles[0],
+ * });
+ * ```
+ *
+ * ### Unlinking an authentication method with account deletion
+ *
+ * ```ts
+ * import { unlinkProfile } from "thirdweb/wallets/in-app";
+ *
+ * const updatedProfiles = await unlinkProfile({
+ *  client,
+ *  profileToUnlink: profiles[0],
+ *  allowAccountDeletion: true, // This will delete the account if it's the last profile linked to the account
+ * });
+ * ```
+ *
  * @wallet
  */
 export async function unlinkProfile(args: UnlinkParams) {
   const connector = await getInAppWalletConnector(args.client, args.ecosystem);
-  return await connector.unlinkProfile(args.profileToUnlink);
+  return await connector.unlinkProfile(
+    args.profileToUnlink,
+    args.allowAccountDeletion,
+  );
 }
 
 /**

--- a/packages/thirdweb/src/wallets/in-app/web/lib/web-connector.ts
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/web-connector.ts
@@ -470,12 +470,13 @@ export class InAppWebConnector implements InAppConnector {
     });
   }
 
-  async unlinkProfile(profile: Profile) {
+  async unlinkProfile(profile: Profile, allowAccountDeletion?: boolean) {
     return await unlinkAccount({
       client: this.client,
       storage: this.storage,
       ecosystem: this.ecosystem,
       profileToUnlink: profile,
+      allowAccountDeletion,
     });
   }
 


### PR DESCRIPTION
Fixes TOOL-4637

<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces an optional `allowAccountDeletion` parameter to the `unlinkProfile` functionality, enabling the deletion of an entire account when unlinking the last associated profile. This enhances user control over profile management.

### Detailed summary
- Added `allowAccountDeletion` parameter to `unlinkProfile` in various files.
- Updated function signatures to accept `allowAccountDeletion`.
- Modified the `unlinkAccount` function to handle account deletion logic.
- Enhanced tests to cover scenarios with account deletion.
- Updated documentation and examples to reflect the new parameter.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to delete an entire account when unlinking the last profile, available as an optional setting during the unlink process.
  - Enhanced documentation with examples showing how to enable account deletion when unlinking profiles.

- **Documentation**
  - Updated usage examples to illustrate the new account deletion option during profile unlinking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->