### PR TITLE
fix: typo on a field in webhook event helper

### DIFF
--- a/.changeset/itchy-pandas-punch.md
+++ b/.changeset/itchy-pandas-punch.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+fix: wrong casing on a field in webhook event helper

--- a/packages/service-utils/src/node/webhookProducer.ts
+++ b/packages/service-utils/src/node/webhookProducer.ts
@@ -51,7 +51,7 @@ export class WebhookEventProducer {
       return {
         ...event,
         // Default to now.
-        created_at: event.createdAt ?? new Date(),
+        createdAt: event.createdAt ?? new Date(),
         // Default to a generated UUID.
         id: event.id ?? `evt_${createId()}`,
       };


### PR DESCRIPTION
# [SDK] Fix: Correct field casing in webhook event helper

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the casing of a field in the webhook event helper to ensure consistency in the `service-utils` package.

### Detailed summary
- Updated the field name from `created_at` to `createdAt` in the `webhookProducer.ts` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->