### PR TITLE
[MNY-142] Dashboard: Do not render BuyWidget if token is not supported by Bridge

### DIFF
--- a/apps/dashboard/src/app/(app)/(dashboard)/(chain)/[chain_id]/[contractAddress]/public-pages/erc20/erc20.tsx
+++ b/apps/dashboard/src/app/(app)/(dashboard)/(chain)/[chain_id]/[contractAddress]/public-pages/erc20/erc20.tsx
@@ -28,7 +28,7 @@ export async function ERC20PublicPage(props: {
     contractMetadata,
     activeClaimCondition,
     tokenDecimals,
-    tokenInfo,
+    tokenInfoFromUB,
     functionSelectors,
     tokenPriceData,
   ] = await Promise.all([
@@ -51,8 +51,8 @@ export async function ERC20PublicPage(props: {
     }),
   ]);
 
-  if (!contractMetadata.image && tokenInfo) {
-    contractMetadata.image = tokenInfo.iconUri;
+  if (!contractMetadata.image && tokenInfoFromUB) {
+    contractMetadata.image = tokenInfoFromUB.iconUri;
   }
 
   const [contractCreator, claimConditionCurrencyMeta] = await Promise.all([
@@ -70,24 +70,15 @@ export async function ERC20PublicPage(props: {
   const cookieStore = await cookies();
   const isDashboardUser = cookieStore.has(HAS_USED_DASHBOARD);
 
-  const buyEmbed = (
-    <BuyEmbed
-      chainMetadata={props.chainMetadata}
-      claimConditionMeta={
-        activeClaimCondition && claimConditionCurrencyMeta
-          ? {
-              activeClaimCondition,
-              claimConditionCurrency: claimConditionCurrencyMeta,
-            }
-          : undefined
-      }
-      clientContract={props.clientContract}
-      tokenAddress={props.clientContract.address}
-      tokenDecimals={tokenDecimals}
-      tokenName={contractMetadata.name}
-      tokenSymbol={contractMetadata.symbol}
-    />
-  );
+  const claimConditionMeta =
+    activeClaimCondition && claimConditionCurrencyMeta
+      ? {
+          activeClaimCondition,
+          claimConditionCurrency: claimConditionCurrencyMeta,
+        }
+      : undefined;
+  const isUBSupported = !!tokenInfoFromUB;
+  const showBuyEmbed = isUBSupported || claimConditionMeta;
 
   return (
     <div className="flex grow flex-col">
@@ -116,21 +107,33 @@ export async function ERC20PublicPage(props: {
 
       <div className="container flex max-w-5xl grow flex-col pt-8 pb-10">
         <div className="flex grow flex-col gap-8">
-          <div className="sm:flex sm:justify-center w-full sm:border sm:border-dashed sm:bg-accent/20 sm:py-12 rounded-lg overflow-hidden relative">
-            <GridPattern
-              width={30}
-              height={30}
-              x={-1}
-              y={-1}
-              strokeDasharray={"4 2"}
-              className="text-border dark:text-border/70"
-              style={{
-                maskImage:
-                  "linear-gradient(to bottom right,white,transparent,transparent)",
-              }}
-            />
-            <div className="sm:w-[420px] z-10">{buyEmbed}</div>
-          </div>
+          {showBuyEmbed && (
+            <div className="sm:flex sm:justify-center w-full sm:border sm:border-dashed sm:bg-accent/20 sm:py-12 rounded-lg overflow-hidden relative">
+              <GridPattern
+                width={30}
+                height={30}
+                x={-1}
+                y={-1}
+                strokeDasharray={"4 2"}
+                className="text-border dark:text-border/70"
+                style={{
+                  maskImage:
+                    "linear-gradient(to bottom right,white,transparent,transparent)",
+                }}
+              />
+              <div className="sm:w-[420px] z-10">
+                <BuyEmbed
+                  chainMetadata={props.chainMetadata}
+                  claimConditionMeta={claimConditionMeta}
+                  clientContract={props.clientContract}
+                  tokenAddress={props.clientContract.address}
+                  tokenDecimals={tokenDecimals}
+                  tokenName={contractMetadata.name}
+                  tokenSymbol={contractMetadata.symbol}
+                />
+              </div>
+            </div>
+          )}
 
           {tokenPriceData ? (
             <>


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `ERC20PublicPage` component to utilize `tokenInfoFromUB` instead of `tokenInfo`, modifies the logic around displaying the `BuyEmbed` component, and adjusts the rendering accordingly.

### Detailed summary
- Replaced `tokenInfo` with `tokenInfoFromUB` for contract metadata image.
- Created `claimConditionMeta` object for managing claim conditions.
- Introduced `isUBSupported` to determine support for `tokenInfoFromUB`.
- Conditionally rendered the `BuyEmbed` component based on `showBuyEmbed`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Buy section now appears only when the token/provider supports it or when a claim condition exists.
  * Unified buy experience: automatically shows either a direct buy flow or a claim flow based on available conditions.

* **Bug Fixes**
  * More reliable token image fallback to reduce missing/blank icons.

* **Style**
  * Preserved decorative layout while conditionally rendering the buy UI for a cleaner, consistent appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->