### PR TITLE
[SDK] Skip chain switching for Coinbase Wallet if already on correct chain

### DIFF
--- a/.changeset/vast-nails-wash.md
+++ b/.changeset/vast-nails-wash.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Dont attempt chain switching for cb wallet if already connected to the right chain

--- a/packages/thirdweb/src/wallets/coinbase/coinbase-web.ts
+++ b/packages/thirdweb/src/wallets/coinbase/coinbase-web.ts
@@ -474,6 +474,16 @@ async function switchChainCoinbaseWalletSDK(
   provider: ProviderInterface,
   chain: Chain,
 ) {
+  // check if chain is already connected
+  const connectedChainId = (await provider.request({
+    method: "eth_chainId",
+  })) as string | number;
+  const connectedChain = getCachedChain(normalizeChainId(connectedChainId));
+  if (connectedChain?.id === chain.id) {
+    // chain is already connected, no need to switch
+    return;
+  }
+
   const chainIdHex = numberToHex(chain.id);
 
   try {


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `thirdweb` wallet functionality by preventing unnecessary chain switching for the `cb wallet` if it is already connected to the correct blockchain.

### Detailed summary
- Added a check to see if the current connected chain matches the desired chain in `coinbase-web.ts`.
- If the chains match, the function returns early, avoiding unnecessary chain switching.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized Coinbase wallet chain switching to skip redundant operations when already connected to the target network, improving performance and reducing unnecessary network requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->