### PR TITLE
Dashboard: Fix autoconnect in /bridge page

### DIFF
--- a/apps/dashboard/src/app/(app)/components/autoconnect.tsx
+++ b/apps/dashboard/src/app/(app)/components/autoconnect.tsx
@@ -1,16 +1,7 @@
 "use client";
 import type { ThirdwebClient } from "thirdweb";
 import { AutoConnect } from "thirdweb/react";
-import type { SmartWalletOptions } from "thirdweb/wallets";
 
-export function TWAutoConnect(props: {
-  accountAbstraction?: SmartWalletOptions;
-  client: ThirdwebClient;
-}) {
-  return (
-    <AutoConnect
-      accountAbstraction={props.accountAbstraction}
-      client={props.client}
-    />
-  );
+export function TWAutoConnect(props: { client: ThirdwebClient }) {
+  return <AutoConnect client={props.client} />;
 }

--- a/apps/dashboard/src/app/bridge/components/client/Providers.client.tsx
+++ b/apps/dashboard/src/app/bridge/components/client/Providers.client.tsx
@@ -2,10 +2,15 @@
 import { ThemeProvider } from "next-themes";
 import { ThirdwebProvider } from "thirdweb/react";
 import { Toaster } from "@/components/ui/sonner";
+import { getClientThirdwebClient } from "@/constants/thirdweb-client.client";
+import { TWAutoConnect } from "../../../(app)/components/autoconnect";
+
+const thirdwebClient = getClientThirdwebClient();
 
 export function BridgeProviders({ children }: { children: React.ReactNode }) {
   return (
     <ThirdwebProvider>
+      <TWAutoConnect client={thirdwebClient} />
       <ThemeProvider
         attribute="class"
         defaultTheme="dark"


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR simplifies the `TWAutoConnect` component by removing the optional `accountAbstraction` prop and streamlining its usage in the `BridgeProviders` component.

### Detailed summary
- Removed the `accountAbstraction` prop from the `TWAutoConnect` function in `autoconnect.tsx`.
- Updated the return statement in `TWAutoConnect` to only pass the `client` prop.
- Added the `TWAutoConnect` component usage in `Providers.client.tsx` with the `thirdwebClient`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified the auto-connect component API so it only requires the client, removing an unnecessary configuration prop.
  * Integrated the streamlined auto-connect into the app provider stack so wallet/client initialization occurs earlier during startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->