### PR TITLE
Feature: Adds onramp webhook schema to sdk

### DIFF
--- a/.changeset/eleven-taxis-mix.md
+++ b/.changeset/eleven-taxis-mix.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Adds onramp webhook parsing for Universal Bridge

--- a/packages/thirdweb/src/bridge/Status.test.ts
+++ b/packages/thirdweb/src/bridge/Status.test.ts
@@ -7,10 +7,10 @@ describe.runIf(process.env.TW_SECRET_KEY)("Bridge.status", () => {
   // TODO: flaky test
   it.skip("should handle successful status", async () => {
     const result = await status({
-      chainId: 137,
+      chainId: 8453,
       client: TEST_CLIENT,
       transactionHash:
-        "0x5959b9321ec581640db531b80bac53cbd968f3d34fc6cb1d5f4ea75f26df2ad7",
+        "0x8e8ab7c998bdfef6e10951c801a862373ce87af62c21fb870e62fca57683bf10",
     });
 
     expect(result).toBeDefined();
@@ -46,7 +46,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("Bridge.status", () => {
       chain: defineChain(8453),
       client: TEST_CLIENT,
       transactionHash:
-        "0x06ac91479b3ea4c6507f9b7bff1f2d5f553253fa79af9a7db3755563b60f7dfb",
+        "0x8e8ab7c998bdfef6e10951c801a862373ce87af62c21fb870e62fca57683bf10",
     });
 
     expect(result).toBeDefined();


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding onramp webhook parsing for the Universal Bridge in the `thirdweb` package, along with updates to existing tests and schema definitions.

### Detailed summary
- Introduced onramp webhook parsing logic.
- Updated test cases in `Status.test.ts` with new `chainId` and `transactionHash`.
- Refactored `Webhook.test.ts` to use `bigint` for amounts and added new payload validation.
- Expanded `Webhook.ts` with new schemas for onramp transactions.
- Adjusted parsing functions to accommodate new payload structure.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced webhook parsing to support onramp webhooks for the Universal Bridge.

* **Refactor**
  * Improved validation and structure of webhook payloads for clearer distinction between onchain and onramp types.
  * Updated numeric fields to ensure correct data types and improved payload handling.

* **Documentation**
  * Added a changeset file describing the new onramp webhook parsing capability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->