### PR TITLE
Handle null metadata in ERC721 and ERC1155 getNFT functions

### DIFF
--- a/packages/thirdweb/src/extensions/erc1155/read/getNFT.ts
+++ b/packages/thirdweb/src/extensions/erc1155/read/getNFT.ts
@@ -83,11 +83,23 @@ async function getNFTFromRPC(
       client: options.contract.client,
       tokenId: options.tokenId,
       tokenUri,
-    }).catch(() => ({
-      id: options.tokenId,
-      type: "ERC1155",
-      uri: tokenUri,
-    })),
+    })
+      .then((metadata) => {
+        // if the metadata is null-ish, return a default metadata object
+        if (!metadata) {
+          return {
+            id: options.tokenId,
+            type: "ERC1155",
+            uri: tokenUri,
+          };
+        }
+        return metadata;
+      })
+      .catch(() => ({
+        id: options.tokenId,
+        type: "ERC1155",
+        uri: tokenUri,
+      })),
     {
       chainId: options.contract.chain.id,
       owner: null,

--- a/packages/thirdweb/src/extensions/erc1155/read/getNFTs.ts
+++ b/packages/thirdweb/src/extensions/erc1155/read/getNFTs.ts
@@ -52,18 +52,12 @@ export async function getNFTs(
   const { useIndexer = true } = options;
   if (useIndexer) {
     try {
-      return await getNFTsFromInsight(options).then((nfts) =>
-        nfts.filter((nft) => nft?.id !== undefined && nft?.id !== null),
-      );
+      return await getNFTsFromInsight(options);
     } catch {
-      return await getNFTsFromRPC(options).then((nfts) =>
-        nfts.filter((nft) => nft?.id !== undefined && nft?.id !== null),
-      );
+      return await getNFTsFromRPC(options);
     }
   }
-  return await getNFTsFromRPC(options).then((nfts) =>
-    nfts.filter((nft) => nft?.id !== undefined && nft?.id !== null),
-  );
+  return await getNFTsFromRPC(options);
 }
 
 async function getNFTsFromInsight(

--- a/packages/thirdweb/src/extensions/erc721/read/getNFT.ts
+++ b/packages/thirdweb/src/extensions/erc721/read/getNFT.ts
@@ -139,11 +139,23 @@ async function getNFTFromRPC(
       client: options.contract.client,
       tokenId,
       tokenUri: uri,
-    }).catch(() => ({
-      id: tokenId,
-      type: "ERC721",
-      uri,
-    })),
+    })
+      .then((metadata) => {
+        // if the metadata is null-ish, return a default metadata object
+        if (!metadata) {
+          return {
+            id: tokenId,
+            type: "ERC721",
+            uri,
+          };
+        }
+        return metadata;
+      })
+      .catch(() => ({
+        id: tokenId,
+        type: "ERC721",
+        uri,
+      })),
     {
       chainId: options.contract.chain.id,
       owner,

--- a/packages/thirdweb/src/extensions/erc721/read/getNFTs.ts
+++ b/packages/thirdweb/src/extensions/erc721/read/getNFTs.ts
@@ -71,18 +71,12 @@ export async function getNFTs(
   const { useIndexer = true } = options;
   if (useIndexer) {
     try {
-      return await getNFTsFromInsight(options).then((nfts) =>
-        nfts.filter((nft) => nft?.id !== undefined && nft?.id !== null),
-      );
+      return await getNFTsFromInsight(options);
     } catch {
-      return await getNFTsFromRPC(options).then((nfts) =>
-        nfts.filter((nft) => nft?.id !== undefined && nft?.id !== null),
-      );
+      return await getNFTsFromRPC(options);
     }
   }
-  return await getNFTsFromRPC(options).then((nfts) =>
-    nfts.filter((nft) => nft?.id !== undefined && nft?.id !== null),
-  );
+  return await getNFTsFromRPC(options);
 }
 
 /**


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the handling of metadata retrieval for `ERC721` and `ERC1155` NFTs. It ensures that a default metadata object is returned when metadata is null or undefined, and it simplifies the filtering of NFTs in the `getNFTsFromInsight` function.

### Detailed summary
- In `getNFT.ts` and `getNFTs.ts`, added logic to return a default metadata object if the fetched metadata is null or undefined.
- Removed unnecessary filtering of NFTs based on `id` in `getNFTsFromInsight` and `getNFTsFromRPC` functions.
- Improved error handling by maintaining the structure of the catch blocks.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of incomplete or missing NFT metadata for ERC1155 and ERC721 operations, now returning default values when metadata is unavailable.
  * Removed ID-based filtering that was excluding NFTs from results, improving data completeness and result accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->