### PR TITLE
SDK: Fix getNFT tests, Playground: Fix build

### DIFF
--- a/apps/playground-web/src/app/api/chat/route.ts
+++ b/apps/playground-web/src/app/api/chat/route.ts
@@ -4,12 +4,14 @@ import { convertToModelMessages, streamText, type UIMessage } from "ai";
 // Allow streaming responses up to 5 minutes
 export const maxDuration = 300;
 
-const thirdwebAI = createThirdwebAI({
-  baseURL: `https://${process.env.NEXT_PUBLIC_API_URL}`,
-  secretKey: process.env.THIRDWEB_SECRET_KEY,
-});
-
 export async function POST(req: Request) {
+  const SECRET_KEY = process.env.THIRDWEB_SECRET_KEY as string;
+
+  const thirdwebAI = createThirdwebAI({
+    baseURL: `https://${process.env.NEXT_PUBLIC_API_URL}`,
+    secretKey: SECRET_KEY,
+  });
+
   const body = await req.json();
   const { messages, id }: { messages: UIMessage[]; id: string } = body;
 

--- a/apps/playground-web/src/app/api/paywall/route.ts
+++ b/apps/playground-web/src/app/api/paywall/route.ts
@@ -7,25 +7,27 @@ import { token } from "../../payments/x402/components/constants";
 // Allow streaming responses up to 5 minutes
 export const maxDuration = 300;
 
-const client = createThirdwebClient({
-  secretKey: process.env.THIRDWEB_SECRET_KEY as string,
-});
-
-const BACKEND_WALLET_ADDRESS = process.env.ENGINE_BACKEND_WALLET as string;
-// const BACKEND_WALLET_ADDRESS = process.env.ENGINE_BACKEND_SMART_WALLET as string;
-const ENGINE_VAULT_ACCESS_TOKEN = process.env
-  .ENGINE_VAULT_ACCESS_TOKEN as string;
-// const API_URL = `https://${process.env.NEXT_PUBLIC_API_URL || "api.thirdweb.com"}`;
-const API_URL = "http://localhost:3030";
-
-const twFacilitator = facilitator({
-  baseUrl: `${API_URL}/v1/payments/x402`,
-  client,
-  serverWalletAddress: BACKEND_WALLET_ADDRESS,
-  vaultAccessToken: ENGINE_VAULT_ACCESS_TOKEN,
-});
-
 export async function GET(request: NextRequest) {
+  const SECRET_KEY = process.env.THIRDWEB_SECRET_KEY as string;
+
+  const client = createThirdwebClient({
+    secretKey: SECRET_KEY,
+  });
+
+  const BACKEND_WALLET_ADDRESS = process.env.ENGINE_BACKEND_WALLET as string;
+  // const BACKEND_WALLET_ADDRESS = process.env.ENGINE_BACKEND_SMART_WALLET as string;
+  const ENGINE_VAULT_ACCESS_TOKEN = process.env
+    .ENGINE_VAULT_ACCESS_TOKEN as string;
+  // const API_URL = `https://${process.env.NEXT_PUBLIC_API_URL || "api.thirdweb.com"}`;
+  const API_URL = "http://localhost:3030";
+
+  const twFacilitator = facilitator({
+    baseUrl: `${API_URL}/v1/payments/x402`,
+    client,
+    serverWalletAddress: BACKEND_WALLET_ADDRESS,
+    vaultAccessToken: ENGINE_VAULT_ACCESS_TOKEN,
+  });
+
   const paymentData = request.headers.get("X-PAYMENT");
   const queryParams = request.nextUrl.searchParams;
 

--- a/packages/thirdweb/src/extensions/erc721/read/getNFT.test.ts
+++ b/packages/thirdweb/src/extensions/erc721/read/getNFT.test.ts
@@ -44,7 +44,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("erc721.getNFT", () => {
           "uri": "ipfs://QmPMc4tcBsMqLRuCQtPmPe84bpSjrC3Ky7t3JWuHXYB4aS/1",
         },
         "owner": null,
-        "tokenAddress": "0x8a90cab2b38dba80c64b7734e58ee1db38b8992e",
+        "tokenAddress": "0x8a90CAb2b38dba80c64b7734e58Ee1dB38B8992e",
         "tokenURI": "ipfs://QmPMc4tcBsMqLRuCQtPmPe84bpSjrC3Ky7t3JWuHXYB4aS/1",
         "type": "ERC721",
       }

--- a/packages/thirdweb/src/extensions/erc721/read/getNFTs.test.ts
+++ b/packages/thirdweb/src/extensions/erc721/read/getNFTs.test.ts
@@ -13,7 +13,6 @@ describe.runIf(process.env.TW_SECRET_KEY)("erc721.getNFTs", () => {
     });
 
     expect(nfts.length).toBe(5);
-    // TODO (insight): re-enable once insight fixes the client id caching issue
     expect(nfts).toMatchInlineSnapshot(`
       [
         {
@@ -49,7 +48,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("erc721.getNFTs", () => {
             "uri": "ipfs://QmPMc4tcBsMqLRuCQtPmPe84bpSjrC3Ky7t3JWuHXYB4aS/0",
           },
           "owner": null,
-          "tokenAddress": "0x8a90cab2b38dba80c64b7734e58ee1db38b8992e",
+          "tokenAddress": "0x8a90CAb2b38dba80c64b7734e58Ee1dB38B8992e",
           "tokenURI": "ipfs://QmPMc4tcBsMqLRuCQtPmPe84bpSjrC3Ky7t3JWuHXYB4aS/0",
           "type": "ERC721",
         },
@@ -86,7 +85,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("erc721.getNFTs", () => {
             "uri": "ipfs://QmPMc4tcBsMqLRuCQtPmPe84bpSjrC3Ky7t3JWuHXYB4aS/1",
           },
           "owner": null,
-          "tokenAddress": "0x8a90cab2b38dba80c64b7734e58ee1db38b8992e",
+          "tokenAddress": "0x8a90CAb2b38dba80c64b7734e58Ee1dB38B8992e",
           "tokenURI": "ipfs://QmPMc4tcBsMqLRuCQtPmPe84bpSjrC3Ky7t3JWuHXYB4aS/1",
           "type": "ERC721",
         },
@@ -123,7 +122,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("erc721.getNFTs", () => {
             "uri": "ipfs://QmPMc4tcBsMqLRuCQtPmPe84bpSjrC3Ky7t3JWuHXYB4aS/2",
           },
           "owner": null,
-          "tokenAddress": "0x8a90cab2b38dba80c64b7734e58ee1db38b8992e",
+          "tokenAddress": "0x8a90CAb2b38dba80c64b7734e58Ee1dB38B8992e",
           "tokenURI": "ipfs://QmPMc4tcBsMqLRuCQtPmPe84bpSjrC3Ky7t3JWuHXYB4aS/2",
           "type": "ERC721",
         },
@@ -160,7 +159,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("erc721.getNFTs", () => {
             "uri": "ipfs://QmPMc4tcBsMqLRuCQtPmPe84bpSjrC3Ky7t3JWuHXYB4aS/3",
           },
           "owner": null,
-          "tokenAddress": "0x8a90cab2b38dba80c64b7734e58ee1db38b8992e",
+          "tokenAddress": "0x8a90CAb2b38dba80c64b7734e58Ee1dB38B8992e",
           "tokenURI": "ipfs://QmPMc4tcBsMqLRuCQtPmPe84bpSjrC3Ky7t3JWuHXYB4aS/3",
           "type": "ERC721",
         },
@@ -197,7 +196,7 @@ describe.runIf(process.env.TW_SECRET_KEY)("erc721.getNFTs", () => {
             "uri": "ipfs://QmPMc4tcBsMqLRuCQtPmPe84bpSjrC3Ky7t3JWuHXYB4aS/4",
           },
           "owner": null,
-          "tokenAddress": "0x8a90cab2b38dba80c64b7734e58ee1db38b8992e",
+          "tokenAddress": "0x8a90CAb2b38dba80c64b7734e58Ee1dB38B8992e",
           "tokenURI": "ipfs://QmPMc4tcBsMqLRuCQtPmPe84bpSjrC3Ky7t3JWuHXYB4aS/4",
           "type": "ERC721",
         },


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `tokenAddress` format in NFT tests and improving the handling of the `THIRDWEB_SECRET_KEY` in API routes.

### Detailed summary
- Changed `tokenAddress` format in `getNFT.test.ts` and `getNFTs.test.ts` from `"0x8a90cab2b38dba80c64b7734e58ee1db38b8992e"` to `"0x8a90CAb2b38dba80c64b7734e58Ee1dB38B8992e"`.
- Refactored `thirdwebAI` initialization in `chat/route.ts` to use `SECRET_KEY`.
- Updated `paywall/route.ts` to initialize `client` with `SECRET_KEY`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public GET paywall endpoint.

* **Tests**
  * Updated NFT test snapshots to correct token address casing.
  * Removed an obsolete single-line test comment.

* **Chores**
  * API handlers now initialize services per request and read required environment secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->