### PR TITLE
SDK, Dashboard: Fix error when airdropping decimal token amount in new token creation flow

### DIFF
--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/tokens/create/token/create-token-page-impl.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/tokens/create/token/create-token-page-impl.tsx
@@ -179,7 +179,7 @@ export function CreateTokenAssetPage(props: {
       chain: contract.chain,
       client: props.client,
       contents: values.airdropAddresses.map((recipient) => ({
-        amount: BigInt(recipient.quantity),
+        amount: recipient.quantity,
         recipient: recipient.address,
       })),
       tokenAddress: contract.address,
@@ -200,8 +200,8 @@ export function CreateTokenAssetPage(props: {
     const contract = getDeployedContract({ chain: values.chain });
 
     const totalAmountToAirdrop = values.airdropAddresses.reduce(
-      (acc, recipient) => acc + BigInt(recipient.quantity),
-      0n,
+      (acc, recipient) => acc + Number(recipient.quantity),
+      0,
     );
 
     const entrypoint = await getDeployedEntrypointERC20({

--- a/packages/thirdweb/src/tokens/types.ts
+++ b/packages/thirdweb/src/tokens/types.ts
@@ -22,7 +22,7 @@ export type PoolConfig = {
 };
 
 export type DistributeContent = {
-  amount: bigint;
+  amount: string;
   recipient: string;
 };
 


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on changing the type of the `amount` field from `bigint` to `string` in the `DistributeContent` type and updating related code to accommodate this change throughout the application.

### Detailed summary
- Updated `amount` type from `bigint` to `string` in `DistributeContent`.
- Adjusted mapping of `airdropAddresses` to use `recipient.quantity` directly as a `string`.
- Changed the calculation of `totalAmountToAirdrop` to sum `Number(recipient.quantity)` instead of `BigInt(recipient.quantity)`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistencies in token airdrop amount handling, ensuring accurate totals and smoother approvals.
  * Resolved submission issues caused by mismatched numeric formats during distribution.

* **Refactor**
  * Standardized how token distribution amounts are represented for better compatibility with forms and APIs.
  * Simplified airdrop calculations for improved reliability and user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->