### PR TITLE
[MNY-286] SDK: Do not require connecting wallet in BuyWidget if receiverAddress is set

### DIFF
--- a/.changeset/light-signs-send.md
+++ b/.changeset/light-signs-send.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Do not require connecting wallet in `BuyWidget` if `receiverAddress` is set

--- a/packages/thirdweb/src/react/web/ui/Bridge/BuyWidget.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/BuyWidget.tsx
@@ -39,7 +39,6 @@ import { PaymentSelection } from "./payment-selection/PaymentSelection.js";
 import { SuccessScreen } from "./payment-success/SuccessScreen.js";
 import { QuoteLoader } from "./QuoteLoader.js";
 import { StepRunner } from "./StepRunner.js";
-import { useActiveWalletInfo } from "./swap-widget/hooks.js";
 import type { PaymentMethod, RequiredParams } from "./types.js";
 
 export type BuyOrOnrampPrepareResult = Extract<
@@ -432,7 +431,6 @@ function BridgeWidgetContent(
   >,
 ) {
   const [screen, setScreen] = useState<BuyWidgetScreen>({ id: "1:buy-ui" });
-  const activeWalletInfo = useActiveWalletInfo();
 
   const handleError = useCallback(
     (error: Error, quote: BridgePrepareResult | undefined) => {
@@ -478,7 +476,7 @@ function BridgeWidgetContent(
     };
   });
 
-  if (screen.id === "1:buy-ui" || !activeWalletInfo) {
+  if (screen.id === "1:buy-ui") {
     return (
       <FundWallet
         theme={props.theme}

--- a/packages/thirdweb/src/react/web/ui/Bridge/FundWallet.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/FundWallet.tsx
@@ -167,6 +167,9 @@ export function FundWallet(props: FundWalletProps) {
   const actionLabel = isReceiverDifferentFromActiveWallet ? "Pay" : "Buy";
   const isMobile = useIsMobile();
 
+  // if no receiver address is set - wallet must be connected because the user's wallet is the receiver
+  const showConnectButton = !props.receiverAddress && !activeWalletInfo;
+
   return (
     <WithHeader
       client={props.client}
@@ -283,7 +286,20 @@ export function FundWallet(props: FundWalletProps) {
       )}
 
       {/* Continue Button */}
-      {activeWalletInfo ? (
+      {showConnectButton ? (
+        <ConnectButton
+          client={props.client}
+          connectButton={{
+            label: props.buttonLabel || actionLabel,
+            style: {
+              width: "100%",
+              borderRadius: radius.full,
+            },
+          }}
+          theme={theme}
+          {...props.connectOptions}
+        />
+      ) : (
         <Button
           disabled={!receiver}
           fullWidth
@@ -316,19 +332,6 @@ export function FundWallet(props: FundWalletProps) {
         >
           {props.buttonLabel || actionLabel}
         </Button>
-      ) : (
-        <ConnectButton
-          client={props.client}
-          connectButton={{
-            label: props.buttonLabel || actionLabel,
-            style: {
-              width: "100%",
-              borderRadius: radius.full,
-            },
-          }}
-          theme={theme}
-          {...props.connectOptions}
-        />
       )}
 
       {props.showThirdwebBranding ? (


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR modifies the `BuyWidget` component to allow users to bypass wallet connection if a `receiverAddress` is provided. It introduces a new condition for displaying the connection button based on the presence of the `receiverAddress`.

### Detailed summary
- Updated `BuyWidget` logic to not require wallet connection if `receiverAddress` is set.
- Removed `activeWalletInfo` dependency for displaying the wallet connection button in `BridgeWidgetContent`.
- Introduced `showConnectButton` in `FundWallet` to determine if the connect button should be shown based on `receiverAddress`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * BuyWidget no longer requires wallet connection when a receiver address is preset, enabling streamlined transactions in applicable scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->