### PR TITLE
[Dashboard] Add Sophon testnet to custom claim amounts

### DIFF
--- a/apps/dashboard/src/app/(app)/api/testnet-faucet/claim/claim-amount.ts
+++ b/apps/dashboard/src/app/(app)/api/testnet-faucet/claim/claim-amount.ts
@@ -3,6 +3,8 @@ const customClaimAmounts: Record<number, number> = {
   631571: 0.1,
   // Aleph Zero
   2039: 0.1,
+  // Sophon testnet
+  531050104: 5,
 };
 
 const defaultClaimAmount = 0.01;


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new claim amount for the Sophon testnet in the `claim-amount.ts` file while retaining the existing claim amount for Aleph Zero.

### Detailed summary
- Added a new claim amount for the Sophon testnet: `531050104: 5`.
- Retained the existing claim amount for Aleph Zero: `0.1`.
- Defined a default claim amount of `0.01`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the Sophon testnet, allowing users to claim a specific amount (5) from the faucet when using this network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->