### PR TITLE
[Dashboard] Fix: Update PayAnalytics component to use projectClientId instead of …

### DIFF
--- a/apps/dashboard/src/components/pay/PayAnalytics/PayAnalytics.tsx
+++ b/apps/dashboard/src/components/pay/PayAnalytics/PayAnalytics.tsx
@@ -60,7 +60,7 @@ export async function PayAnalytics(props: {
   const hasVolume = volumeData.some((d) => d.amountUsdCents > 0);
   const hasWallet = walletData.some((d) => d.count > 0);
   if (!hasVolume && !hasWallet) {
-    return <PayEmbedFTUX clientId={props.clientId} />;
+    return <PayEmbedFTUX clientId={props.projectClientId} />;
   }
 
   return (


### PR DESCRIPTION
…clientId for better clarity in prop usage

<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `PayAnalytics` component to use `props.projectClientId` instead of `props.clientId` when rendering the `PayEmbedFTUX` component, ensuring the correct client ID is passed.

### Detailed summary
- Changed the `clientId` prop in the `PayEmbedFTUX` component from `props.clientId` to `props.projectClientId`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue that could cause errors when displaying the Pay Analytics component in cases with no volume or wallet data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->