### PR TITLE
[BLD-277] Fix Server Wallets balance fetching for custom chains

### DIFF
--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/transactions/server-wallets/wallet-table/wallet-table-ui.client.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/transactions/server-wallets/wallet-table/wallet-table-ui.client.tsx
@@ -9,8 +9,8 @@ import {
   XIcon,
 } from "lucide-react";
 import Link from "next/link";
-import { useMemo, useState } from "react";
-import { defineChain, type ThirdwebClient } from "thirdweb";
+import { useState } from "react";
+import type { ThirdwebClient } from "thirdweb";
 import { useWalletBalance } from "thirdweb/react";
 import {
   DEFAULT_ACCOUNT_FACTORY_V0_7,
@@ -48,6 +48,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { ToolTipLabel } from "@/components/ui/tooltip";
+import { useV5DashboardChain } from "@/hooks/chains/v5-adapter";
 import { WalletProductIcon } from "@/icons/WalletProductIcon";
 import { cn } from "@/lib/utils";
 import CreateServerWallet from "../components/create-server-wallet.client";
@@ -277,10 +278,7 @@ function ServerWalletTableRow(props: {
   const { wallet, project, teamSlug, client, chainId, showSmartAccount } =
     props;
 
-  const chain = useMemo(() => {
-    // eslint-disable-next-line no-restricted-syntax
-    return defineChain(chainId);
-  }, [chainId]);
+  const chain = useV5DashboardChain(chainId);
 
   const smartAccountAddressQuery = useQuery({
     queryFn: async () => {
@@ -458,10 +456,10 @@ function WalletBalanceCell(props: {
   chainId: number;
   client: ThirdwebClient;
 }) {
+  const chain = useV5DashboardChain(props.chainId);
   const balance = useWalletBalance({
     address: props.address,
-    // eslint-disable-next-line no-restricted-syntax
-    chain: defineChain(props.chainId),
+    chain: chain,
     client: props.client,
   });
 

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/webhooks/hooks/useAbiProcessing.ts
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/webhooks/hooks/useAbiProcessing.ts
@@ -3,8 +3,8 @@
 import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 import type { ThirdwebClient } from "thirdweb";
-import { defineChain } from "thirdweb/chains";
 import { getContract, resolveAbiFromContractApi } from "thirdweb/contract";
+import { useGetV5DashboardChain } from "@/hooks/chains/v5-adapter";
 import { parseAddresses } from "../utils/webhookPayloadUtils";
 import type {
   AbiData,
@@ -29,6 +29,7 @@ export function useAbiMultiFetch({
   ) => EventSignature[] | FunctionSignature[];
   type: "event" | "transaction";
 }) {
+  const getChain = useGetV5DashboardChain();
   const pairs = useMemo(() => {
     const result: { chainId: string; address: string }[] = [];
     const seen = new Set<string>();
@@ -54,8 +55,7 @@ export function useAbiMultiFetch({
       return Promise.all(
         pairs.map(async ({ chainId, address }) => {
           try {
-            // eslint-disable-next-line no-restricted-syntax
-            const chainObj = defineChain(Number(chainId));
+            const chainObj = getChain(Number(chainId));
             const contract = getContract({
               address,
               chain: chainObj,


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the code in the `useAbiProcessing.ts` and `wallet-table-ui.client.tsx` files to replace the usage of `defineChain` from `thirdweb/chains` with a new custom hook, `useGetV5DashboardChain` and `useV5DashboardChain`, improving the chain handling logic.

### Detailed summary
- In `useAbiProcessing.ts`:
  - Replaced `defineChain` with `getChain` from `useGetV5DashboardChain`.
  
- In `wallet-table-ui.client.tsx`:
  - Removed `defineChain` usage in favor of `useV5DashboardChain`.
  - Updated the chain handling logic for wallet balance and server wallet table row components.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified chain data retrieval across wallet tables and webhook ABI processing using the new dashboard adapter for more consistent behavior.
  * Streamlined balance and smart-account address resolution to reduce redundant computation and potential mismatches.
  * Updated internal hooks and imports; no changes to public interfaces or user workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->