### PR TITLE
[SDK] Fix: Respect supported tokens in payment widgets

### DIFF
--- a/packages/thirdweb/src/react/core/hooks/usePaymentMethods.ts
+++ b/packages/thirdweb/src/react/core/hooks/usePaymentMethods.ts
@@ -8,6 +8,7 @@ import { getClientFetch } from "../../../utils/fetch.js";
 import { toTokens, toUnits } from "../../../utils/units.js";
 import type { Wallet } from "../../../wallets/interfaces/wallet.js";
 import type { PaymentMethod } from "../machines/paymentMachine.js";
+import type { SupportedTokens } from "../utils/defaultTokens.js";
 import { useActiveWallet } from "./wallets/useActiveWallet.js";
 
 /**
@@ -33,6 +34,7 @@ export function usePaymentMethods(options: {
   client: ThirdwebClient;
   payerWallet?: Wallet;
   includeDestinationToken?: boolean;
+  supportedTokens?: SupportedTokens;
 }) {
   const {
     destinationToken,
@@ -40,6 +42,7 @@ export function usePaymentMethods(options: {
     client,
     payerWallet,
     includeDestinationToken,
+    supportedTokens,
   } = options;
   const localWallet = useActiveWallet(); // TODO (bridge): get all connected wallets
   const wallet = payerWallet || localWallet;
@@ -118,8 +121,28 @@ export function usePaymentMethods(options: {
               (a.originToken.prices.USD || 1)
           );
         });
-      // Move all sufficient balance quotes to the top
-      return [...sufficientBalanceQuotes, ...insufficientBalanceQuotes];
+
+      // Filter out quotes that are not included in the supportedTokens (if provided)
+      const tokensToInclude = supportedTokens
+        ? Object.keys(supportedTokens).flatMap(
+            (c: string) =>
+              supportedTokens[Number(c)]?.map((t) => ({
+                chainId: Number(c),
+                address: t.address,
+              })) ?? [],
+          )
+        : [];
+      const finalQuotes = supportedTokens
+        ? [...sufficientBalanceQuotes, ...insufficientBalanceQuotes].filter(
+            (q) =>
+              tokensToInclude.find(
+                (t) =>
+                  t.chainId === q.originToken.chainId &&
+                  t.address === q.originToken.address,
+              ),
+          )
+        : [...sufficientBalanceQuotes, ...insufficientBalanceQuotes];
+      return finalQuotes;
     },
     queryKey: [
       "payment-methods",
@@ -128,6 +151,7 @@ export function usePaymentMethods(options: {
       destinationAmount,
       payerWallet?.getAccount()?.address,
       includeDestinationToken,
+      supportedTokens,
     ], // 5 minutes
     refetchOnWindowFocus: false,
     staleTime: 5 * 60 * 1000,

--- a/packages/thirdweb/src/react/web/ui/Bridge/BridgeOrchestrator.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/BridgeOrchestrator.tsx
@@ -17,6 +17,7 @@ import {
   type PaymentMethod,
   usePaymentMachine,
 } from "../../../core/machines/paymentMachine.js";
+import type { SupportedTokens } from "../../../core/utils/defaultTokens.js";
 import { webWindowAdapter } from "../../adapters/WindowAdapter.js";
 import en from "../ConnectWallet/locale/en.js";
 import type { ConnectLocale } from "../ConnectWallet/locale/types.js";
@@ -128,6 +129,7 @@ export interface BridgeOrchestratorProps {
    * @default true
    */
   showThirdwebBranding?: boolean;
+  supportedTokens?: SupportedTokens;
 }
 
 export function BridgeOrchestrator({
@@ -144,6 +146,7 @@ export function BridgeOrchestrator({
   presetOptions,
   paymentMethods = ["crypto", "card"],
   showThirdwebBranding = true,
+  supportedTokens,
 }: BridgeOrchestratorProps) {
   // Initialize adapters
   const adapters = useMemo(
@@ -313,6 +316,7 @@ export function BridgeOrchestrator({
             paymentMethods={paymentMethods}
             receiverAddress={state.context.receiverAddress}
             currency={uiOptions.currency}
+            supportedTokens={supportedTokens}
           />
         )}
 

--- a/packages/thirdweb/src/react/web/ui/Bridge/BuyWidget.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/BuyWidget.tsx
@@ -398,6 +398,7 @@ export function BuyWidget(props: BuyWidgetProps) {
     // Show normal bridge orchestrator
     content = (
       <BridgeOrchestrator
+        supportedTokens={props.supportedTokens}
         client={props.client}
         connectLocale={localeQuery.data}
         connectOptions={props.connectOptions}

--- a/packages/thirdweb/src/react/web/ui/Bridge/CheckoutWidget.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/CheckoutWidget.tsx
@@ -369,6 +369,7 @@ export function CheckoutWidget(props: CheckoutWidgetProps) {
         receiverAddress={props.seller}
         showThirdwebBranding={props.showThirdwebBranding}
         uiOptions={bridgeDataQuery.data.data}
+        supportedTokens={props.supportedTokens}
       />
     );
   }

--- a/packages/thirdweb/src/react/web/ui/Bridge/TransactionWidget.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/TransactionWidget.tsx
@@ -409,6 +409,7 @@ export function TransactionWidget(props: TransactionWidgetProps) {
     // Show normal bridge orchestrator
     content = (
       <BridgeOrchestrator
+        supportedTokens={props.supportedTokens}
         client={props.client}
         connectLocale={localeQuery.data}
         connectOptions={props.connectOptions}

--- a/packages/thirdweb/src/react/web/ui/Bridge/payment-selection/PaymentSelection.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/payment-selection/PaymentSelection.tsx
@@ -13,6 +13,7 @@ import { usePaymentMethods } from "../../../../core/hooks/usePaymentMethods.js";
 import { useActiveWallet } from "../../../../core/hooks/wallets/useActiveWallet.js";
 import { useConnectedWallets } from "../../../../core/hooks/wallets/useConnectedWallets.js";
 import type { PaymentMethod } from "../../../../core/machines/paymentMachine.js";
+import type { SupportedTokens } from "../../../../core/utils/defaultTokens.js";
 import type { ConnectLocale } from "../../ConnectWallet/locale/types.js";
 import { WalletSwitcherConnectionScreen } from "../../ConnectWallet/screens/WalletSwitcherConnectionScreen.js";
 import { Container, ModalHeader } from "../../components/basic.js";
@@ -89,6 +90,8 @@ export interface PaymentSelectionProps {
    * @default "USD"
    */
   currency?: SupportedFiatCurrency;
+
+  supportedTokens?: SupportedTokens;
 }
 
 type Step =
@@ -109,6 +112,7 @@ export function PaymentSelection({
   connectLocale,
   includeDestinationToken,
   paymentMethods = ["crypto", "card"],
+  supportedTokens,
   feePayer,
   currency,
 }: PaymentSelectionProps) {
@@ -149,6 +153,7 @@ export function PaymentSelection({
       receiverAddress?.toLowerCase() !==
         payerWallet?.getAccount()?.address?.toLowerCase(),
     payerWallet,
+    supportedTokens,
   });
 
   // Handle error from usePaymentMethods


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces support for `supportedTokens` across multiple components in the `Bridge` module, enhancing the functionality of payment methods and token selection.

### Detailed summary
- Added `supportedTokens` prop to `CheckoutWidget`, `BuyWidget`, and `TransactionWidget`.
- Updated `BridgeOrchestrator` to accept and utilize `supportedTokens`.
- Enhanced `PaymentSelection` to support `supportedTokens`.
- Modified `usePaymentMethods` to filter quotes based on `supportedTokens`.
- Updated `TokenSelector` to implement a search feature and use `SelectWithSearch`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying a list of supported tokens when selecting payment methods in bridge-related widgets.
  * Payment method options are now filtered to show only those matching the supported tokens, if provided.

* **Enhancements**
  * Bridge, Buy, Checkout, and Transaction widgets now accept and utilize a supported tokens list for improved customization.
  * Token selector component updated with enhanced search functionality and simplified user interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->