### PR TITLE
[Docs] Update MCP server URLs and reorder usage sections

### DIFF
--- a/apps/portal/src/app/ai/mcp/page.mdx
+++ b/apps/portal/src/app/ai/mcp/page.mdx
@@ -15,6 +15,27 @@ Host: api.thirdweb.com
 x-secret-key <your-project-secret-key>
 ```
 
+### Usage with LLM clients
+
+You can also use the MCP server on your own LLM client, like cursor, claude code and more. Refer to your LLM client's documentation for more information.
+
+#### Example usage with Cursor:
+
+Add the following to your `.cursor/mcp.json` file:
+
+```json
+{
+  "mcpServers": {
+    "thirdweb-api": {
+      "url": "https://api.thirdweb.com/mcp",
+      "headers": {
+        "x-secret-key": "<your-project-secret-key>"
+      }
+    }
+  }
+}
+```
+
 ### Usage with agents
 
 Use your favorite agent framework to plug in the MCP server as a collection of tools for your agent.  Refer to your agent framework's documentation for more information.
@@ -29,7 +50,7 @@ client = MultiServerMCPClient(
     {
         "thirdweb-api": {
             "transport": "streamable_http",
-            "url": "https://api.thirdweb-dev.com/mcp",
+            "url": "https://api.thirdweb.com/mcp",
             "headers": {
                 "x-secret-key": "<your-project-secret-key>"
             },
@@ -41,23 +62,3 @@ agent = create_react_agent("openai:gpt-4.1", tools)
 response = await agent.ainvoke({"messages": "create a server wallet called 'my-wallet'"})
 ```
 
-### Usage with LLM clients
-
-You can also use the MCP server on your own LLM client, like cursor, claude code and more. Refer to your LLM client's documentation for more information.
-
-#### Example usage with Cursor:
-
-Add the following to your `.cursor/mcp.json` file:
-
-```json
-{
-  "mcpServers": {
-    "thirdweb-api": {
-      "url": "https://api.thirdweb-dev.com/mcp",
-      "headers": {
-        "x-secret-key": "<your-project-secret-key>"
-      }
-    }
-  }
-}
-```


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the documentation for using the MCP server with LLM clients and modifies the URL for the `thirdweb-api` in the `MultiServerMCPClient` configuration.

### Detailed summary
- Added a section on usage with LLM clients, detailing integration with Cursor.
- Provided an example configuration for `.cursor/mcp.json`.
- Updated the URL for `thirdweb-api` from `https://api.thirdweb-dev.com/mcp` to `https://api.thirdweb.com/mcp`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->