### PR TITLE
[SDK] Update NATIVE_TOKEN_ADDRESS to checksummed address

### DIFF
--- a/packages/thirdweb/src/constants/addresses.ts
+++ b/packages/thirdweb/src/constants/addresses.ts
@@ -1,3 +1,5 @@
+import { getAddress } from "src/utils/address.js";
+
 /**
  * The address of the native token.
  */
@@ -8,7 +10,7 @@ export const NATIVE_TOKEN_ADDRESS =
  * @internal
  */
 export function isNativeTokenAddress(address: string) {
-  return address.toLowerCase() === NATIVE_TOKEN_ADDRESS;
+  return getAddress(address) === getAddress(NATIVE_TOKEN_ADDRESS);
 }
 
 /**


### PR DESCRIPTION
Changed the NATIVE_TOKEN_ADDRESS constant to use the checksummed version as some services might have checks for it.

<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `NATIVE_TOKEN_ADDRESS` constant to a new address format and modifies the `isNativeTokenAddress` function to use `getAddress` for comparison, ensuring address normalization.

### Detailed summary
- Updated `NATIVE_TOKEN_ADDRESS` from `"0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"` to `"0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"`.
- Changed `isNativeTokenAddress` to use `getAddress` for both the input `address` and `NATIVE_TOKEN_ADDRESS` for case-insensitive comparison.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the format of the native token address to use a checksummed Ethereum address for improved consistency and readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->