### PR TITLE
Rename "Payment Links" to "Payments" in UI text

### DIFF
--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/payments/links/components/PaymentLinksTable.client.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/payments/links/components/PaymentLinksTable.client.tsx
@@ -44,9 +44,9 @@ export function PaymentLinksTable(props: { clientId: string; teamId: string }) {
   return (
     <section>
       <div className="mb-4">
-        <h2 className="font-semibold text-xl tracking-tight">Payment Links</h2>
+        <h2 className="font-semibold text-xl tracking-tight">Payments</h2>
         <p className="text-muted-foreground text-sm">
-          Payment links you have created in this project.
+          Payments you have created in this project.
         </p>
       </div>
       <PaymentLinksTableInner clientId={props.clientId} teamId={props.teamId} />

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/payments/page.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/payments/page.tsx
@@ -67,7 +67,7 @@ export default async function Page(props: {
               >
                 <Button className="gap-1.5 rounded-full">
                   <PlusIcon className="size-4" />
-                  Create Payment Link
+                  Create Payment
                 </Button>
               </CreatePaymentLinkButton>
             ),


### PR DESCRIPTION
### TL;DR

Updated payment-related terminology in the dashboard UI to be more concise.

### What changed?

- Changed "Payment Links" heading to "Payments"
- Updated the description text from "Payment links you have created in this project" to "Payments you have created in this project"
- Changed the button text from "Create Payment Link" to "Create Payment"

### How to test?

1. Navigate to the payments section in the dashboard
2. Verify the heading now displays "Payments" instead of "Payment Links"
3. Confirm the description text has been updated
4. Check that the create button now says "Create Payment"

### Why make this change?

This change simplifies the terminology used in the payments section, making the UI more concise and user-friendly. The more generic "Payments" term better encompasses the functionality while reducing redundancy in the interface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Payments section header from “Payment Links” to “Payments.”
  * Revised description to “Payments you have created in this project.”
  * Changed primary action label from “Create Payment Link” to “Create Payment” for consistency.
  * These are copy/label updates only; no functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->