### PR TITLE
[SDK] Fix fiat payments with no wallet connected

### DIFF
--- a/.changeset/fuzzy-suits-wear.md
+++ b/.changeset/fuzzy-suits-wear.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix fiat payments with no wallets connected

--- a/packages/thirdweb/src/react/core/machines/paymentMachine.ts
+++ b/packages/thirdweb/src/react/core/machines/paymentMachine.ts
@@ -29,7 +29,7 @@ export type PaymentMethod =
     }
   | {
       type: "fiat";
-      payerWallet: Wallet;
+      payerWallet?: Wallet;
       currency: string;
       onramp: "stripe" | "coinbase" | "transak";
     };

--- a/packages/thirdweb/src/react/web/ui/Bridge/BridgeOrchestrator.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/BridgeOrchestrator.tsx
@@ -369,8 +369,7 @@ export function BridgeOrchestrator({
 
       {state.value === "execute" &&
         state.context.quote &&
-        state.context.request &&
-        state.context.selectedPaymentMethod?.payerWallet && (
+        state.context.request && (
           <StepRunner
             autoStart={true}
             client={client}

--- a/packages/thirdweb/src/react/web/ui/Bridge/BuyWidget.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/BuyWidget.tsx
@@ -193,6 +193,11 @@ export type BuyWidgetProps = {
    * Custom label for the main action button.
    */
   buttonLabel?: string;
+
+  /**
+   * The receiver address for the purchased funds.
+   */
+  receiverAddress?: Address;
 };
 
 // Enhanced UIOptions to handle unsupported token state
@@ -455,7 +460,7 @@ export function BuyWidget(props: BuyWidgetProps) {
         paymentMethods={props.paymentMethods}
         presetOptions={props.presetOptions}
         purchaseData={props.purchaseData}
-        receiverAddress={undefined}
+        receiverAddress={props.receiverAddress}
         uiOptions={bridgeDataQuery.data.data}
         showThirdwebBranding={props.showThirdwebBranding}
       />

--- a/packages/thirdweb/src/react/web/ui/Bridge/QuoteLoader.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/QuoteLoader.tsx
@@ -133,6 +133,7 @@ export function QuoteLoader({
         toChainId: destinationToken.chainId,
         toToken: destinationToken.address,
       });
+      return true;
     },
     queryKey: ["loading_quote", paymentMethod.type],
   });

--- a/packages/thirdweb/src/react/web/ui/Bridge/StepRunner.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/StepRunner.tsx
@@ -30,7 +30,7 @@ interface StepRunnerProps {
   /**
    * Wallet instance for executing transactions
    */
-  wallet: Wallet;
+  wallet?: Wallet;
 
   /**
    * Thirdweb client for API calls

--- a/packages/thirdweb/src/react/web/ui/Bridge/payment-details/PaymentDetails.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/payment-details/PaymentDetails.tsx
@@ -101,6 +101,7 @@ export function PaymentDetails({
               : preparedQuote.intent.destinationTokenAddress,
         });
       }
+      return true;
     },
     queryKey: ["payment_details", preparedQuote.type],
   });
@@ -239,7 +240,7 @@ export function PaymentDetails({
               receiver={preparedQuote.intent.receiver}
               sender={
                 preparedQuote.intent.sender ||
-                paymentMethod.payerWallet.getAccount()?.address
+                paymentMethod.payerWallet?.getAccount()?.address
               }
               toAmount={displayData.destinationAmount}
               toToken={displayData.destinationToken}

--- a/packages/thirdweb/src/react/web/ui/Bridge/payment-selection/PaymentSelection.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/payment-selection/PaymentSelection.tsx
@@ -196,15 +196,17 @@ export function PaymentSelection({
   const handleOnrampProviderSelected = (
     provider: "coinbase" | "stripe" | "transak",
   ) => {
-    if (!payerWallet) {
-      onError(new Error("No wallet available for fiat payment"));
+    const recipientAddress =
+      receiverAddress || payerWallet?.getAccount()?.address;
+    if (!recipientAddress) {
+      onError(new Error("No recipient address available for fiat payment"));
       return;
     }
 
     const fiatPaymentMethod: PaymentMethod = {
-      currency: "USD",
+      currency: currency || "USD",
       onramp: provider,
-      payerWallet, // Default to USD for now
+      payerWallet,
       type: "fiat",
     };
     handlePaymentMethodSelected(fiatPaymentMethod);
@@ -307,7 +309,9 @@ export function PaymentSelection({
             country={country}
             client={client}
             onProviderSelected={handleOnrampProviderSelected}
-            toAddress={receiverAddress || ""}
+            toAddress={
+              receiverAddress || payerWallet?.getAccount()?.address || ""
+            }
             toAmount={destinationAmount}
             toChainId={destinationToken.chainId}
             toTokenAddress={destinationToken.address}

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/FiatValue.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Buy/swap/FiatValue.tsx
@@ -36,6 +36,7 @@ export function FiatValue(
       props.chain.id,
       getTokenAddress(props.token),
       deferredTokenAmount,
+      props.currency,
     ],
   });
 


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the handling of fiat payments in the `thirdweb` package by making `wallet` and `payerWallet` optional, enhancing error handling, and refining transaction execution logic.

### Detailed summary
- Added optional chaining for `wallet` and `payerWallet` in multiple files.
- Improved error messages for missing recipient addresses and wallets.
- Enhanced transaction execution logic to handle cases where no wallet is provided.
- Updated `PaymentDetails` and `BuyWidget` components to utilize new optional props.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional receiverAddress prop to the buy widget so callers can specify the recipient.

- **Bug Fixes**
  - Fiat payments can proceed without a connected wallet when no transactions run; flows now validate recipient addresses and show clearer wallet-related errors when required.
  - Wallet handling made optional across bridge/payment steps to improve flow flexibility.
  - Background queries now return explicit values and cache by currency to stabilize quote tracking and refreshes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->