### PR TITLE
[Dashboard] Fix date handling in analytics components

### DIFF
--- a/apps/dashboard/src/@/components/analytics/date-range-selector.tsx
+++ b/apps/dashboard/src/@/components/analytics/date-range-selector.tsx
@@ -86,7 +86,9 @@ export function getLastNDaysRange(id: DurationId) {
     throw new Error(`Invalid duration id: ${id}`);
   }
 
-  const todayDate = new Date(Date.now());
+  const todayDate = new Date();
+  todayDate.setDate(todayDate.getDate() + 1); // Move to next day
+  todayDate.setHours(0, 0, 0, 0); // Set to start of next day (00:00)
 
   const value: Range = {
     from: subDays(todayDate, durationInfo.days),

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/overview/highlights-card.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/overview/highlights-card.tsx
@@ -105,25 +105,26 @@ function processTimeSeriesData(
   volumeStats: UniversalBridgeStats[],
 ): TimeSeriesMetrics[] {
   const metrics: TimeSeriesMetrics[] = [];
-  const dates = [...new Set(userStats.map((a) => a.date))];
+  const dates = [
+    ...new Set([
+      ...userStats.map((a) => new Date(a.date).toISOString().slice(0, 10)),
+      ...volumeStats.map((a) => new Date(a.date).toISOString().slice(0, 10)),
+    ]),
+  ];
 
   for (const date of dates) {
     const activeUsers = userStats
-      .filter(
-        (u) => new Date(u.date).toISOString() === new Date(date).toISOString(),
-      )
+      .filter((u) => new Date(u.date).toISOString().slice(0, 10) === date)
       .reduce((acc, curr) => acc + curr.uniqueWalletsConnected, 0);
 
     const newUsers = userStats
-      .filter(
-        (u) => new Date(u.date).toISOString() === new Date(date).toISOString(),
-      )
+      .filter((u) => new Date(u.date).toISOString().slice(0, 10) === date)
       .reduce((acc, curr) => acc + curr.newUsers, 0);
 
     const volume = volumeStats
       .filter(
         (v) =>
-          new Date(v.date).toISOString() === new Date(date).toISOString() &&
+          new Date(v.date).toISOString().slice(0, 10) === date &&
           v.status === "completed",
       )
       .reduce((acc, curr) => acc + curr.amountUsdCents / 100, 0);
@@ -131,7 +132,7 @@ function processTimeSeriesData(
     const fees = volumeStats
       .filter(
         (v) =>
-          new Date(v.date).toISOString() === new Date(date).toISOString() &&
+          new Date(v.date).toISOString().slice(0, 10) === date &&
           v.status === "completed",
       )
       .reduce((acc, curr) => acc + curr.developerFeeUsdCents / 100, 0);

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/wallets/analytics/chart/index.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/wallets/analytics/chart/index.tsx
@@ -40,7 +40,7 @@ type AsyncInAppWalletAnalyticsProps = Omit<
 async function AsyncInAppWalletAnalytics(
   props: AsyncInAppWalletAnalyticsProps,
 ) {
-  const range = props.range ?? getLastNDaysRange("last-120");
+  const range = props.range ?? getLastNDaysRange("last-30");
 
   const stats = await getInAppWalletUsage(
     {


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying date handling and analytics calculations in the `wallets` and `highlights-card` components to improve data accuracy and adjust the date range for analytics.

### Detailed summary
- Changed the default date range from `"last-120"` to `"last-30"` in `index.tsx`.
- Updated `todayDate` to set it to the start of the next day in `date-range-selector.tsx`.
- Enhanced date filtering logic in `highlights-card.tsx` to ensure consistency by using `slice(0, 10)` for date comparisons.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected date range handling to make the end date inclusive by using the start of the next day.
  - Standardized date-only comparisons across analytics to align user and volume metrics, ensuring accurate daily counts and totals.
- Improvements
  - Unified time-series date axis across datasets for clearer, consistent charts.
  - Default analytics window for In-App Wallets now shows the last 30 days (was 120), offering a more focused view by default.
  - Metrics now consistently reflect only completed transactions for volume and fees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->