### PR TITLE
Dashboard: Migrate engine/admins page from chakra to tailwind

### DIFF
--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/engine/dedicated/(instance)/[engineId]/admins/components/engine-admins.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/engine/dedicated/(instance)/[engineId]/admins/components/engine-admins.tsx
@@ -1,45 +1,40 @@
 "use client";
 
-import { Heading } from "chakra/heading";
-import { Link } from "chakra/link";
-import { Text } from "chakra/text";
 import type { ThirdwebClient } from "thirdweb";
+import { UnderlineLink } from "@/components/ui/UnderlineLink";
 import { useEnginePermissions } from "@/hooks/useEngine";
 import { AddAdminButton } from "./add-admin-button";
 import { AdminsTable } from "./admins-table";
 
-interface EngineAdminsProps {
-  instanceUrl: string;
-  authToken: string;
-  client: ThirdwebClient;
-}
-
-export const EngineAdmins: React.FC<EngineAdminsProps> = ({
+export function EngineAdmins({
   instanceUrl,
   authToken,
   client,
-}) => {
+}: {
+  instanceUrl: string;
+  authToken: string;
+  client: ThirdwebClient;
+}) {
   const admins = useEnginePermissions({
     authToken,
     instanceUrl,
   });
 
   return (
-    <div className="flex flex-col gap-4">
-      <div className="flex flex-col gap-2">
-        <Heading size="title.md">Admins</Heading>
-        <Text>
-          Admins are allowed to manage your Engine instance from the dashboard.{" "}
-          <Link
-            color="primary.500"
-            href="https://portal.thirdweb.com/engine/features/admins"
-            isExternal
-          >
-            Learn more about admins
-          </Link>
-          .
-        </Text>
-      </div>
+    <div>
+      <h2 className="text-2xl font-semibold tracking-tight mb-1">Admins</h2>
+      <p className="text-muted-foreground text-sm mb-5">
+        Admins are allowed to manage your Engine instance from the dashboard.{" "}
+        <UnderlineLink
+          href="https://portal.thirdweb.com/engine/features/admins"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Learn more about admins
+        </UnderlineLink>
+        .
+      </p>
+
       <AdminsTable
         admins={admins.data || []}
         authToken={authToken}
@@ -48,7 +43,10 @@ export const EngineAdmins: React.FC<EngineAdminsProps> = ({
         isFetched={admins.isFetched}
         isPending={admins.isPending}
       />
-      <AddAdminButton authToken={authToken} instanceUrl={instanceUrl} />
+
+      <div className="mt-4 flex justify-end">
+        <AddAdminButton authToken={authToken} instanceUrl={instanceUrl} />
+      </div>
     </div>
   );
-};
+}


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the `EngineAdmins`, `AddAdminButton`, and `AdminsTable` components to enhance the UI and improve code structure by replacing Chakra UI components with custom components and integrating form validation using Zod.

### Detailed summary
- Replaced `Heading`, `Link`, and `Text` with custom components in `EngineAdmins`.
- Modified `EngineAdmins` to use a simpler function syntax and improved layout.
- Updated `AddAdminButton` to use Zod for form validation and replaced Chakra UI modal with a custom dialog.
- Refactored `AdminsTable` to improve state management and UI consistency.
- Changed modal components to dialog components for editing and removing admins.
- Enhanced error handling with toast notifications for admin actions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->