### PR TITLE
fix: handle short storage values in beacon proxy pattern

### DIFF
--- a/.changeset/cold-icons-shop.md
+++ b/.changeset/cold-icons-shop.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+fix implementation resolution for Beacon

--- a/packages/thirdweb/src/utils/bytecode/handleBeaconProxyPattern.test.ts
+++ b/packages/thirdweb/src/utils/bytecode/handleBeaconProxyPattern.test.ts
@@ -1,0 +1,52 @@
+import type { EIP1193RequestFn, EIP1474Methods } from "viem";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ANVIL_CHAIN } from "../../../test/src/chains.js";
+import { TEST_CLIENT } from "../../../test/src/test-clients.js";
+import { getBytecode } from "../../contract/actions/get-bytecode.js";
+import { eth_getStorageAt } from "../../rpc/actions/eth_getStorageAt.js";
+import { getRpcClient } from "../../rpc/rpc.js";
+import { resolveImplementation } from "./resolveImplementation.js";
+
+// Mock dependencies
+vi.mock("../../contract/actions/get-bytecode.js");
+vi.mock("../../rpc/rpc.js");
+vi.mock("../../rpc/actions/eth_getStorageAt.js");
+
+describe.runIf(process.env.TW_SECRET_KEY)(
+  "Handle beacon proxy pattern",
+  async () => {
+    beforeEach(() => {
+      vi.resetAllMocks();
+    });
+    it("should handle beacon proxy pattern with short storage values", async () => {
+      // This test verifies that the implementation can handle short storage values
+      // which was the original issue we were trying to fix
+      const mockContract = {
+        address: "0x0000000000000000000000000000000000000001",
+        client: TEST_CLIENT,
+        chain: ANVIL_CHAIN,
+      } as const;
+
+      // Mock getBytecode to return a minimal proxy bytecode that will trigger the beacon check
+      const mockGetBytecode = vi
+        .fn()
+        .mockResolvedValueOnce("") // First call for proxy (empty bytecode triggers beacon check)
+        .mockResolvedValueOnce("0x1234"); // Second call for implementation
+
+      vi.mocked(getBytecode).mockImplementation(mockGetBytecode);
+
+      // Mock eth_getStorageAt to return a short value
+      const mockRpcRequest = { request: vi.fn() };
+      vi.mocked(getRpcClient).mockReturnValue(
+        mockRpcRequest as unknown as EIP1193RequestFn<EIP1474Methods>,
+      );
+      vi.mocked(eth_getStorageAt).mockResolvedValue("0x1234"); // Short storage value
+
+      const result = await resolveImplementation(mockContract);
+
+      // Should not throw and should return some result (even if it's the original address)
+      expect(result).toBeDefined();
+      expect(result.address).toBeDefined();
+    });
+  },
+);


### PR DESCRIPTION
## [SDK] Fix: Handle short storage values in beacon proxy pattern

## Notes for the reviewer

Tests follow-up to #7281 

Added a unit test that specifically verifies the implementation can handle short storage values returned from `eth_getStorageAt`, which was the original issue we were trying to fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Added a new test suite to verify correct handling of beacon proxy patterns, including edge cases with short storage values in smart contract bytecode resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the implementation resolution for the Beacon proxy pattern in the `thirdweb` package by enhancing the test coverage to ensure proper handling of short storage values.

### Detailed summary
- Updated the test in `handleBeaconProxyPattern.test.ts` to verify handling of short storage values.
- Mocked dependencies such as `getBytecode`, `eth_getStorageAt`, and `getRpcClient`.
- Created a mock contract to test the resolution of implementation addresses.
- Ensured that the test checks for defined results without throwing errors.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->