### PR TITLE
Filter out null-ish values from ERC721 and ERC1155 getNFTs() arrays

### DIFF
--- a/.changeset/good-regions-dig.md
+++ b/.changeset/good-regions-dig.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+filter out null-ish values from `ERC721.getNFTs()` and `ERC1155.getNFTs()` arrays

--- a/packages/thirdweb/src/extensions/erc1155/read/getNFTs.ts
+++ b/packages/thirdweb/src/extensions/erc1155/read/getNFTs.ts
@@ -52,12 +52,18 @@ export async function getNFTs(
   const { useIndexer = true } = options;
   if (useIndexer) {
     try {
-      return await getNFTsFromInsight(options);
+      return await getNFTsFromInsight(options).then((nfts) =>
+        nfts.filter((nft) => nft?.id !== undefined && nft?.id !== null),
+      );
     } catch {
-      return await getNFTsFromRPC(options);
+      return await getNFTsFromRPC(options).then((nfts) =>
+        nfts.filter((nft) => nft?.id !== undefined && nft?.id !== null),
+      );
     }
   }
-  return await getNFTsFromRPC(options);
+  return await getNFTsFromRPC(options).then((nfts) =>
+    nfts.filter((nft) => nft?.id !== undefined && nft?.id !== null),
+  );
 }
 
 async function getNFTsFromInsight(

--- a/packages/thirdweb/src/extensions/erc721/read/getNFTs.ts
+++ b/packages/thirdweb/src/extensions/erc721/read/getNFTs.ts
@@ -71,12 +71,18 @@ export async function getNFTs(
   const { useIndexer = true } = options;
   if (useIndexer) {
     try {
-      return await getNFTsFromInsight(options);
+      return await getNFTsFromInsight(options).then((nfts) =>
+        nfts.filter((nft) => nft?.id !== undefined && nft?.id !== null),
+      );
     } catch {
-      return await getNFTsFromRPC(options);
+      return await getNFTsFromRPC(options).then((nfts) =>
+        nfts.filter((nft) => nft?.id !== undefined && nft?.id !== null),
+      );
     }
   }
-  return await getNFTsFromRPC(options);
+  return await getNFTsFromRPC(options).then((nfts) =>
+    nfts.filter((nft) => nft?.id !== undefined && nft?.id !== null),
+  );
 }
 
 /**


### PR DESCRIPTION
## [SDK] Fix: Filter out null-ish values from ERC721 and ERC1155 getNFTs() arrays

## Notes for the reviewer

This PR adds filtering to ensure that only NFTs with valid IDs are returned from the `getNFTs()` methods in both ERC721 and ERC1155 extensions. The change applies to results from both indexer and RPC data sources.

## How to test

Verify that `ERC721.getNFTs()` and `ERC1155.getNFTs()` no longer return null or undefined values in their result arrays.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NFT data reliability for ERC721 and ERC1155 by filtering out null/undefined entries across all retrieval methods and fallback paths, ensuring returned lists include only NFTs with defined IDs. This prevents incomplete items from appearing and improves consistency across indexer and RPC sources, reducing unexpected missing data and improving downstream display and handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on filtering out nullish values from the arrays returned by the `ERC721.getNFTs()` and `ERC1155.getNFTs()` methods to ensure only valid NFT objects are processed.

### Detailed summary
- Added filtering for nullish values in the `ERC721.getNFTs()` method.
- Added filtering for nullish values in the `ERC1155.getNFTs()` method.
- Updated the handling of `getNFTsFromInsight` and `getNFTsFromRPC` to include the filtering logic.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->