### PR TITLE
Rename Universal Bridge to Payments

### DIFF
--- a/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/analytics/page.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/analytics/page.tsx
@@ -367,7 +367,7 @@ function AppHighlightsCard({
       color: "hsl(var(--chart-2))",
       emptyContent: (
         <EmptyStateContent
-          description="Onramp, swap, and bridge with thirdweb's Universal Bridge."
+          description="Onramp, swap, and bridge with thirdweb's Payments."
           link="https://portal.thirdweb.com/connect/pay/overview"
           metric="Payments"
         />

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/components/ProjectFTUX/ProjectFTUX.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/components/ProjectFTUX/ProjectFTUX.tsx
@@ -257,7 +257,7 @@ function ProductsSection(props: { teamSlug: string; projectSlug: string }) {
         "Bridge, swap, and purchase cryptocurrencies with any fiat options or tokens via cross-chain routing",
       href: `/team/${props.teamSlug}/${props.projectSlug}/universal-bridge`,
       icon: PayIcon,
-      title: "Universal Bridge",
+      title: "Payments",
     },
   ];
 

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/components/ProjectSidebarLayout.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/components/ProjectSidebarLayout.tsx
@@ -75,7 +75,7 @@ export function ProjectSidebarLayout(props: {
             {
               href: `${layoutPath}/universal-bridge`,
               icon: PayIcon,
-              label: "Universal Bridge",
+              label: "Payments",
             },
             {
               href: `${layoutPath}/tokens`,

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/page.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/page.tsx
@@ -435,7 +435,7 @@ function AppHighlightsCard({
       color: "hsl(var(--chart-2))",
       emptyContent: (
         <EmptyStateContent
-          description="Onramp, swap, and bridge with thirdweb's Universal Bridge."
+          description="Onramp, swap, and bridge with thirdweb's Payments."
           link="https://portal.thirdweb.com/connect/pay/overview"
           metric="Payments"
         />

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/universal-bridge/layout.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/universal-bridge/layout.tsx
@@ -25,10 +25,10 @@ export default async function Layout(props: {
       <div className="pt-4 lg:pt-6">
         <div className="container max-w-7xl">
           <h1 className="mb-1 font-semibold text-2xl tracking-tight lg:text-3xl">
-            Universal Bridge
+            Payments
           </h1>
           <p className="max-w-3xl text-muted-foreground text-sm leading-relaxed">
-            Universal Bridge allows your users to bridge, swap, and purchase
+            Payments allows your users to bridge, swap, and purchase
             cryptocurrencies and execute transactions with any fiat options or
             tokens via cross-chain routing.{" "}
             <UnderlineLink

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/universal-bridge/page.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/universal-bridge/page.tsx
@@ -63,9 +63,7 @@ export default async function Page(props: {
           <div className="absolute inset-0 bg-gradient-to-br from-green-500/5 to-transparent" />
           <div className="relative flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex flex-col gap-1">
-              <h3 className="font-medium text-lg">
-                Get Started with Universal Bridge
-              </h3>
+              <h3 className="font-medium text-lg">Get Started with Payments</h3>
               <p className="text-muted-foreground text-sm">
                 Simple, instant, and secure payments across any token and chain.
               </p>

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/webhooks/layout.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/webhooks/layout.tsx
@@ -29,7 +29,7 @@ export default async function WebhooksLayout(props: {
             path: `/team/${params.team_slug}/${params.project_slug}/webhooks`,
           },
           {
-            name: "Universal Bridge",
+            name: "Payments",
             path: `/team/${params.team_slug}/${params.project_slug}/webhooks/universal-bridge`,
           },
         ]}

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/webhooks/universal-bridge/page.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/webhooks/universal-bridge/page.tsx
@@ -19,7 +19,7 @@ export default async function Page(props: {
   return (
     <div>
       <h2 className="mb-0.5 font-semibold text-xl tracking-tight">
-        Universal Bridge Webhooks
+        Payments Webhooks
       </h2>
       <p className="text-muted-foreground text-sm">
         Get notified for Bridge, Swap and Onramp events.{" "}


### PR DESCRIPTION
```
<!--

## title your PR with this format: "[Dashboard] Feature: Rename Universal Bridge to Payments"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

This PR renames all instances of "Universal Bridge" to "Payments" across the projects dashboard. This is a branding update and does not change any underlying functionality or URLs.

Changes include:
- Sidebar navigation label
- Page titles and descriptions
- Callouts and sub-text (e.g., analytics, FTUX)
- Webhooks section (tab name and heading)

## How to test

1. Navigate to any project dashboard.
2. Verify the sidebar now shows "Payments" instead of "Universal Bridge".
3. Click on "Payments" in the sidebar and confirm the page title and description are updated.
4. Check the "Analytics" page to ensure "Universal Bridge" references are updated to "Payments".
5. Go to "Webhooks" and then the "Payments" tab to confirm the heading and tab name are correct.
6. Verify the FTUX section also reflects "Payments".

-->
```

---

[Slack Thread](https://thirdwebdev.slack.com/archives/C08GEMP858V/p1752037029611589?thread_ts=1752037029.611589&cid=C08GEMP858V)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on renaming references from "Universal Bridge" to "Payments" across various components and pages in the application, reflecting a rebranding or feature update.

### Detailed summary
- Changed `name` from "Universal Bridge" to "Payments" in `webhooks/layout.tsx`.
- Updated `label` from "Universal Bridge" to "Payments" in `ProjectSidebarLayout.tsx`.
- Modified `title` from "Universal Bridge" to "Payments" in `ProjectFTUX.tsx`.
- Updated heading from "Universal Bridge Webhooks" to "Payments Webhooks" in `webhooks/universal-bridge/page.tsx`.
- Changed description from "Universal Bridge" to "Payments" in `analytics/page.tsx`.
- Updated description in `sidebar/page.tsx` from "Universal Bridge" to "Payments".
- Changed heading from "Get Started with Universal Bridge" to "Get Started with Payments" in `sidebar/universal-bridge/page.tsx`.
- Updated `h1` from "Universal Bridge" to "Payments" in `sidebar/universal-bridge/layout.tsx`.
- Changed description in `layout.tsx` to reflect "Payments" instead of "Universal Bridge".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated all user-facing references of "Universal Bridge" to "Payments" across dashboard sections, including headings, sidebar links, product cards, tab labels, and descriptive text. No changes to navigation, links, or underlying functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->