### PR TITLE
[SDK] Fix `useContractEvents` persisting previous data when filters change

### DIFF
--- a/.changeset/witty-ducks-lie.md
+++ b/.changeset/witty-ducks-lie.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fixed `useContractEvents` persisting previous data when filters change

--- a/packages/thirdweb/src/react/core/hooks/contract/useContractEvents.ts
+++ b/packages/thirdweb/src/react/core/hooks/contract/useContractEvents.ts
@@ -92,7 +92,7 @@ export function useContractEvents<
     () =>
       events?.reduce((acc, curr) => {
         // we can use the event hash as a unique identifier?
-        return `${acc}${curr.hash}_`;
+        return `${acc}${curr.hash}${curr.topics.join("")}_`;
       }, "") || "__all__",
     [events],
   );


### PR DESCRIPTION
Closes #7737 

Test code used:

```ts
  const [from, setFrom] = useState(
    "0x83359747324E83eAAa596C7414D80365Bd75438A",
  );

  const { data: events = [] } = useContractEvents({
    contract: getContract({
      client: THIRDWEB_CLIENT,
      chain: baseSepolia,
      address: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
    }),
    events: [
      prepareEvent({
        signature:
          "event Transfer(address indexed from, address indexed to, uint256 value)",
        filters: {
          from,
        },
      }),
    ],
  });

  <button onClick={() => setFrom(ZERO_ADDRESS)}>Toggle From</button>
```

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the `useContractEvents` hook to ensure it correctly handles changes in filters by updating how event identifiers are generated.

### Detailed summary
- Updated the logic in `useContractEvents` to generate unique identifiers for events.
- Changed the return statement to concatenate `curr.hash` with `curr.topics.join("")`, improving how identifiers are formed when filters change.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where event data could persist from previous filters in contract event queries. Event data now accurately reflects the current filter criteria without mixing in stale results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->