### PR TITLE
Port gas sponsorship analytics to Team usage tab

### DIFF
--- a/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/usage/account-abstraction/page.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/usage/account-abstraction/page.tsx
@@ -1,26 +1,37 @@
 import { redirect } from "next/navigation";
+import type { SearchParams } from "nuqs/server";
+import { getUserOpUsage } from "@/api/analytics";
 import { getAuthToken } from "@/api/auth-token";
 import { getProjects } from "@/api/project/projects";
 import { getTeamBySlug } from "@/api/team/get-team";
 import { getTeamSubscriptions } from "@/api/team/team-subscription";
-import { SponsoredTransactionsTable } from "@/components/sponsored-transactions-table/SponsoredTransactionsTable";
+import {
+  getLastNDaysRange,
+  type Range,
+} from "@/components/analytics/date-range-selector";
 import { getClientThirdwebClient } from "@/constants/thirdweb-client.client";
 import { loginRedirect } from "@/utils/redirects";
+import { AccountAbstractionSummary } from "../../../../[project_slug]/(sidebar)/account-abstraction/AccountAbstractionAnalytics/AccountAbstractionSummary";
+import { AccountAbstractionAnalytics } from "../../../../[project_slug]/(sidebar)/account-abstraction/aa-analytics";
+import { searchParamLoader } from "../../../../[project_slug]/(sidebar)/account-abstraction/search-params";
 
 export default async function Page(props: {
   params: Promise<{
     team_slug: string;
   }>;
+  searchParams: Promise<SearchParams>;
 }) {
-  const params = await props.params;
-  const [team, authToken] = await Promise.all([
-    getTeamBySlug(params.team_slug),
+  const [params, parsedSearchParams, authToken] = await Promise.all([
+    props.params,
+    searchParamLoader(props.searchParams),
     getAuthToken(),
   ]);
 
   if (!authToken) {
     loginRedirect(`/team/${params.team_slug}/~/usage/account-abstraction`);
   }
+
+  const team = await getTeamBySlug(params.team_slug);
 
   if (!team) {
     redirect("/team");
@@ -44,20 +55,51 @@ export default async function Page(props: {
     );
   }
 
+  const interval = parsedSearchParams.interval ?? "week";
+  const rangeType = parsedSearchParams.range || "last-120";
+
+  const range: Range = {
+    from:
+      rangeType === "custom"
+        ? parsedSearchParams.from
+        : getLastNDaysRange(rangeType).from,
+    to:
+      rangeType === "custom"
+        ? parsedSearchParams.to
+        : getLastNDaysRange(rangeType).to,
+    type: rangeType,
+  };
+
+  const userOpStats = await getUserOpUsage(
+    {
+      from: range.from,
+      period: interval,
+      teamId: team.id,
+      to: range.to,
+    },
+    authToken,
+  );
+
   const client = getClientThirdwebClient({
     jwt: authToken,
     teamId: team.id,
   });
 
   return (
-    <div className="flex flex-col gap-14">
-      <SponsoredTransactionsTable
+    <div className="flex flex-col gap-10">
+      <AccountAbstractionSummary
+        authToken={authToken}
+        teamId={team.id}
+        from={range.from}
+        to={range.to}
+      />
+
+      <AccountAbstractionAnalytics
         client={client}
-        from={usageSubscription.currentPeriodStart}
         projects={projects}
         teamId={team.id}
         teamSlug={team.slug}
-        to={usageSubscription.currentPeriodEnd}
+        userOpStats={userOpStats}
         variant="team"
       />
     </div>

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/account-abstraction/AccountAbstractionAnalytics/AccountAbstractionSummary.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/account-abstraction/AccountAbstractionAnalytics/AccountAbstractionSummary.tsx
@@ -34,13 +34,17 @@ function AccountAbstractionSummaryInner(props: {
 
 async function AsyncAccountAbstractionSummary(props: {
   teamId: string;
-  projectId: string;
+  projectId?: string;
   authToken: string;
+  from?: Date;
+  to?: Date;
 }) {
   const aggregateUserOpStats = await getAggregateUserOpUsage(
     {
       projectId: props.projectId,
       teamId: props.teamId,
+      from: props.from,
+      to: props.to,
     },
     props.authToken,
   );
@@ -55,8 +59,10 @@ async function AsyncAccountAbstractionSummary(props: {
 
 export function AccountAbstractionSummary(props: {
   teamId: string;
-  projectId: string;
+  projectId?: string;
   authToken: string;
+  from?: Date;
+  to?: Date;
 }) {
   return (
     <Suspense
@@ -71,6 +77,8 @@ export function AccountAbstractionSummary(props: {
         projectId={props.projectId}
         teamId={props.teamId}
         authToken={props.authToken}
+        from={props.from}
+        to={props.to}
       />
     </Suspense>
   );

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/wallets/sponsored-gas/page.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/wallets/sponsored-gas/page.tsx
@@ -99,10 +99,13 @@ export default async function Page(props: {
           projectId={project.id}
           teamId={project.teamId}
           authToken={authToken}
+          from={range.from}
+          to={range.to}
         />
 
         <AccountAbstractionAnalytics
           client={client}
+          variant="project"
           projectId={project.id}
           teamId={project.teamId}
           teamSlug={params.team_slug}


### PR DESCRIPTION
Updated AccountAbstractionAnalytics to support both team and project variants, allowing for flexible rendering based on context. Refactored usage and summary components to accept optional projectId, and updated the team usage page to use the new analytics and summary components. Adjusted SponsoredTransactionsTable usage to match the new props structure.

Closes BLD-500

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `AccountAbstractionAnalytics` and `AccountAbstractionSummary` components by adding support for date range parameters and making the `projectId` optional. It also updates the `Page` component to handle search parameters for analytics.

### Detailed summary
- Added `from` and `to` props to `AccountAbstractionSummary` and `AccountAbstractionAnalytics`.
- Made `projectId` optional in `AsyncAccountAbstractionSummary` and `AccountAbstractionSummary`.
- Updated `AccountAbstractionAnalytics` to handle different variants (project/team).
- Refactored `Page` to process search parameters for date ranges.
- Integrated `AccountAbstractionSummary` and `AccountAbstractionAnalytics` into the main `Page` layout.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added search parameter support for usage views and explicit date-range (from/to) filtering.
  * Analytics can render as team- or project-level variants.

* **Improvements**
  * Summary and analytics are separated (summary first, analytics after) with improved spacing and conditional rendering when ranges are provided.
  * Project scope is now optional for summaries; data loading sequence refined to ensure auth, params, and usage metrics are resolved before render.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->