### PR TITLE
[SDK] Show policy error for 7702 transactions

### DIFF
--- a/.changeset/smart-mugs-doubt.md
+++ b/.changeset/smart-mugs-doubt.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Show policy error for 7702 transactions

--- a/packages/thirdweb/src/wallets/smart/lib/bundler.ts
+++ b/packages/thirdweb/src/wallets/smart/lib/bundler.ts
@@ -361,6 +361,10 @@ export async function executeWithSignature(args: {
     ],
   });
 
+  if (!res.queueId) {
+    throw new Error(`Error executing 7702 transaction: ${stringify(res)}`);
+  }
+
   return {
     transactionId: res.queueId,
   };


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving error handling for 7702 transactions in the `thirdweb` package by throwing a specific error when the `queueId` is not present in the response.

### Detailed summary
- Added error handling for 7702 transactions in `packages/thirdweb/src/wallets/smart/lib/bundler.ts`.
- Introduced a new error message: `Error executing 7702 transaction: ${stringify(res)}` when `res.queueId` is not found.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Surface clear policy errors for 7702 transactions, improving transparency when transactions are blocked.
- Bug Fixes
  - Prevent undefined transaction IDs by validating transaction responses for 7702 flows.
  - Improve reliability of transaction status reporting with stricter runtime checks.
- Chores
  - Added release metadata for a patch update to reflect these improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->