### PR TITLE
[MNY-289] SDK: Fix token selection UI loading state when wallet is connected to a chain that is not supported by tw bridge

### DIFF
--- a/.changeset/fine-bobcats-rhyme.md
+++ b/.changeset/fine-bobcats-rhyme.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix Select Token UI stuck in loading state if wallet is connected to a chain that is not supported by thirdweb Bridge in BuyWidget, SwapWidget and BridgeWidget

--- a/packages/thirdweb/src/react/web/ui/Bridge/swap-widget/select-token-ui.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/swap-widget/select-token-ui.tsx
@@ -45,11 +45,11 @@ type SelectTokenUIProps = {
   activeWalletInfo: ActiveWalletInfo | undefined;
 };
 
-function getDefaultSelectedChain(
-  chains: BridgeChain[],
-  activeChainId: number | undefined,
-) {
-  return chains.find((chain) => chain.chainId === (activeChainId || 1));
+function findChain(chains: BridgeChain[], activeChainId: number | undefined) {
+  if (!activeChainId) {
+    return undefined;
+  }
+  return chains.find((chain) => chain.chainId === activeChainId);
 }
 
 /**
@@ -67,11 +67,9 @@ export function SelectToken(props: SelectTokenUIProps) {
   const selectedChain =
     _selectedChain ||
     (chainQuery.data
-      ? getDefaultSelectedChain(
-          chainQuery.data,
-          props.selectedToken?.chainId ||
-            props.activeWalletInfo?.activeChain.id,
-        )
+      ? findChain(chainQuery.data, props.selectedToken?.chainId) ||
+        findChain(chainQuery.data, props.activeWalletInfo?.activeChain.id) ||
+        findChain(chainQuery.data, 1)
       : undefined);
 
   // all tokens


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview

This PR addresses an issue where the Select Token UI gets stuck in a loading state when the wallet is connected to an unsupported chain in the `BuyWidget`, `SwapWidget`, and `BridgeWidget`. It refines the chain selection logic to improve functionality.

### Detailed summary

- Updated function name from `getDefaultSelectedChain` to `findChain`.
- Added a check to return `undefined` if `activeChainId` is not provided.
- Modified the logic to find the selected chain using `findChain` for better clarity and functionality.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
    - Fixed Select Token components from remaining in a loading state when the connected wallet chain isn't supported by the Bridge (affects BuyWidget, SwapWidget, BridgeWidget).
- **Chores**
    - Added a changeset entry for a patch release documenting the bugfix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->