### PR TITLE
[SDK] move over some utility read only endpoints to API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ storybook-static
 tsconfig.tsbuildinfo
 .cursor
 apps/dashboard/node-compile-cache
+.tmp/

--- a/biome.json
+++ b/biome.json
@@ -35,6 +35,10 @@
           }
         }
       },
+      "formatter": {
+        "enabled": true,
+        "indentStyle": "space"
+      },
       "includes": ["package.json"]
     }
   ]

--- a/packages/thirdweb/biome.json
+++ b/packages/thirdweb/biome.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.0.6/schema.json",
   "extends": "//",
+  "root": false,
   "overrides": [
     {
       "assist": {
@@ -9,6 +10,10 @@
             "useSortedKeys": "off"
           }
         }
+      },
+      "formatter": {
+        "enabled": true,
+        "indentStyle": "space"
       },
       "includes": ["package.json"]
     }

--- a/packages/thirdweb/package.json
+++ b/packages/thirdweb/package.json
@@ -23,6 +23,7 @@
     "@radix-ui/react-tooltip": "1.2.7",
     "@storybook/react": "9.0.15",
     "@tanstack/react-query": "5.81.5",
+    "@thirdweb-dev/api": "workspace:*",
     "@thirdweb-dev/engine": "workspace:*",
     "@thirdweb-dev/insight": "workspace:*",
     "@walletconnect/sign-client": "2.20.1",

--- a/packages/thirdweb/src/extensions/common/read/getContractMetadata.test.ts
+++ b/packages/thirdweb/src/extensions/common/read/getContractMetadata.test.ts
@@ -7,11 +7,17 @@ describe.runIf(process.env.TW_SECRET_KEY)("shared.getContractMetadata", () => {
     const metadata = await getContractMetadata({
       contract: USDT_CONTRACT,
     });
-    expect(metadata).toMatchInlineSnapshot(`
-      {
-        "name": "Tether USD",
-        "symbol": "USDT",
-      }
-    `);
+
+    // Test the existing interface that consumers expect (from the original snapshot)
+    expect(metadata).toMatchObject({
+      name: "Tether USD",
+      symbol: "USDT",
+    });
+
+    // Ensure the required properties exist
+    expect(metadata).toHaveProperty("name");
+    expect(metadata).toHaveProperty("symbol");
+    expect(typeof metadata.name).toBe("string");
+    expect(typeof metadata.symbol).toBe("string");
   });
 });

--- a/packages/thirdweb/src/extensions/common/read/getContractMetadata.ts
+++ b/packages/thirdweb/src/extensions/common/read/getContractMetadata.ts
@@ -1,3 +1,7 @@
+import {
+  getContractMetadata as apiGetContractMetadata,
+  configure,
+} from "@thirdweb-dev/api";
 import type { BaseTransactionOptions } from "../../../transaction/types.js";
 import { fetchContractMetadata } from "../../../utils/contract/fetchContractMetadata.js";
 import { contractURI } from "../__generated__/IContractMetadata/read/contractURI.js";
@@ -25,6 +29,72 @@ export async function getContractMetadata(
   // biome-ignore lint/suspicious/noExplicitAny: TODO: fix any
   [key: string]: any;
 }> {
+  // Configure the API client
+  configure({
+    clientId: options.contract.client.clientId,
+    secretKey: options.contract.client.secretKey,
+  });
+
+  try {
+    // Try to get metadata from the API first
+    const response = await apiGetContractMetadata({
+      path: {
+        chainId: options.contract.chain.id,
+        address: options.contract.address,
+      },
+    });
+
+    if (response.data?.result?.output?.abi) {
+      // Extract name and symbol from ABI or devdoc/userdoc
+      const abi = response.data.result.output.abi;
+      const devdoc = response.data.result.output.devdoc;
+      const userdoc = response.data.result.output.userdoc;
+
+      // Try to find name and symbol from ABI functions
+      let contractName = "";
+      let contractSymbol = "";
+
+      if (Array.isArray(abi)) {
+        const nameFunc = abi.find(
+          (item: any) =>
+            item.type === "function" &&
+            item.name === "name" &&
+            item.inputs?.length === 0,
+        );
+        const symbolFunc = abi.find(
+          (item: any) =>
+            item.type === "function" &&
+            item.name === "symbol" &&
+            item.inputs?.length === 0,
+        );
+
+        if (nameFunc || symbolFunc) {
+          // Fall back to RPC if we found name/symbol functions in ABI
+          const [resolvedName, resolvedSymbol] = await Promise.all([
+            nameFunc ? name(options).catch(() => null) : null,
+            symbolFunc ? symbol(options).catch(() => null) : null,
+          ]);
+          contractName = resolvedName || "";
+          contractSymbol = resolvedSymbol || "";
+        }
+      }
+
+      return {
+        name: contractName,
+        symbol: contractSymbol,
+        abi: abi,
+        compiler: response.data.result.compiler,
+        language: response.data.result.language,
+        devdoc: devdoc,
+        userdoc: userdoc,
+      };
+    }
+  } catch (error) {
+    // API failed, fall back to original implementation
+    console.debug("Contract metadata API failed, falling back to RPC:", error);
+  }
+
+  // Fallback to original RPC-based implementation
   const [resolvedMetadata, resolvedName, resolvedSymbol] = await Promise.all([
     contractURI(options)
       .then((uri) => {
@@ -41,7 +111,6 @@ export async function getContractMetadata(
     symbol(options).catch(() => null),
   ]);
 
-  // TODO: basic parsing?
   return {
     ...resolvedMetadata,
     name: resolvedMetadata?.name ?? resolvedName,

--- a/packages/thirdweb/src/wallets/utils/getTokenBalance.test.ts
+++ b/packages/thirdweb/src/wallets/utils/getTokenBalance.test.ts
@@ -1,77 +1,45 @@
 import { describe, expect, it } from "vitest";
-import { ANVIL_CHAIN, FORKED_ETHEREUM_CHAIN } from "~test/chains.js";
-import { TEST_CONTRACT_URI } from "~test/ipfs-uris.js";
 import { TEST_CLIENT } from "~test/test-clients.js";
-import { TEST_ACCOUNT_D } from "~test/test-wallets.js";
-import { getContract } from "../../contract/contract.js";
-import { mintTo } from "../../extensions/erc20/write/mintTo.js";
-import { deployERC20Contract } from "../../extensions/prebuilts/deploy-erc20.js";
-import { sendAndConfirmTransaction } from "../../transaction/actions/send-and-confirm-transaction.js";
+import { baseSepolia } from "../../chains/chain-definitions/base-sepolia.js";
 import { getTokenBalance } from "./getTokenBalance.js";
 
-const account = TEST_ACCOUNT_D;
+// Create a mock account for testing
+const testAccount = {
+  address: "0x742d35Cc6645C0532b6C766684f4b4E99Bf87E8A", // Base deployer address
+};
 
 describe.runIf(process.env.TW_SECRET_KEY)("getTokenBalance", () => {
   it("should work for native token", async () => {
     const result = await getTokenBalance({
-      account,
-      chain: FORKED_ETHEREUM_CHAIN,
+      account: testAccount,
+      chain: baseSepolia,
       client: TEST_CLIENT,
     });
 
-    expect(result).toStrictEqual({
-      decimals: 18,
-      displayValue: "10000",
-      name: "Ether",
-      symbol: "ETH",
-      value: 10000000000000000000000n,
-    });
+    expect(result).toBeDefined();
+    expect(result.decimals).toBe(18);
+    expect(result.name).toBe("Sepolia Ether");
+    expect(result.symbol).toBe("ETH");
+    expect(result.value).toBeTypeOf("bigint");
+    expect(result.displayValue).toBeTypeOf("string");
   });
 
   it("should work for ERC20 token", async () => {
-    const erc20Address = await deployERC20Contract({
-      account,
-      chain: ANVIL_CHAIN,
-      client: TEST_CLIENT,
-      params: {
-        contractURI: TEST_CONTRACT_URI,
-        name: "",
-      },
-      type: "TokenERC20",
-    });
-    const erc20Contract = getContract({
-      address: erc20Address,
-      chain: ANVIL_CHAIN,
-      client: TEST_CLIENT,
-    });
-
-    const amount = 1000;
-
-    // Mint some tokens
-    const tx = mintTo({
-      amount,
-      contract: erc20Contract,
-      to: account.address,
-    });
-
-    await sendAndConfirmTransaction({
-      account,
-      transaction: tx,
-    });
+    // Use a known ERC20 token on Base Sepolia
+    const usdcAddress = "0x036CbD53842c5426634e7929541eC2318f3dCF7e"; // USDC on Base Sepolia
 
     const result = await getTokenBalance({
-      account,
-      chain: ANVIL_CHAIN,
+      account: testAccount,
+      chain: baseSepolia,
       client: TEST_CLIENT,
-      tokenAddress: erc20Address,
+      tokenAddress: usdcAddress,
     });
 
-    const expectedDecimal = 18;
     expect(result).toBeDefined();
-    expect(result.decimals).toBe(expectedDecimal);
+    expect(result.decimals).toBe(6); // USDC has 6 decimals
     expect(result.symbol).toBeDefined();
     expect(result.name).toBeDefined();
-    expect(result.value).toBe(BigInt(amount) * 10n ** BigInt(expectedDecimal));
-    expect(result.displayValue).toBe(amount.toString());
+    expect(result.value).toBeTypeOf("bigint");
+    expect(result.displayValue).toBeTypeOf("string");
   });
 });

--- a/packages/thirdweb/src/wallets/utils/getWalletBalance.test.ts
+++ b/packages/thirdweb/src/wallets/utils/getWalletBalance.test.ts
@@ -1,71 +1,50 @@
 import { describe, expect, it } from "vitest";
-import { ANVIL_CHAIN } from "~test/chains.js";
-import { TEST_CONTRACT_URI } from "~test/ipfs-uris.js";
 import { TEST_CLIENT } from "~test/test-clients.js";
-import { TEST_ACCOUNT_A } from "~test/test-wallets.js";
-import { getContract } from "../../contract/contract.js";
-import { mintTo } from "../../extensions/erc20/write/mintTo.js";
-import { deployERC20Contract } from "../../extensions/prebuilts/deploy-erc20.js";
-import { sendAndConfirmTransaction } from "../../transaction/actions/send-and-confirm-transaction.js";
+import { baseSepolia } from "../../chains/chain-definitions/base-sepolia.js";
 import { getWalletBalance } from "./getWalletBalance.js";
 
 describe.runIf(process.env.TW_SECRET_KEY)("getWalletBalance", () => {
-  it("should work for erc20 token", async () => {
-    const erc20Address = await deployERC20Contract({
-      account: TEST_ACCOUNT_A,
-      chain: ANVIL_CHAIN,
-      client: TEST_CLIENT,
-      params: {
-        contractURI: TEST_CONTRACT_URI,
-        name: "",
-      },
-      type: "TokenERC20",
-    });
-    const erc20Contract = getContract({
-      address: erc20Address,
-      chain: ANVIL_CHAIN,
-      client: TEST_CLIENT,
-    });
-
-    const amount = 1000;
-
-    // Mint some tokens
-    const tx = mintTo({
-      amount,
-      contract: erc20Contract,
-      to: TEST_ACCOUNT_A.address,
-    });
-
-    await sendAndConfirmTransaction({
-      account: TEST_ACCOUNT_A,
-      transaction: tx,
-    });
+  it("should work for native currency", async () => {
+    // Use a known address with ETH on Base Sepolia
+    // This is a public address that should have some ETH for testing
+    const testAddress = "0x742d35Cc6645C0532b6C766684f4b4E99Bf87E8A"; // Base deployer address
 
     const result = await getWalletBalance({
-      address: TEST_ACCOUNT_A.address,
-      chain: ANVIL_CHAIN,
+      address: testAddress,
+      chain: baseSepolia,
       client: TEST_CLIENT,
-      tokenAddress: erc20Address,
     });
-    const expectedDecimal = 18;
+
     expect(result).toBeDefined();
-    expect(result.decimals).toBe(expectedDecimal);
-    expect(result.symbol).toBeDefined();
-    expect(result.name).toBeDefined();
-    expect(result.value).toBe(BigInt(amount) * 10n ** BigInt(expectedDecimal));
-    expect(result.displayValue).toBe(amount.toString());
+    expect(result.chainId).toBe(84532); // Base Sepolia chain ID
+    expect(result.decimals).toBe(18);
+    expect(result.symbol).toBe("ETH");
+    expect(result.name).toBe("Sepolia Ether");
+    expect(result.tokenAddress).toBeDefined();
+    expect(result.value).toBeTypeOf("bigint");
+    expect(result.displayValue).toBeTypeOf("string");
   });
 
-  it("should work for native currency", async () => {
+  it("should work for ERC20 token", async () => {
+    // Use a known ERC20 token on Base Sepolia
+    // Using the official test token: Base Sepolia USD Coin
+    const usdcAddress = "0x036CbD53842c5426634e7929541eC2318f3dCF7e"; // USDC on Base Sepolia
+    const testAddress = "0x742d35Cc6645C0532b6C766684f4b4E99Bf87E8A"; // Address with potential balance
+
     const result = await getWalletBalance({
-      address: TEST_ACCOUNT_A.address,
-      chain: ANVIL_CHAIN,
+      address: testAddress,
+      chain: baseSepolia,
       client: TEST_CLIENT,
+      tokenAddress: usdcAddress,
     });
+
     expect(result).toBeDefined();
-    expect(result.decimals).toBe(18);
+    expect(result.chainId).toBe(84532);
+    expect(result.decimals).toBe(6); // USDC has 6 decimals
     expect(result.symbol).toBeDefined();
-    expect(result.value).toBeGreaterThan(0n);
-    expect(result.displayValue).toBeDefined();
+    expect(result.name).toBeDefined();
+    expect(result.tokenAddress).toBe(usdcAddress);
+    expect(result.value).toBeTypeOf("bigint");
+    expect(result.displayValue).toBeTypeOf("string");
   });
 });

--- a/packages/thirdweb/src/wallets/utils/getWalletBalance.ts
+++ b/packages/thirdweb/src/wallets/utils/getWalletBalance.ts
@@ -1,16 +1,10 @@
-import type { Chain } from "../../chains/types.js";
 import {
-  getChainDecimals,
-  getChainNativeCurrencyName,
-  getChainSymbol,
-} from "../../chains/utils.js";
+  getWalletBalance as apiGetWalletBalance,
+  configure,
+} from "@thirdweb-dev/api";
+import type { Chain } from "../../chains/types.js";
 import type { ThirdwebClient } from "../../client/client.js";
-import { NATIVE_TOKEN_ADDRESS } from "../../constants/addresses.js";
-import { getContract } from "../../contract/contract.js";
 import type { GetBalanceResult } from "../../extensions/erc20/read/getBalance.js";
-import { eth_getBalance } from "../../rpc/actions/eth_getBalance.js";
-import { getRpcClient } from "../../rpc/rpc.js";
-import { toTokens } from "../../utils/units.js";
 
 export type GetWalletBalanceOptions = {
   address: string;
@@ -43,35 +37,42 @@ export async function getWalletBalance(
   options: GetWalletBalanceOptions,
 ): Promise<GetBalanceResult> {
   const { address, client, chain, tokenAddress } = options;
-  // erc20 case
-  if (tokenAddress) {
-    // load balanceOf dynamically to avoid circular dependency
-    const { getBalance } = await import(
-      "../../extensions/erc20/read/getBalance.js"
-    );
-    return getBalance({
+
+  // Configure the API client with credentials from the thirdweb client
+  configure({
+    clientId: client.clientId,
+    secretKey: client.secretKey,
+  });
+
+  const response = await apiGetWalletBalance({
+    path: {
       address,
-      contract: getContract({ address: tokenAddress, chain, client }),
-    });
+    },
+    query: {
+      chainId: [chain.id],
+      ...(tokenAddress && { tokenAddress }),
+    },
+  });
+
+  if (!response.data?.result || response.data.result.length === 0) {
+    throw new Error("No balance data returned from API");
   }
-  // native token case
-  const rpcRequest = getRpcClient({ chain, client });
 
-  const [nativeSymbol, nativeDecimals, nativeName, nativeBalance] =
-    await Promise.all([
-      getChainSymbol(chain),
-      getChainDecimals(chain),
-      getChainNativeCurrencyName(chain),
-      eth_getBalance(rpcRequest, { address }),
-    ]);
+  // Get the first result (should match our chain)
+  const balanceData = response.data.result[0];
 
+  if (!balanceData) {
+    throw new Error("Balance data not found for the specified chain");
+  }
+
+  // Transform API response to match the existing GetBalanceResult interface
   return {
-    chainId: chain.id,
-    decimals: nativeDecimals,
-    displayValue: toTokens(nativeBalance, nativeDecimals),
-    name: nativeName,
-    symbol: nativeSymbol,
-    tokenAddress: tokenAddress ?? NATIVE_TOKEN_ADDRESS,
-    value: nativeBalance,
+    chainId: balanceData.chainId,
+    decimals: balanceData.decimals,
+    displayValue: balanceData.displayValue,
+    name: balanceData.name,
+    symbol: balanceData.symbol,
+    tokenAddress: balanceData.tokenAddress,
+    value: BigInt(balanceData.value),
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1321,6 +1321,9 @@ importers:
       '@tanstack/react-query':
         specifier: 5.81.5
         version: 5.81.5(react@19.1.0)
+      '@thirdweb-dev/api':
+        specifier: workspace:*
+        version: link:../api
       '@thirdweb-dev/engine':
         specifier: workspace:*
         version: link:../engine


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the wallet and token balance functionalities to utilize the `@thirdweb-dev/api` for fetching balances and contract metadata, improving the structure and error handling in the code.

### Detailed summary
- Added `formatter` configuration to `biome.json`.
- Updated `pnpm-lock.yaml` to link workspace dependencies.
- Refactored `getTokenBalance` and `getWalletBalance` to use API methods for fetching balances.
- Enhanced error handling in balance fetching functions.
- Updated tests to reflect changes in token and wallet balance retrieval.
- Used specific test accounts and addresses for testing on Base Sepolia.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Enhanced contract metadata retrieval with API-backed lookup and automatic RPC fallback.
  - Unified wallet/token balance fetching via API, improving reliability for native and ERC20 balances.

- Tests
  - Updated balance and metadata tests to use Base Sepolia and known tokens/addresses; relaxed assertions for stability.

- Chores
  - Added @thirdweb-dev/api as a dependency.
  - Ignored .tmp directories in version control.
  - Adjusted formatting configuration (biome) and set package-level root behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->