### PR TITLE
[BLD-247] Add propagation time in domain restrictions in project settings page

### DIFF
--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/settings/ProjectGeneralSettingsPage.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/settings/ProjectGeneralSettingsPage.tsx
@@ -539,7 +539,12 @@ function AllowedDomainsSetting(props: {
 
   return (
     <SettingsCard
-      bottomText="This is only applicable for web applications"
+      bottomText={
+        <>
+          This is only applicable for web applications. Changes to domain
+          restrictions may take up to 5 minutes to take effect
+        </>
+      }
       errorText={form.getFieldState("domains", form.formState).error?.message}
       header={{
         description:


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `bottomText` prop in the `SettingsCard` component of the `ProjectGeneralSettingsPage` to provide additional information regarding domain restrictions for web applications.

### Detailed summary
- Changed `bottomText` from a string to a fragment containing:
  - A message about the applicability to web applications.
  - An additional note that changes to domain restrictions may take up to 5 minutes to take effect.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Allowed Domains copy to indicate it's only applicable for web applications.
  * Added note that domain restriction changes may take up to 5 minutes to take effect.
  * UI text-only update; no functional or behavioral changes.
  * Improves in-app guidance and reduces configuration confusion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->