### PR TITLE
[SDK] Show all tokens in payment selection regardless of balance

### DIFF
--- a/.changeset/three-parts-rush.md
+++ b/.changeset/three-parts-rush.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Show all tokens in payment selection screen, even if not enough balance

--- a/packages/thirdweb/src/react/core/hooks/usePaymentMethods.ts
+++ b/packages/thirdweb/src/react/core/hooks/usePaymentMethods.ts
@@ -122,9 +122,6 @@ export function usePaymentMethods(options: {
         page += 1;
       }
 
-      const requiredDollarAmount =
-        Number.parseFloat(destinationAmount) * destinationToken.priceUsd;
-
       // sort by dollar balance descending
       owned.sort((a, b) => {
         const aDollarBalance =
@@ -140,13 +137,6 @@ export function usePaymentMethods(options: {
 
       for (const b of owned) {
         if (b.originToken && b.balance > 0n) {
-          const dollarBalance =
-            Number.parseFloat(toTokens(b.balance, b.originToken.decimals)) *
-            b.originToken.priceUsd;
-          if (b.originToken.priceUsd && dollarBalance < requiredDollarAmount) {
-            continue;
-          }
-
           if (
             includeDestinationToken &&
             b.originToken.address.toLowerCase() ===


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on displaying all tokens in the payment selection screen, regardless of whether the user has enough balance for a specific token.

### Detailed summary
- Modified the logic in the `usePaymentMethods` hook to show all tokens in the payment selection screen.
- Removed the calculation of `requiredDollarAmount` and the filtering condition based on `dollarBalance` for owned tokens.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The payment selection screen now displays all available tokens, regardless of whether the user has sufficient balance for them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->