### PR TITLE
Portal: remove underlines from links in changelog page

### DIFF
--- a/apps/portal/src/app/changelog/[slug]/styles.css
+++ b/apps/portal/src/app/changelog/[slug]/styles.css
@@ -2,15 +2,6 @@
   display: none;
 }
 
-.changelog-page a {
-  text-decoration: underline;
-  text-decoration-color: hsl(var(--muted-foreground));
-  text-decoration-style: dotted;
-  color: hsl(var(--foreground));
-  text-underline-offset: 5px;
-  transition: color 200ms ease;
-}
-
 .changelog-page h2 a {
   text-decoration: none;
 }


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the styles for the `.changelog-page` in the `styles.css` file by removing the underline styles from links.

### Detailed summary
- Removed the following styles from `.changelog-page a`:
  - `text-decoration: underline;`
  - `text-decoration-color: hsl(var(--muted-foreground));`
  - `text-decoration-style: dotted;`
  - `color: hsl(var(--foreground));`
  - `text-underline-offset: 5px;`
  - `transition: color 200ms ease;`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated link appearance on the changelog page to align with global styles: removed custom underlines, dotted/colored underline styling, underline offset, and color transition for regular links. Headings remain without underlines and hover behavior is unchanged. Result is a cleaner, more consistent visual experience with no functional changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->