### PR TITLE
[MNY-163] Portal: Fix broken links in payments sidebar

### DIFF
--- a/apps/portal/src/app/bridge/sidebar.tsx
+++ b/apps/portal/src/app/bridge/sidebar.tsx
@@ -1,4 +1,4 @@
-import { ExternalLinkIcon, ZapIcon } from "lucide-react";
+import { ZapIcon } from "lucide-react";
 import type { SideBar } from "@/components/Layouts/DocLayout";
 import { EngineIcon, ReactIcon, TypeScriptIcon, UnityIcon } from "@/icons";
 import { UnrealEngineIcon } from "../../icons/sdks/UnrealEngineIcon";
@@ -11,11 +11,6 @@ export const sidebar: SideBar = {
       href: bridgeSlug,
       name: "Get Started",
       icon: <ZapIcon />,
-    },
-    {
-      href: "https://playground.thirdweb.com/",
-      icon: <ExternalLinkIcon />,
-      name: "Playground",
     },
     { separator: true },
     {

--- a/apps/portal/src/app/payments/sidebar.tsx
+++ b/apps/portal/src/app/payments/sidebar.tsx
@@ -13,7 +13,7 @@ export const sidebar: SideBar = {
       icon: <ZapIcon />,
     },
     {
-      href: "https://playground.thirdweb.com/",
+      href: "https://playground.thirdweb.com/payments",
       icon: <ExternalLinkIcon />,
       name: "Playground",
     },
@@ -38,19 +38,19 @@ export const sidebar: SideBar = {
           name: "Send a Payment",
         },
         {
-          href: `bridge/sell`,
+          href: `/bridge/sell`,
           name: "Sell Tokens",
         },
         {
-          href: `bridge/swap`,
+          href: `/bridge/swap`,
           name: "Swap Tokens",
         },
         {
-          href: `bridge/tokens`,
+          href: `/bridge/tokens`,
           name: "Get Token Prices",
         },
         {
-          href: `bridge/routes`,
+          href: `/bridge/routes`,
           name: "Get Routes",
         },
         {


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `sidebar` configuration in two files: `sidebar.tsx` in the `bridge` and `payments` directories. It modifies the links for the Playground and adjusts the `href` paths for various items to ensure they are correctly routed.

### Detailed summary
- Removed the `Playground` entry from the `bridge` sidebar.
- Updated the `Playground` link in the `payments` sidebar to point to `/payments`.
- Changed `href` values for several items in the `payments` sidebar from relative paths to absolute paths:
  - `bridge/sell` to `/bridge/sell`
  - `bridge/swap` to `/bridge/swap`
  - `bridge/tokens` to `/bridge/tokens`
  - `bridge/routes` to `/bridge/routes`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Payments sidebar destinations: Playground now points to the dedicated payments playground, and Bridge-related items use absolute root paths for reliable, consistent navigation across the app.

* **Chores**
  * Removed the obsolete Playground entry from the Bridge sidebar to streamline navigation.
  * Cleaned up an unused icon import.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->