### PR TITLE
[SDK] Fix decodeFunction and decodeError functions

### DIFF
--- a/.changeset/tangy-ghosts-joke.md
+++ b/.changeset/tangy-ghosts-joke.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix decodeFunction and decodeError functions

--- a/packages/thirdweb/src/utils/abi/decodeError.ts
+++ b/packages/thirdweb/src/utils/abi/decodeError.ts
@@ -3,6 +3,7 @@ import * as ox__AbiError from "ox/AbiError";
 import { resolveContractAbi } from "../../contract/actions/resolve-abi.js";
 import type { ThirdwebContract } from "../../contract/contract.js";
 import type { Hex } from "../encoding/hex.js";
+import { AbiError } from "ox";
 
 /**
  * Decodes an error.
@@ -32,6 +33,10 @@ export async function decodeError<abi extends ox__Abi.Abi>(options: {
       `No ABI found for contract ${contract.address} on chain ${contract.chain.id}`,
     );
   }
-  const abiError = ox__AbiError.fromAbi(abi, data) as ox__AbiError.AbiError;
+  const err = abi.filter((i) => i.type === "error" && AbiError.getSelector(i) === data.slice(0, 10))
+  const abiError = err[0] as ox__AbiError.AbiError;
+  if (!abiError) {
+    throw new Error(`No ABI function found for selector ${data.slice(0, 10)}`);
+  }
   return ox__AbiError.decode(abiError, data);
 }

--- a/packages/thirdweb/src/utils/abi/decodeError.ts
+++ b/packages/thirdweb/src/utils/abi/decodeError.ts
@@ -1,9 +1,9 @@
+import { AbiError } from "ox";
 import type * as ox__Abi from "ox/Abi";
 import * as ox__AbiError from "ox/AbiError";
 import { resolveContractAbi } from "../../contract/actions/resolve-abi.js";
 import type { ThirdwebContract } from "../../contract/contract.js";
 import type { Hex } from "../encoding/hex.js";
-import { AbiError } from "ox";
 
 /**
  * Decodes an error.
@@ -33,7 +33,9 @@ export async function decodeError<abi extends ox__Abi.Abi>(options: {
       `No ABI found for contract ${contract.address} on chain ${contract.chain.id}`,
     );
   }
-  const err = abi.filter((i) => i.type === "error" && AbiError.getSelector(i) === data.slice(0, 10))
+  const err = abi.filter(
+    (i) => i.type === "error" && AbiError.getSelector(i) === data.slice(0, 10),
+  );
   const abiError = err[0] as ox__AbiError.AbiError;
   if (!abiError) {
     throw new Error(`No ABI function found for selector ${data.slice(0, 10)}`);

--- a/packages/thirdweb/src/utils/abi/decodeFunctionData.test.ts
+++ b/packages/thirdweb/src/utils/abi/decodeFunctionData.test.ts
@@ -1,0 +1,25 @@
+import { expect, it } from "vitest";
+import { decodeFunctionData } from "./decodeFunctionData.js";
+import { getContract } from "../../contract/contract.js";
+import { defineChain } from "../../chains/utils.js";
+import { TEST_CLIENT } from "../../../test/src/test-clients.js";
+
+it.runIf(process.env.TW_SECRET_KEY)(
+  "decodes function data correctly",
+  async () => {
+    const result = await decodeFunctionData({ 
+      contract: getContract({
+        address: "0x9480d58e14b1851a2A3C7aEFAd17D48e31D3F93b",
+        client: TEST_CLIENT,
+        chain: defineChain(17177)
+      }),
+      data: "0xd8fd8f44000000000000000000000000f117ed9dcc8960062484b781097321c8380cead30000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000002466353238316131632d363830352d343536622d623738322d38356165326165623336643800000000000000000000000000000000000000000000000000000000"
+    });
+    expect(result).toMatchInlineSnapshot(`
+      [
+        "0xf117ed9dcc8960062484b781097321c8380cead3",
+        "0x66353238316131632d363830352d343536622d623738322d383561653261656233366438",
+      ]
+    `);
+  },
+);

--- a/packages/thirdweb/src/utils/abi/decodeFunctionData.test.ts
+++ b/packages/thirdweb/src/utils/abi/decodeFunctionData.test.ts
@@ -1,19 +1,19 @@
 import { expect, it } from "vitest";
-import { decodeFunctionData } from "./decodeFunctionData.js";
-import { getContract } from "../../contract/contract.js";
-import { defineChain } from "../../chains/utils.js";
 import { TEST_CLIENT } from "../../../test/src/test-clients.js";
+import { defineChain } from "../../chains/utils.js";
+import { getContract } from "../../contract/contract.js";
+import { decodeFunctionData } from "./decodeFunctionData.js";
 
 it.runIf(process.env.TW_SECRET_KEY)(
   "decodes function data correctly",
   async () => {
-    const result = await decodeFunctionData({ 
+    const result = await decodeFunctionData({
       contract: getContract({
         address: "0x9480d58e14b1851a2A3C7aEFAd17D48e31D3F93b",
         client: TEST_CLIENT,
-        chain: defineChain(17177)
+        chain: defineChain(17177),
       }),
-      data: "0xd8fd8f44000000000000000000000000f117ed9dcc8960062484b781097321c8380cead30000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000002466353238316131632d363830352d343536622d623738322d38356165326165623336643800000000000000000000000000000000000000000000000000000000"
+      data: "0xd8fd8f44000000000000000000000000f117ed9dcc8960062484b781097321c8380cead30000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000002466353238316131632d363830352d343536622d623738322d38356165326165623336643800000000000000000000000000000000000000000000000000000000",
     });
     expect(result).toMatchInlineSnapshot(`
       [

--- a/packages/thirdweb/src/utils/abi/decodeFunctionData.ts
+++ b/packages/thirdweb/src/utils/abi/decodeFunctionData.ts
@@ -32,7 +32,11 @@ export async function decodeFunctionData<abi extends ox__Abi.Abi>(options: {
       `No ABI found for contract ${contract.address} on chain ${contract.chain.id}`,
     );
   }
-  const fn = abi.filter((i) => i.type === "function" && ox__AbiFunction.getSelector(i) === data.slice(0, 10))
+  const fn = abi.filter(
+    (i) =>
+      i.type === "function" &&
+      ox__AbiFunction.getSelector(i) === data.slice(0, 10),
+  );
   const abiFunction = fn[0] as ox__AbiFunction.AbiFunction;
   if (!abiFunction) {
     throw new Error(`No ABI function found for selector ${data.slice(0, 10)}`);

--- a/packages/thirdweb/src/utils/abi/decodeFunctionData.ts
+++ b/packages/thirdweb/src/utils/abi/decodeFunctionData.ts
@@ -32,6 +32,10 @@ export async function decodeFunctionData<abi extends ox__Abi.Abi>(options: {
       `No ABI found for contract ${contract.address} on chain ${contract.chain.id}`,
     );
   }
-  const abiFunction = ox__AbiFunction.fromAbi(abi, data);
+  const fn = abi.filter((i) => i.type === "function" && ox__AbiFunction.getSelector(i) === data.slice(0, 10))
+  const abiFunction = fn[0] as ox__AbiFunction.AbiFunction;
+  if (!abiFunction) {
+    throw new Error(`No ABI function found for selector ${data.slice(0, 10)}`);
+  }
   return ox__AbiFunction.decodeData(abiFunction, data);
 }

--- a/packages/thirdweb/src/utils/abi/decodeFunctionResult.ts
+++ b/packages/thirdweb/src/utils/abi/decodeFunctionResult.ts
@@ -32,6 +32,10 @@ export async function decodeFunctionResult<abi extends ox__Abi.Abi>(options: {
       `No ABI found for contract ${contract.address} on chain ${contract.chain.id}`,
     );
   }
-  const abiFunction = ox__AbiFunction.fromAbi(abi, rest.data);
+  const fn = abi.filter((i) => i.type === "function" && ox__AbiFunction.getSelector(i) === rest.data.slice(0, 10))
+  const abiFunction = fn[0] as ox__AbiFunction.AbiFunction;
+  if (!abiFunction) {
+    throw new Error(`No ABI function found for selector ${rest.data.slice(0, 10)}`);
+  }
   return ox__AbiFunction.decodeResult(abiFunction, rest.data);
 }

--- a/packages/thirdweb/src/utils/abi/decodeFunctionResult.ts
+++ b/packages/thirdweb/src/utils/abi/decodeFunctionResult.ts
@@ -32,10 +32,16 @@ export async function decodeFunctionResult<abi extends ox__Abi.Abi>(options: {
       `No ABI found for contract ${contract.address} on chain ${contract.chain.id}`,
     );
   }
-  const fn = abi.filter((i) => i.type === "function" && ox__AbiFunction.getSelector(i) === rest.data.slice(0, 10))
+  const fn = abi.filter(
+    (i) =>
+      i.type === "function" &&
+      ox__AbiFunction.getSelector(i) === rest.data.slice(0, 10),
+  );
   const abiFunction = fn[0] as ox__AbiFunction.AbiFunction;
   if (!abiFunction) {
-    throw new Error(`No ABI function found for selector ${rest.data.slice(0, 10)}`);
+    throw new Error(
+      `No ABI function found for selector ${rest.data.slice(0, 10)}`,
+    );
   }
   return ox__AbiFunction.decodeResult(abiFunction, rest.data);
 }


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the `decodeFunction` and `decodeError` functionalities in the `thirdweb` package by enhancing error handling and ensuring the correct ABI function or error is found based on the provided selector.

### Detailed summary
- Updated `decodeFunctionData.ts` to filter ABI functions and throw an error if none is found.
- Updated `decodeFunctionResult.ts` similarly to handle ABI function filtering and error throwing.
- Enhanced `decodeError.ts` to filter ABI errors and throw an error if none is found.
- Added a test case in `decodeFunctionData.test.ts` to validate correct decoding of function data.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of function and error data decoding, with enhanced error handling for unmatched selectors.

* **Tests**
  * Added a new test to verify correct decoding of function data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->