### PR TITLE
[SDK] Fix: update React Native Send Funds screen to allow decimal amounts

### DIFF
--- a/.changeset/clear-seals-kneel.md
+++ b/.changeset/clear-seals-kneel.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+[React Native] Fixed Send Funds screen not allowing decimal amounts

--- a/packages/thirdweb/src/react/native/ui/connect/SendScreen.tsx
+++ b/packages/thirdweb/src/react/native/ui/connect/SendScreen.tsx
@@ -183,7 +183,7 @@ export const SendScreen = (props: SendScreenProps) => {
             Amount
           </ThemedText>
           <ThemedInput
-            inputMode="numeric"
+            inputMode="decimal"
             onChangeText={setAmount}
             rightView={
               <ThemedText


### PR DESCRIPTION
Updates the `inputMode` prop on the React Native's Send Funds screen amount input to show a keyboard with a decimal place, so amounts with decimals can be sent.

Before             |  After
:-------------------------:|:-------------------------:
![](https://github.com/user-attachments/assets/decc1f54-7081-4a76-9840-16ce8114774c)  |  ![](https://github.com/user-attachments/assets/60f6d25a-63cd-4ea7-9be9-fa4aa353acc0)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the `Send Funds` screen in the `thirdweb` React Native application to allow users to input decimal amounts.

### Detailed summary
- Updated the `inputMode` property of the `ThemedInput` component in `SendScreen.tsx` from `"numeric"` to `"decimal"` to support decimal input.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Send Funds screen now accepts decimal amounts for transaction inputs, enabling more precise fund transfer amounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->