### PR TITLE
[Paywall] Support string price format when tokenAddress is not provided

### DIFF
--- a/apps/playground-web/src/app/api/paywall/route.ts
+++ b/apps/playground-web/src/app/api/paywall/route.ts
@@ -41,7 +41,7 @@ export async function GET(request: NextRequest) {
 
   const amount = queryParams.get("amount") || "0.01";
   const payTo = queryParams.get("payTo") ?? undefined;
-  const tokenAddress = queryParams.get("tokenAddress") || token.address;
+  const tokenAddress = queryParams.get("tokenAddress");
   const decimals = queryParams.get("decimals") || token.decimals.toString();
   const waitUntil =
     (queryParams.get("waitUntil") as "simulated" | "submitted" | "confirmed") ||
@@ -53,13 +53,15 @@ export async function GET(request: NextRequest) {
     paymentData,
     network: defineChain(Number(chainId)),
     payTo,
-    price: {
-      amount: toUnits(amount, parseInt(decimals)).toString(),
-      asset: {
-        address: tokenAddress as `0x${string}`,
-        decimals: decimals ? parseInt(decimals) : token.decimals,
-      },
-    },
+    price: tokenAddress
+      ? {
+          amount: toUnits(amount, parseInt(decimals)).toString(),
+          asset: {
+            address: tokenAddress as `0x${string}`,
+            decimals: decimals ? parseInt(decimals) : token.decimals,
+          },
+        }
+      : amount,
     routeConfig: {
       description: "Access to paid content",
     },


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying the handling of the `tokenAddress` in the `GET` function of the `paywall` route. It adjusts how the `price` object is constructed based on the presence of `tokenAddress`.

### Detailed summary
- Changed `const tokenAddress` to directly assign the value from `queryParams` without a fallback.
- Updated the construction of the `price` object to conditionally include `amount` only if `tokenAddress` is present.
- Adjusted the structure of the `price` object to reflect the new conditional logic.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Paywall pricing response now conditionally includes asset details when a token address is supplied; price will include amount plus asset (address and decimals).
  * When no token address is provided, the response preserves the original behavior and returns the plain amount string.
  * This ensures compatible responses for both token-based and native-amount requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->