### PR TITLE
feat(chains): add Core testnet and mainnet chains

### DIFF
--- a/.changeset/afraid-rats-open.md
+++ b/.changeset/afraid-rats-open.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+add core chains

--- a/packages/thirdweb/src/chains/chain-definitions/core-mainnet.ts
+++ b/packages/thirdweb/src/chains/chain-definitions/core-mainnet.ts
@@ -1,0 +1,20 @@
+import { defineChain } from "../utils.js";
+
+/**
+ * @chain
+ */
+export const coreMainnet = /* @__PURE__ */ defineChain({
+  blockExplorers: [
+    {
+      name: "Core Scan",
+      url: "https://scan.coredao.org/",
+    },
+  ],
+  id: 1116,
+  name: "Core",
+  nativeCurrency: {
+    decimals: 18,
+    name: "Ether",
+    symbol: "ETH",
+  },
+});

--- a/packages/thirdweb/src/chains/chain-definitions/core-testnet.ts
+++ b/packages/thirdweb/src/chains/chain-definitions/core-testnet.ts
@@ -1,0 +1,21 @@
+import { defineChain } from "../utils.js";
+
+/**
+ * @chain
+ */
+export const coreTestnet = /* @__PURE__ */ defineChain({
+  blockExplorers: [
+    {
+      name: "Core Testnet Scan",
+      url: "https://scan.test2.btcs.network/",
+    },
+  ],
+  id: 1114,
+  name: "Core Testnet",
+  nativeCurrency: {
+    decimals: 18,
+    name: "Ether",
+    symbol: "ETH",
+  },
+  testnet: true,
+});

--- a/packages/thirdweb/src/exports/chains.ts
+++ b/packages/thirdweb/src/exports/chains.ts
@@ -24,6 +24,8 @@ export { bsc } from "../chains/chain-definitions/bsc.js";
 export { bscTestnet } from "../chains/chain-definitions/bsc-testnet.js";
 export { celo } from "../chains/chain-definitions/celo.js";
 export { celoAlfajoresTestnet } from "../chains/chain-definitions/celo-alfajores-testnet.js";
+export { coreMainnet } from "../chains/chain-definitions/core-mainnet.js";
+export { coreTestnet } from "../chains/chain-definitions/core-testnet.js";
 export { cronos } from "../chains/chain-definitions/cronos.js";
 export { degen } from "../chains/chain-definitions/degen.js";
 // mainnet = alias for ethereum


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces new chain definitions for the `Core` and `Core Testnet`, adding them to the `thirdweb` package.

### Detailed summary
- Added `coreMainnet` chain definition in `core-mainnet.ts` with block explorer and native currency details.
- Added `coreTestnet` chain definition in `core-testnet.ts` with block explorer, native currency details, and a testnet flag.
- Exported `coreMainnet` and `coreTestnet` in `chains.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Core mainnet and Core testnet blockchain networks.
  * Users can now interact with these new chains, including viewing block explorer links and using native currency details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->