### PR TITLE
Properly type purchaseData as Record<string, unknown>

### DIFF
--- a/.changeset/orange-files-admire.md
+++ b/.changeset/orange-files-admire.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+properly type purchaseData

--- a/packages/thirdweb/src/bridge/Buy.ts
+++ b/packages/thirdweb/src/bridge/Buy.ts
@@ -1,6 +1,7 @@
 import type { Address as ox__Address } from "ox";
 import { defineChain } from "../chains/utils.js";
 import type { ThirdwebClient } from "../client/client.js";
+import type { PurchaseData } from "../pay/types.js";
 import { getThirdwebBaseUrl } from "../utils/domains.js";
 import { getClientFetch } from "../utils/fetch.js";
 import { stringify } from "../utils/json.js";
@@ -413,7 +414,7 @@ export declare namespace prepare {
     receiver: ox__Address.Address;
     amount: bigint;
     client: ThirdwebClient;
-    purchaseData?: unknown;
+    purchaseData?: PurchaseData;
     maxSteps?: number;
     /**
      * @hidden
@@ -430,7 +431,7 @@ export declare namespace prepare {
       amount: bigint;
       sender: ox__Address.Address;
       receiver: ox__Address.Address;
-      purchaseData?: unknown;
+      purchaseData?: PurchaseData;
     };
   };
 }

--- a/packages/thirdweb/src/bridge/Onramp.ts
+++ b/packages/thirdweb/src/bridge/Onramp.ts
@@ -1,6 +1,7 @@
 import type { Address as ox__Address } from "ox";
 import { defineChain } from "../chains/utils.js";
 import type { ThirdwebClient } from "../client/client.js";
+import type { PurchaseData } from "../pay/types.js";
 import { getThirdwebBaseUrl } from "../utils/domains.js";
 import { getClientFetch } from "../utils/fetch.js";
 import { stringify } from "../utils/json.js";
@@ -17,7 +18,7 @@ type OnrampIntent = {
   tokenAddress: ox__Address.Address;
   receiver: ox__Address.Address;
   amount?: string; // Corresponds to buyAmountWei in some other contexts
-  purchaseData?: unknown;
+  purchaseData?: PurchaseData;
   sender?: ox__Address.Address;
   onrampTokenAddress?: ox__Address.Address;
   onrampChainId?: number;
@@ -46,7 +47,7 @@ interface OnrampApiRequestBody {
   tokenAddress: ox__Address.Address;
   receiver: ox__Address.Address;
   amount?: string;
-  purchaseData?: unknown;
+  purchaseData?: PurchaseData;
   sender?: ox__Address.Address;
   onrampTokenAddress?: ox__Address.Address;
   onrampChainId?: number;
@@ -265,7 +266,7 @@ export declare namespace prepare {
     tokenAddress: ox__Address.Address;
     receiver: ox__Address.Address;
     amount?: bigint;
-    purchaseData?: unknown;
+    purchaseData?: PurchaseData;
     sender?: ox__Address.Address;
     onrampTokenAddress?: ox__Address.Address;
     onrampChainId?: number;

--- a/packages/thirdweb/src/bridge/OnrampStatus.ts
+++ b/packages/thirdweb/src/bridge/OnrampStatus.ts
@@ -1,5 +1,6 @@
 import type { Hex as ox__Hex } from "ox";
 import type { ThirdwebClient } from "../client/client.js";
+import type { PurchaseData } from "../pay/types.js";
 import { getThirdwebBaseUrl } from "../utils/domains.js";
 import { getClientFetch } from "../utils/fetch.js";
 import { ApiError } from "./types/Errors.js";
@@ -108,7 +109,7 @@ export declare namespace status {
           chainId: number;
           transactionHash: ox__Hex.Hex;
         }>;
-        purchaseData?: unknown;
+        purchaseData?: PurchaseData;
       }
     | {
         status: "PENDING";
@@ -116,7 +117,7 @@ export declare namespace status {
           chainId: number;
           transactionHash: ox__Hex.Hex;
         }>;
-        purchaseData?: unknown;
+        purchaseData?: PurchaseData;
       }
     | {
         status: "CREATED";
@@ -124,7 +125,7 @@ export declare namespace status {
           chainId: number;
           transactionHash: ox__Hex.Hex;
         }>;
-        purchaseData?: unknown;
+        purchaseData?: PurchaseData;
       }
     | {
         status: "FAILED";
@@ -132,6 +133,6 @@ export declare namespace status {
           chainId: number;
           transactionHash: ox__Hex.Hex;
         }>;
-        purchaseData?: unknown;
+        purchaseData?: PurchaseData;
       };
 }

--- a/packages/thirdweb/src/bridge/Sell.ts
+++ b/packages/thirdweb/src/bridge/Sell.ts
@@ -1,6 +1,7 @@
 import type { Address as ox__Address } from "ox";
 import { defineChain } from "../chains/utils.js";
 import type { ThirdwebClient } from "../client/client.js";
+import type { PurchaseData } from "../pay/types.js";
 import { getThirdwebBaseUrl } from "../utils/domains.js";
 import { getClientFetch } from "../utils/fetch.js";
 import { stringify } from "../utils/json.js";
@@ -402,7 +403,7 @@ export declare namespace prepare {
     sender: ox__Address.Address;
     receiver: ox__Address.Address;
     client: ThirdwebClient;
-    purchaseData?: unknown;
+    purchaseData?: PurchaseData;
     maxSteps?: number;
     /**
      * @hidden
@@ -419,7 +420,7 @@ export declare namespace prepare {
       amount: bigint;
       sender: ox__Address.Address;
       receiver: ox__Address.Address;
-      purchaseData?: unknown;
+      purchaseData?: PurchaseData;
     };
   };
 }

--- a/packages/thirdweb/src/bridge/Transfer.ts
+++ b/packages/thirdweb/src/bridge/Transfer.ts
@@ -1,6 +1,7 @@
 import type { Address as ox__Address } from "ox";
 import { defineChain } from "../chains/utils.js";
 import type { ThirdwebClient } from "../client/client.js";
+import type { PurchaseData } from "../pay/types.js";
 import { getThirdwebBaseUrl } from "../utils/domains.js";
 import { getClientFetch } from "../utils/fetch.js";
 import { stringify } from "../utils/json.js";
@@ -258,7 +259,7 @@ export declare namespace prepare {
     receiver: ox__Address.Address;
     amount: bigint;
     client: ThirdwebClient;
-    purchaseData?: unknown;
+    purchaseData?: PurchaseData;
     feePayer?: "sender" | "receiver";
     /**
      * @hidden
@@ -273,7 +274,7 @@ export declare namespace prepare {
       amount: bigint;
       sender: ox__Address.Address;
       receiver: ox__Address.Address;
-      purchaseData?: unknown;
+      purchaseData?: PurchaseData;
       feePayer?: "sender" | "receiver";
     };
   };

--- a/packages/thirdweb/src/bridge/types/Status.ts
+++ b/packages/thirdweb/src/bridge/types/Status.ts
@@ -1,4 +1,5 @@
 import type { Address as ox__Address, Hex as ox__Hex } from "ox";
+import type { PurchaseData } from "../../pay/types.js";
 import type { Token } from "./Token.js";
 export type Status =
   | {
@@ -18,7 +19,7 @@ export type Status =
         chainId: number;
         transactionHash: ox__Hex.Hex;
       }>;
-      purchaseData?: unknown;
+      purchaseData?: PurchaseData;
     }
   | {
       status: "PENDING";
@@ -36,7 +37,7 @@ export type Status =
         chainId: number;
         transactionHash: ox__Hex.Hex;
       }>;
-      purchaseData?: unknown;
+      purchaseData?: PurchaseData;
     }
   | {
       status: "FAILED";
@@ -45,7 +46,7 @@ export type Status =
         chainId: number;
         transactionHash: ox__Hex.Hex;
       }>;
-      purchaseData?: unknown;
+      purchaseData?: PurchaseData;
     }
   | {
       status: "NOT_FOUND";

--- a/packages/thirdweb/src/pay/buyWithCrypto/getQuote.ts
+++ b/packages/thirdweb/src/pay/buyWithCrypto/getQuote.ts
@@ -7,6 +7,7 @@ import { NATIVE_TOKEN_ADDRESS } from "../../constants/addresses.js";
 import { getContract } from "../../contract/contract.js";
 import { decimals } from "../../extensions/erc20/read/decimals.js";
 import type { PrepareTransactionOptions } from "../../transaction/prepare-transaction.js";
+import type { PurchaseData } from "../types.js";
 import type {
   QuoteApprovalInfo,
   QuotePaymentToken,
@@ -76,7 +77,7 @@ export type GetBuyWithCryptoQuoteParams = {
    *
    * This details will be stored with the purchase and can be retrieved later via the status API or Webhook
    */
-  purchaseData?: object;
+  purchaseData?: PurchaseData;
 
   /**
    * The maximum slippage in basis points (bps) allowed for the swap.

--- a/packages/thirdweb/src/pay/buyWithCrypto/getStatus.ts
+++ b/packages/thirdweb/src/pay/buyWithCrypto/getStatus.ts
@@ -3,6 +3,7 @@ import type { Token } from "../../bridge/types/Token.js";
 import type { ThirdwebClient } from "../../client/client.js";
 import type { Hex } from "../../utils/encoding/hex.js";
 import { toTokens } from "../../utils/units.js";
+import type { PurchaseData } from "../types.js";
 import type {
   PayOnChainTransactionDetails,
   PayTokenInfo,
@@ -80,7 +81,7 @@ export type BuyWithCryptoStatus =
       toAddress: string;
       failureMessage?: string;
       bridge?: string;
-      purchaseData?: object;
+      purchaseData?: PurchaseData;
     };
 
 export type ValidBuyWithCryptoStatus = Exclude<
@@ -162,7 +163,7 @@ export async function getBuyWithCryptoStatus(
           originTokenAddress: result.originTokenAddress,
           originTransaction,
           paymentId: result.paymentId,
-          purchaseData: result.purchaseData as object | undefined,
+          purchaseData: result.purchaseData,
           receiver: result.receiver,
           sender: result.sender,
           status: result.status,
@@ -178,7 +179,7 @@ export async function getBuyWithCryptoStatus(
           originToken: result.originToken,
           originTokenAddress: result.originTokenAddress,
           paymentId: result.paymentId,
-          purchaseData: result.purchaseData as object | undefined,
+          purchaseData: result.purchaseData,
           receiver: result.receiver,
           sender: result.sender,
           status: result.status,
@@ -202,7 +203,7 @@ export async function getBuyWithCryptoStatus(
           originTokenAddress: "",
           originTransaction,
           paymentId: "",
-          purchaseData: result.purchaseData as object | undefined,
+          purchaseData: result.purchaseData,
           receiver: "",
           sender: "",
           status: result.status,
@@ -230,7 +231,7 @@ function toBuyWithCryptoStatus(args: {
   originChainId: number;
   destinationChainId: number;
   status: Status["status"];
-  purchaseData?: object;
+  purchaseData?: PurchaseData;
   sender: string;
   receiver: string;
   paymentId: string;
@@ -277,7 +278,7 @@ function toBuyWithCryptoStatus(args: {
       transactionHash: destinationTransaction?.transactionHash ?? "",
     },
     fromAddress: sender,
-    purchaseData: purchaseData as object | undefined, // TODO transfer type?
+    purchaseData: purchaseData,
     quote: {
       createdAt: new Date().toISOString(),
       estimated: {

--- a/packages/thirdweb/src/pay/buyWithCrypto/getTransfer.ts
+++ b/packages/thirdweb/src/pay/buyWithCrypto/getTransfer.ts
@@ -7,6 +7,7 @@ import { NATIVE_TOKEN_ADDRESS } from "../../constants/addresses.js";
 import { getContract } from "../../contract/contract.js";
 import { decimals } from "../../extensions/erc20/read/decimals.js";
 import type { PrepareTransactionOptions } from "../../transaction/prepare-transaction.js";
+import type { PurchaseData } from "../types.js";
 import type { QuoteApprovalInfo, QuotePaymentToken } from "./commonTypes.js";
 
 /**
@@ -54,7 +55,7 @@ export type GetBuyWithCryptoTransferParams = {
    *
    * This details will be stored with the purchase and can be retrieved later via the status API or Webhook
    */
-  purchaseData?: object;
+  purchaseData?: PurchaseData;
 
   /**
    * For direct transfers, specify who will pay for the transfer fee. Can be "sender" or "receiver".

--- a/packages/thirdweb/src/pay/buyWithFiat/getQuote.ts
+++ b/packages/thirdweb/src/pay/buyWithFiat/getQuote.ts
@@ -6,6 +6,7 @@ import { getContract } from "../../contract/contract.js";
 import { decimals } from "../../extensions/erc20/read/decimals.js";
 import type { CurrencyMeta } from "../../react/web/ui/ConnectWallet/screens/Buy/fiat/currencies.js";
 import { toTokens, toUnits } from "../../utils/units.js";
+import type { PurchaseData } from "../types.js";
 import type { FiatProvider, PayTokenInfo } from "../utils/commonTypes.js";
 /**
  * Parameters for [`getBuyWithFiatQuote`](https://portal.thirdweb.com/references/typescript/v5/getBuyWithFiatQuote) function
@@ -80,7 +81,7 @@ export type GetBuyWithFiatQuoteParams = {
    *
    * This details will be stored with the purchase and can be retrieved later via the status API or Webhook
    */
-  purchaseData?: object;
+  purchaseData?: PurchaseData;
 
   /**
    * Optional parameter to onramp gas with the purchase

--- a/packages/thirdweb/src/pay/buyWithFiat/getStatus.ts
+++ b/packages/thirdweb/src/pay/buyWithFiat/getStatus.ts
@@ -1,5 +1,6 @@
 import { status as onrampStatus } from "../../bridge/OnrampStatus.js";
 import type { ThirdwebClient } from "../../client/client.js";
+import type { PurchaseData } from "../types.js";
 import type {
   PayOnChainTransactionDetails,
   PayTokenInfo,
@@ -109,7 +110,7 @@ export type BuyWithFiatStatus =
       /**
        * Arbitrary data sent at the time of fetching the quote
        */
-      purchaseData?: object;
+      purchaseData?: PurchaseData;
     };
 
 /**
@@ -202,7 +203,7 @@ function buildPlaceholderStatus(args: {
     | "PENDING_PAYMENT"
     | "PAYMENT_FAILED"
     | "ON_RAMP_TRANSFER_COMPLETED";
-  purchaseData?: unknown;
+  purchaseData?: PurchaseData;
 }): BuyWithFiatStatus {
   const { intentId, status, purchaseData } = args;
 
@@ -253,7 +254,7 @@ function buildPlaceholderStatus(args: {
   const base: Exclude<BuyWithFiatStatus, { status: "NOT_FOUND" }> = {
     fromAddress: "",
     intentId,
-    purchaseData: purchaseData as object | undefined,
+    purchaseData,
     quote,
     status,
     toAddress: "",

--- a/packages/thirdweb/src/pay/types.ts
+++ b/packages/thirdweb/src/pay/types.ts
@@ -1,0 +1,1 @@
+export type PurchaseData = Record<string, unknown>;

--- a/packages/thirdweb/src/react/core/hooks/connection/ConnectButtonProps.ts
+++ b/packages/thirdweb/src/react/core/hooks/connection/ConnectButtonProps.ts
@@ -4,6 +4,7 @@ import type { ThirdwebClient } from "../../../../client/client.js";
 import type { BuyWithCryptoStatus } from "../../../../pay/buyWithCrypto/getStatus.js";
 import type { BuyWithFiatStatus } from "../../../../pay/buyWithFiat/getStatus.js";
 import type { SupportedFiatCurrency } from "../../../../pay/convert/type.js";
+import type { PurchaseData } from "../../../../pay/types.js";
 import type { FiatProvider } from "../../../../pay/utils/commonTypes.js";
 import type { AssetTabs } from "../../../../react/web/ui/ConnectWallet/screens/ViewAssets.js";
 import type { PreparedTransaction } from "../../../../transaction/prepare-transaction.js";
@@ -117,7 +118,7 @@ export type PayUIOptions = Prettify<
      *
      * This details will be stored with the purchase and can be retrieved later via the status API or Webhook
      */
-    purchaseData?: object;
+    purchaseData?: PurchaseData;
 
     /**
      * Callback to be called when the user successfully completes the purchase.

--- a/packages/thirdweb/src/react/core/hooks/transaction/useSendTransaction.ts
+++ b/packages/thirdweb/src/react/core/hooks/transaction/useSendTransaction.ts
@@ -6,6 +6,7 @@ import * as Bridge from "../../../../bridge/index.js";
 import type { Chain } from "../../../../chains/types.js";
 import type { BuyWithCryptoStatus } from "../../../../pay/buyWithCrypto/getStatus.js";
 import type { BuyWithFiatStatus } from "../../../../pay/buyWithFiat/getStatus.js";
+import type { PurchaseData } from "../../../../pay/types.js";
 import type { FiatProvider } from "../../../../pay/utils/commonTypes.js";
 import type { GaslessOptions } from "../../../../transaction/actions/gasless/types.js";
 import { sendTransaction } from "../../../../transaction/actions/send-transaction.js";
@@ -65,7 +66,7 @@ export type SendTransactionPayModalConfig =
             testMode?: boolean;
             preferredProvider?: FiatProvider;
           };
-      purchaseData?: object;
+      purchaseData?: PurchaseData;
       /**
        * Callback to be called when the user successfully completes the purchase.
        */

--- a/packages/thirdweb/src/react/web/ui/Bridge/BridgeOrchestrator.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/BridgeOrchestrator.tsx
@@ -2,6 +2,7 @@
 import { useCallback, useMemo } from "react";
 import type { Token } from "../../../../bridge/types/Token.js";
 import type { ThirdwebClient } from "../../../../client/client.js";
+import type { PurchaseData } from "../../../../pay/types.js";
 import type { PreparedTransaction } from "../../../../transaction/prepare-transaction.js";
 import type { Address } from "../../../../utils/address.js";
 import { webLocalStorage } from "../../../../utils/storage/webStorage.js";
@@ -102,7 +103,7 @@ export interface BridgeOrchestratorProps {
   /**
    * Optional purchase data for the payment
    */
-  purchaseData: object | undefined;
+  purchaseData?: PurchaseData;
 
   /**
    * Optional payment link ID for the payment

--- a/packages/thirdweb/src/react/web/ui/Bridge/BuyWidget.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/BuyWidget.tsx
@@ -7,6 +7,7 @@ import type { Chain } from "../../../../chains/types.js";
 import type { ThirdwebClient } from "../../../../client/client.js";
 import { NATIVE_TOKEN_ADDRESS } from "../../../../constants/addresses.js";
 import { getToken } from "../../../../pay/convert/get-token.js";
+import type { PurchaseData } from "../../../../pay/types.js";
 import {
   type Address,
   checksumAddress,
@@ -139,7 +140,7 @@ export type BuyWidgetProps = {
   /**
    * Arbitrary data to be included in the returned status and webhook events.
    */
-  purchaseData?: Record<string, unknown>;
+  purchaseData?: PurchaseData;
 
   /**
    * Callback triggered when the purchase is successful.

--- a/packages/thirdweb/src/react/web/ui/Bridge/CheckoutWidget.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/CheckoutWidget.tsx
@@ -7,6 +7,7 @@ import type { Chain } from "../../../../chains/types.js";
 import type { ThirdwebClient } from "../../../../client/client.js";
 import { NATIVE_TOKEN_ADDRESS } from "../../../../constants/addresses.js";
 import { getToken } from "../../../../pay/convert/get-token.js";
+import type { PurchaseData } from "../../../../pay/types.js";
 import { type Address, checksumAddress } from "../../../../utils/address.js";
 import { stringify } from "../../../../utils/json.js";
 import type { Wallet } from "../../../../wallets/interfaces/wallet.js";
@@ -145,7 +146,7 @@ export type CheckoutWidgetProps = {
   /**
    * Arbitrary data to be included in the returned status and webhook events.
    */
-  purchaseData?: Record<string, unknown>;
+  purchaseData?: PurchaseData;
 
   /**
    * Callback triggered when the purchase is successful.

--- a/packages/thirdweb/src/react/web/ui/Bridge/QuoteLoader.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/QuoteLoader.tsx
@@ -4,6 +4,7 @@ import { useEffect } from "react";
 import { trackPayEvent } from "../../../../analytics/track/pay.js";
 import type { Token } from "../../../../bridge/types/Token.js";
 import type { ThirdwebClient } from "../../../../client/client.js";
+import type { PurchaseData } from "../../../../pay/types.js";
 import { toUnits } from "../../../../utils/units.js";
 import {
   type BridgePrepareRequest,
@@ -69,7 +70,7 @@ interface QuoteLoaderProps {
   /**
    * Optional purchase data for the payment
    */
-  purchaseData?: object;
+  purchaseData?: PurchaseData;
 
   /**
    * Optional payment link ID for the payment
@@ -175,7 +176,7 @@ function getBridgeParams(args: {
   client: ThirdwebClient;
   sender?: string;
   feePayer?: "sender" | "receiver";
-  purchaseData?: object;
+  purchaseData?: PurchaseData;
   paymentLinkId?: string;
 }): UseBridgePrepareParams {
   const { paymentMethod, amount, destinationToken, receiver, client, sender } =

--- a/packages/thirdweb/src/react/web/ui/Bridge/TransactionWidget.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/TransactionWidget.tsx
@@ -7,6 +7,7 @@ import type { Chain } from "../../../../chains/types.js";
 import type { ThirdwebClient } from "../../../../client/client.js";
 import { NATIVE_TOKEN_ADDRESS } from "../../../../constants/addresses.js";
 import { getToken } from "../../../../pay/convert/get-token.js";
+import type { PurchaseData } from "../../../../pay/types.js";
 import {
   type PreparedTransaction,
   prepareTransaction,
@@ -143,7 +144,7 @@ export type TransactionWidgetProps = {
   /**
    * Arbitrary data to be included in the returned status and webhook events.
    */
-  purchaseData?: Record<string, unknown>;
+  purchaseData?: PurchaseData;
 
   /**
    * Callback triggered when the purchase is successful.

--- a/packages/thirdweb/src/react/web/ui/PayEmbed.tsx
+++ b/packages/thirdweb/src/react/web/ui/PayEmbed.tsx
@@ -363,9 +363,7 @@ export function PayEmbed(props: PayEmbedProps) {
               ? ["card"]
               : ["crypto", "card"]
         }
-        purchaseData={
-          props.payOptions?.purchaseData as Record<string, unknown> | undefined
-        }
+        purchaseData={props.payOptions?.purchaseData}
         theme={theme}
         title={metadata?.name || "Buy"}
         tokenAddress={
@@ -390,9 +388,7 @@ export function PayEmbed(props: PayEmbedProps) {
             ? ["crypto"]
             : ["crypto", "card"]
         }
-        purchaseData={
-          props.payOptions?.purchaseData as Record<string, unknown> | undefined
-        }
+        purchaseData={props.payOptions?.purchaseData}
         seller={props.payOptions.paymentInfo.sellerAddress as Address}
         theme={theme}
         tokenAddress={
@@ -414,9 +410,7 @@ export function PayEmbed(props: PayEmbedProps) {
             ? ["crypto"]
             : ["crypto", "card"]
         }
-        purchaseData={
-          props.payOptions?.purchaseData as Record<string, unknown> | undefined
-        }
+        purchaseData={props.payOptions?.purchaseData}
         theme={theme}
         title={metadata?.name}
         transaction={props.payOptions.transaction}


### PR DESCRIPTION
# Properly Type `purchaseData` Parameter

This PR improves type safety by changing the type of `purchaseData` from `object` to `Record<string, unknown>` in multiple locations:

- ConnectButtonProps.ts
- useSendTransaction.ts

Additionally, it removes unnecessary type casting in PayEmbed.tsx where `purchaseData` was being cast to `Record<string, unknown>`.

A changeset has been added to document this patch-level change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved type safety for purchase data by refining its type definition across multiple features.
  * Simplified user interface components by removing redundant type assertions related to purchase data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving type safety by replacing instances of `Record<string, unknown>` and `object` with the new type `PurchaseData` across various files.

### Detailed summary
- Added `PurchaseData` type in `types.ts`.
- Replaced `purchaseData?: Record<string, unknown>` with `purchaseData?: PurchaseData` in multiple components and types.
- Updated relevant files to ensure consistent use of `PurchaseData`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->