### PR TITLE
[MNY-232] SDK: Fix ExecutingTxScreen missing back button in TransactionWidget

### DIFF
--- a/packages/thirdweb/src/react/web/ui/Bridge/TransactionWidget.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/TransactionWidget.tsx
@@ -770,6 +770,9 @@ function TransactionWidgetContent(
   if (screen.id === "execute-tx") {
     return (
       <ExecutingTxScreen
+        onBack={() => {
+          setScreen({ id: "init-ui" });
+        }}
         closeModal={() => {
           setScreen({ id: "init-ui" });
         }}

--- a/packages/thirdweb/src/react/web/ui/TransactionButton/ExecutingScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/TransactionButton/ExecutingScreen.tsx
@@ -20,7 +20,7 @@ export function ExecutingTxScreen(props: {
   tx: PreparedTransaction;
   closeModal: () => void;
   onTxSent: (data: WaitForReceiptOptions) => void;
-  onBack?: () => void;
+  onBack: (() => void) | undefined;
   windowAdapter: WindowAdapter;
 }) {
   const sendTxCore = useSendTransaction({

--- a/packages/thirdweb/src/react/web/ui/TransactionButton/TransactionModal.tsx
+++ b/packages/thirdweb/src/react/web/ui/TransactionButton/TransactionModal.tsx
@@ -133,6 +133,9 @@ function DepositAndExecuteTx(props: ModalProps) {
   if (screen === "execute-tx") {
     return (
       <ExecutingTxScreen
+        onBack={() => {
+          setScreen("deposit");
+        }}
         closeModal={props.onClose}
         onTxSent={props.onTxSent}
         tx={props.tx}


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `onBack` functionality in the `ExecutingTxScreen` component across different files, allowing for better navigation management in transaction workflows.

### Detailed summary
- In `TransactionWidget.tsx`, `onBack` is updated to set the screen to `"init-ui"`.
- In `TransactionModal.tsx`, `onBack` now sets the screen to `"deposit"`.
- In `ExecutingScreen.tsx`, the `onBack` prop is changed from optional to required (`onBack: (() => void) | undefined`).

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added back-navigation from the executing transaction screen so users can return to the previous step without closing the modal.
  * Consistent back-button behavior across transaction and bridge flows for a smoother experience.
  * Enables returning to the deposit/init step during long-running executions.
  * Navigation change is purely UI flow—transaction processing remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->