### PR TITLE
fix polygon amoy gasstation url

### DIFF
--- a/.changeset/huge-bees-tan.md
+++ b/.changeset/huge-bees-tan.md
@@ -1,0 +1,6 @@
+---
+"thirdweb": patch
+---
+
+Polygon amoy gasstation url fix
+https://github.com/thirdweb-dev/js/pull/8004


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on a patch for the `thirdweb` library, specifically addressing an issue with the Polygon `amoy` gas station URL.

### Detailed summary
- Added a patch for the `thirdweb` library.
- Fixed the URL for the Polygon `amoy` gas station.
- Related to GitHub PR [8004](https://github.com/thirdweb-dev/js/pull/8004).

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Polygon Amoy gas station endpoint, improving gas price fetching, estimations, and transaction reliability on that network.

* **Chores**
  * Prepared a patch release entry to publish the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->