### PR TITLE
Portal: Add missing redirects for bridge pages

### DIFF
--- a/apps/portal/redirects.mjs
+++ b/apps/portal/redirects.mjs
@@ -738,6 +738,10 @@ const paymentRedirects = {
   "/connect/pay/buy-with-fiat": "/payments",
   "/connect/pay/enable-test-mode": "/payments",
   "/connect/pay/guides/enable-test-mode": "/payments",
+  "/payments/sell": "/bridge/sell",
+  "/payments/swap": "/bridge/swap",
+  "/payments/tokens": "/bridge/tokens",
+  "/payments/routes": "/bridge/routes",
 };
 
 const contractRedirects = {


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the redirect paths in the `redirects.mjs` file to streamline payment-related routes, directing them to new bridge endpoints.

### Detailed summary
- Added new redirect paths:
  - `"/payments/sell"` now redirects to `"/bridge/sell"`
  - `"/payments/swap"` now redirects to `"/bridge/swap"`
  - `"/payments/tokens"` now redirects to `"/bridge/tokens"`
  - `"/payments/routes"` now redirects to `"/bridge/routes"`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added redirects so payment URLs now route to corresponding bridge destinations:
    * /payments/sell → /bridge/sell
    * /payments/swap → /bridge/swap
    * /payments/tokens → /bridge/tokens
    * /payments/routes → /bridge/routes
  * Existing bookmarks and shared links to payment pages will continue working and automatically route to the updated locations with no UI changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->