### PR TITLE
Add reason code type to team capabilities response

### DIFF
--- a/.changeset/fuzzy-bars-wish.md
+++ b/.changeset/fuzzy-bars-wish.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+add reason code type into team capabilities response

--- a/apps/dashboard/src/@/storybook/stubs.ts
+++ b/apps/dashboard/src/@/storybook/stubs.ts
@@ -74,6 +74,12 @@ export function teamStub(id: string, billingPlan: Team["billingPlan"]): Team {
       rpc: {
         enabled: true,
         rateLimit: 1000,
+        websockets: {
+          enabled: false,
+          reasonCode: "enterprise_plan_required",
+          maxConnections: 0,
+          maxSubscriptions: 0,
+        },
       },
       storage: {
         download: {

--- a/packages/service-utils/src/core/api.ts
+++ b/packages/service-utils/src/core/api.ts
@@ -55,25 +55,34 @@ export type ApiResponse = {
 
 /**
  * Stores service-specific capabilities.
- * This type should match the schema from API server.
+ * These types should match the schema from API server.
  */
+export type ReasonCode =
+  | "free_limit_exceeded"
+  | "subscription_required"
+  | "invoice_past_due"
+  | "enterprise_plan_required"
+  | "other";
+type EnabledWithReason<T> = T &
+  ({ enabled: true } | { enabled: false; reasonCode: ReasonCode });
 type TeamCapabilities = {
   platform: {
     auditLogs: boolean;
     ecosystemWallets: boolean;
     seats: boolean;
   };
-  rpc: {
-    enabled: boolean;
+  rpc: EnabledWithReason<{
     rateLimit: number;
-  };
-  insight: {
-    enabled: boolean;
+    websockets: EnabledWithReason<{
+      maxConnections: number;
+      maxSubscriptions: number;
+    }>;
+  }>;
+  insight: EnabledWithReason<{
     rateLimit: number;
     webhooks: boolean;
-  };
-  storage: {
-    enabled: boolean;
+  }>;
+  storage: EnabledWithReason<{
     download: {
       rateLimit: number;
     };
@@ -81,45 +90,38 @@ type TeamCapabilities = {
       totalFileSizeBytesLimit: number;
       rateLimit: number;
     };
-  };
-  nebula: {
-    enabled: boolean;
+  }>;
+  nebula: EnabledWithReason<{
     rateLimit: {
       perSecond: number;
       perMinute: number;
     };
-  };
-  bundler: {
-    enabled: boolean;
+  }>;
+  bundler: EnabledWithReason<{
     mainnetEnabled: boolean;
     rateLimit: number;
-  };
-  embeddedWallets: {
-    enabled: boolean;
+  }>;
+  embeddedWallets: EnabledWithReason<{
     customAuth: boolean;
     customBranding: boolean;
     sms: {
       domestic: boolean;
       international: boolean;
     };
-  };
-  engineCloud: {
-    enabled: boolean;
+  }>;
+  engineCloud: EnabledWithReason<{
     mainnetEnabled: boolean;
     rateLimit: number;
-  };
-  pay: {
-    enabled: boolean;
+  }>;
+  pay: EnabledWithReason<{
     rateLimit: number;
-  };
-  mcp: {
-    enabled: boolean;
+  }>;
+  mcp: EnabledWithReason<{
     rateLimit: number;
-  };
-  gateway: {
-    enabled: boolean;
+  }>;
+  gateway: EnabledWithReason<{
     rateLimit: number;
-  };
+  }>;
 };
 
 type TeamPlan =

--- a/packages/service-utils/src/mocks.ts
+++ b/packages/service-utils/src/mocks.ts
@@ -92,6 +92,12 @@ export const validTeamResponse: TeamResponse = {
     rpc: {
       enabled: true,
       rateLimit: 1000,
+      websockets: {
+        enabled: false,
+        reasonCode: "enterprise_plan_required",
+        maxConnections: 0,
+        maxSubscriptions: 0,
+      },
     },
     storage: {
       download: {


### PR DESCRIPTION
# Add reason code type into team capabilities response

This PR enhances the team capabilities response by:

- Adding a `ReasonCode` type with specific values like "free_limit_exceeded", "subscription_required", etc.
- Creating an `EnabledWithReason<T>` generic type that includes a reason code when a capability is disabled
- Updating all service capability types to use this new pattern
- Improving the authorization flow to provide more specific error messages based on the reason code
- Adding different HTTP status codes and error messages for various scenarios (402 for payment-related issues, 403 for other restrictions)

These changes allow for more detailed feedback to users when a service is disabled, with specific guidance based on the reason (e.g., directing to billing page for payment issues or support for enterprise features).

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a `reasonCode` for team capabilities responses, enhancing the error handling for service access based on subscription status. It modifies the type definitions and adds specific error messages based on different reasons for service unavailability.

### Detailed summary
- Added `reasonCode` to `websockets` and `storage` capabilities.
- Introduced new `ReasonCode` type with specific reasons.
- Updated `EnabledWithReason` type to include `reasonCode`.
- Refactored `authorize` function to handle specific error cases based on `reasonCode`.
- Renamed `isServiceEnabledForTeam` to `getServiceDisabledReason`, returning `ReasonCode` instead of a boolean.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Capabilities now include detailed enablement status with reason codes (free_limit_exceeded, subscription_required, invoice_past_due, enterprise_plan_required, other).
  - Added a websockets capability with connection/subscription limits inside team capabilities.
  - Authorization responses are more specific: tailored 402/403 statuses with contextual team info and direct guidance links (upgrade, billing, invoices, support).
- Chores
  - Added a patch changeset documenting the capability reason codes and schema alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->