### PR TITLE
Make RPC optional in chain infrastructure checkout

### DIFF
--- a/apps/dashboard/src/@/analytics/report.ts
+++ b/apps/dashboard/src/@/analytics/report.ts
@@ -526,3 +526,24 @@ export function reportTokenUpsellClicked(params: {
 }) {
   posthog.capture("token upsell clicked", params);
 }
+
+// ----------------------------
+// CHAIN INFRASTRUCTURE CHECKOUT
+// ----------------------------
+/**
+ * ### Why do we need to report this event?
+ * - To record explicit user acknowledgement when proceeding to checkout without RPC
+ * - To measure how often customers choose to omit RPC while purchasing Insight and/or Account Abstraction
+ * - To correlate potential support issues arising from missing RPC
+ *
+ * ### Who is responsible for this event?
+ * @jnsdls
+ */
+export function reportChainInfraRpcOmissionAgreed(properties: {
+  chainId: number;
+  frequency: "monthly" | "annual";
+  includeInsight: boolean;
+  includeAccountAbstraction: boolean;
+}) {
+  posthog.capture("chain infra checkout rpc omission agreed", properties);
+}

--- a/apps/dashboard/src/@/components/project/create-project-modal/index.tsx
+++ b/apps/dashboard/src/@/components/project/create-project-modal/index.tsx
@@ -1,5 +1,4 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import { DialogDescription } from "@radix-ui/react-dialog";
 import { useMutation } from "@tanstack/react-query";
 import type { ProjectService } from "@thirdweb-dev/service-utils";
 import { SERVICES } from "@thirdweb-dev/service-utils";
@@ -18,6 +17,7 @@ import {
   Dialog,
   DialogClose,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/infrastructure/deploy/search-params.ts
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/infrastructure/deploy/search-params.ts
@@ -3,4 +3,5 @@ import { parseAsString, parseAsStringEnum } from "nuqs/server";
 export const searchParams = {
   addons: parseAsString.withDefault(""),
   freq: parseAsStringEnum(["monthly", "annual"]).withDefault("monthly"),
+  rpc: parseAsStringEnum(["on", "off"]).withDefault("on"),
 };

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/engine/dedicated/(instance)/[engineId]/alerts/components/EngineDeleteAlertModal.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/engine/dedicated/(instance)/[engineId]/alerts/components/EngineDeleteAlertModal.tsx
@@ -1,8 +1,8 @@
-import { DialogDescription } from "@radix-ui/react-dialog";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/webhooks/components/delete-webhook-modal.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/webhooks/components/delete-webhook-modal.tsx
@@ -1,4 +1,3 @@
-import { DialogDescription } from "@radix-ui/react-dialog";
 import { AlertTriangleIcon } from "lucide-react";
 import type { WebhookConfig } from "@/api/project/webhook-configs";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -6,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,


### PR DESCRIPTION
### TL;DR

Made RPC optional in the Chain Infrastructure checkout flow, with a warning dialog when proceeding without it.

### What changed?

- Made RPC service optional instead of required in the Chain Infrastructure deployment form
- Added a warning dialog that appears when users try to proceed to checkout with Insight or Account Abstraction but without RPC
- Added analytics tracking for when users acknowledge the warning and proceed without RPC
- Updated the checkout logic to handle RPC as an optional service
- Added a new URL search parameter `rpc` to track the RPC selection state

### How to test?

1. Navigate to the Chain Infrastructure deployment page
2. Toggle off RPC while having Insight and/or Account Abstraction selected
3. Click "Proceed to Checkout"
4. Verify the warning dialog appears explaining the risks of proceeding without RPC
5. Confirm the dialog and verify the checkout process continues
6. Verify that selecting no services disables the checkout button

### Why make this change?

While RPC is recommended for optimal functionality of Insight and Account Abstraction services, some users may have their own RPC solutions or specific requirements. This change gives users more flexibility in their infrastructure choices while clearly communicating the potential risks and limitations of omitting RPC from their setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - RPC service is now optional with a toggle and updated labeling.
  - RPC selection persists via a URL parameter for easier sharing and revisit.
  - Pricing and discounts update dynamically based on selected addons, with bundle and annual discounts applied.
  - Checkout includes only chosen addons; a warning dialog appears if proceeding with other addons but without RPC, with an option to continue.
  - “Proceed to Checkout” is disabled when no services are selected.
  - UI copy updated to reflect RPC optionality.
  - Added analytics tracking when a user confirms proceeding without RPC.

- **Chores**
  - Unified dialog component imports to the project UI wrapper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->