### PR TITLE
remove looking for engine on project view page

### DIFF
--- a/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/page.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/page.tsx
@@ -4,7 +4,6 @@ import { getInAppWalletUsage } from "@/api/analytics";
 import { getAuthToken } from "@/api/auth-token";
 import { getProjects, type Project } from "@/api/project/projects";
 import { getTeamBySlug } from "@/api/team/get-team";
-import { DismissibleAlert } from "@/components/blocks/dismissible-alert";
 import { getClientThirdwebClient } from "@/constants/thirdweb-client.client";
 import { loginRedirect } from "@/utils/redirects";
 import { Changelog } from "./_components/Changelog";
@@ -63,15 +62,8 @@ export default async function Page(props: {
           team={team}
         />
 
-        {team.billingPlan === "free" ? (
+        {team.billingPlan === "free" && (
           <FreePlanUpsellBannerUI highlightPlan="growth" teamSlug={team.slug} />
-        ) : (
-          <DismissibleAlert
-            preserveState={true}
-            description="Engines, contracts, project settings, and more are now managed within projects. Open or create a project to access them."
-            localStorageId={`${team.id}-engines-alert`}
-            title="Looking for Engines?"
-          />
         )}
 
         <Changelog />


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

https://linear.app/thirdweb/issue/BLD-238/remove-looking-for-engine-hint-from-project-view

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on simplifying the conditional rendering logic in the `page.tsx` file by removing the `DismissibleAlert` component and replacing the ternary operator with a logical AND operator for the `FreePlanUpsellBannerUI`.

### Detailed summary
- Removed the `DismissibleAlert` component entirely.
- Changed the conditional rendering of `FreePlanUpsellBannerUI` from a ternary operator to a logical AND operator.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Paid teams no longer see an unnecessary alert on the team page.
  * Free plan teams continue to see the upgrade/upsell banner as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->