### PR TITLE
Feature: predictAddress token function

### DIFF
--- a/.changeset/hot-showers-throw.md
+++ b/.changeset/hot-showers-throw.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Adds predictAddress token extension function

--- a/packages/thirdweb/src/exports/tokens.ts
+++ b/packages/thirdweb/src/exports/tokens.ts
@@ -13,6 +13,7 @@ export {
   getDeployedEntrypointERC20,
 } from "../tokens/get-entrypoint-erc20.js";
 export { isPoolRouterEnabled } from "../tokens/is-router-enabled.js";
+export { predictAddress } from "../tokens/predict-address.js";
 export {
   generateSalt,
   SaltFlag,

--- a/packages/thirdweb/src/tokens/predict-address.ts
+++ b/packages/thirdweb/src/tokens/predict-address.ts
@@ -1,0 +1,48 @@
+import { bytesToHex, randomBytes } from "@noble/hashes/utils";
+import type { Hex } from "viem";
+import { predictAddress as _predictAddress } from "../extensions/tokens/__generated__/ERC20Entrypoint/read/predictAddress.js";
+import { padHex, toHex } from "../utils/encoding/hex.js";
+import { DEFAULT_DEVELOPER_ADDRESS } from "./constants.js";
+import { getDeployedEntrypointERC20 } from "./get-entrypoint-erc20.js";
+import {
+  encodeInitParams,
+  encodePoolConfig,
+  generateSalt,
+} from "./token-utils.js";
+import type { CreateTokenOptions } from "./types.js";
+
+export async function predictAddress(options: CreateTokenOptions) {
+  const { client, account, params, launchConfig } = options;
+
+  const creator = params.owner || account.address;
+  const encodedInitData = await encodeInitParams({
+    client,
+    creator,
+    params,
+  });
+
+  const salt: Hex = generateSalt(options.salt || bytesToHex(randomBytes(31)));
+
+  const entrypoint = await getDeployedEntrypointERC20(options);
+
+  let hookData: Hex = "0x";
+  let contractId = padHex(toHex("ERC20Asset"), { size: 32 });
+  if (launchConfig?.kind === "pool") {
+    hookData = encodePoolConfig(launchConfig.config);
+    contractId = padHex(toHex("ERC20Asset_Pool"), { size: 32 });
+  }
+
+  const address = await _predictAddress({
+    contract: entrypoint,
+    contractId,
+    params: {
+      data: encodedInitData,
+      hookData,
+      developer: options.developerAddress || DEFAULT_DEVELOPER_ADDRESS,
+      salt,
+    },
+    creator,
+  });
+
+  return address;
+}


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `predictAddress` function to the `thirdweb` token extension, allowing for the prediction of contract addresses based on provided parameters and configurations.

### Detailed summary
- Added `predictAddress` function in `packages/thirdweb/src/tokens/predict-address.ts`.
- Imported necessary utilities and types for the function.
- Encodes initialization parameters and generates a unique salt.
- Handles different configurations for contract types, including pools.
- Returns the predicted address based on the configured parameters.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a predictAddress function so users can obtain a token contract's predicted deployment address before creation; supports standard and pool token deployments.

- **Chores**
  - Added a changeset to publish this update as a patch release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->