### PR TITLE
[Dashboard] Feature: Update payment success copy on payment page

### DIFF
--- a/.changeset/cuddly-results-play.md
+++ b/.changeset/cuddly-results-play.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Updates copy on the payment widgets

--- a/apps/dashboard/src/app/pay/components/client/PayPageWidget.client.tsx
+++ b/apps/dashboard/src/app/pay/components/client/PayPageWidget.client.tsx
@@ -60,6 +60,7 @@ export function PayPageWidget({
             createWallet("io.metamask"),
             createWallet("io.rabby"),
             createWallet("com.okex.wallet"),
+            createWallet("me.rainbow"),
             createWallet("walletConnect"),
           ],
           showAllWallets: true,

--- a/packages/thirdweb/src/react/web/ui/Bridge/BridgeOrchestrator.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/BridgeOrchestrator.tsx
@@ -389,6 +389,7 @@ export function BridgeOrchestrator({
             preparedQuote={state.context.quote}
             uiOptions={uiOptions}
             windowAdapter={webWindowAdapter}
+            hasPaymentId={!!paymentLinkId}
           />
         )}
 

--- a/packages/thirdweb/src/react/web/ui/Bridge/payment-success/SuccessScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/payment-success/SuccessScreen.tsx
@@ -42,6 +42,11 @@ export interface SuccessScreenProps {
   windowAdapter: WindowAdapter;
 
   client: ThirdwebClient;
+
+  /**
+   * Whether or not this payment is associated with a payment ID. If it does, we show a different message.
+   */
+  hasPaymentId?: boolean;
 }
 
 type ViewState = "success" | "detail";
@@ -53,6 +58,7 @@ export function SuccessScreen({
   onDone,
   windowAdapter,
   client,
+  hasPaymentId = false,
 }: SuccessScreenProps) {
   const theme = useCustomTheme();
   const [viewState, setViewState] = useState<ViewState>("success");
@@ -120,7 +126,11 @@ export function SuccessScreen({
         </Text>
 
         <Text center color="secondaryText" size="sm">
-          Your cross-chain payment has been completed successfully.
+          {hasPaymentId
+            ? "You can now close this page and return to the application."
+            : uiOptions.mode === "transaction"
+              ? "Click continue to execute your transaction."
+              : "Your payment has been completed successfully."}
         </Text>
       </Container>
       <Spacer y="lg" />
@@ -135,9 +145,11 @@ export function SuccessScreen({
           View Payment Receipt
         </Button>
 
-        <Button fullWidth onClick={onDone} variant="accent">
-          {uiOptions.mode === "transaction" ? "Continue" : "Done"}
-        </Button>
+        {!hasPaymentId && (
+          <Button fullWidth onClick={onDone} variant="accent">
+            {uiOptions.mode === "transaction" ? "Continue" : "Done"}
+          </Button>
+        )}
       </Container>
 
       {/* CSS Animations */}

--- a/packages/thirdweb/src/stories/Bridge/SuccessScreen.stories.tsx
+++ b/packages/thirdweb/src/stories/Bridge/SuccessScreen.stories.tsx
@@ -222,3 +222,17 @@ export const TransactionPayment: Story = {
     backgrounds: { default: "light" },
   },
 };
+
+export const PaymentId: Story = {
+  args: {
+    client: storyClient,
+    completedStatuses: mockBuyCompletedStatuses,
+    hasPaymentId: true,
+    preparedQuote: simpleBuyQuote,
+    theme: "light",
+    uiOptions: TRANSACTION_UI_OPTIONS.contractInteraction,
+  },
+  parameters: {
+    backgrounds: { default: "light" },
+  },
+};


### PR DESCRIPTION
<img width="538" height="456" alt="Screenshot 2025-08-27 at 16 48 08" src="https://github.com/user-attachments/assets/3db76484-19b8-4bd8-be71-3cb44f06903e" />

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the payment widget's user experience by incorporating a `hasPaymentId` feature, which alters the success message and button visibility based on the presence of a payment ID.

### Detailed summary
- Updated copy on payment widgets to reflect payment ID status.
- Added `hasPaymentId` prop to `SuccessScreen` component.
- Modified success message based on `hasPaymentId`.
- Conditionally rendered the "Continue" button in `SuccessScreen`. 
- Introduced a new story for `PaymentId` in `SuccessScreen` stories.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Rainbow wallet to checkout, expanding available wallet options.

* **UI/Behavior**
  * Payment success screen: when a payment link is present it shows a "close and return" message and hides the action button; existing transaction and standard flows unchanged.

* **Documentation**
  * Added a Storybook example demonstrating the success-screen variant with a payment ID.

* **Chores**
  * Added release metadata to trigger a patch/changelog update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->