### PR TITLE
[Changeset] Add nebula-app to ignore list and reorder config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,5 +1,11 @@
 {
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true,
+    "updateInternalDependents": "always"
+  },
   "$schema": "https://unpkg.com/@changesets/config@2.1.1/schema.json",
+  "access": "public",
+  "baseBranch": "main",
   "changelog": [
     "@changesets/changelog-github",
     {
@@ -7,21 +13,16 @@
     }
   ],
   "commit": false,
-  "access": "public",
-  "baseBranch": "main",
-  "updateInternalDependencies": "patch",
   "ignore": [
     "playground-web",
     "thirdweb-dashboard",
     "wallet-ui",
     "portal",
-    "thirdweb-login"
+    "thirdweb-login",
+    "nebula-app"
   ],
-  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
-    "updateInternalDependents": "always",
-    "onlyUpdatePeerDependentsWhenOutOfRange": true
-  },
   "snapshot": {
     "prereleaseTemplate": "{tag}-{commit}-{datetime}"
-  }
+  },
+  "updateInternalDependencies": "patch"
 }


### PR DESCRIPTION
# Update Changeset Configuration

This PR updates the `.changeset/config.json` file with the following changes:

- Reorganized the configuration properties in a more structured order
- Added "nebula-app" to the list of ignored packages
- Moved experimental unsafe options to the top of the file
- Maintained all existing configuration values and behavior