### PR TITLE
[TOOL-5047] Dashboard: Fix client object missing teamId on contract publish page

### DIFF
--- a/apps/dashboard/src/app/(app)/(dashboard)/contracts/publish/[publish_uri]/page.tsx
+++ b/apps/dashboard/src/app/(app)/(dashboard)/contracts/publish/[publish_uri]/page.tsx
@@ -2,9 +2,9 @@ import { ChakraProviderSetup } from "chakra/ChakraProviderSetup";
 import { revalidatePath } from "next/cache";
 import { notFound, redirect } from "next/navigation";
 import { fetchDeployMetadata } from "thirdweb/contract";
+import { getUserThirdwebClient } from "@/api/auth-token";
 import { ContractPublishForm } from "@/components/contract-components/contract-publish-form";
 import { getActiveAccountCookie, getJWTCookie } from "@/constants/cookie";
-import { getClientThirdwebClient } from "@/constants/thirdweb-client.client";
 import { serverThirdwebClient } from "@/constants/thirdweb-client.server";
 import { getLatestPublishedContractsWithPublisherMapping } from "../../../published-contract/[publisher]/[contract_id]/utils/getPublishedContractsWithPublisherMapping";
 
@@ -68,14 +68,15 @@ export default async function PublishContractPage(
     redirect(`/login?next=${encodeURIComponent(pathname)}`);
   }
 
+  const userThirdwebClient = await getUserThirdwebClient({
+    teamId: undefined,
+  });
+
   return (
     <div className="container flex max-w-[1130px] flex-col gap-8 py-8">
       <ChakraProviderSetup>
         <ContractPublishForm
-          client={getClientThirdwebClient({
-            jwt: token,
-            teamId: undefined,
-          })}
+          client={userThirdwebClient}
           isLoggedIn={!!token}
           onPublishSuccess={async () => {
             "use server";


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `PublishContractPage` to use the `getUserThirdwebClient` instead of the `getClientThirdwebClient`. This change likely aims to enhance user-specific interactions within the contract publishing process.

### Detailed summary
- Added import for `getUserThirdwebClient` from `@/api/auth-token`.
- Removed import of `getClientThirdwebClient` from `@/constants/thirdweb-client.client`.
- Replaced the client in `ContractPublishForm` with `userThirdwebClient`, initialized with `teamId: undefined`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the client retrieval process for the contract publish form to enhance consistency. No changes to user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->