### PR TITLE
Add custom amount input to credit balance section

### DIFF
--- a/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/billing/components/credit-balance-section.client.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/billing/components/credit-balance-section.client.tsx
@@ -11,6 +11,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Separator } from "@/components/ui/separator";
@@ -39,6 +40,12 @@ export function CreditBalanceSection({
   const [selectedAmount, setSelectedAmount] = useState<string>(
     predefinedAmounts[0].value,
   );
+  const [customAmount, setCustomAmount] = useState<string>("");
+
+  const isSelectedAmountValid =
+    selectedAmount !== "" &&
+    Number.isInteger(Number(selectedAmount)) &&
+    Number(selectedAmount) > 0;
 
   return (
     <Card className="w-full">
@@ -74,7 +81,10 @@ export function CreditBalanceSection({
             <Label className="font-medium text-base">Select Amount</Label>
             <RadioGroup
               className="grid grid-cols-4 gap-3"
-              onValueChange={setSelectedAmount}
+              onValueChange={(value) => {
+                setSelectedAmount(value);
+                setCustomAmount("");
+              }}
               value={selectedAmount}
             >
               {predefinedAmounts.map((amount) => (
@@ -95,6 +105,30 @@ export function CreditBalanceSection({
                 </div>
               ))}
             </RadioGroup>
+
+            {/* Custom Amount Input */}
+            <div className="space-y-2">
+              <Label className="font-medium text-base" htmlFor="customAmount">
+                Or enter custom amount
+              </Label>
+              <Input
+                id="customAmount"
+                type="number"
+                inputMode="numeric"
+                pattern="[0-9]*"
+                min={1}
+                step={1}
+                value={customAmount}
+                placeholder="Custom amount"
+                onChange={(e) => {
+                  const val = e.target.value.replace(/^0+/, "");
+                  if (/^\d*$/.test(val)) {
+                    setCustomAmount(val);
+                    setSelectedAmount(val);
+                  }
+                }}
+              />
+            </div>
           </div>
 
           {/* Top-up Summary and Button */}
@@ -125,7 +159,7 @@ export function CreditBalanceSection({
                 <Button
                   asChild
                   className="w-full"
-                  disabled={!isOwnerAccount}
+                  disabled={!isOwnerAccount || !isSelectedAmountValid}
                   size="lg"
                 >
                   <a


### PR DESCRIPTION
### TL;DR

Added a custom amount input option to the credit balance top-up section.

### What changed?

- Added a new input field that allows users to enter a custom credit amount
- Implemented validation to ensure the selected amount is a positive integer
- Added state management for the custom amount input
- Connected the custom input with the existing radio button selection
- Disabled the top-up button when the selected amount is invalid

### How to test?

1. Navigate to the team billing page
2. Verify the predefined credit amount options work as before
3. Try entering a custom amount in the new input field
4. Confirm that selecting a predefined amount clears the custom input
5. Verify the top-up button is disabled when an invalid amount is entered
6. Test that only positive integers are accepted in the custom field

### Why make this change?

This enhancement provides users with more flexibility when adding credits to their account. Instead of being limited to predefined amounts, users can now specify exactly how many credits they want to purchase, improving the user experience and accommodating various budget requirements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability for users to enter a custom credit top-up amount in addition to selecting from predefined options.
  * Input validation ensures only positive integer amounts can be entered for custom top-ups.
  * The top-up button is now only enabled when a valid amount is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->