### PR TITLE
[Dashboard] Disable 7-day trial for growth plan

### DIFF
--- a/apps/dashboard/src/@/components/blocks/pricing-card.tsx
+++ b/apps/dashboard/src/@/components/blocks/pricing-card.tsx
@@ -60,11 +60,8 @@ export const PricingCard: React.FC<PricingCardProps> = ({
   const remainingTrialDays =
     (activeTrialEndsAt ? remainingDays(activeTrialEndsAt) : 0) || 0;
 
-  // if the team has just signed up and has not subscribed yet, and the billing plan is growth, then they get a 7 day trial
-  const has7DayTrial =
-    remainingTrialDays === 0 &&
-    billingStatus === "noPayment" &&
-    billingPlan === "growth";
+  // trials are disabled for now
+  const has7DayTrial = false;
 
   return (
     <div


### PR DESCRIPTION
Disabled 7-day trial period for new growth plan users

Previously, users who signed up for the growth plan would automatically receive a 7-day trial period. This PR disables this functionality by setting `has7DayTrial` to `false` with a comment indicating that trials are temporarily disabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Disabled the 7-day free trial feature for all users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->