### PR TITLE
Link to team billing page in faucet button on free plan

### DIFF
--- a/apps/dashboard/src/app/(app)/(dashboard)/(chain)/[chain_id]/(chainPage)/components/client/FaucetButton.tsx
+++ b/apps/dashboard/src/app/(app)/(dashboard)/(chain)/[chain_id]/(chainPage)/components/client/FaucetButton.tsx
@@ -3,6 +3,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { Turnstile } from "@marsidev/react-turnstile";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { CanClaimResponseType } from "app/(app)/api/testnet-faucet/can-claim/CanClaimResponseType";
+import { ArrowUpRightIcon } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useForm } from "react-hook-form";
@@ -192,6 +193,20 @@ export function FaucetButton({
 
   // Can not claim
   if (canClaimFaucetQuery.data && canClaimFaucetQuery.data.canClaim === false) {
+    if (canClaimFaucetQuery.data.type === "paid-plan-required") {
+      return (
+        <Button
+          asChild
+          className="w-full gap-2 whitespace-pre-wrap h-auto min-h-10 text-center bg-background"
+          variant="outline"
+        >
+          <Link href="/team/~/~/billing">
+            Faucet is not available on Free plan. Upgrade your plan to continue
+            <ArrowUpRightIcon className="size-4 shrink-0 text-muted-foreground" />
+          </Link>
+        </Button>
+      );
+    }
     return (
       <Button className="!opacity-100 w-full " disabled variant="outline">
         {canClaimFaucetQuery.data.type === "throttle" && (
@@ -203,10 +218,6 @@ export function FaucetButton({
 
         {canClaimFaucetQuery.data.type === "unsupported-chain" &&
           "Faucet is empty right now"}
-
-        {/* TODO: add an upsell path here to subscribe to one of these plans */}
-        {canClaimFaucetQuery.data.type === "paid-plan-required" &&
-          "Faucet is only available on Starter, Growth, Scale and Pro plans."}
       </Button>
     );
   }


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new user interface for the `FaucetButton` component that informs users on the `paid-plan-required` condition, encouraging them to upgrade their plan if they are on a free plan.

### Detailed summary
- Added a condition to check if `canClaimFaucetQuery.data.type` is `"paid-plan-required"`.
- If true, renders a `Button` linking to the billing page with a message about upgrading the plan.
- Removed a commented-out line regarding an upsell path for subscription plans.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Faucet button now provides a direct link to billing/subscription when claiming is blocked by plan limits and shows an inline arrow indicator for a clearer call-to-action.
* **Bug Fixes**
  * Retained the disabled button behavior and messages for throttle and unsupported-chain scenarios to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->