### PR TITLE
add webhook id to test webhook

### DIFF
--- a/apps/dashboard/src/@/api/insight/webhooks.ts
+++ b/apps/dashboard/src/@/api/insight/webhooks.ts
@@ -58,6 +58,7 @@ interface WebhookSingleResponse {
 }
 
 interface TestWebhookPayload {
+  webhook_id?: string;
   webhook_url: string;
   type?: "event" | "transaction";
 }

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/webhooks/hooks/useTestWebhook.ts
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/webhooks/hooks/useTestWebhook.ts
@@ -41,7 +41,7 @@ export function useTestWebhook(clientId: string) {
       });
 
       const result = await testWebhook(
-        { type, webhook_url: webhookUrl },
+        { type, webhook_url: webhookUrl, webhook_id: id },
         clientId,
       );
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces an optional `webhook_id` property to the `TestWebhookPayload` interface and updates the `testWebhook` function call to include this new property.

### Detailed summary
- Added an optional `webhook_id` property to the `TestWebhookPayload` interface in `webhooks.ts`.
- Updated the `testWebhook` function call in `useTestWebhook.ts` to include `webhook_id` when calling the function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Test Webhook requests now include the webhook ID when available, ensuring the test targets the correct webhook and improving reliability.
  * Payload now consistently includes the webhook identifier field (may be empty if not provided), with no other behavioral changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->