### PR TITLE
Update import path in createSessionKey example

### DIFF
--- a/packages/thirdweb/src/extensions/erc7702/account/createSessionKey.ts
+++ b/packages/thirdweb/src/extensions/erc7702/account/createSessionKey.ts
@@ -52,7 +52,7 @@ export type CreateSessionKeyOptions = {
  * @returns The transaction object to be sent.
  * @example
  * ```ts
- * import { createSessionKey } from 'thirdweb/extensions/7702';
+ * import { createSessionKey } from 'thirdweb/wallets/in-app';
  * import { sendTransaction } from 'thirdweb';
  *
  * const transaction = createSessionKey({


### PR DESCRIPTION
Changed the import path in the createSessionKey usage example from 'thirdweb/extensions/7702' to 'thirdweb/wallets/in-app' to reflect the correct module location.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the import path for the `createSessionKey` function in the `createSessionKey.ts` file, changing it from the `thirdweb/extensions/7702` module to the `thirdweb/wallets/in-app` module.

### Detailed summary
- Changed import of `createSessionKey` from `thirdweb/extensions/7702` to `thirdweb/wallets/in-app`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example code in documentation to reflect the correct import path for the session key creation function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->