### PR TITLE
[Docs] Update pregenerate wallets API endpoint and request format

### DIFF
--- a/apps/portal/src/app/wallets/custom-auth/page.mdx
+++ b/apps/portal/src/app/wallets/custom-auth/page.mdx
@@ -57,12 +57,30 @@ You will be asked to enter the following values
 
 ### Usage example
 
-<Tabs defaultValue="typescript">
+<Tabs defaultValue="http">
 <TabsList>
+	<TabsTrigger value="http">HTTP</TabsTrigger>
 	<TabsTrigger value="typescript">TypeScript</TabsTrigger>
 	<TabsTrigger value="react">React</TabsTrigger>
 	<TabsTrigger value="dotnet">.NET</TabsTrigger>
 </TabsList>
+
+<TabsContent value="http">
+
+```http
+POST https://api.thirdweb.com/v1/wallets/user/generic-auth
+Content-Type: application/json
+x-client-id: <your-client-id>
+x-ecosystem-id: <your-ecosystem-id> (optional)
+x-ecosystem-partner-id: <your-ecosystem-partner-id> (optional)
+
+{
+	"type": "jwt",
+	"jwt": "<your-jwt>"
+}
+```
+
+</TabsContent>
 
 <TabsContent value="react">
 
@@ -81,7 +99,7 @@ const handlePostLogin = async () => {
 		wallet.connect({
 			client,
 			strategy: "jwt",
-			jwt: "<your-jwt-token>",
+			jwt: "<your-jwt>",
 		});
 		return wallet;
 	});
@@ -107,7 +125,7 @@ const wallet = inAppWallet();
 const account = await wallet.connect({
 	client,
 	strategy: "jwt",
-	jwt: "<your-jwt-token>",
+	jwt: "<your-jwt>",
 });
 
 // use the account to send transactions
@@ -122,7 +140,7 @@ using Thirdweb;
 
 var client = ThirdwebClient.Create(clientId: "your-client-id");
 var wallet = await InAppWallet.Create(client: client, authProvider: AuthProvider.JWT);
-var address = await wallet.LoginWithCustomAuth(jwt: "<your-jwt-token>");
+var address = await wallet.LoginWithCustomAuth(jwt: "<your-jwt>");
 ```
 
 </TabsContent>
@@ -170,12 +188,32 @@ You can also pass a list of headers. These headers will be sent with every reque
 
 Once you've logged in with your own auth, you can pass the user's JWT to the in-app wallet to authenticate and connect.
 
-<Tabs defaultValue="typescript">
+<Tabs defaultValue="http">
 <TabsList>
+	<TabsTrigger value="http">HTTP</TabsTrigger>
 	<TabsTrigger value="typescript">TypeScript</TabsTrigger>
 	<TabsTrigger value="react">React</TabsTrigger>
 	<TabsTrigger value="dotnet">.NET</TabsTrigger>
 </TabsList>
+
+<TabsContent value="http">
+
+```http
+POST https://api.thirdweb.com/v1/wallets/user/generic-auth
+Content-Type: application/json
+x-client-id: <your-client-id>
+x-ecosystem-id: <your-ecosystem-id> (optional)
+x-ecosystem-partner-id: <your-ecosystem-partner-id> (optional)
+
+{
+	"type": "auth-payload",
+	"payload": "<your-auth-payload>"
+}
+```
+
+
+
+</TabsContent>
 
 <TabsContent value="react">
 
@@ -213,8 +251,6 @@ const MyComponent = () => {
 </TabsContent>
 
 <TabsContent value="typescript">
-
-In other frameworks, use your own instance of the wallet to authenticate and connect.
 
 ```typescript
 import { inAppWallet } from "thirdweb/wallets";

--- a/apps/portal/src/app/wallets/pregenerate-wallets/page.mdx
+++ b/apps/portal/src/app/wallets/pregenerate-wallets/page.mdx
@@ -7,7 +7,7 @@ export const metadata = createMetadata({
 		icon: "wallets",
 	},
 	title: "Pregenerate Wallets | thirdweb",
-	description: "Create wallets before users sign up with thirdweb’s wallet pregeneration. Pre-fund with tokens, NFTs, or game assets to enable smooth onboarding and asset claiming.",
+	description: "Create wallets before users sign up with thirdweb's wallet pregeneration. Pre-fund with tokens, NFTs, or game assets to enable smooth onboarding and asset claiming.",
 });
 
 # Pregenerate Wallets
@@ -35,21 +35,34 @@ You can distribute assets to wallets before users claim them, enabling:
 
 To pregenerate an in-app or ecosystem wallet wallet, you can make a `POST` request to the following endpoint:
 
-```
-https://in-app-wallet.thirdweb.com/api/v1/pregenerate
+```http
+POST https://api.thirdweb.com/v1/wallets/user/pregenerate
+Content-Type: application/json
+x-secret-key: <your-secret-key>
+x-ecosystem-id: <your-ecosystem-id> (optional)
+x-ecosystem-partner-id: <your-ecosystem-partner-id> (optional)
+
+{
+  "type": "email",
+  "email": "user@example.com"
+}
 ```
 
 ## Request Body
 
 The request body should be a JSON object with the following parameters:
 
-- `strategy`: The strategy for wallet generation
-- `email` or `phone` or `userId`: The user identifier associated with the wallet to be generated
+- `type`: The type of wallet identifier to pregenerate a wallet for: 
+  - Email based: `email`, `google`, `facebook`, `discord`
+  - Phone based: `phone`
+  - Wallet based: `signer`
+  - User ID based: `custom_jwt` or `custom_auth_endpoint`
+- `email` or `phone` or `userId` or `walletAddress`: The user identifier associated with the wallet to be generated
 
 ### Email based wallets
 
 ```
-{ strategy: "email", email: "user@example.com" }
+{ type: "email", email: "user@example.com" }
 ```
 
 When the user logs in with any method associated with that email (including google, facebook, discord auth), they will get access to the same pregenerated wallet.
@@ -57,13 +70,13 @@ When the user logs in with any method associated with that email (including goog
 ### Phone based wallets
 
 ```
-{ strategy: "phone", phone: "+1321123321" }
+{ type: "phone", phone: "+1321123321" }
 ```
 
 ### Custom user id based wallets
 
 ```
-{ strategy: "custom_auth_endpoint", userId: "some_user_id" }
+{ type: "custom_auth_endpoint", userId: "some_user_id" }
 ```
 
 {/* TODO: update link when custom auth documentation has been updated */}
@@ -83,13 +96,13 @@ You need to include the following headers:
 Here's an example curl command to pregenerate a thirdweb wallet for the user `user@example.com`:
 
 ```bash
-curl -X POST 'https://in-app-wallet.thirdweb.com/api/v1/pregenerate' \
+curl -X POST 'https://api.thirdweb.com/v1/wallets/user/pregenerate' \
   -H 'x-ecosystem-id: ecosystem.example-eco-123' \
   -H 'x-ecosystem-partner-id: 1415d24e-c7b0-4fce-846e-740841ef2c32' \
-  -H 'x-secret-key: 9f8e7d6c5b4a3f2e1d0c9b8a7ffge434b2a1f0e9d8c7b6a5f4e3d2c1b0a9f8e7' \
+  -H 'x-secret-key: <your-project-secret-key>' \
   -H 'Content-Type: application/json' \
   -d '{
-    "strategy": "email",
+    "type": "email",
     "email": "user@example.com"
   }'
 ```
@@ -107,9 +120,10 @@ A successful API call returns a JSON object in the following format:
 
 ```json
 {
-  "wallet": {
+  "result": {
       "address": "string",
       "createdAt": "string",
+      "profile": "object[]"
   }
 }
 ```


### PR DESCRIPTION
Fixes BLD-47

<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the documentation for the `wallets` feature in the `thirdweb` portal, refining usage examples and correcting endpoint details for authentication and wallet pregeneration.

### Detailed summary
- Changed default tab from `typescript` to `http` in usage examples.
- Added HTTP request examples for generic authentication.
- Updated JWT placeholder from `<your-jwt-token>` to `<your-jwt>`.
- Revised pregeneration endpoint and request body format.
- Clarified wallet identifier types in the request body.
- Adjusted curl command to reflect new endpoint and parameters.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated wallet pregeneration API docs with a new endpoint, request format, and expanded identifier types.
  * Added explicit HTTP request examples for custom authentication strategies including JWT and auth endpoint.
  * Unified placeholder strings and improved example clarity across authentication documentation.
  * Clarified required HTTP headers and revised example requests and responses.
  * Made minor textual corrections for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->