### PR TITLE
[Docs] Rename listDiscoveryResources to listPayableServices in MCP tools

### DIFF
--- a/apps/portal/src/app/ai/mcp/page.mdx
+++ b/apps/portal/src/app/ai/mcp/page.mdx
@@ -245,7 +245,7 @@ Currently, the following tools are available:
 - `paymentsPurchase`
 - `getPaymentHistory`
 - `fetchWithPayment`
-- `listDiscoveryResources`
+- `listPayableServices`
 - `createToken`
 - `listTokens`
 - `getTokenOwners`

--- a/apps/portal/src/app/payments/x402/agents/page.mdx
+++ b/apps/portal/src/app/payments/x402/agents/page.mdx
@@ -20,7 +20,7 @@ The easiest way to equip your agents with the ability to pay for API calls is to
 
 The MCP server comes with all the tools by default, but you can filter the tools available by passing a comma-separated list of tools as a query parameter.
 
-In this example, we create a ReAct agent using LangChain and filter the MCP tools to `fetchWithPayment` and `listDiscoveryResources` as the only 2 tools we give our agent. You can view the full list of available tools [here](/ai/mcp#available-tools).
+In this example, we create a ReAct agent using LangChain and filter the MCP tools to `fetchWithPayment` and `listPayableServices` as the only 2 tools we give our agent. You can view the full list of available tools [here](/ai/mcp#available-tools).
 
 <Tabs defaultValue="typescript">
 
@@ -42,7 +42,7 @@ const model = new ChatOpenAI({
 
 const mcpServers = {
   thirdweb: {
-    url: `https://api.thirdweb.com/mcp?secretKey=<your-project-secret-key>&tools=fetchWithPayment,listDiscoveryResources`
+    url: `https://api.thirdweb.com/mcp?secretKey=<your-project-secret-key>&tools=fetchWithPayment,listPayableServices`
   }
 };
 
@@ -53,7 +53,7 @@ const tools = await client.getTools();
 const agent = createReactAgent({
   llm: model,
   tools: tools,
-  prompt: "Use the fetchWithPayment tool to fetch any endpoint. Discover the available endpoints with the listDiscoveryResources tool."
+  prompt: "Use the fetchWithPayment tool to fetch any endpoint. Discover the available endpoints with the listPayableServices tool."
 });
 ```
 
@@ -68,12 +68,12 @@ from langgraph.prebuilt import create_react_agent
 client = MultiServerMCPClient(
     {
         "thirdweb": {
-            "url": "https://api.thirdweb.com/mcp?secretKey=<your-project-secret-key>&tools=fetchWithPayment,listDiscoveryResources",
+            "url": "https://api.thirdweb.com/mcp?secretKey=<your-project-secret-key>&tools=fetchWithPayment,listPayableServices",
         }
     }
 )
 tools = await client.get_tools()
-agent = create_react_agent("openai:gpt-4.1", tools, prompt="Use the fetchWithPayment tool to fetch any endpoint. Discover the available endpoints with the listDiscoveryResources tool.")
+agent = create_react_agent("openai:gpt-4.1", tools, prompt="Use the fetchWithPayment tool to fetch any endpoint. Discover the available endpoints with the listPayableServices tool.")
 ```
 
 </TabsContent>


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview

This PR focuses on updating references from `listDiscoveryResources` to `listPayableServices` in the documentation and code related to the MCP server tools.

### Detailed summary

- Replaced `listDiscoveryResources` with `listPayableServices` in the documentation example for creating a ReAct agent.
- Updated the URL in the `mcpServers` object to use `listPayableServices`.
- Modified the prompt in the agent creation to reference `listPayableServices`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated tool references across portal documentation pages to reflect current naming conventions for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->