### PR TITLE
Update branding from Engine Cloud to Transactions

### DIFF
--- a/apps/portal/src/app/Header.tsx
+++ b/apps/portal/src/app/Header.tsx
@@ -137,7 +137,7 @@ const apisLinks = [
   },
   {
     href: "https://engine.thirdweb.com/reference#tag/write",
-    name: "Engine Cloud",
+    name: "Transactions",
   },
   {
     href: "https://bridge.thirdweb.com/reference",

--- a/apps/portal/src/app/dotnet/wallets/providers/engine-wallet/page.mdx
+++ b/apps/portal/src/app/dotnet/wallets/providers/engine-wallet/page.mdx
@@ -8,7 +8,7 @@ export const metadata = createMetadata({
 
 # EngineWallet.Create
 
-A .NET integration of thirdweb [Engine](https://thirdweb.com/engine).
+A .NET integration of thirdweb Transactions.
 
 Instantiate a `Engine` with a given private key. This wallet is capable of signing transactions and messages, interacting with smart contracts, and performing other blockchain operations. **This wallet type is intended for backend applications only,** due to the sensitive nature of private keys.
 


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating references from "Engine Cloud" to "Transactions" in the codebase, reflecting a shift in terminology and functionality related to thirdweb's offerings.

### Detailed summary
- In `Header.tsx`, the name was changed from `"Engine Cloud"` to `"Transactions"` for a specific link.
- In `page.mdx`, the description was updated from "A .NET integration of thirdweb Engine" to "A .NET integration of thirdweb Transactions."

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the display name of a navigation link from "Engine Cloud" to "Transactions" in the user interface.

* **Documentation**
  * Revised documentation to refer to "thirdweb Transactions" instead of "thirdweb Engine" in the .NET integration guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->