### PR TITLE
Add daily revalidation to TypeScript pages

### DIFF
--- a/apps/portal/src/app/contracts/extensions/page.tsx
+++ b/apps/portal/src/app/contracts/extensions/page.tsx
@@ -77,3 +77,5 @@ export default async function ExtensionPage() {
     </>
   );
 }
+
+export const revalidate = 86400; // revalidate every day

--- a/apps/portal/src/app/contracts/layout.tsx
+++ b/apps/portal/src/app/contracts/layout.tsx
@@ -19,3 +19,5 @@ export const metadata = createMetadata({
   },
   title: "Contracts",
 });
+
+export const revalidate = 86400; // revalidate every day

--- a/apps/portal/src/app/react/v5/[...slug]/page.tsx
+++ b/apps/portal/src/app/react/v5/[...slug]/page.tsx
@@ -27,3 +27,5 @@ export default async function Page(props: PageProps) {
 
   notFound();
 }
+
+export const revalidate = 86400; // revalidate every day

--- a/apps/portal/src/app/react/v5/layout.tsx
+++ b/apps/portal/src/app/react/v5/layout.tsx
@@ -20,3 +20,5 @@ export const metadata = createMetadata({
     "A type-safe library to interact with any EVM-compatible blockchain in React applications.",
   title: "thirdweb React SDK",
 });
+
+export const revalidate = 86400; // revalidate every day

--- a/apps/portal/src/app/references/typescript/[version]/[[...slug]]/page.tsx
+++ b/apps/portal/src/app/references/typescript/[version]/[[...slug]]/page.tsx
@@ -14,3 +14,5 @@ const config = getTDocPage({
 export default config.default;
 export const generateStaticParams = config.generateStaticParams;
 export const generateMetadata = config.generateMetadata;
+
+export const revalidate = 86400; // revalidate every day

--- a/apps/portal/src/app/typescript/v5/[...slug]/page.tsx
+++ b/apps/portal/src/app/typescript/v5/[...slug]/page.tsx
@@ -28,3 +28,5 @@ export default async function Page(props: PageProps) {
 
   notFound();
 }
+
+export const revalidate = 86400; // revalidate every day

--- a/apps/portal/src/app/typescript/v5/layout.tsx
+++ b/apps/portal/src/app/typescript/v5/layout.tsx
@@ -20,3 +20,5 @@ export const metadata = createMetadata({
     "A type-safe library to interact with any EVM-compatible blockchain in Node, web and native applications.",
   title: "thirdweb TypeScript SDK",
 });
+
+export const revalidate = 86400; // revalidate every day


### PR DESCRIPTION
Added daily revalidation to TypeScript reference pages

This PR adds a revalidation period of 24 hours (86400 seconds) to TypeScript reference pages to ensure content stays fresh while minimizing unnecessary rebuilds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled daily automatic revalidation across multiple portal pages and layouts, causing affected pages to refresh their cached content every 24 hours to improve content freshness and reduce risk of stale data for end users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new constant, `revalidate`, set to `86400` seconds (one day) in multiple files across the project to manage data revalidation periods.

### Detailed summary
- Added `export const revalidate = 86400; // revalidate every day` in:
  - `apps/portal/src/app/contracts/extensions/page.tsx`
  - `apps/portal/src/app/react/v5/[...slug]/page.tsx`
  - `apps/portal/src/app/contracts/layout.tsx`
  - `apps/portal/src/app/typescript/v5/[...slug]/page.tsx`
  - `apps/portal/src/app/react/v5/layout.tsx`
  - `apps/portal/src/app/typescript/v5/layout.tsx`
  - `apps/portal/src/app/references/typescript/[version]/[[...slug]]/page.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->