### PR TITLE
[Dashboard] Replace Sentry Replay with PostHog integration

### DIFF
--- a/apps/dashboard/src/instrumentation-client.ts
+++ b/apps/dashboard/src/instrumentation-client.ts
@@ -99,12 +99,11 @@ Sentry.init({
     "Non-Error promise rejection captured",
   ],
 
-  // You can remove this option if you're not planning to use the Sentry Session Replay feature:
+  // integrate sentry with posthog
   integrations: [
-    Sentry.replayIntegration({
-      blockAllMedia: true,
-      // Additional Replay configuration goes in here, for example:
-      maskAllText: true,
+    posthog.sentryIntegration({
+      organization: "thirdweb-dev",
+      projectId: 6690186,
     }),
   ],
 


### PR DESCRIPTION
### TL;DR

Replaced Sentry Replay integration with PostHog Sentry integration in the dashboard app.

### What changed?

- Removed the Sentry Replay integration that was blocking media and masking text
- Added PostHog Sentry integration with organization set to "thirdweb-dev" and projectId set to 6690186
- Updated the comment to indicate the integration of Sentry with PostHog

### How to test?

1. Verify that Sentry events are properly forwarded to PostHog
2. Check that the PostHog dashboard shows Sentry events from the thirdweb-dev organization
3. Confirm that error tracking continues to work as expected

### Why make this change?

This change integrates Sentry with PostHog to consolidate analytics and error tracking data in one platform. This will provide better correlation between user behavior and errors, improving our ability to diagnose issues and understand their impact.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on integrating `Sentry` for error tracking and monitoring in the application, alongside existing `PostHog` analytics. It involves the initialization of `Sentry` with various configurations to filter errors and integrate with `PostHog`.

### Detailed summary
- Removed `sentry.client.config.ts`.
- Added `Sentry` initialization in `instrumentation-client.ts` with:
  - `allowUrls` and `denyUrls` for filtering.
  - `dsn` for Sentry project.
  - `ignoreErrors` to ignore specific common errors.
  - Integration with `PostHog` using `posthog.sentryIntegration`.
  - Configuration for error sampling rates. 
- Exported `onRouterTransitionStart` for router navigation tracking.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->