### PR TITLE
[SDK] Fix: Adds BuyWidget fallback when native isn't supported

### DIFF
--- a/apps/playground-web/src/hooks/useTokensData.ts
+++ b/apps/playground-web/src/hooks/useTokensData.ts
@@ -4,8 +4,10 @@ import { useQuery } from "@tanstack/react-query";
 import type { TokenMetadata } from "@/lib/types";
 
 async function fetchTokensFromApi(chainId?: number) {
-  const domain = process.env.NEXT_PUBLIC_BRIDGE_URL;
-  const url = new URL(`https://${domain}/v1/tokens`);
+  const domain = process.env.NEXT_PUBLIC_BRIDGE_URL || "bridge.thirdweb.com";
+  const url = new URL(
+    `${domain.includes("localhost") ? "http" : "https"}://${domain}/v1/tokens`,
+  );
 
   if (chainId) {
     url.searchParams.append("chainId", String(chainId));

--- a/packages/thirdweb/src/react/web/ui/Bridge/BuyWidget.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/BuyWidget.tsx
@@ -312,7 +312,18 @@ export function BuyWidget(props: BuyWidgetProps) {
           props.client,
           NATIVE_TOKEN_ADDRESS,
           props.chain.id,
-        );
+        ).catch((err) => {
+          err.message.includes("not supported")
+            ? undefined
+            : Promise.reject(err);
+        });
+        if (!ETH) {
+          return {
+            chain: props.chain,
+            tokenAddress: props.tokenAddress || NATIVE_TOKEN_ADDRESS,
+            type: "unsupported_token",
+          };
+        }
         return {
           data: {
             destinationToken: ETH,


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving error handling and default values in the `BuyWidget` component and enhancing the `fetchTokensFromApi` function by allowing a fallback for the bridge URL.

### Detailed summary
- In `BuyWidget.tsx`:
  - Added error handling for unsupported tokens.
  - Returned a default object for unsupported tokens.

- In `useTokensData.ts`:
  - Set a fallback for `domain` in `fetchTokensFromApi`.
  - Adjusted URL creation to handle localhost correctly.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in the BuyWidget to better manage unsupported native tokens, ensuring the UI displays appropriate feedback.
  * Enhanced URL construction logic for token data fetching, providing better support for different environments, including local development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->