### PR TITLE
Add ai usage section to dashboard

### DIFF
--- a/apps/dashboard/src/@/api/analytics.ts
+++ b/apps/dashboard/src/@/api/analytics.ts
@@ -236,10 +236,7 @@ const cached_getAiUsage = unstable_cache(
   },
 );
 
-export function getAiUsage(
-  params: AnalyticsQueryParams,
-  authToken: string,
-) {
+export function getAiUsage(params: AnalyticsQueryParams, authToken: string) {
   return cached_getAiUsage(normalizedParams(params), authToken);
 }
 

--- a/apps/dashboard/src/@/types/analytics.ts
+++ b/apps/dashboard/src/@/types/analytics.ts
@@ -78,6 +78,14 @@ export interface WebhookSummaryStats {
   errorBreakdown: Record<string, number>;
 }
 
+export interface AIUsageStats {
+  date: string;
+  totalPromptTokens: number;
+  totalCompletionTokens: number;
+  totalSessions: number;
+  totalRequests: number;
+}
+
 export interface AnalyticsQueryParams {
   teamId: string;
   projectId?: string;

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/ai/analytics/chart/AiTokenUsageChartCard.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/ai/analytics/chart/AiTokenUsageChartCard.tsx
@@ -5,11 +5,10 @@ import { ThirdwebBarChart } from "@/components/blocks/charts/bar-chart";
 import { DocLink } from "@/components/blocks/DocLink";
 import { ExportToCSVButton } from "@/components/blocks/ExportToCSVButton";
 import type { ChartConfig } from "@/components/ui/chart";
-import { ReactIcon } from "@/icons/brand-icons/ReactIcon";
-import { TypeScriptIcon } from "@/icons/brand-icons/TypeScriptIcon";
+import { NebulaIcon } from "@/icons/NebulaIcon";
 import type { AIUsageStats } from "@/types/analytics";
 
-type ChartData = {
+type ChartData = Record<string, number> & {
   time: string; // human readable date
   tokens: number;
 };
@@ -30,10 +29,15 @@ export function AiTokenUsageChartCardUI(props: {
       },
     };
 
-    const _chartData: ChartData[] = aiUsageStats.map((stat) => ({
-      time: stat.date,
-      tokens: stat.totalPromptTokens + stat.totalCompletionTokens,
-    }));
+    const _chartData: ChartData[] = aiUsageStats
+      .filter((stat) => stat.totalPromptTokens + stat.totalCompletionTokens > 0)
+      .map(
+        (stat) =>
+          ({
+            time: stat.date,
+            tokens: stat.totalPromptTokens + stat.totalCompletionTokens,
+          }) as ChartData,
+      );
 
     return {
       chartConfig: _chartConfig,
@@ -88,7 +92,7 @@ export function AiTokenUsageChartCardUI(props: {
         }
         return undefined;
       }}
-      variant="default"
+      variant="stacked"
     />
   );
 }
@@ -97,17 +101,13 @@ function AiTokenUsageEmptyChartState() {
   return (
     <div className="flex flex-col items-center justify-center px-4">
       <span className="mb-6 text-center text-lg">
-        Start using AI to interact with any EVM chain
+        Integrate thirdweb AI to interact with any EVM chain using natural
+        language
       </span>
       <div className="flex max-w-md flex-wrap items-center justify-center gap-x-6 gap-y-4">
         <DocLink
-          icon={TypeScriptIcon}
-          label="TypeScript"
-          link="https://portal.thirdweb.com/ai/chat"
-        />
-        <DocLink
-          icon={ReactIcon}
-          label="React"
+          icon={NebulaIcon}
+          label="Get Started"
           link="https://portal.thirdweb.com/ai/chat"
         />
       </div>

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/ai/analytics/chart/AiTokenUsageChartCard.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/ai/analytics/chart/AiTokenUsageChartCard.tsx
@@ -1,0 +1,116 @@
+"use client";
+import { format } from "date-fns";
+import { useMemo } from "react";
+import { ThirdwebBarChart } from "@/components/blocks/charts/bar-chart";
+import { DocLink } from "@/components/blocks/DocLink";
+import { ExportToCSVButton } from "@/components/blocks/ExportToCSVButton";
+import type { ChartConfig } from "@/components/ui/chart";
+import { ReactIcon } from "@/icons/brand-icons/ReactIcon";
+import { TypeScriptIcon } from "@/icons/brand-icons/TypeScriptIcon";
+import type { AIUsageStats } from "@/types/analytics";
+
+type ChartData = {
+  time: string; // human readable date
+  tokens: number;
+};
+
+export function AiTokenUsageChartCardUI(props: {
+  aiUsageStats: AIUsageStats[];
+  isPending: boolean;
+  title: string;
+  description: string;
+}) {
+  const { aiUsageStats } = props;
+
+  const { chartConfig, chartData } = useMemo(() => {
+    const _chartConfig: ChartConfig = {
+      tokens: {
+        color: "hsl(var(--chart-1))",
+        label: "Tokens",
+      },
+    };
+
+    const _chartData: ChartData[] = aiUsageStats.map((stat) => ({
+      time: stat.date,
+      tokens: stat.totalPromptTokens + stat.totalCompletionTokens,
+    }));
+
+    return {
+      chartConfig: _chartConfig,
+      chartData: _chartData.sort(
+        (a, b) => new Date(a.time).getTime() - new Date(b.time).getTime(),
+      ),
+    };
+  }, [aiUsageStats]);
+
+  const disableActions =
+    props.isPending ||
+    chartData.length === 0 ||
+    chartData.every((data) => data.tokens === 0);
+
+  return (
+    <ThirdwebBarChart
+      chartClassName="aspect-[1.5] lg:aspect-[3.5]"
+      config={chartConfig}
+      customHeader={
+        <div className="relative px-6 pt-6">
+          <h3 className="mb-0.5 font-semibold text-xl tracking-tight">
+            {props.title}
+          </h3>
+          <p className="mb-3 text-muted-foreground text-sm">
+            {props.description}
+          </p>
+
+          <ExportToCSVButton
+            className="top-6 right-6 mb-4 w-full bg-background md:absolute md:mb-0 md:flex md:w-auto"
+            disabled={disableActions}
+            fileName="AI Token Usage"
+            getData={async () => {
+              const header = ["Date", "Tokens"];
+              const rows = chartData.map((data) => [
+                data.time,
+                data.tokens.toString(),
+              ]);
+              return { header, rows };
+            }}
+          />
+        </div>
+      }
+      data={chartData}
+      emptyChartState={<AiTokenUsageEmptyChartState />}
+      hideLabel={false}
+      isPending={props.isPending}
+      showLegend={false}
+      toolTipLabelFormatter={(_v, item) => {
+        if (Array.isArray(item)) {
+          const time = item[0].payload.time as string;
+          return format(new Date(time), "MMM d, yyyy");
+        }
+        return undefined;
+      }}
+      variant="default"
+    />
+  );
+}
+
+function AiTokenUsageEmptyChartState() {
+  return (
+    <div className="flex flex-col items-center justify-center px-4">
+      <span className="mb-6 text-center text-lg">
+        Start using AI to interact with any EVM chain
+      </span>
+      <div className="flex max-w-md flex-wrap items-center justify-center gap-x-6 gap-y-4">
+        <DocLink
+          icon={TypeScriptIcon}
+          label="TypeScript"
+          link="https://portal.thirdweb.com/ai/chat"
+        />
+        <DocLink
+          icon={ReactIcon}
+          label="React"
+          link="https://portal.thirdweb.com/ai/chat"
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/ai/analytics/chart/Summary.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/ai/analytics/chart/Summary.tsx
@@ -1,0 +1,94 @@
+import { ActivityIcon, MessageSquareIcon, CoinsIcon } from "lucide-react";
+import { Suspense } from "react";
+import { getAiUsage } from "@/api/analytics";
+import type { Range } from "@/components/analytics/date-range-selector";
+import { StatCard } from "@/components/analytics/stat";
+import type { AIUsageStats } from "@/types/analytics";
+
+function AiSummaryInner(props: {
+  stats: AIUsageStats[] | undefined;
+  isPending: boolean;
+}) {
+  const totalRequests = props.stats?.reduce((acc, curr) => {
+    return acc + curr.totalRequests;
+  }, 0);
+
+  const totalSessions = props.stats?.reduce((acc, curr) => {
+    return acc + curr.totalSessions;
+  }, 0);
+
+  const totalTokens = props.stats?.reduce((acc, curr) => {
+    return acc + curr.totalPromptTokens + curr.totalCompletionTokens;
+  }, 0);
+
+  return (
+    <div className="grid grid-cols-3 gap-4">
+      <StatCard
+        icon={ActivityIcon}
+        isPending={props.isPending}
+        label="Requests"
+        value={totalRequests || 0}
+      />
+      <StatCard
+        icon={MessageSquareIcon}
+        isPending={props.isPending}
+        label="Sessions"
+        value={totalSessions || 0}
+      />
+      <StatCard
+        icon={CoinsIcon}
+        isPending={props.isPending}
+        label="Tokens"
+        value={totalTokens || 0}
+      />
+    </div>
+  );
+}
+
+async function AsyncAiSummary(props: {
+  teamId: string;
+  projectId: string;
+  authToken: string;
+  range: Range;
+}) {
+  const { teamId, projectId, authToken, range } = props;
+  const aggregatedStatsPromise = getAiUsage(
+    {
+      from: range.from,
+      period: "all",
+      projectId,
+      teamId,
+      to: range.to,
+    },
+    authToken,
+  );
+
+  const aggregatedStats = await aggregatedStatsPromise.catch(() => null);
+
+  return (
+    <AiSummaryInner
+      stats={aggregatedStats || undefined}
+      isPending={false}
+    />
+  );
+}
+
+export function AiSummary(props: {
+  teamId: string;
+  projectId: string;
+  authToken: string;
+  range: Range;
+}) {
+  return (
+    <Suspense
+      fallback={<AiSummaryInner stats={undefined} isPending={true} />}
+    >
+      <AsyncAiSummary
+        projectId={props.projectId}
+        teamId={props.teamId}
+        authToken={props.authToken}
+        range={props.range}
+      />
+    </Suspense>
+  );
+}

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/ai/analytics/chart/Summary.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/ai/analytics/chart/Summary.tsx
@@ -1,4 +1,4 @@
-import { ActivityIcon, MessageSquareIcon, CoinsIcon } from "lucide-react";
+import { ActivityIcon, MessageSquareIcon } from "lucide-react";
 import { Suspense } from "react";
 import { getAiUsage } from "@/api/analytics";
 import type { Range } from "@/components/analytics/date-range-selector";
@@ -9,10 +9,6 @@ function AiSummaryInner(props: {
   stats: AIUsageStats[] | undefined;
   isPending: boolean;
 }) {
-  const totalRequests = props.stats?.reduce((acc, curr) => {
-    return acc + curr.totalRequests;
-  }, 0);
-
   const totalSessions = props.stats?.reduce((acc, curr) => {
     return acc + curr.totalSessions;
   }, 0);
@@ -22,21 +18,15 @@ function AiSummaryInner(props: {
   }, 0);
 
   return (
-    <div className="grid grid-cols-3 gap-4">
+    <div className="grid grid-cols-2 gap-4">
       <StatCard
         icon={ActivityIcon}
-        isPending={props.isPending}
-        label="Requests"
-        value={totalRequests || 0}
-      />
-      <StatCard
-        icon={MessageSquareIcon}
         isPending={props.isPending}
         label="Sessions"
         value={totalSessions || 0}
       />
       <StatCard
-        icon={CoinsIcon}
+        icon={MessageSquareIcon}
         isPending={props.isPending}
         label="Tokens"
         value={totalTokens || 0}
@@ -66,10 +56,7 @@ async function AsyncAiSummary(props: {
   const aggregatedStats = await aggregatedStatsPromise.catch(() => null);
 
   return (
-    <AiSummaryInner
-      stats={aggregatedStats || undefined}
-      isPending={false}
-    />
+    <AiSummaryInner stats={aggregatedStats || undefined} isPending={false} />
   );
 }
 
@@ -80,9 +67,7 @@ export function AiSummary(props: {
   range: Range;
 }) {
   return (
-    <Suspense
-      fallback={<AiSummaryInner stats={undefined} isPending={true} />}
-    >
+    <Suspense fallback={<AiSummaryInner stats={undefined} isPending={true} />}>
       <AsyncAiSummary
         projectId={props.projectId}
         teamId={props.teamId}

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/ai/analytics/chart/index.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/ai/analytics/chart/index.tsx
@@ -14,10 +14,7 @@ type AiAnalyticsProps = {
   isPending: boolean;
 };
 
-function AiAnalyticsUI({
-  stats,
-  isPending,
-}: AiAnalyticsProps) {
+function AiAnalyticsUI({ stats, isPending }: AiAnalyticsProps) {
   return (
     <AiTokenUsageChartCardUI
       title="Token Usage"
@@ -28,18 +25,13 @@ function AiAnalyticsUI({
   );
 }
 
-type AsyncAiAnalyticsProps = Omit<
-  AiAnalyticsProps,
-  "stats" | "isPending"
-> & {
+type AsyncAiAnalyticsProps = Omit<AiAnalyticsProps, "stats" | "isPending"> & {
   teamId: string;
   projectId: string;
   authToken: string;
 };
 
-async function AsyncAiAnalytics(
-  props: AsyncAiAnalyticsProps,
-) {
+async function AsyncAiAnalytics(props: AsyncAiAnalyticsProps) {
   const range = props.range ?? getLastNDaysRange("last-30");
 
   const stats = await getAiUsage(
@@ -57,12 +49,7 @@ async function AsyncAiAnalytics(
   });
 
   return (
-    <AiAnalyticsUI
-      {...props}
-      isPending={false}
-      range={range}
-      stats={stats}
-    />
+    <AiAnalyticsUI {...props} isPending={false} range={range} stats={stats} />
   );
 }
 
@@ -70,9 +57,7 @@ export function AiAnalytics(props: AsyncAiAnalyticsProps) {
   return (
     <ResponsiveSuspense
       searchParamsUsed={["from", "to", "interval"]}
-      fallback={
-        <AiAnalyticsUI {...props} isPending={true} stats={[]} />
-      }
+      fallback={<AiAnalyticsUI {...props} isPending={true} stats={[]} />}
     >
       <AsyncAiAnalytics {...props} />
     </ResponsiveSuspense>

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/ai/analytics/chart/index.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/ai/analytics/chart/index.tsx
@@ -1,0 +1,80 @@
+import { ResponsiveSuspense } from "responsive-rsc";
+import { getAiUsage } from "@/api/analytics";
+import {
+  getLastNDaysRange,
+  type Range,
+} from "@/components/analytics/date-range-selector";
+import type { AIUsageStats } from "@/types/analytics";
+import { AiTokenUsageChartCardUI } from "./AiTokenUsageChartCard";
+
+type AiAnalyticsProps = {
+  interval: "day" | "week";
+  range: Range;
+  stats: AIUsageStats[];
+  isPending: boolean;
+};
+
+function AiAnalyticsUI({
+  stats,
+  isPending,
+}: AiAnalyticsProps) {
+  return (
+    <AiTokenUsageChartCardUI
+      title="Token Usage"
+      description="The total number of tokens used for AI interactions on your project."
+      aiUsageStats={stats || []}
+      isPending={isPending}
+    />
+  );
+}
+
+type AsyncAiAnalyticsProps = Omit<
+  AiAnalyticsProps,
+  "stats" | "isPending"
+> & {
+  teamId: string;
+  projectId: string;
+  authToken: string;
+};
+
+async function AsyncAiAnalytics(
+  props: AsyncAiAnalyticsProps,
+) {
+  const range = props.range ?? getLastNDaysRange("last-30");
+
+  const stats = await getAiUsage(
+    {
+      from: range.from,
+      period: props.interval,
+      projectId: props.projectId,
+      teamId: props.teamId,
+      to: range.to,
+    },
+    props.authToken,
+  ).catch((error) => {
+    console.error(error);
+    return [];
+  });
+
+  return (
+    <AiAnalyticsUI
+      {...props}
+      isPending={false}
+      range={range}
+      stats={stats}
+    />
+  );
+}
+
+export function AiAnalytics(props: AsyncAiAnalyticsProps) {
+  return (
+    <ResponsiveSuspense
+      searchParamsUsed={["from", "to", "interval"]}
+      fallback={
+        <AiAnalyticsUI {...props} isPending={true} stats={[]} />
+      }
+    >
+      <AsyncAiAnalytics {...props} />
+    </ResponsiveSuspense>
+  );
+}

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/ai/page.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/ai/page.tsx
@@ -45,30 +45,45 @@ export default async function Page(props: {
     teamId: project.teamId,
   });
 
-  const { range, interval, defaultRange } = getFiltersFromSearchParams({
-    defaultRange: "last-30" as DurationId,
+  const defaultRange = "last-30" as DurationId;
+  const { range, interval } = getFiltersFromSearchParams({
+    defaultRange,
     from: searchParams.from,
     interval: searchParams.interval,
     to: searchParams.to,
   });
 
   return (
-    <ResponsiveSearchParamsProvider>
+    <ResponsiveSearchParamsProvider value={searchParams}>
       <ProjectPage
-        project={project}
         header={{
+          client,
           title: "AI",
-          description:
-            "Interact with any EVM chain with natural language",
-          docsLink: "https://portal.thirdweb.com/ai/chat",
+          description: "Interact with any EVM chain with natural language",
+          actions: {
+            primary: {
+              label: "Documentation",
+              href: "https://portal.thirdweb.com/ai/chat",
+              external: true,
+            },
+            secondary: {
+              label: "API Reference",
+              href: "https://api.thirdweb.com/reference#tag/ai/post/ai/chat",
+              external: true,
+            },
+          },
           links: [
             {
+              href: "https://portal.thirdweb.com/ai/chat",
+              type: "docs",
+            },
+            {
               href: "https://api.thirdweb.com/reference#tag/ai/post/ai/chat",
-              label: "API Reference",
+              type: "api",
             },
             {
               href: "https://playground.thirdweb.com/ai/chat",
-              label: "Playground",
+              type: "playground",
             },
           ],
         }}

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/ai/page.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/ai/page.tsx
@@ -1,0 +1,96 @@
+import { redirect } from "next/navigation";
+import { ResponsiveSearchParamsProvider } from "responsive-rsc";
+import { getAuthToken } from "@/api/auth-token";
+import { getProject } from "@/api/project/projects";
+import type { DurationId } from "@/components/analytics/date-range-selector";
+import { ResponsiveTimeFilters } from "@/components/analytics/responsive-time-filters";
+import { ProjectPage } from "@/components/blocks/project-page/project-page";
+import { getClientThirdwebClient } from "@/constants/thirdweb-client.client";
+import { getFiltersFromSearchParams } from "@/lib/time";
+import { loginRedirect } from "@/utils/redirects";
+import { AiAnalytics } from "./analytics/chart";
+import { AiSummary } from "./analytics/chart/Summary";
+
+export default async function Page(props: {
+  params: Promise<{ team_slug: string; project_slug: string }>;
+  searchParams: Promise<{
+    from?: string;
+    to?: string;
+    type?: string;
+    interval?: string;
+  }>;
+}) {
+  const [searchParams, params] = await Promise.all([
+    props.searchParams,
+    props.params,
+  ]);
+
+  const { team_slug, project_slug } = params;
+
+  const [project, authToken] = await Promise.all([
+    getProject(team_slug, project_slug),
+    getAuthToken(),
+  ]);
+
+  if (!authToken) {
+    loginRedirect(`/team/${team_slug}/${project_slug}/ai`);
+  }
+
+  if (!project) {
+    redirect(`/team/${team_slug}`);
+  }
+
+  const client = getClientThirdwebClient({
+    jwt: authToken,
+    teamId: project.teamId,
+  });
+
+  const { range, interval, defaultRange } = getFiltersFromSearchParams({
+    defaultRange: "last-30" as DurationId,
+    from: searchParams.from,
+    interval: searchParams.interval,
+    to: searchParams.to,
+  });
+
+  return (
+    <ResponsiveSearchParamsProvider>
+      <ProjectPage
+        project={project}
+        header={{
+          title: "AI",
+          description:
+            "Interact with any EVM chain with natural language",
+          docsLink: "https://portal.thirdweb.com/ai/chat",
+          links: [
+            {
+              href: "https://api.thirdweb.com/reference#tag/ai/post/ai/chat",
+              label: "API Reference",
+            },
+            {
+              href: "https://playground.thirdweb.com/ai/chat",
+              label: "Playground",
+            },
+          ],
+        }}
+      >
+        <div className="flex flex-col gap-4 md:gap-6">
+          <ResponsiveTimeFilters defaultRange={defaultRange} />
+          <AiSummary
+            projectId={project.id}
+            teamId={project.teamId}
+            authToken={authToken}
+            range={range}
+          />
+
+          <AiAnalytics
+            interval={interval}
+            projectId={project.id}
+            range={range}
+            teamId={project.teamId}
+            authToken={authToken}
+          />
+        </div>
+      </ProjectPage>
+    </ResponsiveSearchParamsProvider>
+  );
+}

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/components/ProjectSidebarLayout.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/components/ProjectSidebarLayout.tsx
@@ -14,6 +14,7 @@ import { FullWidthSidebarLayout } from "@/components/blocks/full-width-sidebar-l
 import { Badge } from "@/components/ui/badge";
 import { ContractIcon } from "@/icons/ContractIcon";
 import { InsightIcon } from "@/icons/InsightIcon";
+import { NebulaIcon } from "@/icons/NebulaIcon";
 import { PayIcon } from "@/icons/PayIcon";
 import { SmartAccountIcon } from "@/icons/SmartAccountIcon";
 import { TokenIcon } from "@/icons/TokenIcon";
@@ -53,6 +54,11 @@ export function ProjectSidebarLayout(props: {
               href: `${props.layoutPath}/contracts`,
               icon: ContractIcon,
               label: "Contracts",
+            },
+            {
+              href: `${props.layoutPath}/ai`,
+              icon: NebulaIcon,
+              label: "AI",
             },
           ],
         },


### PR DESCRIPTION
```
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

This PR introduces a new "AI" section under the "Build" category in the project sidebar. It provides analytics for AI usage, mirroring the structure and data fetching patterns of the existing "Wallets" analytics page.

Key additions include:
- A new `getAiUsage` function to fetch data from the `/v2/nebula/usage` endpoint.
- Summary cards displaying aggregated requests, sessions, and total tokens.
- A "Token Usage" chart visualizing token consumption over time.
- Comprehensive UI with header, documentation links, date range selector, and CSV export.

## How to test

1.  Navigate to any project in the dashboard.
2.  In the left sidebar, under the "Build" section, verify that a new "AI" link is present.
3.  Click on the "AI" link.
4.  Confirm that the AI usage analytics page loads correctly, displaying:
    *   Header with "AI" title, description, and links (Documentation, API Reference, Playground).
    *   A date range selector.
    *   Three summary cards: "Requests", "Sessions", and "Tokens".
    *   A "Token Usage" chart.
5.  Change the date range using the selector and verify that the data in the summary cards and chart updates accordingly.
6.  Test the "Export to CSV" functionality for the chart.
7.  (Optional) If you have a project with AI usage, ensure the data is displayed correctly. If not, verify the empty state is shown.

-->
```

---
[Slack Thread](https://thirdwebdev.slack.com/archives/C099GV12WQ3/p1756085656575749?thread_ts=1756085656.575749&cid=C099GV12WQ3)

<a href="https://cursor.com/background-agent?bcId=bc-aeb411cc-d90f-4755-b998-d218d5e3a069">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-aeb411cc-d90f-4755-b998-d218d5e3a069">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces new features related to AI usage statistics in a dashboard application, including the addition of an `AIUsageStats` interface, new components for displaying AI analytics, and modifications to existing files to fetch and visualize AI-related data.

### Detailed summary
- Added `AIUsageStats` interface in `analytics.ts`.
- Introduced `NebulaIcon` in `ProjectSidebarLayout.tsx`.
- Implemented `cached_getAiUsage` function in `analytics.ts` for fetching AI usage data.
- Created `AiAnalyticsUI` and `AsyncAiAnalytics` components for displaying AI statistics.
- Developed `AiSummary` and `AsyncAiSummary` components for summarizing AI usage.
- Updated `page.tsx` to include AI analytics and summary components.
- Created `AiTokenUsageChartCardUI` for visualizing AI token usage data.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an AI Analytics page and an “AI” link in the project sidebar.
  * Token usage chart with tooltip, loading and empty states, and CSV export.
  * Summary cards showing Sessions and Tokens totals.
  * Date range and interval filters with sensible defaults.
  * Graceful handling when data is unavailable (shows zero/empty states).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->