### PR TITLE
Replace PayEmbed with BuyWidget code

### DIFF
--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/universal-bridge/components/code-examples.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/universal-bridge/components/code-examples.tsx
@@ -1,13 +1,20 @@
 export const embedCode = (clientId: string) => `\
 import { createThirdwebClient } from "thirdweb";
-import { PayEmbed } from "thirdweb/react";
+import { BuyWidget } from "thirdweb/react";
+import { ethereum } from "thirdweb/chains";
 
 const client = createThirdwebClient({
   clientId: "${clientId}",
 });
 
 export default function App() {
-  return <PayEmbed client={client} />;
+  return (
+    <BuyWidget
+      client={client}
+      chain={ethereum}
+      amount="0.1"
+    />
+  );
 }`;
 
 export const sdkCode = (clientId: string) => `\


### PR DESCRIPTION
```
<!--

## title your PR with this format: "[Dashboard] Fix: Replace PayEmbed with BuyWidget code snippet"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Replaced the outdated `PayEmbed` code snippet on the analytics page with a functional `BuyWidget` example. The new snippet includes `client`, `ethereum` chain, and a demo `amount` of "0.1" as derived from `BuyWidget` JSDoc examples.

## How to test

Navigate to the analytics page in the dashboard and verify the displayed code snippet for the "Universal Bridge" section now shows the `BuyWidget` example.

-->
```

---

[Slack Thread](https://thirdwebdev.slack.com/archives/C08GEMP858V/p1752037950172289?thread_ts=1752037950.172289&cid=C08GEMP858V)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the code in the `code-examples.tsx` file to replace the `PayEmbed` component with the `BuyWidget` component, enhancing the functionality of the application by allowing users to buy items instead of just making payments.

### Detailed summary
- Replaced the import of `PayEmbed` with `BuyWidget` from `thirdweb/react`.
- Updated the return statement in the `App` function to use `BuyWidget`.
- Added `chain` and `amount` props to `BuyWidget` with values `ethereum` and `"0.1"` respectively.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the code example to showcase the new BuyWidget component for purchasing, including support for the Ethereum chain and a preset amount.

* **Style**
  * Improved clarity of the code example for end-users by updating component usage and displayed props.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->