### PR TITLE
chore: Enable telegram support channel, add join link button

### DIFF
--- a/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/settings/_components/settings-cards/dedicated-support.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/settings/_components/settings-cards/dedicated-support.tsx
@@ -1,5 +1,7 @@
 "use client";
 import { useMutation } from "@tanstack/react-query";
+import { ExternalLinkIcon } from "lucide-react";
+import Link from "next/link";
 import { useState } from "react";
 import { toast } from "sonner";
 import { createDedicatedSupportChannel } from "@/api/dedicated-support";
@@ -16,7 +18,7 @@ import { useDashboardRouter } from "@/lib/DashboardRouter";
 
 const CHANNEL_TYPES = {
   slack: "Slack",
-  telegram: "Telegram (Coming Soon)",
+  telegram: "Telegram",
 } as const;
 
 type ChannelType = keyof typeof CHANNEL_TYPES;
@@ -57,6 +59,7 @@ export function TeamDedicatedSupportCard(props: {
 
   const channelType = props.team.dedicatedSupportChannel?.type;
   const channelName = props.team.dedicatedSupportChannel?.name;
+  const channelLink = props.team.dedicatedSupportChannel?.link;
 
   const hasDefaultTeamName = props.team.name.startsWith("Your Projects");
 
@@ -73,11 +76,27 @@ export function TeamDedicatedSupportCard(props: {
         }}
         noPermissionText={undefined}
       >
-        <div className="md:w-[450px]">
-          <p className="text-muted-foreground text-sm">
-            Your dedicated support channel: #<strong>{channelName}</strong>{" "}
-            {CHANNEL_TYPES[channelType]}
-          </p>
+        <div className="space-y-3">
+          <div className="rounded-lg border bg-muted/50 p-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="font-bold">{channelName}</p>
+                <p className="text-muted-foreground text-sm">
+                  {CHANNEL_TYPES[channelType]} channel
+                </p>
+              </div>
+              {channelType === "telegram" && channelLink && (
+                <Link
+                  className="inline-flex items-center gap-2 rounded-md border border-input px-3 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground transition-colors"
+                  href={channelLink}
+                  target="_blank"
+                >
+                  Join channel
+                  <ExternalLinkIcon className="size-4" />
+                </Link>
+              )}
+            </div>
+          </div>
         </div>
       </SettingsCard>
     );
@@ -145,15 +164,11 @@ export function TeamDedicatedSupportCard(props: {
           value={selectedChannelType}
         >
           <SelectTrigger>
-            <SelectValue placeholder="Select Channel Type" />
+            <SelectValue placeholder="Select platform" />
           </SelectTrigger>
           <SelectContent>
             {Object.entries(CHANNEL_TYPES).map(([value, name]) => (
-              <SelectItem
-                disabled={value === "telegram"}
-                key={value}
-                value={value}
-              >
+              <SelectItem key={value} value={value}>
                 {name}
               </SelectItem>
             ))}

--- a/packages/service-utils/src/core/api.ts
+++ b/packages/service-utils/src/core/api.ts
@@ -150,6 +150,7 @@ export type TeamResponse = {
   dedicatedSupportChannel: {
     type: "slack" | "telegram";
     name: string;
+    link: string | null;
   } | null;
 };
 


### PR DESCRIPTION
## [Dashboard] Feature: Enable Telegram Support for Dedicated Support Channels

Screenshot after TG is added.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/vKjRiOG6EUjD7XH4cppU/17d1879d-06a9-4f7c-8e25-d8e8f6760cdf.png)


## Notes for the reviewer
This PR enables Telegram as a fully supported channel type for dedicated support, removing the "Coming Soon" label. It also enhances the UI for displaying existing support channels by adding a "Join channel" button that links directly to the channel when available.

## How to test
1. Navigate to team settings
2. Create a dedicated support channel using Telegram
3. Verify that the channel is created successfully and the join link is displayed
4. Test that the "Join channel" button opens the link in a new tab

AI/ML Systems

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a direct "Join channel" button with an external link for dedicated support channels, allowing users to quickly access their support platform.
  * Enabled Telegram as a selectable and fully available platform for dedicated support channels.
  * Updated dropdown placeholder text to "Select platform" for improved clarity.

* **User Interface**
  * Improved the display of dedicated support channel information with clearer styling and actionable links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `TeamDedicatedSupportCard` component by adding a `link` property to the dedicated support channel and updating the UI to include a link for Telegram channels. It also modifies the display of channel types and improves the layout of the component.

### Detailed summary
- Added `link` property to the dedicated support channel type in `api.ts`.
- Updated `CHANNEL_TYPES` to change the Telegram label from "Telegram (Coming Soon)" to "Telegram".
- Integrated a link to join the Telegram channel if `channelLink` is available.
- Improved the layout of the support channel display in the `TeamDedicatedSupportCard` component. 
- Changed the placeholder in the channel type selection from "Select Channel Type" to "Select platform".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->