### PR TITLE
Fix: Add brief pause after onramp

### DIFF
--- a/.changeset/floppy-clocks-wave.md
+++ b/.changeset/floppy-clocks-wave.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Prevents incorrect failures in widget onramps.

--- a/packages/thirdweb/src/react/core/hooks/useStepExecutor.ts
+++ b/packages/thirdweb/src/react/core/hooks/useStepExecutor.ts
@@ -372,6 +372,11 @@ export function useStepExecutor(
 
         const status = statusResult.status;
         if (status === "COMPLETED") {
+          /*
+           * The occasional race condition can happen where the onramp provider gives us completed status before the token balance has updated in our RPC.
+           * We add this pause so the simulation doesn't fail on the next step.
+           */
+          await new Promise((resolve) => setTimeout(resolve, 2000));
           setOnrampStatus("completed");
           // Add type field for discriminated union
           const typedStatusResult = {


### PR DESCRIPTION
Adds a brief pause after we receive a COMPLETED onramp status. This ensures balance is the latest value in our RPC and any subsequent transactions do not fail on simulation.

<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR addresses a potential race condition in the `thirdweb` widget onramps, ensuring that the simulation does not fail due to timing issues with token balance updates.

### Detailed summary
- Added a 2-second pause using `setTimeout` in `useStepExecutor.ts` to handle race conditions where the onramp provider reports a completed status before the token balance updates.
- Updated the onramp status to "completed" after the pause.
- Introduced a `typedStatusResult` object for a discriminated union.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of widget onramps by adding a brief post-completion delay to prevent false failure states and reduce flakiness after successful transactions. No changes to user flows or interfaces.

* **Chores**
  * Added release metadata for a patch update noting the onramp reliability fix.
  * No code-visible API changes or alterations to exported functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->