### PR TITLE
[X402] Simplify FacilitatorNetworkSchema to accept any string

### DIFF
--- a/.changeset/five-plums-kiss.md
+++ b/.changeset/five-plums-kiss.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Loosen network schema

--- a/packages/thirdweb/src/x402/schemas.ts
+++ b/packages/thirdweb/src/x402/schemas.ts
@@ -11,20 +11,7 @@ import {
 import { z } from "zod";
 import type { Chain } from "../chains/types.js";
 
-const FacilitatorNetworkSchema = z.union([
-  z.literal("base-sepolia"),
-  z.literal("base"),
-  z.literal("avalanche-fuji"),
-  z.literal("avalanche"),
-  z.literal("iotex"),
-  z.literal("solana-devnet"),
-  z.literal("solana"),
-  z.literal("sei"),
-  z.literal("sei-testnet"),
-  z.string().refine((value) => value.startsWith("eip155:"), {
-    message: "Invalid network",
-  }),
-]);
+const FacilitatorNetworkSchema = z.string();
 
 export type FacilitatorNetwork = z.infer<typeof FacilitatorNetworkSchema>;
 


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on loosening the `FacilitatorNetworkSchema` in the `packages/thirdweb/src/x402/schemas.ts` file, changing it from a union of specific literals to a more general string type.

### Detailed summary
- Updated `FacilitatorNetworkSchema` from a union of specific network literals to `z.string()`.
- This change allows for a broader range of network identifiers. 
- `FacilitatorNetwork` type remains inferred from the updated schema.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded network schema validation to accept a broader range of network identifiers, improving flexibility and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->