### PR TITLE
[SDK] Chore: Remove onrampTokenAddress set to ETH

### DIFF
--- a/.changeset/old-bats-love.md
+++ b/.changeset/old-bats-love.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+A number of important fixes for payment widgets

--- a/packages/thirdweb/src/bridge/Onramp.ts
+++ b/packages/thirdweb/src/bridge/Onramp.ts
@@ -6,6 +6,7 @@ import { stringify } from "../utils/json.js";
 import { ApiError } from "./types/Errors.js";
 import type { RouteStep } from "./types/Route.js";
 import type { Token } from "./types/Token.js";
+import { defineChain } from "../chains/utils.js";
 
 // export status within the Onramp module
 export { status } from "./OnrampStatus.js";
@@ -237,6 +238,8 @@ export async function prepare(
     originAmount: BigInt(step.originAmount),
     transactions: step.transactions.map((tx) => ({
       ...tx,
+      chain: defineChain(tx.chainId),
+      client,
       value: tx.value ? BigInt(tx.value) : undefined,
     })),
   }));

--- a/packages/thirdweb/src/bridge/Onramp.ts
+++ b/packages/thirdweb/src/bridge/Onramp.ts
@@ -1,4 +1,5 @@
 import type { Address as ox__Address } from "ox";
+import { defineChain } from "../chains/utils.js";
 import type { ThirdwebClient } from "../client/client.js";
 import { getThirdwebBaseUrl } from "../utils/domains.js";
 import { getClientFetch } from "../utils/fetch.js";
@@ -6,7 +7,6 @@ import { stringify } from "../utils/json.js";
 import { ApiError } from "./types/Errors.js";
 import type { RouteStep } from "./types/Route.js";
 import type { Token } from "./types/Token.js";
-import { defineChain } from "../chains/utils.js";
 
 // export status within the Onramp module
 export { status } from "./OnrampStatus.js";

--- a/packages/thirdweb/src/pay/buyWithFiat/getQuote.ts
+++ b/packages/thirdweb/src/pay/buyWithFiat/getQuote.ts
@@ -326,7 +326,7 @@ export async function getBuyWithFiatQuote(
       maxSteps: 2,
       onramp: onrampProvider,
       onrampChainId: params.onrampChainId,
-      onrampTokenAddress: params.onrampTokenAddress ?? NATIVE_TOKEN_ADDRESS,
+      onrampTokenAddress: params.onrampTokenAddress,
       paymentLinkId: params.paymentLinkId,
       purchaseData: params.purchaseData,
       receiver: params.toAddress, // force onramp to native token to avoid missing gas issues

--- a/packages/thirdweb/src/react/core/hooks/useStepExecutor.ts
+++ b/packages/thirdweb/src/react/core/hooks/useStepExecutor.ts
@@ -27,9 +27,9 @@ export type CompletedStatusResult =
   | ({ type: "sell" } & Extract<Status, { status: "COMPLETED" }>)
   | ({ type: "transfer" } & Extract<Status, { status: "COMPLETED" }>)
   | ({ type: "onramp" } & Extract<
-    OnrampStatus.Result,
-    { status: "COMPLETED" }
-  >);
+      OnrampStatus.Result,
+      { status: "COMPLETED" }
+    >);
 
 /**
  * Options for the step executor hook

--- a/packages/thirdweb/src/react/core/hooks/useStepExecutor.ts
+++ b/packages/thirdweb/src/react/core/hooks/useStepExecutor.ts
@@ -27,9 +27,9 @@ export type CompletedStatusResult =
   | ({ type: "sell" } & Extract<Status, { status: "COMPLETED" }>)
   | ({ type: "transfer" } & Extract<Status, { status: "COMPLETED" }>)
   | ({ type: "onramp" } & Extract<
-      OnrampStatus.Result,
-      { status: "COMPLETED" }
-    >);
+    OnrampStatus.Result,
+    { status: "COMPLETED" }
+  >);
 
 /**
  * Options for the step executor hook
@@ -237,6 +237,7 @@ export function useStepExecutor(
       if (tx.action === "approval" || tx.action === "fee") {
         // don't poll status for approval transactions, just wait for confirmation
         await waitForReceipt(result);
+        await new Promise((resolve) => setTimeout(resolve, 1000)); // Add an extra second delay for RPC to catch up to new state
         return;
       }
 

--- a/packages/thirdweb/src/react/web/ui/Bridge/QuoteLoader.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/QuoteLoader.tsx
@@ -4,7 +4,6 @@ import { useEffect } from "react";
 import { trackPayEvent } from "../../../../analytics/track/pay.js";
 import type { Token } from "../../../../bridge/types/Token.js";
 import type { ThirdwebClient } from "../../../../client/client.js";
-import { NATIVE_TOKEN_ADDRESS } from "../../../../constants/addresses.js";
 import { toUnits } from "../../../../utils/units.js";
 import {
   type BridgePrepareRequest,
@@ -191,7 +190,6 @@ function getBridgeParams(args: {
         currency: paymentMethod.currency,
         enabled: !!(destinationToken && amount && client),
         onramp: paymentMethod.onramp || "coinbase",
-        onrampTokenAddress: NATIVE_TOKEN_ADDRESS,
         paymentLinkId: args.paymentLinkId,
         purchaseData: args.purchaseData,
         receiver,

--- a/packages/thirdweb/src/react/web/ui/Bridge/StepRunner.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/StepRunner.tsx
@@ -322,7 +322,8 @@ export function StepRunner({
 
               <Container flex="column" gap="3xs" style={{ flex: 1 }}>
                 <Text color="primaryText" size="sm">
-                  TEST
+                  {request.onramp.slice(0, 1).toUpperCase() +
+                    request.onramp.slice(1)}
                 </Text>
                 <Text color="secondaryText" size="xs">
                   {getStepStatusText(onrampStatus)}

--- a/packages/thirdweb/src/react/web/ui/Bridge/payment-details/PaymentDetails.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/payment-details/PaymentDetails.tsx
@@ -1,9 +1,11 @@
 "use client";
 import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
 import { trackPayEvent } from "../../../../../analytics/track/pay.js";
 import type { ThirdwebClient } from "../../../../../client/client.js";
 import { useCustomTheme } from "../../../../core/design-system/CustomThemeProvider.js";
 import { radius, spacing } from "../../../../core/design-system/index.js";
+import { useChainsQuery } from "../../../../core/hooks/others/useChainQuery.js";
 import type { BridgePrepareResult } from "../../../../core/hooks/useBridgePrepare.js";
 import type { PaymentMethod } from "../../../../core/machines/paymentMachine.js";
 import {
@@ -101,6 +103,15 @@ export function PaymentDetails({
     },
     queryKey: ["payment_details", preparedQuote.type],
   });
+
+  const chainsQuery = useChainsQuery(
+    preparedQuote.steps.flatMap((s) => s.transactions.map((t) => t.chain)),
+    10,
+  );
+  const chainsMetadata = useMemo(
+    () => chainsQuery.map((c) => c.data),
+    [chainsQuery],
+  ).filter((c) => !!c);
 
   // Extract common data based on quote type
   const getDisplayData = () => {
@@ -321,12 +332,48 @@ export function PaymentDetails({
                     >
                       <Container flex="column" gap="3xs" style={{ flex: 1 }}>
                         <Text color="primaryText" size="sm">
-                          {step.originToken.symbol} →{" "}
-                          {step.destinationToken.symbol}
+                          {step.destinationToken.chainId !==
+                          step.originToken.chainId ? (
+                            <>
+                              Bridge{" "}
+                              {step.originToken.symbol ===
+                              step.destinationToken.symbol
+                                ? step.originToken.symbol
+                                : `${step.originToken.symbol} to ${step.destinationToken.symbol}`}
+                            </>
+                          ) : (
+                            <>
+                              Swap {step.originToken.symbol} to{" "}
+                              {step.destinationToken.symbol}
+                            </>
+                          )}
                         </Text>
                         <Text color="secondaryText" size="xs">
-                          {step.originToken.name} to{" "}
-                          {step.destinationToken.name}
+                          {step.originToken.chainId !==
+                          step.destinationToken.chainId ? (
+                            <>
+                              {
+                                chainsMetadata.find(
+                                  (c) => c.chainId === step.originToken.chainId,
+                                )?.name
+                              }{" "}
+                              to{" "}
+                              {
+                                chainsMetadata.find(
+                                  (c) =>
+                                    c.chainId === step.destinationToken.chainId,
+                                )?.name
+                              }
+                            </>
+                          ) : (
+                            <>
+                              {
+                                chainsMetadata.find(
+                                  (c) => c.chainId === step.originToken.chainId,
+                                )?.name
+                              }
+                            </>
+                          )}
                         </Text>
                       </Container>
                     </Container>

--- a/packages/thirdweb/src/react/web/ui/Bridge/payment-selection/FiatProviderSelection.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/payment-selection/FiatProviderSelection.tsx
@@ -71,6 +71,16 @@ export function FiatProviderSelection({
     return quoteQueries.map((q) => q.data).filter((q) => !!q);
   }, [quoteQueries]);
 
+  if (quoteQueries.every((q) => q.isError)) {
+    return (
+      <Container center="both" flex="column" style={{ minHeight: "120px" }}>
+        <Text color="secondaryText" size="sm">
+          No quotes available
+        </Text>
+      </Container>
+    );
+  }
+
   // TODO: add a "remember my choice" checkbox
 
   return (


### PR DESCRIPTION
We no longer need to force onramping to ETH with the new native fee abstractions. Apps that might need to onramp to a multi-hop route with IAWs should use gas sponsorship.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the payment widgets in the `thirdweb` library by implementing various fixes, improving user experience, and refining the handling of onramp and bridge transactions.

### Detailed summary
- Added an extra second delay for RPC in `useStepExecutor.ts`.
- Updated text rendering in `StepRunner.tsx` to capitalize the onramp request.
- Handled no quotes available scenario in `FiatProviderSelection.tsx`.
- Removed default `NATIVE_TOKEN_ADDRESS` in `getQuote.ts`.
- Defined chain in transaction mapping in `Onramp.ts`.
- Adjusted `QuoteLoader.tsx` to remove unused `NATIVE_TOKEN_ADDRESS`.
- Introduced `chainsQuery` and `chainsMetadata` in `PaymentDetails.tsx` to enhance data handling.
- Improved display logic for token swaps and bridge transactions in `PaymentDetails.tsx`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved onramp step display with dynamic, formatted text replacing placeholder labels.
  - Added user notification when no fiat payment quotes are available.
- **Bug Fixes**
  - Fixed payment widget issues with important patches.
  - Added delay to improve transaction state updates after approvals.
- **Enhancements**
  - Enhanced transaction data with detailed chain and client information.
  - Removed default token fallback for onramp payments to ensure accurate token handling.
  - Updated payment step details to clearly differentiate between swap and bridge actions with chain context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->