### PR TITLE
Add missing ERC7702 exports for documentation

### DIFF
--- a/packages/thirdweb/src/exports/extensions/erc7702.ts
+++ b/packages/thirdweb/src/exports/extensions/erc7702.ts
@@ -1,0 +1,59 @@
+// ERC7702 - MinimalAccount Events
+export { executedEvent } from "../../extensions/erc7702/__generated__/MinimalAccount/events/Executed.js";
+export { sessionCreatedEvent } from "../../extensions/erc7702/__generated__/MinimalAccount/events/SessionCreated.js";
+export { valueReceivedEvent } from "../../extensions/erc7702/__generated__/MinimalAccount/events/ValueReceived.js";
+
+// ERC7702 - MinimalAccount Read Functions
+export {
+  eip712Domain,
+  isEip712DomainSupported,
+} from "../../extensions/erc7702/__generated__/MinimalAccount/read/eip712Domain.js";
+export {
+  type GetCallPoliciesForSignerParams,
+  getCallPoliciesForSigner,
+  isGetCallPoliciesForSignerSupported,
+} from "../../extensions/erc7702/__generated__/MinimalAccount/read/getCallPoliciesForSigner.js";
+export {
+  type GetSessionExpirationForSignerParams,
+  getSessionExpirationForSigner,
+  isGetSessionExpirationForSignerSupported,
+} from "../../extensions/erc7702/__generated__/MinimalAccount/read/getSessionExpirationForSigner.js";
+export {
+  type GetSessionStateForSignerParams,
+  getSessionStateForSigner,
+  isGetSessionStateForSignerSupported,
+} from "../../extensions/erc7702/__generated__/MinimalAccount/read/getSessionStateForSigner.js";
+export {
+  type GetTransferPoliciesForSignerParams,
+  getTransferPoliciesForSigner,
+  isGetTransferPoliciesForSignerSupported,
+} from "../../extensions/erc7702/__generated__/MinimalAccount/read/getTransferPoliciesForSigner.js";
+export {
+  type IsWildcardSignerParams,
+  isWildcardSigner,
+  isIsWildcardSignerSupported,
+} from "../../extensions/erc7702/__generated__/MinimalAccount/read/isWildcardSigner.js";
+
+// ERC7702 - MinimalAccount Write Functions
+export {
+  type CreateSessionWithSigParams,
+  createSessionWithSig,
+  isCreateSessionWithSigSupported,
+} from "../../extensions/erc7702/__generated__/MinimalAccount/write/createSessionWithSig.js";
+export {
+  type ExecuteParams,
+  execute,
+  isExecuteSupported,
+} from "../../extensions/erc7702/__generated__/MinimalAccount/write/execute.js";
+export {
+  type ExecuteWithSigParams,
+  executeWithSig,
+  isExecuteWithSigSupported,
+} from "../../extensions/erc7702/__generated__/MinimalAccount/write/executeWithSig.js";
+
+// ERC7702 - Account Utilities
+export {
+  type CreateSessionKeyParams,
+  createSessionKey,
+} from "../../extensions/erc7702/account/createSessionKey.js";
+export type { SessionKeyConfig } from "../../extensions/erc7702/account/types.js";


### PR DESCRIPTION
- Create exports/extensions/erc7702.ts to expose ERC7702 functions
- Export all MinimalAccount read/write functions and events
- Include getSessionStateForSigner and other session management functions
- Add session key utilities and types

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces exports related to the `ERC7702` standard, specifically for `MinimalAccount` events, read functions, write functions, and account utilities.

### Detailed summary
- Added exports for events: `executedEvent`, `sessionCreatedEvent`, `valueReceivedEvent`.
- Added read functions: `eip712Domain`, `getCallPoliciesForSigner`, `getSessionExpirationForSigner`, `getSessionStateForSigner`, `getTransferPoliciesForSigner`, `isWildcardSigner`.
- Added write functions: `createSessionWithSig`, `execute`, `executeWithSig`.
- Added utility function: `createSessionKey` and type `SessionKeyConfig`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->