### PR TITLE
Remove ability to disable Transactions

### DIFF
--- a/apps/dashboard/src/@/schema/validations.ts
+++ b/apps/dashboard/src/@/schema/validations.ts
@@ -147,4 +147,4 @@ export type ApiKeyPayConfigValidationSchema = z.infer<
 >;
 
 // FIXME: Remove
-export const HIDDEN_SERVICES = ["relayer", "chainsaw"];
+export const HIDDEN_SERVICES = ["relayer", "chainsaw", "engineCloud"];


### PR DESCRIPTION
The 'engineCloud' service has been added to the HIDDEN_SERVICES array, to hide it from certain UI elements or logic.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `HIDDEN_SERVICES` constant in the `validations.ts` file to include an additional service, `engineCloud`, alongside the existing services `relayer` and `chainsaw`.

### Detailed summary
- Modified the `HIDDEN_SERVICES` export:
  - Added `engineCloud` to the existing array `["relayer", "chainsaw"]`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Updated the dashboard to hide the Engine Cloud service from service lists, selectors, and related views.
  - Reduces confusion by ensuring only supported services are visible across navigation and forms.
  - Visibility change only; no other functionality is altered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->