### PR TITLE
Add tier6 for SMS country pricing

### DIFF
--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/settings/wallets/api/sms.ts
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/settings/wallets/api/sms.ts
@@ -8,6 +8,7 @@ export type SMSCountryTiers = {
   tier3: string[];
   tier4: string[];
   tier5: string[];
+  tier6: string[];
 };
 
 export async function getSMSCountryTiers() {
@@ -40,6 +41,7 @@ export async function getSMSCountryTiers() {
       tier3: [],
       tier4: [],
       tier5: [],
+      tier6: [],
     };
   }
 
@@ -53,6 +55,7 @@ export async function getSMSCountryTiers() {
       tier3: [],
       tier4: [],
       tier5: [],
+      tier6: [],
     };
   }
 }

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/settings/wallets/components/InAppWalletSettingsUI.stories.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/settings/wallets/components/InAppWalletSettingsUI.stories.tsx
@@ -66,6 +66,7 @@ function Variants(props: { currentPlan: Team["billingPlan"] }) {
             tier3: ["FR", "DE", "ES", "IT"],
             tier4: ["JP", "KR", "MX", "RU"],
             tier5: ["BR", "AR", "CO", "CL", "PE", "VE", "SA"],
+            tier6: ["RU", "PG", "UZ", "TZ", "KM", "BT"],
           }}
           teamId="bar"
           teamPlan={props.currentPlan}

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/settings/wallets/components/sms-country-select/utils.ts
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/settings/wallets/components/sms-country-select/utils.ts
@@ -5,6 +5,7 @@ export const tierPricing = {
   tier3: "$0.10 per SMS",
   tier4: "$0.20 per SMS",
   tier5: "$0.40 per SMS",
+  tier6: "$1.00 per SMS",
 } as const;
 
 // Country names mapped to ISO codes
@@ -20,6 +21,14 @@ export const countryNames: Record<string, string> = {
   AL: "Albania",
   AM: "Armenia",
   AO: "Angola",
+
+  // Tier 6
+  RU: "Russia/Kazakhstan",
+  PG: "Papua New Guinea",
+  UZ: "Uzbekistan",
+  TZ: "Tanzania",
+  KM: "Comoros",
+  BT: "Bhutan",
 
   // Tier 3
   AR: "Argentina",
@@ -243,6 +252,14 @@ export const countryPrefixes: Record<string, string> = {
   AL: "+355",
   AM: "+374",
   AO: "+244",
+
+  // Tier 6
+  RU: "+7",
+  PG: "+675",
+  UZ: "+998",
+  TZ: "+255",
+  KM: "+269",
+  BT: "+975",
 
   // Tier 3
   AR: "+54",


### PR DESCRIPTION
### TL;DR

Added a new SMS pricing tier (tier6) at $1.00 per SMS with support for additional countries.

### What changed?

- Added a new `tier6` to the SMS country tiers data structure
- Set the pricing for tier6 at "$1.00 per SMS"
- Added 6 new countries to the tier6 pricing:
  - Russia/Kazakhstan
  - Papua New Guinea
  - Uzbekistan
  - Tanzania
  - Comoros
  - Bhutan
- Added corresponding country codes and prefixes for the new countries

### How to test?

1. Navigate to the SMS country selection interface
2. Verify that the new tier6 countries appear with the correct $1.00 per SMS pricing
3. Confirm that the country codes and prefixes for Russia/Kazakhstan (+7), Papua New Guinea (+675), Uzbekistan (+998), Tanzania (+255), Comoros (+269), and Bhutan (+975) are correctly displayed

### Why make this change?

To expand SMS service coverage to additional countries that require higher pricing due to increased carrier costs or operational complexity. This allows users to send SMS to these regions while appropriately accounting for the higher costs associated with these destinations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Tier 6 support to SMS pricing and country selection.
  * New Tier 6 countries: Russia/Kazakhstan, Papua New Guinea, Uzbekistan, Tanzania, Comoros, Bhutan.
  * Displays Tier 6 pricing: $1.00 per SMS.
* **Bug Fixes**
  * Improved fallback handling when loading SMS country tiers to ensure Tier 6 data defaults gracefully if unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `tier6` category for SMS country tiers and updates the corresponding country names and prefixes in the application.

### Detailed summary
- Added `tier6` to various files, including `InAppWalletSettingsUI.stories.tsx`, `sms.ts`, and `utils.ts`.
- Defined new countries in `tier6`: `RU`, `PG`, `UZ`, `TZ`, `KM`, `BT`.
- Updated SMS pricing for `tier6` to "$1.00 per SMS".
- Included country names and prefixes for `tier6` in `utils.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->