### PR TITLE
[BLD-259] Playground, Portal: Add revalidation for API Reference page

### DIFF
--- a/apps/playground-web/src/app/reference/page.tsx
+++ b/apps/playground-web/src/app/reference/page.tsx
@@ -1,7 +1,15 @@
-import { ScalarApiReference } from "../../components/blocks/scalar-api/ScalarClient";
+import { ScalarApiReference } from "@/components/blocks/scalar-api/ScalarClient";
+import { createMetadata } from "@/lib/metadata";
 
 export default async function ReferencePage() {
   const responses = await fetch("https://api.thirdweb.com/openapi.json");
   const spec = await responses.json();
   return <ScalarApiReference spec={spec} />;
 }
+
+export const metadata = createMetadata({
+  title: "thirdwebAPI Reference",
+  description: "A Unified interface for Web3 development",
+});
+
+export const revalidate = 3600;

--- a/apps/portal/src/app/reference/page.tsx
+++ b/apps/portal/src/app/reference/page.tsx
@@ -3,11 +3,11 @@ import { ScalarApiReference } from "./ScalarClient";
 
 export const metadata = createMetadata({
   image: {
-    title: "API Reference",
+    title: "thirdweb API Reference",
     icon: "thirdweb",
   },
   title: "thirdweb API Reference",
-  description: "Complete REST API reference for all thirdweb services",
+  description: "A Unified interface for Web3 development",
 });
 
 export default async function ApiReferencePage() {
@@ -19,3 +19,5 @@ export default async function ApiReferencePage() {
     </div>
   );
 }
+
+export const revalidate = 3600;


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the metadata and revalidation settings for the API reference pages in the `portal` and `playground-web` applications. It updates titles and descriptions to better reflect the purpose of the documentation.

### Detailed summary
- Updated `metadata` in `apps/portal/src/app/reference/page.tsx`:
  - Changed `title` to "thirdweb API Reference".
  - Changed `description` to "A Unified interface for Web3 development".
- Added `revalidate` property set to `3600` in `apps/portal/src/app/reference/page.tsx`.
- In `apps/playground-web/src/app/reference/page.tsx`:
  - Imported `ScalarApiReference` and `createMetadata`.
  - Added `metadata` with `title` as "thirdwebAPI Reference" and description as "A Unified interface for Web3 development".
  - Added `revalidate` property set to `3600`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->