### PR TITLE
Remove "dedicated" from engine URLs

### DIFF
--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/engine/(general)/_components.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/engine/(general)/_components.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { Button } from "@/components/ui/button";
 
 function EngineInfoSection(props: { team_slug: string; project_slug: string }) {
-  const engineLinkPrefix = `/team/${props.team_slug}/${props.project_slug}/engine/dedicated`;
+  const engineLinkPrefix = `/team/${props.team_slug}/${props.project_slug}/engine`;
 
   return (
     <div className="">

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/engine/(general)/import/import-engine-dialog.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/engine/(general)/import/import-engine-dialog.tsx
@@ -83,9 +83,7 @@ export function ImportEngineButton(props: {
   const importMutation = useMutation({
     mutationFn: async (importParams: ImportEngineParams) => {
       await importEngine({ ...importParams, teamIdOrSlug: props.teamSlug });
-      router.push(
-        `/team/${props.teamSlug}/${props.projectSlug}/engine/dedicated`,
-      );
+      router.push(`/team/${props.teamSlug}/${props.projectSlug}/engine`);
     },
   });
 

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/engine/(general)/overview/engine-list.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/engine/(general)/overview/engine-list.tsx
@@ -8,7 +8,7 @@ export const EngineInstancesList = (props: {
   projectSlug: string;
   instances: EngineInstance[];
 }) => {
-  const engineLinkPrefix = `/team/${props.team.slug}/${props.projectSlug}/engine/dedicated`;
+  const engineLinkPrefix = `/team/${props.team.slug}/${props.projectSlug}/engine`;
 
   return (
     <div className="flex grow flex-col gap-12">

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/engine/(instance)/[engineId]/_components/EnginePageLayout.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/engine/(instance)/[engineId]/_components/EnginePageLayout.tsx
@@ -54,7 +54,7 @@ export function EngineSidebarLayout(props: {
   projectSlug: string;
   children: React.ReactNode;
 }) {
-  const rootPath = `/team/${props.teamSlug}/${props.projectSlug}/engine/dedicated`;
+  const rootPath = `/team/${props.teamSlug}/${props.projectSlug}/engine`;
 
   const links: SidebarLink[] = sidebarLinkMeta.map((linkMeta) => {
     return {

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/engine/(instance)/[engineId]/_components/EnsureEnginePermission.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/engine/(instance)/[engineId]/_components/EnsureEnginePermission.tsx
@@ -17,7 +17,7 @@ export function EnsureEnginePermission(props: {
   instance: EngineInstance;
 }) {
   const { instance } = props;
-  const rootPath = `/team/${props.teamSlug}/${props.projectSlug}/engine/dedicated`;
+  const rootPath = `/team/${props.teamSlug}/${props.projectSlug}/engine`;
 
   const permissionQuery = useQuery({
     queryFn: () => {


### PR DESCRIPTION
### TL;DR

Updated engine URL paths by removing the `/dedicated` segment from all engine-related navigation links.

### What changed?

Modified the engine URL path structure across multiple components by removing the `/dedicated` segment from the path. The changes affect:

- Engine info section navigation links
- Import engine redirect path
- Engine instances list links
- Engine sidebar layout paths
- Engine permission check paths

All paths now use the simplified format: `/team/{team_slug}/{project_slug}/engine` instead of `/team/{team_slug}/{project_slug}/engine/dedicated`.

### How to test?

1. Navigate to the engine pages for a project
2. Verify all links work correctly with the new URL structure
3. Test the import engine functionality to ensure it redirects to the correct page
4. Check that the sidebar navigation works properly with the updated paths

### Why make this change?

This change simplifies the URL structure for engine-related pages, making the paths more intuitive and consistent. Removing the `/dedicated` segment streamlines navigation and creates a cleaner URL hierarchy.