### PR TITLE
Add Google Click ID tracking to Stripe checkout

### DIFF
--- a/apps/dashboard/src/@/actions/stripe-actions.ts
+++ b/apps/dashboard/src/@/actions/stripe-actions.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { headers } from "next/headers";
+import { cookies, headers } from "next/headers";
 import Stripe from "stripe";
 import type { Team } from "@/api/team/get-team";
 import {
@@ -88,6 +88,9 @@ export async function fetchClientSecret(team: Team) {
     throw new Error("No customer ID found");
   }
 
+  // try to get the gclid cookie
+  const gclid = (await cookies()).get("gclid")?.value;
+
   // Create Checkout Sessions from body params.
   const session = await stripe.checkout.sessions.create({
     ui_mode: "embedded",
@@ -117,6 +120,8 @@ export async function fetchClientSecret(team: Team) {
           missing_payment_method: "cancel",
         },
       },
+      // if gclid exists, set it as a metadata field so we can attribute the conversion later
+      metadata: gclid ? { gclid } : undefined,
     },
   });
 


### PR DESCRIPTION
### TL;DR

Added Google Click ID (gclid) tracking to Stripe checkout sessions for conversion attribution.

### What changed?

- Modified the middleware to capture `gclid` from URL search parameters and store it in a cookie with a 7-day expiration
- Updated the Stripe checkout process to retrieve the `gclid` cookie value and include it in the Stripe checkout session metadata
- Enhanced cookie handling in the middleware to support additional cookie options like `maxAge`, `httpOnly`, etc.

### How to test?

1. Visit the dashboard with a URL containing a gclid parameter (e.g., `?gclid=test123`)
2. Verify the gclid cookie is set in your browser
3. Proceed to checkout and complete a payment
4. Verify in Stripe dashboard that the checkout session includes the gclid in its metadata

### Why make this change?

This change enables proper attribution of conversions to Google Ads campaigns. By tracking the gclid through the user journey to payment, we can accurately measure which ad campaigns are driving successful conversions, improving our marketing analytics and ROI measurement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatically captures Google ad click ID (gclid) from the landing page, stores it for 7 days, and passes it through checkout to improve campaign attribution and analytics. No UI changes.

- Refactor
  - Updated internal cookie handling to more reliably set and forward cookies across navigation and checkout flows. No impact on user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->