### PR TITLE
[MNY-200] SDK: Fix onSuccess callback not called when tx is sent in TransactionWidget

### DIFF
--- a/packages/thirdweb/src/react/web/ui/Bridge/BridgeOrchestrator.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/BridgeOrchestrator.tsx
@@ -189,13 +189,9 @@ export function BridgeOrchestrator({
   }, [send, uiOptions.mode]);
 
   // Handle post-buy transaction completion
-  const handlePostBuyTransactionComplete = useCallback(
-    (quote: BridgePrepareResult) => {
-      onComplete?.(quote);
-      send({ type: "RESET" });
-    },
-    [onComplete, send],
-  );
+  const handlePostBuyTransactionComplete = useCallback(() => {
+    send({ type: "RESET" });
+  }, [send]);
 
   // Handle errors
   const handleError = useCallback(
@@ -416,9 +412,9 @@ export function BridgeOrchestrator({
         quote &&
         uiOptions.transaction && (
           <ExecutingTxScreen
-            closeModal={() => handlePostBuyTransactionComplete(quote)}
+            closeModal={handlePostBuyTransactionComplete}
             onTxSent={() => {
-              // Do nothing
+              onComplete?.(quote);
             }}
             tx={uiOptions.transaction}
             windowAdapter={webWindowAdapter}


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR simplifies the `handlePostBuyTransactionComplete` function in the `BridgeOrchestrator` component by removing the `quote` parameter and associated logic, streamlining the transaction completion process.

### Detailed summary
- Removed the `quote` parameter from `handlePostBuyTransactionComplete`.
- Eliminated the call to `onComplete?.(quote)` within `handlePostBuyTransactionComplete`.
- Updated the `closeModal` prop in `ExecutingTxScreen` to directly use `handlePostBuyTransactionComplete`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->