### PR TITLE
[SDK] Add x402 recipientAddress to payment request and replace deprecated payTo

### DIFF
--- a/.changeset/loud-apples-poke.md
+++ b/.changeset/loud-apples-poke.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Add optional recipientAddress to x402 settlePayment

--- a/.changeset/lucky-meals-join.md
+++ b/.changeset/lucky-meals-join.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Expose 7702 utility functions

--- a/packages/thirdweb/src/exports/wallets/in-app.ts
+++ b/packages/thirdweb/src/exports/wallets/in-app.ts
@@ -54,6 +54,7 @@ export {
   createSessionKey,
   isCreateSessionKeySupported,
 } from "../../extensions/erc7702/account/createSessionKey.js";
+
 export type {
   Condition,
   LimitType,

--- a/packages/thirdweb/src/x402/common.ts
+++ b/packages/thirdweb/src/x402/common.ts
@@ -44,6 +44,7 @@ export async function decodePaymentRequest(
     price,
     network,
     facilitator,
+    payTo,
     resourceUrl,
     routeConfig = {},
     method,
@@ -104,7 +105,7 @@ export async function decodePaymentRequest(
     resource: resourceUrl,
     description: description ?? "",
     mimeType: mimeType ?? "application/json",
-    payTo: getAddress(facilitator.address),
+    payTo: getAddress(facilitator.address), // always pay to the facilitator address first
     maxTimeoutSeconds: maxTimeoutSeconds ?? 300,
     asset: getAddress(asset.address),
     outputSchema: {
@@ -117,6 +118,7 @@ export async function decodePaymentRequest(
       output: outputSchema,
     },
     extra: {
+      recipientAddress: payTo, // input payTo is the final recipient address
       ...((asset as ERC20TokenAmount["asset"]).eip712 ?? {}),
     },
   });

--- a/packages/thirdweb/src/x402/types.ts
+++ b/packages/thirdweb/src/x402/types.ts
@@ -34,7 +34,7 @@ export type PaymentArgs = {
   facilitator: ThirdwebX402Facilitator;
   /** Optional configuration for the payment middleware route */
   routeConfig?: PaymentMiddlewareConfig;
-  /** @deprecated Use facilitator.address instead */
+  /** Optional recipient address to receive the payment if different from your facilitator address */
   payTo?: string;
 };
 


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview

This PR focuses on enhancing the payment functionality in the `thirdweb` package by introducing an optional `recipientAddress` parameter in the `x402 settlePayment` method, allowing payments to be directed to a different address from the facilitator.

### Detailed summary

- Added optional `recipientAddress` parameter to `x402 settlePayment`.
- Updated documentation for `payTo` to clarify its purpose.
- Modified `decodePaymentRequest` to include `recipientAddress` in the output.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
    - Optional recipientAddress for settle payment, allowing payouts to a different recipient.
    - Exposed new in-app wallet types for account conditions and limits.
- Refactor
    - Payment argument signatures updated to include an optional recipient address.
- Documentation
    - Updated parameter descriptions to reflect the new recipient address field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->