### PR TITLE
[SDK] Feature: add ability to exclude token prices from Bridge.tokens

### DIFF
--- a/.changeset/ripe-teeth-fold.md
+++ b/.changeset/ripe-teeth-fold.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Adds the ability to exclude prices from Bridge.tokens

--- a/packages/thirdweb/src/bridge/Onramp.ts
+++ b/packages/thirdweb/src/bridge/Onramp.ts
@@ -7,7 +7,7 @@ import { getClientFetch } from "../utils/fetch.js";
 import { stringify } from "../utils/json.js";
 import { ApiError } from "./types/Errors.js";
 import type { RouteStep } from "./types/Route.js";
-import type { Token } from "./types/Token.js";
+import type { TokenWithPrices } from "./types/Token.js";
 
 // export status within the Onramp module
 export { status } from "./OnrampStatus.js";
@@ -33,7 +33,7 @@ type OnrampPrepareQuoteResponseData = {
   currency: string;
   currencyAmount: number;
   destinationAmount: bigint;
-  destinationToken: Token;
+  destinationToken: TokenWithPrices;
   timestamp?: number;
   expiration?: number;
   steps: RouteStep[];

--- a/packages/thirdweb/src/bridge/Token.test.ts
+++ b/packages/thirdweb/src/bridge/Token.test.ts
@@ -22,7 +22,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("tokens", () => {
       expect(token).toHaveProperty("decimals");
       expect(token).toHaveProperty("symbol");
       expect(token).toHaveProperty("name");
-      expect(token).toHaveProperty("priceUsd");
+      expect(token).toHaveProperty("prices");
 
       if (token) {
         expect(typeof token.chainId).toBe("number");
@@ -30,8 +30,26 @@ describe.runIf(process.env.TW_SECRET_KEY)("tokens", () => {
         expect(typeof token.decimals).toBe("number");
         expect(typeof token.symbol).toBe("string");
         expect(typeof token.name).toBe("string");
-        expect(typeof token.priceUsd).toBe("number");
       }
+    }
+  });
+
+  it("should exclude prices if includePrices is false", async () => {
+    // Setup
+    const client = TEST_CLIENT;
+
+    // Test
+    const result = await tokens({
+      client,
+      includePrices: false,
+    });
+
+    // Verify
+    expect(result).toBeInstanceOf(Array);
+
+    // All tokens should not have prices
+    for (const token of result) {
+      expect(token.prices).toBeUndefined();
     }
   });
 

--- a/packages/thirdweb/src/bridge/index.ts
+++ b/packages/thirdweb/src/bridge/index.ts
@@ -17,7 +17,7 @@ export type {
   RouteTransaction,
 } from "./types/Route.js";
 export type { Status } from "./types/Status.js";
-export type { Token } from "./types/Token.js";
+export type { Token, TokenWithPrices } from "./types/Token.js";
 export type { WebhookPayload } from "./Webhook.js";
 export * as Webhook from "./Webhook.js";
 export { parse } from "./Webhook.js";

--- a/packages/thirdweb/src/bridge/types/Route.ts
+++ b/packages/thirdweb/src/bridge/types/Route.ts
@@ -2,24 +2,24 @@ import type { Hex as ox__Hex } from "ox";
 import type { Chain } from "../../chains/types.js";
 import type { ThirdwebClient } from "../../client/client.js";
 import type { Action } from "./BridgeAction.js";
-import type { Token } from "./Token.js";
+import type { TokenWithPrices } from "./Token.js";
 
 export type Route = {
-  originToken: Token;
-  destinationToken: Token;
+  originToken: TokenWithPrices;
+  destinationToken: TokenWithPrices;
 };
 
 export type RouteQuoteStep = {
-  originToken: Token;
-  destinationToken: Token;
+  originToken: TokenWithPrices;
+  destinationToken: TokenWithPrices;
   originAmount: bigint;
   destinationAmount: bigint;
   estimatedExecutionTimeMs: number;
 };
 
 export type RouteStep = {
-  originToken: Token;
-  destinationToken: Token;
+  originToken: TokenWithPrices;
+  destinationToken: TokenWithPrices;
   originAmount: bigint;
   destinationAmount: bigint;
   estimatedExecutionTimeMs: number;

--- a/packages/thirdweb/src/bridge/types/Token.ts
+++ b/packages/thirdweb/src/bridge/types/Token.ts
@@ -7,5 +7,8 @@ export type Token = {
   symbol: string;
   name: string;
   iconUri?: string;
+};
+
+export type TokenWithPrices = Token & {
   prices: Record<string, number>;
 };

--- a/packages/thirdweb/src/pay/convert/get-token.ts
+++ b/packages/thirdweb/src/pay/convert/get-token.ts
@@ -1,5 +1,5 @@
 import { add, tokens } from "../../bridge/Token.js";
-import type { Token } from "../../bridge/types/Token.js";
+import type { TokenWithPrices } from "../../bridge/types/Token.js";
 import type { ThirdwebClient } from "../../client/client.js";
 import { withCache } from "../../utils/promise/withCache.js";
 
@@ -7,7 +7,7 @@ export async function getToken(
   client: ThirdwebClient,
   tokenAddress: string,
   chainId: number,
-): Promise<Token> {
+): Promise<TokenWithPrices> {
   return withCache(
     async () => {
       const result = await tokens({

--- a/packages/thirdweb/src/react/core/hooks/usePaymentMethods.ts
+++ b/packages/thirdweb/src/react/core/hooks/usePaymentMethods.ts
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import type { Quote } from "../../../bridge/index.js";
 import { ApiError } from "../../../bridge/types/Errors.js";
-import type { Token } from "../../../bridge/types/Token.js";
+import type { Token, TokenWithPrices } from "../../../bridge/types/Token.js";
 import type { ThirdwebClient } from "../../../client/client.js";
 import { getThirdwebBaseUrl } from "../../../utils/domains.js";
 import { getClientFetch } from "../../../utils/fetch.js";
@@ -82,7 +82,7 @@ export function usePaymentMethods(options: {
 
       const {
         data: allValidOriginTokens,
-      }: { data: { quote: Quote; balance: string; token: Token }[] } =
+      }: { data: { quote: Quote; balance: string; token: TokenWithPrices }[] } =
         await response.json();
 
       // Sort by enough balance to pay THEN gross balance

--- a/packages/thirdweb/src/react/core/hooks/useTransactionDetails.ts
+++ b/packages/thirdweb/src/react/core/hooks/useTransactionDetails.ts
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import type { AbiFunction } from "abitype";
 import { toFunctionSelector } from "viem";
-import type { Token } from "../../../bridge/index.js";
+import type { TokenWithPrices } from "../../../bridge/index.js";
 import type { ThirdwebClient } from "../../../client/client.js";
 import { NATIVE_TOKEN_ADDRESS } from "../../../constants/addresses.js";
 import type { CompilerMetadata } from "../../../contract/actions/compiler-metadata.js";
@@ -34,7 +34,7 @@ interface TransactionDetails {
   usdValueDisplay: string | null;
   txCostDisplay: string;
   gasCostDisplay: string | null;
-  tokenInfo: Token | null;
+  tokenInfo: TokenWithPrices | null;
   costWei: bigint;
   gasCostWei: bigint | null;
   totalCost: string;

--- a/packages/thirdweb/src/react/core/machines/paymentMachine.ts
+++ b/packages/thirdweb/src/react/core/machines/paymentMachine.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from "react";
 import type { Quote } from "../../../bridge/index.js";
-import type { Token } from "../../../bridge/types/Token.js";
+import type { TokenWithPrices } from "../../../bridge/types/Token.js";
 import type { Address } from "../../../utils/address.js";
 import type { AsyncStorage } from "../../../utils/storage/AsyncStorage.js";
 import type { Wallet } from "../../../wallets/interfaces/wallet.js";
@@ -23,7 +23,7 @@ export type PaymentMethod =
   | {
       type: "wallet";
       payerWallet: Wallet;
-      originToken: Token;
+      originToken: TokenWithPrices;
       balance: bigint;
       quote: Quote;
     }
@@ -43,7 +43,7 @@ export interface PaymentMachineContext {
 
   // Target requirements (resolved in init state)
   destinationAmount?: string;
-  destinationToken?: Token;
+  destinationToken?: TokenWithPrices;
   receiverAddress?: Address;
 
   // User selections (set in methodSelection state)
@@ -73,7 +73,7 @@ export interface PaymentMachineContext {
 type PaymentMachineEvent =
   | {
       type: "DESTINATION_CONFIRMED";
-      destinationToken: Token;
+      destinationToken: TokenWithPrices;
       destinationAmount: string;
       receiverAddress: Address;
     }

--- a/packages/thirdweb/src/react/web/ui/Bridge/BridgeOrchestrator.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/BridgeOrchestrator.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useCallback, useMemo } from "react";
-import type { Token } from "../../../../bridge/types/Token.js";
+import type { TokenWithPrices } from "../../../../bridge/types/Token.js";
 import type { ThirdwebClient } from "../../../../client/client.js";
 import type { SupportedFiatCurrency } from "../../../../pay/convert/type.js";
 import type { PurchaseData } from "../../../../pay/types.js";
@@ -46,7 +46,7 @@ export type UIOptions = Prettify<
   } & (
     | {
         mode: "fund_wallet";
-        destinationToken: Token;
+        destinationToken: TokenWithPrices;
         initialAmount?: string;
         presetOptions?: [number, number, number];
       }
@@ -54,7 +54,7 @@ export type UIOptions = Prettify<
         mode: "direct_payment";
         paymentInfo: {
           sellerAddress: Address;
-          token: Token;
+          token: TokenWithPrices;
           amount: string;
           feePayer?: "sender" | "receiver";
         };
@@ -235,7 +235,7 @@ export function BridgeOrchestrator({
 
   // Handle requirements resolved from FundWallet and DirectPayment
   const handleRequirementsResolved = useCallback(
-    (amount: string, token: Token, receiverAddress: Address) => {
+    (amount: string, token: TokenWithPrices, receiverAddress: Address) => {
       send({
         destinationAmount: amount,
         destinationToken: token,

--- a/packages/thirdweb/src/react/web/ui/Bridge/DirectPayment.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/DirectPayment.tsx
@@ -1,5 +1,5 @@
 "use client";
-import type { Token } from "../../../../bridge/types/Token.js";
+import type { TokenWithPrices } from "../../../../bridge/types/Token.js";
 import { defineChain } from "../../../../chains/utils.js";
 import type { ThirdwebClient } from "../../../../client/client.js";
 import type { Address } from "../../../../utils/address.js";
@@ -28,7 +28,11 @@ export interface DirectPaymentProps {
   /**
    * Called when user continues with the payment
    */
-  onContinue: (amount: string, token: Token, receiverAddress: Address) => void;
+  onContinue: (
+    amount: string,
+    token: TokenWithPrices,
+    receiverAddress: Address,
+  ) => void;
 
   /**
    * Whether to show thirdweb branding in the widget.

--- a/packages/thirdweb/src/react/web/ui/Bridge/FundWallet.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/FundWallet.tsx
@@ -1,7 +1,7 @@
 /** biome-ignore-all lint/a11y/useSemanticElements: FIXME */
 "use client";
 import { useRef, useState } from "react";
-import type { Token } from "../../../../bridge/types/Token.js";
+import type { TokenWithPrices } from "../../../../bridge/types/Token.js";
 import type { ThirdwebClient } from "../../../../client/client.js";
 import { type Address, getAddress } from "../../../../utils/address.js";
 import { numberToPlainString } from "../../../../utils/formatNumber.js";
@@ -46,7 +46,11 @@ export interface FundWalletProps {
   /**
    * Called when continue is clicked with the resolved requirements
    */
-  onContinue: (amount: string, token: Token, receiverAddress: Address) => void;
+  onContinue: (
+    amount: string,
+    token: TokenWithPrices,
+    receiverAddress: Address,
+  ) => void;
 
   /**
    * Quick buy amounts

--- a/packages/thirdweb/src/react/web/ui/Bridge/TransactionPayment.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/TransactionPayment.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useQuery } from "@tanstack/react-query";
-import type { Token } from "../../../../bridge/index.js";
+import type { TokenWithPrices } from "../../../../bridge/types/Token.js";
 import type { ThirdwebClient } from "../../../../client/client.js";
 import { NATIVE_TOKEN_ADDRESS } from "../../../../constants/addresses.js";
 import {
@@ -46,7 +46,11 @@ export interface TransactionPaymentProps {
   /**
    * Called when user confirms transaction execution
    */
-  onContinue: (amount: string, token: Token, receiverAddress: Address) => void;
+  onContinue: (
+    amount: string,
+    token: TokenWithPrices,
+    receiverAddress: Address,
+  ) => void;
 
   /**
    * Request to execute the transaction immediately (skips funding flow)

--- a/packages/thirdweb/src/stories/Bridge/fixtures.ts
+++ b/packages/thirdweb/src/stories/Bridge/fixtures.ts
@@ -1,5 +1,5 @@
 import { stringify } from "viem";
-import type { Token } from "../../bridge/index.js";
+import type { TokenWithPrices } from "../../bridge/types/Token.js";
 import { base } from "../../chains/chain-definitions/base.js";
 import { baseSepolia } from "../../chains/chain-definitions/base-sepolia.js";
 import { polygon } from "../../chains/chain-definitions/polygon.js";
@@ -19,7 +19,7 @@ import { toWei } from "../../utils/units.js";
 import type { Account, Wallet } from "../../wallets/interfaces/wallet.js";
 import { storyClient } from "../utils.js";
 
-export const ETH: Token = {
+export const ETH: TokenWithPrices = {
   address: NATIVE_TOKEN_ADDRESS,
   chainId: 10,
   decimals: 18,
@@ -32,7 +32,7 @@ export const ETH: Token = {
   symbol: "ETH",
 };
 
-export const USDC: Token = {
+export const USDC: TokenWithPrices = {
   address: getDefaultToken(base, "USDC")?.address ?? "",
   chainId: base.id,
   decimals: 6,
@@ -45,7 +45,7 @@ export const USDC: Token = {
   symbol: "USDC",
 };
 
-export const UNI: Token = {
+export const UNI: TokenWithPrices = {
   address: "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
   chainId: 10,
   decimals: 18,


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the `TokenWithPrices` type to manage tokens with associated prices, enhancing the `Bridge.tokens` functionality. It allows for the exclusion of prices when fetching tokens, improving efficiency and flexibility in token management.

### Detailed summary
- Added `TokenWithPrices` type extending `Token` to include `prices`.
- Updated various modules to use `TokenWithPrices` instead of `Token`.
- Modified `tokens` function to accept an `includePrices` option.
- Added tests to verify the exclusion of prices when `includePrices` is false.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Tokens across Bridge, Onramp, and Pay now include pricing data, enabling USD calculations and richer UI displays.
  - Bridge.tokens supports an option to exclude prices for faster responses when pricing isn’t needed.
  - Routes and quotes surface price-aware origin/destination tokens throughout SDK and React components.
  - Route steps now include their associated transactions for better transparency in bridging flows.
- Refactor
  - Standardized token data to a price-aware format across APIs, hooks, and UI components for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->