### PR TITLE
[Playground] Add payTo parameter to X402 payment API

### DIFF
--- a/apps/playground-web/src/app/api/paywall/route.ts
+++ b/apps/playground-web/src/app/api/paywall/route.ts
@@ -7,24 +7,25 @@ import { token } from "../../payments/x402/components/constants";
 // Allow streaming responses up to 5 minutes
 export const maxDuration = 300;
 
+const client = createThirdwebClient({
+  secretKey: process.env.THIRDWEB_SECRET_KEY as string,
+});
+
+const BACKEND_WALLET_ADDRESS = process.env.ENGINE_BACKEND_WALLET as string;
+// const BACKEND_WALLET_ADDRESS = process.env.ENGINE_BACKEND_SMART_WALLET as string;
+const ENGINE_VAULT_ACCESS_TOKEN = process.env
+  .ENGINE_VAULT_ACCESS_TOKEN as string;
+// const API_URL = `https://${process.env.NEXT_PUBLIC_API_URL || "api.thirdweb.com"}`;
+const API_URL = "http://localhost:3030";
+
+const twFacilitator = facilitator({
+  baseUrl: `${API_URL}/v1/payments/x402`,
+  client,
+  serverWalletAddress: BACKEND_WALLET_ADDRESS,
+  vaultAccessToken: ENGINE_VAULT_ACCESS_TOKEN,
+});
+
 export async function GET(request: NextRequest) {
-  const client = createThirdwebClient({
-    secretKey: process.env.THIRDWEB_SECRET_KEY as string,
-  });
-
-  const BACKEND_WALLET_ADDRESS = process.env.ENGINE_BACKEND_WALLET as string;
-  // const BACKEND_WALLET_ADDRESS = process.env.ENGINE_BACKEND_SMART_WALLET as string;
-  const ENGINE_VAULT_ACCESS_TOKEN = process.env
-    .ENGINE_VAULT_ACCESS_TOKEN as string;
-  const API_URL = `https://${process.env.NEXT_PUBLIC_API_URL || "api.thirdweb.com"}`;
-
-  const twFacilitator = facilitator({
-    baseUrl: `${API_URL}/v1/payments/x402`,
-    client,
-    serverWalletAddress: BACKEND_WALLET_ADDRESS,
-    vaultAccessToken: ENGINE_VAULT_ACCESS_TOKEN,
-  });
-
   const paymentData = request.headers.get("X-PAYMENT");
   const queryParams = request.nextUrl.searchParams;
 
@@ -38,6 +39,7 @@ export async function GET(request: NextRequest) {
   }
 
   const amount = queryParams.get("amount") || "0.01";
+  const payTo = queryParams.get("payTo") ?? undefined;
   const tokenAddress = queryParams.get("tokenAddress") || token.address;
   const decimals = queryParams.get("decimals") || token.decimals.toString();
   const waitUntil =
@@ -49,6 +51,7 @@ export async function GET(request: NextRequest) {
     method: "GET",
     paymentData,
     network: defineChain(Number(chainId)),
+    payTo,
     price: {
       amount: toUnits(amount, parseInt(decimals)).toString(),
       asset: {

--- a/apps/playground-web/src/app/payments/x402/components/X402LeftSection.tsx
+++ b/apps/playground-web/src/app/payments/x402/components/X402LeftSection.tsx
@@ -45,6 +45,7 @@ export function X402LeftSection(props: {
   const tokenId = useId();
   const amountId = useId();
   const waitUntilId = useId();
+  const payToId = useId();
 
   const handleChainChange = (chainId: number) => {
     setSelectedChain(chainId);
@@ -78,6 +79,13 @@ export function X402LeftSection(props: {
     setOptions((v) => ({
       ...v,
       amount: e.target.value,
+    }));
+  };
+
+  const handlePayToChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setOptions((v) => ({
+      ...v,
+      payTo: e.target.value as `0x${string}`,
     }));
   };
 
@@ -138,6 +146,22 @@ export function X402LeftSection(props: {
                 Amount in {options.tokenSymbol}
               </p>
             )}
+          </div>
+
+          {/* Pay To input */}
+          <div className="flex flex-col gap-2">
+            <Label htmlFor={payToId}>Pay To Address</Label>
+            <Input
+              id={payToId}
+              type="text"
+              placeholder="0x..."
+              value={options.payTo}
+              onChange={handlePayToChange}
+              className="bg-card"
+            />
+            <p className="text-sm text-muted-foreground">
+              The wallet address that will receive the payment
+            </p>
           </div>
 
           {/* Wait Until selection */}


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview

This PR adds a new input field for a "Pay To Address" in the `X402LeftSection` component and updates the API route to handle the `payTo` parameter in the payment request.

### Detailed summary

- Added `payToId` using `useId()` in `X402LeftSection`.
- Introduced `handlePayToChange` function to update the `payTo` option.
- Created a new input field for "Pay To Address" in the UI.
- Updated the API route to retrieve `payTo` from query parameters.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
    - Added a “Pay To Address” field in the payment form, allowing users to direct payments to a specific address.
    - The payments API now accepts an optional payTo parameter and includes it in successful payment responses for end-to-end recipient control.
- Improvements
    - Streamlined request handling to improve reliability and responsiveness during payment initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->