### PR TITLE
Fix: Fallback insight owned tokens request to mainnet

### DIFF
--- a/packages/thirdweb/src/insight/get-tokens.ts
+++ b/packages/thirdweb/src/insight/get-tokens.ts
@@ -51,7 +51,7 @@ export async function getOwnedTokens(args: {
 
   const defaultQueryOptions: GetV1TokensData["query"] = {
     owner_address: ownerAddress,
-    chain_id: chains.map((chain) => chain.id),
+    chain_id: chains.length > 0 ? chains.map((chain) => chain.id) : [1],
     include_native: "true",
     include_spam: "false",
     metadata: "true",


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR modifies the `defaultQueryOptions` in the `get-tokens.ts` file to ensure that if no chains are provided, a default chain ID of `1` is used instead of an empty array.

### Detailed summary
- Changed the `chain_id` property in `defaultQueryOptions`:
  - From: `-chain_id: chains.map((chain) => chain.id)`
  - To: `+chain_id: chains.length > 0 ? chains.map((chain) => chain.id) : [1]`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured that token queries always include at least one chain ID, defaulting to mainnet if none are specified. This prevents issues when no chains are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->