### PR TITLE
[Docs] Update API domains

### DIFF
--- a/apps/portal/src/app/ai/chat/page.mdx
+++ b/apps/portal/src/app/ai/chat/page.mdx
@@ -22,7 +22,7 @@ You can use the API with the HTTP API directly, or with any OpenAI-compatible cl
     <TabsTrigger value="openai">OpenAI Client</TabsTrigger>
   </TabsList>
   <TabsContent value="api">
-    <OpenApiEndpoint path="/ai/chat" method="POST" specUrl="https://api.thirdweb-dev.com/openapi.json" />
+    <OpenApiEndpoint path="/ai/chat" method="POST" />
   </TabsContent>
   <TabsContent value="openai">
 
@@ -52,4 +52,4 @@ print(chat_completion)
 ### Going further
 
 - [Handle streaming responses](/ai/chat/streaming)
-- [Full API Reference](https://api.thirdweb-dev.com/reference#tag/ai/post/ai/chat)
+- [Full API Reference](https://api.thirdweb.com/reference#tag/ai/post/ai/chat)

--- a/apps/portal/src/app/ai/sidebar.tsx
+++ b/apps/portal/src/app/ai/sidebar.tsx
@@ -23,7 +23,7 @@ export const sidebar: SideBar = {
         },
         {
           name: "API Reference",
-          href: "https://api.thirdweb-dev.com/reference#tag/ai/post/ai/chat",
+          href: "https://api.thirdweb.com/reference#tag/ai/post/ai/chat",
         },
       ],
     },

--- a/packages/api/src/client/types.gen.ts
+++ b/packages/api/src/client/types.gen.ts
@@ -3096,8 +3096,5 @@ export type TransferTokenWithUsdResponse =
 	TransferTokenWithUsdResponses[keyof TransferTokenWithUsdResponses];
 
 export type ClientOptions = {
-	baseUrl:
-		| "https://api.thirdweb-dev.com"
-		| "http://localhost:3030"
-		| (string & {});
+	baseUrl: "https://api.thirdweb.com" | "http://localhost:3030" | (string & {});
 };


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the API reference URLs from `https://api.thirdweb-dev.com` to `https://api.thirdweb.com` across multiple files for consistency and accuracy.

### Detailed summary
- Updated `href` in the `sidebar.tsx` file.
- Modified `baseUrl` in the `types.gen.ts` file.
- Removed `specUrl` from the `OpenApiEndpoint` in `page.mdx`.
- Changed the link for the full API reference in `page.mdx`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated AI Chat API reference links to api.thirdweb.com.
  - Simplified HTTP API docs by removing an explicit spec URL, using the default source.

- Chores
  - Aligned API client configuration to use the production base URL (api.thirdweb.com) by default, while retaining localhost support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->