### PR TITLE
Update error response URL for project settings

### DIFF
--- a/.changeset/ninety-heads-work.md
+++ b/.changeset/ninety-heads-work.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+update error response url

--- a/packages/service-utils/src/core/authorize/client.test.ts
+++ b/packages/service-utils/src/core/authorize/client.test.ts
@@ -80,7 +80,7 @@ describe("authorizeClient", () => {
     ) as any;
     expect(result.authorized).toBe(false);
     expect(result.errorMessage).toBe(
-      "Invalid request: Unauthorized Bundle ID: com.foo.bar. You can view the restrictions on this API key at https://thirdweb.com/create-api-key",
+      "Invalid request: Unauthorized Bundle ID: com.foo.bar. You can view the restrictions for this project at https://thirdweb.com/test-team/test-project/settings",
     );
     expect(result.errorCode).toBe("BUNDLE_UNAUTHORIZED");
     expect(result.status).toBe(401);
@@ -101,7 +101,7 @@ describe("authorizeClient", () => {
     ) as any;
     expect(result.authorized).toBe(false);
     expect(result.errorMessage).toBe(
-      "Invalid request: Unauthorized domain: unauthorized.com. You can view the restrictions on this API key at https://thirdweb.com/create-api-key",
+      "Invalid request: Unauthorized domain: unauthorized.com. You can view the restrictions for this project at https://thirdweb.com/test-team/test-project/settings",
     );
     expect(result.errorCode).toBe("ORIGIN_UNAUTHORIZED");
     expect(result.status).toBe(401);

--- a/packages/service-utils/src/core/authorize/client.ts
+++ b/packages/service-utils/src/core/authorize/client.ts
@@ -62,7 +62,7 @@ export function authorizeClient(
     return {
       authorized: false,
       errorCode: "ORIGIN_UNAUTHORIZED",
-      errorMessage: `Invalid request: Unauthorized domain: ${origin}. You can view the restrictions on this API key at https://thirdweb.com/create-api-key`,
+      errorMessage: `Invalid request: Unauthorized domain: ${origin}. You can view the restrictions for this project at https://thirdweb.com/${team.slug}/${project.slug}/settings`,
       status: 401,
     };
   }
@@ -81,7 +81,7 @@ export function authorizeClient(
     return {
       authorized: false,
       errorCode: "BUNDLE_UNAUTHORIZED",
-      errorMessage: `Invalid request: Unauthorized Bundle ID: ${bundleId}. You can view the restrictions on this API key at https://thirdweb.com/create-api-key`,
+      errorMessage: `Invalid request: Unauthorized Bundle ID: ${bundleId}. You can view the restrictions for this project at https://thirdweb.com/${team.slug}/${project.slug}/settings`,
       status: 401,
     };
   }

--- a/packages/service-utils/src/core/authorize/service.ts
+++ b/packages/service-utils/src/core/authorize/service.ts
@@ -43,7 +43,7 @@ export function authorizeService(
     return {
       authorized: false,
       errorCode: "SERVICE_UNAUTHORIZED",
-      errorMessage: `Invalid request: Unauthorized service: ${serviceConfig.serviceScope} for project: ${project.name} (${project.publishableKey}). You can view the restrictions on this project in your dashboard: https://thirdweb.com`,
+      errorMessage: `Invalid request: Unauthorized service: ${serviceConfig.serviceScope} for project: ${project.name} (${project.publishableKey}). You can view the restrictions for this project at https://thirdweb.com/${team.slug}/${project.slug}/settings`,
       status: 403,
     };
   }
@@ -57,7 +57,7 @@ export function authorizeService(
       return {
         authorized: false,
         errorCode: "SERVICE_ACTION_UNAUTHORIZED",
-        errorMessage: `Invalid request: Unauthorized action: ${serviceConfig.serviceScope} ${serviceConfig.serviceAction} for project: ${project.name} (${project.publishableKey}). You can view the restrictions on this API key in your dashboard:  https://thirdweb.com/create-api-key`,
+        errorMessage: `Invalid request: Unauthorized action: ${serviceConfig.serviceScope} ${serviceConfig.serviceAction} for project: ${project.name} (${project.publishableKey}). You can view the restrictions for this project at https://thirdweb.com/${team.slug}/${project.slug}/settings`,
         status: 403,
       };
     }


### PR DESCRIPTION
# Update error response URL in service-utils

This PR updates the error response URLs in the service-utils package to point to the project-specific settings page instead of the generic API key creation page. The new URLs follow the format `https://thirdweb.com/${team.slug}/${project.slug}/settings`, providing users with a direct link to manage restrictions for their specific project.

The changes affect error messages for:
- Unauthorized domains
- Unauthorized bundle IDs
- Unauthorized services
- Unauthorized service actions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated error messages for unauthorized access to provide project-specific URLs, directing users to the relevant project settings page for more accurate guidance.

* **Chores**
  * Added documentation to track the patch update related to error response URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the error messages in the `service-utils` package to provide more specific URLs for project settings instead of the general API key creation page, enhancing clarity for users regarding restrictions.

### Detailed summary
- Updated `errorMessage` in `authorizeClient` for unauthorized domain to link to project settings.
- Updated `errorMessage` in `authorizeClient` for unauthorized Bundle ID to link to project settings.
- Updated `errorMessage` in `authorizeService` for unauthorized service to link to project settings.
- Updated `errorMessage` in `authorizeService` for unauthorized action to link to project settings.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->