### PR TITLE
[MNY-295] Fix BuyWidget autoconnect not working when receiverAddress prop is set

### DIFF
--- a/.changeset/bumpy-shoes-flow.md
+++ b/.changeset/bumpy-shoes-flow.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix BuyWidget autoconnect not working when receiverAddress prop is set

--- a/packages/thirdweb/src/react/web/ui/Bridge/BuyWidget.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/BuyWidget.tsx
@@ -25,6 +25,7 @@ import type {
 import type { CompletedStatusResult } from "../../../core/hooks/useStepExecutor.js";
 import type { SupportedTokens } from "../../../core/utils/defaultTokens.js";
 import { webWindowAdapter } from "../../adapters/WindowAdapter.js";
+import { AutoConnect } from "../AutoConnect/AutoConnect.js";
 import connectLocaleEn from "../ConnectWallet/locale/en.js";
 import { EmbedContainer } from "../ConnectWallet/Modal/ConnectEmbed.js";
 import { DynamicHeight } from "../components/DynamicHeight.js";
@@ -359,6 +360,21 @@ export function BuyWidget(props: BuyWidgetProps) {
       className={props.className}
       style={props.style}
     >
+      {props.connectOptions?.autoConnect !== false && (
+        <AutoConnect
+          client={props.client}
+          wallets={props.connectOptions?.wallets}
+          timeout={
+            typeof props.connectOptions?.autoConnect === "object"
+              ? props.connectOptions?.autoConnect?.timeout
+              : undefined
+          }
+          appMetadata={props.connectOptions?.appMetadata}
+          accountAbstraction={props.connectOptions?.accountAbstraction}
+          chain={props.connectOptions?.chain}
+        />
+      )}
+
       <BridgeWidgetContent
         {...props}
         theme={props.theme || "dark"}

--- a/packages/thirdweb/src/react/web/ui/Bridge/FundWallet.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/FundWallet.tsx
@@ -298,6 +298,7 @@ export function FundWallet(props: FundWalletProps) {
           }}
           theme={theme}
           {...props.connectOptions}
+          autoConnect={false}
         />
       ) : (
         <Button

--- a/packages/thirdweb/src/stories/BuyWidget.stories.tsx
+++ b/packages/thirdweb/src/stories/BuyWidget.stories.tsx
@@ -138,6 +138,20 @@ export function LargeAmount() {
   );
 }
 
+export function NoAutoConnect() {
+  return (
+    <Variant
+      client={storyClient}
+      chain={ethereum}
+      tokenAddress="0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"
+      amount="150000"
+      connectOptions={{
+        autoConnect: false,
+      }}
+    />
+  );
+}
+
 function Variant(props: BuyWidgetProps) {
   return (
     <div


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the `BuyWidget` component's auto-connect functionality, particularly when the `receiverAddress` prop is set. It adds support for auto-connect options and introduces a new story variant to demonstrate the feature.

### Detailed summary
- Added support for `autoConnect` option in the `BuyWidget`.
- Updated the `BuyWidget` component to conditionally render the `AutoConnect` component based on `connectOptions`.
- Introduced a new story `NoAutoConnect` to showcase the `BuyWidget` without auto-connect enabled.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed auto-connect so it behaves correctly when a receiver address is set in the buy flow.

* **New Features**
  * Added a configurable auto-connect option for the buy widget so users can enable or disable automatic wallet connection.
  * Connect buttons that opt out of auto-connect will no longer auto-connect.

* **Documentation**
  * Added a story/example showing the buy widget with auto-connect disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->