### PR TITLE
[Docs] Remove POST method from MCP server URL

### DIFF
--- a/apps/portal/src/app/ai/mcp/page.mdx
+++ b/apps/portal/src/app/ai/mcp/page.mdx
@@ -9,7 +9,7 @@ You can use the thirdweb MCP server to interact with the thirdweb API from your 
 You can access the MCP server at the following url, with your project secret key.
 
 ```http
-POST https://api.thirdweb.com/mcp?secretKey=<your-project-secret-key>
+https://api.thirdweb.com/mcp?secretKey=<your-project-secret-key>
 ```
 
 Make sure to keep your secret key safe and never share it with anyone.


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates a URL in the `page.mdx` file by removing the `POST` method from the API call documentation.

### Detailed summary
- Changed the API call from `POST https://api.thirdweb.com/mcp?secretKey=<your-project-secret-key>` to `https://api.thirdweb.com/mcp?secretKey=<your-project-secret-key>` by removing the `POST` method.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->