### PR TITLE
Dashboard: Fix BuyAndSwapWidget width

### DIFF
--- a/apps/dashboard/src/@/components/blocks/BuyAndSwapEmbed.tsx
+++ b/apps/dashboard/src/@/components/blocks/BuyAndSwapEmbed.tsx
@@ -85,7 +85,7 @@ export function BuyAndSwapEmbed(props: {
         <BuyWidget
           amount={props.buyAmount || "1"}
           chain={props.chain}
-          className="!rounded-2xl !w-full !border-none"
+          className="!rounded-2xl !border-none"
           title=""
           client={client}
           connectOptions={{
@@ -179,7 +179,7 @@ export function BuyAndSwapEmbed(props: {
         <SwapWidget
           client={client}
           theme={themeObj}
-          className="!rounded-2xl !border-none !w-full"
+          className="!rounded-2xl !border-none"
           prefill={{
             // buy this token by default
             buyToken: {

--- a/apps/dashboard/src/@/components/blocks/grid-pattern-embed-container.tsx
+++ b/apps/dashboard/src/@/components/blocks/grid-pattern-embed-container.tsx
@@ -17,7 +17,7 @@ export function GridPatternEmbedContainer(props: {
             "linear-gradient(to bottom right,white,transparent,transparent)",
         }}
       />
-      <div className="sm:w-[420px] z-10">{props.children}</div>
+      <div className="z-10">{props.children}</div>
     </div>
   );
 }


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on minor adjustments to the layout and styling of components in the dashboard, specifically in `grid-pattern-embed-container.tsx` and `BuyAndSwapEmbed.tsx`.

### Detailed summary
- In `grid-pattern-embed-container.tsx`, removed the fixed width class from the `<div>`, allowing it to be responsive.
- In `BuyAndSwapEmbed.tsx`, removed the width class from the `<SwapWidget>` to maintain a consistent border styling without enforcing a full width.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Style
  * Buy and Swap widgets no longer force full width and now adapt to their container while keeping rounded, borderless visuals.
  * Embed container relaxes small-screen width limits so content can use available space more naturally.
  * Improves responsiveness, spacing, and alignment across devices; visual-only changes with no behavior or control updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->