### PR TITLE
SDK, Dashboard: Fix SwapWidget setting same token for buy and sell in chain page

### DIFF
--- a/.changeset/cuddly-steaks-bathe.md
+++ b/.changeset/cuddly-steaks-bathe.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix SwapWidget setting same token for buy and sell in some cases when using last used token from storage

--- a/apps/dashboard/src/@/components/blocks/BuyAndSwapEmbed.tsx
+++ b/apps/dashboard/src/@/components/blocks/BuyAndSwapEmbed.tsx
@@ -97,9 +97,12 @@ export function BuyAndSwapEmbed(props: {
               chainId: props.chain.id,
               tokenAddress: props.tokenAddress,
             },
-            buyToken: {
-              chainId: props.chain.id,
-            },
+            // only set `buyToken` as "Native token" if `sellToken` is not a "native token" already
+            buyToken: props.tokenAddress
+              ? {
+                  chainId: props.chain.id,
+                }
+              : undefined,
           }}
           onError={(error, quote) => {
             const errorMessage = parseError(error);

--- a/packages/thirdweb/src/react/web/ui/Bridge/swap-widget/SwapWidget.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/swap-widget/SwapWidget.tsx
@@ -323,33 +323,30 @@ function SwapWidgetContent(props: SwapWidgetProps) {
         chainId: props.prefill.buyToken.chainId,
       };
     }
-    const last = getLastUsedTokens()?.buyToken;
-    if (last) {
-      return {
-        tokenAddress: getAddress(last.tokenAddress),
-        chainId: last.chainId,
-      };
+    const lastUsedBuyToken = getLastUsedTokens()?.buyToken;
+
+    // the token that will be set as initial value of sell token
+    const sellToken = getInitialSellToken(
+      props.prefill,
+      getLastUsedTokens()?.sellToken,
+    );
+
+    // if both tokens are same, ignore "buyToken", keep "sellToken"
+    if (
+      lastUsedBuyToken &&
+      sellToken &&
+      lastUsedBuyToken.tokenAddress.toLowerCase() ===
+        sellToken.tokenAddress.toLowerCase() &&
+      lastUsedBuyToken.chainId === sellToken.chainId
+    ) {
+      return undefined;
     }
-    return undefined;
+
+    return lastUsedBuyToken;
   });
 
   const [sellToken, setSellToken] = useState<TokenSelection | undefined>(() => {
-    if (props.prefill?.sellToken) {
-      return {
-        tokenAddress:
-          props.prefill.sellToken.tokenAddress ||
-          getAddress(NATIVE_TOKEN_ADDRESS),
-        chainId: props.prefill.sellToken.chainId,
-      };
-    }
-    const last = getLastUsedTokens()?.sellToken;
-    if (last) {
-      return {
-        tokenAddress: getAddress(last.tokenAddress),
-        chainId: last.chainId,
-      };
-    }
-    return undefined;
+    return getInitialSellToken(props.prefill, getLastUsedTokens()?.sellToken);
   });
 
   // persist selections to localStorage whenever they change
@@ -514,4 +511,18 @@ function SwapWidgetContent(props: SwapWidgetProps) {
   }
 
   return null;
+}
+
+function getInitialSellToken(
+  prefill: SwapWidgetProps["prefill"],
+  lastUsedSellToken: TokenSelection | undefined,
+) {
+  if (prefill?.sellToken) {
+    return {
+      tokenAddress:
+        prefill.sellToken.tokenAddress || getAddress(NATIVE_TOKEN_ADDRESS),
+      chainId: prefill.sellToken.chainId,
+    };
+  }
+  return lastUsedSellToken;
 }


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the `SwapWidget` component to correctly handle scenarios where the same token is used for both buying and selling. It ensures that the `buyToken` is only set if it is not the same as the `sellToken`.

### Detailed summary
- Updated logic in `BuyAndSwapEmbed.tsx` to conditionally set `buyToken`.
- Enhanced `SwapWidget.tsx` to prevent using the same token for both buy and sell.
- Introduced `getInitialSellToken` function to streamline sell token initialization.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - SwapWidget no longer defaults buy and sell to the same token when restoring last-used selections.
  - Improved initial token selection logic to respect prefilled values and chain IDs.
  - Consistent handling of native tokens; buy token is not prefilled if it matches the sell token.
  - Dashboard embed updated to only prefill buy token when appropriate.

- Chores
  - Added a changeset entry documenting the patch release and the SwapWidget fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->