### PR TITLE
[Dashboard] Add date range filtering to transaction analytics

### DIFF
--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/transactions/analytics/summary.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/transactions/analytics/summary.tsx
@@ -1,7 +1,12 @@
+"use client";
+import { useQuery } from "@tanstack/react-query";
 import { ActivityIcon, CoinsIcon } from "lucide-react";
 import { toEther } from "thirdweb/utils";
 import { StatCard } from "@/components/analytics/stat"; // Assuming correct path
-import type { TransactionSummaryData } from "../lib/analytics-summary.client";
+import {
+  getTransactionAnalyticsSummary,
+  type TransactionSummaryData,
+} from "../lib/analytics-summary.client";
 
 // Renders the UI based on fetched data or pending state
 function TransactionAnalyticsSummaryUI(props: {
@@ -88,9 +93,37 @@ function TransactionAnalyticsSummaryUI(props: {
 export function TransactionAnalyticsSummary(props: {
   teamId: string;
   clientId: string;
-  initialData: TransactionSummaryData | undefined;
+  authToken: string;
+  startDate?: string;
+  endDate?: string;
 }) {
+  const engineTxSummaryQuery = useQuery({
+    queryKey: [
+      "engine-tx-analytics-summary",
+      props.teamId,
+      props.clientId,
+      props.authToken,
+      props.startDate,
+      props.endDate,
+    ],
+    queryFn: async () => {
+      const data = await getTransactionAnalyticsSummary({
+        clientId: props.clientId,
+        teamId: props.teamId,
+        authToken: props.authToken,
+        startDate: props.startDate,
+        endDate: props.endDate,
+      });
+      return data;
+    },
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+  });
+
   return (
-    <TransactionAnalyticsSummaryUI data={props.initialData} isPending={false} />
+    <TransactionAnalyticsSummaryUI
+      data={engineTxSummaryQuery.data}
+      isPending={engineTxSummaryQuery.isPending}
+    />
   );
 }

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/transactions/analytics/tx-chart/tx-chart.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/transactions/analytics/tx-chart/tx-chart.tsx
@@ -9,6 +9,7 @@ import {
 import { IntervalSelector } from "@/components/analytics/interval-selector";
 import { normalizeTimeISOString } from "@/lib/time";
 import type { Wallet } from "../../server-wallets/wallet-table/types";
+import { TransactionAnalyticsSummary } from "../summary";
 import { getTransactionsChartData } from "./data";
 import { TransactionsChartCardUI } from "./tx-chart-ui";
 
@@ -21,12 +22,15 @@ export function TransactionsAnalytics(props: {
   const [range, setRange] = useState(() => getLastNDaysRange("last-30"));
   const [interval, setInterval] = useState<"day" | "week">("day");
 
+  const normalizedFrom = normalizeTimeISOString(range.from);
+  const normalizedTo = normalizeTimeISOString(range.to);
+
   const params = {
     clientId: props.project.publishableKey,
-    from: normalizeTimeISOString(range.from),
+    from: normalizedFrom,
     interval: interval,
     teamId: props.project.teamId,
-    to: normalizeTimeISOString(range.to),
+    to: normalizedTo,
     authToken: props.authToken,
   };
 
@@ -56,6 +60,13 @@ export function TransactionsAnalytics(props: {
           />
         </div>
       </div>
+      <TransactionAnalyticsSummary
+        authToken={props.authToken}
+        clientId={props.project.publishableKey}
+        teamId={props.project.teamId}
+        startDate={normalizedFrom}
+        endDate={normalizedTo}
+      />
       <TransactionsChartCardUI
         isPending={engineTxAnalytics.isPending}
         project={props.project}

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/transactions/lib/analytics-summary.client.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/transactions/lib/analytics-summary.client.tsx
@@ -27,8 +27,21 @@ export async function getTransactionAnalyticsSummary(props: {
   teamId: string;
   clientId: string;
   authToken: string;
+  startDate?: string;
+  endDate?: string;
 }): Promise<TransactionSummaryData> {
-  const body = {};
+  const body: {
+    startDate?: string;
+    endDate?: string;
+  } = {};
+
+  if (props.startDate) {
+    body.startDate = props.startDate;
+  }
+
+  if (props.endDate) {
+    body.endDate = props.endDate;
+  }
   const defaultData: TransactionSummaryData = {
     totalCount: 0,
     totalGasCostWei: "0",


### PR DESCRIPTION
Introduces start and end date parameters to transaction analytics summary queries, enabling date range filtering. Refactors the summary and chart components to use these parameters, ensuring analytics data reflects the selected date range. Removes the summary card from the analytics page and integrates it within the chart view for consistency.

Closes MNY-306

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces optional `startDate` and `endDate` parameters to enhance transaction analytics, enabling date filtering in the analytics summary and chart components.

### Detailed summary
- Added `startDate` and `endDate` parameters to the analytics summary client.
- Updated the `TransactionsAnalytics` component to use normalized date values.
- Integrated `TransactionAnalyticsSummary` with date filtering in the summary UI.
- Modified the `TransactionsAnalyticsPageContent` to utilize a default date range for queries.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transaction analytics now support customizable date range filtering, enabling users to analyze specific periods
  * Analytics default to displaying the last 30 days of transaction data for immediate insights
  * Users can select custom time periods to view transaction patterns and trends according to their analytical needs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->