### PR TITLE
[SDK] Add support for extra metadata in x402 payment requests

### DIFF
--- a/.changeset/four-ghosts-tickle.md
+++ b/.changeset/four-ghosts-tickle.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Add support for extraMetadata in x402 payment requirements

--- a/packages/thirdweb/src/x402/common.ts
+++ b/packages/thirdweb/src/x402/common.ts
@@ -44,6 +44,7 @@ export async function decodePaymentRequest(
     routeConfig = {},
     method,
     paymentData,
+    extraMetadata,
   } = args;
   const { errorMessages } = routeConfig;
 
@@ -54,6 +55,7 @@ export async function decodePaymentRequest(
     price,
     routeConfig,
     payTo,
+    extraMetadata,
   });
 
   // Check for payment header, if none, return the payment requirements

--- a/packages/thirdweb/src/x402/facilitator.ts
+++ b/packages/thirdweb/src/x402/facilitator.ts
@@ -281,6 +281,7 @@ export function facilitator(
           routeConfig: args.routeConfig,
           serverWalletAddress: facilitator.address,
           recipientAddress: args.payTo,
+          extraMetadata: args.extraMetadata,
         }),
       });
       if (res.status !== 402) {

--- a/packages/thirdweb/src/x402/types.ts
+++ b/packages/thirdweb/src/x402/types.ts
@@ -35,6 +35,8 @@ export type PaymentArgs = {
   routeConfig?: PaymentMiddlewareConfig;
   /** Optional recipient address to receive the payment if different from your facilitator address */
   payTo?: string;
+  /** Optional extra data to be included in the payment request */
+  extraMetadata?: Record<string, unknown>;
 };
 
 export type SettlePaymentArgs = PaymentArgs & {


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces support for `extraMetadata` in the x402 payment requirements, allowing additional data to be included in payment requests.

### Detailed summary
- Added `extraMetadata` to the payment request in `facilitator.ts`.
- Included `extraMetadata` in the function parameters in `common.ts`.
- Updated the `decodePaymentRequest` function to accept `extraMetadata`.
- Documented `extraMetadata` as an optional field in `types.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Payment requests now accept an optional extraMetadata field, allowing callers to attach arbitrary metadata to x402 payment flows for improved context and processing.

* **Chores**
  * Patch release recorded to include extraMetadata support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->