### PR TITLE
Clarify authentication flows in wallet API docs

### DIFF
--- a/apps/portal/src/app/wallets/page.mdx
+++ b/apps/portal/src/app/wallets/page.mdx
@@ -72,13 +72,14 @@ Create wallets for your users with flexible authentication options. Choose from 
 
 ## API Authentication
 
-Authenticating a user is done in two steps:
+For email, phone, passkey, or SIWE authentication, a two-step process is used:
+- Initiate authentication to get a challenge
+- Complete authentication with the challenge response
 
-1. Initiate authentication
-2. Complete authentication
+For guest or custom (jwt/auth-payload) authentication, you can skip the first step and directly use the `/v1/auth/complete` endpoint with the required parameters.
 
 ### Initiate Authentication
-Start authentication with email, phone, passkey, or social providers
+Start authentication with email, phone, passkey, or SIWE
 
 <OpenApiEndpoint path="/v1/auth/initiate" method="POST" />
 
@@ -86,6 +87,15 @@ Start authentication with email, phone, passkey, or social providers
 Verify and complete the authentication process:
 
 <OpenApiEndpoint path="/v1/auth/complete" method="POST" />
+
+## Social Authentication
+
+### Single Step Flow
+OAuth is done in a single step using a dedicated endpoint.
+
+Visit the API reference for more details on the available social providers and code snippets.
+
+<OpenApiEndpoint path="/v1/auth/social" method="GET" />
 
 ### Get Wallet Information
 Retrieve authenticated user's wallet details:


### PR DESCRIPTION
Updated the documentation to distinguish between two-step authentication for email, phone, passkey, and SIWE, and single-step flows for guest, custom, and social authentication. Added details and endpoint references for each flow to improve clarity for API users.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the API Authentication documentation to clarify the authentication processes, including a new section on social authentication.

### Detailed summary
- Revised the explanation of the authentication process for clarity.
- Added details about skipping the first step for guest or custom authentication.
- Introduced a new section on `Social Authentication` with a single-step flow.
- Updated the endpoint descriptions for clarity.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified API Authentication flows: explicit two-step flow for email, phone, passkey, or SIWE (initiate to get a challenge, then complete) and a skip-first-step path for guest/custom auth.
  * Updated headings and examples to reflect the revised two-step flow.
  * Added Social Authentication section describing a single-step OAuth flow via a dedicated endpoint with links to provider details and code samples.
  * Moved Get Wallet Information after authentication for clearer sequencing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->