### PR TITLE
[Dashboard] Add support for Sophon mainnet

### DIFF
--- a/apps/dashboard/src/@/constants/thirdweb.server.ts
+++ b/apps/dashboard/src/@/constants/thirdweb.server.ts
@@ -42,10 +42,13 @@ export function getConfiguredThirdwebClient(options: {
 
   if (!getTransactionDecorator()) {
     setTransactionDecorator(async ({ account, transaction }) => {
-      // special override for sophon testnet (zk chain)
+      // special override for sophon (zk chain)
       // sophon only allows transactions through their paymaster
       // so always use eip712 tx + paymaster
-      if (transaction.chain.id === 531050104) {
+      if (
+        transaction.chain.id === 531050104 ||
+        transaction.chain.id === 50104
+      ) {
         const serializedTx = await populateEip712Transaction({
           transaction,
           account,

--- a/apps/dashboard/src/components/buttons/MismatchButton.tsx
+++ b/apps/dashboard/src/components/buttons/MismatchButton.tsx
@@ -59,6 +59,7 @@ const GAS_FREE_CHAINS = [
   75513, // Geek verse testnet
   75512, // Geek verse mainnet
   531050104, // sophon testnet
+  50104, // sophon mainnet
   37111, // lens sepolia
   4457845, // zero testnet
   978658, // treasure topaz


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the handling of the `sophon` blockchain in the `MismatchButton` and `thirdweb.server` files, specifically adding support for the `sophon mainnet` and modifying transaction handling for both the `sophon testnet` and `sophon mainnet`.

### Detailed summary
- Added `50104` for `sophon mainnet` in `MismatchButton.tsx`.
- Updated transaction handling in `thirdweb.server.ts` to include `sophon mainnet` (`50104`) alongside `sophon testnet` (`531050104`).

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the Sophon mainnet (chain ID 50104) for gas-free transactions.

- **Bug Fixes**
  - Improved transaction handling to ensure compatibility with both Sophon testnet and mainnet chains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->