### PR TITLE
Add Zephyr testnet to pre-1559 chains

### DIFF
--- a/.changeset/sad-cloths-obey.md
+++ b/.changeset/sad-cloths-obey.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+add zephyr testnet to pre-1559 chains

--- a/packages/thirdweb/src/gas/fee-data.ts
+++ b/packages/thirdweb/src/gas/fee-data.ts
@@ -47,6 +47,7 @@ const FORCE_GAS_PRICE_CHAIN_IDS = [
   2020, // Ronin Mainnet
   2021, // Ronin Testnet (Saigon)
   98866, // Plume mainnet
+  1417429182, // Wilderworld Zephyr Testnet
 ];
 
 /**


### PR DESCRIPTION
Included Wilderworld Zephyr Testnet (chain ID 1417429182) in the FORCE_GAS_PRICE_CHAIN_IDS array to ensure correct gas price handling for this network.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding support for the Wilderworld Zephyr Testnet to the `thirdweb` package's fee data.

### Detailed summary
- Updated the `.changeset/sad-cloths-obey.md` file to include a patch for `thirdweb`.
- Added `Wilderworld Zephyr Testnet` with a fee data value of `1417429182` in `packages/thirdweb/src/gas/fee-data.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->