### PR TITLE
[BLD-28] Dashboard: Fix error style in contract explorer

### DIFF
--- a/apps/dashboard/src/@/components/contracts/functions/interactive-abi-function.tsx
+++ b/apps/dashboard/src/@/components/contracts/functions/interactive-abi-function.tsx
@@ -30,7 +30,6 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { CodeClient } from "@/components/ui/code/code.client";
 import { PlainTextCodeBlock } from "@/components/ui/code/plaintext-code";
-import { InlineCode } from "@/components/ui/inline-code";
 import { Input } from "@/components/ui/input";
 import { Spinner } from "@/components/ui/Spinner/Spinner";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -414,14 +413,13 @@ export const InteractiveAbiFunction: React.FC<InteractiveAbiFunctionProps> = (
           )}
 
           {error ? (
-            <>
-              <h3 className="text-sm font-medium">Error</h3>
-              <InlineCode
-                className="relative w-full whitespace-pre-wrap rounded-md border border-border p-4 text-red-500"
-                //  biome-ignore lint/suspicious/noExplicitAny: FIXME
-                code={formatError(error as any)}
+            <div>
+              <h3 className="text-sm font-medium mb-2">Error</h3>
+              <PlainTextCodeBlock
+                className="text-red-500 bg-background"
+                code={formatError(error)}
               />
-            </>
+            </div>
           ) : readLoading ? (
             <Skeleton className="h-20 w-full rounded-lg" />
           ) : formattedResponseData ? (


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the error display in the `InteractiveAbiFunction` component by replacing the `InlineCode` component with the `PlainTextCodeBlock` for better styling and readability.

### Detailed summary
- Removed the import of `InlineCode`.
- Changed the error display from using `InlineCode` to `PlainTextCodeBlock`.
- Updated the structure of the error display from a fragment (`<>`) to a `div`, adding a margin to the heading.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the visual appearance of error messages in the interactive ABI function section for improved readability, using a new code block style with enhanced formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->