### PR TITLE
[Dashboard] Change default x402 metric from volume to payments

### DIFF
--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/x402/analytics/ChartsSection.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/x402/analytics/ChartsSection.tsx
@@ -11,7 +11,7 @@ export function ChartMetricSwitcher() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
-  const metric = (searchParams.get("metric") as Metric) || "volume";
+  const metric = (searchParams.get("metric") as Metric) || "payments";
 
   const handleMetricChange = useCallback(
     (newMetric: Metric) => {

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/x402/page.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/x402/page.tsx
@@ -75,7 +75,7 @@ export default async function Page(props: {
   // Get project wallet for prefilling the code snippet
   const projectWallet = await getProjectWallet(project);
 
-  const metric = (searchParams.metric as "payments" | "volume") || "volume";
+  const metric = (searchParams.metric as "payments" | "volume") || "payments";
 
   return (
     <ResponsiveSearchParamsProvider value={searchParams}>


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on changing the default metric used in the analytics section of the dashboard from "volume" to "payments" to better align with user expectations.

### Detailed summary
- In `ChartsSection.tsx`, changed the default `metric` from `"volume"` to `"payments"`.
- In `page.tsx`, updated the default `metric` from `"volume"` to `"payments"` when retrieving from `searchParams`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->