### PR TITLE
[MNY-231] SDK: Fix TransactionWidget not updating on currency prop change after initial render

### DIFF
--- a/.changeset/rich-pens-hug.md
+++ b/.changeset/rich-pens-hug.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix TransactionWidget not updating when `currency` prop is changed after initial render

--- a/packages/thirdweb/src/react/core/hooks/useTransactionDetails.ts
+++ b/packages/thirdweb/src/react/core/hooks/useTransactionDetails.ts
@@ -9,7 +9,6 @@ import { getCompilerMetadata } from "../../../contract/actions/get-compiler-meta
 import { getContract } from "../../../contract/contract.js";
 import { decimals } from "../../../extensions/erc20/read/decimals.js";
 import { getToken } from "../../../pay/convert/get-token.js";
-import type { SupportedFiatCurrency } from "../../../pay/convert/type.js";
 import { encode } from "../../../transaction/actions/encode.js";
 import type { PreparedTransaction } from "../../../transaction/prepare-transaction.js";
 import { getTransactionGasCost } from "../../../transaction/utils.js";
@@ -18,10 +17,7 @@ import { resolvePromisedValue } from "../../../utils/promise/resolve-promised-va
 import { toTokens } from "../../../utils/units.js";
 import type { Wallet } from "../../../wallets/interfaces/wallet.js";
 import { hasSponsoredTransactionsEnabled } from "../../../wallets/smart/is-smart-wallet.js";
-import {
-  formatCurrencyAmount,
-  formatTokenAmount,
-} from "../../web/ui/ConnectWallet/screens/formatTokenBalance.js";
+import { formatTokenAmount } from "../../web/ui/ConnectWallet/screens/formatTokenBalance.js";
 import { useChainMetadata } from "./others/useChainQuery.js";
 
 interface TransactionDetails {
@@ -31,7 +27,6 @@ interface TransactionDetails {
     selector: string;
     description?: string;
   };
-  usdValueDisplay: string | null;
   txCostDisplay: string;
   gasCostDisplay: string | null;
   tokenInfo: TokenWithPrices | null;
@@ -45,7 +40,6 @@ interface UseTransactionDetailsOptions {
   transaction: PreparedTransaction;
   client: ThirdwebClient;
   wallet: Wallet | undefined;
-  currency: SupportedFiatCurrency | undefined;
 }
 
 /**
@@ -54,7 +48,6 @@ interface UseTransactionDetailsOptions {
  */
 export function useTransactionDetails({
   transaction,
-  currency,
   client,
   wallet,
 }: UseTransactionDetailsOptions) {
@@ -158,9 +151,6 @@ export function useTransactionDetails({
           : (value || 0n) + (gasCostWei || 0n);
       const totalCost = toTokens(totalCostWei, decimal);
 
-      const price = tokenInfo?.prices[currency || "USD"] || 0;
-      const usdValue = price ? Number(totalCost) * price : null;
-
       return {
         contractMetadata,
         costWei,
@@ -173,9 +163,6 @@ export function useTransactionDetails({
         totalCost,
         totalCostWei,
         txCostDisplay: `${formatTokenAmount(costWei, decimal)} ${tokenSymbol}`,
-        usdValueDisplay: usdValue
-          ? formatCurrencyAmount(currency || "USD", usdValue)
-          : null,
       };
     },
     queryKey: [

--- a/packages/thirdweb/src/react/web/ui/Bridge/TransactionPayment.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/TransactionPayment.tsx
@@ -24,6 +24,7 @@ import { useActiveAccount } from "../../../core/hooks/wallets/useActiveAccount.j
 import { useActiveWallet } from "../../../core/hooks/wallets/useActiveWallet.js";
 import { ConnectButton } from "../ConnectWallet/ConnectButton.js";
 import { PoweredByThirdweb } from "../ConnectWallet/PoweredByTW.js";
+import { formatCurrencyAmount } from "../ConnectWallet/screens/formatTokenBalance.js";
 import { Container, Line } from "../components/basic.js";
 import { Button } from "../components/buttons.js";
 import { ChainName } from "../components/ChainName.js";
@@ -100,7 +101,6 @@ export function TransactionPayment({
     client,
     transaction: transaction,
     wallet,
-    currency: currency,
   });
 
   // We can't use useWalletBalance here because erc20Value is a possibly async value
@@ -133,6 +133,19 @@ export function TransactionPayment({
   const isLoading = transactionDataQuery.isLoading || chainMetadata.isLoading;
 
   const buttonLabel = _buttonLabel || `Execute ${functionName}`;
+
+  const tokenFiatPricePerToken =
+    transactionDataQuery.data?.tokenInfo?.prices[currency] || undefined;
+
+  const totalFiatCost =
+    tokenFiatPricePerToken && transactionDataQuery.data
+      ? tokenFiatPricePerToken * Number(transactionDataQuery.data.totalCost)
+      : undefined;
+
+  const costToDisplay =
+    totalFiatCost !== undefined
+      ? formatCurrencyAmount(currency, totalFiatCost)
+      : transactionDataQuery.data?.txCostDisplay;
 
   if (isLoading) {
     return (
@@ -207,8 +220,7 @@ export function TransactionPayment({
       >
         {/* USD Value */}
         <Text color="primaryText" size="xl" weight={600}>
-          {transactionDataQuery.data?.usdValueDisplay ||
-            transactionDataQuery.data?.txCostDisplay}
+          {costToDisplay}
         </Text>
 
         {/* Function Name */}

--- a/packages/thirdweb/src/react/web/ui/Bridge/payment-details/PaymentOverview.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/payment-details/PaymentOverview.tsx
@@ -199,7 +199,6 @@ export function PaymentOverview(props: {
           <TransactionOverViewCompact
             client={props.client}
             paymentMethod={props.paymentMethod}
-            currency={props.currency}
             transaction={props.modeInfo.transaction}
             metadata={props.metadata}
           />
@@ -211,7 +210,6 @@ export function PaymentOverview(props: {
 
 const TransactionOverViewCompact = (props: {
   transaction: PreparedTransaction;
-  currency: SupportedFiatCurrency;
   paymentMethod: PaymentMethod;
   client: ThirdwebClient;
   metadata: {
@@ -224,7 +222,6 @@ const TransactionOverViewCompact = (props: {
     client: props.client,
     transaction: props.transaction,
     wallet: props.paymentMethod.payerWallet,
-    currency: props.currency,
   });
 
   if (!txInfo.data) {


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the `TransactionWidget` to ensure it updates correctly when the `currency` prop changes after the initial render. 

### Detailed summary
- Updated `PaymentOverview` to remove `currency` prop from `TransactionOverViewCompact`.
- Modified `TransactionPayment` to calculate and display the total fiat cost based on the selected `currency`.
- Adjusted `useTransactionDetails` to remove `currency` from options and related calculations.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Transaction widget now updates correctly when the selected currency changes after initial render.
  * Payment and transaction details show correct fiat totals, with graceful fallback when pricing data is unavailable.

* **Improvements**
  * Simplified and more consistent fiat cost display across payment views for clearer totals and formatting.

* **Chores**
  * Added a patch-level changeset entry documenting the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->