### PR TITLE
[wagmi-adapter] Add onConnect callback

### DIFF
--- a/.changeset/famous-places-hug.md
+++ b/.changeset/famous-places-hug.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/wagmi-adapter": patch
+---
+
+Add onConnect callback

--- a/packages/wagmi-adapter/src/connector.ts
+++ b/packages/wagmi-adapter/src/connector.ts
@@ -9,12 +9,14 @@ import {
   type MultiStepAuthArgsType,
   type SingleStepAuthArgsType,
   inAppWallet as thirdwebInAppWallet,
+  type Wallet,
 } from "thirdweb/wallets";
 
 export type InAppWalletParameters = Prettify<
   InAppWalletCreationOptions & {
     client: ThirdwebClient;
     ecosystemId?: `ecosystem.${string}`;
+    onConnect?: (wallet: Wallet) => void;
   }
 >;
 export type InAppWalletConnector = ReturnType<typeof inAppWalletConnector>;
@@ -106,6 +108,7 @@ export function inAppWalletConnector(
           chain: defineChain(chainId),
           client,
           wallets: [wallet],
+          onConnect: args.onConnect,
         });
 
         const account = wallet.getAccount();
@@ -140,6 +143,7 @@ export function inAppWalletConnector(
       rawStorage?.setItem(connectedWalletIdsKey, JSON.stringify([wallet.id]));
       rawStorage?.setItem(activeWalletIdKey, wallet.id);
       await config.storage?.setItem("thirdweb:lastChainId", chain.id);
+      args.onConnect?.(wallet);
       return { accounts: [getAddress(account.address)], chainId: chain.id };
     },
     disconnect: async () => {
@@ -166,6 +170,7 @@ export function inAppWalletConnector(
           chain,
           client,
           wallets: [wallet],
+          onConnect: args.onConnect,
         });
       }
       return EIP1193.toProvider({


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview

This PR introduces an `onConnect` callback to the `InAppWalletParameters` type and updates the `inAppWalletConnector` function to support this new feature, allowing developers to execute custom logic when a wallet is connected.

### Detailed summary

- Added `onConnect` optional callback to `InAppWalletParameters`.
- Updated `inAppWalletConnector` to accept and handle `onConnect`.
- Called `args.onConnect(wallet)` upon successful wallet connection.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Added an optional onConnect callback in the wagmi adapter that runs when a wallet connects or reconnects, letting apps perform custom actions (e.g., UI updates, analytics).
- **Chores**
    - Patch release of the wagmi adapter to include the new callback capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->