### PR TITLE
[PRO-130] Move RPC methods chart from project overview to RPC tab

### DIFF
--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/components/RpcMethodBarChartCard/RpcMethodBarChartCardUI.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/components/RpcMethodBarChartCard/RpcMethodBarChartCardUI.tsx
@@ -109,8 +109,8 @@ export function RpcMethodBarChartCardUI({
 
   return (
     <Card>
-      <CardHeader className="flex flex-col items-stretch space-y-0 border-b p-0">
-        <div className="flex flex-1 flex-col justify-center gap-1 p-6">
+      <CardHeader className="flex flex-col items-stretch space-y-0 p-0">
+        <div className="flex flex-1 flex-col justify-center gap-1 p-6 pb-0">
           <CardTitle className="font-semibold text-lg">RPC Methods</CardTitle>
         </div>
       </CardHeader>

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/gateway/rpc/components/MethodsTable.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/gateway/rpc/components/MethodsTable.tsx
@@ -4,7 +4,6 @@ import type { ThirdwebClient } from "thirdweb";
 import { shortenLargeNumber } from "thirdweb/utils";
 import type { RpcMethodStats } from "@/api/analytics";
 import { PaginationButtons } from "@/components/blocks/pagination-buttons";
-import { Card } from "@/components/ui/card";
 import { SkeletonContainer } from "@/components/ui/skeleton";
 import {
   Table,
@@ -15,7 +14,6 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { CardHeading } from "../../../payments/components/common";
 
 export function TopRPCMethodsTable(props: {
   data: RpcMethodStats[];
@@ -41,18 +39,22 @@ export function TopRPCMethodsTable(props: {
   const isEmpty = useMemo(() => sortedData.length === 0, [sortedData]);
 
   return (
-    <Card className="relative flex flex-col rounded-xl border border-border bg-card p-4">
+    <div className="rounded-lg border bg-card">
       {/* header */}
-      <div className="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
-        <CardHeading>Top EVM Methods Called </CardHeading>
+      <div className="p-6 border-b">
+        <h2 className="tracking-tight font-semibold text-lg">
+          Top EVM Methods Called
+        </h2>
       </div>
 
-      <div className="h-5" />
-      <TableContainer scrollableContainerClassName="h-[280px]">
+      <TableContainer
+        scrollableContainerClassName="max-h-[380px] min-h-[200px]"
+        className="border-none"
+      >
         <Table>
           <TableHeader className="sticky top-0 z-10 bg-background">
             <TableRow>
-              <TableHead>Method</TableHead>
+              <TableHead className="lg:w-[320px]">Method</TableHead>
               <TableHead>Requests</TableHead>
             </TableRow>
           </TableHeader>
@@ -85,7 +87,7 @@ export function TopRPCMethodsTable(props: {
           />
         </div>
       )}
-    </Card>
+    </div>
   );
 }
 

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/gateway/rpc/components/RequestsGraph.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/gateway/rpc/components/RequestsGraph.tsx
@@ -33,12 +33,11 @@ export function RequestsGraph(props: { data: RpcUsageTypeStats[] }) {
           [] as { requests: number; time: string }[],
         )}
       header={{
-        description: "Requests over time.",
         title: "RPC Requests",
+        titleClassName: "tracking-tight font-semibold text-lg",
       }}
       hideLabel={false}
       isPending={false}
-      showLegend
       toolTipLabelFormatter={(label) => {
         return format(label, "MMM dd, HH:mm");
       }}
@@ -48,7 +47,6 @@ export function RequestsGraph(props: { data: RpcUsageTypeStats[] }) {
       xAxis={{
         sameDay: true,
       }}
-      yAxis
     />
   );
 }

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/gateway/rpc/components/RpcAnalytics.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/gateway/rpc/components/RpcAnalytics.tsx
@@ -3,8 +3,10 @@ import { ResponsiveSuspense } from "responsive-rsc";
 import type { ThirdwebClient } from "thirdweb";
 import { getRpcMethodUsage, getRpcUsageByType } from "@/api/analytics";
 import type { Range } from "@/components/analytics/date-range-selector";
+import { LoadingChartState } from "@/components/analytics/empty-chart-state";
 import { StatCard } from "@/components/analytics/stat";
 import { Skeleton } from "@/components/ui/skeleton";
+import { RpcMethodBarChartCardAsync } from "../../../components/RpcMethodBarChartCard";
 import { TopRPCMethodsTable } from "./MethodsTable";
 import { RequestsGraph } from "./RequestsGraph";
 import { RpcAnalyticsFilter } from "./RpcAnalyticsFilter";
@@ -102,6 +104,24 @@ export async function RPCAnalytics(props: {
             data={evmMethodsData || []}
           />
         </div>
+      </ResponsiveSuspense>
+
+      <div className="h-6" />
+
+      <ResponsiveSuspense
+        fallback={<LoadingChartState className="h-[377px] border" />}
+        searchParamsUsed={["from", "to", "interval"]}
+      >
+        <RpcMethodBarChartCardAsync
+          params={{
+            from: range.from,
+            period: interval,
+            projectId: projectId,
+            teamId: teamId,
+            to: range.to,
+          }}
+          authToken={authToken}
+        />
       </ResponsiveSuspense>
     </div>
   );

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/page.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/page.tsx
@@ -41,7 +41,6 @@ import { PieChartCard } from "../../../components/Analytics/PieChartCard";
 import { EngineCloudChartCardAsync } from "./components/EngineCloudChartCard";
 import { ProjectFTUX } from "./components/ProjectFTUX/ProjectFTUX";
 import { ProjectWalletSection } from "./components/project-wallet/project-wallet";
-import { RpcMethodBarChartCardAsync } from "./components/RpcMethodBarChartCard";
 import { TransactionsChartCardAsync } from "./components/Transactions";
 import { ProjectHighlightsCard } from "./overview/highlights-card";
 import { TotalSponsoredCardUI } from "./overview/total-sponsored";
@@ -269,22 +268,6 @@ async function ProjectAnalytics(props: {
               : undefined
           }
           selectedChartQueryParam="totalSponsored"
-          authToken={authToken}
-        />
-      </ResponsiveSuspense>
-
-      <ResponsiveSuspense
-        fallback={<LoadingChartState className="h-[377px] border" />}
-        searchParamsUsed={["from", "to", "interval"]}
-      >
-        <RpcMethodBarChartCardAsync
-          params={{
-            from: range.from,
-            period: interval,
-            projectId: project.id,
-            teamId: project.teamId,
-            to: range.to,
-          }}
           authToken={authToken}
         />
       </ResponsiveSuspense>


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the UI components related to the RPC analytics dashboard, enhancing styling, and improving the layout of various charts and tables.

### Detailed summary
- Added `titleClassName` to `RequestsGraph` header for improved styling.
- Removed `showLegend` from `RequestsGraph`.
- Simplified `CardHeader` and adjusted padding in `RpcMethodBarChartCardUI`.
- Reintroduced `RpcMethodBarChartCardAsync` in `RPCAnalytics`.
- Updated layout and styling in `TopRPCMethodsTable`, replacing `Card` with a `div`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->