### PR TITLE
SDK: Fix onSuccess prop not called properly on CheckoutWidget and BuyWidget

### DIFF
--- a/.changeset/slimy-chefs-buy.md
+++ b/.changeset/slimy-chefs-buy.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix `onSuccess` callback was not called correctly on `CheckoutWidget`, `BuyWidget` components

--- a/packages/thirdweb/src/react/web/ui/Bridge/BridgeOrchestrator.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/BridgeOrchestrator.tsx
@@ -180,14 +180,13 @@ export function BridgeOrchestrator({
   const [state, send] = usePaymentMachine(adapters, uiOptions.mode);
 
   // Handle buy completion
-  const handleBuyComplete = useCallback(() => {
+  const handleDoneOrContinueClick = useCallback(() => {
     if (uiOptions.mode === "transaction") {
       send({ type: "CONTINUE_TO_TRANSACTION" });
     } else {
-      onComplete?.();
       send({ type: "RESET" });
     }
-  }, [onComplete, send, uiOptions.mode]);
+  }, [send, uiOptions.mode]);
 
   // Handle post-buy transaction completion
   const handlePostBuyTransactionComplete = useCallback(() => {
@@ -230,8 +229,11 @@ export function BridgeOrchestrator({
   const handleExecutionComplete = useCallback(
     (completedStatuses: CompletedStatusResult[]) => {
       send({ completedStatuses, type: "EXECUTION_COMPLETE" });
+      if (uiOptions.mode !== "transaction") {
+        onComplete?.();
+      }
     },
-    [send],
+    [send, onComplete, uiOptions.mode],
   );
 
   // Handle retry
@@ -390,7 +392,7 @@ export function BridgeOrchestrator({
           <SuccessScreen
             client={client}
             completedStatuses={state.context.completedStatuses}
-            onDone={handleBuyComplete}
+            onDone={handleDoneOrContinueClick}
             preparedQuote={state.context.quote}
             uiOptions={uiOptions}
             windowAdapter={webWindowAdapter}


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR addresses an issue where the `onSuccess` callback was not correctly triggered in the `CheckoutWidget` and `BuyWidget` components, improving the handling of buy completion and post-buy transaction completion.

### Detailed summary
- Renamed `handleBuyComplete` to `handleDoneOrContinueClick`.
- Updated the logic in `handleExecutionComplete` to call `onComplete` only if `uiOptions.mode` is not "transaction".
- Changed the `onDone` prop in `SuccessScreen` to use `handleDoneOrContinueClick`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the success/onComplete callback in Checkout and Buy widgets did not fire reliably; non-transaction flows now trigger completion after execution finishes, improving state reset and consistency.

* **Chores**
  * Added a patch-level changeset entry documenting the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->