### PR TITLE
[SDK] Fix TransactionWidget when wallet has enough currency

### DIFF
--- a/.changeset/lucky-ravens-hope.md
+++ b/.changeset/lucky-ravens-hope.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix TransactionWidget when wallet has enough currency for the transaction

--- a/apps/playground-web/src/components/pay/transaction-button.tsx
+++ b/apps/playground-web/src/components/pay/transaction-button.tsx
@@ -41,7 +41,6 @@ export function PayTransactionPreview() {
 
   return (
     <TransactionWidget
-      amount={"0.001"}
       client={THIRDWEB_CLIENT}
       description={nft?.metadata?.description}
       image={nft?.metadata?.image}

--- a/packages/thirdweb/src/react/web/ui/Bridge/TransactionPayment.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/TransactionPayment.tsx
@@ -361,12 +361,26 @@ export function TransactionPayment({
           fullWidth
           onClick={() => {
             if (transactionDataQuery.data?.tokenInfo) {
+              if (
+                userBalance &&
+                Number(userBalance) <
+                  Number(transactionDataQuery.data.totalCost)
+              ) {
+                // if user has funds, but not enough, we need to fund the wallet with the difference
+                onContinue(
+                  (
+                    Number(transactionDataQuery.data.totalCost) -
+                    Number(userBalance)
+                  ).toString(),
+                  transactionDataQuery.data.tokenInfo,
+                  getAddress(activeAccount.address),
+                );
+                return;
+              }
+
+              // otherwise, use the full transaction cost
               onContinue(
-                Math.max(
-                  0,
-                  Number(transactionDataQuery.data.totalCost) -
-                    Number(userBalance ?? "0"),
-                ).toString(),
+                transactionDataQuery.data.totalCost,
                 transactionDataQuery.data.tokenInfo,
                 getAddress(activeAccount.address),
               );


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the `TransactionWidget` to handle scenarios where a user's wallet has insufficient funds for a transaction, ensuring they are prompted to fund their wallet with the necessary amount.

### Detailed summary
- Updated the `TransactionWidget` in `transaction-button.tsx` to reflect the correct amount.
- Enhanced the logic in `TransactionPayment.tsx` to check if the `userBalance` is less than the `totalCost`.
- Added a condition to fund the wallet with the difference if the balance is insufficient.
- Adjusted the `onContinue` function to handle both cases: insufficient funds and sufficient funds.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue in the transaction widget where wallet balances were not correctly checked, ensuring transactions only proceed when sufficient funds are available.
  * Improved handling of transaction amounts, so the widget now accurately requests additional funds only when the wallet balance is insufficient.

* **Chores**
  * Removed a hardcoded transaction amount from the payment preview interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->