### PR TITLE
add arc testnet to chains package

### DIFF
--- a/.changeset/hip-spoons-go.md
+++ b/.changeset/hip-spoons-go.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Add Arc testnet to chains package

--- a/packages/thirdweb/src/chains/chain-definitions/arc-testnet.ts
+++ b/packages/thirdweb/src/chains/chain-definitions/arc-testnet.ts
@@ -1,0 +1,17 @@
+import { defineChain } from "../utils.js";
+
+/**
+ * @chain
+ */
+export const arcTestnet = /* @__PURE__ */ defineChain({
+  blockExplorers: [
+    {
+      name: "Arc Testnet Explorer",
+      url: "https://testnet.arcscan.app",
+    },
+  ],
+  id: 5042002,
+  name: "Arc Testnet",
+  nativeCurrency: { decimals: 6, name: "USDC", symbol: "USDC" },
+  testnet: true,
+});

--- a/packages/thirdweb/src/exports/chains.ts
+++ b/packages/thirdweb/src/exports/chains.ts
@@ -10,6 +10,7 @@ export { anvil } from "../chains/chain-definitions/anvil.js";
 export { arbitrum } from "../chains/chain-definitions/arbitrum.js";
 export { arbitrumNova } from "../chains/chain-definitions/arbitrum-nova.js";
 export { arbitrumSepolia } from "../chains/chain-definitions/arbitrum-sepolia.js";
+export { arcTestnet } from "../chains/chain-definitions/arc-testnet.js";
 export { assetChainTestnet } from "../chains/chain-definitions/assetchain-testnet.js";
 export { astriaEvmDusknet } from "../chains/chain-definitions/astria-evm-dusknet.js";
 export { avalanche } from "../chains/chain-definitions/avalanche.js";


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the `arcTestnet` chain to the `thirdweb` package, adding details about its properties and exporting it for use in other parts of the application.

### Detailed summary
- Added a new file `arc-testnet.ts` defining the `arcTestnet` chain with properties such as `id`, `name`, `nativeCurrency`, and `blockExplorers`.
- Exported `arcTestnet` from `chains.ts` to make it available for use in the application.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Arc Testnet is now available as a predefined network option, configured with testnet settings, USDC as the native currency, and integrated block explorer access for transaction verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->