### PR TITLE
Dashboard: use BuyWidget instead of CheckoutWidget in TransactionButton

### DIFF
--- a/apps/dashboard/src/@/components/tx-button/MismatchButton.tsx
+++ b/apps/dashboard/src/@/components/tx-button/MismatchButton.tsx
@@ -18,7 +18,7 @@ import {
 } from "thirdweb";
 import { type Chain, type ChainMetadata, localhost } from "thirdweb/chains";
 import {
-  CheckoutWidget,
+  BuyWidget,
   useActiveAccount,
   useActiveWallet,
   useActiveWalletChain,
@@ -267,14 +267,12 @@ export const MismatchButton = forwardRef<
             />
           )}
 
-          {dialog === "pay" && account && (
-            <CheckoutWidget
+          {dialog === "pay" && (
+            <BuyWidget
               className="!w-full"
               client={props.client}
               chain={txChain}
               amount="0.01"
-              name="Buy Funds"
-              seller={account.address as `0x${string}`}
               theme={getSDKTheme(theme === "dark" ? "dark" : "light")}
             />
           )}


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `MismatchButton` component by replacing the `CheckoutWidget` with the `BuyWidget` for handling payment interactions.

### Detailed summary
- Replaced `CheckoutWidget` with `BuyWidget` in the `MismatchButton` component.
- Removed the `name` and `seller` props from the `BuyWidget`.
- Retained the `client`, `chain`, and `amount` props in the updated widget.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Introduced a new Buy experience in the pay dialog for adding funds.

* Improvements
  * Streamlined purchase flow with fewer required inputs and a cleaner interface.
  * Pay dialog can be opened and initiated without first connecting a wallet/account.
  * Consistent styling and theming applied across the new purchase widget.

* Chores
  * Updated dependencies to use the latest purchase widget component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->