### PR TITLE
Fix z-index issue in NFT asset page

### DIFF
--- a/apps/dashboard/src/@/components/blocks/media-renderer.tsx
+++ b/apps/dashboard/src/@/components/blocks/media-renderer.tsx
@@ -17,7 +17,7 @@ export function CustomMediaRenderer(props: MediaRendererProps) {
 
   return (
     <div
-      className="relative"
+      className="relative z-0"
       onLoad={() => {
         if (props.src) {
           setLoadedSrc(props.src);


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `className` of a `div` in the `media-renderer.tsx` file to include a new z-index value, enhancing its stacking context.

### Detailed summary
- Changed `className` from `"relative"` to `"relative z-0"` in the `div` element.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Adjusted stacking order of the media renderer component to improve layering with surrounding elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->