### PR TITLE
[SDK] Feature: Adds optional `transactionId` parameter to `Bridge.status`

### DIFF
--- a/.changeset/four-trams-fetch.md
+++ b/.changeset/four-trams-fetch.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Bridge.status: Adds optional transactionId parameter

--- a/packages/thirdweb/src/bridge/Status.ts
+++ b/packages/thirdweb/src/bridge/Status.ts
@@ -96,6 +96,7 @@ import type { Status } from "./types/Status.js";
  * @param options - The options for the quote.
  * @param options.transactionHash - The hash of the origin transaction to get the bridge status for.
  * @param options.chainId - The chain ID of the origin token.
+ * @param options.transactionId - The transaction ID received from the `prepare` request.
  * @param options.client - Your thirdweb client.
  *
  * @returns A promise that resolves to a status object for the transaction.
@@ -105,13 +106,16 @@ import type { Status } from "./types/Status.js";
  * @beta
  */
 export async function status(options: status.Options): Promise<status.Result> {
-  const { transactionHash, client } = options;
+  const { transactionHash, client, transactionId } = options;
   const chainId = "chainId" in options ? options.chainId : options.chain.id;
 
   const clientFetch = getClientFetch(client);
   const url = new URL(`${getThirdwebBaseUrl("bridge")}/v1/status`);
   url.searchParams.set("transactionHash", transactionHash);
   url.searchParams.set("chainId", chainId.toString());
+  if (transactionId) {
+    url.searchParams.set("transactionId", transactionId);
+  }
 
   const response = await clientFetch(url.toString());
   if (!response.ok) {
@@ -195,6 +199,8 @@ export declare namespace status {
         transactionHash: ox__Hex.Hex;
         /** The chain ID where the transaction occurred */
         chainId: number;
+        /** The transaction ID received from the `prepare` request */
+        transactionId?: string;
         /** Your thirdweb client */
         client: ThirdwebClient;
       }
@@ -203,6 +209,8 @@ export declare namespace status {
         transactionHash: ox__Hex.Hex;
         /** The chain object where the transaction occurred */
         chain: Chain;
+        /** The transaction ID received from the `prepare` request */
+        transactionId?: string;
         /** Your thirdweb client */
         client: ThirdwebClient;
       };


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces an optional `transactionId` parameter to the `status` function in the `Bridge` module of the `thirdweb` package, enhancing the ability to retrieve bridge status by allowing users to specify the transaction ID received from the `prepare` request.

### Detailed summary
- Added `transactionId` parameter to the `status` function in `packages/thirdweb/src/bridge/Status.ts`.
- Updated JSDoc comments to include `transactionId` in the parameter descriptions.
- Modified the `status` function to append `transactionId` to the request URL if provided.
- Updated the `status.Options` and `status.Result` types to include `transactionId` as an optional field.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an optional transaction ID when checking bridge status, allowing users to provide an additional identifier for their transaction status queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->