### PR TITLE
[Dashboard] Add ai usage billing banner to dashboard

### DIFF
--- a/apps/dashboard/src/@/components/misc/AnnouncementBanner.tsx
+++ b/apps/dashboard/src/@/components/misc/AnnouncementBanner.tsx
@@ -44,11 +44,12 @@ function AnnouncementBannerUI(props: {
 }
 
 export function AnnouncementBanner() {
-  return (
-    <AnnouncementBannerUI
-      href="https://blog.thirdweb.com/the-fastest-way-to-build-web3-applications/"
-      label="We have re-branded our Engine, Payments, and Connect products. Please read the full blog post for details on changes"
-      trackingLabel="product-rebrand"
-    />
-  );
+  // return (
+  //   <AnnouncementBannerUI
+  //     href="https://blog.thirdweb.com/the-fastest-way-to-build-web3-applications/"
+  //     label="We have re-branded our Engine, Payments, and Connect products. Please read the full blog post for details on changes"
+  //     trackingLabel="product-rebrand"
+  //   />
+  // );
+  return null;
 }

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/ai/components/EmptyStateChatPageContent.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/ai/components/EmptyStateChatPageContent.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ArrowUpRightIcon } from "lucide-react";
+import { ArrowUpRightIcon, InfoIcon } from "lucide-react";
 import type { ThirdwebClient } from "thirdweb";
 import { Button } from "@/components/ui/button";
 import { NebulaIcon } from "@/icons/NebulaIcon";
@@ -24,6 +24,7 @@ export function EmptyStateChatPageContent(props: {
 }) {
   return (
     <div className="overflow-hidden py-10 lg:py-16">
+      <AIUsageBanner />
       {props.showAurora && (
         <Aurora className="top-0 left-1/2 h-[800px] w-[1000px] text-[hsl(var(--primary-foreground)/8%)] lg:w-[150%] dark:text-[hsl(var(--primary-foreground)/10%)]" />
       )}
@@ -165,3 +166,35 @@ const Aurora: React.FC<AuroraProps> = ({ className }) => {
     />
   );
 };
+
+function AIUsageBanner() {
+  return (
+    <div className="absolute top-0 left-0 right-0 z-10 flex justify-center px-4 pt-4">
+      <div className="max-w-4xl">
+        <div className="relative overflow-hidden rounded-lg border border-blue-200 bg-gradient-to-r from-blue-50 to-blue-50/50 p-3 shadow-sm dark:border-blue-800 dark:from-blue-950/50 dark:to-blue-950/20">
+          <div className="relative flex items-center gap-3 px-2">
+            <div className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-blue-100 dark:bg-blue-900">
+              <InfoIcon className="size-3.5 text-blue-600 dark:text-blue-400" />
+            </div>
+
+            <div className="flex-1 text-sm">
+              <p className="text-blue-800 dark:text-blue-200">
+                thirdweb AI usage is billed based on number of tokens used. See
+                the{" "}
+                <a
+                  href="https://thirdweb.com/pricing"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="font-medium text-blue-700 underline decoration-blue-300 underline-offset-2 transition-colors hover:text-blue-800 hover:decoration-blue-500 dark:text-blue-300 dark:decoration-blue-600 dark:hover:text-blue-200 dark:hover:decoration-blue-400"
+                >
+                  pricing page
+                </a>
+                .
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/nebula/src/app/(app)/components/EmptyStateChatPageContent.tsx
+++ b/apps/nebula/src/app/(app)/components/EmptyStateChatPageContent.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ArrowUpRightIcon, InfoIcon } from "lucide-react";
+import { ArrowUpRightIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { nebulaAppThirdwebClient } from "@/constants/nebula-client";
 import { NebulaIcon } from "@/icons/NebulaIcon";
@@ -24,7 +24,6 @@ export function EmptyStateChatPageContent(props: {
 }) {
   return (
     <div className="relative overflow-hidden py-10 lg:py-16">
-      <AIUsageBanner />
       {props.showAurora && (
         <Aurora className="top-0 left-1/2 h-[800px] w-[1000px] text-[hsl(var(--nebula-pink-foreground)/8%)] lg:w-[150%] dark:text-[hsl(var(--nebula-pink-foreground)/10%)]" />
       )}
@@ -166,37 +165,3 @@ const Aurora: React.FC<AuroraProps> = ({ className }) => {
     />
   );
 };
-
-function AIUsageBanner() {
-  return (
-    <div className="absolute top-0 left-0 right-0 z-10 flex justify-center px-4 pt-4">
-      <div className="w-full max-w-4xl">
-        <div className="relative overflow-hidden rounded-lg border border-blue-200 bg-gradient-to-r from-blue-50 to-blue-50/50 p-3 shadow-sm dark:border-blue-800 dark:from-blue-950/50 dark:to-blue-950/20">
-          {/* Decorative blur */}
-          <div className="absolute -right-6 -top-6 size-20 rounded-full bg-blue-600 opacity-10 blur-xl" />
-          
-          <div className="relative flex items-start gap-3">
-            <div className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-blue-100 dark:bg-blue-900">
-              <InfoIcon className="size-3.5 text-blue-600 dark:text-blue-400" />
-            </div>
-            
-            <div className="flex-1 text-sm">
-              <p className="text-blue-800 dark:text-blue-200">
-                thirdweb AI usage is billable based on number of tokens used. For more details, see the{" "}
-                <a
-                  href="https://thirdweb.com/pricing"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="font-medium text-blue-700 underline decoration-blue-300 underline-offset-2 transition-colors hover:text-blue-800 hover:decoration-blue-500 dark:text-blue-300 dark:decoration-blue-600 dark:hover:text-blue-200 dark:hover:decoration-blue-400"
-                >
-                  pricing page
-                </a>
-                .
-              </p>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}

--- a/apps/playground-web/src/app/payments/x402/page.tsx
+++ b/apps/playground-web/src/app/payments/x402/page.tsx
@@ -59,7 +59,6 @@ function ServerCodeExample() {
 
 import { facilitator, verifyPayment } from "thirdweb/x402";
 import { createThirdwebClient } from "thirdweb";
-import { paymentMiddleware } from "x402-next";
 
 const client = createThirdwebClient({ secretKey: "your-secret-key" });
 const thirdwebX402Facilitator = facilitator({

--- a/apps/portal/src/app/payments/x402/page.mdx
+++ b/apps/portal/src/app/payments/x402/page.mdx
@@ -50,7 +50,6 @@ Here's an example with a Next.js middleware:
 ```typescript
 import { createThirdwebClient } from "thirdweb";
 import { facilitator, verifyPayment } from "thirdweb/x402";
-import { paymentMiddleware } from "x402-next";
 
 const client = createThirdwebClient({ secretKey: "your-secret-key" });
 const thirdwebX402Facilitator = facilitator({


### PR DESCRIPTION
## [Dashboard] Feature: Add AI usage billing banner to Nebula chat empty state

## Notes for the reviewer

This PR introduces a new `AIUsageBanner` component to `EmptyStateChatPageContent.tsx`. The banner informs users about thirdweb AI usage billing and links to the pricing page. It is styled to be consistent with existing info/alert banners in the dashboard, floating at the top of the component.

## How to test

1. Navigate to the Nebula AI chat page (e.g., `/nebula`).
2. Ensure no active chat is selected, so the empty state content is displayed.
3. Verify that the "thirdweb AI usage is billable..." banner is visible at the top of the content.
4. Check that the "pricing page" link correctly navigates to `https://thirdweb.com/pricing`.
5. Test in both light and dark modes, and verify responsiveness.

---
[Slack Thread](https://thirdwebdev.slack.com/archives/D094H4S4KKN/p1758587451014379?thread_ts=1758587451.014379&cid=D094H4S4KKN)

<a href="https://cursor.com/background-agent?bcId=bc-552bfe8f-f46f-40a9-ae82-38d2e6abe05a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-552bfe8f-f46f-40a9-ae82-38d2e6abe05a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on code modifications across multiple files, including changes to UI components and the addition of a new banner for AI usage information.

### Detailed summary
- In `EmptyStateChatPageContent.tsx`, added `<AIUsageBanner />` to display information about AI usage billing.
- Modified `AnnouncementBanner.tsx` to return `null` instead of rendering the announcement UI.
- Updated the `div` class in `EmptyStateChatPageContent.tsx` to `relative` for proper positioning.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an AI usage banner to the AI chat empty state with info and a link to pricing.
- Style
  - Removed the announcement banner from the dashboard (no banner now shown).
  - Minor layout tweak to the empty state chat container for improved positioning.
- Documentation
  - Updated payments (x402) examples by removing an outdated middleware import.
- Chores
  - Cleaned up unused imports in the payments example app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->