### PR TITLE
[SDK] Add wallet validation before executing transactions

### DIFF
--- a/packages/thirdweb/src/react/core/hooks/useStepExecutor.ts
+++ b/packages/thirdweb/src/react/core/hooks/useStepExecutor.ts
@@ -408,6 +408,14 @@ export function useStepExecutor(
     abortControllerRef.current = abortController;
 
     try {
+      if (flatTxs.length > 0 && !wallet) {
+        throw new ApiError({
+          code: "INVALID_INPUT",
+          message: "No wallet provided to execute transactions",
+          statusCode: 400,
+        });
+      }
+
       // Execute onramp first if configured and not already completed
       if (preparedQuote.type === "onramp" && onrampStatus === "pending") {
         await executeOnramp(


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a validation check in the `useStepExecutor` hook to ensure that a wallet is provided before executing transactions, enhancing error handling for transaction execution.

### Detailed summary
- Added a check to verify if `flatTxs` has elements and if `wallet` is not provided.
- If the wallet is absent, an `ApiError` is thrown with code "INVALID_INPUT" and a message indicating the issue.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Provides an immediate, clear error when attempting to execute transactions without a connected wallet.
  * Returns a standardized INVALID_INPUT (400) instead of failing later in the flow, reducing confusing failures.
  * Maintains existing behavior when a wallet is connected; onramp and execution paths are unchanged.
  * No public API changes; improves consistency and reliability of error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->