### PR TITLE
Dashboard: group project sidebar links

### DIFF
--- a/apps/dashboard/src/@/components/blocks/SidebarLayout.tsx
+++ b/apps/dashboard/src/@/components/blocks/SidebarLayout.tsx
@@ -4,9 +4,11 @@ import {
   SidebarFooter,
   SidebarGroup,
   SidebarGroupContent,
+  SidebarGroupLabel,
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
+  SidebarMenuSubItem,
   SidebarRail,
   SidebarSeparator,
   SidebarTrigger,
@@ -66,23 +68,13 @@ export function FullWidthSidebarLayout(props: {
     >
       {/* left - sidebar */}
       <Sidebar className="pt-2" collapsible="icon" side="left">
-        <SidebarContent>
-          <SidebarGroup>
-            <SidebarGroupContent>
-              <RenderSidebarGroup
-                groupName={undefined}
-                sidebarLinks={contentSidebarLinks}
-              />
-            </SidebarGroupContent>
-          </SidebarGroup>
+        <SidebarContent className="p-2">
+          <RenderSidebarMenu links={contentSidebarLinks} />
         </SidebarContent>
 
         {footerSidebarLinks && (
           <SidebarFooter className="pb-3">
-            <RenderSidebarGroup
-              groupName={undefined}
-              sidebarLinks={footerSidebarLinks}
-            />
+            <RenderSidebarMenu links={footerSidebarLinks} />
           </SidebarFooter>
         )}
 
@@ -106,17 +98,29 @@ export function FullWidthSidebarLayout(props: {
 
 function RenderSidebarGroup(props: {
   sidebarLinks: SidebarLink[];
-  groupName: string | undefined;
+  groupName: string;
 }) {
-  const { sidebarLinks } = props;
-  const sidebar = useSidebar();
+  return (
+    <SidebarGroup className="p-0">
+      <SidebarMenuItem>
+        <SidebarGroupLabel> {props.groupName}</SidebarGroupLabel>
+        <SidebarGroupContent>
+          <RenderSidebarMenu links={props.sidebarLinks} />
+        </SidebarGroupContent>
+      </SidebarMenuItem>
+    </SidebarGroup>
+  );
+}
 
+function RenderSidebarMenu(props: { links: SidebarLink[] }) {
+  const sidebar = useSidebar();
   return (
     <SidebarMenu className="gap-1.5">
-      {sidebarLinks.map((link) => {
+      {props.links.map((link, idx) => {
+        // link
         if ("href" in link) {
           return (
-            <SidebarMenuItem key={link.href}>
+            <SidebarMenuSubItem key={link.href}>
               <SidebarMenuButton asChild>
                 <NavLink
                   activeClassName="text-foreground bg-accent"
@@ -132,14 +136,24 @@ function RenderSidebarGroup(props: {
                   <span>{link.label}</span>
                 </NavLink>
               </SidebarMenuButton>
-            </SidebarMenuItem>
+            </SidebarMenuSubItem>
           );
         }
 
+        // separator
         if ("separator" in link) {
-          return <SidebarSeparator className="my-1" key={Math.random()} />;
+          return (
+            <SidebarSeparator
+              className="my-1"
+              key={`separator-${
+                // biome-ignore lint/suspicious/noArrayIndexKey: index is fine here
+                idx
+              }`}
+            />
+          );
         }
 
+        // group
         return (
           <RenderSidebarGroup
             groupName={link.group}

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/components/ProjectSidebarLayout.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/components/ProjectSidebarLayout.tsx
@@ -34,57 +34,81 @@ export function ProjectSidebarLayout(props: {
           label: "Overview",
         },
         {
-          href: `${layoutPath}/wallets`,
-          icon: WalletIcon,
-          label: "Wallets",
+          separator: true,
         },
         {
-          href: `${layoutPath}/account-abstraction`,
-          icon: SmartAccountIcon,
-          label: "Account Abstraction",
+          group: "Build",
+          links: [
+            {
+              href: `${layoutPath}/wallets`,
+              icon: WalletIcon,
+              label: "Wallets",
+            },
+            {
+              href:
+                engineLinkType === "cloud"
+                  ? `${layoutPath}/transactions`
+                  : `${layoutPath}/engine/dedicated`,
+              icon: ArrowLeftRightIcon,
+              isActive: (pathname) => {
+                return (
+                  pathname.startsWith(`${layoutPath}/transactions`) ||
+                  pathname.startsWith(`${layoutPath}/engine/dedicated`)
+                );
+              },
+              label: "Transactions",
+            },
+            {
+              href: `${layoutPath}/contracts`,
+              icon: ContractIcon,
+              label: "Contracts",
+            },
+          ],
         },
         {
-          href: `${layoutPath}/universal-bridge`,
-          icon: PayIcon,
-          label: "Universal Bridge",
+          separator: true,
         },
         {
-          href: `${layoutPath}/contracts`,
-          icon: ContractIcon,
-          label: "Contracts",
+          group: "Monetize",
+          links: [
+            {
+              href: `${layoutPath}/universal-bridge`,
+              icon: PayIcon,
+              label: "Universal Bridge",
+            },
+            {
+              href: `${layoutPath}/tokens`,
+              icon: CoinsIcon,
+              label: (
+                <span className="flex items-center gap-2">
+                  Tokens <Badge>New</Badge>
+                </span>
+              ),
+            },
+          ],
         },
         {
-          href: `${layoutPath}/tokens`,
-          icon: CoinsIcon,
-          label: (
-            <span className="flex items-center gap-2">
-              Tokens <Badge>New</Badge>
-            </span>
-          ),
+          separator: true,
         },
         {
-          href:
-            engineLinkType === "cloud"
-              ? `${layoutPath}/transactions`
-              : `${layoutPath}/engine/dedicated`,
-          icon: ArrowLeftRightIcon,
-          isActive: (pathname) => {
-            return (
-              pathname.startsWith(`${layoutPath}/transactions`) ||
-              pathname.startsWith(`${layoutPath}/engine/dedicated`)
-            );
-          },
-          label: "Transactions",
-        },
-        {
-          href: `${layoutPath}/insight`,
-          icon: InsightIcon,
-          label: "Insight",
-        },
-        {
-          href: `${layoutPath}/vault`,
-          icon: LockIcon,
-          label: "Vault",
+          group: "Scale",
+          links: [
+            {
+              href: `${layoutPath}/insight`,
+              icon: InsightIcon,
+              label: "Insight",
+            },
+            {
+              href: `${layoutPath}/account-abstraction`,
+              icon: SmartAccountIcon,
+              label: "Account Abstraction",
+            },
+            {
+              href: `${layoutPath}/vault`,
+              icon: LockIcon,
+              label: "Vault",
+            },
+          ],
         },
       ]}
       footerSidebarLinks={[


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR refactors the `ProjectSidebarLayout.tsx` to enhance the sidebar structure by introducing groups for links and improving the rendering of sidebar items. It also modifies the way sidebar links are displayed, replacing `SidebarGroup` with `RenderSidebarMenu`.

### Detailed summary
- Added grouping for sidebar links: "Build", "Monetize", and "Scale".
- Introduced `RenderSidebarMenu` for rendering links instead of `RenderSidebarGroup`.
- Updated link structure to include `links` arrays for grouped items.
- Changed sidebar item rendering from `SidebarMenuItem` to `SidebarMenuSubItem`.
- Improved handling of separators in the sidebar.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Organized sidebar navigation into clear groups ("Build," "Monetize," "Scale") for easier access to related links.
  - Enhanced sidebar menu rendering with a new modular structure for improved navigation and interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->