### PR TITLE
[SDK] Feat: export `useSiweAuth` for React Native

### DIFF
--- a/.changeset/short-icons-care.md
+++ b/.changeset/short-icons-care.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Added `useSiweAuth` to the React Native exports

--- a/packages/thirdweb/src/exports/react.native.ts
+++ b/packages/thirdweb/src/exports/react.native.ts
@@ -8,6 +8,9 @@ export type {
 } from "../react/core/design-system/index.js";
 // theme
 export { darkTheme, lightTheme } from "../react/core/design-system/index.js";
+// auth
+export type { SiweAuthOptions } from "../react/core/hooks/auth/useSiweAuth.js";
+export { useSiweAuth } from "../react/core/hooks/auth/useSiweAuth.js";
 export type {
   ConnectButton_connectButtonOptions,
   ConnectButton_connectModalOptions,


### PR DESCRIPTION
Updates the React Native exports to include `useSiweAuth`, making it easier to build a custom login flow with SIWE auth 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `thirdweb` library by adding the `useSiweAuth` hook to the React Native exports, allowing for improved authentication functionality in React Native applications.

### Detailed summary
- Added `useSiweAuth` to the React Native exports.
- Exported `SiweAuthOptions` type from `../react/core/hooks/auth/useSiweAuth.js`.
- Exported `useSiweAuth` function from `../react/core/hooks/auth/useSiweAuth.js`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to use the `useSiweAuth` authentication hook in React Native projects.
  * Introduced support for the `SiweAuthOptions` type in React Native exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->