### PR TITLE
Portal: Fix widget component API reference links

### DIFF
--- a/apps/portal/src/app/bridge/page.mdx
+++ b/apps/portal/src/app/bridge/page.mdx
@@ -102,7 +102,7 @@ const preparedQuote = await Bridge.Buy.prepare({
   </TabsContent>
 
   <TabsContent value="react">
-    The quickest way to setup Bridge in your React app is with the [`SwapWidget`](/references/typescript/v5/widgets/SwapWidget) component.
+    The quickest way to setup Bridge in your React app is with the [`SwapWidget`](/references/typescript/v5/SwapWidget) component.
 
     ### Live Playground
 

--- a/apps/portal/src/app/payments/custom-data/page.mdx
+++ b/apps/portal/src/app/payments/custom-data/page.mdx
@@ -195,7 +195,7 @@ To connect with other auth strategies, use external wallets, or sponsor gas for 
 
 - [Buy.prepare](/references/typescript/v5/buy/prepare)
 - [Sell.prepare](/references/typescript/v5/sell/prepare)
-- [BuyWidget](/references/typescript/v5/widgets/BuyWidget)
-- [CheckoutWidget](/references/typescript/v5/widgets/CheckoutWidget)
-- [TransactionWidget](/references/typescript/v5/widgets/TransactionWidget)
+- [BuyWidget](/references/typescript/v5/BuyWidget)
+- [CheckoutWidget](/references/typescript/v5/CheckoutWidget)
+- [TransactionWidget](/references/typescript/v5/TransactionWidget)
 

--- a/apps/portal/src/app/payments/page.mdx
+++ b/apps/portal/src/app/payments/page.mdx
@@ -106,8 +106,8 @@ const preparedQuote = await Bridge.Buy.prepare({
   </TabsContent>
 
   <TabsContent value="react">
-    The quickest way to setup payments in your React app is with the [`BuyWidget`](/references/typescript/v5/widgets/BuyWidget), [`CheckoutWidget`](/references/typescript/v5/widgets/CheckoutWidget), and [`TransactionWidget`](/references/typescript/v5/widgets/TransactionWidget) components.
-    
+    The quickest way to setup payments in your React app is with the [`BuyWidget`](/references/typescript/v5/BuyWidget), [`CheckoutWidget`](/references/typescript/v5/CheckoutWidget), and [`TransactionWidget`](/references/typescript/v5/TransactionWidget) components.
+
     ### Live Playground
 
 <ArticleIconCard
@@ -116,7 +116,7 @@ const preparedQuote = await Bridge.Buy.prepare({
   icon={ReactIcon}
   href="https://playground.thirdweb.com/connect/pay/transactions"
 />
-    
+
     ### Installation
 
     Install the thirdweb SDK in your React project:

--- a/apps/portal/src/app/payments/products/page.mdx
+++ b/apps/portal/src/app/payments/products/page.mdx
@@ -82,4 +82,4 @@ The CheckoutWidget handles the complete payment flow, supporting both crypto and
 
 ## API Reference
 
-- [CheckoutWidget](/references/typescript/v5/widgets/CheckoutWidget)
+- [CheckoutWidget](/references/typescript/v5/CheckoutWidget)


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the documentation links for various widgets in the `payments` and `bridge` sections to remove the `/widgets` path from the URLs.

### Detailed summary
- Updated link for `CheckoutWidget` in `apps/portal/src/app/payments/products/page.mdx`.
- Updated link for `SwapWidget` in `apps/portal/src/app/bridge/page.mdx`.
- Updated links for `BuyWidget`, `CheckoutWidget`, and `TransactionWidget` in `apps/portal/src/app/payments/custom-data/page.mdx`.
- Updated links for `BuyWidget`, `CheckoutWidget`, and `TransactionWidget` in `apps/portal/src/app/payments/page.mdx`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Updated API reference links to the latest v5 paths for SwapWidget, BuyWidget, CheckoutWidget, and TransactionWidget across Bridge and Payments pages, including React tab examples.
  * Replaced outdated “widgets” subpaths with top-level references to improve navigation consistency and reduce redirects.
  * Minor formatting cleanups; no behavioral changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->