### PR TITLE
[MNY-212] SDK: Set `refetch: false` on token list queries in SwapWidget

### DIFF
--- a/.changeset/large-lizards-feel.md
+++ b/.changeset/large-lizards-feel.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Remove retries when fetching list of tokens fails in SwapWidget to reduce time loading skeletons are shown in the UI

--- a/packages/thirdweb/src/react/web/ui/Bridge/swap-widget/use-tokens.ts
+++ b/packages/thirdweb/src/react/web/ui/Bridge/swap-widget/use-tokens.ts
@@ -15,6 +15,7 @@ export function useTokens(options: {
   return useQuery<Token[]>({
     queryKey: ["tokens", options],
     enabled: !!options.chainId,
+    retry: false,
     queryFn: () => {
       if (!options.chainId) {
         throw new Error("Chain ID is required");
@@ -115,6 +116,7 @@ export function useTokenBalances(options: {
       return json.result;
     },
     refetchOnMount: false,
+    retry: false,
     refetchOnWindowFocus: false,
   });
 }


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the user experience in the `SwapWidget` by removing retries when fetching the list of tokens fails. This change aims to reduce the loading time for skeletons displayed in the UI.

### Detailed summary
- Updated `use-tokens.ts` to set `retry: false` when fetching tokens.
- Ensured that `retry: false` is applied under `refetchOnMount` and `refetchOnWindowFocus`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SwapWidget responsiveness by stopping automatic retrying when fetching token lists and balances. Loading placeholders now disappear sooner and errors surface faster so users can act without long waits.

* **Chores**
  * Added a changelog entry documenting this behavior change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->