### PR TITLE
[SDK] Respect feePayer property in Payment widgets

### DIFF
--- a/.changeset/angry-dragons-smash.md
+++ b/.changeset/angry-dragons-smash.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Respect feePayer property in Payment widgets

--- a/packages/thirdweb/src/react/web/ui/Bridge/BridgeOrchestrator.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/BridgeOrchestrator.tsx
@@ -292,7 +292,6 @@ export function BridgeOrchestrator({
             amount={state.context.destinationAmount}
             client={client}
             destinationToken={state.context.destinationToken}
-            mode={uiOptions.mode}
             onBack={() => {
               send({ type: "BACK" });
             }}
@@ -302,6 +301,7 @@ export function BridgeOrchestrator({
             paymentMethod={state.context.selectedPaymentMethod}
             purchaseData={purchaseData}
             receiver={state.context.receiverAddress}
+            uiOptions={uiOptions}
           />
         )}
 

--- a/packages/thirdweb/src/react/web/ui/Bridge/QuoteLoader.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/QuoteLoader.tsx
@@ -17,6 +17,7 @@ import { Container } from "../components/basic.js";
 import { Spacer } from "../components/Spacer.js";
 import { Spinner } from "../components/Spinner.js";
 import { Text } from "../components/text.js";
+import type { UIOptions } from "./BridgeOrchestrator.js";
 
 interface QuoteLoaderProps {
   /**
@@ -78,14 +79,13 @@ interface QuoteLoaderProps {
   paymentLinkId?: string;
 
   /**
-   * Fee payer for direct transfers (defaults to sender)
+   * UI options
    */
-  feePayer?: "sender" | "receiver";
-  mode: "fund_wallet" | "direct_payment" | "transaction";
+  uiOptions: UIOptions;
 }
 
 export function QuoteLoader({
-  mode,
+  uiOptions,
   destinationToken,
   paymentMethod,
   amount,
@@ -96,10 +96,14 @@ export function QuoteLoader({
   onError,
   purchaseData,
   paymentLinkId,
-  feePayer,
 }: QuoteLoaderProps) {
   // For now, we'll use a simple buy operation
   // This will be expanded to handle different bridge types based on the payment method
+  const feePayer =
+    uiOptions.mode === "direct_payment"
+      ? uiOptions.paymentInfo.feePayer
+      : undefined;
+  const mode = uiOptions.mode;
   const request: BridgePrepareRequest = getBridgeParams({
     amount,
     client,

--- a/packages/thirdweb/src/react/web/ui/PayEmbed.tsx
+++ b/packages/thirdweb/src/react/web/ui/PayEmbed.tsx
@@ -380,6 +380,9 @@ export function PayEmbed(props: PayEmbedProps) {
         chain={props.payOptions.paymentInfo.chain}
         client={props.client}
         description={metadata?.description}
+        feePayer={
+          props.payOptions.paymentInfo.feePayer === "sender" ? "user" : "seller"
+        }
         image={metadata?.image}
         name={metadata?.name || "Checkout"}
         onSuccess={() => props.payOptions?.onPurchaseSuccess?.()}


### PR DESCRIPTION
Fixes #7518

<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing payment widget functionality by properly respecting the `feePayer` property and incorporating `uiOptions` into various components for better payment handling.

### Detailed summary
- Updated `PayEmbed.tsx` to set `feePayer` based on `props.payOptions.paymentInfo.feePayer`.
- Added `uiOptions` prop to `BridgeOrchestrator`.
- Modified `QuoteLoader` to accept `uiOptions` and derive `feePayer` and `mode` from it.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Payment widgets now properly respect the `feePayer` setting, ensuring accurate fee handling during transactions.

* **Refactor**
  * Improved configuration management in payment and bridge widgets by consolidating multiple options into a single settings object for better maintainability and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->