### PR TITLE
Dashboard: Fix Active Users calculation in team and project analytics charts

### DIFF
--- a/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/analytics/highlights-card.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/analytics/highlights-card.tsx
@@ -76,9 +76,6 @@ export function TeamHighlightsCard({
           : "activeUsers"
       }
       aggregateFn={(_data, key) => {
-        if (key === "activeUsers") {
-          return Math.max(...timeSeriesData.map((d) => d[key]));
-        }
         return timeSeriesData.reduce((acc, curr) => acc + curr[key], 0);
       }}
       chartConfig={chartConfig}

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/overview/highlights-card.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/overview/highlights-card.tsx
@@ -70,9 +70,6 @@ export function ProjectHighlightsCard(props: {
           : "activeUsers"
       }
       aggregateFn={(_data, key) => {
-        if (key === "activeUsers") {
-          return Math.max(...timeSeriesData.map((d) => d[key]));
-        }
         return timeSeriesData.reduce((acc, curr) => acc + curr[key], 0);
       }}
       chartConfig={chartConfig}


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on the removal of redundant code in the `aggregateFn` function across two files, specifically in the `highlights-card.tsx` components for different paths.

### Detailed summary
- Removed the `if` condition checking for `key === "activeUsers"` in the `aggregateFn`.
- The logic for calculating the maximum active users is no longer present in both `highlights-card.tsx` files.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized analytics aggregation across Highlights cards: all metrics, including Active Users, now show the total over the selected period (Active Users previously showed the peak). Expect updated figures in Team Analytics Highlights and Project Overview Highlights and consistent summary vs. detailed views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->