### PR TITLE
Dashboard: Fix Payment link buy completion tracking

### DIFF
--- a/apps/dashboard/src/@/analytics/report.ts
+++ b/apps/dashboard/src/@/analytics/report.ts
@@ -435,11 +435,8 @@ export function reportPaymentLinkCreated(properties: {
  * ### Who is responsible for this event?
  * @greg
  */
-export function reportPaymentLinkBuySuccessful(properties: {
-  linkId: string;
-  clientId: string;
-}) {
-  posthog.capture("payment link buy successful", properties);
+export function reportPaymentLinkBuySuccessful() {
+  posthog.capture("payment link buy successful");
 }
 
 /**
@@ -451,8 +448,6 @@ export function reportPaymentLinkBuySuccessful(properties: {
  * @greg
  */
 export function reportPaymentLinkBuyFailed(properties: {
-  linkId: string;
-  clientId: string;
   errorMessage: string;
 }) {
   posthog.capture("payment link buy failed", properties);

--- a/apps/dashboard/src/app/pay/components/client/PayPageWidget.client.tsx
+++ b/apps/dashboard/src/app/pay/components/client/PayPageWidget.client.tsx
@@ -62,24 +62,16 @@ export function PayPageWidget({
         image={image}
         name={name}
         onSuccess={() => {
+          reportPaymentLinkBuySuccessful();
+
           if (!redirectUri) return;
           const url = new URL(redirectUri);
-          if (paymentLinkId && clientId) {
-            reportPaymentLinkBuySuccessful({
-              linkId: paymentLinkId,
-              clientId: clientId,
-            });
-          }
           return window.open(url.toString());
         }}
         onError={(error) => {
-          if (paymentLinkId && clientId) {
-            reportPaymentLinkBuyFailed({
-              linkId: paymentLinkId,
-              clientId: clientId,
-              errorMessage: error.message,
-            });
-          }
+          reportPaymentLinkBuyFailed({
+            errorMessage: error.message,
+          });
         }}
         paymentLinkId={paymentLinkId}
         purchaseData={purchaseData}


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on simplifying the `reportPaymentLinkBuySuccessful` and `reportPaymentLinkBuyFailed` functions by removing unnecessary parameters and adjusting their calls in the `PayPageWidget.client.tsx` component.

### Detailed summary
- Removed `linkId` and `clientId` parameters from `reportPaymentLinkBuySuccessful`.
- Adjusted the call to `reportPaymentLinkBuySuccessful` in `PayPageWidget.client.tsx` to not pass any arguments.
- Updated `reportPaymentLinkBuyFailed` to only pass `errorMessage` without `linkId` and `clientId` in `PayPageWidget.client.tsx`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined payment reporting by simplifying success and failure event tracking. Payment success is now always reported without additional details, and payment failure reports only include the error message. No impact on payment or redirect flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->