### PR TITLE
[Dashboard] Update URL rewrites for grants and superchain pages

### DIFF
--- a/apps/dashboard/framer-rewrites.js
+++ b/apps/dashboard/framer-rewrites.js
@@ -40,7 +40,8 @@ module.exports = [
   "/community/ambassadors",
   "/community/startup-program",
   // -- grants --
-  "/grant/superchain",
+  "/grants",
+  "/superchain",
   // -- templates --
   "/templates",
   "/templates/:template_slug",

--- a/apps/dashboard/redirects.js
+++ b/apps/dashboard/redirects.js
@@ -368,6 +368,12 @@ async function redirects() {
       destination: "/learn/guides",
       permanent: false,
     },
+    // redirect to /grant/superchain to /superchain
+    {
+      source: "/grant/superchain",
+      destination: "/superchain",
+      permanent: false,
+    },
 
     ...legacyDashboardToTeamRedirects,
   ];

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/connect/account-abstraction/AccountAbstractionPage.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/connect/account-abstraction/AccountAbstractionPage.tsx
@@ -110,7 +110,7 @@ function GasCreditAlert(props: {
             target="_blank"
             label="superchain-landing"
             category={TRACKING_CATEGORY}
-            href="https://thirdweb.com/grant/superchain"
+            href="https://thirdweb.com/superchain"
           >
             Learn More
           </TrackedUnderlineLink>

--- a/apps/portal/src/app/account/billing/credits/page.mdx
+++ b/apps/portal/src/app/account/billing/credits/page.mdx
@@ -16,7 +16,7 @@ export const metadata = createMetadata({
 Credits let you cover the costs of using thirdweb services. There are currently two types of credits available on thirdweb:
 
 - **Optimism Superchain Credits**
-Optimism superchain credits are redeemed from a program which aims to enable developers to create seamless web3 user onboarding experiences powered by Smart Accounts. [Learn more about the OP Superchain program.](https://thirdweb.com/grant/superchain)
+Optimism superchain credits are redeemed from a program which aims to enable developers to create seamless web3 user onboarding experiences powered by Smart Accounts. [Learn more about the OP Superchain program.](https://thirdweb.com/superchain)
 
 - **Service Credits**: These credits can be applied across any thirdweb service on any chain. This includes usage across In-App Wallets, RPC, and IPFS storage. To get thirdweb credits, apply to join the [startup program.](https://thirdweb.com/community/startup-program).
 


### PR DESCRIPTION
### TL;DR

Updated URL routing for grants section in the dashboard app.

### What changed?

- Removed the combined `/grant/superchain` route
- Added two separate routes:
  - `/grants` - for the general grants page
  - `/superchain` - for the superchain-specific content

### How to test?

1. Navigate to `/grants` and verify it loads the grants page correctly
2. Navigate to `/superchain` and verify it loads the superchain page correctly
3. Verify that the old `/grant/superchain` route no longer works or redirects appropriately

### Why make this change?

This change improves URL structure by separating the grants and superchain content into their own distinct routes, making the navigation more intuitive and allowing each section to have its own dedicated URL path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated grants section routes to split "/grant/superchain" into separate "/grants" and "/superchain" paths for improved navigation.
- **Bug Fixes**
  - Corrected a link in the Gas Credit Alert to point directly to the updated superchain page.
  - Added a redirect from "/grant/superchain" to "/superchain" to ensure seamless navigation.
- **Documentation**
  - Updated links in billing credits and informational pages to reflect the new superchain URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating references from `/grant/superchain` to `/superchain` across multiple files, improving clarity and consistency in the application.

### Detailed summary
- In `apps/dashboard/framer-rewrites.js`, changed `/grant/superchain` to `/grants` and added `/superchain`.
- In `apps/dashboard/redirects.js`, added a redirect from `/grant/superchain` to `/superchain`.
- In `apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/connect/account-abstraction/AccountAbstractionPage.tsx`, updated the `href` from `https://thirdweb.com/grant/superchain` to `https://thirdweb.com/superchain`.
- In `apps/portal/src/app/account/billing/credits/page.mdx`, updated the text to reflect the new link to `https://thirdweb.com/superchain`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->