### PR TITLE
[SDK] Add caching and timeout for fetching capabilities

### DIFF
--- a/.changeset/twelve-grapes-drop.md
+++ b/.changeset/twelve-grapes-drop.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Add caching and timeout for fetching capabilities

--- a/packages/thirdweb/src/wallets/eip5792/wait-for-calls-receipt.ts
+++ b/packages/thirdweb/src/wallets/eip5792/wait-for-calls-receipt.ts
@@ -94,8 +94,9 @@ export function waitForCallsReceipt(
             resolve(result);
             return;
           }
-        } catch {
-          // noop, we'll try again on the next blocks
+        } catch (error) {
+          // we'll try again on the next blocks
+          console.error("waitForCallsReceipt error", error);
         }
       },
     });

--- a/packages/thirdweb/src/wallets/injected/index.ts
+++ b/packages/thirdweb/src/wallets/injected/index.ts
@@ -378,7 +378,10 @@ function createAccount({
       try {
         const result = await provider.request({
           method: "wallet_getCapabilities",
-          params: [getAddress(account.address)],
+          params: [
+            getAddress(account.address),
+            chainIdFilter ? [numberToHex(chainIdFilter)] : undefined,
+          ],
         });
         return toGetCapabilitiesResult(result, chainIdFilter);
       } catch (error: unknown) {


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces caching and timeout mechanisms for fetching wallet capabilities, improving error handling and performance in the `thirdweb` package.

### Detailed summary
- Added caching for `supportsAtomic` results in `supportAtomicCache`.
- Implemented a 5-second timeout for fetching capabilities.
- Enhanced error handling in `waitForCallsReceipt` by logging errors.
- Updated parameters for `wallet_getCapabilities` to include an optional `chainIdFilter`.
- Threw an `ApiError` for transaction failures in `useStepExecutor`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced caching and timeout for capability checks to improve responsiveness and reduce repeated calls
  * Capability requests now support optional chain filtering for more accurate results

* **Bug Fixes**
  * Improved error handling for failed transaction receipts with clearer reporting
  * Enhanced error logging to aid troubleshooting and prevent hangs during capability verification

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->