### PR TITLE
polygon amoy gasstation update

### DIFF
--- a/packages/thirdweb/src/gas/fee-data.ts
+++ b/packages/thirdweb/src/gas/fee-data.ts
@@ -242,7 +242,7 @@ function getGasStationUrl(chainId: 137 | 80002): string {
     case 137:
       return "https://gasstation.polygon.technology/v2";
     case 80002:
-      return "https://gasstation-testnet.polygon.technology/v2";
+      return "https://gasstation.polygon.technology/amoy";
   }
 }
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the URL returned for the `80002` case in the `fee-data.ts` file, changing it from a testnet gas station to a specific endpoint.

### Detailed summary
- In the `fee-data.ts` file, the return value for the case `80002` was changed from:
  - `"https://gasstation-testnet.polygon.technology/v2"` 
  - to `"https://gasstation.polygon.technology/amoy"`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the gas fee data source for Polygon Amoy (chain 80002) to the current Amoy gas station endpoint, improving accuracy and reliability of priority fee estimates.
  * Enhances transaction success rates and fee predictions for users interacting with the Amoy network.
  * No changes for Polygon mainnet (137).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->