### PR TITLE
Remove "dedicated" from Engine URLs

### DIFF
--- a/apps/dashboard/src/@/hooks/useEngine.ts
+++ b/apps/dashboard/src/@/hooks/useEngine.ts
@@ -1662,7 +1662,7 @@ export function useEngineSystemMetrics(
     queryFn: async () => {
       const res = await apiServerProxy({
         method: "GET",
-        pathname: `/v1/teams/${teamIdOrSlug}/${projectSlug}/engine/dedicated/${engineId}/metrics`,
+        pathname: `/v1/teams/${teamIdOrSlug}/${projectSlug}/engine/${engineId}/metrics`,
       });
 
       if (!res.ok) {

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/engine/(general)/overview/engine-instances-table.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/engine/(general)/overview/engine-instances-table.tsx
@@ -954,7 +954,7 @@ function EmptyEngineState(props: { team: Team; projectSlug: string }) {
                 variant="default"
               >
                 <Link
-                  href={`/team/${props.team.slug}/${props.projectSlug}/engine/dedicated/import`}
+                  href={`/team/${props.team.slug}/${props.projectSlug}/engine`}
                 >
                   Import self-hosted Engine
                   <ArrowRightIcon size={16} />

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/engine/(general)/page.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/engine/(general)/page.tsx
@@ -25,7 +25,7 @@ export default async function Page(props: {
 
   if (searchParams.importUrl) {
     redirect(
-      `/team/${params.team_slug}/${params.project_slug}/engine/dedicated/import?importUrl=${searchParams.importUrl}`,
+      `/team/${params.team_slug}/${params.project_slug}/engine?importUrl=${searchParams.importUrl}`,
     );
   }
 
@@ -35,9 +35,7 @@ export default async function Page(props: {
   ]);
 
   if (!authToken) {
-    loginRedirect(
-      `/team/${params.team_slug}/${params.project_slug}/engine/dedicated`,
-    );
+    loginRedirect(`/team/${params.team_slug}/${params.project_slug}/engine`);
   }
 
   if (!team) {

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/engine/(instance)/[engineId]/configuration/components/engine-wallet-config.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/engine/(instance)/[engineId]/configuration/components/engine-wallet-config.tsx
@@ -73,7 +73,7 @@ export function EngineWalletConfig({
         <p className="text-muted-foreground text-sm">
           Create backend wallets on the{" "}
           <UnderlineLink
-            href={`/team/${teamSlug}/${projectSlug}/engine/dedicated/${instance.id}`}
+            href={`/team/${teamSlug}/${projectSlug}/engine/${instance.id}`}
           >
             Overview
           </UnderlineLink>{" "}

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/engine/(instance)/[engineId]/layout.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/engine/(instance)/[engineId]/layout.tsx
@@ -30,7 +30,7 @@ export default async function Layout(props: {
 
   if (!authToken) {
     loginRedirect(
-      `/team/${params.team_slug}/${params.project_slug}/engine/dedicated/${params.engineId}`,
+      `/team/${params.team_slug}/${params.project_slug}/engine/${params.engineId}`,
     );
   }
 
@@ -41,7 +41,7 @@ export default async function Layout(props: {
     teamIdOrSlug: params.team_slug,
   });
 
-  const engineRootLayoutPath = `/team/${params.team_slug}/${params.project_slug}/engine/dedicated`;
+  const engineRootLayoutPath = `/team/${params.team_slug}/${params.project_slug}/engine`;
 
   if (!instance) {
     return (

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/engine/(instance)/[engineId]/metrics/components/EngineSystemMetrics.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/engine/(instance)/[engineId]/metrics/components/EngineSystemMetrics.tsx
@@ -51,7 +51,7 @@ export function EngineSystemMetrics({
           <AlertDescription className="text-muted-foreground text-sm">
             Upgrade to a{" "}
             <UnderlineLink
-              href={`/team/${teamSlug}/${projectSlug}/engine/dedicated/create`}
+              href={`/team/${teamSlug}/${projectSlug}/engine/create`}
               rel="noopener noreferrer"
               target="_blank"
             >

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/engine/(instance)/[engineId]/overview/components/create-backend-wallet-button.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/engine/(instance)/[engineId]/overview/components/create-backend-wallet-button.tsx
@@ -184,7 +184,7 @@ export const CreateBackendWalletButton: React.FC<
                         Provide your credentials on the{" "}
                         <Link
                           className="text-link-foreground hover:text-foreground"
-                          href={`/team/${teamSlug}/${projectSlug}/engine/dedicated/${instance.id}/configuration`}
+                          href={`/team/${teamSlug}/${projectSlug}/engine/${instance.id}/configuration`}
                         >
                           Configuration
                         </Link>{" "}
@@ -241,7 +241,7 @@ export const CreateBackendWalletButton: React.FC<
                               wallet. You can find this in the{" "}
                               <Link
                                 className="text-link-foreground hover:text-foreground"
-                                href={`/team/${teamSlug}/${projectSlug}/engine/dedicated/${instance.id}/wallet-credentials`}
+                                href={`/team/${teamSlug}/${projectSlug}/engine/${instance.id}/wallet-credentials`}
                               >
                                 Wallet Credentials
                               </Link>{" "}

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/engine/(instance)/[engineId]/overview/components/engine-overview.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/engine/(instance)/[engineId]/overview/components/engine-overview.tsx
@@ -98,7 +98,7 @@ function BackendWalletsSection(props: {
           <p className="text-muted-foreground text-sm leading-relaxed">
             Set up other wallet types from the{" "}
             <UnderlineLink
-              href={`/team/${teamSlug}/${projectSlug}/engine/dedicated/${instance.id}/configuration`}
+              href={`/team/${teamSlug}/${projectSlug}/engine/${instance.id}/configuration`}
             >
               Configuration
             </UnderlineLink>{" "}

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/engine/(instance)/[engineId]/overview/components/import-backend-wallet-button.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/engine/(instance)/[engineId]/overview/components/import-backend-wallet-button.tsx
@@ -194,7 +194,7 @@ export const ImportBackendWalletButton: React.FC<
                         Provide your credentials on the{" "}
                         <Link
                           className="text-link-foreground hover:text-foreground"
-                          href={`/team/${teamSlug}/${projectSlug}/engine/dedicated/${instance.id}/configuration`}
+                          href={`/team/${teamSlug}/${projectSlug}/engine/${instance.id}/configuration`}
                         >
                           Configuration
                         </Link>{" "}

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/engine/_utils/getEngineInstancePageMeta.ts
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/engine/_utils/getEngineInstancePageMeta.ts
@@ -11,7 +11,7 @@ export async function engineInstancePageHandler(params: {
   projectSlug: string;
   engineId: string;
 }) {
-  const pagePath = `/team/${params.teamSlug}/${params.projectSlug}/engine/dedicated/${params.engineId}/access-tokens`;
+  const pagePath = `/team/${params.teamSlug}/${params.projectSlug}/engine/${params.engineId}/access-tokens`;
 
   const [authToken, account, team] = await Promise.all([
     getAuthToken(),


### PR DESCRIPTION
### TL;DR

Updated URL paths for Engine instances by removing the "dedicated" segment from all routes.

### What changed?

- Removed the `/dedicated` segment from all Engine-related URL paths in API calls and internal links
- Updated API endpoint from `/v1/teams/${teamIdOrSlug}/${projectSlug}/engine/dedicated/${engineId}/metrics` to `/v1/teams/${teamIdOrSlug}/${projectSlug}/engine/${engineId}/metrics`
- Updated all internal navigation links to use the simplified path structure
- Modified redirect paths to match the new URL pattern

### How to test?

1. Navigate through the Engine UI and verify all links work correctly
2. Test the import functionality with the new URL structure
3. Verify API calls for metrics and other Engine-related endpoints function properly
4. Check that all redirects work as expected, especially for login redirects

### Why make this change?

This change simplifies the URL structure for Engine instances by removing the redundant "dedicated" segment from all paths. This creates a more consistent and cleaner URL pattern throughout the application, making navigation more intuitive and reducing path complexity.