### PR TITLE
[SDK] Add signAuthorization support to 1193 provider

### DIFF
--- a/.changeset/eighty-taxis-own.md
+++ b/.changeset/eighty-taxis-own.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Add signAuthorization support to 1193 provider

--- a/packages/thirdweb/src/wallets/injected/index.ts
+++ b/packages/thirdweb/src/wallets/injected/index.ts
@@ -1,3 +1,4 @@
+import * as ox__Authorization from "ox/Authorization";
 import type { EIP1193Provider } from "viem";
 import {
   getTypesForEIP712Domain,
@@ -14,6 +15,7 @@ import {
 import type { Chain } from "../../chains/types.js";
 import { getCachedChain, getChainMetadata } from "../../chains/utils.js";
 import type { ThirdwebClient } from "../../client/client.js";
+import type { AuthorizationRequest } from "../../transaction/actions/eip7702/authorization.js";
 import { getAddress } from "../../utils/address.js";
 import {
   type Hex,
@@ -263,6 +265,13 @@ function createAccount({
       return await provider.request({
         method: "personal_sign",
         params: [messageToSign, getAddress(account.address)],
+      });
+    },
+    async signAuthorization(authorization: AuthorizationRequest) {
+      const payload = ox__Authorization.getSignPayload(authorization);
+      return await provider.request({
+        method: "eth_sign",
+        params: [getAddress(account.address), payload],
       });
     },
     async signTypedData(typedData) {


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces support for signing authorizations in the `1193` provider of the `thirdweb` library by adding a new method.

### Detailed summary
- Added a new method `signAuthorization` in the `packages/thirdweb/src/wallets/injected/index.ts` file.
- The `signAuthorization` method takes an `AuthorizationRequest` as a parameter.
- It constructs a payload using `ox__Authorization.getSignPayload` and requests signing via the `eth_sign` method.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for signing authorization requests in injected wallets and EIP-1193 providers, enabling smoother authorization flows alongside existing message and typed data signing.

* **Chores**
  * Prepared a patch release entry documenting the new authorization signing support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->