### PR TITLE
[SDK] Allow passing overrides to common extension functions

### DIFF
--- a/.changeset/two-steaks-melt.md
+++ b/.changeset/two-steaks-melt.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Allow passing overrides to common extension functions

--- a/apps/playground-web/src/components/account-abstraction/gateway.tsx
+++ b/apps/playground-web/src/components/account-abstraction/gateway.tsx
@@ -28,7 +28,7 @@ import {
   TableRow,
 } from "../ui/table";
 
-const url = `http://${process.env.NEXT_PUBLIC_API_URL}`;
+const url = `https://${process.env.NEXT_PUBLIC_API_URL}`;
 
 const chain = baseSepolia;
 const editionDropAddress = "0x638263e3eAa3917a53630e61B1fBa685308024fa";

--- a/packages/thirdweb/src/extensions/erc1155/drops/write/claimTo.ts
+++ b/packages/thirdweb/src/extensions/erc1155/drops/write/claimTo.ts
@@ -1,4 +1,7 @@
-import type { BaseTransactionOptions } from "../../../../transaction/types.js";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../transaction/types.js";
 import { getClaimParams } from "../../../../utils/extensions/drops/get-claim-params.js";
 import { isGetContractMetadataSupported } from "../../../common/read/getContractMetadata.js";
 import * as GeneratedClaim from "../../__generated__/IDrop1155/write/claim.js";
@@ -51,7 +54,9 @@ export type ClaimToParams = {
  * @throws If no claim condition is set
  * @returns The prepared transaction
  */
-export function claimTo(options: BaseTransactionOptions<ClaimToParams>) {
+export function claimTo(
+  options: BaseTransactionOptions<WithOverrides<ClaimToParams>>,
+) {
   return GeneratedClaim.claim({
     async asyncParams() {
       const params = await getClaimParams({
@@ -70,6 +75,7 @@ export function claimTo(options: BaseTransactionOptions<ClaimToParams>) {
       };
     },
     contract: options.contract,
+    overrides: options.overrides,
   });
 }
 

--- a/packages/thirdweb/src/extensions/erc1155/drops/write/resetClaimEligibility.ts
+++ b/packages/thirdweb/src/extensions/erc1155/drops/write/resetClaimEligibility.ts
@@ -1,5 +1,8 @@
 import type { Hex } from "viem";
-import type { BaseTransactionOptions } from "../../../../transaction/types.js";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../transaction/types.js";
 import type { ClaimCondition } from "../../../../utils/extensions/drops/types.js";
 import {
   isSetClaimConditionsSupported,
@@ -40,7 +43,9 @@ export type ResetClaimEligibilityParams = GetClaimConditionsParams;
  * ```
  */
 export function resetClaimEligibility(
-  options: BaseTransactionOptions<ResetClaimEligibilityParams> & {
+  options: BaseTransactionOptions<
+    WithOverrides<ResetClaimEligibilityParams>
+  > & {
     singlePhaseDrop?: boolean;
   },
 ) {
@@ -79,6 +84,7 @@ export function resetClaimEligibility(
         };
       },
       contract: options.contract,
+      overrides: options.overrides,
     });
   }
   // download existing conditions
@@ -101,6 +107,7 @@ export function resetClaimEligibility(
       };
     },
     contract: options.contract,
+    overrides: options.overrides,
   });
 }
 

--- a/packages/thirdweb/src/extensions/erc1155/drops/write/setClaimConditions.ts
+++ b/packages/thirdweb/src/extensions/erc1155/drops/write/setClaimConditions.ts
@@ -1,4 +1,7 @@
-import type { BaseTransactionOptions } from "../../../../transaction/types.js";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../transaction/types.js";
 import { getMulticallSetClaimConditionTransactions } from "../../../../utils/extensions/drops/get-multicall-set-claim-claim-conditon-transactions.js";
 import type { ClaimConditionsInput } from "../../../../utils/extensions/drops/types.js";
 import { isSetContractURISupported } from "../../../common/__generated__/IContractMetadata/write/setContractURI.js";
@@ -49,7 +52,7 @@ export type SetClaimConditionsParams = {
  * ```
  */
 export function setClaimConditions(
-  options: BaseTransactionOptions<SetClaimConditionsParams>,
+  options: BaseTransactionOptions<WithOverrides<SetClaimConditionsParams>>,
 ) {
   return multicall({
     asyncParams: async () => {
@@ -65,6 +68,7 @@ export function setClaimConditions(
       };
     },
     contract: options.contract,
+    overrides: options.overrides,
   });
 }
 

--- a/packages/thirdweb/src/extensions/erc1155/drops/write/updateMetadata.ts
+++ b/packages/thirdweb/src/extensions/erc1155/drops/write/updateMetadata.ts
@@ -1,4 +1,7 @@
-import type { BaseTransactionOptions } from "../../../../transaction/types.js";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../transaction/types.js";
 import type { NFT, NFTInput } from "../../../../utils/nft/parseNft.js";
 import * as BaseURICount from "../../../erc721/__generated__/IBatchMintMetadata/read/getBaseURICount.js";
 import * as BatchAtIndex from "../../__generated__/BatchMintMetadata/read/getBatchIdAtIndex.js";
@@ -116,12 +119,13 @@ async function getUpdateMetadataParams(
  * ```
  */
 export function updateMetadata(
-  options: BaseTransactionOptions<UpdateMetadataParams>,
+  options: BaseTransactionOptions<WithOverrides<UpdateMetadataParams>>,
 ) {
   const { contract } = options;
   return BatchBaseURI.updateBatchBaseURI({
     asyncParams: async () => getUpdateMetadataParams(options),
     contract,
+    overrides: options.overrides,
   });
 }
 

--- a/packages/thirdweb/src/extensions/erc1155/write/lazyMint.ts
+++ b/packages/thirdweb/src/extensions/erc1155/write/lazyMint.ts
@@ -1,5 +1,8 @@
 import type { FileOrBufferOrString } from "../../../storage/upload/types.js";
-import type { BaseTransactionOptions } from "../../../transaction/types.js";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../transaction/types.js";
 import {
   getBaseUriFromBatch,
   uploadOrExtractURIs,
@@ -31,9 +34,9 @@ type NFTInput = Prettify<
 /**
  * @extension ERC1155
  */
-export type LazyMintParams = {
+export type LazyMintParams = WithOverrides<{
   nfts: (NFTInput | string)[];
-};
+}>;
 
 /**
  * Lazily mints ERC1155 tokens.
@@ -83,6 +86,7 @@ export function lazyMint(options: BaseTransactionOptions<LazyMintParams>) {
       } as const;
     },
     contract: options.contract,
+    overrides: options.overrides,
   });
 }
 

--- a/packages/thirdweb/src/extensions/erc1155/write/mintAdditionalSupplyTo.ts
+++ b/packages/thirdweb/src/extensions/erc1155/write/mintAdditionalSupplyTo.ts
@@ -1,15 +1,18 @@
-import type { BaseTransactionOptions } from "../../../transaction/types.js";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../transaction/types.js";
 import * as URI from "../__generated__/IERC1155/read/uri.js";
 import * as MintTo from "../__generated__/IMintableERC1155/write/mintTo.js";
 
 /**
  * @extension ERC1155
  */
-export type MintAdditionalSupplyToParams = {
+export type MintAdditionalSupplyToParams = WithOverrides<{
   to: string;
   tokenId: bigint;
   supply: bigint;
-};
+}>;
 
 /**
  * Mints a "supply" number of additional ERC1155 tokens to the specified "to" address.
@@ -46,6 +49,7 @@ export function mintAdditionalSupplyTo(
       };
     },
     contract: options.contract,
+    overrides: options.overrides,
   });
 }
 

--- a/packages/thirdweb/src/extensions/erc1155/write/updateTokenURI.ts
+++ b/packages/thirdweb/src/extensions/erc1155/write/updateTokenURI.ts
@@ -1,5 +1,8 @@
 import { upload } from "../../../storage/upload.js";
-import type { BaseTransactionOptions } from "../../../transaction/types.js";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../transaction/types.js";
 import type { NFTInput } from "../../../utils/nft/parseNft.js";
 import {
   type SetTokenURIParams,
@@ -10,10 +13,10 @@ export { isSetTokenURISupported as isUpdateTokenURISupported } from "../../erc11
 /**
  * @extension ERC1155
  */
-export type UpdateTokenURIParams = {
+export type UpdateTokenURIParams = WithOverrides<{
   tokenId: bigint;
   newMetadata: NFTInput;
-};
+}>;
 
 /**
  * This function is an abstracted layer of the [`setTokenURI` extension](https://portal.thirdweb.com/references/typescript/v5/erc1155/setTokenURI),
@@ -47,6 +50,7 @@ export function updateTokenURI(
   return setTokenURI({
     asyncParams: async () => getUpdateTokenParams(options),
     contract,
+    overrides: options.overrides,
   });
 }
 

--- a/packages/thirdweb/src/extensions/erc20/drops/write/claimTo.ts
+++ b/packages/thirdweb/src/extensions/erc20/drops/write/claimTo.ts
@@ -1,5 +1,8 @@
 import type { Address } from "abitype";
-import type { BaseTransactionOptions } from "../../../../transaction/types.js";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../transaction/types.js";
 import { getClaimParams } from "../../../../utils/extensions/drops/get-claim-params.js";
 import { isGetContractMetadataSupported } from "../../../common/read/getContractMetadata.js";
 import * as GeneratedClaim from "../../__generated__/IDropERC20/write/claim.js";
@@ -51,7 +54,9 @@ export type ClaimToParams = {
  * @throws If no claim condition is set
  * @returns A promise that resolves with the submitted transaction hash.
  */
-export function claimTo(options: BaseTransactionOptions<ClaimToParams>) {
+export function claimTo(
+  options: BaseTransactionOptions<WithOverrides<ClaimToParams>>,
+) {
   return GeneratedClaim.claim({
     asyncParams: async () => {
       const quantity = await (async () => {
@@ -77,6 +82,7 @@ export function claimTo(options: BaseTransactionOptions<ClaimToParams>) {
       });
     },
     contract: options.contract,
+    overrides: options.overrides,
   });
 }
 

--- a/packages/thirdweb/src/extensions/erc20/drops/write/resetClaimEligibility.ts
+++ b/packages/thirdweb/src/extensions/erc20/drops/write/resetClaimEligibility.ts
@@ -1,5 +1,8 @@
 import type { Hex } from "viem";
-import type { BaseTransactionOptions } from "../../../../transaction/types.js";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../transaction/types.js";
 import type { ClaimCondition } from "../../../../utils/extensions/drops/types.js";
 import {
   isSetClaimConditionsSupported,
@@ -28,7 +31,9 @@ import {
  * await sendTransaction({ transaction, account });
  * ```
  */
-export function resetClaimEligibility(options: BaseTransactionOptions) {
+export function resetClaimEligibility(
+  options: BaseTransactionOptions<WithOverrides<{}>>,
+) {
   // download existing conditions
   return setClaimConditions({
     asyncParams: async () => {
@@ -48,6 +53,7 @@ export function resetClaimEligibility(options: BaseTransactionOptions) {
       };
     },
     contract: options.contract,
+    overrides: options.overrides,
   });
 }
 

--- a/packages/thirdweb/src/extensions/erc20/drops/write/setClaimConditions.ts
+++ b/packages/thirdweb/src/extensions/erc20/drops/write/setClaimConditions.ts
@@ -1,4 +1,7 @@
-import type { BaseTransactionOptions } from "../../../../transaction/types.js";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../transaction/types.js";
 import { getMulticallSetClaimConditionTransactions } from "../../../../utils/extensions/drops/get-multicall-set-claim-claim-conditon-transactions.js";
 import type { ClaimConditionsInput } from "../../../../utils/extensions/drops/types.js";
 import { isSetContractURISupported } from "../../../common/__generated__/IContractMetadata/write/setContractURI.js";
@@ -47,7 +50,7 @@ export type SetClaimConditionsParams = {
  * ```
  */
 export function setClaimConditions(
-  options: BaseTransactionOptions<SetClaimConditionsParams>,
+  options: BaseTransactionOptions<WithOverrides<SetClaimConditionsParams>>,
 ) {
   return multicall({
     asyncParams: async () => {
@@ -62,6 +65,7 @@ export function setClaimConditions(
       };
     },
     contract: options.contract,
+    overrides: options.overrides,
   });
 }
 

--- a/packages/thirdweb/src/extensions/erc20/write/approve.ts
+++ b/packages/thirdweb/src/extensions/erc20/write/approve.ts
@@ -1,5 +1,8 @@
 import type { Address } from "abitype";
-import type { BaseTransactionOptions } from "../../../transaction/types.js";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../transaction/types.js";
 import type { Prettify } from "../../../utils/type-utils.js";
 import { toUnits } from "../../../utils/units.js";
 import { approve as generatedApprove } from "../__generated__/IERC20/write/approve.js";
@@ -9,14 +12,16 @@ import { approve as generatedApprove } from "../__generated__/IERC20/write/appro
  * @extension ERC20
  */
 export type ApproveParams = Prettify<
-  { spender: Address } & (
-    | {
-        amount: number | string;
-      }
-    | {
-        amountWei: bigint;
-      }
-  )
+  WithOverrides<
+    { spender: Address } & (
+      | {
+          amount: number | string;
+        }
+      | {
+          amountWei: bigint;
+        }
+    )
+  >
 >;
 
 /**
@@ -58,6 +63,7 @@ export function approve(options: BaseTransactionOptions<ApproveParams>) {
             amountWei: amount,
             tokenAddress: options.contract.address,
           },
+          ...options.overrides,
         },
         spender: options.spender,
         value: amount,

--- a/packages/thirdweb/src/extensions/erc20/write/deposit.ts
+++ b/packages/thirdweb/src/extensions/erc20/write/deposit.ts
@@ -1,16 +1,20 @@
 import { prepareContractCall } from "../../../transaction/prepare-contract-call.js";
-import type { BaseTransactionOptions } from "../../../transaction/types.js";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../transaction/types.js";
 import { toWei } from "../../../utils/units.js";
 import { FN_SELECTOR } from "../__generated__/IWETH/write/deposit.js";
 
 /**
  * @extension ERC20
  */
-export type DepositParams =
+export type DepositParams = WithOverrides<
   | {
       amount: string;
     }
-  | { amountWei: bigint };
+  | { amountWei: bigint }
+>;
 
 /**
  * Calls the "deposit" function on the contract (useful to wrap ETH).
@@ -38,5 +42,6 @@ export function deposit(options: BaseTransactionOptions<DepositParams>) {
     },
     method: [FN_SELECTOR, [], []] as const,
     value,
+    ...options.overrides,
   });
 }

--- a/packages/thirdweb/src/extensions/erc20/write/transferBatch.ts
+++ b/packages/thirdweb/src/extensions/erc20/write/transferBatch.ts
@@ -1,4 +1,7 @@
-import type { BaseTransactionOptions } from "../../../transaction/types.js";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../transaction/types.js";
 import type { Prettify } from "../../../utils/type-utils.js";
 import { toUnits } from "../../../utils/units.js";
 import { multicall } from "../../common/__generated__/IMulticall/write/multicall.js";
@@ -8,18 +11,20 @@ import { encodeTransfer } from "../__generated__/IERC20/write/transfer.js";
  * Represents the parameters for a batch transfer operation.
  * @extension ERC20
  */
-export type TransferBatchParams = Prettify<{
-  batch: Array<
-    { to: string } & (
-      | {
-          amount: number | string;
-        }
-      | {
-          amountWei: bigint;
-        }
-    )
-  >;
-}>;
+export type TransferBatchParams = Prettify<
+  WithOverrides<{
+    batch: Array<
+      { to: string } & (
+        | {
+            amount: number | string;
+          }
+        | {
+            amountWei: bigint;
+          }
+      )
+    >;
+  }>
+>;
 
 /**
  * Transfers a batch of ERC20 tokens from the sender's address to the specified recipient address.
@@ -69,6 +74,7 @@ export function transferBatch(
       };
     },
     contract: options.contract,
+    overrides: options.overrides,
   });
 }
 

--- a/packages/thirdweb/src/extensions/erc721/drops/write/claimTo.ts
+++ b/packages/thirdweb/src/extensions/erc721/drops/write/claimTo.ts
@@ -1,5 +1,8 @@
 import type { Address } from "abitype";
-import type { BaseTransactionOptions } from "../../../../transaction/types.js";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../transaction/types.js";
 import { getClaimParams } from "../../../../utils/extensions/drops/get-claim-params.js";
 import { isGetContractMetadataSupported } from "../../../common/read/getContractMetadata.js";
 import {
@@ -54,7 +57,9 @@ export type ClaimToParams = {
  * @throws If no claim condition is set
  * @returns A promise that resolves with the submitted transaction hash.
  */
-export function claimTo(options: BaseTransactionOptions<ClaimToParams>) {
+export function claimTo(
+  options: BaseTransactionOptions<WithOverrides<ClaimToParams>>,
+) {
   return claim({
     asyncParams: () =>
       getClaimParams({
@@ -66,6 +71,7 @@ export function claimTo(options: BaseTransactionOptions<ClaimToParams>) {
         type: "erc721",
       }),
     contract: options.contract,
+    overrides: options.overrides,
   });
 }
 

--- a/packages/thirdweb/src/extensions/erc721/drops/write/resetClaimEligibility.ts
+++ b/packages/thirdweb/src/extensions/erc721/drops/write/resetClaimEligibility.ts
@@ -1,5 +1,8 @@
 import type { Hex } from "viem";
-import type { BaseTransactionOptions } from "../../../../transaction/types.js";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../transaction/types.js";
 import type { ClaimCondition } from "../../../../utils/extensions/drops/types.js";
 import {
   isSetClaimConditionsSupported,
@@ -28,7 +31,9 @@ import {
  * await sendTransaction({ transaction, account });
  * ```
  */
-export function resetClaimEligibility(options: BaseTransactionOptions) {
+export function resetClaimEligibility(
+  options: BaseTransactionOptions<WithOverrides<{}>>,
+) {
   // download existing conditions
   return setClaimConditions({
     asyncParams: async () => {
@@ -48,6 +53,7 @@ export function resetClaimEligibility(options: BaseTransactionOptions) {
       };
     },
     contract: options.contract,
+    overrides: options.overrides,
   });
 }
 

--- a/packages/thirdweb/src/extensions/erc721/drops/write/setClaimConditions.ts
+++ b/packages/thirdweb/src/extensions/erc721/drops/write/setClaimConditions.ts
@@ -1,4 +1,7 @@
-import type { BaseTransactionOptions } from "../../../../transaction/types.js";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../transaction/types.js";
 import { getMulticallSetClaimConditionTransactions } from "../../../../utils/extensions/drops/get-multicall-set-claim-claim-conditon-transactions.js";
 import type { ClaimConditionsInput } from "../../../../utils/extensions/drops/types.js";
 import { isSetContractURISupported } from "../../../common/__generated__/IContractMetadata/write/setContractURI.js";
@@ -47,7 +50,7 @@ export type SetClaimConditionsParams = {
  * ```
  */
 export function setClaimConditions(
-  options: BaseTransactionOptions<SetClaimConditionsParams>,
+  options: BaseTransactionOptions<WithOverrides<SetClaimConditionsParams>>,
 ) {
   return multicall({
     asyncParams: async () => {
@@ -62,6 +65,7 @@ export function setClaimConditions(
       };
     },
     contract: options.contract,
+    overrides: options.overrides,
   });
 }
 

--- a/packages/thirdweb/src/extensions/erc721/drops/write/updateMetadata.ts
+++ b/packages/thirdweb/src/extensions/erc721/drops/write/updateMetadata.ts
@@ -1,4 +1,7 @@
-import type { BaseTransactionOptions } from "../../../../transaction/types.js";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../transaction/types.js";
 import type { NFT, NFTInput } from "../../../../utils/nft/parseNft.js";
 import * as BatchBaseURI from "../../__generated__/DropERC721/write/updateBatchBaseURI.js";
 import * as BaseURICount from "../../__generated__/IBatchMintMetadata/read/getBaseURICount.js";
@@ -128,12 +131,13 @@ async function getUpdateMetadataParams(
  * ```
  */
 export function updateMetadata(
-  options: BaseTransactionOptions<UpdateMetadataParams>,
+  options: BaseTransactionOptions<WithOverrides<UpdateMetadataParams>>,
 ) {
   const { contract } = options;
   return BatchBaseURI.updateBatchBaseURI({
     asyncParams: async () => getUpdateMetadataParams(options),
     contract,
+    overrides: options.overrides,
   });
 }
 

--- a/packages/thirdweb/src/extensions/erc721/write/lazyMint.ts
+++ b/packages/thirdweb/src/extensions/erc721/write/lazyMint.ts
@@ -1,4 +1,7 @@
-import type { BaseTransactionOptions } from "../../../transaction/types.js";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../transaction/types.js";
 import {
   getBaseUriFromBatch,
   uploadOrExtractURIs,
@@ -13,9 +16,9 @@ import * as LazyMint from "../__generated__/ILazyMint/write/lazyMint.js";
 /**
  * @extension ERC721
  */
-export type LazyMintParams = {
+export type LazyMintParams = WithOverrides<{
   nfts: (NFTInput | string)[];
-};
+}>;
 
 /**
  * Lazily mints ERC721 tokens.
@@ -66,6 +69,7 @@ export function lazyMint(options: BaseTransactionOptions<LazyMintParams>) {
       } as const;
     },
     contract: options.contract,
+    overrides: options.overrides,
   });
 }
 

--- a/packages/thirdweb/src/extensions/erc721/write/setSharedMetadata.ts
+++ b/packages/thirdweb/src/extensions/erc721/write/setSharedMetadata.ts
@@ -1,4 +1,7 @@
-import type { BaseTransactionOptions } from "../../../transaction/types.js";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../transaction/types.js";
 import type { NFTInput } from "../../../utils/nft/parseNft.js";
 import { setSharedMetadata as generatedSharedMetadata } from "../__generated__/ISharedMetadata/write/setSharedMetadata.js";
 
@@ -7,9 +10,9 @@ export { isSetSharedMetadataSupported } from "../__generated__/ISharedMetadata/w
 /**
  * @extension ERC721
  */
-export type SetSharedMetadataParams = {
+export type SetSharedMetadataParams = WithOverrides<{
   nft: NFTInput;
-};
+}>;
 
 /**
  * Sets the shared metadata for a OpenEdition contract.
@@ -69,6 +72,7 @@ export function setSharedMetadata(
       };
     },
     contract: options.contract,
+    overrides: options.overrides,
   });
 }
 

--- a/packages/thirdweb/src/extensions/erc721/write/updateTokenURI.ts
+++ b/packages/thirdweb/src/extensions/erc721/write/updateTokenURI.ts
@@ -1,5 +1,8 @@
 import { upload } from "../../../storage/upload.js";
-import type { BaseTransactionOptions } from "../../../transaction/types.js";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../transaction/types.js";
 import type { NFTInput } from "../../../utils/nft/parseNft.js";
 import {
   type SetTokenURIParams,
@@ -11,10 +14,10 @@ export { isSetTokenURISupported as isUpdateTokenURISupported } from "../../erc72
 /**
  * @extension ERC721
  */
-export type UpdateTokenURIParams = {
+export type UpdateTokenURIParams = WithOverrides<{
   tokenId: bigint;
   newMetadata: NFTInput;
-};
+}>;
 
 /**
  * This function is an abstracted layer of the [`setTokenURI` extension](https://portal.thirdweb.com/references/typescript/v5/erc721/setTokenURI),
@@ -48,6 +51,7 @@ export function updateTokenURI(
   return setTokenURI({
     asyncParams: async () => getUpdateTokenParams(options),
     contract,
+    overrides: options.overrides,
   });
 }
 


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `thirdweb` library by allowing the passing of overrides to common extension functions, which improves flexibility in transaction options across various ERC standards.

### Detailed summary
- Updated `url` from HTTP to HTTPS in `gateway.tsx`.
- Modified multiple `LazyMintParams`, `MintAdditionalSupplyToParams`, `DepositParams`, and other parameters to use `WithOverrides`.
- Added `overrides` to function calls in various files, including `lazyMint`, `setSharedMetadata`, and `resetClaimEligibility`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for per-transaction overrides across ERC1155, ERC721, and ERC20 write flows, including claim, set claim conditions, reset claim eligibility, update metadata/token URI, lazy mint, shared metadata, approve, deposit, and batch transfer.

- Bug Fixes
  - Updated Playground web app to use HTTPS for API requests.

- Chores
  - Added a changeset for a patch release noting override support in common extension functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->