### PR TITLE
[Playground] Remove hardcoded limit from wrapFetchWithPayment

### DIFF
--- a/apps/playground-web/src/app/payments/x402/components/X402RightSection.tsx
+++ b/apps/playground-web/src/app/payments/x402/components/X402RightSection.tsx
@@ -43,7 +43,6 @@ export function X402RightSection(props: { options: X402PlaygroundOptions }) {
         fetch,
         THIRDWEB_CLIENT,
         activeWallet,
-        BigInt(1 * 10 ** 18),
       );
       const searchParams = new URLSearchParams();
       searchParams.set("chainId", props.options.chain.id.toString());


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `X402RightSection` component by removing a specific value and modifying how `chainId` is set in the `searchParams`.

### Detailed summary
- Removed the line with `BigInt(1 * 10 ** 18)`.
- Updated the `searchParams` to set `chainId` using `props.options.chain.id.toString()`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Removed hardcoded payment parameter from payment processing flow, allowing for more flexible payment amount handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->