### PR TITLE
Add `gateway` team capabilities

### DIFF
--- a/.changeset/cute-houses-own.md
+++ b/.changeset/cute-houses-own.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+add `gateway` team capabilities

--- a/apps/dashboard/src/@/storybook/stubs.ts
+++ b/apps/dashboard/src/@/storybook/stubs.ts
@@ -89,6 +89,10 @@ export function teamStub(id: string, billingPlan: Team["billingPlan"]): Team {
         enabled: true,
         rateLimit: 10,
       },
+      gateway: {
+        enabled: true,
+        rateLimit: 1000,
+      },
     },
     createdAt: new Date().toISOString(),
     dedicatedSupportChannel: null,

--- a/packages/service-utils/src/core/api.ts
+++ b/packages/service-utils/src/core/api.ts
@@ -116,6 +116,10 @@ type TeamCapabilities = {
     enabled: boolean;
     rateLimit: number;
   };
+  gateway: {
+    enabled: boolean;
+    rateLimit: number;
+  };
 };
 
 type TeamPlan =

--- a/packages/service-utils/src/mocks.ts
+++ b/packages/service-utils/src/mocks.ts
@@ -107,6 +107,10 @@ export const validTeamResponse: TeamResponse = {
       enabled: true,
       rateLimit: 10,
     },
+    gateway: {
+      enabled: true,
+      rateLimit: 1000,
+    },
   },
   createdAt: new Date("2024-06-01").toISOString(),
   dedicatedSupportChannel: null,


### PR DESCRIPTION
# Add `gateway` team capabilities

This PR adds the `gateway` capability to the team capabilities structure in the service-utils package. The gateway capability includes:
- `enabled` flag
- `rateLimit` property set to 1000 by default

The changes are implemented across:
- Service-utils core API types
- Mock data for testing
- Dashboard storybook stubs

A changeset has been added to track this patch update.