### PR TITLE
Update nebula rateLimit type to include perSecond and perMinute

### DIFF
--- a/.changeset/loud-clocks-begin.md
+++ b/.changeset/loud-clocks-begin.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+update nebula ratelimit type

--- a/apps/dashboard/src/@/storybook/stubs.ts
+++ b/apps/dashboard/src/@/storybook/stubs.ts
@@ -57,7 +57,10 @@ export function teamStub(id: string, billingPlan: Team["billingPlan"]): Team {
       },
       nebula: {
         enabled: true,
-        rateLimit: 1000,
+        rateLimit: {
+          perSecond: 1000,
+          perMinute: 1000,
+        },
       },
       pay: {
         enabled: true,

--- a/packages/service-utils/src/core/api.ts
+++ b/packages/service-utils/src/core/api.ts
@@ -84,7 +84,10 @@ type TeamCapabilities = {
   };
   nebula: {
     enabled: boolean;
-    rateLimit: number;
+    rateLimit: {
+      perSecond: number;
+      perMinute: number;
+    };
   };
   bundler: {
     enabled: boolean;

--- a/packages/service-utils/src/mocks.ts
+++ b/packages/service-utils/src/mocks.ts
@@ -75,7 +75,10 @@ export const validTeamResponse: TeamResponse = {
     },
     nebula: {
       enabled: true,
-      rateLimit: 1000,
+      rateLimit: {
+        perSecond: 1000,
+        perMinute: 1000,
+      },
     },
     pay: {
       enabled: true,


### PR DESCRIPTION
# Update Nebula Rate Limit Type

This PR updates the Nebula rate limit type to provide more granular control by replacing the single `rateLimit` number with an object containing `perSecond` and `perMinute` properties. The change affects:

- The `TeamCapabilities` type in the service-utils package
- Corresponding mock data and stubs in the dashboard app
- Added a changeset to document this patch update

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `rateLimit` type for the `nebula` object in the `service-utils` package. It changes the `rateLimit` from a single number to an object that specifies limits per second and per minute.

### Detailed summary
- Updated `rateLimit` in `packages/service-utils/src/mocks.ts` from a number to an object with `perSecond` and `perMinute`.
- Updated `rateLimit` in `apps/dashboard/src/@/storybook/stubs.ts` similarly.
- Updated type definition in `packages/service-utils/src/core/api.ts` for `rateLimit` to reflect the new object structure.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->