### PR TITLE
SDK: Fix toUnits throwing error for values in scientific notation

### DIFF
--- a/packages/thirdweb/src/utils/units.test.ts
+++ b/packages/thirdweb/src/utils/units.test.ts
@@ -199,6 +199,19 @@ describe("toUnits", () => {
     expect(toUnits("69.59000000059", 9)).toMatchInlineSnapshot("69590000001n");
     expect(toUnits("69.59000002359", 9)).toMatchInlineSnapshot("69590000024n");
   });
+
+  it("scientific notation", () => {
+    // negative exponents
+    expect(toUnits("1e-18", 18)).toMatchInlineSnapshot("1n");
+    expect(toUnits("1e-16", 18)).toMatchInlineSnapshot("100n");
+    expect(toUnits("1.23456789012345e-7", 18)).toMatchInlineSnapshot(
+      "123456789012n",
+    );
+    // positive exponents
+    expect(toUnits("1.234e3", 18)).toMatchInlineSnapshot(
+      "1234000000000000000000n",
+    );
+  });
 });
 
 describe("toWei", () => {

--- a/packages/thirdweb/src/utils/units.ts
+++ b/packages/thirdweb/src/utils/units.ts
@@ -73,6 +73,10 @@ export function toEther(wei: bigint) {
  * @utils
  */
 export function toUnits(tokens: string, decimals: number): bigint {
+  if (tokens.includes("e")) {
+    tokens = Number(tokens).toFixed(decimals);
+  }
+
   let [integerPart, fractionPart = ""] = tokens.split(".") as [string, string];
   const prefix = integerPart.startsWith("-") ? "-" : "";
   if (prefix) {


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `toUnits` function in the `units.ts` file to handle scientific notation for token inputs and adds corresponding tests in `units.test.ts`.

### Detailed summary
- Updated the `toUnits` function to convert scientific notation strings to fixed decimal format.
- Added a test case for the `toUnits` function to verify handling of negative and positive exponents in scientific notation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unit conversion now accepts scientific notation (positive and negative exponents), normalizing values to the configured decimal precision for consistent fixed-point results.

* **Tests**
  * Added tests covering positive and negative exponent cases to validate parsing and conversion of scientific notation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->