### PR TITLE
[SDK] Fix ecosystem wallet connection with default chains

### DIFF
--- a/.changeset/slimy-pigs-rest.md
+++ b/.changeset/slimy-pigs-rest.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix ecosystem wallet connection with default chains

--- a/packages/thirdweb/src/wallets/in-app/core/wallet/in-app-core.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/wallet/in-app-core.ts
@@ -57,7 +57,7 @@ export function createInAppWallet(args: {
   let client: ThirdwebClient | undefined;
   let authToken: string | null = null;
 
-  const resolveSmartAccountOptionsFromEcosystem = async (options: {
+  const resolveSmartAccountOptionsFromEcosystem = async (options?: {
     chain?: Chain;
   }) => {
     if (ecosystem) {
@@ -78,7 +78,7 @@ export function createInAppWallet(args: {
           // default to 4337
           const { defaultChainId } = ecosystemOptions.smartAccountOptions;
           const preferredChain =
-            options.chain ??
+            options?.chain ??
             (defaultChainId ? getCachedChain(defaultChainId) : undefined);
           if (!preferredChain) {
             throw new Error(
@@ -108,7 +108,7 @@ export function createInAppWallet(args: {
         ecosystem,
       );
 
-      await resolveSmartAccountOptionsFromEcosystem(options);
+      await resolveSmartAccountOptionsFromEcosystem();
 
       const {
         account: connectedAccount,
@@ -145,7 +145,7 @@ export function createInAppWallet(args: {
         ecosystem,
       );
 
-      await resolveSmartAccountOptionsFromEcosystem(options);
+      await resolveSmartAccountOptionsFromEcosystem();
 
       const {
         account: connectedAccount,

--- a/packages/thirdweb/src/wallets/smart/index.ts
+++ b/packages/thirdweb/src/wallets/smart/index.ts
@@ -80,7 +80,7 @@ export async function connectSmartAccount(
   connectionOptions: SmartWalletConnectionOptions,
   creationOptions: SmartWalletOptions,
 ): Promise<[Account, Chain]> {
-  const { personalAccount, client, chain: connectChain } = connectionOptions;
+  const { personalAccount, client } = connectionOptions;
 
   if (!personalAccount) {
     throw new Error(
@@ -89,7 +89,7 @@ export async function connectSmartAccount(
   }
 
   const options = creationOptions;
-  const chain = connectChain ?? options.chain;
+  const chain = creationOptions.chain;
   const sponsorGas =
     "gasless" in options ? options.gasless : options.sponsorGas;
   if (await isZkSyncChain(chain)) {

--- a/packages/thirdweb/src/wallets/smart/smart-wallet.ts
+++ b/packages/thirdweb/src/wallets/smart/smart-wallet.ts
@@ -229,7 +229,7 @@ export function smartWallet(
       const { connectSmartAccount } = await import("./index.js");
       const [connectedAccount, connectedChain] = await connectSmartAccount(
         { ...lastConnectOptions, chain: newChain },
-        createOptions,
+        { ...createOptions, chain: newChain },
       );
       // set the states
       account = connectedAccount;


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the wallet connection process in the `thirdweb` package by refining how options are passed and ensuring compatibility with default chains.

### Detailed summary
- Updated the `connectSmartAccount` call to merge `createOptions` with `newChain`.
- Removed `connectChain` from `connectionOptions` destructuring in `connectSmartAccount`.
- Changed how `chain` is determined in `connectSmartAccount` to use `creationOptions.chain`.
- Made `options` parameter optional in `resolveSmartAccountOptionsFromEcosystem`.
- Updated calls to `resolveSmartAccountOptionsFromEcosystem` to omit `options` parameter in `createInAppWallet`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ecosystem wallet connection reliability with default chains by ensuring correct chain handling during connection and chain switching.

* **Chores**
  * Added a changeset documenting the patch update for the wallet connection fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->