### PR TITLE
SDK: Fix Safe wallet connection issues with WalletConnect

### DIFF
--- a/.changeset/early-spoons-say.md
+++ b/.changeset/early-spoons-say.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix Safe wallet connection issues with WalletConnect

--- a/packages/thirdweb/src/wallets/wallet-connect/controller.ts
+++ b/packages/thirdweb/src/wallets/wallet-connect/controller.ts
@@ -157,7 +157,7 @@ export async function connectWC(
   );
   const currentChainId = chainsToRequest[0]?.split(":")[1] || 1;
   const providerChainId = normalizeChainId(currentChainId);
-  const account = firstAccountOn(provider.session, `eip155:1`); // grab the address from mainnet
+  const account = firstAccountOn(provider.session, `eip155:1`); // grab the address from mainnet if available
   const address = account;
   if (!address) {
     throw new Error("No accounts found on provider.");
@@ -291,7 +291,8 @@ function hasChainEnabled(session: WCSession, caip: string) {
 }
 function firstAccountOn(session: WCSession, caip: string): string | null {
   const ns = getNS(session);
-  const hit = ns?.accounts?.find((a) => a.startsWith(`${caip}:`));
+  const hit =
+    ns?.accounts?.find((a) => a.startsWith(`${caip}:`)) || ns?.accounts[0];
   return hit ? (hit.split(":")[2] ?? null) : null;
 }
 function anyRoutableChain(session: WCSession): string | null {


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview

This PR addresses issues with the `Safe` wallet connection when using `WalletConnect`, enhancing the reliability of account retrieval.

### Detailed summary

- Updated the comment for `account` in `controller.ts` to clarify it retrieves the address from mainnet if available.
- Modified the `firstAccountOn` function to return the first account if no account matches the specified `caip`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
    - Fixed Safe wallet connection issues with WalletConnect.
    - Improved account selection fallback when a mainnet account isn't available, so WalletConnect can connect using an available account.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->