### PR TITLE
Update minimal account implementation address

### DIFF
--- a/packages/thirdweb/src/wallets/in-app/core/eip7702/minimal-account.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/eip7702/minimal-account.ts
@@ -24,7 +24,7 @@ import {
 import type { BundlerOptions } from "../../../smart/types.js";
 
 const MINIMAL_ACCOUNT_IMPLEMENTATION_ADDRESS =
-  "0xbaC7e770af15d130Cd72838ff386f14FBF3e9a3D";
+  "0x173217d7f8c26Dc3c01e37e1c04813CC7cC9fEc2";
 
 export const create7702MinimalAccount = (args: {
   client: ThirdwebClient;


### PR DESCRIPTION
Changed MINIMAL_ACCOUNT_IMPLEMENTATION_ADDRESS to a new address in minimal-account.ts with full granular session key functionality

<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the implementation address for the minimal account in the `minimal-account.ts` file, which is part of the in-app wallet functionality. This change likely reflects an update in the smart contract address being used.

### Detailed summary
- Changed `MINIMAL_ACCOUNT_IMPLEMENTATION_ADDRESS` from `"0xbaC7e770af15d130Cd72838ff386f14FBF3e9a3D"` to `"0x173217d7f8c26Dc3c01e37e1c04813CC7cC9fEc2"` in `minimal-account.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the address used for the minimal account implementation contract.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->