### PR TITLE
[TOOL-4972] Dashboard: Add field to configure admins in NFT asset creation

### DIFF
--- a/apps/dashboard/src/@/analytics/report.ts
+++ b/apps/dashboard/src/@/analytics/report.ts
@@ -362,7 +362,11 @@ export function reportAssetCreationFailed(
   properties: { contractType: AssetContractType; error: string } & (
     | {
         assetType: "nft";
-        step: "deploy-contract" | "mint-nfts" | "set-claim-conditions";
+        step:
+          | "deploy-contract"
+          | "mint-nfts"
+          | "set-claim-conditions"
+          | "set-admins";
       }
     | {
         assetType: "coin";

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/tokens/create/_common/schema.ts
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/tokens/create/_common/schema.ts
@@ -22,6 +22,22 @@ export const socialUrlsSchema = z.array(
   }),
 );
 
+export const addressArraySchema = z.array(
+  z.object({
+    address: z.string().refine(
+      (value) => {
+        if (isAddress(value)) {
+          return true;
+        }
+        return false;
+      },
+      {
+        message: "Invalid address",
+      },
+    ),
+  }),
+);
+
 export const addressSchema = z.string().refine(
   (value) => {
     if (isAddress(value)) {

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/tokens/create/nft/_common/form.ts
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/tokens/create/nft/_common/form.ts
@@ -1,23 +1,21 @@
-import { isAddress } from "thirdweb";
 import * as z from "zod";
-import { socialUrlsSchema } from "../../_common/schema";
+import {
+  addressArraySchema,
+  addressSchema,
+  socialUrlsSchema,
+} from "../../_common/schema";
 import type { NFTMetadataWithPrice } from "../upload-nfts/batch-upload/process-files";
 
 export const nftCollectionInfoFormSchema = z.object({
+  admins: addressArraySchema.refine((addresses) => addresses.length > 0, {
+    message: "At least one admin is required",
+  }),
   chain: z.string().min(1, "Chain is required"),
   description: z.string().optional(),
   image: z.instanceof(File).optional(),
   name: z.string().min(1, "Name is required"),
   socialUrls: socialUrlsSchema,
   symbol: z.string(),
-});
-
-const addressSchema = z.string().refine((value) => {
-  if (isAddress(value)) {
-    return true;
-  }
-
-  return false;
 });
 
 export const nftSalesSettingsFormSchema = z.object({
@@ -37,6 +35,14 @@ export type CreateNFTCollectionAllValues = {
 };
 
 export type CreateNFTCollectionFunctions = {
+  setAdmins: (values: {
+    contractAddress: string;
+    contractType: "DropERC721" | "DropERC1155";
+    admins: {
+      address: string;
+    }[];
+    chain: string;
+  }) => Promise<void>;
   erc721: {
     deployContract: (values: CreateNFTCollectionAllValues) => Promise<{
       contractAddress: string;

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/tokens/create/nft/collection-info/nft-collection-info-fieldset.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/tokens/create/nft/collection-info/nft-collection-info-fieldset.tsx
@@ -10,6 +10,7 @@ import { SingleNetworkSelector } from "@/components/blocks/NetworkSelectors";
 import { Form } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import { AdminAddressesFieldset } from "../../_common/admin-addresses-fieldset";
 import { SocialUrlsFieldset } from "../../_common/SocialUrls";
 import { StepCard } from "../../_common/step-card";
 import type { NFTCollectionInfoFormValues } from "../_common/form";
@@ -126,6 +127,8 @@ export function NFTCollectionInfoFieldset(props: {
           </div>
 
           <SocialUrlsFieldset form={form} />
+
+          <AdminAddressesFieldset form={form} />
         </StepCard>
       </form>
     </Form>

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/tokens/create/nft/create-nft-page-ui.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/tokens/create/nft/create-nft-page-ui.tsx
@@ -8,7 +8,7 @@ import {
   NATIVE_TOKEN_ADDRESS,
   type ThirdwebClient,
 } from "thirdweb";
-import { useActiveAccount } from "thirdweb/react";
+import { useActiveAccount, useActiveWalletChain } from "thirdweb/react";
 import { reportAssetCreationStepConfigured } from "@/analytics/report";
 import type { Team } from "@/api/team";
 import {
@@ -163,11 +163,16 @@ export function CreateNFTPageUI(props: {
 }
 
 function useNFTCollectionInfoForm() {
+  const chain = useActiveWalletChain();
+  const account = useActiveAccount();
   return useForm<NFTCollectionInfoFormValues>({
-    resolver: zodResolver(nftCollectionInfoFormSchema),
-    reValidateMode: "onChange",
-    values: {
-      chain: "1",
+    defaultValues: {
+      admins: [
+        {
+          address: account?.address || "",
+        },
+      ],
+      chain: chain?.id.toString() || "1",
       description: "",
       image: undefined,
       name: "",
@@ -183,5 +188,7 @@ function useNFTCollectionInfoForm() {
       ],
       symbol: "",
     },
+    resolver: zodResolver(nftCollectionInfoFormSchema),
+    reValidateMode: "onChange",
   });
 }

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/tokens/create/nft/upload-nfts/single-upload/single-upload-nft.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/tokens/create/nft/upload-nfts/single-upload/single-upload-nft.tsx
@@ -4,7 +4,11 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { ArrowLeftIcon, ArrowRightIcon, AsteriskIcon } from "lucide-react";
 import { useId } from "react";
 import { useForm } from "react-hook-form";
-import type { ThirdwebClient } from "thirdweb";
+import {
+  getAddress,
+  NATIVE_TOKEN_ADDRESS,
+  type ThirdwebClient,
+} from "thirdweb";
 import { FileInput } from "@/components/blocks/FileInput";
 import { FormFieldSetup } from "@/components/blocks/FormFieldSetup";
 import { TokenSelector } from "@/components/blocks/TokenSelector";
@@ -32,6 +36,8 @@ import type { NFTMetadataWithPrice } from "../batch-upload/process-files";
 import { nftWithPriceSchema } from "../schema";
 import { AttributesFieldset } from "./attributes";
 
+const nativeTokenAddress = getAddress(NATIVE_TOKEN_ADDRESS);
+
 export function SingleUploadNFT(props: {
   client: ThirdwebClient;
   onNext: () => void;
@@ -46,6 +52,9 @@ export function SingleUploadNFT(props: {
       description: "",
       image: undefined,
       name: "",
+      price_amount: "1",
+      price_currency: nativeTokenAddress,
+      supply: "1",
     },
     resolver: zodResolver(nftWithPriceSchema),
     reValidateMode: "onChange",

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/tokens/create/token/create-token-page.client.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/tokens/create/token/create-token-page.client.tsx
@@ -8,6 +8,7 @@ import {
   NATIVE_TOKEN_ADDRESS,
   type ThirdwebClient,
 } from "thirdweb";
+import { useActiveWalletChain } from "thirdweb/react";
 import { reportAssetCreationStepConfigured } from "@/analytics/report";
 import type { Team } from "@/api/team";
 import {
@@ -44,12 +45,11 @@ export function CreateTokenAssetPageUI(props: {
   const [step, setStep] = useState<"token-info" | "distribution" | "launch">(
     "token-info",
   );
+  const activeWalletChain = useActiveWalletChain();
 
   const tokenInfoForm = useForm<TokenInfoFormValues>({
-    resolver: zodResolver(tokenInfoFormSchema),
-    reValidateMode: "onChange",
-    values: {
-      chain: "1",
+    defaultValues: {
+      chain: activeWalletChain?.id.toString() || "1",
       description: "",
       image: undefined,
       name: "",
@@ -65,6 +65,8 @@ export function CreateTokenAssetPageUI(props: {
       ],
       symbol: "",
     },
+    resolver: zodResolver(tokenInfoFormSchema),
+    reValidateMode: "onChange",
   });
 
   const tokenDistributionForm = useForm<TokenDistributionFormValues>({

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/tokens/create/token/launch/launch-token.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/tokens/create/token/launch/launch-token.tsx
@@ -262,7 +262,7 @@ export function LaunchTokenStatus(props: {
           dialogCloseClassName="hidden"
         >
           <div className="flex flex-col gap-6 p-6">
-            <DialogHeader>
+            <DialogHeader className="space-y-0.5">
               <DialogTitle className="font-semibold text-xl tracking-tight">
                 Status
               </DialogTitle>


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the NFT creation process by introducing an `AdminAddressesFieldset`, adding admin management capabilities, and refining the user interface for better usability. It also includes schema updates for address validation and improves form handling.

### Detailed summary
- Added `"set-admins"` step to the NFT asset type.
- Introduced `AdminAddressesFieldset` for managing admin addresses.
- Updated form schemas to include admin addresses validation.
- Enhanced UI components with improved spacing and styles.
- Integrated admin management into the NFT launch process.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to specify multiple admin wallet addresses when creating an NFT collection, with dynamic form fields and validation.
  * NFT launch workflow now includes a step to assign admin roles to specified addresses.
  * NFT collection info and launch dialogs now display the list of assigned admins.

* **Improvements**
  * The NFT and token creation forms now automatically set the default blockchain network based on the active wallet chain.
  * NFT upload form includes default values for price and supply fields.
  * Visual spacing adjustments in social URL and token launch dialogs for improved UI consistency.

* **Bug Fixes**
  * Ensured at least one admin address is required when creating an NFT collection.

* **Other**
  * Extended error reporting to include a new "set-admins" step for NFT asset creation failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->