### PR TITLE
[SDK] Fix: update hooks to use core transaction types

### DIFF
--- a/.changeset/smooth-crabs-reply.md
+++ b/.changeset/smooth-crabs-reply.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+react: update hooks to use core transaction types

--- a/packages/thirdweb/src/react/core/hooks/transaction/useSendAndConfirmTransaction.ts
+++ b/packages/thirdweb/src/react/core/hooks/transaction/useSendAndConfirmTransaction.ts
@@ -1,7 +1,7 @@
 import { type UseMutationResult, useMutation } from "@tanstack/react-query";
 import type { GaslessOptions } from "../../../../transaction/actions/gasless/types.js";
 import { sendAndConfirmTransaction } from "../../../../transaction/actions/send-and-confirm-transaction.js";
-import type { PreparedTransaction } from "../../../../transaction/prepare-transaction.js";
+import type { SendTransactionOptions } from "../../../../transaction/actions/send-transaction.js";
 import type { TransactionReceipt } from "../../../../transaction/types.js";
 import { useActiveAccount } from "../wallets/useActiveAccount.js";
 
@@ -56,7 +56,7 @@ type SendAndConfirmTransactionConfig = {
  */
 export function useSendAndConfirmTransaction(
   config: SendAndConfirmTransactionConfig = {},
-): UseMutationResult<TransactionReceipt, Error, PreparedTransaction> {
+): UseMutationResult<TransactionReceipt, Error, SendTransactionOptions["transaction"]> {
   const account = useActiveAccount();
   const { gasless } = config;
   return useMutation({

--- a/packages/thirdweb/src/react/core/hooks/transaction/useSendAndConfirmTransaction.ts
+++ b/packages/thirdweb/src/react/core/hooks/transaction/useSendAndConfirmTransaction.ts
@@ -56,7 +56,11 @@ type SendAndConfirmTransactionConfig = {
  */
 export function useSendAndConfirmTransaction(
   config: SendAndConfirmTransactionConfig = {},
-): UseMutationResult<TransactionReceipt, Error, SendTransactionOptions["transaction"]> {
+): UseMutationResult<
+  TransactionReceipt,
+  Error,
+  SendTransactionOptions["transaction"]
+> {
   const account = useActiveAccount();
   const { gasless } = config;
   return useMutation({

--- a/packages/thirdweb/src/react/core/hooks/transaction/useSendBatchTransaction.ts
+++ b/packages/thirdweb/src/react/core/hooks/transaction/useSendBatchTransaction.ts
@@ -1,7 +1,7 @@
 import { type UseMutationResult, useMutation } from "@tanstack/react-query";
 import { sendBatchTransaction } from "../../../../transaction/actions/send-batch-transaction.js";
 import type { WaitForReceiptOptions } from "../../../../transaction/actions/wait-for-tx-receipt.js";
-import type { PreparedTransaction } from "../../../../transaction/prepare-transaction.js";
+import type { SendTransactionOptions } from "../../../../transaction/actions/send-transaction.js";
 import { useActiveAccount } from "../wallets/useActiveAccount.js";
 
 /**
@@ -20,7 +20,7 @@ import { useActiveAccount } from "../wallets/useActiveAccount.js";
 export function useSendBatchTransaction(): UseMutationResult<
   WaitForReceiptOptions,
   Error,
-  PreparedTransaction[]
+  SendTransactionOptions["transaction"][]
 > {
   const account = useActiveAccount();
   return useMutation({

--- a/packages/thirdweb/src/react/core/hooks/transaction/useSendBatchTransaction.ts
+++ b/packages/thirdweb/src/react/core/hooks/transaction/useSendBatchTransaction.ts
@@ -1,7 +1,7 @@
 import { type UseMutationResult, useMutation } from "@tanstack/react-query";
 import { sendBatchTransaction } from "../../../../transaction/actions/send-batch-transaction.js";
-import type { WaitForReceiptOptions } from "../../../../transaction/actions/wait-for-tx-receipt.js";
 import type { SendTransactionOptions } from "../../../../transaction/actions/send-transaction.js";
+import type { WaitForReceiptOptions } from "../../../../transaction/actions/wait-for-tx-receipt.js";
 import { useActiveAccount } from "../wallets/useActiveAccount.js";
 
 /**

--- a/packages/thirdweb/src/react/core/hooks/transaction/useSendTransaction.ts
+++ b/packages/thirdweb/src/react/core/hooks/transaction/useSendTransaction.ts
@@ -9,7 +9,10 @@ import type { BuyWithFiatStatus } from "../../../../pay/buyWithFiat/getStatus.js
 import type { PurchaseData } from "../../../../pay/types.js";
 import type { FiatProvider } from "../../../../pay/utils/commonTypes.js";
 import type { GaslessOptions } from "../../../../transaction/actions/gasless/types.js";
-import { sendTransaction, type SendTransactionOptions } from "../../../../transaction/actions/send-transaction.js";
+import {
+  type SendTransactionOptions,
+  sendTransaction,
+} from "../../../../transaction/actions/send-transaction.js";
 import type { WaitForReceiptOptions } from "../../../../transaction/actions/wait-for-tx-receipt.js";
 import type { PreparedTransaction } from "../../../../transaction/prepare-transaction.js";
 import { getTransactionGasCost } from "../../../../transaction/utils.js";
@@ -132,7 +135,11 @@ export function useSendTransactionCore(args: {
   gasless?: GaslessOptions;
   wallet: Wallet | undefined;
   switchChain: (chain: Chain) => Promise<void>;
-}): UseMutationResult<WaitForReceiptOptions, Error, SendTransactionOptions["transaction"]> {
+}): UseMutationResult<
+  WaitForReceiptOptions,
+  Error,
+  SendTransactionOptions["transaction"]
+> {
   const { showPayModal, gasless, wallet, switchChain } = args;
   let _account = wallet?.getAccount();
 

--- a/packages/thirdweb/src/react/core/hooks/transaction/useSendTransaction.ts
+++ b/packages/thirdweb/src/react/core/hooks/transaction/useSendTransaction.ts
@@ -9,7 +9,7 @@ import type { BuyWithFiatStatus } from "../../../../pay/buyWithFiat/getStatus.js
 import type { PurchaseData } from "../../../../pay/types.js";
 import type { FiatProvider } from "../../../../pay/utils/commonTypes.js";
 import type { GaslessOptions } from "../../../../transaction/actions/gasless/types.js";
-import { sendTransaction } from "../../../../transaction/actions/send-transaction.js";
+import { sendTransaction, type SendTransactionOptions } from "../../../../transaction/actions/send-transaction.js";
 import type { WaitForReceiptOptions } from "../../../../transaction/actions/wait-for-tx-receipt.js";
 import type { PreparedTransaction } from "../../../../transaction/prepare-transaction.js";
 import { getTransactionGasCost } from "../../../../transaction/utils.js";
@@ -132,7 +132,7 @@ export function useSendTransactionCore(args: {
   gasless?: GaslessOptions;
   wallet: Wallet | undefined;
   switchChain: (chain: Chain) => Promise<void>;
-}): UseMutationResult<WaitForReceiptOptions, Error, PreparedTransaction> {
+}): UseMutationResult<WaitForReceiptOptions, Error, SendTransactionOptions["transaction"]> {
   const { showPayModal, gasless, wallet, switchChain } = args;
   let _account = wallet?.getAccount();
 

--- a/packages/thirdweb/src/transaction/actions/send-batch-transaction.ts
+++ b/packages/thirdweb/src/transaction/actions/send-batch-transaction.ts
@@ -3,12 +3,12 @@ import type {
   Account,
   SendTransactionOption,
 } from "../../wallets/interfaces/wallet.js";
-import type { PreparedTransaction } from "../prepare-transaction.js";
 import { encode } from "./encode.js";
+import type { SendTransactionOptions } from "./send-transaction.js";
 import type { WaitForReceiptOptions } from "./wait-for-tx-receipt.js";
 
 export type SendBatchTransactionOptions = {
-  transactions: PreparedTransaction[];
+  transactions: SendTransactionOptions["transaction"][];
   account: Account;
 };
 


### PR DESCRIPTION
Fixes #7646

See above issue for error explanation - it boils down to type mismatches between `PreparedTransaction` and `PreparedTransaction<any>`

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the transaction handling in the `thirdweb` package by transitioning from using `PreparedTransaction` to `SendTransactionOptions["transaction"]` across various hooks and actions, enhancing type safety and consistency in transaction processing.

### Detailed summary
- Updated `SendBatchTransactionOptions` to use `SendTransactionOptions["transaction"]` instead of `PreparedTransaction[]`.
- Modified `useSendBatchTransaction` to accept `SendTransactionOptions["transaction"][]`.
- Changed `useSendAndConfirmTransaction` to use `SendTransactionOptions["transaction"]` instead of `PreparedTransaction`.
- Updated `useSendTransactionCore` to accept `SendTransactionOptions["transaction"]` instead of `PreparedTransaction`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated React hooks to use core transaction types for improved consistency across transaction-related functionality.

* **Documentation**
  * Added a changeset summarizing the update to transaction hooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->