### PR TITLE
Add force-dynamic to Stripe-related pages

### DIFF
--- a/apps/dashboard/src/app/(app)/(stripe)/cancel-plan/[team_id]/page.tsx
+++ b/apps/dashboard/src/app/(app)/(stripe)/cancel-plan/[team_id]/page.tsx
@@ -2,6 +2,8 @@ import { redirect } from "next/navigation";
 import { StripeRedirectErrorPage } from "../../_components/StripeRedirectErrorPage";
 import { getPlanCancelUrl } from "../../utils/billing";
 
+export const dynamic = "force-dynamic";
+
 export default async function CancelPlanPage(props: {
   params: Promise<{
     team_id: string;

--- a/apps/dashboard/src/app/(app)/(stripe)/checkout/[team_slug]/[sku]/page.tsx
+++ b/apps/dashboard/src/app/(app)/(stripe)/checkout/[team_slug]/[sku]/page.tsx
@@ -7,6 +7,8 @@ import {
   getInvoicePaymentUrl,
 } from "../../../utils/billing";
 
+export const dynamic = "force-dynamic";
+
 export default async function CheckoutPage(props: {
   params: Promise<{
     team_slug: string;

--- a/apps/dashboard/src/app/(app)/(stripe)/manage-billing/[team_slug]/page.tsx
+++ b/apps/dashboard/src/app/(app)/(stripe)/manage-billing/[team_slug]/page.tsx
@@ -2,6 +2,8 @@ import { redirect } from "next/navigation";
 import { StripeRedirectErrorPage } from "../../_components/StripeRedirectErrorPage";
 import { getBillingPortalUrl } from "../../utils/billing";
 
+export const dynamic = "force-dynamic";
+
 export default async function ManageBillingPage(props: {
   params: Promise<{
     team_slug: string;


### PR DESCRIPTION
### TL;DR

Added `dynamic = "force-dynamic"` to Stripe-related pages to ensure they always fetch fresh data.

### What changed?

Added the `export const dynamic = "force-dynamic"` directive to three Stripe-related pages:
- `cancel-plan/[team_id]/page.tsx`
- `checkout/[team_slug]/[sku]/page.tsx`
- `manage-billing/[team_slug]/page.tsx`

### How to test?

1. Navigate to any of the affected Stripe pages (cancel plan, checkout, manage billing)
2. Verify that the pages load correctly and display up-to-date billing information
3. Confirm that the pages don't serve cached content by making changes to billing information and refreshing

### Why make this change?

The `force-dynamic` directive ensures these pages are always server-rendered with fresh data on each request, which is critical for billing-related operations. This prevents caching issues that could lead to displaying outdated billing information or processing payments with stale data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated billing pages (cancel plan, checkout, and manage billing) to ensure they always display the latest information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->