### PR TITLE
[Dashboard] Move Contracts back to top level sidebar

### DIFF
--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/components/ProjectSidebarLayout.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/components/ProjectSidebarLayout.tsx
@@ -56,6 +56,11 @@ export function ProjectSidebarLayout(props: {
       ],
     },
     {
+      href: `${props.layoutPath}/contracts`,
+      icon: ContractIcon,
+      label: "Contracts",
+    },
+    {
       href: `${props.layoutPath}/x402`,
       icon: PayIcon,
       label: (
@@ -78,11 +83,6 @@ export function ProjectSidebarLayout(props: {
       href: `${props.layoutPath}/ai`,
       icon: NebulaIcon,
       label: "AI",
-    },
-    {
-      href: `${props.layoutPath}/contracts`,
-      icon: ContractIcon,
-      label: "Contracts",
     },
     {
       subMenu: {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a new entry for "Contracts" in the `ProjectSidebarLayout` component's sidebar, enhancing the navigation options available to users.

### Detailed summary
- Imported `ContractIcon` from `@/icons/ContractIcon`.
- Added a new sidebar item for "Contracts":
  - `href`: `${props.layoutPath}/contracts`
  - `icon`: `ContractIcon`
  - `label`: "Contracts"
- Removed the previous "Contracts" entry from the sidebar.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Contracts is now a top-level item in the project sidebar for improved navigation and visibility.
  * Contracts entry removed from the Gateway submenu to reduce duplication and streamline the sidebar.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->