### PR TITLE
[SDK] Fix: Deprecate test mode

### DIFF
--- a/packages/thirdweb/src/react/core/hooks/connection/ConnectButtonProps.ts
+++ b/packages/thirdweb/src/react/core/hooks/connection/ConnectButtonProps.ts
@@ -77,6 +77,9 @@ export type PayUIOptions = Prettify<
     buyWithCrypto?:
       | false
       | {
+          /**
+           * @deprecated
+           */
           testMode?: boolean;
           prefillSource?: {
             chain: Chain;
@@ -95,6 +98,9 @@ export type PayUIOptions = Prettify<
      */
     buyWithFiat?:
       | {
+          /**
+           * @deprecated
+           */
           testMode?: boolean;
           prefillSource?: {
             currency?: CurrencyMeta["shorthand"];


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces deprecation notices for the `testMode` property in two types within the `ConnectButtonProps.ts` file, signaling that these properties should no longer be used.

### Detailed summary
- Added a `@deprecated` comment to the `testMode` property in the first instance.
- Added a `@deprecated` comment to the `testMode` property in the `buyWithFiat` options.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Marked the testMode option as deprecated in both buyWithCrypto and buyWithFiat payment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->