### PR TITLE
[SDK] Support ERC-2612 permit for x402 payments

### DIFF
--- a/.changeset/giant-suns-drive.md
+++ b/.changeset/giant-suns-drive.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Support ERC-2612 permit for x402 payments

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/transactions/server-wallets/wallet-table/wallet-table-ui.client.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/transactions/server-wallets/wallet-table/wallet-table-ui.client.tsx
@@ -215,7 +215,7 @@ export function ServerWalletsTableUI({
               <PaginationContent>
                 <PaginationItem>
                   <Link
-                    href={`/team/${teamSlug}/${project.slug}/transactions/server-wallets?page=${
+                    href={`/team/${teamSlug}/${project.slug}/transactions?page=${
                       currentPage > 1 ? currentPage - 1 : 1
                     }`}
                     legacyBehavior
@@ -232,7 +232,7 @@ export function ServerWalletsTableUI({
                   (pageNumber) => (
                     <PaginationItem key={`page-${pageNumber}`}>
                       <Link
-                        href={`/team/${teamSlug}/${project.slug}/transactions/server-wallets?page=${pageNumber}`}
+                        href={`/team/${teamSlug}/${project.slug}/transactions?page=${pageNumber}`}
                         passHref
                       >
                         <PaginationLink isActive={currentPage === pageNumber}>
@@ -244,7 +244,7 @@ export function ServerWalletsTableUI({
                 )}
                 <PaginationItem>
                   <Link
-                    href={`/team/${teamSlug}/${project.slug}/transactions/server-wallets?page=${
+                    href={`/team/${teamSlug}/${project.slug}/transactions?page=${
                       currentPage < totalPages ? currentPage + 1 : totalPages
                     }`}
                     passHref

--- a/apps/playground-web/src/app/api/paywall/route.ts
+++ b/apps/playground-web/src/app/api/paywall/route.ts
@@ -5,6 +5,6 @@ export const maxDuration = 300;
 export async function GET(_req: Request) {
   return NextResponse.json({
     success: true,
-    message: "Congratulations! You have accessed the protected route.",
+    message: "Payment successful. You have accessed the protected route.",
   });
 }

--- a/apps/playground-web/src/app/payments/x402/components/constants.ts
+++ b/apps/playground-web/src/app/payments/x402/components/constants.ts
@@ -1,0 +1,31 @@
+// const chain = arbitrumSepolia;
+
+import { arbitrumSepolia } from "thirdweb/chains";
+import { getDefaultToken } from "thirdweb/react";
+
+export const chain = arbitrumSepolia;
+export const token = getDefaultToken(chain, "USDC")!;
+// export const chain = base;
+// export const token = {
+//   address: "0x0578d8A44db98B23BF096A382e016e29a5Ce0ffe",
+//   decimals: 18,
+//   name: "Higher",
+//   symbol: "HIGHER",
+//   version: "1",
+// };
+// export const token = {
+//     address: "0xfdcC3dd6671eaB0709A4C0f3F53De9a333d80798",
+//     decimals: 18,
+//     name: "Stable Coin",
+//     symbol: "SBC",
+//     version: "1",
+//     // primaryType: "Permit",
+//   }
+// export const chain = defineChain(3338);
+// export const token = {
+//   address: "0xbbA60da06c2c5424f03f7434542280FCAd453d10",
+//   decimals: 6,
+//   name: "USDC",
+//   symbol: "USDC",
+//   version: "2",
+// }

--- a/packages/thirdweb/scripts/generate/abis/erc20/USDC.json
+++ b/packages/thirdweb/scripts/generate/abis/erc20/USDC.json
@@ -1,0 +1,3 @@
+[
+  "function transferWithAuthorization(address from, address to, uint256 value, uint256 validAfter, uint256 validBefore, bytes32 nonce, bytes signature)"
+]

--- a/packages/thirdweb/scripts/generate/abis/erc7702/MinimalAccount.json
+++ b/packages/thirdweb/scripts/generate/abis/erc7702/MinimalAccount.json
@@ -24,9 +24,4 @@
   "function getSessionStateForSigner(address signer) view returns (((uint256 remaining, address target, bytes4 selector, uint256 index)[] transferValue, (uint256 remaining, address target, bytes4 selector, uint256 index)[] callValue, (uint256 remaining, address target, bytes4 selector, uint256 index)[] callParams))",
   "function getTransferPoliciesForSigner(address signer) view returns ((address target, uint256 maxValuePerUse, (uint8 limitType, uint256 limit, uint256 period) valueLimit)[])",
   "function isWildcardSigner(address signer) view returns (bool)",
-  "function onERC1155BatchReceived(address, address, uint256[], uint256[], bytes) returns (bytes4)",
-  "function onERC1155Received(address, address, uint256, uint256, bytes) returns (bytes4)",
-  "function onERC721Received(address, address, uint256, bytes) returns (bytes4)",
-  "function supportsInterface(bytes4 interfaceId) view returns (bool)",
-  "receive() external payable"
 ]

--- a/packages/thirdweb/src/exports/x402.ts
+++ b/packages/thirdweb/src/exports/x402.ts
@@ -1,6 +1,7 @@
 export { decodePayment, encodePayment } from "../x402/encode.js";
 export {
   facilitator,
+  type ThirdwebX402Facilitator,
   type ThirdwebX402FacilitatorConfig,
 } from "../x402/facilitator.js";
 export { wrapFetchWithPayment } from "../x402/fetchWithPayment.js";

--- a/packages/thirdweb/src/extensions/erc20/__generated__/USDC/write/transferWithAuthorization.ts
+++ b/packages/thirdweb/src/extensions/erc20/__generated__/USDC/write/transferWithAuthorization.ts
@@ -1,0 +1,215 @@
+import type { AbiParameterToPrimitiveType } from "abitype";
+import { prepareContractCall } from "../../../../../transaction/prepare-contract-call.js";
+import type {
+  BaseTransactionOptions,
+  WithOverrides,
+} from "../../../../../transaction/types.js";
+import { encodeAbiParameters } from "../../../../../utils/abi/encodeAbiParameters.js";
+import { detectMethod } from "../../../../../utils/bytecode/detectExtension.js";
+import { once } from "../../../../../utils/promise/once.js";
+
+/**
+ * Represents the parameters for the "transferWithAuthorization" function.
+ */
+export type TransferWithAuthorizationParams = WithOverrides<{
+  from: AbiParameterToPrimitiveType<{ type: "address"; name: "from" }>;
+  to: AbiParameterToPrimitiveType<{ type: "address"; name: "to" }>;
+  value: AbiParameterToPrimitiveType<{ type: "uint256"; name: "value" }>;
+  validAfter: AbiParameterToPrimitiveType<{
+    type: "uint256";
+    name: "validAfter";
+  }>;
+  validBefore: AbiParameterToPrimitiveType<{
+    type: "uint256";
+    name: "validBefore";
+  }>;
+  nonce: AbiParameterToPrimitiveType<{ type: "bytes32"; name: "nonce" }>;
+  signature: AbiParameterToPrimitiveType<{ type: "bytes"; name: "signature" }>;
+}>;
+
+export const FN_SELECTOR = "0xcf092995" as const;
+const FN_INPUTS = [
+  {
+    type: "address",
+    name: "from",
+  },
+  {
+    type: "address",
+    name: "to",
+  },
+  {
+    type: "uint256",
+    name: "value",
+  },
+  {
+    type: "uint256",
+    name: "validAfter",
+  },
+  {
+    type: "uint256",
+    name: "validBefore",
+  },
+  {
+    type: "bytes32",
+    name: "nonce",
+  },
+  {
+    type: "bytes",
+    name: "signature",
+  },
+] as const;
+const FN_OUTPUTS = [] as const;
+
+/**
+ * Checks if the `transferWithAuthorization` method is supported by the given contract.
+ * @param availableSelectors An array of 4byte function selectors of the contract. You can get this in various ways, such as using "whatsabi" or if you have the ABI of the contract available you can use it to generate the selectors.
+ * @returns A boolean indicating if the `transferWithAuthorization` method is supported.
+ * @extension ERC20
+ * @example
+ * ```ts
+ * import { isTransferWithAuthorizationSupported } from "thirdweb/extensions/erc20";
+ *
+ * const supported = isTransferWithAuthorizationSupported(["0x..."]);
+ * ```
+ */
+export function isTransferWithAuthorizationSupported(
+  availableSelectors: string[],
+) {
+  return detectMethod({
+    availableSelectors,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+  });
+}
+
+/**
+ * Encodes the parameters for the "transferWithAuthorization" function.
+ * @param options - The options for the transferWithAuthorization function.
+ * @returns The encoded ABI parameters.
+ * @extension ERC20
+ * @example
+ * ```ts
+ * import { encodeTransferWithAuthorizationParams } from "thirdweb/extensions/erc20";
+ * const result = encodeTransferWithAuthorizationParams({
+ *  from: ...,
+ *  to: ...,
+ *  value: ...,
+ *  validAfter: ...,
+ *  validBefore: ...,
+ *  nonce: ...,
+ *  signature: ...,
+ * });
+ * ```
+ */
+export function encodeTransferWithAuthorizationParams(
+  options: TransferWithAuthorizationParams,
+) {
+  return encodeAbiParameters(FN_INPUTS, [
+    options.from,
+    options.to,
+    options.value,
+    options.validAfter,
+    options.validBefore,
+    options.nonce,
+    options.signature,
+  ]);
+}
+
+/**
+ * Encodes the "transferWithAuthorization" function into a Hex string with its parameters.
+ * @param options - The options for the transferWithAuthorization function.
+ * @returns The encoded hexadecimal string.
+ * @extension ERC20
+ * @example
+ * ```ts
+ * import { encodeTransferWithAuthorization } from "thirdweb/extensions/erc20";
+ * const result = encodeTransferWithAuthorization({
+ *  from: ...,
+ *  to: ...,
+ *  value: ...,
+ *  validAfter: ...,
+ *  validBefore: ...,
+ *  nonce: ...,
+ *  signature: ...,
+ * });
+ * ```
+ */
+export function encodeTransferWithAuthorization(
+  options: TransferWithAuthorizationParams,
+) {
+  // we do a "manual" concat here to avoid the overhead of the "concatHex" function
+  // we can do this because we know the specific formats of the values
+  return (FN_SELECTOR +
+    encodeTransferWithAuthorizationParams(options).slice(
+      2,
+    )) as `${typeof FN_SELECTOR}${string}`;
+}
+
+/**
+ * Prepares a transaction to call the "transferWithAuthorization" function on the contract.
+ * @param options - The options for the "transferWithAuthorization" function.
+ * @returns A prepared transaction object.
+ * @extension ERC20
+ * @example
+ * ```ts
+ * import { sendTransaction } from "thirdweb";
+ * import { transferWithAuthorization } from "thirdweb/extensions/erc20";
+ *
+ * const transaction = transferWithAuthorization({
+ *  contract,
+ *  from: ...,
+ *  to: ...,
+ *  value: ...,
+ *  validAfter: ...,
+ *  validBefore: ...,
+ *  nonce: ...,
+ *  signature: ...,
+ *  overrides: {
+ *    ...
+ *  }
+ * });
+ *
+ * // Send the transaction
+ * await sendTransaction({ transaction, account });
+ * ```
+ */
+export function transferWithAuthorization(
+  options: BaseTransactionOptions<
+    | TransferWithAuthorizationParams
+    | {
+        asyncParams: () => Promise<TransferWithAuthorizationParams>;
+      }
+  >,
+) {
+  const asyncOptions = once(async () => {
+    return "asyncParams" in options ? await options.asyncParams() : options;
+  });
+
+  return prepareContractCall({
+    contract: options.contract,
+    method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
+    params: async () => {
+      const resolvedOptions = await asyncOptions();
+      return [
+        resolvedOptions.from,
+        resolvedOptions.to,
+        resolvedOptions.value,
+        resolvedOptions.validAfter,
+        resolvedOptions.validBefore,
+        resolvedOptions.nonce,
+        resolvedOptions.signature,
+      ] as const;
+    },
+    value: async () => (await asyncOptions()).overrides?.value,
+    accessList: async () => (await asyncOptions()).overrides?.accessList,
+    gas: async () => (await asyncOptions()).overrides?.gas,
+    gasPrice: async () => (await asyncOptions()).overrides?.gasPrice,
+    maxFeePerGas: async () => (await asyncOptions()).overrides?.maxFeePerGas,
+    maxPriorityFeePerGas: async () =>
+      (await asyncOptions()).overrides?.maxPriorityFeePerGas,
+    nonce: async () => (await asyncOptions()).overrides?.nonce,
+    extraGas: async () => (await asyncOptions()).overrides?.extraGas,
+    erc20Value: async () => (await asyncOptions()).overrides?.erc20Value,
+    authorizationList: async () =>
+      (await asyncOptions()).overrides?.authorizationList,
+  });
+}

--- a/packages/thirdweb/src/x402/common.ts
+++ b/packages/thirdweb/src/x402/common.ts
@@ -9,7 +9,7 @@ import { isPermitSupported } from "../extensions/erc20/__generated__/IERC20Permi
 import { isTransferWithAuthorizationSupported } from "../extensions/erc20/__generated__/USDC/write/transferWithAuthorization.js";
 import { getAddress } from "../utils/address.js";
 import { decodePayment } from "./encode.js";
-import type { facilitator as facilitatorType } from "./facilitator.js";
+import type { ThirdwebX402Facilitator } from "./facilitator.js";
 import {
   networkToChainId,
   type RequestedPaymentPayload,
@@ -197,7 +197,7 @@ export async function decodePaymentRequest(
 async function processPriceToAtomicAmount(
   price: Money | ERC20TokenAmount,
   chainId: number,
-  facilitator: ReturnType<typeof facilitatorType>,
+  facilitator: ThirdwebX402Facilitator,
 ): Promise<
   | { maxAmountRequired: string; asset: ERC20TokenAmount["asset"] }
   | { error: string }
@@ -237,7 +237,7 @@ async function processPriceToAtomicAmount(
 
 async function getDefaultAsset(
   chainId: number,
-  facilitator: ReturnType<typeof facilitatorType>,
+  facilitator: ThirdwebX402Facilitator,
 ): Promise<ERC20TokenAmount["asset"] | undefined> {
   const supportedAssets = await facilitator.supported();
   const matchingAsset = supportedAssets.kinds.find(

--- a/packages/thirdweb/src/x402/facilitator.ts
+++ b/packages/thirdweb/src/x402/facilitator.ts
@@ -15,6 +15,10 @@ export type ThirdwebX402FacilitatorConfig = {
   baseUrl?: string;
 };
 
+/**
+ * facilitator for the x402 payment protocol.
+ * @public
+ */
 export type ThirdwebX402Facilitator = {
   url: `${string}://${string}`;
   address: string;

--- a/packages/thirdweb/src/x402/facilitator.ts
+++ b/packages/thirdweb/src/x402/facilitator.ts
@@ -15,6 +15,26 @@ export type ThirdwebX402FacilitatorConfig = {
   baseUrl?: string;
 };
 
+export type ThirdwebX402Facilitator = {
+  url: `${string}://${string}`;
+  address: string;
+  createAuthHeaders: () => Promise<{
+    verify: Record<string, string>;
+    settle: Record<string, string>;
+    supported: Record<string, string>;
+    list: Record<string, string>;
+  }>;
+  verify: (
+    payload: RequestedPaymentPayload,
+    paymentRequirements: RequestedPaymentRequirements,
+  ) => Promise<VerifyResponse>;
+  settle: (
+    payload: RequestedPaymentPayload,
+    paymentRequirements: RequestedPaymentRequirements,
+  ) => Promise<FacilitatorSettleResponse>;
+  supported: () => Promise<SupportedPaymentKindsResponse>;
+};
+
 const DEFAULT_BASE_URL = "https://api.thirdweb.com/v1/payments/x402";
 
 /**
@@ -56,7 +76,9 @@ const DEFAULT_BASE_URL = "https://api.thirdweb.com/v1/payments/x402";
  *
  * @bridge x402
  */
-export function facilitator(config: ThirdwebX402FacilitatorConfig) {
+export function facilitator(
+  config: ThirdwebX402FacilitatorConfig,
+): ThirdwebX402Facilitator {
   const secretKey = config.client.secretKey;
   if (!secretKey) {
     throw new Error("Client secret key is required for the x402 facilitator");

--- a/packages/thirdweb/src/x402/facilitator.ts
+++ b/packages/thirdweb/src/x402/facilitator.ts
@@ -69,6 +69,7 @@ export function facilitator(config: ThirdwebX402FacilitatorConfig) {
   }
   const facilitator = {
     url: (config.baseUrl ?? DEFAULT_BASE_URL) as `${string}://${string}`,
+    address: serverWalletAddress,
     createAuthHeaders: async () => {
       return {
         verify: {

--- a/packages/thirdweb/src/x402/fetchWithPayment.ts
+++ b/packages/thirdweb/src/x402/fetchWithPayment.ts
@@ -106,6 +106,7 @@ export function wrapFetchWithPayment(
       client,
       account,
       selectedPaymentRequirements,
+      x402Version,
     );
 
     const initParams = init || {};

--- a/packages/thirdweb/src/x402/fetchWithPayment.ts
+++ b/packages/thirdweb/src/x402/fetchWithPayment.ts
@@ -50,7 +50,7 @@ import { createPaymentHeader } from "./sign.js";
  */
 export function wrapFetchWithPayment(
   fetch: typeof globalThis.fetch,
-  _client: ThirdwebClient,
+  client: ThirdwebClient,
   wallet: Wallet,
   maxValue: bigint = BigInt(1 * 10 ** 6), // Default to 1 USDC
 ) {
@@ -103,8 +103,8 @@ export function wrapFetchWithPayment(
     }
 
     const paymentHeader = await createPaymentHeader(
+      client,
       account,
-      x402Version,
       selectedPaymentRequirements,
     );
 

--- a/packages/thirdweb/src/x402/sign.ts
+++ b/packages/thirdweb/src/x402/sign.ts
@@ -1,4 +1,8 @@
+import { hexToBigInt } from "viem";
 import type { ExactEvmPayloadAuthorization } from "x402/types";
+import { getCachedChain } from "../chains/utils.js";
+import type { ThirdwebClient } from "../client/client.js";
+import { getContract } from "../contract/contract.js";
 import { type Address, getAddress } from "../utils/address.js";
 import { type Hex, toHex } from "../utils/encoding/hex.js";
 import type { Account } from "../wallets/interfaces/wallet.js";
@@ -9,6 +13,11 @@ import {
   type RequestedPaymentRequirements,
   type UnsignedPaymentPayload,
 } from "./schemas.js";
+import {
+  detectSupportedAuthorizationMethods,
+} from "./common.js";
+import { nonces } from "../extensions/erc20/__generated__/IERC20Permit/read/nonces.js";
+import { x402Version } from "./types.js";
 
 /**
  * Prepares an unsigned payment header with the given sender address and payment requirements.
@@ -22,14 +31,13 @@ function preparePaymentHeader(
   from: Address,
   x402Version: number,
   paymentRequirements: RequestedPaymentRequirements,
+  nonce: Hex
 ): UnsignedPaymentPayload {
-  const nonce = createNonce();
-
   const validAfter = BigInt(
-    Math.floor(Date.now() / 1000) - 600, // 10 minutes before
+    Math.floor(Date.now() / 1000) - 600 // 10 minutes before
   ).toString();
   const validBefore = BigInt(
-    Math.floor(Date.now() / 1000 + paymentRequirements.maxTimeoutSeconds),
+    Math.floor(Date.now() / 1000 + paymentRequirements.maxTimeoutSeconds)
   ).toString();
 
   return {
@@ -44,7 +52,7 @@ function preparePaymentHeader(
         value: paymentRequirements.maxAmountRequired,
         validAfter: validAfter.toString(),
         validBefore: validBefore.toString(),
-        nonce,
+        nonce: nonce,
       },
     },
   };
@@ -59,45 +67,69 @@ function preparePaymentHeader(
  * @returns A promise that resolves to the signed payment payload
  */
 async function signPaymentHeader(
+  client: ThirdwebClient,
   account: Account,
-  paymentRequirements: RequestedPaymentRequirements,
-  unsignedPaymentHeader: UnsignedPaymentPayload,
-): Promise<RequestedPaymentPayload> {
-  const { signature } = await signAuthorization(
-    account,
-    unsignedPaymentHeader.payload.authorization,
-    paymentRequirements,
-  );
-
-  return {
-    ...unsignedPaymentHeader,
-    payload: {
-      ...unsignedPaymentHeader.payload,
-      signature,
-    },
-  };
-}
-
-/**
- * Creates a complete payment payload by preparing and signing a payment header.
- *
- * @param client - The signer wallet instance used to create and sign the payment
- * @param x402Version - The version of the X402 protocol to use
- * @param paymentRequirements - The payment requirements containing scheme and network information
- * @returns A promise that resolves to the complete signed payment payload
- */
-async function createPayment(
-  account: Account,
-  x402Version: number,
-  paymentRequirements: RequestedPaymentRequirements,
+  paymentRequirements: RequestedPaymentRequirements
 ): Promise<RequestedPaymentPayload> {
   const from = getAddress(account.address);
-  const unsignedPaymentHeader = preparePaymentHeader(
-    from,
-    x402Version,
-    paymentRequirements,
-  );
-  return signPaymentHeader(account, paymentRequirements, unsignedPaymentHeader);
+  const chainId = networkToChainId(paymentRequirements.network);
+  const { hasPermit, hasTransferWithAuthorization } =
+    await detectSupportedAuthorizationMethods({
+      client,
+      asset: paymentRequirements.asset,
+      chainId: chainId,
+    });
+
+  // only use permit if no transfer with authorization is supported
+  if (hasPermit && !hasTransferWithAuthorization) {
+    const nonce = await nonces({
+      contract: getContract({
+        address: paymentRequirements.asset,
+        chain: getCachedChain(chainId),
+        client: client,
+      }),
+      owner: from,
+    });
+    const unsignedPaymentHeader = preparePaymentHeader(
+      from,
+      x402Version,
+      paymentRequirements,
+      toHex(nonce, { size: 32 }) // permit nonce
+    );
+    const { signature } = await signERC2612Permit(
+      account,
+      unsignedPaymentHeader.payload.authorization,
+      paymentRequirements
+    );
+    return {
+      ...unsignedPaymentHeader,
+      payload: {
+        ...unsignedPaymentHeader.payload,
+        signature,
+      },
+    };
+  } else {
+    // default to transfer with authorization
+    const nonce = await createNonce();
+    const unsignedPaymentHeader = preparePaymentHeader(
+      from,
+      x402Version,
+      paymentRequirements,
+      nonce // random nonce
+    );
+    const { signature } = await signERC3009Authorization(
+      account,
+      unsignedPaymentHeader.payload.authorization,
+      paymentRequirements
+    );
+    return {
+      ...unsignedPaymentHeader,
+      payload: {
+        ...unsignedPaymentHeader.payload,
+        signature,
+      },
+    };
+  }
 }
 
 /**
@@ -109,15 +141,11 @@ async function createPayment(
  * @returns A promise that resolves to the encoded payment header string
  */
 export async function createPaymentHeader(
+  client: ThirdwebClient,
   account: Account,
-  x402Version: number,
-  paymentRequirements: RequestedPaymentRequirements,
+  paymentRequirements: RequestedPaymentRequirements
 ): Promise<string> {
-  const payment = await createPayment(
-    account,
-    x402Version,
-    paymentRequirements,
-  );
+  const payment = await signPaymentHeader(client, account, paymentRequirements);
   return encodePayment(payment);
 }
 
@@ -138,7 +166,7 @@ export async function createPaymentHeader(
  * @param paymentRequirements.extra - The extra information containing the name and version of the ERC20 contract
  * @returns The signature for the authorization
  */
-async function signAuthorization(
+async function signERC3009Authorization(
   account: Account,
   {
     from,
@@ -148,14 +176,13 @@ async function signAuthorization(
     validBefore,
     nonce,
   }: ExactEvmPayloadAuthorization,
-  { asset, network, extra }: RequestedPaymentRequirements,
+  { asset, network, extra }: RequestedPaymentRequirements
 ): Promise<{ signature: Hex }> {
   const chainId = networkToChainId(network);
   const name = extra?.name;
   const version = extra?.version;
 
-  // TODO (402): detect permit vs transfer on asset contract
-  const data = {
+  const signature = await account.signTypedData({
     types: {
       TransferWithAuthorization: [
         { name: "from", type: "address" },
@@ -176,14 +203,61 @@ async function signAuthorization(
     message: {
       from: getAddress(from),
       to: getAddress(to),
-      value,
-      validAfter,
-      validBefore,
-      nonce: nonce,
+      value: BigInt(value),
+      validAfter: BigInt(validAfter),
+      validBefore: BigInt(validBefore),
+      nonce: nonce as Hex,
     },
-  };
+  });
 
-  const signature = await account.signTypedData(data);
+  return {
+    signature,
+  };
+}
+
+async function signERC2612Permit(
+  account: Account,
+  { from, value, validBefore, nonce }: ExactEvmPayloadAuthorization,
+  { asset, network, extra }: RequestedPaymentRequirements
+): Promise<{ signature: Hex }> {
+  const chainId = networkToChainId(network);
+  const name = extra?.name;
+  const version = extra?.version;
+
+  const facilitatorAddress = extra?.facilitatorAddress;
+  if (!facilitatorAddress) {
+    throw new Error(
+      "facilitatorAddress is required in PaymentRequirements extra to pay with permit-based assets"
+    );
+  }
+
+  //Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline
+  const signature = await account.signTypedData({
+    types: {
+      Permit: [
+        { name: "owner", type: "address" },
+        { name: "spender", type: "address" },
+        { name: "value", type: "uint256" },
+        { name: "nonce", type: "uint256" },
+        { name: "deadline", type: "uint256" },
+      ],
+    },
+    domain: {
+      name,
+      version,
+      chainId,
+      verifyingContract: getAddress(asset),
+    },
+    primaryType: "Permit" as const,
+    message: {
+      owner: getAddress(from),
+      spender: getAddress(facilitatorAddress), // approve the facilitator
+      value: BigInt(value),
+      nonce: hexToBigInt(nonce as Hex),
+      deadline: BigInt(validBefore),
+    },
+  });
+
   return {
     signature,
   };
@@ -194,7 +268,7 @@ async function signAuthorization(
  *
  * @returns A random 32-byte nonce as a hex string
  */
-function createNonce(): Hex {
+async function createNonce(): Promise<Hex> {
   const cryptoObj =
     typeof globalThis.crypto !== "undefined" &&
     typeof globalThis.crypto.getRandomValues === "function"

--- a/packages/thirdweb/src/x402/types.ts
+++ b/packages/thirdweb/src/x402/types.ts
@@ -86,6 +86,8 @@ export type VerifyPaymentResult = Prettify<
   | PaymentRequiredResult
 >;
 
+export type SupportedSignatureType = "TransferWithAuthorization" | "Permit";
+
 export type ERC20TokenAmount = {
   amount: string;
   asset: {
@@ -94,7 +96,7 @@ export type ERC20TokenAmount = {
     eip712: {
       name: string;
       version: string;
-      primaryType: "TransferWithAuthorization" | "Permit";
+      primaryType: SupportedSignatureType;
     };
   };
 };

--- a/packages/thirdweb/src/x402/types.ts
+++ b/packages/thirdweb/src/x402/types.ts
@@ -2,7 +2,7 @@ import type { Money, PaymentMiddlewareConfig } from "x402/types";
 import type { Chain } from "../chains/types.js";
 import type { Address } from "../utils/address.js";
 import type { Prettify } from "../utils/type-utils.js";
-import type { facilitator as facilitatorType } from "./facilitator.js";
+import type { ThirdwebX402Facilitator } from "./facilitator.js";
 import type {
   FacilitatorNetwork,
   FacilitatorSettleResponse,
@@ -31,7 +31,7 @@ export type PaymentArgs = {
   /** The price for accessing the resource - either a USD amount (e.g., "$0.10") or a specific token amount */
   price: Money | ERC20TokenAmount;
   /** The payment facilitator instance used to verify and settle payments */
-  facilitator: ReturnType<typeof facilitatorType>;
+  facilitator: ThirdwebX402Facilitator;
   /** Optional configuration for the payment middleware route */
   routeConfig?: PaymentMiddlewareConfig;
 };

--- a/packages/thirdweb/src/x402/types.ts
+++ b/packages/thirdweb/src/x402/types.ts
@@ -1,8 +1,4 @@
-import type {
-  ERC20TokenAmount,
-  Money,
-  PaymentMiddlewareConfig,
-} from "x402/types";
+import type { Money, PaymentMiddlewareConfig } from "x402/types";
 import type { Chain } from "../chains/types.js";
 import type { Address } from "../utils/address.js";
 import type { Prettify } from "../utils/type-utils.js";
@@ -89,3 +85,16 @@ export type VerifyPaymentResult = Prettify<
     }
   | PaymentRequiredResult
 >;
+
+export type ERC20TokenAmount = {
+  amount: string;
+  asset: {
+    address: `0x${string}`;
+    decimals: number;
+    eip712: {
+      name: string;
+      version: string;
+      primaryType: "TransferWithAuthorization" | "Permit";
+    };
+  };
+};


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces support for ERC-2612 permit functionality in the `thirdweb` library, enhancing payment capabilities for `x402` transactions. It updates various components, adds new types, and modifies existing functions to accommodate the new feature.

### Detailed summary
- Added support for ERC-2612 permit for `x402` payments.
- Updated `message` in `apps/playground-web/src/app/api/paywall/route.ts` to reflect payment success.
- Introduced `transferWithAuthorization` function in `packages/thirdweb/scripts/generate/abis/erc20/USDC.json`.
- Modified `wrapFetchWithPayment` to accept a `client` parameter.
- Updated payment handling in `packages/thirdweb/src/x402/sign.ts` to include ERC-2612 permit logic.
- Enhanced `ThirdwebX402Facilitator` type with new methods for payment processing.
- Updated `createPaymentHeader` to include `client` parameter.
- Introduced new utility functions for signature handling related to permits.
- Adjusted UI components to reflect changes in payment messaging and token handling.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - ERC-2612 Permit support for x402 payments with automatic detection between Permit and TransferWithAuthorization; USDC authorized-transfer flow supported.
  - Facilitator now exposes its address for easier configuration.
  - New ERC20 token amount type to standardize payment payloads.

- UI
  - Playgrounds: dynamic chain/token preview, token amount badge, button relabeled "Access Premium Content", paywall message updated, testnet faucet guidance added.
  - Pagination links updated to main transactions route.

- Refactor
  - Payment signing/header flow is client-aware and API updated; fetch-with-payment wrapper adjusted.

- Chores
  - Patch release changeset added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->