### PR TITLE
Update converter SDK reference

### DIFF
--- a/apps/dashboard/src/app/(app)/(dashboard)/tools/hex-converter/components/HexConverter.tsx
+++ b/apps/dashboard/src/app/(app)/(dashboard)/tools/hex-converter/components/HexConverter.tsx
@@ -63,14 +63,14 @@ export const HexConverter = () => {
 
       <Card className="flex flex-col gap-2 p-4">
         <p>
-          Or use the
+          Convert values using the{" "}
           <a
             className="underline"
             href="https://portal.thirdweb.com/typescript/v5"
             rel="noopener noreferrer"
             target="_blank"
           >
-            Connect SDK
+            thirdweb SDK
           </a>
           :
         </p>

--- a/apps/dashboard/src/app/(app)/(dashboard)/tools/keccak256-converter/components/Keccak256Converter.tsx
+++ b/apps/dashboard/src/app/(app)/(dashboard)/tools/keccak256-converter/components/Keccak256Converter.tsx
@@ -49,14 +49,14 @@ export const Keccak256Converter = () => {
 
       <Card className="flex flex-col gap-2 p-4">
         <p>
-          Or use the{" "}
+          Convert values using the{" "}
           <a
             className="underline"
             href="https://portal.thirdweb.com/typescript/v5"
             rel="noopener noreferrer"
             target="_blank"
           >
-            Connect SDK
+            thirdweb SDK
           </a>
           :
         </p>

--- a/apps/dashboard/src/app/(app)/(dashboard)/tools/wei-converter/components/WeiConverter.tsx
+++ b/apps/dashboard/src/app/(app)/(dashboard)/tools/wei-converter/components/WeiConverter.tsx
@@ -79,14 +79,14 @@ export const WeiConverter = () => {
 
       <Card className="flex flex-col gap-2 p-4">
         <p>
-          Or use the{" "}
+          Convert values using the{" "}
           <a
             className="underline"
             href="https://portal.thirdweb.com/typescript/v5"
             rel="noopener noreferrer"
             target="_blank"
           >
-            Connect SDK
+            thirdweb SDK
           </a>
           :
         </p>


### PR DESCRIPTION
```
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

[Dashboard] Fix: Update SDK branding text in converters

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

This PR updates the text "Or use the Connect SDK" to "Convert values using the thirdweb SDK" on the Wei, Hex, and Keccak-256 converter pages. This is a branding consistency update. The associated link remains unchanged.

## How to test

1. Navigate to the Wei Converter (`/tools/wei-converter`), Hex Converter (`/tools/hex-converter`), and Keccak-256 Converter (`/tools/keccak256-converter`) pages on the dashboard.
2. Verify that the text "Or use the Connect SDK" has been updated to "Convert values using the thirdweb SDK" on all three pages.
3. Confirm that the link associated with "thirdweb SDK" still points to `https://portal.thirdweb.com/typescript/v5`.

-->
```

---

[Slack Thread](https://thirdwebdev.slack.com/archives/C04DYC3G5NZ/p1752467935229539?thread_ts=1752467935.229539&cid=C04DYC3G5NZ)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the text in multiple components of the dashboard to provide a more consistent reference to the `thirdweb SDK` instead of the previous term `Connect SDK`.

### Detailed summary
- In `HexConverter.tsx`, changed text from "Or use the Connect SDK" to "Convert values using the thirdweb SDK".
- In `WeiConverter.tsx`, changed text from "Or use the Connect SDK" to "Convert values using the thirdweb SDK".
- In `Keccak256Converter.tsx`, changed text from "Or use the Connect SDK" to "Convert values using the thirdweb SDK".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated phrasing in tool descriptions for a clearer user experience, including changing references from "Connect SDK" to "thirdweb SDK".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->