### PR TITLE
[SDK] Expose useInvalidateBalances()

### DIFF
--- a/.changeset/clever-horses-turn.md
+++ b/.changeset/clever-horses-turn.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Respect from address when simulating with Engine.serverWallet

--- a/.changeset/curvy-pillows-return.md
+++ b/.changeset/curvy-pillows-return.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Expose useInvalidateBalances() react hook

--- a/packages/thirdweb/src/engine/server-wallet.ts
+++ b/packages/thirdweb/src/engine/server-wallet.ts
@@ -332,6 +332,7 @@ export function serverWallet(options: ServerWalletOptions): ServerWallet {
       if (args.simulate) {
         serializedTransaction = await toSerializableTransaction({
           transaction: args.transaction,
+          from: address,
         });
       } else {
         const [to, data, value] = await Promise.all([

--- a/packages/thirdweb/src/exports/react.native.ts
+++ b/packages/thirdweb/src/exports/react.native.ts
@@ -22,6 +22,7 @@ export { useContractEvents } from "../react/core/hooks/contract/useContractEvent
 // contract
 export { useReadContract } from "../react/core/hooks/contract/useReadContract.js";
 export { useWaitForReceipt } from "../react/core/hooks/contract/useWaitForReceipt.js";
+export { useInvalidateBalances } from "../react/core/hooks/others/useInvalidateBalances.js";
 export { useInvalidateContractQuery } from "../react/core/hooks/others/useInvalidateQueries.js";
 export { useWalletBalance } from "../react/core/hooks/others/useWalletBalance.js";
 export {

--- a/packages/thirdweb/src/exports/react.ts
+++ b/packages/thirdweb/src/exports/react.ts
@@ -29,6 +29,7 @@ export { useReadContract } from "../react/core/hooks/contract/useReadContract.js
 export { useWaitForReceipt } from "../react/core/hooks/contract/useWaitForReceipt.js";
 // chain hooks
 export { useChainMetadata } from "../react/core/hooks/others/useChainQuery.js";
+export { useInvalidateBalances } from "../react/core/hooks/others/useInvalidateBalances.js";
 export { useInvalidateContractQuery } from "../react/core/hooks/others/useInvalidateQueries.js";
 export { useWalletBalance } from "../react/core/hooks/others/useWalletBalance.js";
 export {

--- a/packages/thirdweb/src/react/core/hooks/others/useInvalidateBalances.ts
+++ b/packages/thirdweb/src/react/core/hooks/others/useInvalidateBalances.ts
@@ -1,0 +1,18 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { invalidateWalletBalance } from "../../providers/invalidateWalletBalance.js";
+
+/**
+ * Invalidate the balances for a given chainId. If no chainId is provided, invalidate all balances.
+ * @example
+ * ```ts
+ * const invalidateBalances = useInvalidateBalances();
+ * invalidateBalances();
+ * ```
+ */
+export function useInvalidateBalances() {
+  const queryClient = useQueryClient();
+
+  return ({ chainId }: { chainId?: number }) => {
+    invalidateWalletBalance(queryClient, chainId);
+  };
+}


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `thirdweb` package by introducing a new React hook and improving transaction handling with respect to the `from` address.

### Detailed summary
- Added the `useInvalidateBalances` React hook to invalidate wallet balances for a specific `chainId`.
- Modified transaction serialization in `server-wallet.ts` to respect the `from` address during simulation.
- Exported the new `useInvalidateBalances` hook in both `react.ts` and `react.native.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exposed useInvalidateBalances React hook for manually refreshing wallet balance caches with optional chain filtering
  * Server wallet transaction simulation now respects the specified sender address

<!-- end of auto-generated comment: release notes by coderabbit.ai -->