### PR TITLE
chore: redirect /universal-bridge -> /payments

### DIFF
--- a/apps/dashboard/framer-rewrites.js
+++ b/apps/dashboard/framer-rewrites.js
@@ -9,7 +9,7 @@ module.exports = [
   // -- build category
   "/wallets",
   "/account-abstraction",
-  "/universal-bridge",
+  "/payments",
   "/auth",
   "/in-app-wallets",
   "/transactions",

--- a/apps/dashboard/redirects.js
+++ b/apps/dashboard/redirects.js
@@ -416,7 +416,7 @@ async function redirects() {
       source: "/connect/account-abstraction",
     },
     {
-      destination: "/universal-bridge",
+      destination: "/payments",
       permanent: false,
       source: "/connect/universal-bridge",
     },
@@ -439,6 +439,11 @@ async function redirects() {
       destination: "/rpc",
       permanent: false,
       source: "/rpc-edge",
+    },
+    {
+      destination: "/payments",
+      permanent: false,
+      source: "/universal-bridge",
     },
     ...legacyDashboardToTeamRedirects,
     ...projectPageRedirects,


### PR DESCRIPTION
## [Dashboard] Fix: Redirect Universal Bridge to Payments

## Notes for the reviewer

This PR removes the `/universal-bridge` path from the framer-rewrites list and adds a redirect from `/universal-bridge` to `/payments`.

## How to test

Verify that navigating to `/universal-bridge` redirects to `/payments` correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added redirects from /universal-bridge and /connect/universal-bridge to /payments.

* **Chores**
  * Updated navigation paths by replacing /universal-bridge with /payments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the routing configuration in the `apps/dashboard/framer-rewrites.js` and `apps/dashboard/redirects.js` files, specifically replacing the `/universal-bridge` route with `/payments`.

### Detailed summary
- In `apps/dashboard/framer-rewrites.js`, replaced `"/universal-bridge"` with `"/payments"`.
- In `apps/dashboard/redirects.js`, updated the `destination` from `"/universal-bridge"` to `"/payments"` in an existing redirect.
- Added a new redirect entry for `"/universal-bridge"` to `"/payments"`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->