### PR TITLE
[Dashboard] Add 7-day free trial for Growth plan

### DIFF
--- a/apps/dashboard/src/@/components/blocks/pricing-card.tsx
+++ b/apps/dashboard/src/@/components/blocks/pricing-card.tsx
@@ -16,7 +16,6 @@ import { CheckoutButton } from "../billing";
 
 type PricingCardCta = {
   hint?: string;
-
   onClick?: () => void;
 } & (
   | {
@@ -58,11 +57,16 @@ export const PricingCard: React.FC<PricingCardProps> = ({
   activeTrialEndsAt,
 }) => {
   const plan = TEAM_PLANS[billingPlan];
-  const isCustomPrice = typeof plan.price === "string";
 
   const trackEvent = useTrack();
   const remainingTrialDays =
     (activeTrialEndsAt ? remainingDays(activeTrialEndsAt) : 0) || 0;
+
+  // if the team has just signed up and has not subscribed yet, and the billing plan is growth, then they get a 7 day trial
+  const has7DayTrial =
+    remainingTrialDays === 0 &&
+    billingStatus === "noPayment" &&
+    billingPlan === "growth";
 
   const handleCTAClick = () => {
     cta?.onClick?.();
@@ -97,6 +101,7 @@ export const PricingCard: React.FC<PricingCardProps> = ({
               {plan.title}
             </h3>
             {current && <Badge className="capitalize">Current plan</Badge>}
+            {has7DayTrial && <Badge variant="success">7 Day Free Trial</Badge>}
           </div>
           <p className="max-w-[320px] text-muted-foreground text-sm">
             {plan.description}
@@ -108,15 +113,23 @@ export const PricingCard: React.FC<PricingCardProps> = ({
           {plan.isStartingPriceOnly && (
             <span className="text-muted-foreground text-xs">Starting at</span>
           )}
-          <div className="flex items-center gap-2">
-            <span className="font-semibold text-2xl text-foreground tracking-tight">
-              ${plan.price.toLocaleString()}
-            </span>
-
-            {!isCustomPrice && (
+          {has7DayTrial ? (
+            <div className="flex flex-col items-start gap-0">
+              <span className="font-bold text-2xl text-foreground tracking-tight">
+                7 days free
+              </span>
+              <span className="text-muted-foreground text-sm">
+                Then ${plan.price.toLocaleString()} / month
+              </span>
+            </div>
+          ) : (
+            <div className="flex items-center gap-2">
+              <span className="font-semibold text-2xl text-foreground tracking-tight">
+                ${plan.price.toLocaleString()}
+              </span>
               <span className="text-muted-foreground">/ month</span>
-            )}
-          </div>
+            </div>
+          )}
 
           {remainingTrialDays > 0 && (
             <p className="text-muted-foreground text-sm">
@@ -155,7 +168,7 @@ export const PricingCard: React.FC<PricingCardProps> = ({
               teamSlug={teamSlug}
               sku={billingPlanToSkuMap[billingPlan]}
             >
-              {cta.label}
+              {has7DayTrial ? "Start 7 Day Free Trial" : cta.label}
             </CheckoutButton>
           )}
 
@@ -166,7 +179,7 @@ export const PricingCard: React.FC<PricingCardProps> = ({
               asChild
             >
               <Link href={cta.href} target="_blank" onClick={handleCTAClick}>
-                {cta.label}
+                {has7DayTrial ? "Start 7 Day Free Trial" : cta.label}
               </Link>
             </Button>
           )}

--- a/apps/dashboard/src/app/(app)/login/onboarding/team-onboarding/InviteTeamMembers.tsx
+++ b/apps/dashboard/src/app/(app)/login/onboarding/team-onboarding/InviteTeamMembers.tsx
@@ -49,7 +49,8 @@ export function InviteTeamMembersUI(props: {
     await pollWithTimeout({
       shouldStop: async () => {
         const team = await props.getTeam();
-        const isNonFreePlan = team.billingPlan !== "free";
+        const isNonFreePlan =
+          team.billingPlan !== "free" && team.billingPlan !== "starter";
 
         if (isNonFreePlan) {
           props.trackEvent({
@@ -233,8 +234,8 @@ function InviteModalContent(props: {
           Choose a plan
         </SheetTitle>
         <SheetDescription className="text-left leading-relaxed">
-          Get started with the free Starter plan or upgrade to Growth plan for
-          increased limits and advanced features.{" "}
+          Upgrade to the Growth plan to unlock team members and advanced
+          features.{" "}
           <UnderlineLink href="https://thirdweb.com/pricing" target="_blank">
             Learn more about pricing
           </UnderlineLink>

--- a/apps/dashboard/src/utils/pricing.tsx
+++ b/apps/dashboard/src/utils/pricing.tsx
@@ -11,7 +11,7 @@ export const TEAM_PLANS: Record<
   {
     title: string;
     isStartingPriceOnly?: boolean;
-    price: string | number;
+    price: number;
     subTitle: string | null;
     trialPeriodDays: number;
     description: string;


### PR DESCRIPTION
# Add 7-day free trial for Growth plan and include Starter plan in team onboarding

This PR adds a 7-day free trial indicator for teams that have just signed up but haven't subscribed yet when selecting the Growth plan. It also updates the team onboarding flow to properly handle the Starter plan.

Changes include:
- Added logic to detect if a team qualifies for the 7-day trial (new signup with no payment on Growth plan)
- Added a "7 day free trial" text display for qualifying teams
- Updated the polling logic to consider both "free" and "starter" plans as non-paid plans
- Modified the onboarding description text to remove reference to "free Starter plan"

## Summary by CodeRabbit

- **New Features**
  - Added a clear "7 day free trial" indicator for eligible Growth plan users.

- **Enhancements**
  - Updated onboarding modal text to remove "free" from the Starter plan description.
  - Modified billing plan polling logic to exclude both "free" and "starter" plans before proceeding.

---

## PR-Codex overview
This PR focuses on updating the logic for determining billing plans and enhancing the user experience regarding trial periods in the `InviteTeamMembers` and `PricingCard` components.

### Detailed summary
- In `InviteTeamMembers.tsx`, updated the condition for `isNonFreePlan` to exclude both "free" and "starter" plans.
- Modified the text in `InviteModalContent` to clarify the Starter plan.
- In `pricing-card.tsx`, added a condition for a 7-day trial for teams with a "growth" billing plan and "noPayment" status.
- Changed the rendering logic for remaining trial days to include a message for the 7-day trial.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the pricing logic and user experience in the dashboard application. It includes changes to pricing data types, conditional checks for billing plans, and updates to the display of pricing and trial information.

### Detailed summary
- Changed `price` type from `string | number` to `number`.
- Updated the condition for `isNonFreePlan` to exclude the "starter" plan.
- Modified the onboarding description for clarity.
- Introduced a `has7DayTrial` variable to manage trial display logic.
- Updated pricing display to show "7 days free" when applicable.
- Adjusted button labels to reflect the trial status.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a "7 Day Free Trial" badge and updated price display for eligible users on the Growth plan.
  - Call-to-action button now shows "Start 7 Day Free Trial" when applicable.

- **Bug Fixes**
  - Improved onboarding flow by updating plan detection logic to better handle "Starter" and "Free" plans.

- **Style**
  - Revised onboarding text to emphasize upgrading to the Growth plan and removed mention of the Starter plan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->