### PR TITLE
[MNY-201] SDK: Rename leftover of Universal Bridge to Bridge

### DIFF
--- a/apps/dashboard/src/@/api/analytics.ts
+++ b/apps/dashboard/src/@/api/analytics.ts
@@ -592,7 +592,7 @@ const cached_getUniversalBridgeUsage = unstable_cache(
     if (res?.status !== 200) {
       const reason = await res?.text();
       console.error(
-        `Failed to fetch universal bridge stats: ${res?.status} - ${res.statusText} - ${reason}`,
+        `Failed to fetch bridge stats: ${res?.status} - ${res.statusText} - ${reason}`,
       );
       return [];
     }
@@ -636,7 +636,7 @@ const cached_getUniversalBridgeWalletUsage = unstable_cache(
     if (res?.status !== 200) {
       const reason = await res?.text();
       console.error(
-        `Failed to fetch universal bridge wallet stats: ${res?.status} - ${res.statusText} - ${reason}`,
+        `Failed to fetch bridge wallet stats: ${res?.status} - ${res.statusText} - ${reason}`,
       );
       return [];
     }

--- a/packages/thirdweb/src/bridge/Buy.ts
+++ b/packages/thirdweb/src/bridge/Buy.ts
@@ -9,7 +9,7 @@ import { ApiError } from "./types/Errors.js";
 import type { PreparedQuote, Quote } from "./types/Quote.js";
 
 /**
- * Retrieves a Universal Bridge quote for the provided buy intent. The quote will specify the necessary `originAmount` to receive the desired `destinationAmount`, which is specified with the `buyAmountWei` option.
+ * Retrieves a Bridge quote for the provided buy intent. The quote will specify the necessary `originAmount` to receive the desired `destinationAmount`, which is specified with the `buyAmountWei` option.
  *
  * @example
  * ```typescript
@@ -209,7 +209,7 @@ export declare namespace quote {
 }
 
 /**
- * Prepares a **finalized** Universal Bridge quote for the provided buy request with transaction data. This function will return everything `quote` does, with the addition of a series of prepared transactions and the associated expiration timestamp.
+ * Prepares a **finalized** Bridge quote for the provided buy request with transaction data. This function will return everything `quote` does, with the addition of a series of prepared transactions and the associated expiration timestamp.
  *
  * @example
  * ```typescript

--- a/packages/thirdweb/src/bridge/Chains.ts
+++ b/packages/thirdweb/src/bridge/Chains.ts
@@ -6,7 +6,7 @@ import type { Chain } from "./types/Chain.js";
 import { ApiError } from "./types/Errors.js";
 
 /**
- * Retrieves supported Universal Bridge chains.
+ * Retrieves supported Bridge chains.
  *
  * @example
  * ```typescript

--- a/packages/thirdweb/src/bridge/Routes.ts
+++ b/packages/thirdweb/src/bridge/Routes.ts
@@ -6,7 +6,7 @@ import { ApiError } from "./types/Errors.js";
 import type { Route } from "./types/Route.js";
 
 /**
- * Retrieves supported Universal Bridge routes based on the provided filters.
+ * Retrieves supported Bridge routes based on the provided filters.
  *
  * When multiple filters are specified, a route must satisfy all filters to be included (it acts as an AND operator).
  *

--- a/packages/thirdweb/src/bridge/Sell.ts
+++ b/packages/thirdweb/src/bridge/Sell.ts
@@ -9,7 +9,7 @@ import { ApiError } from "./types/Errors.js";
 import type { PreparedQuote, Quote } from "./types/Quote.js";
 
 /**
- * Retrieves a Universal Bridge quote for the provided sell intent. The quote will specify the expected `destinationAmount` that will be received in exchange for the specified `originAmount`, which is specified with the `sellAmountWei` option.
+ * Retrieves a Bridge quote for the provided sell intent. The quote will specify the expected `destinationAmount` that will be received in exchange for the specified `originAmount`, which is specified with the `sellAmountWei` option.
  *
  * @example
  * ```typescript
@@ -200,7 +200,7 @@ export declare namespace quote {
 }
 
 /**
- * Prepares a **finalized** Universal Bridge quote for the provided sell request with transaction data. This function will return everything `quote` does, with the addition of a series of prepared transactions and the associated expiration timestamp.
+ * Prepares a **finalized** Bridge quote for the provided sell request with transaction data. This function will return everything `quote` does, with the addition of a series of prepared transactions and the associated expiration timestamp.
  *
  * @example
  * ```typescript

--- a/packages/thirdweb/src/bridge/Status.ts
+++ b/packages/thirdweb/src/bridge/Status.ts
@@ -7,7 +7,7 @@ import { ApiError } from "./types/Errors.js";
 import type { Status } from "./types/Status.js";
 
 /**
- * Retrieves a Universal Bridge quote for the provided sell intent. The quote will specify the expected `destinationAmount` that will be received in exchange for the specified `originAmount`, which is specified with the `sellAmountWei` option.
+ * Retrieves a Bridge quote for the provided sell intent. The quote will specify the expected `destinationAmount` that will be received in exchange for the specified `originAmount`, which is specified with the `sellAmountWei` option.
  *
  * The returned status will include both the origin and destination transactions and any finalized amounts for the route.
  *

--- a/packages/thirdweb/src/bridge/Token.ts
+++ b/packages/thirdweb/src/bridge/Token.ts
@@ -5,7 +5,7 @@ import { ApiError } from "./types/Errors.js";
 import type { Token, TokenWithPrices } from "./types/Token.js";
 
 /**
- * Retrieves supported Universal Bridge tokens based on the provided filters.
+ * Retrieves supported Bridge tokens based on the provided filters.
  *
  * When multiple filters are specified, a token must satisfy all filters to be included (it acts as an AND operator).
  *
@@ -226,9 +226,9 @@ export declare namespace tokens {
 }
 
 /**
- * Adds a token to the Universal Bridge for indexing.
+ * Adds a token to the Bridge for indexing.
  *
- * This function requests the Universal Bridge to index a specific token on a given chain.
+ * This function requests the Bridge to index a specific token on a given chain.
  * Once indexed, the token will be available for cross-chain operations.
  *
  * @example

--- a/packages/thirdweb/src/bridge/Transfer.ts
+++ b/packages/thirdweb/src/bridge/Transfer.ts
@@ -9,7 +9,7 @@ import { ApiError } from "./types/Errors.js";
 import type { PreparedQuote } from "./types/Quote.js";
 
 /**
- * Prepares a **finalized** Universal Bridge quote for the provided transfer request with transaction data.
+ * Prepares a **finalized** Bridge quote for the provided transfer request with transaction data.
  *
  * @example
  * ```typescript

--- a/packages/thirdweb/src/bridge/Webhook.ts
+++ b/packages/thirdweb/src/bridge/Webhook.ts
@@ -90,7 +90,7 @@ export type WebhookPayload = Exclude<
 >;
 
 /**
- * Parses an incoming Universal Bridge webhook payload.
+ * Parses an incoming Bridge webhook payload.
  *
  * @param payload - The raw text body received from thirdweb.
  * @param headers - The webhook headers received from thirdweb.

--- a/packages/thirdweb/src/bridge/types/Chain.ts
+++ b/packages/thirdweb/src/bridge/types/Chain.ts
@@ -1,5 +1,5 @@
 /**
- * Represents a blockchain chain in the Universal Bridge.
+ * Represents a blockchain chain in the Bridge.
  * @public
  */
 export interface Chain {

--- a/packages/thirdweb/src/exports/thirdweb.ts
+++ b/packages/thirdweb/src/exports/thirdweb.ts
@@ -6,7 +6,7 @@ declare module "abitype" {
 }
 
 /**
- * UNIVERSAL BRIDGE
+ * BRIDGE
  */
 export * as Bridge from "../bridge/index.js";
 /**

--- a/packages/thirdweb/src/stories/Bridge/UnsupportedTokenScreen.stories.tsx
+++ b/packages/thirdweb/src/stories/Bridge/UnsupportedTokenScreen.stories.tsx
@@ -68,7 +68,7 @@ export const TokenNotSupported: Story = {
     docs: {
       description: {
         story:
-          "Shows the loading state when a token is being indexed by the Universal Bridge on a mainnet chain.",
+          "Shows the loading state when a token is being indexed by the Bridge on a mainnet chain.",
       },
     },
   },
@@ -85,7 +85,7 @@ export const TokenNotSupportedLight: Story = {
     docs: {
       description: {
         story:
-          "Shows the loading state when a token is being indexed by the Universal Bridge on a mainnet chain (light theme).",
+          "Shows the loading state when a token is being indexed by the Bridge on a mainnet chain (light theme).",
       },
     },
   },
@@ -102,7 +102,7 @@ export const TestnetNotSupported: Story = {
     docs: {
       description: {
         story:
-          "Shows the error state when trying to use the Universal Bridge on a testnet chain (Sepolia in this example).",
+          "Shows the error state when trying to use the Bridge on a testnet chain (Sepolia in this example).",
       },
     },
   },
@@ -119,7 +119,7 @@ export const TestnetNotSupportedLight: Story = {
     docs: {
       description: {
         story:
-          "Shows the error state when trying to use the Universal Bridge on a testnet chain (Sepolia in this example, light theme).",
+          "Shows the error state when trying to use the Bridge on a testnet chain (Sepolia in this example, light theme).",
       },
     },
   },

--- a/packages/thirdweb/src/utils/domains.ts
+++ b/packages/thirdweb/src/utils/domains.ts
@@ -45,7 +45,7 @@ type DomainOverrides = {
    */
   engineCloud?: string;
   /**
-   * The base URL for the universal bridge service.
+   * The base URL for the bridge service.
    * @default "bridge.thirdweb.com"
    */
   bridge?: string;


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on renaming references from `Universal Bridge` to `Bridge` across various files in the codebase for consistency and clarity.

### Detailed summary
- Updated comments and documentation to replace `Universal Bridge` with `Bridge`.
- Changed error messages in `apps/dashboard/src/@/api/analytics.ts` to reflect the new terminology.
- Adjusted descriptions in multiple files, including `Chain.ts`, `Webhook.ts`, `Transfer.ts`, `Routes.ts`, `Status.ts`, `Token.ts`, `Buy.ts`, and `Sell.ts`, to align with the new naming.
- Modified story descriptions in `UnsupportedTokenScreen.stories.tsx` to use `Bridge` instead of `Universal Bridge`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Replaced “Universal Bridge” with “Bridge” across API docs, stories, and descriptions. No functional changes.
- Chores
  - Updated error log messages for bridge and bridge wallet usage to remove “universal.” Functionality unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->