### PR TITLE
[Nebula] Add permanent redirect to thirdweb.com/ai

### DIFF
--- a/apps/nebula/next.config.ts
+++ b/apps/nebula/next.config.ts
@@ -64,6 +64,15 @@ const baseNextConfig: NextConfig = {
   },
   productionBrowserSourceMaps: false,
   reactStrictMode: true,
+  async redirects() {
+    return [
+      {
+        source: "/:path*",
+        destination: "https://thirdweb.com/ai",
+        permanent: true,
+      },
+    ];
+  },
   async rewrites() {
     return [
       {


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview

This PR introduces a new `redirects` function in the `next.config.ts` file to redirect all incoming traffic to a specified external URL.

### Detailed summary

- Added an `async redirects()` function.
- The `redirects` function returns an array containing a single redirect rule.
- The rule redirects all paths (`/:path*`) to `https://thirdweb.com/ai` with a permanent status.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented a global, permanent redirect: all app routes now forward to https://thirdweb.com/ai. Users visiting any path will be automatically redirected to the new destination, ensuring a consistent entry point to the AI experience across the site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->