### PR TITLE
Adjust icon sizes in Header, DocSearch, and ThemeSwitcher components for consistency

### DIFF
--- a/apps/playground-web/src/app/connect/pay/transactions/page.tsx
+++ b/apps/playground-web/src/app/connect/pay/transactions/page.tsx
@@ -40,7 +40,7 @@ function BuyOnchainAsset() {
   return (
     <CodeExample
       code={`import { claimTo } from "thirdweb/extensions/erc1155";
-          import { PayEmbed, useActiveAccount } from "thirdweb/react";
+          import { TransactionWidget, useActiveAccount } from "thirdweb/react";
 
         function App() {
           const account = useActiveAccount();

--- a/apps/portal/src/app/Header.tsx
+++ b/apps/portal/src/app/Header.tsx
@@ -195,7 +195,7 @@ export function Header() {
   const pathname = usePathname();
 
   return (
-    <header className="flex w-full flex-col gap-2 border-b bg-background pt-4 px-4 lg:px-8 overflow-hidden">
+    <header className="flex w-full flex-col gap-2 border-b bg-background p-4 px-4 lg:px-8 overflow-hidden">
       <div className="container flex items-center justify-between gap-6">
         {/* Top row */}
         <div className="flex items-center gap-2">
@@ -250,14 +250,14 @@ export function Header() {
               onClick={() => router.push("/chat")}
               variant="ghost"
             >
-              <MessageCircleIcon className="size-7" />
+              <MessageCircleIcon className="size-5 lg:size-6" />
             </Button>
             <Button
               className="p-2"
               onClick={() => setShowBurgerMenu(!showBurgerMenu)}
               variant="ghost"
             >
-              <MenuIcon className="size-7" />
+              <MenuIcon className="size-5 lg:size-6" />
             </Button>
           </div>
         </div>

--- a/apps/portal/src/components/others/DocSearch.tsx
+++ b/apps/portal/src/components/others/DocSearch.tsx
@@ -198,7 +198,7 @@ function SearchModalContent(props: { closeModal: () => void }) {
           {/* links */}
           {data && data.length > 0 && (
             <div
-              className="styled-scrollbar flex max-h-[50vh] min-h-[200px] flex-col gap-2 overflow-y-auto p-4"
+              className="styled-scrollbar flex max-h-[50vh] min-h-[200px] flex-col gap-2 overflow-y-scroll no-scrollbar p-4"
               ref={scrollableElement}
             >
               {data.map((result) => {
@@ -368,7 +368,7 @@ export function DocSearch(props: { variant: "icon" | "search" }) {
         {!forDesktop && (
           <DialogTrigger asChild>
             <Button className="px-3" variant="ghost">
-              <SearchIcon className="size-6 text-foreground" />
+              <SearchIcon className="size-5 text-foreground" />
             </Button>
           </DialogTrigger>
         )}

--- a/apps/portal/src/components/others/theme/ThemeSwitcher.tsx
+++ b/apps/portal/src/components/others/theme/ThemeSwitcher.tsx
@@ -22,11 +22,11 @@ export function ThemeSwitcher(props: { className?: string }) {
       variant="outline"
     >
       {!hasMounted ? (
-        <Skeleton className="size-6 lg:size-5" />
+        <Skeleton className="size-5 lg:size-6" />
       ) : theme === "light" ? (
-        <SunIcon className="size-6 lg:size-5" />
+        <SunIcon className="size-5 lg:size-6" />
       ) : (
-        <MoonIcon className="size-6 lg:size-5" />
+        <MoonIcon className="size-5 lg:size-6" />
       )}
     </Button>
   );


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adjusting the size of various components in the `ThemeSwitcher`, `DocSearch`, and `Header` files to ensure consistent styling and improved layout.

### Detailed summary
- In `ThemeSwitcher.tsx`, swapped sizes for `Skeleton`, `SunIcon`, and `MoonIcon`.
- In `DocSearch.tsx`, changed the scrollbar class from `overflow-y-auto` to `overflow-y-scroll` and added `no-scrollbar`.
- In `Header.tsx`, updated padding in the `header` class and adjusted sizes for `MessageCircleIcon` and `MenuIcon`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted icon and element sizes in the header, theme switcher, and search components for improved visual consistency and responsiveness.
  * Updated header and search modal padding and scrollbar appearance for a more polished layout.

* **Documentation**
  * Updated code examples to use the latest transaction UI component, reflecting current best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->