### PR TITLE
[Playground] Use production API URL

### DIFF
--- a/apps/playground-web/src/app/api/paywall/route.ts
+++ b/apps/playground-web/src/app/api/paywall/route.ts
@@ -18,8 +18,7 @@ export async function GET(request: NextRequest) {
   // const BACKEND_WALLET_ADDRESS = process.env.ENGINE_BACKEND_SMART_WALLET as string;
   const ENGINE_VAULT_ACCESS_TOKEN = process.env
     .ENGINE_VAULT_ACCESS_TOKEN as string;
-  // const API_URL = `https://${process.env.NEXT_PUBLIC_API_URL || "api.thirdweb.com"}`;
-  const API_URL = "http://localhost:3030";
+  const API_URL = `https://${process.env.NEXT_PUBLIC_API_URL || "api.thirdweb.com"}`;
 
   const twFacilitator = facilitator({
     baseUrl: `${API_URL}/v1/payments/x402`,


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview

This PR updates the `API_URL` constant in the `route.ts` file to use a secure HTTPS URL instead of a local HTTP URL, enhancing the security of API calls.

### Detailed summary

- Changed the `API_URL` from `"http://localhost:3030"` to `https://${process.env.NEXT_PUBLIC_API_URL || "api.thirdweb.com"}`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
    - Updated payment API connection to use production-appropriate endpoints instead of local development settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->