### PR TITLE
Remove "starter" plan checks from team invitation logic

### DIFF
--- a/apps/dashboard/src/@/utils/pricing.tsx
+++ b/apps/dashboard/src/@/utils/pricing.tsx
@@ -23,7 +23,6 @@ export const TEAM_PLANS: Record<
     features: [
       "Email Support",
       "48hr Guaranteed Response",
-      "Invite Team Members",
       "Custom In-App Wallet Auth",
     ],
     price: 99,

--- a/apps/dashboard/src/app/(app)/login/onboarding/team-onboarding/InviteTeamMembers.tsx
+++ b/apps/dashboard/src/app/(app)/login/onboarding/team-onboarding/InviteTeamMembers.tsx
@@ -87,8 +87,7 @@ export function InviteTeamMembersUI(props: {
         client={props.client}
         customCTASection={
           <div className="flex gap-3">
-            {(props.team.billingPlan === "free" ||
-              props.team.billingPlan === "starter") && (
+            {props.team.billingPlan === "free" && (
               <Button
                 className="gap-2"
                 onClick={() => {

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/settings/members/InviteSection.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/settings/members/InviteSection.tsx
@@ -85,10 +85,7 @@ export function InviteSection(props: {
   let bottomSection: React.ReactNode = null;
   const maxAllowedInvitesAtOnce = 10;
   // invites are enabled if user has edit permission and team plan is not "free"
-  const inviteEnabled =
-    teamPlan !== "free" &&
-    teamPlan !== "starter" &&
-    props.userHasEditPermission;
+  const inviteEnabled = teamPlan !== "free" && props.userHasEditPermission;
 
   const form = useForm<InviteFormValues>({
     defaultValues: {
@@ -111,7 +108,7 @@ export function InviteSection(props: {
     },
   });
 
-  if (teamPlan === "free" || teamPlan === "starter") {
+  if (teamPlan === "free") {
     bottomSection = (
       <div className="lg:px6 flex items-center justify-between gap-4 border-border border-t px-4 py-4">
         <p className="text-muted-foreground text-sm">


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the logic for team member invitations and modifying the pricing options in the dashboard. It simplifies conditions for enabling invites and removes an invitation option from the pricing list.

### Detailed summary
- Removed `"Invite Team Members"` from the pricing options in `pricing.tsx`.
- Simplified the condition for showing the invite button in `InviteTeamMembers.tsx` to only check for the `"free"` billing plan.
- Updated the invite enabling logic in `InviteSection.tsx` to remove the `"starter"` plan condition.
- Adjusted the conditional check for the bottom section display in `InviteSection.tsx` to only check for the `"free"` plan.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated team plan features by removing "Invite Team Members" from the "growth" plan feature list.

* **Bug Fixes**
  * Adjusted upgrade prompts and invite functionality so that upgrade options and invite restrictions now apply only to teams on the "free" plan, rather than both "free" and "starter" plans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->