### PR TITLE
[Docs] Update MCP tool filtering to use comma-separated list

### DIFF
--- a/apps/portal/src/app/ai/mcp/page.mdx
+++ b/apps/portal/src/app/ai/mcp/page.mdx
@@ -17,10 +17,10 @@ https://api.thirdweb.com/mcp?secretKey=<your-project-secret-key>
 
 Make sure to keep your secret key safe and never share it with anyone.
 
-By default, all tools are available. You can filter the tools available by passing multiple `tool` query parameter.
+By default, all tools are available. You can filter the tools available by passing a comma-separated list of tools as a query parameter.
 
 ```http
-https://api.thirdweb.com/mcp?secretKey=<your-project-secret-key>&tool=fetchWithPayment&tool=getWalletBalance
+https://api.thirdweb.com/mcp?secretKey=<your-project-secret-key>&tools=fetchWithPayment,getWalletBalance
 ```
 
 You can find all available tools at the bottom of this page.

--- a/apps/portal/src/app/payments/x402/agents/page.mdx
+++ b/apps/portal/src/app/payments/x402/agents/page.mdx
@@ -9,7 +9,7 @@ Easily create AI agents that can pay for any x402-compatible API calls.
 
 The easiest way to equip your agents with the ability to pay for API calls is to use the [remote MCP server](/ai/mcp) and provide the tools to your agent.
 
-The MCP server comes with all the tools by default, but you can filter the tools available by passing multiple `tool` query parameter.
+The MCP server comes with all the tools by default, but you can filter the tools available by passing a comma-separated list of tools as a query parameter.
 
 In this example, we create a ReAct agent using LangChain and filter the MCP tools to `fetchWithPayment` and `getWalletBalance` as the only 2 tools we give our agent. You can view the full list of available tools [here](/ai/mcp#available-tools).
 
@@ -33,7 +33,7 @@ const model = new ChatOpenAI({
 
 const mcpServers = {
   thirdweb: {
-    url: `https://api.thirdweb.com/mcp?secretKey=<your-project-secret-key>&tool=fetchWithPayment&tool=getWalletBalance`
+    url: `https://api.thirdweb.com/mcp?secretKey=<your-project-secret-key>&tools=fetchWithPayment,getWalletBalance`
   }
 };
 
@@ -59,7 +59,7 @@ from langgraph.prebuilt import create_react_agent
 client = MultiServerMCPClient(
     {
         "thirdweb": {
-            "url": "https://api.thirdweb.com/mcp?secretKey=<your-project-secret-key>&tool=fetchWithPayment&tool=getWalletBalance",
+            "url": "https://api.thirdweb.com/mcp?secretKey=<your-project-secret-key>&tools=fetchWithPayment,getWalletBalance",
         }
     }
 )


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview

This PR updates the documentation and code to clarify how to filter available tools for the MCP server by using a comma-separated list of tools instead of multiple `tool` query parameters.

### Detailed summary

- Updated text in `page.mdx` files to specify using a comma-separated list of tools for filtering.
- Changed example URLs in `apps/portal/src/app/ai/mcp/page.mdx` and `apps/portal/src/app/payments/x402/agents/page.mdx` to reflect the new query parameter format.
- Updated `url` in the `mcpServers` object and `MultiServerMCPClient` to use `tools` instead of `tool`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->