### PR TITLE
Dashboard: Fix project links footer not sticked to the bottom on short pages

### DIFF
--- a/apps/dashboard/src/@/components/blocks/project-page/project-page.tsx
+++ b/apps/dashboard/src/@/components/blocks/project-page/project-page.tsx
@@ -21,7 +21,7 @@ type ProjectPageProps = {
 
 export function ProjectPage(props: React.PropsWithChildren<ProjectPageProps>) {
   return (
-    <div className={cn("flex flex-col pb-20", props.footer && "pb-0")}>
+    <div className="flex flex-col grow">
       <div className={cn(!props.tabs && "border-b")}>
         <ProjectPageHeader {...props.header} />
         {props.tabs && (
@@ -33,8 +33,9 @@ export function ProjectPage(props: React.PropsWithChildren<ProjectPageProps>) {
       </div>
 
       <main className="container max-w-7xl pt-6">{props.children}</main>
+      <div className="h-20" />
       {props.footer && (
-        <div className="border-t mt-20">
+        <div className="border-t mt-auto">
           <ProjectPageFooter {...props.footer} />
         </div>
       )}


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the layout of the `ProjectPage` component in the `project-page.tsx` file, specifically adjusting the styling of the main container and footer.

### Detailed summary
- Changed the class of the main `div` from `pb-20` and conditional `pb-0` to `grow`.
- Added a new `div` with a class of `h-20` for spacing.
- Updated the footer `div` class from `mt-20` to `mt-auto` for better alignment.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated project page layout for more consistent spacing and alignment.
  - Removed conditional bottom padding for predictable layout across views.
  - Footer now uses automatic spacing to align toward the bottom on longer pages.
  - Added a vertical spacer between main content and footer to improve hierarchy and readability.
  - No changes to public APIs or user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->