### PR TITLE
[Docs] Broken Engine Links

### DIFF
--- a/apps/portal/src/app/engine/v3/get-started/page.mdx
+++ b/apps/portal/src/app/engine/v3/get-started/page.mdx
@@ -30,7 +30,7 @@ Learn how to get started with thirdweb Transactions. This guide will walk you th
 		Create a server wallet to perform blockchain actions with Transactions.
 
 		<Callout variant="info" title="Server Wallet">
-			Server wallets are smart wallets Transactions uses to perform blockchain actions. [Learn more about server wallets](/engine/v2/configure-wallets/server-wallets).
+			Server wallets are smart wallets Transactions uses to perform blockchain actions. [Learn more about server wallets](/engine/v3/configure-wallets/server-wallets).
 		</Callout>
 	</Step>
 

--- a/apps/portal/src/app/engine/v3/get-started/page.mdx
+++ b/apps/portal/src/app/engine/v3/get-started/page.mdx
@@ -30,7 +30,7 @@ Learn how to get started with thirdweb Transactions. This guide will walk you th
 		Create a server wallet to perform blockchain actions with Transactions.
 
 		<Callout variant="info" title="Server Wallet">
-			Server wallets are smart wallets Transactions uses to perform blockchain actions. [Learn more about server wallets](/Transactions/v2/configure-wallets/server-wallets).
+			Server wallets are smart wallets Transactions uses to perform blockchain actions. [Learn more about server wallets](/engine/v2/configure-wallets/server-wallets).
 		</Callout>
 	</Step>
 
@@ -42,7 +42,7 @@ Learn how to get started with thirdweb Transactions. This guide will walk you th
 	</Step>
 
 	<Step title="Integrate with your app">
-		Integrate Transactions into your application using the thirdweb SDK or Transactions API. [View full API reference.](https://client.scalar.com/workspace/default/request/yq_Wx56PL4Ur6jOZsAOpA)
+		Integrate Transactions into your application using the thirdweb SDK or Transactions API. [View full API reference.](https://engine.thirdweb.com/reference#tag/write)
 
 		<Tabs defaultValue="curl">
 			<TabsList>


### PR DESCRIPTION
CORE-0000

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the content in the `page.mdx` file to correct links related to server wallets and the API reference for Transactions.

### Detailed summary
- Updated the link for server wallets from `/Transactions/v2/configure-wallets/server-wallets` to `/engine/v3/configure-wallets/server-wallets`.
- Changed the API reference link from `https://client.scalar.com/workspace/default/request/yq_Wx56PL4Ur6jOZsAOpA` to `https://engine.thirdweb.com/reference#tag/write`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated documentation links for server wallets and API reference to point to the latest official sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->