### PR TITLE
Fix: Hide manage contract button when foreign wallet

### DIFF
--- a/apps/dashboard/src/app/(app)/(dashboard)/(chain)/[chain_id]/[contractAddress]/public-pages/erc20/_components/ContractHeader.tsx
+++ b/apps/dashboard/src/app/(app)/(dashboard)/(chain)/[chain_id]/[contractAddress]/public-pages/erc20/_components/ContractHeader.tsx
@@ -1,3 +1,4 @@
+"use client";
 import {
   ExternalLinkIcon,
   GlobeIcon,
@@ -8,6 +9,7 @@ import Link from "next/link";
 import { useMemo } from "react";
 import { type ThirdwebContract, ZERO_ADDRESS } from "thirdweb";
 import type { ChainMetadata } from "thirdweb/chains";
+import { useActiveAccount } from "thirdweb/react";
 import { Img } from "@/components/blocks/Img";
 import { Button } from "@/components/ui/button";
 import { CopyAddressButton } from "@/components/ui/CopyAddressButton";
@@ -64,6 +66,7 @@ export function ContractHeaderUI(props: {
 
     return socialUrlsValue;
   }, [props.socialUrls]);
+  const activeAccount = useActiveAccount();
 
   const cleanedChainName = props.chainMetadata?.name
     ?.replace("Mainnet", "")
@@ -169,29 +172,32 @@ export function ContractHeaderUI(props: {
             variant="outline"
           />
 
-          <ToolTipLabel
-            contentClassName="max-w-[300px]"
-            label={
-              <>
-                View this contract in thirdweb dashboard to view contract
-                management interface
-              </>
-            }
-          >
-            <Button
-              asChild
-              className="rounded-full bg-card gap-1.5 text-xs py-1.5 px-2.5 h-auto"
-              size="sm"
-              variant="outline"
+          {props.contractCreator?.toLowerCase() ===
+            activeAccount?.address?.toLowerCase() && (
+            <ToolTipLabel
+              contentClassName="max-w-[300px]"
+              label={
+                <>
+                  View this contract in thirdweb dashboard to view contract
+                  management interface
+                </>
+              }
             >
-              <Link
-                href={`/team/~/~/contract/${props.chainMetadata.slug}/${props.clientContract.address}`}
+              <Button
+                asChild
+                className="rounded-full bg-card gap-1.5 text-xs py-1.5 px-2.5 h-auto"
+                size="sm"
+                variant="outline"
               >
-                <Settings2Icon className="size-3.5 text-muted-foreground" />
-                Manage Contract
-              </Link>
-            </Button>
-          </ToolTipLabel>
+                <Link
+                  href={`/team/~/~/contract/${props.chainMetadata.slug}/${props.clientContract.address}`}
+                >
+                  <Settings2Icon className="size-3.5 text-muted-foreground" />
+                  Manage Contract
+                </Link>
+              </Button>
+            </ToolTipLabel>
+          )}
 
           {validBlockExplorer && (
             <BadgeLink


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the use of the `useActiveAccount` hook to enhance the `ContractHeaderUI` component by conditionally rendering a tooltip and link for contract management based on the active user's account.

### Detailed summary
- Added the `useActiveAccount` hook to retrieve the active account.
- Conditionally rendered a `ToolTipLabel` with a management link if the contract creator matches the active account's address.
- Updated the button and link structure for contract management.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * “Manage Contract” action on ERC‑20 public pages is now shown only to the contract owner based on the currently connected account.
  * Non‑owners no longer see the management UI for contracts they don’t own.
  * Tooltip text/behavior unchanged; its container is conditionally rendered by ownership.
  * No changes to public APIs or external behaviors beyond conditional UI visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->