### PR TITLE
[SDK] Fix: Deprecate bridge routes sortBy

### DIFF
--- a/.changeset/shaky-candles-rule.md
+++ b/.changeset/shaky-candles-rule.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Deprecates `sortBy` parameter in Bridge.routes

--- a/packages/thirdweb/src/bridge/Routes.ts
+++ b/packages/thirdweb/src/bridge/Routes.ts
@@ -203,7 +203,10 @@ export declare namespace routes {
     destinationTokenAddress?: ox__Address.Address;
     /** Transaction hash to filter routes by */
     transactionHash?: ox__Hex.Hex;
-    /** Sort routes by popularity */
+    /**
+     * Sort routes by popularity
+     * @deprecated
+     */
     sortBy?: "popularity";
     /** Maximum number of steps in the route */
     maxSteps?: number;


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on deprecating the `sortBy` parameter in the `Bridge.routes` of the `thirdweb` package, indicating that it should no longer be used in future implementations.

### Detailed summary
- Deprecates the `sortBy` parameter in `Bridge.routes`.
- Updates the documentation for `sortBy` to include a `@deprecated` tag, clarifying its status.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Documentation
  - Marked the sortBy option in the Bridge routes API as deprecated in public documentation. Behavior remains unchanged; the parameter is still accepted and forwarded if provided. Existing integrations are unaffected, but developers should plan to remove usage.

- Chores
  - Prepared a patch release for the thirdweb package with an added changeset entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->