### PR TITLE
Remove taint from GROWTH_PLAN_SKU and PAYMENT_METHOD_CONFIGURATION

### DIFF
--- a/apps/dashboard/src/@/constants/server-envs.ts
+++ b/apps/dashboard/src/@/constants/server-envs.ts
@@ -92,23 +92,7 @@ if (REDIS_URL) {
   );
 }
 
+// DO NOT TAINT THESE VALUES (for now)
 export const GROWTH_PLAN_SKU = process.env.GROWTH_PLAN_SKU || "";
-
-if (GROWTH_PLAN_SKU) {
-  experimental_taintUniqueValue(
-    "Do not pass GROWTH_PLAN_SKU to the client",
-    process,
-    GROWTH_PLAN_SKU,
-  );
-}
-
 export const PAYMENT_METHOD_CONFIGURATION =
   process.env.PAYMENT_METHOD_CONFIGURATION || "";
-
-if (PAYMENT_METHOD_CONFIGURATION) {
-  experimental_taintUniqueValue(
-    "Do not pass PAYMENT_METHOD_CONFIGURATION to the client",
-    process,
-    PAYMENT_METHOD_CONFIGURATION,
-  );
-}


### PR DESCRIPTION
Temporarily removed tainting of `GROWTH_PLAN_SKU` and `PAYMENT_METHOD_CONFIGURATION` environment variables to allow client-side access. Added a comment to indicate these values should not be tainted for now.