### PR TITLE
Add branding hide prop to widgets

### DIFF
--- a/.changeset/hip-mammals-sip.md
+++ b/.changeset/hip-mammals-sip.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Adds the ability to hide thirdweb branding in the payment widgets with showThirdwebBranding

--- a/apps/playground-web/src/app/connect/pay/components/types.ts
+++ b/apps/playground-web/src/app/connect/pay/components/types.ts
@@ -25,5 +25,7 @@ export type BridgeComponentsPlaygroundOptions = {
     transactionData?: string; // Simplified for demo; could be more complex in real implementation
 
     paymentMethods: ("crypto" | "card")[];
+
+    showThirdwebBranding: boolean;
   };
 };

--- a/apps/playground-web/src/app/connect/pay/embed/LeftSection.tsx
+++ b/apps/playground-web/src/app/connect/pay/embed/LeftSection.tsx
@@ -138,35 +138,35 @@ export function LeftSection(props: {
           {(!payOptions.widget ||
             payOptions.widget === "buy" ||
             payOptions.widget === "checkout") && (
-            <div className="space-y-4">
-              {/* Chain selection */}
-              <div className="flex flex-col gap-2">
-                <Label>Chain</Label>
-                <SingleNetworkSelector
-                  chainId={selectedChain}
-                  disableTestnets={true}
-                  onChange={handleChainChange}
-                  placeholder="Select a chain"
-                />
-              </div>
-
-              {/* Token selection - only show if chain is selected */}
-              {selectedChain && (
+              <div className="space-y-4">
+                {/* Chain selection */}
                 <div className="flex flex-col gap-2">
-                  <Label>Token</Label>
-                  <TokenSelector
-                    addNativeTokenIfMissing={true}
+                  <Label>Chain</Label>
+                  <SingleNetworkSelector
                     chainId={selectedChain}
-                    client={THIRDWEB_CLIENT}
-                    enabled={true}
-                    onChange={handleTokenChange}
-                    placeholder="Select a token"
-                    selectedToken={selectedToken}
+                    disableTestnets={true}
+                    onChange={handleChainChange}
+                    placeholder="Select a chain"
                   />
                 </div>
-              )}
-            </div>
-          )}
+
+                {/* Token selection - only show if chain is selected */}
+                {selectedChain && (
+                  <div className="flex flex-col gap-2">
+                    <Label>Token</Label>
+                    <TokenSelector
+                      addNativeTokenIfMissing={true}
+                      chainId={selectedChain}
+                      client={THIRDWEB_CLIENT}
+                      enabled={true}
+                      onChange={handleTokenChange}
+                      placeholder="Select a token"
+                      selectedToken={selectedToken}
+                    />
+                  </div>
+                )}
+              </div>
+            )}
 
           {/* Mode-specific form fields */}
           <div className="my-2">
@@ -207,14 +207,14 @@ export function LeftSection(props: {
                               ...v.payOptions,
                               paymentMethods: checked
                                 ? [
-                                    ...v.payOptions.paymentMethods.filter(
-                                      (m) => m !== "crypto",
-                                    ),
-                                    "crypto",
-                                  ]
-                                : v.payOptions.paymentMethods.filter(
+                                  ...v.payOptions.paymentMethods.filter(
                                     (m) => m !== "crypto",
                                   ),
+                                  "crypto",
+                                ]
+                                : v.payOptions.paymentMethods.filter(
+                                  (m) => m !== "crypto",
+                                ),
                             },
                           }));
                         }}
@@ -232,14 +232,14 @@ export function LeftSection(props: {
                               ...v.payOptions,
                               paymentMethods: checked
                                 ? [
-                                    ...v.payOptions.paymentMethods.filter(
-                                      (m) => m !== "card",
-                                    ),
-                                    "card",
-                                  ]
-                                : v.payOptions.paymentMethods.filter(
+                                  ...v.payOptions.paymentMethods.filter(
                                     (m) => m !== "card",
                                   ),
+                                  "card",
+                                ]
+                                : v.payOptions.paymentMethods.filter(
+                                  (m) => m !== "card",
+                                ),
                             },
                           }));
                         }}
@@ -307,14 +307,14 @@ export function LeftSection(props: {
                               ...v.payOptions,
                               paymentMethods: checked
                                 ? [
-                                    ...v.payOptions.paymentMethods.filter(
-                                      (m) => m !== "crypto",
-                                    ),
-                                    "crypto",
-                                  ]
-                                : v.payOptions.paymentMethods.filter(
+                                  ...v.payOptions.paymentMethods.filter(
                                     (m) => m !== "crypto",
                                   ),
+                                  "crypto",
+                                ]
+                                : v.payOptions.paymentMethods.filter(
+                                  (m) => m !== "crypto",
+                                ),
                             },
                           }));
                         }}
@@ -334,14 +334,14 @@ export function LeftSection(props: {
                               ...v.payOptions,
                               paymentMethods: checked
                                 ? [
-                                    ...v.payOptions.paymentMethods.filter(
-                                      (m) => m !== "card",
-                                    ),
-                                    "card",
-                                  ]
-                                : v.payOptions.paymentMethods.filter(
+                                  ...v.payOptions.paymentMethods.filter(
                                     (m) => m !== "card",
                                   ),
+                                  "card",
+                                ]
+                                : v.payOptions.paymentMethods.filter(
+                                  (m) => m !== "card",
+                                ),
                             },
                           }));
                         }}
@@ -464,6 +464,24 @@ export function LeftSection(props: {
           }}
           theme={options.theme}
         />
+
+        <div className="my-4 flex items-center gap-2">
+          <Checkbox
+            checked={payOptions.showThirdwebBranding}
+            id={"branding"}
+            onCheckedChange={(checked) => {
+              setOptions((v) => ({
+                ...v,
+                payOptions: {
+                  ...v.payOptions,
+                  showThirdwebBranding: checked === true,
+                },
+              }));
+            }}
+          />
+          <Label htmlFor={"branding"}>Show Branding</Label>
+        </div>
+
       </CollapsibleSection>
 
       <CollapsibleSection icon={FuelIcon} title="Sponsor gas fees">

--- a/apps/playground-web/src/app/connect/pay/embed/LeftSection.tsx
+++ b/apps/playground-web/src/app/connect/pay/embed/LeftSection.tsx
@@ -138,35 +138,35 @@ export function LeftSection(props: {
           {(!payOptions.widget ||
             payOptions.widget === "buy" ||
             payOptions.widget === "checkout") && (
-              <div className="space-y-4">
-                {/* Chain selection */}
+            <div className="space-y-4">
+              {/* Chain selection */}
+              <div className="flex flex-col gap-2">
+                <Label>Chain</Label>
+                <SingleNetworkSelector
+                  chainId={selectedChain}
+                  disableTestnets={true}
+                  onChange={handleChainChange}
+                  placeholder="Select a chain"
+                />
+              </div>
+
+              {/* Token selection - only show if chain is selected */}
+              {selectedChain && (
                 <div className="flex flex-col gap-2">
-                  <Label>Chain</Label>
-                  <SingleNetworkSelector
+                  <Label>Token</Label>
+                  <TokenSelector
+                    addNativeTokenIfMissing={true}
                     chainId={selectedChain}
-                    disableTestnets={true}
-                    onChange={handleChainChange}
-                    placeholder="Select a chain"
+                    client={THIRDWEB_CLIENT}
+                    enabled={true}
+                    onChange={handleTokenChange}
+                    placeholder="Select a token"
+                    selectedToken={selectedToken}
                   />
                 </div>
-
-                {/* Token selection - only show if chain is selected */}
-                {selectedChain && (
-                  <div className="flex flex-col gap-2">
-                    <Label>Token</Label>
-                    <TokenSelector
-                      addNativeTokenIfMissing={true}
-                      chainId={selectedChain}
-                      client={THIRDWEB_CLIENT}
-                      enabled={true}
-                      onChange={handleTokenChange}
-                      placeholder="Select a token"
-                      selectedToken={selectedToken}
-                    />
-                  </div>
-                )}
-              </div>
-            )}
+              )}
+            </div>
+          )}
 
           {/* Mode-specific form fields */}
           <div className="my-2">
@@ -207,14 +207,14 @@ export function LeftSection(props: {
                               ...v.payOptions,
                               paymentMethods: checked
                                 ? [
-                                  ...v.payOptions.paymentMethods.filter(
+                                    ...v.payOptions.paymentMethods.filter(
+                                      (m) => m !== "crypto",
+                                    ),
+                                    "crypto",
+                                  ]
+                                : v.payOptions.paymentMethods.filter(
                                     (m) => m !== "crypto",
                                   ),
-                                  "crypto",
-                                ]
-                                : v.payOptions.paymentMethods.filter(
-                                  (m) => m !== "crypto",
-                                ),
                             },
                           }));
                         }}
@@ -232,14 +232,14 @@ export function LeftSection(props: {
                               ...v.payOptions,
                               paymentMethods: checked
                                 ? [
-                                  ...v.payOptions.paymentMethods.filter(
+                                    ...v.payOptions.paymentMethods.filter(
+                                      (m) => m !== "card",
+                                    ),
+                                    "card",
+                                  ]
+                                : v.payOptions.paymentMethods.filter(
                                     (m) => m !== "card",
                                   ),
-                                  "card",
-                                ]
-                                : v.payOptions.paymentMethods.filter(
-                                  (m) => m !== "card",
-                                ),
                             },
                           }));
                         }}
@@ -307,14 +307,14 @@ export function LeftSection(props: {
                               ...v.payOptions,
                               paymentMethods: checked
                                 ? [
-                                  ...v.payOptions.paymentMethods.filter(
+                                    ...v.payOptions.paymentMethods.filter(
+                                      (m) => m !== "crypto",
+                                    ),
+                                    "crypto",
+                                  ]
+                                : v.payOptions.paymentMethods.filter(
                                     (m) => m !== "crypto",
                                   ),
-                                  "crypto",
-                                ]
-                                : v.payOptions.paymentMethods.filter(
-                                  (m) => m !== "crypto",
-                                ),
                             },
                           }));
                         }}
@@ -334,14 +334,14 @@ export function LeftSection(props: {
                               ...v.payOptions,
                               paymentMethods: checked
                                 ? [
-                                  ...v.payOptions.paymentMethods.filter(
+                                    ...v.payOptions.paymentMethods.filter(
+                                      (m) => m !== "card",
+                                    ),
+                                    "card",
+                                  ]
+                                : v.payOptions.paymentMethods.filter(
                                     (m) => m !== "card",
                                   ),
-                                  "card",
-                                ]
-                                : v.payOptions.paymentMethods.filter(
-                                  (m) => m !== "card",
-                                ),
                             },
                           }));
                         }}
@@ -481,7 +481,6 @@ export function LeftSection(props: {
           />
           <Label htmlFor={"branding"}>Show Branding</Label>
         </div>
-
       </CollapsibleSection>
 
       <CollapsibleSection icon={FuelIcon} title="Sponsor gas fees">

--- a/apps/playground-web/src/app/connect/pay/embed/RightSection.tsx
+++ b/apps/playground-web/src/app/connect/pay/embed/RightSection.tsx
@@ -45,11 +45,11 @@ export function RightSection(props: {
   const themeObj =
     props.options.theme.type === "dark"
       ? darkTheme({
-        colors: props.options.theme.darkColorOverrides,
-      })
+          colors: props.options.theme.darkColorOverrides,
+        })
       : lightTheme({
-        colors: props.options.theme.lightColorOverrides,
-      });
+          colors: props.options.theme.lightColorOverrides,
+        });
 
   let embed: React.ReactNode;
   if (props.options.payOptions.widget === "buy") {

--- a/apps/playground-web/src/app/connect/pay/embed/RightSection.tsx
+++ b/apps/playground-web/src/app/connect/pay/embed/RightSection.tsx
@@ -45,11 +45,11 @@ export function RightSection(props: {
   const themeObj =
     props.options.theme.type === "dark"
       ? darkTheme({
-          colors: props.options.theme.darkColorOverrides,
-        })
+        colors: props.options.theme.darkColorOverrides,
+      })
       : lightTheme({
-          colors: props.options.theme.lightColorOverrides,
-        });
+        colors: props.options.theme.lightColorOverrides,
+      });
 
   let embed: React.ReactNode;
   if (props.options.payOptions.widget === "buy") {
@@ -64,6 +64,7 @@ export function RightSection(props: {
         theme={themeObj}
         title={props.options.payOptions.title}
         tokenAddress={props.options.payOptions.buyTokenAddress}
+        showThirdwebBranding={props.options.payOptions.showThirdwebBranding}
       />
     );
   }
@@ -87,6 +88,7 @@ export function RightSection(props: {
         seller={props.options.payOptions.sellerAddress}
         theme={themeObj}
         tokenAddress={props.options.payOptions.buyTokenAddress}
+        showThirdwebBranding={props.options.payOptions.showThirdwebBranding}
       />
     );
   }
@@ -106,6 +108,7 @@ export function RightSection(props: {
           to: account?.address || "",
           tokenId: 2n,
         })}
+        showThirdwebBranding={props.options.payOptions.showThirdwebBranding}
       />
     );
   }

--- a/apps/playground-web/src/app/connect/pay/embed/page.tsx
+++ b/apps/playground-web/src/app/connect/pay/embed/page.tsx
@@ -18,6 +18,7 @@ const defaultConnectOptions: BridgeComponentsPlaygroundOptions = {
     title: "",
     transactionData: "",
     widget: "buy",
+    showThirdwebBranding: true,
   },
   theme: {
     darkColorOverrides: {},

--- a/packages/thirdweb/src/react/web/ui/Bridge/BridgeOrchestrator.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/BridgeOrchestrator.tsx
@@ -120,6 +120,12 @@ export interface BridgeOrchestratorProps {
    * @default ["crypto", "card"]
    */
   paymentMethods?: ("crypto" | "card")[];
+
+  /**
+   * Whether to show thirdweb branding in the widget.
+   * @default true
+   */
+  showThirdwebBranding?: boolean;
 }
 
 export function BridgeOrchestrator({
@@ -135,6 +141,7 @@ export function BridgeOrchestrator({
   paymentLinkId,
   presetOptions,
   paymentMethods = ["crypto", "card"],
+  showThirdwebBranding = true,
 }: BridgeOrchestratorProps) {
   // Initialize adapters
   const adapters = useMemo(
@@ -144,6 +151,18 @@ export function BridgeOrchestrator({
     }),
     [],
   );
+
+  // Create modified connect options with branding setting
+  const modifiedConnectOptions = useMemo(() => {
+    if (!connectOptions) return undefined;
+    return {
+      ...connectOptions,
+      connectModal: {
+        ...connectOptions.connectModal,
+        showThirdwebBranding,
+      },
+    };
+  }, [connectOptions, showThirdwebBranding]);
 
   // Use the payment machine hook
   const [state, send] = usePaymentMachine(adapters, uiOptions.mode);
@@ -239,10 +258,11 @@ export function BridgeOrchestrator({
       {state.value === "init" && uiOptions.mode === "fund_wallet" && (
         <FundWallet
           client={client}
-          connectOptions={connectOptions}
+          connectOptions={modifiedConnectOptions}
           onContinue={handleRequirementsResolved}
           presetOptions={presetOptions}
           receiverAddress={receiverAddress}
+          showThirdwebBranding={showThirdwebBranding}
           uiOptions={uiOptions}
         />
       )}
@@ -250,8 +270,9 @@ export function BridgeOrchestrator({
       {state.value === "init" && uiOptions.mode === "direct_payment" && (
         <DirectPayment
           client={client}
-          connectOptions={connectOptions}
+          connectOptions={modifiedConnectOptions}
           onContinue={handleRequirementsResolved}
+          showThirdwebBranding={showThirdwebBranding}
           uiOptions={uiOptions}
         />
       )}
@@ -259,8 +280,9 @@ export function BridgeOrchestrator({
       {state.value === "init" && uiOptions.mode === "transaction" && (
         <TransactionPayment
           client={client}
-          connectOptions={connectOptions}
+          connectOptions={modifiedConnectOptions}
           onContinue={handleRequirementsResolved}
+          showThirdwebBranding={showThirdwebBranding}
           uiOptions={uiOptions}
         />
       )}
@@ -272,7 +294,7 @@ export function BridgeOrchestrator({
           <PaymentSelection
             client={client}
             connectLocale={connectLocale || en}
-            connectOptions={connectOptions}
+            connectOptions={modifiedConnectOptions}
             destinationAmount={state.context.destinationAmount}
             destinationToken={state.context.destinationToken}
             feePayer={

--- a/packages/thirdweb/src/react/web/ui/Bridge/BuyWidget.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/BuyWidget.tsx
@@ -103,6 +103,12 @@ export type BuyWidgetProps = {
   className?: string;
 
   /**
+   * Whether to show thirdweb branding in the widget.
+   * @default true
+   */
+  showThirdwebBranding?: boolean;
+
+  /**
    * The chain the accepted token is on.
    */
   chain: Chain;
@@ -391,6 +397,7 @@ export function BuyWidget(props: BuyWidgetProps) {
         purchaseData={props.purchaseData}
         receiverAddress={undefined}
         uiOptions={bridgeDataQuery.data.data}
+        showThirdwebBranding={props.showThirdwebBranding}
       />
     );
   }

--- a/packages/thirdweb/src/react/web/ui/Bridge/CheckoutWidget.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/CheckoutWidget.tsx
@@ -99,6 +99,12 @@ export type CheckoutWidgetProps = {
   className?: string;
 
   /**
+   * Whether to show thirdweb branding in the widget.
+   * @default true
+   */
+  showThirdwebBranding?: boolean;
+
+  /**
    * The chain the accepted token is on.
    */
   chain: Chain;
@@ -353,6 +359,7 @@ export function CheckoutWidget(props: CheckoutWidgetProps) {
         presetOptions={props.presetOptions}
         purchaseData={props.purchaseData}
         receiverAddress={props.seller}
+        showThirdwebBranding={props.showThirdwebBranding}
         uiOptions={bridgeDataQuery.data.data}
       />
     );

--- a/packages/thirdweb/src/react/web/ui/Bridge/DirectPayment.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/DirectPayment.tsx
@@ -39,6 +39,12 @@ export interface DirectPaymentProps {
    * Connect options for wallet connection
    */
   connectOptions?: PayEmbedConnectOptions;
+
+  /**
+   * Whether to show thirdweb branding in the widget.
+   * @default true
+   */
+  showThirdwebBranding?: boolean;
 }
 
 export function DirectPayment({
@@ -46,6 +52,7 @@ export function DirectPayment({
   client,
   onContinue,
   connectOptions,
+  showThirdwebBranding = true,
 }: DirectPaymentProps) {
   const activeAccount = useActiveAccount();
   const chain = defineChain(uiOptions.paymentInfo.token.chainId);
@@ -226,7 +233,7 @@ export function DirectPayment({
 
         <Spacer y="md" />
 
-        <PoweredByThirdweb />
+        {showThirdwebBranding && <PoweredByThirdweb />}
         <Spacer y="lg" />
       </Container>
     </WithHeader>

--- a/packages/thirdweb/src/react/web/ui/Bridge/DirectPayment.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/DirectPayment.tsx
@@ -231,9 +231,12 @@ export function DirectPayment({
           />
         )}
 
-        <Spacer y="md" />
-
-        {showThirdwebBranding && <PoweredByThirdweb />}
+        {showThirdwebBranding ? (
+          <div>
+            <Spacer y="md" />
+            <PoweredByThirdweb />
+          </div>
+        ) : null}
         <Spacer y="lg" />
       </Container>
     </WithHeader>

--- a/packages/thirdweb/src/react/web/ui/Bridge/FundWallet.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/FundWallet.tsx
@@ -342,9 +342,12 @@ export function FundWallet({
         />
       )}
 
-      <Spacer y="md" />
-
-      {showThirdwebBranding && <PoweredByThirdweb />}
+      {showThirdwebBranding ? (
+        <div>
+          <Spacer y="md" />
+          <PoweredByThirdweb />
+        </div>
+      ) : null}
       <Spacer y="lg" />
     </WithHeader>
   );

--- a/packages/thirdweb/src/react/web/ui/Bridge/FundWallet.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/FundWallet.tsx
@@ -56,6 +56,12 @@ export interface FundWalletProps {
    * Connect options for wallet connection
    */
   connectOptions?: PayEmbedConnectOptions;
+
+  /**
+   * Whether to show thirdweb branding in the widget.
+   * @default true
+   */
+  showThirdwebBranding?: boolean;
 }
 
 export function FundWallet({
@@ -65,6 +71,7 @@ export function FundWallet({
   onContinue,
   presetOptions = [5, 10, 20],
   connectOptions,
+  showThirdwebBranding = true,
 }: FundWalletProps) {
   const [amount, setAmount] = useState(uiOptions.initialAmount ?? "");
   const theme = useCustomTheme();
@@ -337,7 +344,7 @@ export function FundWallet({
 
       <Spacer y="md" />
 
-      <PoweredByThirdweb />
+      {showThirdwebBranding && <PoweredByThirdweb />}
       <Spacer y="lg" />
     </WithHeader>
   );

--- a/packages/thirdweb/src/react/web/ui/Bridge/TransactionPayment.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/TransactionPayment.tsx
@@ -128,10 +128,13 @@ export function TransactionPayment({
           }}
         />
 
-        <Spacer y="md" />
-
-        {showThirdwebBranding && <PoweredByThirdweb />}
-        <Spacer y="md" />
+        {showThirdwebBranding ? (
+          <div>
+            <Spacer y="md" />
+            <PoweredByThirdweb />
+            <Spacer y="md" />
+          </div>
+        ) : null}
       </WithHeader>
     );
   }
@@ -349,9 +352,12 @@ export function TransactionPayment({
         />
       )}
 
-      <Spacer y="md" />
-
-      {showThirdwebBranding && <PoweredByThirdweb />}
+      {showThirdwebBranding ? (
+        <div>
+          <Spacer y="md" />
+          <PoweredByThirdweb />
+        </div>
+      ) : null}
       <Spacer y="lg" />
     </WithHeader>
   );

--- a/packages/thirdweb/src/react/web/ui/Bridge/TransactionPayment.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/TransactionPayment.tsx
@@ -48,6 +48,12 @@ export interface TransactionPaymentProps {
    * Connect options for wallet connection
    */
   connectOptions?: PayEmbedConnectOptions;
+
+  /**
+   * Whether to show thirdweb branding in the widget.
+   * @default true
+   */
+  showThirdwebBranding?: boolean;
 }
 
 export function TransactionPayment({
@@ -55,6 +61,7 @@ export function TransactionPayment({
   client,
   onContinue,
   connectOptions,
+  showThirdwebBranding = true,
 }: TransactionPaymentProps) {
   const theme = useCustomTheme();
   const activeAccount = useActiveAccount();
@@ -123,7 +130,7 @@ export function TransactionPayment({
 
         <Spacer y="md" />
 
-        <PoweredByThirdweb />
+        {showThirdwebBranding && <PoweredByThirdweb />}
         <Spacer y="md" />
       </WithHeader>
     );
@@ -344,7 +351,7 @@ export function TransactionPayment({
 
       <Spacer y="md" />
 
-      <PoweredByThirdweb />
+      {showThirdwebBranding && <PoweredByThirdweb />}
       <Spacer y="lg" />
     </WithHeader>
   );

--- a/packages/thirdweb/src/react/web/ui/Bridge/TransactionWidget.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/TransactionWidget.tsx
@@ -107,6 +107,12 @@ export type TransactionWidgetProps = {
   className?: string;
 
   /**
+   * Whether to show thirdweb branding in the widget.
+   * @default true
+   */
+  showThirdwebBranding?: boolean;
+
+  /**
    * The token address needed to complete this transaction. Leave undefined if no token is required.
    */
   tokenAddress?: Address;
@@ -413,6 +419,7 @@ export function TransactionWidget(props: TransactionWidgetProps) {
         purchaseData={props.purchaseData}
         receiverAddress={undefined}
         uiOptions={bridgeDataQuery.data.data}
+        showThirdwebBranding={props.showThirdwebBranding}
       />
     );
   }


### PR DESCRIPTION
```
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

[SDK] Feature: Add `showThirdwebBranding` prop to Checkout, Buy, and Transaction Widgets

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

This PR introduces a `showThirdwebBranding` prop to the `CheckoutWidget`, `BuyWidget`, and `TransactionWidget`. This prop, similar to the one on `ConnectButton`, allows developers to hide thirdweb branding within these widgets.

The prop controls:
1. The "Powered by thirdweb" component at the bottom of the widget.
2. The thirdweb branding inside the ConnectButton modal (if used within the widget).

The default value for `showThirdwebBranding` is `true` to maintain backward compatibility.

## How to test

1. Render any of the `CheckoutWidget`, `BuyWidget`, or `TransactionWidget`.
2. Set `showThirdwebBranding={false}` and verify that:
    - The "Powered by thirdweb" text at the bottom is hidden.
    - The thirdweb branding within the ConnectButton modal (when opened) is hidden.
3. Verify that omitting the prop or setting `showThirdwebBranding={true}` shows all branding as before.

-->
```

---

[Slack Thread](https://thirdwebdev.slack.com/archives/C085FEPFLN9/p1752091842435679?thread_ts=1752091842.435679&cid=C085FEPFLN9)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new feature to control the visibility of the `thirdweb` branding in payment widgets through the `showThirdwebBranding` boolean property.

### Detailed summary
- Added `showThirdwebBranding` property to `types.ts`.
- Set `showThirdwebBranding` to `true` in `page.tsx`.
- Updated `BuyWidget`, `CheckoutWidget`, `TransactionWidget` to accept `showThirdwebBranding`.
- Incorporated branding toggle in `LeftSection.tsx` with a checkbox.
- Modified `FundWallet`, `DirectPayment`, and `TransactionPayment` to conditionally render branding.
- Adjusted `BridgeOrchestrator` to use `modifiedConnectOptions` for branding settings.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to show or hide thirdweb branding in payment widgets, including Buy, Checkout, Transaction, FundWallet, DirectPayment, and BridgeOrchestrator components.
  * Introduced a "Show Branding" toggle in the playground UI for easier appearance customization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->