### PR TITLE
[Dashboard] Update rewrites and redirects for Connect to Build migration

### DIFF
--- a/apps/dashboard/framer-rewrites.js
+++ b/apps/dashboard/framer-rewrites.js
@@ -6,13 +6,14 @@ module.exports = [
   "/bounties",
   "/contact-us",
   // -- product landing pages --
-  // -- connect
-  "/connect",
-  "/connect/sign-in",
-  "/connect/account-abstraction",
-  "/connect/universal-bridge",
-  "/connect/auth",
-  "/connect/in-app-wallets",
+  // -- build category
+  "/wallets",
+  "/account-abstraction",
+  "/universal-bridge",
+  "/auth",
+  "/in-app-wallets",
+  "/transactions",
+  // -- end build category
   // -- storage
   "/storage",
   // -- nebula
@@ -24,8 +25,7 @@ module.exports = [
   "/contracts/modular-contracts",
   "/contracts/explore",
   "/contracts/deployment-tool",
-  // -- engine
-  "/engine",
+
   // -- solutions pages --
   "/solutions/:solution_slug",
   // -- campaigns --

--- a/apps/dashboard/redirects.js
+++ b/apps/dashboard/redirects.js
@@ -239,11 +239,6 @@ async function redirects() {
       permanent: false,
     },
     {
-      source: "/build",
-      destination: "/contracts/modular-contracts",
-      permanent: false,
-    },
-    {
       source: "/ui-components",
       destination: "/sdk",
       permanent: false,
@@ -319,28 +314,10 @@ async function redirects() {
       destination: "/templates/:slug",
       permanent: false,
     },
-    // redirect /account-abstraction to /connect/account-abstraction
-    {
-      source: "/account-abstraction",
-      destination: "/connect/account-abstraction",
-      permanent: false,
-    },
-    // redirect /connect/pay to /connect/universal-bridge
+    // redirect /connect/pay to /universal-bridge
     {
       source: "/connect/pay",
-      destination: "/connect/universal-bridge",
-      permanent: false,
-    },
-    // redirect /auth to /connect/auth
-    {
-      source: "/auth",
-      destination: "/connect/auth",
-      permanent: false,
-    },
-    // redirect /in-app-wallets to /connect/in-app-wallets
-    {
-      source: "/in-app-wallets",
-      destination: "/connect/in-app-wallets",
+      destination: "/universal-bridge",
       permanent: false,
     },
     // PREVIOUS CAMPAIGNS
@@ -372,6 +349,37 @@ async function redirects() {
     {
       source: "/grant/superchain",
       destination: "/superchain",
+      permanent: false,
+    },
+    // connect -> build redirects
+    {
+      source: "/connect",
+      destination: "/wallets",
+      permanent: false,
+    },
+    {
+      source: "/connect/account-abstraction",
+      destination: "/account-abstraction",
+      permanent: false,
+    },
+    {
+      source: "/connect/universal-bridge",
+      destination: "/universal-bridge",
+      permanent: false,
+    },
+    {
+      source: "/connect/auth",
+      destination: "/auth",
+      permanent: false,
+    },
+    {
+      source: "/connect/in-app-wallets",
+      destination: "/in-app-wallets",
+      permanent: false,
+    },
+    {
+      source: "/engine",
+      destination: "/transactions",
       permanent: false,
     },
 


### PR DESCRIPTION
### TL;DR

Updated URL structure for product pages, moving Connect-related pages to a new Build category.

### What changed?

- Added new Framer rewrites for `/wallets`, `/account-abstraction`, `/universal-bridge`, and `/transactions` under the Build category
- Removed `/connect` and `/engine` from Framer rewrites
- Added redirects from old Connect pages to new Build pages:
  - `/connect` → `/build`
  - `/connect/account-abstraction` → `/account-abstraction`
  - `/connect/universal-bridge` → `/universal-bridge`
  - `/engine` → `/transactions`
- Kept legacy Connect rewrites for backward compatibility

### How to test?

1. Verify that the old URLs redirect properly to the new destinations:
   - `/connect` should redirect to `/build`
   - `/connect/account-abstraction` should redirect to `/account-abstraction`
   - `/connect/universal-bridge` should redirect to `/universal-bridge`
   - `/engine` should redirect to `/transactions`
2. Confirm that the new URLs (`/wallets`, `/account-abstraction`, etc.) render correctly

### Why make this change?

Reorganizing the product pages under a more intuitive "Build" category to better represent the product offerings and improve navigation structure. This change maintains backward compatibility through redirects while establishing a clearer information architecture.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on restructuring and updating the routing logic in the `apps/dashboard/framer-rewrites.js` and `apps/dashboard/redirects.js` files. It replaces old routes with new ones, consolidating the redirects under a "build category" and improving the overall organization of the code.

### Detailed summary
- Removed commented-out routes for `/connect` and its sub-paths.
- Added new routes under a "build category" including `/wallets`, `/account-abstraction`, `/universal-bridge`, `/auth`, `/in-app-wallets`, and `/transactions`.
- Updated redirects to point directly to new paths without the `/connect` prefix.
- Added new redirects from `/connect` and its sub-paths to their new corresponding paths.
- Removed deprecated redirects for `/account-abstraction`, `/auth`, and `/in-app-wallets`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated navigation paths to include new build-related categories for easier access to wallets, account abstraction, universal bridge, and transactions sections.

- **Bug Fixes**
  - Adjusted and added redirects to ensure users are routed correctly between build, connect, and engine-related pages. Some outdated redirects were removed for improved navigation consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->