### PR TITLE
[Playground] integration guide link in chat ai footer

### DIFF
--- a/apps/playground-web/src/app/ai/components/ChatPageContent.tsx
+++ b/apps/playground-web/src/app/ai/components/ChatPageContent.tsx
@@ -1,5 +1,9 @@
 "use client";
-import { ArrowRightIcon, MessageCircleIcon } from "lucide-react";
+import {
+  ArrowRightIcon,
+  ExternalLinkIcon,
+  MessageCircleIcon,
+} from "lucide-react";
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { defineChain, prepareTransaction, type ThirdwebClient } from "thirdweb";
@@ -346,8 +350,14 @@ export function ChatPageContent(props: {
               />
 
               {/* Footer disclaimer */}
-              <p className="mt-3 text-center text-muted-foreground text-xs opacity-75 lg:text-sm">
-                thirdweb AI can make mistakes. Please use with discretion
+              <p className="flex items-center justify-center gap-1 mt-3 text-center text-muted-foreground hover:text-foreground text-xs opacity-75 lg:text-sm">
+                <Link
+                  href="https://portal.thirdweb.com/ai/chat"
+                  target="_blank"
+                >
+                  Learn how to integrate thirdweb AI into your apps
+                </Link>
+                <ExternalLinkIcon className="size-3" />
               </p>
             </div>
           </div>
@@ -392,8 +402,14 @@ export function ChatPageContent(props: {
               />
 
               {/* Footer disclaimer */}
-              <p className="mt-3 text-center text-muted-foreground text-xs opacity-75 lg:text-sm">
-                thirdweb AI can make mistakes. Please use with discretion
+              <p className="flex items-center justify-center gap-1 mt-3 text-center text-muted-foreground hover:text-foreground text-xs opacity-75 lg:text-sm">
+                <Link
+                  href="https://portal.thirdweb.com/ai/chat"
+                  target="_blank"
+                >
+                  Learn how to integrate thirdweb AI into your apps
+                </Link>
+                <ExternalLinkIcon className="size-3" />
               </p>
             </div>
           </div>


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `ChatPageContent` component in the `playground-web` application by enhancing the footer disclaimer. It replaces the original text with a link to documentation on integrating thirdweb AI, while also adding an `ExternalLinkIcon`.

### Detailed summary
- Added `ExternalLinkIcon` import from `lucide-react`.
- Replaced the footer disclaimer text with a link to "Learn how to integrate thirdweb AI into your apps".
- Updated the footer to have a flex layout with centered items and a gap.
- Ensured the link opens in a new tab.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a footer link titled "Learn how to integrate thirdweb AI" that opens in a new tab and includes an external-link icon; applied across relevant chat page states.
* **Style**
  * Converted the disclaimer to a horizontal layout with improved spacing, gap and hover styling for clearer readability and interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->