### PR TITLE
[Dashboard] Move RPC Edge to scale category and remove redirect

### DIFF
--- a/apps/dashboard/framer-rewrites.js
+++ b/apps/dashboard/framer-rewrites.js
@@ -14,12 +14,15 @@ module.exports = [
   "/in-app-wallets",
   "/transactions",
   // -- end build category
-  // -- storage
+
+  // -- scale category
+  "/rpc-edge",
+  "/insight",
   "/storage",
+  // -- end scale category
+
   // -- nebula
   "/nebula",
-  // --insight
-  "/insight",
   // -- contracts
   "/contracts",
   "/contracts/modular-contracts",

--- a/apps/dashboard/redirects.js
+++ b/apps/dashboard/redirects.js
@@ -327,13 +327,6 @@ async function redirects() {
       permanent: false,
       source: "/solutions/chains",
     },
-    // redirect /rpc to portal
-    {
-      destination:
-        "https://portal.thirdweb.com/infrastructure/rpc-edge/overview",
-      permanent: false,
-      source: "/rpc-edge",
-    },
     // redirect /sdk to portal
     {
       destination: "https://portal.thirdweb.com/connect/blockchain-api",


### PR DESCRIPTION
### TL;DR

Reorganized navigation structure by adding a "scale category" and removing the RPC Edge redirect.

### What changed?

- Created a new "scale category" in the framer-rewrites.js file that includes:
  - `/rpc-edge`
  - `/insight`
  - `/storage`
- Moved `/storage` from its own category into the new "scale category"
- Moved `/insight` from its own category into the new "scale category"
- Removed the redirect from `/rpc-edge` to the portal URL in redirects.js

### How to test?

1. Verify that the `/rpc-edge`, `/insight`, and `/storage` routes are properly grouped under the "scale category"
2. Confirm that navigating to `/rpc-edge` no longer redirects to the portal URL
3. Check that the other redirects still function as expected

### Why make this change?

This change improves the organization of related services under a logical "scale category" grouping, making the navigation structure more intuitive. It also enables direct access to the RPC Edge page rather than redirecting users to the portal, providing a more seamless user experience.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized and regrouped certain dashboard paths under a new "scale category" for improved clarity.

* **Chores**
  * Removed a redirect rule for the /rpc-edge path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `framer-rewrites.js` and `redirects.js` files in the `dashboard` application. It modifies comments and adjusts the routing structure related to the handling of certain paths.

### Detailed summary
- In `framer-rewrites.js`:
  - Changed comment from `// -- storage` to `// -- scale category`.
  - Added `// -- end scale category`.
  - Removed `// --insight` and the corresponding `"/insight"` line.
  
- In `redirects.js`:
  - Removed the redirect configuration for `"/rpc-edge"` to the portal.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->