### PR TITLE
[SDK] Force legacy for Plume 98866

### DIFF
--- a/packages/thirdweb/src/gas/fee-data.ts
+++ b/packages/thirdweb/src/gas/fee-data.ts
@@ -46,6 +46,7 @@ const FORCE_GAS_PRICE_CHAIN_IDS = [
   5464, // Saga Mainnet
   2020, // Ronin Mainnet
   2021, // Ronin Testnet (Saigon)
+  98866, // Plume mainnet
 ];
 
 /**


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new entry for the `Plume mainnet` in the `fee-data.ts` file, indicating support for this network.

### Detailed summary
- Added a new entry `+98866` for `Plume mainnet` in the array of fee data.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated support for gas pricing on the Plume mainnet chain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->