### PR TITLE
[AI SDK Provider] Update sign swap action type with token fields

### DIFF
--- a/.changeset/quiet-llamas-chew.md
+++ b/.changeset/quiet-llamas-chew.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/ai-sdk-provider": patch
+---
+
+Update sign swap action type

--- a/packages/ai-sdk-provider/src/provider.ts
+++ b/packages/ai-sdk-provider/src/provider.ts
@@ -453,6 +453,8 @@ class ThirdwebLanguageModel implements LanguageModelV2 {
                                 action: parsed.data.action,
                                 intent: parsed.data.intent,
                                 transaction: parsed.data.transaction,
+                                from_token: parsed.data.from_token,
+                                to_token: parsed.data.to_token,
                               } satisfies SignSwapInput;
                               break;
 

--- a/packages/ai-sdk-provider/src/tools.ts
+++ b/packages/ai-sdk-provider/src/tools.ts
@@ -21,10 +21,21 @@ const AgentActionSignSwapDataIntent = z.object({
   max_steps: z.number(),
 });
 
+const AgentActionSignSwapDataToken = z.object({
+  address: z.string(),
+  chain_id: z.number(),
+  amount: z.string(),
+  symbol: z.string(),
+  decimals: z.number(),
+  price: z.number().nullable(),
+});
+
 const AgentActionSignSwapData = z.object({
   action: z.string(),
   intent: AgentActionSignSwapDataIntent,
   transaction: AgentActionSignTransactionData,
+  from_token: AgentActionSignSwapDataToken,
+  to_token: AgentActionSignSwapDataToken,
 });
 
 const AgentActionTransactionOutputData = z.object({


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `sign swap` action type in the `ai-sdk-provider` package by refining the data structure to include `from_token` and `to_token` fields, enhancing the handling of token-related information in the swap action.

### Detailed summary
- Updated the `sign swap` action type in `provider.ts` to include `from_token` and `to_token`.
- Defined `AgentActionSignSwapDataToken` schema in `tools.ts` with fields: `address`, `chain_id`, `amount`, `symbol`, `decimals`, and `price`.
- Updated `AgentActionSignSwapData` schema to include `from_token` and `to_token` using the new `AgentActionSignSwapDataToken` schema.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Enhanced sign_swap action to include source and destination token details (from_token/to_token), providing address, chain ID, symbol, decimals, amount, and price for each token. Enables richer context and validation during swaps.
* Chores
  * Published a patch release for the AI SDK provider reflecting the updated sign_swap action type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->