### PR TITLE
[SDK] Update useAuthToken to find auth token for any connected wallet

### DIFF
--- a/.changeset/clean-tools-learn.md
+++ b/.changeset/clean-tools-learn.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Update useAuthToken() to find the auth token for any connected wallet instead of just the active one

--- a/packages/thirdweb/src/react/core/hooks/wallets/useAuthToken.ts
+++ b/packages/thirdweb/src/react/core/hooks/wallets/useAuthToken.ts
@@ -1,5 +1,8 @@
-import { useActiveAccount } from "./useActiveAccount.js";
-import { useActiveWallet } from "./useActiveWallet.js";
+import type {
+  EcosystemWallet,
+  InAppWallet,
+} from "../../../../wallets/in-app/core/wallet/types.js";
+import { useConnectedWallets } from "./useConnectedWallets.js";
 
 /**
  * A hook that returns the authentication token (JWT) for the currently active wallet.
@@ -26,16 +29,20 @@ import { useActiveWallet } from "./useActiveWallet.js";
  * @wallet
  */
 export function useAuthToken() {
-  const activeWallet = useActiveWallet();
-  const activeAccount = useActiveAccount();
-  // if the active wallet is an in-app wallet and the active account is the same as the active wallet's account, return the auth token for the in-app wallet
-  if (
-    activeWallet?.getAuthToken &&
-    activeAccount &&
-    activeAccount.address === activeWallet.getAccount()?.address
-  ) {
-    return activeWallet.getAuthToken();
+  const walletWithAuthToken = useWalletWithAuthToken();
+  // if any connected wallet has an auth token, return it
+  if (walletWithAuthToken) {
+    return walletWithAuthToken.getAuthToken();
   }
-  // all other wallets don't expose an auth token for now
+  // no wallet with an auth token found
   return null;
+}
+
+function useWalletWithAuthToken(): InAppWallet | EcosystemWallet | undefined {
+  const wallets = useConnectedWallets();
+  const wallet = wallets.find((w) => !!w.getAuthToken) as
+    | InAppWallet
+    | EcosystemWallet
+    | undefined;
+  return wallet ?? undefined;
 }


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `useAuthToken()` hook to retrieve the authentication token from any connected wallet instead of only the active one, enhancing flexibility in wallet management.

### Detailed summary
- Removed `useActiveWallet()` and `useActiveAccount()` imports.
- Introduced `useConnectedWallets()` to access all connected wallets.
- Modified `useAuthToken()` to return the auth token from any wallet with an auth token.
- Added `useWalletWithAuthToken()` function to find a wallet with an auth token.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed authentication token retrieval to search across all connected wallets instead of only the currently active wallet, improving token availability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->