### PR TITLE
[SDK] Add Monad chain definition

### DIFF
--- a/.changeset/angry-monkeys-dress.md
+++ b/.changeset/angry-monkeys-dress.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Add customization options for the signIn modal shown from useFetchWithPayment

--- a/.changeset/moody-camels-hear.md
+++ b/.changeset/moody-camels-hear.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Add monad chain definition

--- a/packages/thirdweb/src/chains/chain-definitions/monad.ts
+++ b/packages/thirdweb/src/chains/chain-definitions/monad.ts
@@ -1,0 +1,20 @@
+import { defineChain } from "../utils.js";
+
+/**
+ * @chain
+ */
+export const monad = /*@__PURE__*/ defineChain({
+  blockExplorers: [
+    {
+      name: "Monad Vision",
+      url: "https://monadvision.com/",
+    },
+    {
+      name: "Monad Scan",
+      url: "https://monadscan.com/",
+    },
+  ],
+  id: 143,
+  name: "Monad",
+  nativeCurrency: { decimals: 18, name: "Mon", symbol: "MON" },
+});

--- a/packages/thirdweb/src/exports/chains.ts
+++ b/packages/thirdweb/src/exports/chains.ts
@@ -52,6 +52,7 @@ export { mantaPacificTestnet } from "../chains/chain-definitions/manta-pacific-t
 export { metalL2Testnet } from "../chains/chain-definitions/metal-l2-testnet.js";
 export { mode } from "../chains/chain-definitions/mode.js";
 export { modeTestnet } from "../chains/chain-definitions/mode-testnet.js";
+export { monad } from "../chains/chain-definitions/monad.js";
 export { monadTestnet } from "../chains/chain-definitions/monad-testnet.js";
 export { moonbeam } from "../chains/chain-definitions/moonbeam.js";
 export { optimism } from "../chains/chain-definitions/optimism.js";

--- a/packages/thirdweb/src/react/core/hooks/others/useInvalidateBalances.ts
+++ b/packages/thirdweb/src/react/core/hooks/others/useInvalidateBalances.ts
@@ -12,7 +12,7 @@ import { invalidateWalletBalance } from "../../providers/invalidateWalletBalance
 export function useInvalidateBalances() {
   const queryClient = useQueryClient();
 
-  return ({ chainId }: { chainId?: number }) => {
+  return ({ chainId }: { chainId?: number } = {}) => {
     invalidateWalletBalance(queryClient, chainId);
   };
 }

--- a/packages/thirdweb/src/react/core/hooks/x402/useFetchWithPaymentCore.ts
+++ b/packages/thirdweb/src/react/core/hooks/x402/useFetchWithPaymentCore.ts
@@ -99,8 +99,9 @@ export function useFetchWithPaymentCore(
                   errorData: errorBody,
                   onRetry: async () => {
                     // Retry the entire fetch+error handling logic recursively
+                    // Pass currentWallet to avoid re-showing connect modal with stale wallet state
                     try {
-                      const result = await executeFetch();
+                      const result = await executeFetch(currentWallet);
                       resolve(result);
                     } catch (error) {
                       reject(error);

--- a/packages/thirdweb/src/react/web/hooks/x402/useFetchWithPayment.tsx
+++ b/packages/thirdweb/src/react/web/hooks/x402/useFetchWithPayment.tsx
@@ -46,6 +46,17 @@ type UseFetchWithPaymentConfig = UseFetchWithPaymentOptions & {
    * These options will be merged with the client, theme, and chain from the hook.
    */
   connectOptions?: Omit<UseConnectModalOptions, "client" | "theme">;
+  /**
+   * Options to customize the SignInRequiredModal that appears when the user needs to sign in.
+   */
+  signInRequiredModal?: {
+    /** Custom title for the modal header */
+    title?: string;
+    /** Custom description text */
+    description?: string;
+    /** Custom label for the sign in button */
+    buttonLabel?: string;
+  };
 };
 
 /**
@@ -73,6 +84,7 @@ type UseFetchWithPaymentConfig = UseFetchWithPaymentOptions & {
  * @param options.theme - Theme for the payment error modal (defaults to "dark")
  * @param options.fundWalletOptions - Customize the BuyWidget shown when user needs to fund their wallet
  * @param options.connectOptions - Customize the ConnectModal shown when user needs to sign in
+ * @param options.signInRequiredModal - Customize the SignInRequiredModal shown when user needs to sign in (title, description, buttonLabel)
  * @returns An object containing:
  * - `fetchWithPayment`: Function to make fetch requests with automatic payment handling (returns parsed data)
  * - `isPending`: Boolean indicating if a request is in progress
@@ -146,6 +158,17 @@ type UseFetchWithPaymentConfig = UseFetchWithPaymentOptions & {
  * });
  * ```
  *
+ * ### Customize the sign in required modal
+ * ```tsx
+ * const { fetchWithPayment } = useFetchWithPayment(client, {
+ *   signInRequiredModal: {
+ *     title: "Authentication Required",
+ *     description: "Please sign in to access this paid content.",
+ *     buttonLabel: "Connect Wallet",
+ *   }
+ * });
+ * ```
+ *
  * ### Disable the UI and handle errors yourself
  * ```tsx
  * const { fetchWithPayment, error } = useFetchWithPayment(client, {
@@ -201,6 +224,9 @@ export function useFetchWithPayment(
         setRootEl(
           <SignInRequiredModal
             theme={theme}
+            title={options?.signInRequiredModal?.title}
+            description={options?.signInRequiredModal?.description}
+            buttonLabel={options?.signInRequiredModal?.buttonLabel}
             onSignIn={async () => {
               // Close the SignInRequiredModal
               setRootEl(null);

--- a/packages/thirdweb/src/react/web/ui/x402/SignInRequiredModal.tsx
+++ b/packages/thirdweb/src/react/web/ui/x402/SignInRequiredModal.tsx
@@ -15,13 +15,23 @@ type SignInRequiredModalProps = {
   theme: Theme | "light" | "dark";
   onSignIn: () => void;
   onCancel: () => void;
+  title?: string;
+  description?: string;
+  buttonLabel?: string;
 };
 
 /**
  * @internal
  */
 export function SignInRequiredModal(props: SignInRequiredModalProps) {
-  const { theme, onSignIn, onCancel } = props;
+  const {
+    theme,
+    onSignIn,
+    onCancel,
+    title = "Sign in required",
+    description = "Account required to complete payment, please sign in to continue.",
+    buttonLabel = "Sign in",
+  } = props;
 
   return (
     <CustomThemeProvider theme={theme}>
@@ -35,10 +45,10 @@ export function SignInRequiredModal(props: SignInRequiredModalProps) {
           }
         }}
         size="compact"
-        title="Sign in required"
+        title={title}
       >
         <Container p="lg">
-          <ModalHeader title="Sign in required" />
+          <ModalHeader title={title} />
 
           <Container
             flex="column"
@@ -55,7 +65,7 @@ export function SignInRequiredModal(props: SignInRequiredModalProps) {
                 lineHeight: 1.5,
               }}
             >
-              Account required to complete payment, please sign in to continue.
+              {description}
             </Text>
           </Container>
         </Container>
@@ -63,7 +73,7 @@ export function SignInRequiredModal(props: SignInRequiredModalProps) {
         {/* Action Buttons */}
         <ScreenBottomContainer>
           <Button fullWidth gap="xs" onClick={onSignIn} variant="accent">
-            Sign in
+            {buttonLabel}
           </Button>
           <Button fullWidth gap="xs" onClick={onCancel} variant="secondary">
             Cancel


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `SignInRequiredModal` in the `thirdweb` library by adding customization options and introducing a new blockchain definition for `monad`. It also updates the `useFetchWithPayment` hook to support these new features.

### Detailed summary
- Added `monad` chain definition with explorers and native currency.
- Introduced customization options (`title`, `description`, `buttonLabel`) for `SignInRequiredModal`.
- Updated `useFetchWithPayment` to accept customization options for the modal.
- Modified `SignInRequiredModal` to utilize new props for dynamic content.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for the Monad blockchain (native currency and block explorer integrations).
  * Customizable sign-in modal options (title, description, button label) for the fetch-with-payment flow.
  * make balance invalidation callable without arguments for convenience.

* **Bug Fixes**
  * Preserve the current wallet during payment retry to avoid re-showing the connect modal with stale state.

* **Chores**
  * Added changeset entries for patch releases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->