### PR TITLE
[SDK] Add transaction hash to max wait time error

### DIFF
--- a/.changeset/odd-fans-tickle.md
+++ b/.changeset/odd-fans-tickle.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Add transaction hash to max wait time error

--- a/packages/thirdweb/src/transaction/actions/wait-for-tx-receipt.test.ts
+++ b/packages/thirdweb/src/transaction/actions/wait-for-tx-receipt.test.ts
@@ -101,7 +101,7 @@ describe("waitForReceipt", () => {
     }
 
     await expect(result).rejects.toThrow(
-      `Transaction not found after ${10} blocks`,
+      `Transaction receipt for ${MOCK_TX_HASH} not found after 10 blocks`,
     );
     expect(mockEthGetTransactionReceipt).toHaveBeenCalledTimes(10);
   });

--- a/packages/thirdweb/src/transaction/actions/wait-for-tx-receipt.ts
+++ b/packages/thirdweb/src/transaction/actions/wait-for-tx-receipt.ts
@@ -72,7 +72,7 @@ export function waitForReceipt(
           unwatch();
           reject(
             new Error(
-              `Transaction not found after ${maxBlocksWaitTime} blocks`,
+              `Transaction receipt for ${transactionHash} not found after ${maxBlocksWaitTime} blocks`,
             ),
           );
           return;


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving error messages related to transaction receipt retrieval in the `thirdweb` package by including the transaction hash in the error messages.

### Detailed summary
- Updated the error message in `wait-for-tx-receipt.ts` to include the `transactionHash`.
- Modified the test in `wait-for-tx-receipt.test.ts` to reflect the new error message format, incorporating `MOCK_TX_HASH`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Error messages for transaction timeouts now include the transaction hash, improving traceability and context when a transaction exceeds the maximum wait time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->