### PR TITLE
[SDK] Export missing x402 types

### DIFF
--- a/.changeset/fluffy-cooks-kiss.md
+++ b/.changeset/fluffy-cooks-kiss.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Export missing x402 types

--- a/.changeset/warm-jokes-vanish.md
+++ b/.changeset/warm-jokes-vanish.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/engine": patch
+---
+
+Update to latest API spec

--- a/apps/portal/src/app/wallets/session-keys/page.mdx
+++ b/apps/portal/src/app/wallets/session-keys/page.mdx
@@ -513,6 +513,11 @@ const serverWallet = Engine.serverWallet({
   address: sessionKeyAccountAddress,
   chain: sepolia,
   client: client,
+  executionOptions: {
+    type: "EIP7702",
+    sessionKeyAddress: sessionKeyAccountAddress,
+    accountAddress: account.address,
+  },
 });
 
 // Execute transactions with the session key
@@ -596,6 +601,11 @@ async function setupSessionKeyWith7702() {
       address: sessionKeyAccountAddress,
       chain: sepolia,
       client: client,
+      executionOptions: {
+        type: "EIP7702",
+        sessionKeyAddress: sessionKeyAccountAddress,
+        accountAddress: account.address,
+      },
     });
     
     // Execute a transaction with the session key

--- a/packages/engine/src/client/types.gen.ts
+++ b/packages/engine/src/client/types.gen.ts
@@ -148,6 +148,9 @@ export type BatchResultItemEncodeResultSuccessItemEngineError =
 						message: string;
 						type: "THIRDWEB_ERROR";
 				  }
+				| (SerialisableAwsSignerError & {
+						type: "AWS_KMS_SIGNER_ERROR";
+				  })
 				| {
 						message: string;
 						type: "INTERNAL_ERROR";
@@ -235,6 +238,9 @@ export type BatchResultItemReadResultSuccessItemEngineError =
 						message: string;
 						type: "THIRDWEB_ERROR";
 				  }
+				| (SerialisableAwsSignerError & {
+						type: "AWS_KMS_SIGNER_ERROR";
+				  })
 				| {
 						message: string;
 						type: "INTERNAL_ERROR";
@@ -331,6 +337,9 @@ export type BatchResultItemSignResultDataEngineError =
 						message: string;
 						type: "THIRDWEB_ERROR";
 				  }
+				| (SerialisableAwsSignerError & {
+						type: "AWS_KMS_SIGNER_ERROR";
+				  })
 				| {
 						message: string;
 						type: "INTERNAL_ERROR";
@@ -472,11 +481,32 @@ export type ContractWrite = ContractCall & {
 /**
  * EIP-7702 Execution Options
  */
-export type Eip7702ExecutionOptions = {
+export type Eip7702ExecutionOptions =
+	| Eip7702OwnerExecution
+	| Eip7702SessionKeyExecution;
+
+/**
+ * EIP-7702 Owner Execution
+ */
+export type Eip7702OwnerExecution = {
 	/**
-	 * The EOA address that will sign the EIP-7702 transaction
+	 * The delegated EOA address
 	 */
 	from: AddressDef;
+};
+
+/**
+ * EIP-7702 Session Key Execution
+ */
+export type Eip7702SessionKeyExecution = {
+	/**
+	 * The session key address is your server wallet, which has been granted a session key to the `account_address`
+	 */
+	sessionKeyAddress: AddressDef;
+	/**
+	 * The account address is the address of a delegated account you want to execute the transaction on. This account has granted a session key to the `session_key_address`
+	 */
+	accountAddress: AddressDef;
 };
 
 export type EmptyIdempotencySetResponse = {
@@ -888,6 +918,64 @@ export type SendTransactionRequest = {
 	params: Array<InnerTransaction>;
 	webhookOptions?: Array<WebhookOptions>;
 };
+
+export type SerialisableAwsSdkError =
+	| {
+			message: string;
+			type: "CONSTRUCTION_FAILURE";
+	  }
+	| {
+			message: string;
+			type: "TIMEOUT_ERROR";
+	  }
+	| {
+			message: string;
+			type: "DISPATCH_FAILURE";
+	  }
+	| {
+			message: string;
+			type: "RESPONSE_ERROR";
+	  }
+	| {
+			message: string;
+			type: "SERVICE_ERROR";
+	  }
+	| {
+			message: string;
+			type: "OTHER";
+	  };
+
+export type SerialisableAwsSignerError =
+	| {
+			aws_sdk_error: SerialisableAwsSdkError;
+			type: "SIGN";
+	  }
+	| {
+			aws_sdk_error: SerialisableAwsSdkError;
+			type: "GET_PUBLIC_KEY";
+	  }
+	| {
+			message: string;
+			type: "K256";
+	  }
+	| {
+			message: string;
+			type: "SPKI";
+	  }
+	| {
+			message: string;
+			type: "HEX";
+	  }
+	| {
+			type: "SIGNATURE_NOT_FOUND";
+	  }
+	| {
+			type: "PUBLIC_KEY_NOT_FOUND";
+	  }
+	| {
+			message: string;
+			type: "UNKNOWN";
+	  };
 
 export type SerializableReqwestError =
 	| {
@@ -1552,6 +1640,7 @@ export type GetTransactionsResponses = {
 					  }
 					| Array<unknown>;
 				transactionHash: string | null;
+				status: string | null;
 				confirmedAt: string | null;
 				confirmedAtBlockNumber: string | null;
 				enrichedData:
@@ -1712,6 +1801,7 @@ export type SearchTransactionsResponses = {
 					  }
 					| Array<unknown>;
 				transactionHash: string | null;
+				status: string | null;
 				confirmedAt: string | null;
 				confirmedAtBlockNumber: string | null;
 				enrichedData:

--- a/packages/thirdweb/src/engine/server-wallet.ts
+++ b/packages/thirdweb/src/engine/server-wallet.ts
@@ -189,8 +189,8 @@ export function serverWallet(options: ServerWalletOptions): ServerWallet {
         };
       case "EIP7702":
         return {
+          ...executionOptions,
           chainId,
-          from: address,
           type: "EIP7702",
         };
     }

--- a/packages/thirdweb/src/exports/x402.ts
+++ b/packages/thirdweb/src/exports/x402.ts
@@ -1,3 +1,4 @@
+export type { Money, PaymentMiddlewareConfig } from "x402/types";
 export { decodePayment, encodePayment } from "../x402/encode.js";
 export {
   facilitator,


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview

This PR focuses on updating the `thirdweb` library with new types and execution options for EIP-7702, as well as refining error handling related to AWS SDK errors.

### Detailed summary

- Added missing `x402` types export in `x402.ts`.
- Updated API spec for `@thirdweb-dev/engine`.
- Introduced `Eip7702OwnerExecution` and `Eip7702SessionKeyExecution` types.
- Enhanced error handling with new `SerialisableAwsSignerError` and `SerialisableAwsSdkError` types.
- Added `executionOptions` for session keys in relevant functions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Exposes Money and PaymentMiddlewareConfig types via the x402 export.
    - Adds EIP-7702 session-key execution support and returns execution options that can include session key info.
    - Transaction responses now include a status field for better visibility.
    - Adds standardized AWS signer error shapes for clearer error reporting.
- **Documentation**
    - Updated docs/examples showing session-key usage.
- **Chores**
    - Added changeset entries to publish as a patch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->