### PR TITLE
[SDK] Fix: Sort payment quotes in ascending order

### DIFF
--- a/.changeset/dirty-roses-carry.md
+++ b/.changeset/dirty-roses-carry.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Sort payment quotes in ascending order

--- a/packages/thirdweb/src/react/core/hooks/usePaymentMethods.ts
+++ b/packages/thirdweb/src/react/core/hooks/usePaymentMethods.ts
@@ -112,13 +112,13 @@ export function usePaymentMethods(options: {
         .sort((a, b) => {
           return (
             Number.parseFloat(
-              toTokens(b.quote.originAmount, b.originToken.decimals),
-            ) *
-              (b.originToken.prices.USD || 1) -
-            Number.parseFloat(
               toTokens(a.quote.originAmount, a.originToken.decimals),
             ) *
-              (a.originToken.prices.USD || 1)
+              (a.originToken.prices.USD || 1) -
+            Number.parseFloat(
+              toTokens(b.quote.originAmount, b.originToken.decimals),
+            ) *
+              (b.originToken.prices.USD || 1)
           );
         });
 


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on sorting payment quotes in ascending order within the `usePaymentMethods.ts` file by adjusting the calculation logic for comparing quotes.

### Detailed summary
- Updated the sorting logic in `usePaymentMethods.ts` to sort payment quotes based on `originAmount` and `prices.USD`.
- Swapped the usage of `a` and `b` in the calculations to ensure correct ascending order sorting.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the sorting of payment quotes to ensure they are now displayed in ascending order based on their USD value.

* **Chores**
  * Added documentation for the patch update related to payment quote sorting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->