### PR TITLE
fix: handle short proxyStorage in getBeaconFromStorageSlot

### DIFF
--- a/packages/thirdweb/src/utils/bytecode/resolveImplementation.ts
+++ b/packages/thirdweb/src/utils/bytecode/resolveImplementation.ts
@@ -110,7 +110,10 @@ async function getBeaconFromStorageSlot(
       position:
         "0xa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50",
     });
-    return `0x${proxyStorage.slice(-40)}`;
+    if (proxyStorage.length >= 40) {
+      return `0x${proxyStorage.slice(-40)}`;
+    }
+    return undefined;
   } catch {
     return undefined;
   }


### PR DESCRIPTION
<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the logic in the `resolveImplementation.ts` file to ensure that the function returns `undefined` if the `proxyStorage` length is less than 40 characters, enhancing error handling.

### Detailed summary
- Added a check to ensure `proxyStorage.length` is at least 40 before returning the sliced value.
- If `proxyStorage` is shorter than 40 characters, the function now returns `undefined`. 
- Maintained the existing error handling with a try-catch block.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of storage slot values to prevent errors when the data is shorter than expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->