### PR TITLE
[SDK] Fix: Token price cache to use proper address

### DIFF
--- a/.changeset/loose-tools-move.md
+++ b/.changeset/loose-tools-move.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fixes token pricing in PayEmbed

--- a/packages/thirdweb/src/pay/convert/cryptoToFiat.ts
+++ b/packages/thirdweb/src/pay/convert/cryptoToFiat.ts
@@ -107,7 +107,7 @@ export async function convertCryptoToFiat(
         },
       }),
     {
-      cacheKey: `convert-fiat-to-crypto-${to}-${chain.id}`,
+      cacheKey: `convert-fiat-to-crypto-${fromTokenAddress}-${chain.id}`,
       cacheTime: 1000 * 60, // 1 minute cache
     },
   );


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR addresses a bug related to token pricing in the `PayEmbed` component by updating the cache key used in the conversion function.

### Detailed summary
- Updated the `cacheKey` in `packages/thirdweb/src/pay/convert/cryptoToFiat.ts` from `convert-fiat-to-crypto-${to}-${chain.id}` to `convert-fiat-to-crypto-${fromTokenAddress}-${chain.id}`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue with token pricing in the PayEmbed feature to improve accuracy when converting crypto to fiat.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->