### PR TITLE
Rename `/nebula` to `/ai` and add redirect

### DIFF
--- a/apps/dashboard/framer-rewrites.js
+++ b/apps/dashboard/framer-rewrites.js
@@ -21,8 +21,8 @@ module.exports = [
   "/storage",
   // -- end scale category
 
-  // -- nebula
-  "/nebula",
+  // -- ai
+  "/ai",
   // -- contracts
   "/contracts",
   "/contracts/modular-contracts",

--- a/apps/dashboard/redirects.js
+++ b/apps/dashboard/redirects.js
@@ -460,6 +460,12 @@ async function redirects() {
       permanent: false,
       source: "/universal-bridge",
     },
+    // redirect /nebula to /ai
+    {
+      destination: "/ai",
+      permanent: false,
+      source: "/nebula",
+    },
     ...legacyDashboardToTeamRedirects,
     ...projectPageRedirects,
     ...teamPageRedirects,


### PR DESCRIPTION
### TL;DR

Renamed "nebula" to "ai" in navigation paths and added a redirect from the old path to the new one.

### What changed?

- Updated the framer-rewrites.js file to change "/nebula" to "/ai" in the navigation paths
- Added a new redirect in redirects.js to automatically redirect users from "/nebula" to "/ai"
- Updated the comment in framer-rewrites.js from "-- nebula" to "-- ai" to reflect the name change

### How to test?

1. Verify that navigating to "/ai" loads the correct page
2. Verify that navigating to "/nebula" automatically redirects to "/ai"
3. Check that all functionality previously available at "/nebula" is working correctly at "/ai"

### Why make this change?

This change renames the "nebula" feature to "ai" to better reflect its purpose and functionality, making it more intuitive for users to find and understand the AI-related features of the platform.