### PR TITLE
[SDK] Improve SIWE chain management for external wallets

### DIFF
--- a/.changeset/sweet-lights-help.md
+++ b/.changeset/sweet-lights-help.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Better SIWE chain management for all external wallets

--- a/packages/thirdweb/src/wallets/in-app/core/authentication/siwe.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/authentication/siwe.ts
@@ -10,6 +10,9 @@ import type { Ecosystem } from "../wallet/types.js";
 import { getLoginCallbackUrl, getLoginUrl } from "./getLoginPath.js";
 import type { AuthStoredTokenWithCookieReturnType } from "./types.js";
 
+// wallets that cannot sign with ethereum mainnet, require a specific chain always
+const NON_ETHEREUM_WALLETS = ["xyz.abs"];
+
 /**
  * @internal
  */
@@ -20,8 +23,10 @@ export async function siweAuthenticate(args: {
   ecosystem?: Ecosystem;
 }): Promise<AuthStoredTokenWithCookieReturnType> {
   const { wallet, client, ecosystem, chain } = args;
-  const siweChain = chain || getCachedChain(1); // fallback to mainnet for SIWE for wide wallet compatibility
-  // only connect if the wallet doesn't already have an account
+  const siweChain = NON_ETHEREUM_WALLETS.includes(wallet.id)
+    ? chain || getCachedChain(1)
+    : getCachedChain(1); // fallback to mainnet for SIWE for wide wallet compatibility
+  // only connect if the wallet doesn't alnready have an account
   const account =
     wallet.getAccount() || (await wallet.connect({ chain: siweChain, client }));
   const clientFetch = getClientFetch(client, ecosystem);


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the management of SIWE (Sign-In with Ethereum) chains for external wallets, particularly those that do not support the Ethereum mainnet.

### Detailed summary
- Added a constant `NON_ETHEREUM_WALLETS` to identify wallets that cannot sign with Ethereum mainnet.
- Updated `siweAuthenticate` function to conditionally set `siweChain` based on whether the wallet is in `NON_ETHEREUM_WALLETS`.
- Ensured fallback to mainnet for SIWE compatibility remains intact.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined SIWE chain management for external wallets to maintain consistent authentication behavior across all wallet types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->