### PR TITLE
insight playground - allow array items to be single item

### DIFF
--- a/apps/playground-web/src/app/insight/[blueprint_slug]/blueprint-playground.client.tsx
+++ b/apps/playground-web/src/app/insight/[blueprint_slug]/blueprint-playground.client.tsx
@@ -815,9 +815,13 @@ function openAPIV3ParamToZodFormSchema(
         }
 
         if (itemSchema) {
-          return isRequired
+          const arraySchema = isRequired
             ? z.array(itemSchema).min(1, { message: "Required" })
-            : z.array(itemSchema).optional();
+            : z.array(itemSchema);
+          const arrayOrSingleItemSchema = z.union([arraySchema, itemSchema]);
+          return isRequired
+            ? arrayOrSingleItemSchema
+            : arrayOrSingleItemSchema.optional();
         }
       }
       break;


### PR DESCRIPTION
Fixes validation for query params that can be single or multiple value. 
E.g. `?contract_address=0x...&contract_address=0x..`  and `?contract_address=0x..` are both valid queries. Doing just 1 value as in the second variant did not pass validation previously, but now does

<!-- start pr-codex -->

---

## PR-Codex overview
This PR refines the schema validation logic in the `blueprint-playground.client.tsx` file. It modifies how required items are handled in an array schema and introduces a union type for better flexibility.

### Detailed summary
- Changed the return value for when `isRequired` is true to use `z.union` to allow either an array or a single item schema.
- Made the array schema always required when `isRequired` is true.
- Made the array schema optional when `isRequired` is false.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced form input flexibility to accept either a single item or an array of items for array-typed parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->