### PR TITLE
add eoa execution options type

### DIFF
--- a/packages/engine/src/client/types.gen.ts
+++ b/packages/engine/src/client/types.gen.ts
@@ -92,6 +92,28 @@ export type AaZksyncExecutionOptions = {
   chainId: string;
 };
 
+/**
+ * Uses EOA for execution. Only supported for signing currently.
+ */
+export type EoaExecutionOptions = {
+  type: "eoa";
+
+  /**
+   * The EOA address
+   */
+  address: string;
+
+  /**
+   * The chain id of the transaction
+   */
+  chainId: string;
+
+  /**
+   * The idempotency key of the transaction. Transaction requests sent with the same idempotency key will be de-duplicated. If not provided, a randomUUID will be generated. This is also used as the ID of a queued/stored transaction.
+   */
+  idempotencyKey?: string;
+};
+
 export type ListAccountsData = {
   body?: never;
   path?: never;
@@ -434,7 +456,8 @@ export type SignTransactionData = {
     executionOptions:
       | AutoExecutionOptions
       | AaExecutionOptions
-      | AaZksyncExecutionOptions;
+      | AaZksyncExecutionOptions
+      | EoaExecutionOptions;
     params: Array<{
       /**
        * The recipient address
@@ -585,7 +608,8 @@ export type SignMessageData = {
     executionOptions:
       | AutoExecutionOptions
       | AaExecutionOptions
-      | AaZksyncExecutionOptions;
+      | AaZksyncExecutionOptions
+      | EoaExecutionOptions;
     params: Array<{
       /**
        * The message to sign
@@ -661,7 +685,8 @@ export type SignTypedDataData = {
     executionOptions:
       | AutoExecutionOptions
       | AaExecutionOptions
-      | AaZksyncExecutionOptions;
+      | AaZksyncExecutionOptions
+      | EoaExecutionOptions;
     params: Array<{
       domain: {
         chainId?: number | number;

--- a/packages/engine/src/client/types.gen.ts
+++ b/packages/engine/src/client/types.gen.ts
@@ -186,7 +186,8 @@ export type WriteContractData = {
     executionOptions:
       | AutoExecutionOptions
       | AaExecutionOptions
-      | AaZksyncExecutionOptions;
+      | AaZksyncExecutionOptions
+      | EoaExecutionOptions;
     params: Array<{
       /**
        * The function to call on the contract
@@ -325,7 +326,8 @@ export type SendTransactionData = {
     executionOptions:
       | AutoExecutionOptions
       | AaExecutionOptions
-      | AaZksyncExecutionOptions;
+      | AaZksyncExecutionOptions
+      | EoaExecutionOptions;
     params: Array<{
       /**
        * The address of the contract to send the transaction to

--- a/packages/thirdweb/src/engine/server-wallet.ts
+++ b/packages/thirdweb/src/engine/server-wallet.ts
@@ -1,6 +1,7 @@
 import {
   type AaExecutionOptions,
   type AaZksyncExecutionOptions,
+  type EoaExecutionOptions,
   sendTransaction,
   signMessage,
   signTypedData,
@@ -46,7 +47,8 @@ export type ServerWalletOptions = {
    */
   executionOptions?:
     | Omit<AaExecutionOptions, "chainId">
-    | Omit<AaZksyncExecutionOptions, "chainId">;
+    | Omit<AaZksyncExecutionOptions, "chainId">
+    | Omit<EoaExecutionOptions, "chainId">;
 };
 
 export type ServerWallet = Account & {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces support for `EoaExecutionOptions` in the `ServerWalletOptions` and various transaction-related types, allowing for execution using externally owned accounts (EOA). This enhances the flexibility of transaction handling in the wallet.

### Detailed summary
- Added `EoaExecutionOptions` type with properties: `type`, `address`, `chainId`, and optional `idempotencyKey`.
- Updated `ServerWalletOptions` to include `EoaExecutionOptions`.
- Modified `executionOptions` in `WriteContractData`, `SendTransactionData`, `SignTransactionData`, `SignMessageData`, and `SignTypedDataData` to include `EoaExecutionOptions`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for execution options using externally owned accounts (EOA) for signing transactions, messages, and typed data.
  - Expanded wallet configuration options to include EOA-based execution alongside existing account abstraction options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->