### PR TITLE
[Dashboard] Add chain, publisher, and contract data to deploy failure analytics

### DIFF
--- a/apps/dashboard/src/@/analytics/report.ts
+++ b/apps/dashboard/src/@/analytics/report.ts
@@ -37,6 +37,9 @@ export function reportContractDeployed(properties: {
  */
 export function reportContractDeployFailed(properties: {
   errorMessage: string;
+  chainId: number;
+  publisher: string | undefined;
+  contractName: string | undefined;
 }) {
   posthog.capture("contract deploy failed", properties);
 }

--- a/apps/dashboard/src/components/contract-components/contract-deploy-form/custom-contract.tsx
+++ b/apps/dashboard/src/components/contract-components/contract-deploy-form/custom-contract.tsx
@@ -696,6 +696,9 @@ export const CustomContractForm: React.FC<CustomContractFormProps> = ({
               const parsedError = parseError(e);
               reportContractDeployFailed({
                 errorMessage: parsedError,
+                chainId: walletChain.id,
+                publisher: rewriteTwPublisher(metadata.publisher),
+                contractName: metadata.name,
               });
 
               deployStatusModal.close();


### PR DESCRIPTION
# Enhanced Error Reporting for Contract Deployment Failures

Added additional context data to the contract deployment failure analytics by including:
- `chainId`: Captures the blockchain network where the deployment failed
- `publisher`: Records the contract publisher information
- `contractName`: Tracks which contract failed during deployment

These parameters provide more comprehensive error tracking, allowing for better debugging and analysis of deployment failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced error reporting for contract deployment failures with additional context, including chain ID, publisher address, and contract name. This provides more detailed feedback when a deployment fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->