### PR TITLE
[Dashboard] Add thirdweb API option alongside Engine API

### DIFF
--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/transactions/analytics/send-test-tx.client.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/transactions/analytics/send-test-tx.client.tsx
@@ -292,7 +292,7 @@ export function SendTestTransaction(props: {
 
   return (
     <div className="mt-3 w-full rounded-md border bg-background p-6">
-      <TryItOut />
+      <TryItOut useEngineAPI={false} />
       <div className="mt-6 flex flex-col gap-2 md:flex-row md:justify-end md:gap-2">
         <Dialog open={isModalOpen} onOpenChange={setIsModalOpen}>
           <DialogTrigger asChild>

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/transactions/explorer/components/scalar.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/transactions/explorer/components/scalar.tsx
@@ -1,22 +1,40 @@
 "use client";
 import { ApiReferenceReact } from "@scalar/api-reference-react";
 import "@scalar/api-reference-react/style.css";
-import { NEXT_PUBLIC_ENGINE_CLOUD_URL } from "@/constants/public-envs";
+import {
+  NEXT_PUBLIC_ENGINE_CLOUD_URL,
+  NEXT_PUBLIC_THIRDWEB_API_HOST,
+} from "@/constants/public-envs";
 
-export function Scalar() {
+interface ScalarProps {
+  useEngineAPI: boolean;
+}
+
+export function Scalar({ useEngineAPI }: ScalarProps) {
+  const apiUrl = useEngineAPI
+    ? NEXT_PUBLIC_ENGINE_CLOUD_URL
+    : NEXT_PUBLIC_THIRDWEB_API_HOST;
+  const openApiUrl = useEngineAPI
+    ? `${apiUrl}/openapi`
+    : `${apiUrl}/openapi.json`;
+  const apiName = useEngineAPI ? "Engine API (advanced)" : "thirdweb API";
+  const serverDescription = useEngineAPI ? "Engine Cloud" : "thirdweb API";
+
   return (
     <div className="flex flex-col gap-4">
-      <h2 className="font-bold text-2xl tracking-tight">Full API Reference</h2>
+      <h2 className="font-bold text-2xl tracking-tight">
+        Full API Reference - {apiName}
+      </h2>
       <ApiReferenceReact
         configuration={{
           hideModels: true,
           servers: [
             {
-              description: "Engine Cloud",
-              url: NEXT_PUBLIC_ENGINE_CLOUD_URL,
+              description: serverDescription,
+              url: apiUrl,
             },
           ],
-          url: `${NEXT_PUBLIC_ENGINE_CLOUD_URL}/openapi`,
+          url: openApiUrl,
         }}
       />
     </div>

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/transactions/explorer/page.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/transactions/explorer/page.tsx
@@ -1,11 +1,47 @@
+"use client";
+import { useState } from "react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { TryItOut } from "../server-wallets/components/try-it-out";
 import { Scalar } from "./components/scalar";
 
-export default async function TransactionsExplorerPage() {
+export default function TransactionsExplorerPage() {
+  const [apiMode, setApiMode] = useState<"thirdweb" | "engine">("thirdweb");
+  const useEngineAPI = apiMode === "engine";
+
   return (
     <div className="flex flex-col gap-4">
-      <TryItOut />
-      <Scalar />
+      <div className="flex items-center justify-between rounded-lg border bg-card p-4">
+        <div className="flex flex-col gap-1">
+          <h3 className="font-medium text-sm">Select API Mode</h3>
+          <p className="text-muted-foreground text-xs">
+            Choose between thirdweb API (recommended) or Engine API (advanced)
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          <Select
+            value={apiMode}
+            onValueChange={(value: "thirdweb" | "engine") => setApiMode(value)}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="thirdweb">
+                thirdweb API (recommended)
+              </SelectItem>
+              <SelectItem value="engine">Engine API (advanced)</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+      <TryItOut useEngineAPI={useEngineAPI} />
+      <Scalar useEngineAPI={useEngineAPI} />
     </div>
   );
 }

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/transactions/layout.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/transactions/layout.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { TabPathLinks } from "@/components/ui/tabs";
-import { NEXT_PUBLIC_ENGINE_CLOUD_URL } from "@/constants/public-envs";
+import { NEXT_PUBLIC_THIRDWEB_API_HOST } from "@/constants/public-envs";
 
 export default async function Page(props: {
   params: Promise<{ team_slug: string; project_slug: string }>;
@@ -45,11 +45,11 @@ function TransactionsLayout(props: {
               <div className="flex items-center gap-2">
                 <Link
                   className="max-w-full truncate text-muted-foreground text-sm hover:text-foreground" // TODO: change this
-                  href={`${NEXT_PUBLIC_ENGINE_CLOUD_URL}/reference`}
+                  href={`${NEXT_PUBLIC_THIRDWEB_API_HOST}/reference`}
                   rel="noopener noreferrer"
                   target="_blank"
                 >
-                  {NEXT_PUBLIC_ENGINE_CLOUD_URL}
+                  {NEXT_PUBLIC_THIRDWEB_API_HOST}
                 </Link>
               </div>
             </div>

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/transactions/server-wallets/components/try-it-out.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/transactions/server-wallets/components/try-it-out.tsx
@@ -3,10 +3,24 @@ import Link from "next/link";
 import { useState } from "react";
 import { CodeClient } from "@/components/ui/code/code.client";
 import { TabButtons } from "@/components/ui/tabs";
-import { NEXT_PUBLIC_ENGINE_CLOUD_URL } from "@/constants/public-envs";
+import {
+  NEXT_PUBLIC_ENGINE_CLOUD_URL,
+  NEXT_PUBLIC_THIRDWEB_API_HOST,
+} from "@/constants/public-envs";
 
-export function TryItOut() {
+interface TryItOutProps {
+  useEngineAPI: boolean;
+}
+
+export function TryItOut({ useEngineAPI }: TryItOutProps) {
   const [activeTab, setActiveTab] = useState<string>("curl");
+
+  const apiTitle = useEngineAPI
+    ? "Engine API (advanced)"
+    : "thirdweb API (recommended)";
+  const apiDescription = useEngineAPI
+    ? "Send transactions from your server wallets using the thirdweb SDK or the Engine HTTP API directly.."
+    : "Send transactions from your server wallets using the thirdweb SDK or the thirdweb HTTP API directly.";
 
   return (
     <>
@@ -14,12 +28,9 @@ export function TryItOut() {
         <div className="flex flex-1 flex-col gap-4 rounded-lg rounded-b-none lg:flex-row lg:justify-between pb-2">
           <div>
             <h2 className="font-semibold text-xl tracking-tight">
-              Usage from your backend
+              Usage from your backend - {apiTitle}
             </h2>
-            <p className="text-muted-foreground text-sm">
-              Send transactions from your server wallets using the thirdweb SDK
-              or the HTTP API directly.
-            </p>
+            <p className="text-muted-foreground text-sm">{apiDescription}</p>
           </div>
         </div>
       </div>
@@ -90,28 +101,30 @@ export function TryItOut() {
         {activeTab === "curl" && (
           <CodeClient
             className="bg-background"
-            code={curlExample()}
+            code={useEngineAPI ? engineCurlExample() : thirdwebCurlExample()}
             lang="bash"
           />
         )}
         {activeTab === "js" && (
           <div className="flex flex-col gap-4 pt-2">
-            <p className="text-muted-foreground text-sm">
-              A lightweight, type safe wrapper package of the Engine HTTP API is
-              available on{" "}
-              <Link
-                className="text-blue-500"
-                href="https://www.npmjs.com/package/@thirdweb-dev/engine"
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                NPM
-              </Link>
-              .
-            </p>
+            {useEngineAPI && (
+              <p className="text-muted-foreground text-sm">
+                A lightweight, type safe wrapper package of the Engine HTTP API
+                is available on{" "}
+                <Link
+                  className="text-blue-500"
+                  href="https://www.npmjs.com/package/@thirdweb-dev/engine"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  NPM
+                </Link>
+                .
+              </p>
+            )}
             <CodeClient
               className="bg-background"
-              code={jsExample()}
+              code={useEngineAPI ? engineJsExample() : thirdwebJsExample()}
               lang="js"
             />
           </div>
@@ -119,17 +132,25 @@ export function TryItOut() {
         {activeTab === "python" && (
           <CodeClient
             className="bg-background"
-            code={pythonExample()}
+            code={
+              useEngineAPI ? enginePythonExample() : thirdwebPythonExample()
+            }
             lang="python"
           />
         )}
         {activeTab === "go" && (
-          <CodeClient className="bg-background" code={goExample()} lang="go" />
+          <CodeClient
+            className="bg-background"
+            code={useEngineAPI ? engineGoExample() : thirdwebGoExample()}
+            lang="go"
+          />
         )}
         {activeTab === "csharp" && (
           <CodeClient
             className="bg-background"
-            code={csharpExample()}
+            code={
+              useEngineAPI ? engineCsharpExample() : thirdwebCsharpExample()
+            }
             lang="csharp"
           />
         )}
@@ -138,54 +159,175 @@ export function TryItOut() {
   );
 }
 
-const sdkExample = () => `\
-import { createThirdwebClient, sendTransaction, getContract, Engine } from "thirdweb";
-import { baseSepolia } from "thirdweb/chains";
-import { claimTo } from "thirdweb/extensions/erc1155";
+// thirdweb API examples
+const thirdwebCurlExample = () => `\
+curl -X POST "${NEXT_PUBLIC_THIRDWEB_API_HOST}/v1/transactions" \\
+  -H "Content-Type: application/json" \\
+  -H "x-secret-key: <your-project-secret-key>" \\
+  -d '{
+    "chainId": "84532",
+    "from": "<your-server-wallet-address>",  
+    "transactions": [
+      {
+        "type": "contractCall",
+        "contractAddress": "0x...",
+        "method": "function mintTo(address to, uint256 amount)",
+        "params": ["0x...", "100"]
+      }
+    ]
+  }'`;
 
-// Create a thirdweb client
-const client = createThirdwebClient({
-  secretKey: "<your-project-secret-key>",
-});
+const thirdwebJsExample = () => `\
+const response = await fetch(
+  "${NEXT_PUBLIC_THIRDWEB_API_HOST}/v1/transactions",
+  {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-secret-key": "<your-project-secret-key>",
+    },
+    body: JSON.stringify({
+      "chainId": "84532",
+      "from": "<your-server-wallet-address>",
+      "transactions": [
+        {
+          "type": "contractCall", 
+          "contractAddress": "0x...",
+          "method": "function mintTo(address to, uint256 amount)",
+          "params": ["0x...", "100"]
+        }
+      ]
+    })
+  }
+);`;
 
-// Create a server wallet
-const serverWallet = Engine.serverWallet({
-  client,
-  address: "<your-server-wallet-address>",
-});
+const thirdwebPythonExample = () => `\
+import requests
+import json
 
-// Prepare the transaction
-const transaction = claimTo({
-  contract: getContract({
-    client,
-    address: "0x...", // Address of the ERC1155 token contract
-    chain: baseSepolia, // Chain of the ERC1155 token contract
-  }),
-  to: "0x...", // The address of the user to mint to
-  tokenId: 0n, // The token ID of the NFT to mint
-  quantity: 1n, // The quantity of NFTs to mint
-});
+url = "${NEXT_PUBLIC_THIRDWEB_API_HOST}/v1/transactions"
+headers = {
+    "Content-Type": "application/json",
+    "x-secret-key": "<your-project-secret-key>",
+}
+payload = {
+    "chainId": "84532",
+    "from": "<your-server-wallet-address>",
+    "transactions": [
+        {
+            "type": "contractCall",
+            "contractAddress": "0x...",
+            "method": "function mintTo(address to, uint256 amount)",
+            "params": ["0x...", "100"]
+        }
+    ]
+}
 
-// Enqueue the transaction via Engine
-const { transactionId } = await serverWallet.enqueueTransaction({
-  transaction,
-});
+response = requests.post(url, headers=headers, json=payload)
+result = response.json()`;
 
-// Get the execution status of the transaction at any point in time
-const executionResult = await Engine.getTransactionStatus({
-  client,
-  transactionId,
-});
+const thirdwebGoExample = () => `\
+package main
 
-// Utility function to poll for the transaction to be submitted onchain
-const txHash = await Engine.waitForTransactionHash({
-  client,
-  transactionId,
-});
-console.log("Transaction hash:", txHash);
-`;
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
 
-const curlExample = () => `\
+func main() {
+	url := "${NEXT_PUBLIC_THIRDWEB_API_HOST}/v1/transactions"
+
+	type Transaction struct {
+		Type            string   \`json:"type"\`
+		ContractAddress string   \`json:"contractAddress"\`
+		Method          string   \`json:"method"\`
+		Params          []string \`json:"params"\`
+	}
+
+	type RequestBody struct {
+		ChainId      string        \`json:"chainId"\`
+		From         string        \`json:"from"\`
+		Transactions []Transaction \`json:"transactions"\`
+	}
+
+	requestBody := RequestBody{
+		ChainId: "84532",
+		From:    "<your-server-wallet-address>",
+		Transactions: []Transaction{
+			{
+				Type:            "contractCall",
+				ContractAddress: "0x...",
+				Method:          "function mintTo(address to, uint256 amount)",
+				Params:          []string{"0x...", "100"},
+			},
+		},
+	}
+
+	jsonData, _ := json.Marshal(requestBody)
+
+	req, _ := http.NewRequest("POST", url, bytes.NewBuffer(jsonData))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-secret-key", "<your-project-secret-key>")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	var result map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&result)
+	fmt.Println("Response:", result)
+}`;
+
+const thirdwebCsharpExample = () => `\
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+class Program
+{
+    static async Task Main()
+    {
+        var url = "${NEXT_PUBLIC_THIRDWEB_API_HOST}/v1/transactions";
+
+        var requestData = new
+        {
+            chainId = "84532",
+            from = "<your-server-wallet-address>",
+            transactions = new[]
+            {
+                new
+                {
+                    type = "contractCall",
+                    contractAddress = "0x...",
+                    method = "function mintTo(address to, uint256 amount)",
+                    @params = new[] { "0x...", "100" }
+                }
+            }
+        };
+
+        var json = JsonSerializer.Serialize(requestData);
+        var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+        using var httpClient = new HttpClient();
+        httpClient.DefaultRequestHeaders.Add("x-secret-key", "<your-project-secret-key>");
+
+        var response = await httpClient.PostAsync(url, content);
+        var responseContent = await response.Content.ReadAsStringAsync();
+
+        Console.WriteLine(responseContent);
+    }
+}`;
+
+// Engine API examples (original examples)
+const engineCurlExample = () => `\
 curl -X POST "${NEXT_PUBLIC_ENGINE_CLOUD_URL}/v1/write/contract" \\
   -H "Content-Type: application/json" \\
   -H "x-secret-key: <your-project-secret-key>" \\
@@ -203,7 +345,7 @@ curl -X POST "${NEXT_PUBLIC_ENGINE_CLOUD_URL}/v1/write/contract" \\
     ]
   }'`;
 
-const jsExample = () => `\
+const engineJsExample = () => `\
 const response = await fetch(
   "${NEXT_PUBLIC_ENGINE_CLOUD_URL}/v1/write/contract",
   {
@@ -228,7 +370,7 @@ const response = await fetch(
   }
 );`;
 
-const pythonExample = () => `\
+const enginePythonExample = () => `\
 import requests
 import json
 
@@ -254,7 +396,7 @@ payload = {
 response = requests.post(url, headers=headers, json=payload)
 result = response.json()`;
 
-const goExample = () => `\
+const engineGoExample = () => `\
 package main
 
 import (
@@ -316,7 +458,7 @@ func main() {
 	fmt.Println("Response:", result)
 }`;
 
-const csharpExample = () => `\
+const engineCsharpExample = () => `\
 using System;
 using System.Net.Http;
 using System.Text;
@@ -359,3 +501,50 @@ class Program
         Console.WriteLine(responseContent);
     }
 }`;
+
+const sdkExample = () => `\
+import { createThirdwebClient, sendTransaction, getContract, Engine } from "thirdweb";
+import { baseSepolia } from "thirdweb/chains";
+import { claimTo } from "thirdweb/extensions/erc1155";
+
+// Create a thirdweb client
+const client = createThirdwebClient({
+  secretKey: "<your-project-secret-key>",
+});
+
+// Create a server wallet
+const serverWallet = Engine.serverWallet({
+  client,
+  address: "<your-server-wallet-address>",
+});
+
+// Prepare the transaction
+const transaction = claimTo({
+  contract: getContract({
+    client,
+    address: "0x...", // Address of the ERC1155 token contract
+    chain: baseSepolia, // Chain of the ERC1155 token contract
+  }),
+  to: "0x...", // The address of the user to mint to
+  tokenId: 0n, // The token ID of the NFT to mint
+  quantity: 1n, // The quantity of NFTs to mint
+});
+
+// Enqueue the transaction via Engine
+const { transactionId } = await serverWallet.enqueueTransaction({
+  transaction,
+});
+
+// Get the execution status of the transaction at any point in time
+const executionResult = await Engine.getTransactionStatus({
+  client,
+  transactionId,
+});
+
+// Utility function to poll for the transaction to be submitted onchain
+const txHash = await Engine.waitForTransactionHash({
+  client,
+  transactionId,
+});
+console.log("Transaction hash:", txHash);
+`;


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the transaction handling in the dashboard by introducing a selection between two API modes: `thirdweb` and `Engine API`. It modifies components to accommodate this new functionality and updates API references accordingly.

### Detailed summary
- Updated `<TryItOut />` to accept `useEngineAPI` prop.
- Replaced `NEXT_PUBLIC_ENGINE_CLOUD_URL` with `NEXT_PUBLIC_THIRDWEB_API_HOST` in various components.
- Introduced API mode selection in `TransactionsExplorerPage`.
- Modified `<Scalar />` to use `useEngineAPI` prop.
- Updated transaction examples to differentiate between `thirdweb` and `Engine API`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to switch between "thirdweb API (recommended)" and "Engine API (advanced)" modes in the Transactions Explorer.
  * Users can now view and interact with tailored API documentation, descriptions, and code examples for both API modes across multiple languages.
  * Enhanced UI with a dropdown selector for API mode and dynamic updates to code samples and documentation based on the selected mode.

* **Style**
  * Updated external links and labels to reflect the current API host and selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->