### PR TITLE
[SDK] Fix signAuthorization for 1193 providers

### DIFF
--- a/.changeset/shaggy-fans-live.md
+++ b/.changeset/shaggy-fans-live.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix signAuthorization implementation for 1193 provider

--- a/packages/thirdweb/src/wallets/injected/index.ts
+++ b/packages/thirdweb/src/wallets/injected/index.ts
@@ -1,6 +1,7 @@
 import * as ox__Authorization from "ox/Authorization";
-import type { EIP1193Provider } from "viem";
+import * as ox__Signature from "ox/Signature";
 import {
+  type EIP1193Provider,
   getTypesForEIP712Domain,
   type SignTypedDataParameters,
   serializeTypedData,
@@ -188,7 +189,7 @@ function createAccount({
     async sendTransaction(tx: SendTransactionOption) {
       const gasFees = tx.gasPrice
         ? {
-            gasPrice: tx.gasPrice ? numberToHex(tx.gasPrice) : undefined,
+            gasPrice: numberToHex(tx.gasPrice),
           }
         : {
             maxFeePerGas: tx.maxFeePerGas
@@ -201,6 +202,9 @@ function createAccount({
       const params = [
         {
           ...tx,
+          authorizationList: tx.authorizationList
+            ? ox__Authorization.toRpcList(tx.authorizationList)
+            : undefined,
           ...gasFees,
           from: this.address,
           gas: tx.gas ? numberToHex(tx.gas) : undefined,
@@ -269,10 +273,25 @@ function createAccount({
     },
     async signAuthorization(authorization: AuthorizationRequest) {
       const payload = ox__Authorization.getSignPayload(authorization);
-      return await provider.request({
-        method: "eth_sign",
-        params: [getAddress(account.address), payload],
-      });
+      let signature: Hex | undefined;
+      try {
+        signature = await provider.request({
+          method: "eth_sign",
+          params: [getAddress(account.address), payload],
+        });
+      } catch {
+        // fallback to secp256k1_sign, some providers don't support eth_sign
+        signature = await provider.request({
+          // @ts-expect-error - overriding types here
+          method: "secp256k1_sign",
+          params: [payload],
+        });
+      }
+      if (!signature) {
+        throw new Error("Failed to sign authorization");
+      }
+      const parsedSignature = ox__Signature.fromHex(signature as Hex);
+      return { ...authorization, ...parsedSignature };
     },
     async signTypedData(typedData) {
       if (!provider || !account.address) {


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the `signAuthorization` implementation for the `1193` provider in the `thirdweb` wallet, enhancing error handling and support for different signing methods.

### Detailed summary
- Modified `sendTransaction` to include `authorizationList` in the transaction parameters.
- Enhanced `signAuthorization` to:
  - Attempt signing with `eth_sign` first.
  - Fallback to `secp256k1_sign` if the first method fails.
  - Throw an error if signing fails.
  - Parse the signature using `ox__Signature.fromHex`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added runtime support for authorization lists in transactions for broader provider compatibility.

* **Bug Fixes**
  * Fixed unreliable authorization signing with EIP-1193 providers by adding a robust fallback signing flow.

* **Improvements**
  * Streamlined gas-fee handling when a gas price is provided for more predictable transactions.
  * Ensured consistent address normalization and merged authorization payloads reliably.

* **Chores**
  * Added a patch-level changeset entry for the thirdweb package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->