### PR TITLE
Dashboard: Use monotone curve type for AreaChart to avoid clipping

### DIFF
--- a/apps/dashboard/src/@/components/analytics/empty-chart-state.tsx
+++ b/apps/dashboard/src/@/components/analytics/empty-chart-state.tsx
@@ -95,7 +95,7 @@ function SkeletonBarChart(props: {
             fill={`url(#${fillAreaSkeletonId})`}
             radius={8}
             stroke="hsl(var(--muted-foreground))"
-            type="natural"
+            type="monotone"
           />
         </AreaChart>
       )}

--- a/apps/dashboard/src/@/components/blocks/charts/area-chart.tsx
+++ b/apps/dashboard/src/@/components/blocks/charts/area-chart.tsx
@@ -172,7 +172,7 @@ export function ThirdwebAreaChart<TConfig extends ChartConfig>(
                     key={key}
                     stackId={props.variant !== "stacked" ? undefined : "a"}
                     stroke={`var(--color-${key})`}
-                    type="natural"
+                    type="monotone"
                   />
                 ),
               )}

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/engine/(instance)/[engineId]/metrics/components/ErrorRate.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/engine/(instance)/[engineId]/metrics/components/ErrorRate.tsx
@@ -59,7 +59,6 @@ export function ErrorRate({ datapoints }: { datapoints: ResultItem[] }) {
           key={tag}
           stackId="a"
           stroke={`var(--color-${tag})`}
-          type="natural"
         />,
       );
     }


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview

This PR focuses on updating the `type` property of chart components from `natural` to `monotone` in various files, likely to improve the visual representation of data in charts.

### Detailed summary

- Updated `type` from `natural` to `monotone` in `empty-chart-state.tsx`.
- Updated `type` from `natural` to `monotone` in `area-chart.tsx`.
- Updated `type` from `natural` to `monotone` in `ErrorRate.tsx`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated area interpolation to a monotone curve for smoother, more consistent area rendering across charts (including skeleton/placeholder charts).
  * Removed an explicit interpolation override on stacked bars so stacking behavior now follows existing stack settings, improving visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->