### PR TITLE
Add allowLinkingProfiles to useWalletDetailsModal hook

### DIFF
--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/Details.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/Details.tsx
@@ -895,6 +895,7 @@ export function DetailsModal(props: {
         client={client}
         closeModal={closeModal}
         locale={locale}
+        manageWallet={props.detailsModal?.manageWallet}
         onBack={() => {
           setScreen("main");
         }}
@@ -1671,6 +1672,18 @@ export type UseWalletDetailsModalOptions = {
    * @param screen The name of the screen that was being shown when user closed the modal
    */
   onClose?: (screen: string) => void;
+
+  /**
+   * Configure options for managing the connected wallet.
+   */
+  manageWallet?: {
+    /**
+     * Allow linking other profiles to the connected wallet.
+     *
+     * By default it is `true`.
+     */
+    allowLinkingProfiles?: boolean;
+  };
 };
 
 /**
@@ -1738,6 +1751,7 @@ export function useWalletDetailsModal() {
               hideReceiveFunds: props.hideReceiveFunds,
               hideSendFunds: props.hideSendFunds,
               hideSwitchWallet: props.hideSwitchWallet,
+              manageWallet: props.manageWallet,
               networkSelector: props.networkSelector,
               onClose: props.onClose,
               payOptions: props.payOptions,


### PR DESCRIPTION
```
[SDK] Feature: Add `allowLinkingProfiles` option to `useWalletDetailsModal`

BLD-125

## Notes for the reviewer

This PR exposes the `allowLinkingProfiles` option, previously only available in `ConnectButton`, to the `useWalletDetailsModal` hook. This allows users to hide the "Linked Profiles" section within the wallet details modal.

The default behavior remains `true` (linking profiles are shown), ensuring backward compatibility.

## How to test

1.  **Verify hidden linking profiles**:
    *   Use `useWalletDetailsModal` and call `detailsModal.open()` with `manageWallet: { allowLinkingProfiles: false }`.
    *   Confirm that the "Linked Profiles" section is hidden in the wallet details modal.
2.  **Verify visible linking profiles (default/explicit true)**:
    *   Use `useWalletDetailsModal` and call `detailsModal.open()` without the `manageWallet` option, or with `manageWallet: { allowLinkingProfiles: true }`.
    *   Confirm that the "Linked Profiles" section is visible in the wallet details modal.
```

---
[Slack Thread](https://thirdwebdev.slack.com/archives/C085FEPFLN9/p1755192390393989?thread_ts=1755192390.393989&cid=C085FEPFLN9)

<a href="https://cursor.com/background-agent?bcId=bc-242b5efc-f043-4b4f-a3a9-7c26f7dd4cf4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-242b5efc-f043-4b4f-a3a9-7c26f7dd4cf4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>



<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds functionality for managing connected wallets in the `useWalletDetailsModal` hook, allowing for options such as linking profiles to a wallet. 

### Detailed summary
- Added a new optional property `manageWallet` to the `UseWalletDetailsModalOptions` type.
- Introduced a sub-property `allowLinkingProfiles` under `manageWallet`, defaulting to `true`.
- Updated the `useWalletDetailsModal` function to include `manageWallet` from `props`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->