### PR TITLE
Dashboard: Fix contract deploy page missing last used teamId in client object

### DIFF
--- a/apps/dashboard/src/app/(app)/(dashboard)/published-contract/[publisher]/[contract_id]/[version]/page.tsx
+++ b/apps/dashboard/src/app/(app)/(dashboard)/published-contract/[publisher]/[contract_id]/[version]/page.tsx
@@ -1,6 +1,5 @@
 import { ChakraProviderSetup } from "@/components/ChakraProviderSetup";
 import { Separator } from "@/components/ui/separator";
-import { getClientThirdwebClient } from "@/constants/thirdweb-client.client";
 import { serverThirdwebClient } from "@/constants/thirdweb-client.server";
 import { SimpleGrid } from "@chakra-ui/react";
 import { fetchPublishedContractVersions } from "components/contract-components/fetch-contracts-with-versions";
@@ -9,7 +8,7 @@ import { notFound } from "next/navigation";
 import { isAddress } from "thirdweb";
 import { resolveAddress } from "thirdweb/extensions/ens";
 import { getRawAccount } from "../../../../../account/settings/getAccount";
-import { getAuthToken } from "../../../../../api/lib/getAuthToken";
+import { getUserThirdwebClient } from "../../../../../api/lib/getAuthToken";
 import { PublishedActions } from "../../../components/contract-actions-published.client";
 import { DeployContractHeader } from "../../../components/contract-header";
 
@@ -68,9 +67,11 @@ export default async function PublishedContractPage(
     return notFound();
   }
 
-  const [authToken, account] = await Promise.all([
-    getAuthToken(),
+  const [account, client] = await Promise.all([
     getRawAccount(),
+    getUserThirdwebClient({
+      teamId: undefined,
+    }),
   ]);
 
   return (
@@ -92,10 +93,7 @@ export default async function PublishedContractPage(
           <PublishedContract
             publishedContract={publishedContract}
             isLoggedIn={!!account}
-            client={getClientThirdwebClient({
-              jwt: authToken,
-              teamId: undefined,
-            })}
+            client={client}
           />
         </SimpleGrid>
       </ChakraProviderSetup>

--- a/apps/dashboard/src/app/(app)/(dashboard)/published-contract/components/uri-based-deploy.tsx
+++ b/apps/dashboard/src/app/(app)/(dashboard)/published-contract/components/uri-based-deploy.tsx
@@ -1,10 +1,9 @@
 import { getProjects } from "@/api/projects";
 import { getTeams } from "@/api/team";
 import { ChakraProviderSetup } from "@/components/ChakraProviderSetup";
-import { getClientThirdwebClient } from "@/constants/thirdweb-client.client";
 import { CustomContractForm } from "components/contract-components/contract-deploy-form/custom-contract";
 import type { FetchDeployMetadataResult } from "thirdweb/contract";
-import { getAuthToken } from "../../../api/lib/getAuthToken";
+import { getUserThirdwebClient } from "../../../api/lib/getAuthToken";
 import { loginRedirect } from "../../../login/loginRedirect";
 
 type DeployFormForUriProps = {
@@ -21,9 +20,14 @@ export async function DeployFormForUri(props: DeployFormForUriProps) {
     return <div>Could not fetch metadata</div>;
   }
 
-  const [authToken, teams] = await Promise.all([getAuthToken(), getTeams()]);
+  const [teams, client] = await Promise.all([
+    getTeams(),
+    getUserThirdwebClient({
+      teamId: undefined,
+    }),
+  ]);
 
-  if (!teams || !authToken) {
+  if (!teams) {
     loginRedirect(pathname);
   }
 
@@ -43,11 +47,6 @@ export async function DeployFormForUri(props: DeployFormForUriProps) {
     })),
   );
 
-  const client = getClientThirdwebClient({
-    jwt: authToken,
-    teamId: undefined,
-  });
-
   // TODO: remove the `ChakraProviderSetup` wrapper once the form is updated to no longer use chakra
   return (
     <ChakraProviderSetup>
@@ -55,7 +54,7 @@ export async function DeployFormForUri(props: DeployFormForUriProps) {
         metadata={contractMetadata}
         metadataNoFee={contractMetadataNoFee}
         modules={modules?.filter((m) => m !== null)}
-        isLoggedIn={!!authToken}
+        isLoggedIn={true}
         teamsAndProjects={teamsAndProjects}
         client={client}
       />


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the authentication mechanism by replacing the use of `getAuthToken` with `getUserThirdwebClient`, streamlining the client initialization process in the `PublishedContractPage` and `DeployFormForUri` components.

### Detailed summary
- Replaced `getAuthToken` with `getUserThirdwebClient` in `page.tsx` and `uri-based-deploy.tsx`.
- Updated the client initialization logic to remove the dependency on `authToken`.
- Adjusted the `isLoggedIn` prop to always return `true` in `DeployFormForUri`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined user client access, simplifying authentication and client setup in published contract and deploy workflows.
  - Enhanced login state logic for clearer and more efficient user session handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->