### PR TITLE
[SDK] Rename otherWallet to allConnectedWallets in autoConnect callback

### DIFF
--- a/.changeset/clear-kiwis-rule.md
+++ b/.changeset/clear-kiwis-rule.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Rename otherWallet to allConnectedWallets in autoConnect onConnect callback

--- a/packages/thirdweb/src/wallets/connection/types.ts
+++ b/packages/thirdweb/src/wallets/connection/types.ts
@@ -1,5 +1,6 @@
 import type { Chain } from "../../chains/types.js";
 import type { ThirdwebClient } from "../../client/client.js";
+import type { OnConnectCallback } from "../../react/core/hooks/connection/types.js";
 import type { Wallet } from "../../wallets/interfaces/wallet.js";
 import type { SmartWalletOptions } from "../../wallets/smart/types.js";
 import type { AppMetadata } from "../../wallets/types.js";
@@ -108,7 +109,7 @@ export type AutoConnectProps = {
    * />
    * ```
    */
-  onConnect?: (activeWallet: Wallet, allConnectedWallets: Wallet[]) => void;
+  onConnect?: OnConnectCallback;
 
   /**
    * Optional chain to autoconnect to


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on renaming the parameter `otherWallet` to `allConnectedWallets` in the `autoConnect` `onConnect` callback and updating its type to `OnConnectCallback`.

### Detailed summary
- Updated the `onConnect` parameter in `AutoConnectProps` from `(activeWallet: Wallet, allConnectedWallets: Wallet[]) => void` to `OnConnectCallback`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->