### PR TITLE
docs: Update imports in react v5 adaptor examples

### DIFF
--- a/apps/portal/src/app/react/v5/adapters/page.mdx
+++ b/apps/portal/src/app/react/v5/adapters/page.mdx
@@ -92,7 +92,7 @@ You can use the thirdweb SDK within a wagmi application by setting the wagmi con
 import { useEffect } from 'react'
 import { defineChain } from 'thirdweb'
 import { useSetActiveWallet } from 'thirdweb/react'
-import { createWalletAdapter } from 'thirdweb/wallets'
+import { EIP1193, createWalletAdapter } from 'thirdweb/wallets'
 import { useDisconnect, useSwitchChain, useWalletClient } from 'wagmi'
 import { client } from './client'
 
@@ -133,7 +133,7 @@ Similarly, you can use the thirdweb SDK with privy by setting the privy wallet a
 import { useEffect } from 'react'
 import { defineChain } from 'thirdweb'
 import { useSetActiveWallet } from 'thirdweb/react'
-import { createWalletAdapter } from 'thirdweb/wallets'
+import { EIP1193, createWalletAdapter } from 'thirdweb/wallets'
 import { ethers5Adapter } from 'thirdweb/adapters/ethers5';
 import { client } from './client'
 import { useWallets } from "@privy-io/react-auth";

--- a/apps/portal/src/app/react/v5/adapters/page.mdx
+++ b/apps/portal/src/app/react/v5/adapters/page.mdx
@@ -92,7 +92,7 @@ You can use the thirdweb SDK within a wagmi application by setting the wagmi con
 import { useEffect } from 'react'
 import { defineChain } from 'thirdweb'
 import { useSetActiveWallet } from 'thirdweb/react'
-import { EIP1193, createWalletAdapter } from 'thirdweb/wallets'
+import { EIP1193 } from 'thirdweb/wallets'
 import { useDisconnect, useSwitchChain, useWalletClient } from 'wagmi'
 import { client } from './client'
 
@@ -133,7 +133,7 @@ Similarly, you can use the thirdweb SDK with privy by setting the privy wallet a
 import { useEffect } from 'react'
 import { defineChain } from 'thirdweb'
 import { useSetActiveWallet } from 'thirdweb/react'
-import { EIP1193, createWalletAdapter } from 'thirdweb/wallets'
+import { EIP1193 } from 'thirdweb/wallets'
 import { ethers5Adapter } from 'thirdweb/adapters/ethers5';
 import { client } from './client'
 import { useWallets } from "@privy-io/react-auth";

--- a/apps/portal/src/app/react/v5/adapters/page.mdx
+++ b/apps/portal/src/app/react/v5/adapters/page.mdx
@@ -94,7 +94,6 @@ import { defineChain } from 'thirdweb'
 import { useSetActiveWallet } from 'thirdweb/react'
 import { createWalletAdapter } from 'thirdweb/wallets'
 import { useDisconnect, useSwitchChain, useWalletClient } from 'wagmi'
-import { viemAdapter } from "thirdweb/adapters/viem";
 import { client } from './client'
 
 


### PR DESCRIPTION
Removes unused viemAdaptor import  and adds the EIP1193 import for clarity

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating wallet adapter imports in the `page.mdx` file to use `EIP1193` instead of `createWalletAdapter`, ensuring compatibility with the latest wallet functionalities.

### Detailed summary
- Replaced the import of `createWalletAdapter` with `EIP1193` from `thirdweb/wallets` in two instances.


> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated code examples to include the `EIP1193` import in relevant usage sections.
  * Removed an unused import from the wagmi integration example for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->