### PR TITLE
[SDK] Add fundWalletLink prop to x402 responses

### DIFF
--- a/.changeset/real-bugs-boil.md
+++ b/.changeset/real-bugs-boil.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Add fundWalletLink prop to x402 responses

--- a/packages/thirdweb/src/x402/schemas.ts
+++ b/packages/thirdweb/src/x402/schemas.ts
@@ -41,6 +41,7 @@ export type RequestedPaymentRequirements = z.infer<
 const FacilitatorSettleResponseSchema = SettleResponseSchema.extend({
   network: FacilitatorNetworkSchema,
   errorMessage: z.string().optional(),
+  fundWalletLink: z.string().optional(),
 });
 export type FacilitatorSettleResponse = z.infer<
   typeof FacilitatorSettleResponseSchema
@@ -48,6 +49,7 @@ export type FacilitatorSettleResponse = z.infer<
 
 const FacilitatorVerifyResponseSchema = VerifyResponseSchema.extend({
   errorMessage: z.string().optional(),
+  fundWalletLink: z.string().optional(),
 });
 
 export type FacilitatorVerifyResponse = z.infer<

--- a/packages/thirdweb/src/x402/settle-payment.ts
+++ b/packages/thirdweb/src/x402/settle-payment.ts
@@ -167,6 +167,7 @@ export async function settlePayment(
           error,
           errorMessage:
             errorMessages?.settlementFailed || settlement.errorMessage,
+          fundWalletLink: settlement.fundWalletLink,
           accepts: paymentRequirements,
         },
       };

--- a/packages/thirdweb/src/x402/types.ts
+++ b/packages/thirdweb/src/x402/types.ts
@@ -58,6 +58,8 @@ export type PaymentRequiredResult = {
     accepts: RequestedPaymentRequirements[];
     /** Optional payer address if verification partially succeeded */
     payer?: string;
+    /** Optional link to a wallet to fund the wallet of the payer */
+    fundWalletLink?: string;
   };
   /** Response headers for the error response */
   responseHeaders: Record<string, string>;

--- a/packages/thirdweb/src/x402/verify-payment.ts
+++ b/packages/thirdweb/src/x402/verify-payment.ts
@@ -112,6 +112,7 @@ export async function verifyPayment(
           error: error,
           errorMessage:
             errorMessages?.verificationFailed || verification.errorMessage,
+          fundWalletLink: verification.fundWalletLink,
           accepts: paymentRequirements,
         },
       };


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new optional property, `fundWalletLink`, to the x402 responses in the `thirdweb` package, enhancing the functionality of payment settlement and verification processes.

### Detailed summary
- Added `fundWalletLink` to the response in `settle-payment.ts`.
- Added `fundWalletLink` to the response in `verify-payment.ts`.
- Updated `types.ts` to include `fundWalletLink` as an optional string.
- Updated `schemas.ts` to add `fundWalletLink` in `FacilitatorSettleResponseSchema` and `FacilitatorVerifyResponseSchema`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Payment verification and settlement error responses now include an optional wallet funding link, enabling users to quickly resolve payment issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->