### PR TITLE
Nebula: Fix AutoConnect not using nebula client in root layout

### DIFF
--- a/apps/dashboard/src/app/(app)/account/layout.tsx
+++ b/apps/dashboard/src/app/(app)/account/layout.tsx
@@ -46,7 +46,7 @@ export default async function AccountLayout(props: {
         />
         {props.children}
       </div>
-      <TWAutoConnect />
+      <TWAutoConnect client={client} />
       <AppFooter />
     </div>
   );

--- a/apps/dashboard/src/app/(app)/components/autoconnect.tsx
+++ b/apps/dashboard/src/app/(app)/components/autoconnect.tsx
@@ -1,16 +1,15 @@
 "use client";
-import { getClientThirdwebClient } from "@/constants/thirdweb-client.client";
+import type { ThirdwebClient } from "thirdweb";
 import { AutoConnect } from "thirdweb/react";
 import type { SmartWalletOptions } from "thirdweb/wallets";
 
-const client = getClientThirdwebClient();
-
 export function TWAutoConnect(props: {
   accountAbstraction?: SmartWalletOptions;
+  client: ThirdwebClient;
 }) {
   return (
     <AutoConnect
-      client={client}
+      client={props.client}
       accountAbstraction={props.accountAbstraction}
     />
   );

--- a/apps/dashboard/src/app/(app)/providers.tsx
+++ b/apps/dashboard/src/app/(app)/providers.tsx
@@ -18,6 +18,7 @@ import {
 import { TWAutoConnect } from "./components/autoconnect";
 
 const queryClient = new QueryClient();
+const thirdwebClient = getClientThirdwebClient();
 
 export function AppRouterProviders(props: { children: React.ReactNode }) {
   return (
@@ -26,7 +27,7 @@ export function AppRouterProviders(props: { children: React.ReactNode }) {
         <SyncChainStores />
         <ThirdwebProvider>
           <SyncChainDefinitionsToConnectionManager />
-          <TWAutoConnect />
+          <TWAutoConnect client={thirdwebClient} />
           <ThemeProvider
             attribute="class"
             disableTransitionOnChange

--- a/apps/dashboard/src/app/nebula-app/providers.tsx
+++ b/apps/dashboard/src/app/nebula-app/providers.tsx
@@ -8,6 +8,7 @@ import { Toaster } from "sonner";
 import { ThirdwebProvider, useActiveAccount } from "thirdweb/react";
 import { TWAutoConnect } from "../(app)/components/autoconnect";
 import { NebulaConnectWallet } from "./(app)/components/NebulaConnectButton";
+import { nebulaAppThirdwebClient } from "./(app)/utils/nebulaThirdwebClient";
 import { nebulaAAOptions } from "./login/account-abstraction";
 
 const queryClient = new QueryClient();
@@ -16,7 +17,10 @@ export function NebulaProviders(props: { children: React.ReactNode }) {
   return (
     <QueryClientProvider client={queryClient}>
       <ThirdwebProvider>
-        <TWAutoConnect accountAbstraction={nebulaAAOptions} />
+        <TWAutoConnect
+          accountAbstraction={nebulaAAOptions}
+          client={nebulaAppThirdwebClient}
+        />
         <ThemeProvider
           attribute="class"
           disableTransitionOnChange


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `TWAutoConnect` component by passing a `client` prop, which allows for better integration with the Thirdweb client. It also introduces a new client for the Nebula application.

### Detailed summary
- Updated `TWAutoConnect` in `layout.tsx` to accept `client={client}`.
- Added `thirdwebClient` initialization in `providers.tsx`.
- Modified `TWAutoConnect` to require a `client` prop of type `ThirdwebClient`.
- Updated `TWAutoConnect` in `nebula-app/providers.tsx` to pass `nebulaAppThirdwebClient`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced wallet auto-connect feature by integrating authenticated client context for improved connectivity.

- **Refactor**
  - Updated wallet auto-connect components to accept client instances via props, streamlining authentication handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->