### PR TITLE
[React Native] Fix onDisconnect callback not being invoked

### DIFF
--- a/.changeset/many-tips-fail.md
+++ b/.changeset/many-tips-fail.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix onDisconnect not being invoked in react native

--- a/packages/thirdweb/src/react/native/ui/connect/ConnectedModal.tsx
+++ b/packages/thirdweb/src/react/native/ui/connect/ConnectedModal.tsx
@@ -293,7 +293,7 @@ const ViewFunds = (props: ConnectedModalPropsInner) => {
 };
 
 const DisconnectWallet = (props: ConnectedModalProps) => {
-  const { wallet, account, theme, onClose } = props;
+  const { wallet, account, theme, onClose, onDisconnect } = props;
   const { disconnect } = useDisconnect();
   const siweAuth = useSiweAuth(wallet, account, props.auth);
   return (
@@ -304,6 +304,10 @@ const DisconnectWallet = (props: ConnectedModalProps) => {
         if (siweAuth.isLoggedIn) {
           siweAuth.doLogout();
         }
+        onDisconnect?.({
+          wallet,
+          account,
+        });
       }}
       style={styles.walletMenuRow}
     >


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->
