### PR TITLE
Move success URL handling from PayPage to StyledBuyWidget component

### DIFF
--- a/apps/dashboard/src/app/pay/landing/styled-buy-widget.tsx
+++ b/apps/dashboard/src/app/pay/landing/styled-buy-widget.tsx
@@ -9,7 +9,12 @@ import { payLandingWallets } from "./wallets";
 const client = getClientThirdwebClient();
 
 export function StyledBuyWidget(
-  props: Omit<BuyWidgetProps, "client" | "theme">,
+  props: Omit<
+    BuyWidgetProps,
+    "client" | "theme" | "onSuccess" | "onError" | "onCancel"
+  > & {
+    successUrl?: string;
+  },
 ) {
   const { theme } = useTheme();
 
@@ -21,6 +26,22 @@ export function StyledBuyWidget(
       className="shadow-xl"
       connectOptions={{
         wallets: payLandingWallets,
+      }}
+      onSuccess={() => {
+        if (props.successUrl) {
+          try {
+            const url = new URL(props.successUrl);
+            url.searchParams.set("success", "true");
+            window.location.href = url.toString();
+          } catch (error) {
+            // Log URL construction error for debugging
+            console.error(
+              "Failed to construct redirect URL:",
+              props.successUrl,
+              error,
+            );
+          }
+        }
       }}
     />
   );

--- a/apps/dashboard/src/app/pay/page.tsx
+++ b/apps/dashboard/src/app/pay/page.tsx
@@ -76,22 +76,7 @@ export default async function PayPage(props: {
             tokenAddress={token}
             receiverAddress={receiver}
             amount={amount ? amount.toString() : undefined}
-            onSuccess={() => {
-              if (successUrl) {
-                try {
-                  const url = new URL(successUrl);
-                  url.searchParams.set("success", "true");
-                  window.location.href = url.toString();
-                } catch (error) {
-                  // Log URL construction error for debugging
-                  console.error(
-                    "Failed to construct redirect URL:",
-                    successUrl,
-                    error,
-                  );
-                }
-              }
-            }}
+            successUrl={successUrl}
           />
         </div>
       </div>


### PR DESCRIPTION
### TL;DR

Refactored the Buy Widget component to handle success URL redirection internally rather than in the parent component.

### What changed?

- Modified the `StyledBuyWidget` component to accept a `successUrl` prop instead of callback handlers
- Moved the success URL redirection logic from the `PayPage` component into the `StyledBuyWidget` component
- Updated the type definition of `StyledBuyWidget` props to exclude `onSuccess`, `onError`, and `onCancel` from the base props and add the new `successUrl` prop

### How to test?

1. Navigate to the Pay page with a success URL parameter
2. Complete a transaction using the Buy Widget
3. Verify you are redirected to the success URL with the `success=true` parameter appended

### Why make this change?

This change improves component encapsulation by moving the redirection logic into the widget itself, making the parent component cleaner and the widget more self-contained. It also ensures consistent handling of success redirects across all implementations of the Buy Widget.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated payment success redirect handling within the buy widget component, enabling simpler post-purchase navigation configuration and improving the completion flow reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->