### PR TITLE
[Dashboard] Replace modular contracts with Arbitrum Stylus contracts in explore page

### DIFF
--- a/apps/dashboard/src/app/(app)/(dashboard)/explore/data.ts
+++ b/apps/dashboard/src/app/(app)/(dashboard)/explore/data.ts
@@ -90,144 +90,6 @@ const MARKETS = {
   name: "Marketplace",
 } satisfies ExploreCategory;
 
-const MODULAR_CONTRACTS = {
-  contracts: [
-    // erc721 drop
-    [
-      "thirdweb.eth/ERC721CoreInitializable",
-      [
-        "deployer.thirdweb.eth/ClaimableERC721",
-        "deployer.thirdweb.eth/BatchMetadataERC721",
-        "deployer.thirdweb.eth/RoyaltyERC721",
-      ],
-      {
-        description: "ERC721 NFTs that anyone can mint.",
-        title: "Modular NFT Drop",
-      },
-    ],
-    // erc721 token
-    [
-      "thirdweb.eth/ERC721CoreInitializable",
-      [
-        "deployer.thirdweb.eth/MintableERC721",
-        "deployer.thirdweb.eth/BatchMetadataERC721",
-        "deployer.thirdweb.eth/TransferableERC721",
-      ],
-      {
-        description: "ERC721 NFTs that only owners can mint.",
-        title: "Modular NFT Collection",
-      },
-    ],
-    // open edition 721
-    [
-      "thirdweb.eth/ERC721CoreInitializable",
-      [
-        "deployer.thirdweb.eth/ClaimableERC721",
-        "deployer.thirdweb.eth/OpenEditionMetadataERC721",
-        "deployer.thirdweb.eth/RoyaltyERC721",
-      ],
-      {
-        description: "ERC721 NFTs with identical metadata.",
-        title: "Modular Open Edition",
-      },
-    ],
-    // erc1155 drop
-    [
-      "thirdweb.eth/ERC1155CoreInitializable",
-      [
-        "deployer.thirdweb.eth/ClaimableERC1155",
-        "deployer.thirdweb.eth/BatchMetadataERC1155",
-        "deployer.thirdweb.eth/RoyaltyERC1155",
-        "deployer.thirdweb.eth/SequentialTokenIdERC1155",
-      ],
-      {
-        description: "ERC1155 NFTs that others can mint.",
-        title: "Modular Edition Drop",
-      },
-    ],
-    // erc1155 token
-    [
-      "thirdweb.eth/ERC1155CoreInitializable",
-      [
-        "deployer.thirdweb.eth/MintableERC1155",
-        "deployer.thirdweb.eth/BatchMetadataERC1155",
-        "deployer.thirdweb.eth/TransferableERC1155",
-        "deployer.thirdweb.eth/SequentialTokenIdERC1155",
-      ],
-      {
-        description: "ERC1155 NFTs that only owners can mint.",
-        title: "Modular Edition",
-      },
-    ],
-    // erc20 drop
-    [
-      "thirdweb.eth/ERC20CoreInitializable",
-      [
-        "deployer.thirdweb.eth/ClaimableERC20",
-        "deployer.thirdweb.eth/TransferableERC20",
-      ],
-      {
-        description: "ERC20 Tokens that others can mint.",
-        title: "Modular Token Drop",
-      },
-    ],
-    // erc20 token
-    [
-      "thirdweb.eth/ERC20CoreInitializable",
-      [
-        "deployer.thirdweb.eth/MintableERC20",
-        "deployer.thirdweb.eth/TransferableERC20",
-      ],
-      {
-        description: "ERC20 Tokens that only owners can mint.",
-        title: "Modular Token",
-      },
-    ],
-  ],
-  description:
-    "Collection of highly customizable and upgradeable smart contracts built with the modular contracts framework.",
-  displayName: "Modular Contracts",
-  id: "modular-contracts",
-  name: "modular",
-} satisfies ExploreCategory;
-
-const SUPERCHAIN = {
-  contracts: [
-    // erc20 token + superchain
-    [
-      "thirdweb.eth/ERC20CoreInitializable",
-      [
-        "deployer.thirdweb.eth/MintableERC20",
-        "deployer.thirdweb.eth/TransferableERC20",
-        "deployer.thirdweb.eth/SuperChainInterop",
-      ],
-      {
-        description: "ERC20 Tokens that only owners can mint.",
-        title: "Modular Superchain Token",
-      },
-    ],
-    // erc20 drop + superchain
-    [
-      "thirdweb.eth/ERC20CoreInitializable",
-      [
-        "deployer.thirdweb.eth/ClaimableERC20",
-        "deployer.thirdweb.eth/TransferableERC20",
-        "deployer.thirdweb.eth/SuperChainInterop",
-      ],
-      {
-        description: "ERC20 Tokens that others can mint.",
-        title: "Modular Superchain Token Drop",
-      },
-    ],
-  ],
-  description: "Modular contracts with OP Superchain support",
-  displayName: "Modular Superchain Contracts",
-  id: "modular-superchain-contracts",
-  isBeta: true,
-  name: "Modular Superchain Contracts",
-  showInExplore: true,
-} satisfies ExploreCategory;
-
 const AIRDROP = {
   contracts: ["thirdweb.eth/Airdrop"],
   description:
@@ -313,12 +175,26 @@ const SMART_WALLET = {
   showInExplore: true,
 } satisfies ExploreCategory;
 
+const STYLUS = {
+  contracts: [
+    "0x6453a486d52e0EB6E79Ec4491038E2522a926936/StylusAirdropERC1155",
+    "0x6453a486d52e0EB6E79Ec4491038E2522a926936/StylusAirdropERC721",
+    "0x6453a486d52e0EB6E79Ec4491038E2522a926936/StylusAirdropERC20",
+  ],
+  description:
+    "Airdrop your NFTs or tokens to a large number of recipients. Built with Arbitrum Stylus.",
+  displayName: "Arbitrum Stylus Contracts",
+  id: "stylus",
+  name: "Stylus",
+  showInExplore: true,
+  isBeta: true,
+} satisfies ExploreCategory;
+
 const CATEGORIES: Record<string, ExploreCategory> = {
   [POPULAR.id]: POPULAR,
-  [MODULAR_CONTRACTS.id]: MODULAR_CONTRACTS,
-  [SUPERCHAIN.id]: SUPERCHAIN,
   [NFTS.id]: NFTS,
   [MARKETS.id]: MARKETS,
+  [STYLUS.id]: STYLUS,
   [DROPS.id]: DROPS,
   [SMART_WALLET.id]: SMART_WALLET,
   [AIRDROP.id]: AIRDROP,

--- a/apps/portal/redirects.mjs
+++ b/apps/portal/redirects.mjs
@@ -339,6 +339,11 @@ const solidityRedirects = {
   "/solidity/extensions/primarysale":
     "/contracts/build/extensions/general/PrimarySale",
   "/solidity/extensions/royalty": "/contracts/build/extensions/general/Royalty",
+
+  // contracts -> tokens
+  "/contracts/deploy/:path*": "/contracts/deploy",
+  "/contracts/build": "/tokens/build",
+  "/contracts/build/:path*": "/tokens/build/:path*",
 };
 
 const extensionsTable = "/typescript/v4/extensions#all-available-extensions";


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the contract management system by removing outdated modular contracts and introducing a new `STYLUS` contract category for airdropping NFTs and tokens.

### Detailed summary
- Removed `MODULAR_CONTRACTS` and `SUPERCHAIN` categories.
- Introduced new `STYLUS` category with contracts for airdropping NFTs and tokens.
- Updated `CATEGORIES` to include `STYLUS` and exclude the removed categories.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new "Stylus" category in the Explore section, featuring contracts related to Arbitrum Stylus airdrops.
  * Added new redirect rules to improve navigation between contract and token deployment/build paths.

* **Removals**
  * Removed the "Modular Contracts" and "Superchain" categories from the Explore section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->