### PR TITLE
[Dashboard] Fix validation for smart account options

### DIFF
--- a/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/components/client/auth-options-form.client.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/components/client/auth-options-form.client.tsx
@@ -90,9 +90,9 @@ export function AuthOptionsForm({
         DEFAULT_ACCOUNT_FACTORY_V0_7
           ? "v0.7"
           : ecosystem.smartAccountOptions?.accountFactoryAddress ===
-              DEFAULT_ACCOUNT_FACTORY_V0_6
-            ? "v0.6"
-            : "custom",
+            DEFAULT_ACCOUNT_FACTORY_V0_6
+          ? "v0.6"
+          : "custom",
       authOptions: ecosystem.authOptions || [],
       customAccountFactoryAddress:
         ecosystem.smartAccountOptions?.accountFactoryAddress || "",
@@ -133,6 +133,8 @@ export function AuthOptionsForm({
           (data) => {
             if (
               data.useSmartAccount &&
+              data.executionMode === "EIP4337" &&
+              data.accountFactoryType === "custom" &&
               data.customAccountFactoryAddress &&
               !isAddress(data.customAccountFactoryAddress)
             ) {
@@ -142,6 +144,23 @@ export function AuthOptionsForm({
           },
           {
             message: "Please enter a valid custom account factory address",
+            path: ["customAccountFactoryAddress"],
+          },
+        )
+        .refine(
+          (data) => {
+            if (
+              data.useSmartAccount &&
+              data.executionMode === "EIP4337" &&
+              data.accountFactoryType === "custom" &&
+              !data.customAccountFactoryAddress
+            ) {
+              return false;
+            }
+            return true;
+          },
+          {
+            message: "Please enter a custom account factory address",
             path: ["customAccountFactoryAddress"],
           },
         )

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/components/client/auth-options-form.client.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/components/client/auth-options-form.client.tsx
@@ -90,9 +90,9 @@ export function AuthOptionsForm({
         DEFAULT_ACCOUNT_FACTORY_V0_7
           ? "v0.7"
           : ecosystem.smartAccountOptions?.accountFactoryAddress ===
-            DEFAULT_ACCOUNT_FACTORY_V0_6
-          ? "v0.6"
-          : "custom",
+              DEFAULT_ACCOUNT_FACTORY_V0_6
+            ? "v0.6"
+            : "custom",
       authOptions: ecosystem.authOptions || [],
       customAccountFactoryAddress:
         ecosystem.smartAccountOptions?.accountFactoryAddress || "",

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/components/client/auth-options-form.client.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/ecosystem/[slug]/(active)/configuration/components/client/auth-options-form.client.tsx
@@ -231,7 +231,7 @@ export function AuthOptionsForm({
     }
 
     let smartAccountOptions: Ecosystem["smartAccountOptions"] | null = null;
-    if (data.useSmartAccount) {
+    if (data.useSmartAccount && data.executionMode === "EIP4337") {
       let accountFactoryAddress: string;
       switch (data.accountFactoryType) {
         case "v0.6":


### PR DESCRIPTION
```
<!--

%23%23 title your PR with this format: "[Dashboard] Fix: Smart account factory validation for EIP-7702"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

%23%23 Notes for the reviewer

This PR fixes a bug where the custom account factory address was being validated even when the smart account execution mode was set to EIP-7702, which does not require a factory address.

The Zod validation schema for `customAccountFactoryAddress` has been updated to only apply validation (both address format and required checks) when:
1. Smart accounts are enabled.
2. The execution mode is `EIP4337`.
3. The account factory type is `custom`.

This ensures the validation logic aligns with the UI, where the factory input is hidden for EIP-7702.

%23%23 How to test

1. Navigate to an ecosystem's configuration page (`/team/[team_slug]/~/ecosystem/[slug]/configuration`).
2. Enable smart accounts.
3. Set "Execution Mode" to "ERC-4337".
4. Set "Account Factory Type" to "Custom".
5. Leave the "Custom Account Factory Address" field empty.
6. Click "Save" (it should show an error, as expected).
7. Now, change "Execution Mode" to "EIP-7702" (without filling the custom factory address).
8. Click "Save".
9. **Expected:** The form should save successfully without any validation error related to the custom factory address.

-->
```

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the validation logic in the `AuthOptionsForm` component to ensure that a custom account factory address is provided when certain conditions are met. It specifically checks for the `EIP4337` execution mode and the custom account factory type.

### Detailed summary
- Added a new validation rule to ensure `customAccountFactoryAddress` is provided when:
  - `useSmartAccount` is true
  - `executionMode` is "EIP4337"
  - `accountFactoryType` is "custom"
- Updated the conditional check for `useSmartAccount` to include `executionMode` in the main logic.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for the custom account factory address field, ensuring it is required when specific smart account options are selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->