### PR TITLE
fix: bug with no results on storage page

### DIFF
--- a/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/usage/storage/your-files.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/usage/storage/your-files.tsx
@@ -137,15 +137,15 @@ export const YourFilesSection = (props: { authToken: string }) => {
     pageSize: pageSize,
   });
 
-  const showPagination = pinnedFilesQuery.data
+  const showPagination = pinnedFilesQuery.data?.result
     ? pinnedFilesQuery.data.result.count > pageSize
     : false;
 
-  const totalPages = pinnedFilesQuery.data
+  const totalPages = pinnedFilesQuery.data?.result
     ? Math.ceil(pinnedFilesQuery.data.result.count / pageSize)
     : 0;
 
-  const pinnedFilesToShow = pinnedFilesQuery.data
+  const pinnedFilesToShow = pinnedFilesQuery.data?.result
     ? pinnedFilesQuery.data.result.pinnedFiles
     : undefined;
 
@@ -206,7 +206,7 @@ export const YourFilesSection = (props: { authToken: string }) => {
           </TableBody>
         </Table>
 
-        {pinnedFilesQuery.data && pinnedFilesQuery.data.result.count === 0 && (
+        {pinnedFilesQuery.data?.result?.count === 0 && (
           <div className="flex min-h-[250px] items-center justify-center rounded-lg">
             No Pinned Files
           </div>


### PR DESCRIPTION
## [Dashboard] Fix: Add optional chaining to prevent undefined errors in YourFilesSection

## Notes for the reviewer

Added optional chaining to prevent potential undefined errors when accessing `pinnedFilesQuery.data.result` properties in the YourFilesSection component. This ensures the component handles cases where the data or result might be undefined more gracefully.

## How to test

Verify that the YourFilesSection component renders correctly when data is loading or when the API returns undefined values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved reliability when displaying pinned files by preventing errors if data is missing or incomplete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the null safety of the `pinnedFilesQuery.data` object in the `your-files.tsx` file by using optional chaining. This change ensures that the code handles cases where `data` might be undefined, preventing potential runtime errors.

### Detailed summary
- Updated `showPagination` to use optional chaining for `pinnedFilesQuery.data?.result`.
- Modified `totalPages` to safely access `pinnedFilesQuery.data?.result`.
- Adjusted `pinnedFilesToShow` to include optional chaining.
- Changed the condition for rendering "No Pinned Files" to use optional chaining.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->