### PR TITLE
add rpc tab with analytics

### DIFF
--- a/apps/dashboard/src/@/api/analytics.ts
+++ b/apps/dashboard/src/@/api/analytics.ts
@@ -6,7 +6,6 @@ import type {
   EcosystemWalletStats,
   EngineCloudStats,
   InAppWalletStats,
-  RpcMethodStats,
   TransactionStats,
   UniversalBridgeStats,
   UniversalBridgeWalletStats,
@@ -38,6 +37,18 @@ export interface InsightEndpointStats {
 interface InsightUsageStats {
   date: string;
   totalRequests: number;
+}
+
+export interface RpcMethodStats {
+  date: string;
+  evmMethod: string;
+  count: number;
+}
+
+export interface RpcUsageTypeStats {
+  date: string;
+  usageType: string;
+  count: number;
 }
 
 async function fetchAnalytics(
@@ -249,6 +260,26 @@ export async function getRpcMethodUsage(
 
   const json = await res.json();
   return json.data as RpcMethodStats[];
+}
+
+export async function getRpcUsageByType(
+  params: AnalyticsQueryParams,
+): Promise<RpcUsageTypeStats[]> {
+  const searchParams = buildSearchParams(params);
+  const res = await fetchAnalytics(
+    `v2/rpc/usage-types?${searchParams.toString()}`,
+    {
+      method: "GET",
+    },
+  );
+
+  if (res?.status !== 200) {
+    console.error("Failed to fetch RPC usage");
+    return [];
+  }
+
+  const json = await res.json();
+  return json.data as RpcUsageTypeStats[];
 }
 
 export async function getWalletUsers(

--- a/apps/dashboard/src/@/types/analytics.ts
+++ b/apps/dashboard/src/@/types/analytics.ts
@@ -39,12 +39,6 @@ export interface TransactionStats {
   count: number;
 }
 
-export interface RpcMethodStats {
-  date: string;
-  evmMethod: string;
-  count: number;
-}
-
 export interface EngineCloudStats {
   date: string;
   chainId: string;

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/components/ProjectSidebarLayout.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/components/ProjectSidebarLayout.tsx
@@ -7,6 +7,7 @@ import {
   CoinsIcon,
   HomeIcon,
   LockIcon,
+  RssIcon,
   SettingsIcon,
   WalletIcon,
 } from "lucide-react";
@@ -102,6 +103,11 @@ export function ProjectSidebarLayout(props: {
               href: `${layoutPath}/account-abstraction`,
               icon: SmartAccountIcon,
               label: "Account Abstraction",
+            },
+            {
+              href: `${layoutPath}/rpc`,
+              icon: RssIcon,
+              label: "RPC",
             },
             {
               href: `${layoutPath}/vault`,

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/components/RpcMethodBarChartCard/RpcMethodBarChartCard.stories.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/components/RpcMethodBarChartCard/RpcMethodBarChartCard.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/nextjs";
+import type { RpcMethodStats } from "@/api/analytics";
 import { BadgeContainer } from "@/storybook/utils";
-import type { RpcMethodStats } from "@/types/analytics";
 import { RpcMethodBarChartCardUI } from "./RpcMethodBarChartCardUI";
 
 const meta = {

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/components/RpcMethodBarChartCard/RpcMethodBarChartCardUI.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/components/RpcMethodBarChartCard/RpcMethodBarChartCardUI.tsx
@@ -7,6 +7,7 @@ import {
   BarChart as RechartsBarChart,
   XAxis,
 } from "recharts";
+import type { RpcMethodStats } from "@/api/analytics";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   type ChartConfig,
@@ -14,7 +15,6 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from "@/components/ui/chart";
-import type { RpcMethodStats } from "@/types/analytics";
 import { EmptyStateCard } from "../../../../../components/Analytics/EmptyStateCard";
 
 export function RpcMethodBarChartCardUI({

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/insight/components/InsightAnalytics.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/insight/components/InsightAnalytics.tsx
@@ -121,7 +121,7 @@ export async function InsightAnalytics(props: {
 
   if (!hasVolume) {
     return (
-      <div className="container flex max-w-7xl grow flex-col">
+      <div className="flex grow flex-col">
         <InsightFTUX clientId={props.projectClientId} />
       </div>
     );
@@ -134,22 +134,18 @@ export async function InsightAnalytics(props: {
       </div>
       <ResponsiveSuspense
         fallback={
-          <div className="flex flex-col gap-10 lg:gap-6">
+          <div className="flex flex-col gap-6">
             <div className="grid grid-cols-2 gap-4 lg:gap-6">
-              <Skeleton className="h-[120px] border rounded-xl" />
-              <Skeleton className="h-[120px] border rounded-xl" />
+              <Skeleton className="h-[88px] border rounded-xl" />
+              <Skeleton className="h-[88px] border rounded-xl" />
             </div>
-            <Skeleton className="h-[350px] border rounded-xl" />
-            <div className="relative grid grid-cols-1 gap-6 rounded-xl border border-border bg-card p-4 lg:gap-12 xl:grid-cols-2 xl:p-6">
-              <Skeleton className="h-[350px] border rounded-xl" />
-              <Skeleton className="h-[350px] border rounded-xl" />
-              <div className="absolute top-6 bottom-6 left-[50%] hidden w-[1px] bg-border xl:block" />
-            </div>
+            <Skeleton className="h-[480px] border rounded-xl" />
+            <Skeleton className="h-[376px] border rounded-xl" />
           </div>
         }
         searchParamsUsed={["from", "to", "interval"]}
       >
-        <div className="flex flex-col gap-10 lg:gap-6">
+        <div className="flex flex-col gap-6">
           <div className="grid grid-cols-2 gap-4 lg:gap-6">
             <StatCard
               icon={ActivityIcon}

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/insight/layout.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/insight/layout.tsx
@@ -19,7 +19,7 @@ export default async function Layout(props: {
 
   return (
     <div className="flex grow flex-col">
-      <div className="pt-4 lg:pt-6">
+      <div className="py-8 border-b">
         <div className="container max-w-7xl">
           <h1 className="mb-1 font-semibold text-2xl tracking-tight lg:text-3xl">
             Insight
@@ -36,8 +36,6 @@ export default async function Layout(props: {
             </UnderlineLink>
           </p>
         </div>
-
-        <div className="h-4" />
       </div>
 
       <div className="h-6" />

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/rpc/components/MethodsTable.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/rpc/components/MethodsTable.tsx
@@ -1,0 +1,132 @@
+"use client";
+import { useMemo, useState } from "react";
+import type { ThirdwebClient } from "thirdweb";
+import { shortenLargeNumber } from "thirdweb/utils";
+import type { RpcMethodStats } from "@/api/analytics";
+import { PaginationButtons } from "@/components/blocks/pagination-buttons";
+import { Card } from "@/components/ui/card";
+import { SkeletonContainer } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { CardHeading } from "../../universal-bridge/components/common";
+
+export function TopRPCMethodsTable(props: {
+  data: RpcMethodStats[];
+  client: ThirdwebClient;
+}) {
+  const [currentPage, setCurrentPage] = useState(1);
+  const itemsPerPage = 30;
+
+  const sortedData = useMemo(() => {
+    return props.data?.sort((a, b) => b.count - a.count) || [];
+  }, [props.data]);
+
+  const totalPages = useMemo(() => {
+    return Math.ceil(sortedData.length / itemsPerPage);
+  }, [sortedData.length]);
+
+  const tableData = useMemo(() => {
+    const startIndex = (currentPage - 1) * itemsPerPage;
+    const endIndex = startIndex + itemsPerPage;
+    return sortedData.slice(startIndex, endIndex);
+  }, [sortedData, currentPage]);
+
+  const isEmpty = useMemo(() => sortedData.length === 0, [sortedData]);
+
+  return (
+    <Card className="relative flex flex-col rounded-xl border border-border bg-card p-4">
+      {/* header */}
+      <div className="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
+        <CardHeading>Top EVM Methods Called </CardHeading>
+      </div>
+
+      <div className="h-5" />
+      <TableContainer scrollableContainerClassName="h-[280px]">
+        <Table>
+          <TableHeader className="sticky top-0 z-10 bg-background">
+            <TableRow>
+              <TableHead>Method</TableHead>
+              <TableHead>Requests</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {tableData.map((method, i) => {
+              return (
+                <MethodTableRow
+                  client={props.client}
+                  key={method.evmMethod}
+                  method={method}
+                  rowIndex={i}
+                />
+              );
+            })}
+          </TableBody>
+        </Table>
+        {isEmpty && (
+          <div className="flex min-h-[240px] w-full items-center justify-center text-muted-foreground text-sm">
+            No data available
+          </div>
+        )}
+      </TableContainer>
+
+      {!isEmpty && totalPages > 1 && (
+        <div className="mt-4 flex justify-center">
+          <PaginationButtons
+            activePage={currentPage}
+            onPageClick={setCurrentPage}
+            totalPages={totalPages}
+          />
+        </div>
+      )}
+    </Card>
+  );
+}
+
+function MethodTableRow(props: {
+  method?: {
+    evmMethod: string;
+    count: number;
+  };
+  client: ThirdwebClient;
+  rowIndex: number;
+}) {
+  const delayAnim = {
+    animationDelay: `${props.rowIndex * 100}ms`,
+  };
+
+  return (
+    <TableRow>
+      <TableCell>
+        <SkeletonContainer
+          className="inline-flex"
+          loadedData={props.method?.evmMethod}
+          render={(v) => (
+            <p className={"truncate max-w-[280px]"} title={v}>
+              {v}
+            </p>
+          )}
+          skeletonData="..."
+          style={delayAnim}
+        />
+      </TableCell>
+      <TableCell>
+        <SkeletonContainer
+          className="inline-flex"
+          loadedData={props.method?.count}
+          render={(v) => {
+            return <p>{shortenLargeNumber(v)}</p>;
+          }}
+          skeletonData={0}
+          style={delayAnim}
+        />
+      </TableCell>
+    </TableRow>
+  );
+}

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/rpc/components/RequestsGraph.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/rpc/components/RequestsGraph.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { format } from "date-fns";
+import { shortenLargeNumber } from "thirdweb/utils";
+import type { RpcUsageTypeStats } from "@/api/analytics";
+import { ThirdwebAreaChart } from "@/components/blocks/charts/area-chart";
+
+export function RequestsGraph(props: { data: RpcUsageTypeStats[] }) {
+  return (
+    <ThirdwebAreaChart
+      chartClassName="aspect-[1.5] lg:aspect-[4]"
+      config={{
+        requests: {
+          color: "hsl(var(--chart-1))",
+          label: "Count",
+        },
+      }}
+      data={props.data
+        .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
+        .reduce(
+          (acc, curr) => {
+            const existingEntry = acc.find((e) => e.time === curr.date);
+            if (existingEntry) {
+              existingEntry.requests += curr.count;
+            } else {
+              acc.push({
+                requests: curr.count,
+                time: curr.date,
+              });
+            }
+            return acc;
+          },
+          [] as { requests: number; time: string }[],
+        )}
+      header={{
+        description: "Requests over time.",
+        title: "RPC Requests",
+      }}
+      hideLabel={false}
+      isPending={false}
+      showLegend
+      toolTipLabelFormatter={(label) => {
+        return format(label, "MMM dd, HH:mm");
+      }}
+      toolTipValueFormatter={(value) => {
+        return shortenLargeNumber(value as number);
+      }}
+      xAxis={{
+        sameDay: true,
+      }}
+      yAxis
+    />
+  );
+}

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/rpc/components/RpcAnalytics.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/rpc/components/RpcAnalytics.tsx
@@ -1,0 +1,98 @@
+import { ActivityIcon } from "lucide-react";
+import { ResponsiveSuspense } from "responsive-rsc";
+import type { ThirdwebClient } from "thirdweb";
+import { getRpcMethodUsage, getRpcUsageByType } from "@/api/analytics";
+import type { Range } from "@/components/analytics/date-range-selector";
+import { StatCard } from "@/components/analytics/stat";
+import { Skeleton } from "@/components/ui/skeleton";
+import { TopRPCMethodsTable } from "./MethodsTable";
+import { RequestsGraph } from "./RequestsGraph";
+import { RpcAnalyticsFilter } from "./RpcAnalyticsFilter";
+import { RpcFTUX } from "./RpcFtux";
+
+export async function RPCAnalytics(props: {
+  projectClientId: string;
+  client: ThirdwebClient;
+  projectId: string;
+  teamId: string;
+  range: Range;
+  interval: "day" | "week";
+}) {
+  const { projectId, teamId, range, interval } = props;
+
+  // TODO: add requests by status code, but currently not performant enough
+  const allRequestsByUsageTypePromise = getRpcUsageByType({
+    from: range.from,
+    period: "all",
+    projectId: projectId,
+    teamId: teamId,
+    to: range.to,
+  });
+  const requestsByUsageTypePromise = getRpcUsageByType({
+    from: range.from,
+    period: interval,
+    projectId: projectId,
+    teamId: teamId,
+    to: range.to,
+  });
+  const evmMethodsPromise = getRpcMethodUsage({
+    from: range.from,
+    period: "all",
+    projectId: projectId,
+    teamId: teamId,
+    to: range.to,
+  }).catch((error) => {
+    console.error(error);
+    return [];
+  });
+
+  const [allUsageData, usageData, evmMethodsData] = await Promise.all([
+    allRequestsByUsageTypePromise,
+    requestsByUsageTypePromise,
+    evmMethodsPromise,
+  ]);
+
+  const totalRequests = allUsageData.reduce((acc, curr) => acc + curr.count, 0);
+
+  if (totalRequests < 1) {
+    return (
+      <div className="container flex max-w-7xl grow flex-col">
+        <RpcFTUX clientId={props.projectClientId} />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="mb-4 flex justify-start">
+        <RpcAnalyticsFilter />
+      </div>
+      <ResponsiveSuspense
+        fallback={
+          <div className="flex flex-col gap-6">
+            <Skeleton className="h-[88px] border rounded-xl" />
+            <Skeleton className="h-[425px] border rounded-xl" />
+            <Skeleton className="h-[360px] border rounded-xl" />
+          </div>
+        }
+        searchParamsUsed={["from", "to", "interval"]}
+      >
+        <div className="flex flex-col gap-6">
+          <div className="flex flex-col gap-6">
+            <StatCard
+              icon={ActivityIcon}
+              isPending={false}
+              label="All Time Requests"
+              value={totalRequests}
+            />
+          </div>
+          <RequestsGraph data={usageData} />
+          <TopRPCMethodsTable
+            client={props.client}
+            data={evmMethodsData || []}
+          />
+        </div>
+      </ResponsiveSuspense>
+    </div>
+  );
+}

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/rpc/components/RpcAnalyticsFilter.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/rpc/components/RpcAnalyticsFilter.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import {
+  useResponsiveSearchParams,
+  useSetResponsiveSearchParams,
+} from "responsive-rsc";
+import { DateRangeSelector } from "@/components/analytics/date-range-selector";
+import { IntervalSelector } from "@/components/analytics/interval-selector";
+import { getFiltersFromSearchParams, normalizeTimeISOString } from "@/lib/time";
+
+type SearchParams = {
+  from?: string;
+  to?: string;
+  interval?: "day" | "week";
+};
+
+export function RpcAnalyticsFilter() {
+  const responsiveSearchParams = useResponsiveSearchParams();
+  const setResponsiveSearchParams = useSetResponsiveSearchParams();
+
+  const { range, interval } = getFiltersFromSearchParams({
+    defaultRange: "last-30",
+    from: responsiveSearchParams.from,
+    interval: responsiveSearchParams.interval,
+    to: responsiveSearchParams.to,
+  });
+
+  return (
+    <div className="no-scrollbar flex items-center gap-3 max-sm:overflow-auto">
+      <DateRangeSelector
+        popoverAlign="end"
+        range={range}
+        setRange={(newRange) => {
+          setResponsiveSearchParams((v: SearchParams) => {
+            const newParams = {
+              ...v,
+              from: normalizeTimeISOString(newRange.from),
+              to: normalizeTimeISOString(newRange.to),
+            };
+            return newParams;
+          });
+        }}
+      />
+
+      <IntervalSelector
+        intervalType={interval}
+        setIntervalType={(newInterval) => {
+          setResponsiveSearchParams((v: SearchParams) => {
+            const newParams = {
+              ...v,
+              interval: newInterval,
+            };
+            return newParams;
+          });
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/rpc/components/RpcFtux.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/rpc/components/RpcFtux.tsx
@@ -1,0 +1,104 @@
+import { CodeServer } from "@/components/ui/code/code.server";
+import { isProd } from "@/constants/env-utils";
+import { ClientIDSection } from "../../components/ProjectFTUX/ClientIDSection";
+import { WaitingForIntegrationCard } from "../../components/WaitingForIntegrationCard/WaitingForIntegrationCard";
+
+export function RpcFTUX(props: { clientId: string }) {
+  return (
+    <WaitingForIntegrationCard
+      codeTabs={[
+        {
+          code: (
+            <CodeServer
+              className="bg-background"
+              code={jsCode(props.clientId)}
+              lang="ts"
+            />
+          ),
+          label: "JavaScript",
+        },
+        {
+          code: (
+            <CodeServer
+              className="bg-background"
+              code={pythonCode(props.clientId)}
+              lang="python"
+            />
+          ),
+          label: "Python",
+        },
+        {
+          code: (
+            <CodeServer
+              className="bg-background"
+              code={curlCode(props.clientId)}
+              lang="bash"
+            />
+          ),
+          label: "Curl",
+        },
+      ]}
+      ctas={[
+        {
+          href: "https://portal.thirdweb.com/rpc-edge",
+          label: "View Docs",
+        },
+      ]}
+      title="Start Using RPC"
+    >
+      <ClientIDSection clientId={props.clientId} />
+      <div className="h-4" />
+    </WaitingForIntegrationCard>
+  );
+}
+
+const twDomain = isProd ? "thirdweb" : "thirdweb-dev";
+
+const jsCode = (clientId: string) => `\
+// Example: Get latest block number on Ethereum
+const res = await fetch("https://1.rpc.${twDomain}.com/${clientId}", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+  },
+  body: JSON.stringify({
+    jsonrpc: "2.0",
+    method: "eth_blockNumber",
+    params: [],
+    id: 1,
+  }),
+});
+const data = await res.json();
+console.log("Latest block number:", parseInt(data.result, 16));
+`;
+
+const curlCode = (clientId: string) => `\
+# Example: Get latest block number on Ethereum
+curl -X POST "https://1.rpc.${twDomain}.com/${clientId}" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "eth_blockNumber",
+    "params": [],
+    "id": 1
+  }'
+`;
+
+const pythonCode = (clientId: string) => `\
+# Example: Get latest block number on Ethereum
+import requests
+import json
+
+response = requests.post(
+    "https://1.rpc.${twDomain}.com/${clientId}",
+    headers={"Content-Type": "application/json"},
+    json={
+        "jsonrpc": "2.0",
+        "method": "eth_blockNumber",
+        "params": [],
+        "id": 1
+    }
+)
+data = response.json()
+print("Latest block number:", int(data["result"], 16))
+`;

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/rpc/layout.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/rpc/layout.tsx
@@ -1,0 +1,46 @@
+import { redirect } from "next/navigation";
+import { getProject } from "@/api/projects";
+import { UnderlineLink } from "@/components/ui/UnderlineLink";
+
+export default async function Layout(props: {
+  params: Promise<{
+    team_slug: string;
+    project_slug: string;
+  }>;
+  children: React.ReactNode;
+}) {
+  const params = await props.params;
+  const project = await getProject(params.team_slug, params.project_slug);
+
+  if (!project) {
+    redirect(`/team/${params.team_slug}`);
+  }
+
+  return (
+    <div className="flex grow flex-col">
+      <div className="py-8 border-b">
+        <div className="container max-w-7xl">
+          <h1 className="mb-1 font-semibold text-2xl tracking-tight lg:text-3xl">
+            RPC
+          </h1>
+          <p className="max-w-3xl text-muted-foreground text-sm leading-relaxed">
+            Remote Procedure Call (RPC) provides reliable access to querying
+            data and interacting with the blockchain through global edge RPCs.{" "}
+            <UnderlineLink
+              href="https://portal.thirdweb.com/rpc-edge"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Learn more
+            </UnderlineLink>
+          </p>
+        </div>
+      </div>
+
+      <div className="h-6" />
+      <div className="container flex max-w-7xl grow flex-col">
+        {props.children}
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/rpc/page.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/rpc/page.tsx
@@ -1,0 +1,61 @@
+import { loginRedirect } from "@app/login/loginRedirect";
+import { redirect } from "next/navigation";
+import { ResponsiveSearchParamsProvider } from "responsive-rsc";
+import { getAuthToken } from "@/api/auth-token";
+import { getProject } from "@/api/projects";
+import { getClientThirdwebClient } from "@/constants/thirdweb-client.client";
+import { getFiltersFromSearchParams } from "@/lib/time";
+import { RPCAnalytics } from "./components/RpcAnalytics";
+
+export default async function Page(props: {
+  params: Promise<{
+    team_slug: string;
+    project_slug: string;
+  }>;
+  searchParams: Promise<{
+    from?: string | undefined | string[];
+    to?: string | undefined | string[];
+    interval?: string | undefined | string[];
+  }>;
+}) {
+  const [params, authToken] = await Promise.all([props.params, getAuthToken()]);
+
+  const project = await getProject(params.team_slug, params.project_slug);
+
+  if (!authToken) {
+    loginRedirect(`/team/${params.team_slug}/${params.project_slug}/rpc`);
+  }
+
+  if (!project) {
+    redirect(`/team/${params.team_slug}`);
+  }
+
+  const searchParams = await props.searchParams;
+  const { range, interval } = getFiltersFromSearchParams({
+    defaultRange: "last-30",
+    from: searchParams.from,
+    interval: searchParams.interval,
+    to: searchParams.to,
+  });
+
+  const client = getClientThirdwebClient({
+    jwt: authToken,
+    teamId: project.teamId,
+  });
+
+  return (
+    <ResponsiveSearchParamsProvider value={searchParams}>
+      <div>
+        <RPCAnalytics
+          client={client}
+          interval={interval}
+          projectClientId={project.publishableKey}
+          projectId={project.id}
+          range={range}
+          teamId={project.teamId}
+        />
+        <div className="h-10" />
+      </div>
+    </ResponsiveSearchParamsProvider>
+  );
+}


### PR DESCRIPTION
# [Dashboard] Feature: Add RPC Edge analytics page

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the RPC (Remote Procedure Call) analytics features in the dashboard. It introduces new components and interfaces for better data handling and visualization of RPC usage statistics.

### Detailed summary
- Added `RpcMethodStats` interface in `analytics.ts`.
- Introduced `getRpcUsageByType` function in `analytics.ts`.
- Created new `RpcAnalyticsFilter` component for filtering data.
- Developed `RequestsGraph` component for visualizing RPC requests over time.
- Updated `RPCAnalytics` component to utilize new data fetching methods.
- Added `TopRPCMethodsTable` to display the most called EVM methods.
- Enhanced UI components with improved styling and layout adjustments.
- Added `RpcFTUX` component to guide users on using RPC features.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a dedicated "RPC" section in the project sidebar for easy access to RPC analytics.
  * Added a comprehensive RPC analytics dashboard, including:
    * Interactive requests graph and top RPC methods table.
    * Date range and interval filtering for analytics.
    * First-time user experience (FTUX) with ready-to-use code examples and documentation links.
  * Enhanced layout and navigation for the new RPC analytics section.

* **Style**
  * Improved UI spacing, sizing, and visual consistency for analytics components and placeholders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->