### PR TITLE
Update airdrop tokens reference link

### DIFF
--- a/apps/playground-web/src/app/transactions/airdrop-tokens/page.tsx
+++ b/apps/playground-web/src/app/transactions/airdrop-tokens/page.tsx
@@ -26,7 +26,7 @@ export default function Page() {
       <PageLayout
         icon={PlaneIcon}
         description={description}
-        docsLink="https://thirdweb-engine.apidocumentation.com/reference#tag/erc20/POST/contract/{chain}/{contractAddress}/erc20/mint-batch-to?utm_source=playground"
+        docsLink="https://engine.thirdweb.com/reference"
         title={title}
       >
         <EngineAirdropPreview />


### PR DESCRIPTION
Update the Airdrop Tokens playground page to link to the correct Engine API reference documentation.

---
[Slack Thread](https://thirdwebdev.slack.com/archives/C09DS2CKGP2/p1759773042404819?thread_ts=1759773042.404819&cid=C09DS2CKGP2)

<a href="https://cursor.com/background-agent?bcId=bc-df7dbc75-1843-4696-b98c-54643efdbd64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-df7dbc75-1843-4696-b98c-54643efdbd64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

