### PR TITLE
[SDK] Filter out AGW from searchable wallets

### DIFF
--- a/.changeset/wide-flies-raise.md
+++ b/.changeset/wide-flies-raise.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Filter out AGW from searchable wallets (needs explicit adding)

--- a/packages/thirdweb/src/react/native/ui/connect/ExternalWalletsList.tsx
+++ b/packages/thirdweb/src/react/native/ui/connect/ExternalWalletsList.tsx
@@ -12,6 +12,7 @@ import {
 import type { Chain } from "../../../../chains/types.js";
 import type { ThirdwebClient } from "../../../../client/client.js";
 import walletInfos from "../../../../wallets/__generated__/wallet-infos.js";
+import { NON_SEARCHABLE_WALLETS } from "../../../../wallets/constants.js";
 import type { Wallet } from "../../../../wallets/interfaces/wallet.js";
 import { createWallet } from "../../../../wallets/native/create-wallet.js";
 import type { WalletId } from "../../../../wallets/wallet-types.js";
@@ -100,10 +101,7 @@ export function AllWalletsList(
       .filter(
         (info) => !externalWallets.find((wallet) => wallet.id === info.id),
       )
-      .filter(
-        (info) =>
-          info.id !== "inApp" && info.id !== "embedded" && info.id !== "smart",
-      )
+      .filter((info) => !NON_SEARCHABLE_WALLETS.includes(info.id))
       .filter((info) => info.hasMobileSupport);
 
     const fuse = new Fuse(filteredWallets, {

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/AllWalletsUI.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/AllWalletsUI.tsx
@@ -5,6 +5,7 @@ import Fuse from "fuse.js";
 import { useMemo, useRef, useState } from "react";
 import type { ThirdwebClient } from "../../../../../client/client.js";
 import walletInfos from "../../../../../wallets/__generated__/wallet-infos.js";
+import { NON_SEARCHABLE_WALLETS } from "../../../../../wallets/constants.js";
 import { createWallet } from "../../../../../wallets/create-wallet.js";
 import type { Wallet } from "../../../../../wallets/interfaces/wallet.js";
 import { useCustomTheme } from "../../../../core/design-system/CustomThemeProvider.js";
@@ -39,8 +40,7 @@ function AllWalletsUI(props: {
 
   const walletList = useMemo(() => {
     return walletInfos.filter(
-      (info) =>
-        info.id !== "inApp" && info.id !== "embedded" && info.id !== "smart",
+      (info) => !NON_SEARCHABLE_WALLETS.includes(info.id),
     );
   }, []);
 

--- a/packages/thirdweb/src/wallets/constants.ts
+++ b/packages/thirdweb/src/wallets/constants.ts
@@ -1,5 +1,15 @@
+import type { WalletId } from "./wallet-types.js";
+
 // Constants for most common wallets
 export const COINBASE = "com.coinbase.wallet";
 export const METAMASK = "io.metamask";
 export const RAINBOW = "me.rainbow";
 export const ZERION = "io.zerion.wallet";
+
+// Wallet IDs that should not appear in searchable wallet lists
+export const NON_SEARCHABLE_WALLETS: WalletId[] = [
+  "inApp",
+  "embedded",
+  "smart",
+  "xyz.abs",
+];


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing wallet search functionality by filtering out specific non-searchable wallets from the lists displayed in the UI.

### Detailed summary
- Added `NON_SEARCHABLE_WALLETS` constant in `packages/thirdweb/src/wallets/constants.ts` to define wallets that should not appear in searchable lists.
- Updated `walletList` in `packages/thirdweb/src/react/web/ui/ConnectWallet/Modal/AllWalletsUI.tsx` to use `NON_SEARCHABLE_WALLETS` for filtering.
- Updated wallet filtering logic in `packages/thirdweb/src/react/native/ui/connect/ExternalWalletsList.tsx` to utilize `NON_SEARCHABLE_WALLETS`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Wallet search now omits non-searchable wallets (including AGW) by default, improving search accuracy in web and native UI.

- **Refactor**
  - Non-searchable wallets are now managed centrally so both web and native wallet lists behave consistently.

- **Chores**
  - Added a changeset entry to publish a patch release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->