### PR TITLE
default sort desc for tokens

### DIFF
--- a/packages/thirdweb/src/insight/get-tokens.ts
+++ b/packages/thirdweb/src/insight/get-tokens.ts
@@ -59,6 +59,7 @@ export async function getOwnedTokens(args: {
     owner_address: [ownerAddress],
     token_address: tokenAddresses ? tokenAddresses : undefined,
     sort_by: "balance",
+    sort_order: "desc",
   };
 
   const result = await getV1Tokens({


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new property to the token fetching function, specifically altering the sorting mechanism to order tokens in descending order based on their balance.

### Detailed summary
- Added `sort_order: "desc"` to the parameters in the function call to `getV1Tokens`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Token balances are now displayed in a consistent descending order by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->