### PR TITLE
[Dashboard] Fix: Do NOT use next's image component

### DIFF
--- a/apps/dashboard/src/app/pay/[id]/page.tsx
+++ b/apps/dashboard/src/app/pay/[id]/page.tsx
@@ -1,6 +1,5 @@
 import { ShieldCheckIcon } from "lucide-react";
 import type { Metadata } from "next";
-import Image from "next/image";
 import { Bridge, defineChain, toTokens } from "thirdweb";
 import { getChainMetadata } from "thirdweb/chains";
 import { shortenAddress } from "thirdweb/utils";
@@ -86,7 +85,7 @@ export default async function PayPage({
         <div>
           <div className="flex flex-row items-center justify-start gap-4">
             {projectMetadata.image && (
-              <Image
+              <img
                 src={
                   resolveSchemeWithErrorHandler({
                     uri: projectMetadata.image,


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on replacing the `Image` component from `next/image` with a standard HTML `<img>` tag in the `PayPage` component of the dashboard application.

### Detailed summary
- Replaced the `Image` component with an `<img>` tag for rendering the project image.
- Adjusted the JSX structure to accommodate the change in image rendering.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the project image in the Pay page header to use a standard image element, preserving the existing source resolution and width/height.
  * Images now load directly without framework-specific effects (such as placeholders or automatic lazy loading), maintaining the current visual appearance for end users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->