### PR TITLE
[Portal] Fix: update sidebar overflow behavior in DocLayout component

### DIFF
--- a/apps/portal/src/app/Header.tsx
+++ b/apps/portal/src/app/Header.tsx
@@ -194,7 +194,7 @@ export function Header() {
   const pathname = usePathname();
 
   return (
-    <header className="flex w-full flex-col gap-2 border-b bg-background pt-4 px-4 pb-4 xl:pb-0 lg:px-8 overflow-hidden">
+    <header className="flex w-full flex-col gap-2 border-b bg-background p-4 xl:pb-0 lg:px-8 overflow-hidden">
       {/* Top row */}
       <div className="container flex items-center justify-between gap-6">
         <div className="flex items-center gap-2">

--- a/apps/portal/src/components/Layouts/DocLayout.tsx
+++ b/apps/portal/src/components/Layouts/DocLayout.tsx
@@ -37,7 +37,7 @@ export function DocLayout(props: DocLayoutProps) {
     >
       <aside
         className={cn(
-          "sticky top-sticky-top-height h-sidebar-height flex-col overflow-y-hidden",
+          "sticky top-sticky-top-height h-sidebar-height flex-col overflow-y-auto no-scrollbar",
           "hidden xl:flex",
         )}
       >

--- a/apps/portal/src/components/others/DocSearch.tsx
+++ b/apps/portal/src/components/others/DocSearch.tsx
@@ -358,7 +358,7 @@ export function DocSearch(props: { variant: "icon" | "search" }) {
               variant="outline"
             >
               <span className="text-xs">Search Docs</span>
-              <div className="flex items-center gap-1 rounded-sm px-1 py-1 text-muted-foreground text-xs">
+              <div className="flex items-center gap-1 rounded-sm p-1 text-muted-foreground text-xs">
                 <CommandIcon className="size-3" />K
               </div>
             </Button>


### PR DESCRIPTION
## [Portal] Fix: update sidebar overflow behavior in DocLayout component

Fix sidebar cant be scroll in portal document

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the layout and styling of components within the application, particularly enhancing the sidebar behavior and adjusting padding within the header and search elements.

### Detailed summary
- In `DocLayout.tsx`, changed `overflow-y-hidden` to `overflow-y-auto no-scrollbar` for better sidebar scrolling.
- In `DocSearch.tsx`, adjusted padding from `py-1` to `p-1` in the search button container.
- In `Header.tsx`, updated padding from `pt-4 px-4 pb-4` to `p-4` for a more uniform header appearance.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Enabled vertical scrolling in the sidebar on extra-large screens, allowing users to scroll through sidebar content when it overflows while keeping the scrollbar visually hidden.
  * Simplified header padding for a cleaner layout.
  * Adjusted spacing inside the search button for improved visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->