### PR TITLE
[X402] Fix network comparison in decodePaymentRequest

### DIFF
--- a/.changeset/plain-maps-draw.md
+++ b/.changeset/plain-maps-draw.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix network comparison when using diff libraries

--- a/packages/thirdweb/src/x402/common.ts
+++ b/packages/thirdweb/src/x402/common.ts
@@ -162,7 +162,8 @@ export async function decodePaymentRequest(
   const selectedPaymentRequirements = paymentRequirements.find(
     (value) =>
       value.scheme === decodedPayment.scheme &&
-      value.network === decodedPayment.network,
+      networkToChainId(value.network) ===
+        networkToChainId(decodedPayment.network),
   );
   if (!selectedPaymentRequirements) {
     return {


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the network comparison logic in the `thirdweb` library by updating the way network values are compared.

### Detailed summary
- Updated the comparison of network values in the `packages/thirdweb/src/x402/common.ts` file.
- Changed the comparison from `value.network === decodedPayment.network` to `networkToChainId(value.network) === networkToChainId(decodedPayment.network)`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Fixed network comparison logic to ensure consistent matching regardless of how networks are represented, improving compatibility when using diff libraries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->