### PR TITLE
Always show Chain Infrastructure in sidebar regardless of subscriptions

### DIFF
--- a/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/TeamSidebarLayout.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/TeamSidebarLayout.tsx
@@ -40,6 +40,8 @@ export function TeamSidebarLayout(props: {
           icon: ChartNoAxesColumnIcon,
           label: "Analytics",
         },
+        // ecosystem below here
+        // TODO: make this one link to an overview page that has a list of all the ecosystems currently deployed
         {
           links: [
             ...props.ecosystems.map((ecosystem) => ({
@@ -66,29 +68,28 @@ export function TeamSidebarLayout(props: {
           icon: DatabaseIcon,
           label: "Usage",
         },
-        ...(props.chainSubscriptions.length > 0
-          ? [
-              {
-                separator: true,
-              } as const,
-              {
-                links: [
-                  ...props.chainSubscriptions.map((chainSubscription) => ({
-                    href: `${layoutPath}/~/infrastructure/${chainSubscription.slug}`,
-                    label: chainSubscription.chainName,
-                  })),
-                  {
-                    href: `${layoutPath}/~/infrastructure/deploy`,
-                    label: "Deploy Infrastructure",
-                  },
-                ],
-                subMenu: {
-                  icon: WalletCardsIcon,
-                  label: "Chain Infrastucture",
-                },
-              },
-            ]
-          : []),
+
+        {
+          separator: true,
+        } as const,
+        // infrastructure below here
+        // TODO: make this one link to an overview page that has a list of all the chains currently deployed
+        {
+          links: [
+            ...props.chainSubscriptions.map((chainSubscription) => ({
+              href: `${layoutPath}/~/infrastructure/${chainSubscription.slug}`,
+              label: chainSubscription.chainName,
+            })),
+            {
+              href: `${layoutPath}/~/infrastructure/deploy`,
+              label: "Deploy Infrastructure",
+            },
+          ],
+          subMenu: {
+            icon: WalletCardsIcon,
+            label: "Chain Infrastucture",
+          },
+        },
       ]}
       footerSidebarLinks={[
         {


### PR DESCRIPTION
### TL;DR

Always display the Chain Infrastructure section in the team sidebar, even when no chain subscriptions exist.

### What changed?

Modified the `TeamSidebarLayout.tsx` file to:
- Always render the Chain Infrastructure section in the sidebar instead of conditionally showing it only when chain subscriptions exist
- Added TODO comments to create overview pages for ecosystems and chains
- Added a separator before the infrastructure section to visually distinguish it from other sections

### How to test?

1. Navigate to a team page with no chain subscriptions
2. Verify that the Chain Infrastructure section appears in the sidebar
3. Check that the separator appears correctly before the infrastructure section
4. Confirm that teams with existing chain subscriptions still display correctly

### Why make this change?

This change improves UI consistency by always showing the infrastructure section, making it discoverable for teams that haven't deployed any chains yet. The added TODOs also indicate future improvements to create overview pages for better navigation.