### PR TITLE
[SDK] Add Hashkey chain configuration

### DIFF
--- a/packages/thirdweb/src/chains/chain-definitions/hashkey-testnet.ts
+++ b/packages/thirdweb/src/chains/chain-definitions/hashkey-testnet.ts
@@ -1,0 +1,22 @@
+import { defineChain } from "../utils.js";
+
+/**
+ * @chain
+ */
+export const HashkeyTestnet = /*@__PURE__*/ defineChain({
+  blockExplorers: [
+    {
+      name: "Hashkey Explorer",
+      url: "https://testnet-explorer.hsk.xyz",
+    },
+  ],
+  rpc: "https://testnet.hsk.xyz",
+  id: 133,
+  name: "Hashkey Testnet",
+  nativeCurrency: {
+    decimals: 18,
+    name: "HashKey Platform Token",
+    symbol: "HSK",
+  },
+  testnet: true,
+});

--- a/packages/thirdweb/src/chains/chain-definitions/hashkey.ts
+++ b/packages/thirdweb/src/chains/chain-definitions/hashkey.ts
@@ -1,0 +1,21 @@
+import { defineChain } from "../utils.js";
+
+/**
+ * @chain
+ */
+export const Hashkey = /*@__PURE__*/ defineChain({
+  blockExplorers: [
+    {
+      name: "Hashkey Explorer",
+      url: "https://hashkey.blockscout.com/",
+    },
+  ],
+  rpc: "https://mainnet.hsk.xyz",
+  id: 177,
+  name: "Hashkey",
+  nativeCurrency: {
+    decimals: 18,
+    name: "HashKey Platform Token",
+    symbol: "HSK",
+  },
+});


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces two new chain definitions for `Hashkey` and `Hashkey Testnet`, including their respective RPC URLs, native currencies, and block explorer details.

### Detailed summary
- Added `Hashkey` chain definition with:
  - RPC URL: `https://mainnet.hsk.xyz`
  - ID: 177
  - Native currency: `HashKey Platform Token` (symbol: `HSK`, decimals: 18)
  - Block explorer: `Hashkey Explorer` (URL: `https://hashkey.blockscout.com/`)
  
- Added `HashkeyTestnet` chain definition with:
  - RPC URL: `https://testnet.hsk.xyz`
  - ID: 133
  - Native currency: `HashKey Platform Token` (symbol: `HSK`, decimals: 18)
  - Block explorer: `Hashkey Explorer` (URL: `https://testnet-explorer.hsk.xyz`)
  - Marked as a testnet.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native support for Hashkey (mainnet) and Hashkey Testnet networks.
  * Preconfigured RPC endpoints for quick, reliable connections.
  * Integrated block explorer links for easier transaction and contract lookups.
  * Recognizes HSK as the native currency with correct decimals and symbol.
  * Enables connecting wallets, deploying, and interacting with contracts on these networks.
  * Includes proper network identifiers for smooth network selection and tooling integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->