### PR TITLE
Dashboard: Disable pay modal in ERC1155 set claim conditions if cost estimation is already done in dashboard

### DIFF
--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/tokens/create/nft/create-nft-page.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/tokens/create/nft/create-nft-page.tsx
@@ -329,6 +329,8 @@ export function CreateNFTPage(props: {
       }
 
       await sendAndConfirmTxNoPayModal.mutateAsync(tx);
+    } else if (totalBatches > 1) {
+      await sendAndConfirmTxNoPayModal.mutateAsync(tx);
     } else {
       await sendAndConfirmTx.mutateAsync(tx);
     }


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the transaction confirmation logic in the `create-nft-page.tsx` file, specifically handling different scenarios based on the number of batches in the transaction.

### Detailed summary
- Added an `else if` condition to check if `totalBatches` is greater than 1.
- Calls `sendAndConfirmTxNoPayModal.mutateAsync(tx)` for both the new condition and the original `else` case when `totalBatches` is 1 or less.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streamlined multi-batch transaction confirmation when configuring NFT claim conditions: when multiple batches are required and a wallet is connected, a no-payment confirmation modal is now used to reduce prompts and improve reliability. Single-batch flows continue to use the standard payment confirmation path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->