### PR TITLE
feat: create/delete teams

### DIFF
--- a/apps/dashboard/src/@/actions/createTeam.ts
+++ b/apps/dashboard/src/@/actions/createTeam.ts
@@ -1,0 +1,74 @@
+"use server";
+import "server-only";
+
+import { randomBytes } from "node:crypto";
+import type { Team } from "@/api/team";
+import { format } from "date-fns";
+import { getAuthToken } from "../../app/(app)/api/lib/getAuthToken";
+import { NEXT_PUBLIC_THIRDWEB_API_HOST } from "../constants/public-envs";
+
+export async function createTeam(options?: {
+  name?: string;
+  slug?: string;
+}) {
+  const token = await getAuthToken();
+
+  if (!token) {
+    return {
+      status: "error",
+      errorMessage: "You are not authorized to perform this action",
+    } as const;
+  }
+
+  const res = await fetch(`${NEXT_PUBLIC_THIRDWEB_API_HOST}/v1/teams`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      name:
+        options?.name ?? `Your Projects ${format(new Date(), "MMM d yyyy")}`,
+      slug: options?.slug ?? randomBytes(20).toString("hex"),
+      billingEmail: null,
+      image: null,
+    }),
+  });
+
+  if (!res.ok) {
+    const reason = await res.text();
+    console.error("failed to create team", {
+      status: res.status,
+      reason,
+    });
+    switch (res.status) {
+      case 400: {
+        return {
+          status: "error",
+          errorMessage: "Invalid team name or slug.",
+        } as const;
+      }
+      case 401: {
+        return {
+          status: "error",
+          errorMessage: "You are not authorized to perform this action.",
+        } as const;
+      }
+      default: {
+        return {
+          status: "error",
+          errorMessage: "An unknown error occurred.",
+        } as const;
+      }
+    }
+  }
+
+  const json = (await res.json()) as {
+    result: Team;
+  };
+
+  return {
+    status: "success",
+    data: json.result,
+  } as const;
+}

--- a/apps/dashboard/src/@/actions/deleteTeam.ts
+++ b/apps/dashboard/src/@/actions/deleteTeam.ts
@@ -1,0 +1,70 @@
+"use server";
+import "server-only";
+import { getAuthToken } from "../../app/(app)/api/lib/getAuthToken";
+import { NEXT_PUBLIC_THIRDWEB_API_HOST } from "../constants/public-envs";
+
+export async function deleteTeam(options: {
+  teamId: string;
+}) {
+  const token = await getAuthToken();
+  if (!token) {
+    return {
+      status: "error",
+      errorMessage: "You are not authorized to perform this action.",
+    } as const;
+  }
+
+  const res = await fetch(
+    `${NEXT_PUBLIC_THIRDWEB_API_HOST}/v1/teams/${options.teamId}`,
+    {
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  );
+  // handle errors
+  if (!res.ok) {
+    const reason = await res.text();
+    console.error("failed to delete team", {
+      status: res.status,
+      reason,
+    });
+    switch (res.status) {
+      case 400: {
+        return {
+          status: "error",
+          errorMessage: "Invalid team ID.",
+        } as const;
+      }
+      case 401: {
+        return {
+          status: "error",
+          errorMessage: "You are not authorized to perform this action.",
+        } as const;
+      }
+
+      case 403: {
+        return {
+          status: "error",
+          errorMessage: "You do not have permission to delete this team.",
+        } as const;
+      }
+      case 404: {
+        return {
+          status: "error",
+          errorMessage: "Team not found.",
+        } as const;
+      }
+      default: {
+        return {
+          status: "error",
+          errorMessage: "An unknown error occurred.",
+        } as const;
+      }
+    }
+  }
+  return {
+    status: "success",
+  } as const;
+}

--- a/apps/dashboard/src/@/api/team.ts
+++ b/apps/dashboard/src/@/api/team.ts
@@ -67,6 +67,7 @@ export async function getTeams() {
   return null;
 }
 
+/** @deprecated */
 export async function getDefaultTeam() {
   const token = await getAuthToken();
   if (!token) {

--- a/apps/dashboard/src/app/(app)/account/components/AccountHeader.tsx
+++ b/apps/dashboard/src/app/(app)/account/components/AccountHeader.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { createTeam } from "@/actions/createTeam";
 import type { Project } from "@/api/projects";
 import type { Team } from "@/api/team";
 import { useDashboardRouter } from "@/lib/DashboardRouter";
@@ -7,6 +8,7 @@ import { CustomConnectWallet } from "@3rdweb-sdk/react/components/connect-wallet
 import type { Account } from "@3rdweb-sdk/react/hooks/useApi";
 import { LazyCreateProjectDialog } from "components/settings/ApiKeys/Create/LazyCreateAPIKeyDialog";
 import { useCallback, useState } from "react";
+import { toast } from "sonner";
 import type { ThirdwebClient } from "thirdweb";
 import { useActiveWallet, useDisconnect } from "thirdweb/react";
 import { doLogout } from "../../login/auth-actions";
@@ -53,6 +55,21 @@ export function AccountHeader(props: {
         team,
         isOpen: true,
       }),
+    createTeam: () => {
+      toast.promise(
+        createTeam().then((res) => {
+          if (res.status === "error") {
+            throw new Error(res.errorMessage);
+          }
+          router.push(`/team/${res.data.slug}`);
+        }),
+        {
+          loading: "Creating team",
+          success: "Team created",
+          error: "Failed to create team",
+        },
+      );
+    },
     account: props.account,
     client: props.client,
     accountAddress: props.accountAddress,

--- a/apps/dashboard/src/app/(app)/account/components/AccountHeaderUI.stories.tsx
+++ b/apps/dashboard/src/app/(app)/account/components/AccountHeaderUI.stories.tsx
@@ -59,6 +59,7 @@ function Variants(props: {
               accountAddress={accountAddressStub}
               connectButton={<ConnectButtonStub />}
               createProject={() => {}}
+              createTeam={() => {}}
               account={{
                 id: "foo",
                 email: "foo@example.com",

--- a/apps/dashboard/src/app/(app)/account/components/AccountHeaderUI.tsx
+++ b/apps/dashboard/src/app/(app)/account/components/AccountHeaderUI.tsx
@@ -18,6 +18,7 @@ export type AccountHeaderCompProps = {
   connectButton: React.ReactNode;
   teamsAndProjects: Array<{ team: Team; projects: Project[] }>;
   createProject: (team: Team) => void;
+  createTeam: () => void;
   account: Pick<Account, "email" | "id" | "image">;
   client: ThirdwebClient;
   accountAddress: string;
@@ -59,6 +60,7 @@ export function AccountHeaderDesktopUI(props: AccountHeaderCompProps) {
               teamsAndProjects={props.teamsAndProjects}
               focus="team-selection"
               createProject={props.createProject}
+              createTeam={props.createTeam}
               account={props.account}
               client={props.client}
             />
@@ -110,6 +112,7 @@ export function AccountHeaderMobileUI(props: AccountHeaderCompProps) {
               upgradeTeamLink={undefined}
               account={props.account}
               client={props.client}
+              createTeam={props.createTeam}
             />
           )}
         </div>

--- a/apps/dashboard/src/app/(app)/account/overview/AccountTeamsUI.tsx
+++ b/apps/dashboard/src/app/(app)/account/overview/AccountTeamsUI.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { createTeam } from "@/actions/createTeam";
 import type { Team } from "@/api/team";
 import type { TeamAccountRole } from "@/api/team-members";
 import { GradientAvatar } from "@/components/blocks/Avatars/GradientAvatar";
@@ -10,10 +11,11 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { ToolTipLabel } from "@/components/ui/tooltip";
+import { useDashboardRouter } from "@/lib/DashboardRouter";
 import { EllipsisIcon, PlusIcon } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
+import { toast } from "sonner";
 import type { ThirdwebClient } from "thirdweb";
 import { TeamPlanBadge } from "../../components/TeamPlanBadge";
 import { getValidTeamPlan } from "../../team/components/TeamHeader/getValidTeamPlan";
@@ -26,6 +28,7 @@ export function AccountTeamsUI(props: {
   }[];
   client: ThirdwebClient;
 }) {
+  const router = useDashboardRouter();
   const [teamSearchValue, setTeamSearchValue] = useState("");
   const teamsToShow = !teamSearchValue
     ? props.teamsWithRole
@@ -34,6 +37,22 @@ export function AccountTeamsUI(props: {
           .toLowerCase()
           .includes(teamSearchValue.toLowerCase());
       });
+
+  const createTeamAndRedirect = () => {
+    toast.promise(
+      createTeam().then((res) => {
+        if (res.status === "error") {
+          throw new Error(res.errorMessage);
+        }
+        router.push(`/team/${res.data.slug}`);
+      }),
+      {
+        loading: "Creating team",
+        success: "Team created",
+        error: "Failed to create team",
+      },
+    );
+  };
 
   return (
     <div>
@@ -45,12 +64,10 @@ export function AccountTeamsUI(props: {
           </p>
         </div>
 
-        <ToolTipLabel label="Coming Soon">
-          <Button disabled className="gap-2 max-sm:w-full">
-            <PlusIcon className="size-4" />
-            Create Team
-          </Button>
-        </ToolTipLabel>
+        <Button className="gap-2 max-sm:w-full" onClick={createTeamAndRedirect}>
+          <PlusIcon className="size-4" />
+          Create Team
+        </Button>
       </div>
 
       <div className="h-4" />

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/settings/general/GeneralSettingsPage.stories.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/settings/general/GeneralSettingsPage.stories.tsx
@@ -62,8 +62,8 @@ function ComponentVariants() {
               await new Promise((resolve) => setTimeout(resolve, 1000));
             }}
           />
-          <DeleteTeamCard enabled={true} teamName="foo" />
-          <DeleteTeamCard enabled={false} teamName="foo" />
+          <DeleteTeamCard canDelete={true} teamId="1" teamName="foo" />
+          <DeleteTeamCard canDelete={false} teamId="2" teamName="foo" />
         </div>
       </div>
     </div>

--- a/apps/dashboard/src/app/(app)/team/components/TeamHeader/TeamAndProjectSelectorPopoverButton.tsx
+++ b/apps/dashboard/src/app/(app)/team/components/TeamHeader/TeamAndProjectSelectorPopoverButton.tsx
@@ -22,6 +22,7 @@ type TeamSwitcherProps = {
   teamsAndProjects: Array<{ team: Team; projects: Project[] }>;
   focus: "project-selection" | "team-selection";
   createProject: (team: Team) => void;
+  createTeam: () => void;
   account: Pick<Account, "email" | "id"> | undefined;
   client: ThirdwebClient;
 };
@@ -100,6 +101,10 @@ export function TeamAndProjectSelectorPopoverButton(props: TeamSwitcherProps) {
               }
               account={props.account}
               client={props.client}
+              createTeam={() => {
+                setOpen(false);
+                props.createTeam();
+              }}
             />
 
             {/* Right */}

--- a/apps/dashboard/src/app/(app)/team/components/TeamHeader/TeamHeaderUI.stories.tsx
+++ b/apps/dashboard/src/app/(app)/team/components/TeamHeader/TeamHeaderUI.stories.tsx
@@ -152,6 +152,7 @@ function Variant(props: {
         logout={() => {}}
         connectButton={<ConnectButtonStub />}
         createProject={() => {}}
+        createTeam={() => {}}
         client={storybookThirdwebClient}
       />
     </div>

--- a/apps/dashboard/src/app/(app)/team/components/TeamHeader/TeamHeaderUI.tsx
+++ b/apps/dashboard/src/app/(app)/team/components/TeamHeader/TeamHeaderUI.tsx
@@ -26,6 +26,7 @@ export type TeamHeaderCompProps = {
   logout: () => void;
   connectButton: React.ReactNode;
   createProject: (team: Team) => void;
+  createTeam: () => void;
   client: ThirdwebClient;
   accountAddress: string;
 };
@@ -73,6 +74,7 @@ export function TeamHeaderDesktopUI(props: TeamHeaderCompProps) {
             teamsAndProjects={props.teamsAndProjects}
             focus="team-selection"
             createProject={props.createProject}
+            createTeam={props.createTeam}
             account={props.account}
             client={props.client}
           />
@@ -100,6 +102,7 @@ export function TeamHeaderDesktopUI(props: TeamHeaderCompProps) {
                 teamsAndProjects={props.teamsAndProjects}
                 focus="project-selection"
                 createProject={props.createProject}
+                createTeam={props.createTeam}
                 account={props.account}
                 client={props.client}
               />
@@ -166,6 +169,7 @@ export function TeamHeaderMobileUI(props: TeamHeaderCompProps) {
             upgradeTeamLink={`/team/${currentTeam.slug}/settings`}
             account={props.account}
             client={props.client}
+            createTeam={props.createTeam}
           />
         </div>
 

--- a/apps/dashboard/src/app/(app)/team/components/TeamHeader/TeamSelectionUI.tsx
+++ b/apps/dashboard/src/app/(app)/team/components/TeamHeader/TeamSelectionUI.tsx
@@ -2,7 +2,6 @@ import type { Project } from "@/api/projects";
 import type { Team } from "@/api/team";
 import { GradientAvatar } from "@/components/blocks/Avatars/GradientAvatar";
 import { ScrollShadow } from "@/components/ui/ScrollShadow/ScrollShadow";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { cn } from "@/lib/utils";
@@ -25,6 +24,7 @@ export function TeamSelectionUI(props: {
   account: Pick<Account, "email" | "id" | "image"> | undefined;
   client: ThirdwebClient;
   isOnProjectPage: boolean;
+  createTeam: () => void;
 }) {
   const { setHoveredTeam, currentTeam, teamsAndProjects } = props;
   const pathname = usePathname();
@@ -127,15 +127,12 @@ export function TeamSelectionUI(props: {
 
             <li className="py-0.5">
               <Button
-                className="w-full justify-start gap-2 px-2 disabled:pointer-events-auto disabled:cursor-not-allowed disabled:opacity-100"
+                className="w-full justify-start gap-2 px-2"
                 variant="ghost"
-                disabled
+                onClick={props.createTeam}
               >
                 <CirclePlusIcon className="size-4 text-link-foreground" />
                 Create Team
-                <Badge className="ml-auto" variant="secondary">
-                  Soon™️
-                </Badge>
               </Button>
             </li>
           </ul>

--- a/apps/dashboard/src/app/(app)/team/components/TeamHeader/TeamSelectorMobileMenuButton.tsx
+++ b/apps/dashboard/src/app/(app)/team/components/TeamHeader/TeamSelectorMobileMenuButton.tsx
@@ -17,6 +17,7 @@ type TeamSelectorMobileMenuButtonProps = {
   account: Pick<Account, "email" | "id"> | undefined;
   client: ThirdwebClient;
   isOnProjectPage: boolean;
+  createTeam: () => void;
 };
 
 export function TeamSelectorMobileMenuButton(
@@ -51,6 +52,7 @@ export function TeamSelectorMobileMenuButton(
             upgradeTeamLink={props.upgradeTeamLink}
             account={props.account}
             client={props.client}
+            createTeam={props.createTeam}
           />
         </DynamicHeight>
       </DialogContent>

--- a/apps/dashboard/src/app/(app)/team/components/TeamHeader/team-header-logged-in.client.tsx
+++ b/apps/dashboard/src/app/(app)/team/components/TeamHeader/team-header-logged-in.client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { createTeam } from "@/actions/createTeam";
 import type { Project } from "@/api/projects";
 import type { Team } from "@/api/team";
 import { useDashboardRouter } from "@/lib/DashboardRouter";
@@ -7,6 +8,7 @@ import { CustomConnectWallet } from "@3rdweb-sdk/react/components/connect-wallet
 import type { Account } from "@3rdweb-sdk/react/hooks/useApi";
 import { LazyCreateProjectDialog } from "components/settings/ApiKeys/Create/LazyCreateAPIKeyDialog";
 import { useCallback, useState } from "react";
+import { toast } from "sonner";
 import type { ThirdwebClient } from "thirdweb";
 import { useActiveWallet, useDisconnect } from "thirdweb/react";
 import { doLogout } from "../../../login/auth-actions";
@@ -59,6 +61,21 @@ export function TeamHeaderLoggedIn(props: {
         isOpen: true,
         team,
       });
+    },
+    createTeam: () => {
+      toast.promise(
+        createTeam().then((res) => {
+          if (res.status === "error") {
+            throw new Error(res.errorMessage);
+          }
+          router.push(`/team/${res.data.slug}`);
+        }),
+        {
+          loading: "Creating team",
+          success: "Team created",
+          error: "Failed to create team",
+        },
+      );
     },
     client: props.client,
     accountAddress: props.accountAddress,

--- a/apps/dashboard/src/app/(app)/team/~/[[...paths]]/page.tsx
+++ b/apps/dashboard/src/app/(app)/team/~/[[...paths]]/page.tsx
@@ -38,7 +38,13 @@ export default async function Page(props: {
     })
     .join("&");
 
+  // if the teams.length is ever 0, redirect to the account page (where the user can create a team then)
+  if (teams.length === 0) {
+    redirect("/account");
+  }
+
   // if there is a single team, redirect to the team page directly
+
   if (teams.length === 1 && teams[0]) {
     redirect(
       createTeamLink({


### PR DESCRIPTION
# [Dashboard] Feature: Add Team Creation and Deletion

## Notes for the reviewer

This PR adds the ability for users to create and delete teams from the dashboard. It includes:

1. Server actions for creating and deleting teams
2. UI integration in the account header, team selector, and account teams page
3. Team deletion functionality in the team settings page

## How to test

- Try creating a new team from the account header dropdown
- Try creating a new team from the account teams page
- Try deleting a team from the team settings page (only available for team owners)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enabled team creation directly from the account and team selection interfaces, allowing users to create a new team and be redirected to its page immediately.
  - Activated the "Create Team" button in relevant menus and headers, making team creation accessible across both desktop and mobile views.

- **Bug Fixes**
  - Improved error handling and user feedback with toast notifications when team creation fails.

- **Refactor**
  - Updated team deletion to use real permission checks and improved the user interface for deleting teams.
  - Added comprehensive handling of authorization and error messages for team creation and deletion operations.
  - Redirected users to the account page when no teams are available.

- **Documentation**
  - Marked the default team retrieval function as deprecated in the documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on enhancing team management features by adding the ability to create and delete teams, updating related UI components, and ensuring proper redirection based on team availability.

### Detailed summary
- Added `createTeam` function in multiple components.
- Introduced `deleteTeam` functionality with error handling.
- Updated UI components to reflect new team creation and deletion capabilities.
- Implemented redirection logic based on team count.
- Modified `DeleteTeamCard` to accept `canDelete` and `teamId` props.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->