### PR TITLE
chore: optional serviceApiKey

### DIFF
--- a/.changeset/good-swans-bet.md
+++ b/.changeset/good-swans-bet.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+fix: make service api key optional to allow services to pass through auth

--- a/packages/service-utils/src/core/api.ts
+++ b/packages/service-utils/src/core/api.ts
@@ -20,7 +20,8 @@ export type CoreServiceConfig = {
   // if EXPLICITLY set to null, service will not be checked for authorization
   // this is meant for services that are not possible to be turned off by users, such as "social" and "analytics"
   serviceScope: ServiceName | null;
-  serviceApiKey: string;
+  // Optional. Some services pass through user-provided authentication (e.g. analytics) and should not have any authed access on their own.
+  serviceApiKey?: string;
   serviceAction?: string;
   useWalletAuth?: boolean;
   /**

--- a/packages/service-utils/src/core/get-auth-headers.test.ts
+++ b/packages/service-utils/src/core/get-auth-headers.test.ts
@@ -111,4 +111,14 @@ describe("getAuthHeaders", () => {
       Authorization: "Bearer test-jwt",
     });
   });
+
+  it("should return empty headers if no auth method and no serviceApiKey is provided", () => {
+    const headers = getAuthHeaders(defaultAuthData);
+    expect(headers).toEqual({});
+  });
+
+  it("should return empty headers if serviceApiKey is undefined and no other auth method is provided", () => {
+    const headers = getAuthHeaders(defaultAuthData, undefined);
+    expect(headers).toEqual({});
+  });
 });

--- a/packages/service-utils/src/core/get-auth-headers.ts
+++ b/packages/service-utils/src/core/get-auth-headers.ts
@@ -9,8 +9,8 @@ import type { AuthorizationInput } from "./authorize/index.js";
  */
 export function getAuthHeaders(
   authData: AuthorizationInput,
-  serviceApiKey: string,
-): Record<string, string> {
+  serviceApiKey?: string,
+): HeadersInit {
   const { teamId, clientId, jwt, secretKey, incomingServiceApiKey } = authData;
 
   switch (true) {
@@ -18,26 +18,31 @@ export function getAuthHeaders(
     case !!secretKey:
       return {
         "x-secret-key": secretKey,
-      } as Record<string, string>;
+      };
 
     // 2. if we have a JWT AND either a teamId or clientId, we'll use the JWT for auth
     case !!(jwt && (teamId || clientId)):
       return {
         Authorization: `Bearer ${jwt}`,
-      } as Record<string, string>;
+      };
 
     // 3. if we have an incoming service api key, we'll use it
     case !!incomingServiceApiKey: {
       return {
         "x-service-api-key": incomingServiceApiKey,
-      } as Record<string, string>;
+      };
     }
 
-    // 4. if nothing else is present, we'll use the service api key
-    default: {
+    // 4. if we have a service api key provided by the service, use it
+    case !!serviceApiKey: {
       return {
         "x-service-api-key": serviceApiKey,
       };
+    }
+
+    // 5. otherwise leave auth headers empty
+    default: {
+      return {};
     }
   }
 }


### PR DESCRIPTION
## [SDK] Fix: Make service API key optional to allow services to pass through auth

## Notes for the reviewer

This PR makes the `serviceApiKey` parameter optional in the service-utils package to support services that pass through user-provided authentication (like analytics) and should not have any authed access on their own.

## How to test

Added unit tests to verify that empty headers are returned when no auth method and no serviceApiKey is provided.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Service API key is now optional, allowing access to certain services without authentication.
- **Bug Fixes**
	- Improved handling of authentication headers when no API key or authentication method is provided.
- **Tests**
	- Added tests to verify correct behavior when API key is omitted or undefined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->