### PR TITLE
Deprecate storage pages and redirect

### DIFF
--- a/apps/portal/redirects.mjs
+++ b/apps/portal/redirects.mjs
@@ -865,6 +865,9 @@ const infrastructureRedirects = {
   "/storage/how-storage-works": "/infrastructure/storage/how-storage-works",
   "/storage/upload-to-ipfs":
     "/infrastructure/storage/how-to-use-storage/upload-files-to-ipfs",
+  
+  // deprecated infrastructure storage pages - redirect to typescript v5 storage functions
+  "/infrastructure/storage/:path*": "/references/typescript/v5/functions#storage",
 };
 
 const glossaryRedirects = {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating redirect paths in the `redirects.mjs` file to improve navigation, including deprecating old infrastructure storage pages and directing users to the new TypeScript v5 storage functions.

### Detailed summary
- Updated redirect from `"/storage/upload-to-ipfs"` to `"/infrastructure/storage/how-to-use-storage/upload-files-to-ipfs"`
- Added a comment indicating that old infrastructure storage pages are deprecated and redirecting to TypeScript v5 storage functions at `"/infrastructure/storage/:path*"`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->