### PR TITLE
[MNY-236] Portal: Update BridgeWidget script docs to reflect new typescript type

### DIFF
--- a/apps/portal/src/app/bridge/bridge-widget-script/page.mdx
+++ b/apps/portal/src/app/bridge/bridge-widget-script/page.mdx
@@ -53,10 +53,6 @@ The BridgeWidget Script makes it easy to embed cross-chain swaps and fiat onramp
   BridgeWidget.render(container, {
     clientId: "your-thirdweb-client-id",
     theme: "dark",
-    buy: {
-      chainId: 8453,
-      amount: "0.1",
-    },
   });
 </script>
 ```
@@ -126,9 +122,9 @@ type Options = {
       };
     };
   };
-  buy: {
-    amount: string;
-    chainId: number;
+  buy?: {
+    amount?: string;
+    chainId?: number;
     tokenAddress?: string;
     buttonLabel?: string;
     onCancel?: (quote: BuyOrOnrampPrepareResult | undefined) => void;
@@ -310,8 +306,8 @@ The options to configure the "Buy" tab UI.
 
 ```ts
 type Buy = {
-    amount: string; // Required
-    chainId: number; // Required
+    amount?: string;
+    chainId?: number;
     tokenAddress?: string;
     buttonLabel?: string;
     onCancel?: (quote: BuyOrOnrampPrepareResult | undefined) => void;
@@ -327,21 +323,21 @@ type Buy = {
 ```
 
 
-<Details summary="amount" tags={["Required"]}>
+<Details summary="amount">
 
 Set the default token amount shown in the "Buy" tab.
 
 </Details>
 
-<Details summary="chainId" tags={["Required"]}>
+<Details summary="chainId">
 
-Specify which chain should be selected in the "Buy" tab.
+Specify the default chain to be selected in the "Buy" tab.
 
 </Details>
 
 <Details summary="tokenAddress">
 
-Specify which token should be selected in the "Buy" tab. If not specified, the native token of the selected chain will be selected.
+Specify the default token to be selected in the "Buy" tab. If not specified, the native token of the selected chain will be selected.
 
 </Details>
 


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `buy` configuration in the `Buy` tab of the widget, making the `amount` and `chainId` properties optional and refining related documentation.

### Detailed summary
- Changed `amount` and `chainId` in the `buy` object to optional properties.
- Updated the `Buy` type to reflect the optional nature of `amount` and `chainId`.
- Revised documentation for `amount` and `chainId` to remove "Required" tags and clarify their usage.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Buy configuration in the bridge widget is now optional; amount and chain selection can be omitted and defaults will apply.
  * Removed enforced preset buy values, allowing more flexible widget initialization and runtime behavior.

* **Documentation**
  * Updated docs and examples to show Buy fields as optional and to explain default behaviors when omitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->