### PR TITLE
Add `mcp` to team capabilities

### DIFF
--- a/.changeset/free-boxes-lose.md
+++ b/.changeset/free-boxes-lose.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+add `mcp` to team capabilities

--- a/apps/dashboard/src/@/storybook/stubs.ts
+++ b/apps/dashboard/src/@/storybook/stubs.ts
@@ -85,6 +85,10 @@ export function teamStub(id: string, billingPlan: Team["billingPlan"]): Team {
           totalFileSizeBytesLimit: 1_000_000_000,
         },
       },
+      mcp: {
+        enabled: true,
+        rateLimit: 10,
+      },
     },
     createdAt: new Date().toISOString(),
     dedicatedSupportChannel: null,

--- a/packages/service-utils/src/core/api.ts
+++ b/packages/service-utils/src/core/api.ts
@@ -112,6 +112,10 @@ type TeamCapabilities = {
     enabled: boolean;
     rateLimit: number;
   };
+  mcp: {
+    enabled: boolean;
+    rateLimit: number;
+  };
 };
 
 type TeamPlan =

--- a/packages/service-utils/src/mocks.ts
+++ b/packages/service-utils/src/mocks.ts
@@ -103,6 +103,10 @@ export const validTeamResponse: TeamResponse = {
         totalFileSizeBytesLimit: 1_000_000_000,
       },
     },
+    mcp: {
+      enabled: true,
+      rateLimit: 10,
+    },
   },
   createdAt: new Date("2024-06-01").toISOString(),
   dedicatedSupportChannel: null,


### PR DESCRIPTION
### TL;DR

Added `mcp` capability to team capabilities in service-utils.

### What changed?

- Added a new `mcp` field to the `TeamCapabilities` type in `packages/service-utils/src/core/api.ts`
- Created a changeset file to document this patch update for the `@thirdweb-dev/service-utils` package

### How to test?

Verify that the `TeamCapabilities` type correctly includes the new `mcp` field with its `enabled` boolean and `rateLimit` number properties.

### Why make this change?

This change adds support for the Multi-Chain Protocol (MCP) capability in team settings, allowing teams to have this capability configured with appropriate rate limiting and enablement controls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the new "mcp" capability, including its enabled status and rate limit, to team capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the `mcp` capability to team configurations within the `@thirdweb-dev/service-utils` package, enhancing team features with new properties.

### Detailed summary
- Added `mcp` capability to team configurations in `packages/service-utils/src/core/api.ts` with properties `enabled` (boolean) and `rateLimit` (number).
- Updated `mcp` settings in `apps/dashboard/src/@/storybook/stubs.ts` to `enabled: true` and `rateLimit: 10`.
- Updated `mcp` settings in `packages/service-utils/src/mocks.ts` to `enabled: true` and `rateLimit: 10`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->