### PR TITLE
[MNY-275] Surface the error from bridge API in SwapWidget UI

### DIFF
--- a/packages/thirdweb/src/react/web/ui/Bridge/swap-widget/swap-ui.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/swap-widget/swap-ui.tsx
@@ -399,13 +399,14 @@ export function SwapUI(props: SwapUIProps) {
         <Text
           size="sm"
           color="danger"
+          multiline
           center
           style={{
             paddingBlock: spacing.md,
           }}
         >
           {preparedResultQuery.error
-            ? "Failed to get a quote"
+            ? preparedResultQuery.error.message || "Failed to get a quote"
             : buyTokenQuery.isError
               ? "Failed to fetch buy token details"
               : sellTokenQuery.isError


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances error handling in the `swap-ui.tsx` component by providing a more informative error message when fetching quote details fails.

### Detailed summary
- Added the `multiline` prop to the component.
- Updated the error message for `preparedResultQuery.error` to display `preparedResultQuery.error.message` if available, defaulting to "Failed to get a quote".
- Retained existing error messages for `buyTokenQuery` and `sellTokenQuery`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error display in the swap widget: error text now shows a more specific message when available, falls back to a generic "Failed to get a quote" message otherwise, and supports multiline wrapping so longer errors are fully visible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->