### PR TITLE
[SDK] Support ERC5792 batch transactions for swaps, add slippage option to Bridge API

### DIFF
--- a/.changeset/thirty-banks-itch.md
+++ b/.changeset/thirty-banks-itch.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": minor
+---
+
+Support erc5792 batch transactions for swaps, add slippage option to Bridge API

--- a/packages/thirdweb/src/bridge/Buy.ts
+++ b/packages/thirdweb/src/bridge/Buy.ts
@@ -366,6 +366,7 @@ export async function prepare(
     purchaseData,
     maxSteps,
     paymentLinkId,
+    slippageToleranceBps,
   } = options;
 
   const clientFetch = getClientFetch(client);
@@ -384,6 +385,7 @@ export async function prepare(
       purchaseData,
       receiver,
       sender,
+      slippageToleranceBps,
     }),
     headers: {
       "Content-Type": "application/json",
@@ -460,6 +462,8 @@ export declare namespace prepare {
     purchaseData?: PurchaseData;
     /** Maximum number of steps in the route */
     maxSteps?: number;
+    /** The maximum slippage in basis points (bps) allowed for the transaction. */
+    slippageToleranceBps?: number;
     /**
      * @hidden
      */

--- a/packages/thirdweb/src/bridge/Sell.ts
+++ b/packages/thirdweb/src/bridge/Sell.ts
@@ -352,6 +352,7 @@ export async function prepare(
     purchaseData,
     maxSteps,
     paymentLinkId,
+    slippageToleranceBps,
   } = options;
 
   const clientFetch = getClientFetch(client);
@@ -370,6 +371,7 @@ export async function prepare(
       receiver,
       sellAmountWei: amount.toString(),
       sender,
+      slippageToleranceBps,
     }),
     headers: {
       "Content-Type": "application/json",
@@ -448,6 +450,8 @@ export declare namespace prepare {
     purchaseData?: PurchaseData;
     /** Maximum number of steps in the route */
     maxSteps?: number;
+    /** The maximum slippage in basis points (bps) allowed for the transaction. */
+    slippageToleranceBps?: number;
     /**
      * @hidden
      */

--- a/packages/thirdweb/src/react/web/ui/Bridge/swap-widget/use-tokens.ts
+++ b/packages/thirdweb/src/react/web/ui/Bridge/swap-widget/use-tokens.ts
@@ -116,8 +116,6 @@ export function useTokenBalances(options: {
       const json = (await response.json()) as TokenBalancesResponse;
       return json.result;
     },
-    refetchOnMount: false,
-    retry: false,
-    refetchOnWindowFocus: false,
+    refetchOnMount: "always",
   });
 }


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces support for `erc5792` batch transactions in the `thirdweb` library, enhancing the `Bridge` API with a slippage option for transactions. It also includes updates to the `SuccessScreen` component and the `useStepExecutor` hook for better transaction handling.

### Detailed summary
- Added support for `erc5792` batch transactions in the `useStepExecutor` hook.
- Introduced `slippageToleranceBps` option in `Buy.ts` and `Sell.ts` for transaction slippage control.
- Enhanced `SuccessScreen` to track payment events and invalidate queries upon success.
- Updated `useStepExecutor` to handle batch execution and send calls if supported.
- Added a gas buffer of `50000n` for transaction preparation.
- Implemented a function to check if atomic transactions are supported for accounts.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * EIP-5792 batch transaction support for swaps, enabling more efficient/atomic swap execution where supported.
  * Optional slippage tolerance parameter for Bridge Buy and Sell to improve price protection.
  * Transfer success tracking on payment success screens for analytics.

* **Improvements**
  * Token balance queries now always refresh on component mount for fresher balances.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->