### PR TITLE
Type profile details by auth provider

### DIFF
--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/WalletRow.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/WalletRow.tsx
@@ -12,6 +12,7 @@ import {
   useWalletInfo,
 } from "../../../../../../core/utils/wallet.js";
 import { useProfiles } from "../../../../../hooks/wallets/useProfiles.js";
+import { getProfileEmail } from "../../../../../../../wallets/in-app/core/authentication/types.js";
 import { Container } from "../../../../components/basic.js";
 import { Skeleton } from "../../../../components/Skeleton.js";
 import { Text } from "../../../../components/text.js";
@@ -36,7 +37,12 @@ export function WalletRow(props: {
     (wallet.id === "inApp" ||
       isEcosystemWallet(wallet) ||
       isSmartWallet(wallet))
-      ? profile.data?.find((p) => !!p.details.email)?.details.email
+      ? (() => {
+          const profileWithEmail = profile.data?.find((p) => {
+            return getProfileEmail(p) !== undefined;
+          });
+          return profileWithEmail ? getProfileEmail(profileWithEmail) : undefined;
+        })()
       : undefined;
   const walletInfo = useWalletInfo(wallet?.id);
   const ensNameQuery = useEnsName({

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/LinkedProfilesScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/LinkedProfilesScreen.tsx
@@ -4,6 +4,7 @@ import type { ThirdwebClient } from "../../../../../client/client.js";
 import { useUnlinkProfile } from "../../../../../react/web/hooks/wallets/useUnlinkProfile.js";
 import { shortenAddress } from "../../../../../utils/address.js";
 import type { Profile } from "../../../../../wallets/in-app/core/authentication/types.js";
+import { getProfileEmail, getProfilePhone, getProfileAddress } from "../../../../../wallets/in-app/core/authentication/types.js";
 import { fontSize, iconSize } from "../../../../core/design-system/index.js";
 import { useSocialProfiles } from "../../../../core/social/useSocialProfiles.js";
 import { getSocialIcon } from "../../../../core/utils/walletIcon.js";
@@ -24,18 +25,21 @@ import { MenuButton } from "../MenuButton.js";
 import type { WalletDetailsModalScreen } from "./types.js";
 
 function getProfileDisplayName(profile: Profile) {
+  const email = getProfileEmail(profile);
+  const phone = getProfilePhone(profile);
+  const address = getProfileAddress(profile);
+  
   switch (true) {
-    case profile.type === "email" && profile.details.email !== undefined:
-      return profile.details.email;
-    case profile.type === "google" && profile.details.email !== undefined:
-      return profile.details.email;
-    case profile.type === "phone" && profile.details.phone !== undefined:
-      return profile.details.phone;
-    case profile.details.address !== undefined:
-      return shortenAddress(profile.details.address, 6);
-    case (profile.type as string) === "cognito" &&
-      profile.details.email !== undefined:
-      return profile.details.email;
+    case profile.type === "email" && email !== undefined:
+      return email;
+    case profile.type === "google" && email !== undefined:
+      return email;
+    case profile.type === "phone" && phone !== undefined:
+      return phone;
+    case address !== undefined:
+      return shortenAddress(address, 6);
+    case (profile.type as string) === "cognito" && email !== undefined:
+      return email;
     case (profile.type as string).toLowerCase() === "custom_auth_endpoint":
       return "Custom Profile";
     default:
@@ -128,8 +132,9 @@ function LinkedProfile({
   enableUnlinking: boolean;
   client: ThirdwebClient;
 }) {
+  const profileAddress = getProfileAddress(profile);
   const { data: socialProfiles } = useSocialProfiles({
-    address: profile.details.address,
+    address: profileAddress,
     client,
   });
   const { mutate: unlinkProfileMutation, isPending } = useUnlinkProfile();
@@ -154,7 +159,7 @@ function LinkedProfile({
           }}
           width={iconSize.lg}
         />
-      ) : profile.details.address !== undefined ? (
+      ) : profileAddress !== undefined ? (
         <Container
           style={{
             borderRadius: "100%",
@@ -163,7 +168,7 @@ function LinkedProfile({
             width: "32px",
           }}
         >
-          <Blobbie address={profile.details.address} size={32} />
+          <Blobbie address={profileAddress} size={32} />
         </Container>
       ) : profile.type === "passkey" ? (
         <FingerPrintIcon size={iconSize.lg} />
@@ -202,9 +207,9 @@ function LinkedProfile({
           }}
         >
           {socialProfiles?.find((p) => p.avatar)?.name &&
-            profile.details.address && (
+            profileAddress && (
               <Text color="secondaryText" size="sm">
-                {shortenAddress(profile.details.address, 4)}
+                {shortenAddress(profileAddress, 4)}
               </Text>
             )}
           {enableUnlinking && (

--- a/packages/thirdweb/src/wallets/in-app/core/authentication/types.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/authentication/types.ts
@@ -2,7 +2,7 @@ import type { Chain } from "../../../../chains/types.js";
 import type { ThirdwebClient } from "../../../../client/client.js";
 import type { Address } from "../../../../utils/address.js";
 import type { Account, Wallet } from "../../../interfaces/wallet.js";
-import type { AuthOption, OAuthOption } from "../../../types.js";
+import type { OAuthOption } from "../../../types.js";
 import type { Ecosystem } from "../wallet/types.js";
 
 export type MultiStepAuthProviderType =
@@ -115,16 +115,298 @@ export type OAuthRedirectObject = {
   redirectUrl: string;
 };
 
-// TODO: type this better for each auth provider
-export type Profile = {
-  type: AuthOption;
+// Provider-specific profile types based on auth provider
+export type GoogleProfile = {
+  type: "google";
   details: {
-    id?: string;
-    email?: string;
-    phone?: string;
-    address?: Address;
+    email: string;
+    emailVerified: boolean;
+    familyName?: string;
+    givenName?: string;
+    hd: string;
+    id: string;
+    locale: string;
+    name?: string;
+    picture: string;
   };
 };
+
+export type FacebookProfile = {
+  type: "facebook";
+  details: {
+    email?: string;
+    firstName?: string;
+    id: string;
+    lastName?: string;
+    name?: string;
+    picture?: string;
+  };
+};
+
+export type AppleProfile = {
+  type: "apple";
+  details: {
+    email?: string;
+    emailVerified: boolean;
+    id: string;
+    isPrivateEmail: boolean;
+  };
+};
+
+export type GitHubProfile = {
+  type: "github";
+  details: {
+    avatar?: string | null;
+    id: string;
+    name?: string | null;
+    username: string;
+  };
+};
+
+export type DiscordProfile = {
+  type: "discord";
+  details: {
+    avatar: string;
+    email?: string;
+    emailVerified: boolean;
+    id: string;
+    username: string;
+  };
+};
+
+export type CoinbaseProfile = {
+  type: "coinbase";
+  details: {
+    avatar?: string;
+    id: string;
+    name: string;
+  };
+};
+
+export type XProfile = {
+  type: "x";
+  details: {
+    id: string;
+    name: string;
+    username: string;
+    profileImageUrl?: string;
+  };
+};
+
+export type SteamProfile = {
+  type: "steam";
+  details: {
+    avatar?: string;
+    id: string;
+    metadata: {
+      avatar: {
+        large?: string;
+        medium?: string;
+        small?: string;
+      };
+      personaname?: string;
+      profileurl?: string;
+      realname?: string;
+    };
+    username?: string;
+  };
+};
+
+export type TelegramProfile = {
+  type: "telegram";
+  details: {
+    firstName?: string;
+    id: string;
+    lastName?: string;
+    picture?: string;
+    username?: string;
+  };
+};
+
+export type TwitchProfile = {
+  type: "twitch";
+  details: {
+    avatar?: string;
+    description?: string;
+    email?: string;
+    id: string;
+    username: string;
+  };
+};
+
+export type LineProfile = {
+  type: "line";
+  details: {
+    avatar?: string;
+    id: string;
+    username?: string;
+  };
+};
+
+export type FarcasterProfile = {
+  type: "farcaster";
+  details: {
+    fid: string;
+    id: string;
+    walletAddress?: string;
+  };
+};
+
+export type PasskeyProfile = {
+  type: "passkey";
+  details: {
+    algorithm: string;
+    credentialId: string;
+    publicKey: string;
+  };
+};
+
+export type EmailProfile = {
+  type: "email";
+  details: {
+    email: string;
+    id: string;
+  };
+};
+
+export type PhoneProfile = {
+  type: "phone";
+  details: {
+    id: string;
+    phone: string;
+  };
+};
+
+export type GuestProfile = {
+  type: "guest";
+  details: {
+    id: string;
+  };
+};
+
+export type BackendProfile = {
+  type: "backend";
+  details: {
+    id: string;
+  };
+};
+
+// Additional types from Zod schemas that may be used
+export type SiweProfile = {
+  type: "siwe";
+  details: {
+    id: string;
+    walletAddress: string;
+  };
+};
+
+export type PreGenerationProfile = {
+  type: "pre_generation";
+  details: {
+    id: string;
+    pregeneratedIdentifier: string;
+  };
+};
+
+export type ServerProfile = {
+  type: "server";
+  details: {
+    identifier: string;
+  };
+};
+
+export type CustomJwtProfile = {
+  type: "custom_jwt";
+  details: {
+    authProviderId?: string;
+    email?: string;
+    id: string;
+    phone?: string;
+    walletAddress?: string;
+  };
+};
+
+export type CustomAuthEndpointProfile = {
+  type: "custom_auth_endpoint";
+  details: {
+    authProviderId?: string;
+    email?: string;
+    id: string;
+    phone?: string;
+    walletAddress?: string;
+  };
+};
+
+// For wallet auth (maps to existing "wallet" AuthOption)
+export type WalletProfile = {
+  type: "wallet";
+  details: {
+    id: string;
+    address: Address;
+  };
+};
+
+// TikTok profile (present in authOptions but not in Zod schemas)
+export type TikTokProfile = {
+  type: "tiktok";
+  details: {
+    id: string;
+    // Add more fields as needed when TikTok provider is implemented
+  };
+};
+
+// Discriminated union of all profile types
+export type Profile =
+  | GoogleProfile
+  | FacebookProfile
+  | AppleProfile
+  | GitHubProfile
+  | DiscordProfile
+  | CoinbaseProfile
+  | XProfile
+  | SteamProfile
+  | TelegramProfile
+  | TwitchProfile
+  | LineProfile
+  | FarcasterProfile
+  | PasskeyProfile
+  | EmailProfile
+  | PhoneProfile
+  | GuestProfile
+  | BackendProfile
+  | WalletProfile
+  | TikTokProfile
+  // Additional types that may be used in the future
+  | SiweProfile
+  | PreGenerationProfile
+  | ServerProfile
+  | CustomJwtProfile
+  | CustomAuthEndpointProfile;
+
+// Utility functions to safely access profile properties
+export function getProfileEmail(profile: Profile): string | undefined {
+  if ('email' in profile.details) {
+    return profile.details.email;
+  }
+  return undefined;
+}
+
+export function getProfilePhone(profile: Profile): string | undefined {
+  if ('phone' in profile.details) {
+    return profile.details.phone;
+  }
+  return undefined;
+}
+
+export function getProfileAddress(profile: Profile): Address | undefined {
+  if ('address' in profile.details) {
+    return profile.details.address;
+  }
+  if ('walletAddress' in profile.details) {
+    return profile.details.walletAddress as Address;
+  }
+  return undefined;
+}
 
 export type UserDetailsApiType = {
   status: string;

--- a/packages/thirdweb/src/wallets/in-app/core/users/getUser.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/users/getUser.ts
@@ -120,7 +120,7 @@ export async function getUser({
         return {
           details: profile.details,
           type: (profile.type as string) === "siwe" ? "wallet" : profile.type,
-        };
+        } as Profile;
       }),
       smartAccountAddress: item.smartAccountAddress,
       userId: item.userId,


### PR DESCRIPTION
<!--
## [SDK] Feature: Improve Profile type with discriminated union for auth providers

## Notes for the reviewer

This PR addresses the `TODO` in the `Profile` type by converting generic `details` into a type-safe discriminated union based on the `type` of the authentication provider.

Key changes:
*   The `Profile` type is now a discriminated union, providing specific `details` types for each auth provider (e.g., `GoogleProfile`, `EmailProfile`, `SiweProfile`).
*   Utility functions (`getProfileEmail`, `getProfilePhone`, `getProfileAddress`) were introduced to safely access common profile properties across different provider types.
*   Existing components (`WalletRow`, `LinkedProfilesScreen`) and utilities (`getUser`) have been updated to use the new type-safe `Profile` structure and helper functions.
*   The `AuthOption` import was removed from `types.ts` as it's no longer directly used for the `Profile` type definition.
*   A type assertion was added in `getUser.ts` for the `siwe` to `wallet` transformation to ensure type correctness.

## How to test

1.  Run `pnpm install` and `pnpm build:types` in `packages/thirdweb` to ensure no type errors are introduced.
2.  Verify the functionality of the `ConnectWallet` components, specifically the `LinkedProfilesScreen` and `WalletRow`, to ensure profile details (email, address) are displayed correctly for various linked accounts.
-->

---
[Slack Thread](https://thirdwebdev.slack.com/archives/C085FEPFLN9/p1756074059386559?thread_ts=1756074059.386559&cid=C085FEPFLN9)

<a href="https://cursor.com/background-agent?bcId=bc-7f6a583a-151b-4795-8a9a-6b9b9cc74a11">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7f6a583a-151b-4795-8a9a-6b9b9cc74a11">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

