### PR TITLE
docs: Fix Typos in docs

### DIFF
--- a/apps/portal/src/app/typescript/v5/extensions/examples/transfering-tokens/page.mdx
+++ b/apps/portal/src/app/typescript/v5/extensions/examples/transfering-tokens/page.mdx
@@ -1,4 +1,4 @@
-# Transfering (sending) tokens using thirdweb extensions
+# Transferring (sending) tokens using thirdweb extensions
 
 ## ERC721
 ```typescript

--- a/apps/portal/src/app/typescript/v5/extensions/use/page.mdx
+++ b/apps/portal/src/app/typescript/v5/extensions/use/page.mdx
@@ -58,7 +58,7 @@ const transactionResult = await sendTransaction({
 
 ### Example: `transfer()` extension for ERC20 tokens
 
-This extension conveniently handles unit conversion when transfering ERC20 tokens. You can pass the amount in tokens, the extension will convert it to the right unit before calling the contract.
+This extension conveniently handles unit conversion when Transferring ERC20 tokens. You can pass the amount in tokens, the extension will convert it to the right unit before calling the contract.
 
 ```typescript
 import { getContract, sendTransaction } from "thirdweb";

--- a/apps/portal/src/app/typescript/v5/migrate/page.mdx
+++ b/apps/portal/src/app/typescript/v5/migrate/page.mdx
@@ -72,7 +72,7 @@ sendTx(transaction);
 
 As you can see, by pairing the contract extensions with `useReadContract` (for read) and `useSendTransaction` (for write),
 we are able to greatly reduce the amount of code that is packaged & shipped to the end users. Plus, with this approach we can dedicate more time
-to building contract extensions. The SDK v5 currenty supports over hundreds of extensions, with some popular protocols like Uniswap, Farcaster, Lens & more to come.
+to building contract extensions. The SDK v5 currently supports over hundreds of extensions, with some popular protocols like Uniswap, Farcaster, Lens & more to come.
 
 View a list of [supported extensions](/typescript/v5/extensions/built-in) here, or [build your own](/typescript/v5/extensions/create)!
 


### PR DESCRIPTION
### Description

This PR corrects several minor typos in comments and documentation across the codebase. The changes are non-functional and purely textual to improve clarity and maintain a clean, professional codebase.

### Details

- Corrected misspellings:
  - `Transfering` → `Transferring`
  - `currenty` → `currently`

These fixes help enhance readability and eliminate minor distractions during development and code reviews.

### Additional Info

No logic or functionality has been modified. All changes are restricted to comments or non-executable doc annotations.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a new section about transferring tokens using thirdweb extensions and making minor text improvements for clarity in existing documentation.

### Detailed summary
- Added a new section on transferring tokens using thirdweb extensions in `page.mdx`.
- Changed "transfering" to "Transferring" for consistency in the `transfer()` extension documentation for ERC20 tokens in `page.mdx`.
- Corrected "currenty" to "currently" in the migration documentation in `page.mdx`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Corrected spelling and capitalization in extension examples and headings (e.g., “Transferring”).
  - Fixed a typo in the migration guide (“currenty” → “currently”) to improve clarity.
  - Aligned terminology and style across v5 documentation for ERC20, ERC721, and ERC1155 examples.
  - No changes to examples’ logic, public APIs, or behavior; content remains functionally identical.
  - Improves readability, professionalism, and consistency throughout the docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->