### PR TITLE
[Portal] Feature: Add Copy Page button to documentation pages

### DIFF
--- a/apps/portal/src/components/Layouts/DocLayout.tsx
+++ b/apps/portal/src/components/Layouts/DocLayout.tsx
@@ -6,6 +6,7 @@ import {
   type SidebarLink,
 } from "../others/Sidebar";
 import { TableOfContentsSideBar } from "../others/TableOfContents";
+import { CopyPageButton } from "../others/CopyPageButton";
 
 export type SideBar = {
   name: string;
@@ -58,9 +59,12 @@ export function DocLayout(props: DocLayoutProps) {
         data-noindex={props.noIndex}
       >
         <div className="grow xl:mt-6">
-          <h5 className="mb-2 text-sm text-muted-foreground">
-            {props.sideBar.name}
-          </h5>
+          <div className="flex items-center justify-between mb-2">
+            <h5 className="text-sm text-muted-foreground">
+              {props.sideBar.name}
+            </h5>
+            <CopyPageButton />
+          </div>
           {props.children}
         </div>
         <div className="mt-16 xl:mt-20">

--- a/apps/portal/src/components/others/CopyPageButton.tsx
+++ b/apps/portal/src/components/others/CopyPageButton.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { CheckIcon, CopyIcon } from "lucide-react";
+import { useState } from "react";
+import { Button } from "../ui/button";
+
+export function CopyPageButton() {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      // Get the main content element
+      const mainElement = document.querySelector("main");
+      if (!mainElement) {
+        return;
+      }
+
+      // Get text content, preserving some structure
+      const textContent = mainElement.innerText || mainElement.textContent || "";
+
+      await navigator.clipboard.writeText(textContent);
+      setCopied(true);
+
+      // Reset after 2 seconds
+      setTimeout(() => {
+        setCopied(false);
+      }, 2000);
+    } catch (error) {
+      console.error("Failed to copy page content:", error);
+    }
+  };
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={handleCopy}
+      className="gap-2"
+    >
+      {copied ? (
+        <>
+          <CheckIcon className="size-4" />
+          Copied!
+        </>
+      ) : (
+        <>
+          <CopyIcon className="size-4" />
+          Copy Page
+        </>
+      )}
+    </Button>
+  );
+}


### PR DESCRIPTION
# Notes for the Reviewer

This PR adds a global **"Copy Page"** button to all documentation pages, allowing users to copy entire page content with one click instead of manually selecting text.

## Key Implementation Details
- Created new `CopyPageButton` client component using existing UI primitives and lucide-react icons  
- Integrated into `DocLayout.tsx` so it automatically appears on all documentation pages   
- No changes to individual MDX files required, works through layout injection  

## Files Changed
- `apps/portal/src/components/others/CopyPageButton.tsx` — **new (53 lines)**
- `apps/portal/src/components/Layouts/DocLayout.tsx` — **modified (7 insertions, 3 deletions)**

## Technical Notes
- Uses `innerText` to preserve readable text formatting  
- Follows existing patterns in codebase (similar to `CopyButton.tsx`)  

---

# How to Test

1. Run the portal locally:
   ```bash
   cd apps/portal
   pnpm dev


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `CopyPageButton` component to the `DocLayout`, allowing users to copy the content of the page. It modifies the layout to include this button and enhances the user interface by adjusting the structure of the sidebar.

### Detailed summary
- Added `CopyPageButton` import to `DocLayout`.
- Replaced the sidebar layout with a flex container for better alignment.
- Introduced the `CopyPageButton` component in `CopyPageButton.tsx`.
- Implemented clipboard functionality in `CopyPageButton` to copy page content.
- Added visual feedback for the copy action (changes button text and icon).

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Copy Page" button to documentation pages, enabling users to quickly copy page content to their clipboard with visual confirmation when the action completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->