### PR TITLE
[TOOL-4908] Dashboard: Fix 'Owner only' claim condition phase type condition

### DIFF
--- a/apps/dashboard/src/app/(app)/(dashboard)/(chain)/[chain_id]/[contractAddress]/_components/claim-conditions/claim-conditions-form/index.tsx
+++ b/apps/dashboard/src/app/(app)/(dashboard)/(chain)/[chain_id]/[contractAddress]/_components/claim-conditions/claim-conditions-form/index.tsx
@@ -130,6 +130,7 @@ const getClaimConditionTypeFromPhase = (
 
   if (phase.snapshot) {
     if (
+      phase.maxClaimablePerWallet?.toString() === "0" &&
       phase.price === "0" &&
       typeof phase.snapshot !== "string" &&
       phase.snapshot.length === 1 &&


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a condition to check if the `maxClaimablePerWallet` is `"0"` and enhancing the validation of the `phase.snapshot` property within the `claim-conditions-form` component.

### Detailed summary
- Added a condition to check if `phase.maxClaimablePerWallet` is `"0"`.
- Ensured `phase.price` is `"0"`.
- Checked that `phase.snapshot` is not a string and has a length of 1.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved claim condition handling to more accurately identify "creator" claim types based on updated criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->