### PR TITLE
[SDK] Rename otherWallets to allConnectedWallets in onConnect callback

### DIFF
--- a/packages/thirdweb/src/wallets/connection/types.ts
+++ b/packages/thirdweb/src/wallets/connection/types.ts
@@ -101,14 +101,14 @@ export type AutoConnectProps = {
    *
    * ```tsx
    * <AutoConnect
-   *  onConnect={(activeWallet, otherWallets) => {
+   *  onConnect={(activeWallet, allConnectedWallets) => {
    *    console.log("auto connected to", activeWallet)
-   *    console.log("other wallets that were also connected", otherWallets)
+   *    console.log("all connected wallets", allConnectedWallets)
    *  }}
    * />
    * ```
    */
-  onConnect?: (activeWallet: Wallet, otherWallets: Wallet[]) => void;
+  onConnect?: (activeWallet: Wallet, allConnectedWallets: Wallet[]) => void;
 
   /**
    * Optional chain to autoconnect to


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `onConnect` callback in the `AutoConnect` component to improve clarity in the variable names, changing `otherWallets` to `allConnectedWallets` and updating the corresponding console log message.

### Detailed summary
- Changed parameter name in `onConnect` from `otherWallets` to `allConnectedWallets`.
- Updated the console log message to reflect the new parameter name, changing from "other wallets that were also connected" to "all connected wallets".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Renamed the second parameter in the onConnect callback from "otherWallets" to "allConnectedWallets" (update any AutoConnect callback usage and examples accordingly).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->