### PR TITLE
[SDK] Add payment selection tracking

### DIFF
--- a/.changeset/large-cats-judge.md
+++ b/.changeset/large-cats-judge.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Payment selection tracking

--- a/packages/thirdweb/src/react/web/ui/Bridge/ErrorBanner.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/ErrorBanner.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { CrossCircledIcon } from "@radix-ui/react-icons";
-import { useQuery } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
 import { trackPayEvent } from "../../../../analytics/track/pay.js";
 import type { ThirdwebClient } from "../../../../client/client.js";
 import { useCustomTheme } from "../../../core/design-system/CustomThemeProvider.js";
@@ -38,17 +38,16 @@ export function ErrorBanner({
 
   const { userMessage } = useBridgeError({ error });
 
-  useQuery({
-    queryFn: () => {
-      trackPayEvent({
-        client,
-        error: error.message,
-        event: "ub:ui:error",
-      });
-      return true;
-    },
-    queryKey: ["error_banner", userMessage],
-  });
+  const hasFiredErrorEvent = useRef(false);
+  useEffect(() => {
+    if (hasFiredErrorEvent.current) return;
+    hasFiredErrorEvent.current = true;
+    trackPayEvent({
+      client,
+      error: error.message,
+      event: "ub:ui:error",
+    });
+  }, [client, error.message]);
 
   return (
     <Container flex="column" fullHeight gap="md" p="md">

--- a/packages/thirdweb/src/react/web/ui/Bridge/QuoteLoader.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/QuoteLoader.tsx
@@ -1,7 +1,5 @@
 "use client";
-import { useQuery } from "@tanstack/react-query";
 import { useEffect } from "react";
-import { trackPayEvent } from "../../../../analytics/track/pay.js";
 import type { Token } from "../../../../bridge/types/Token.js";
 import type { ThirdwebClient } from "../../../../client/client.js";
 import type { PurchaseData } from "../../../../pay/types.js";
@@ -92,7 +90,7 @@ export function QuoteLoader({
   purchaseData,
   paymentLinkId,
   feePayer,
-  mode,
+  mode: _mode,
 }: QuoteLoaderProps) {
   const request: BridgePrepareRequest = getBridgeParams({
     amount,
@@ -106,28 +104,6 @@ export function QuoteLoader({
     sender,
   });
   const prepareQuery = useBridgePrepare(request);
-
-  useQuery({
-    queryFn: () => {
-      trackPayEvent({
-        chainId:
-          paymentMethod.type === "wallet"
-            ? paymentMethod.originToken.chainId
-            : undefined,
-        client,
-        event: `ub:ui:loading_quote:${mode}`,
-        fromToken:
-          paymentMethod.type === "wallet"
-            ? paymentMethod.originToken.address
-            : undefined,
-        toChainId: destinationToken.chainId,
-        toToken: destinationToken.address,
-        walletAddress: sender,
-      });
-      return true;
-    },
-    queryKey: ["loading_quote", paymentMethod.type],
-  });
 
   // Handle successful quote
   useEffect(() => {

--- a/packages/thirdweb/src/react/web/ui/Bridge/UnsupportedTokenScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/UnsupportedTokenScreen.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
 import { trackPayEvent } from "../../../../analytics/track/pay.js";
 import type { Chain } from "../../../../chains/types.js";
 import type { ThirdwebClient } from "../../../../client/client.js";
@@ -27,17 +27,17 @@ export function UnsupportedTokenScreen(props: UnsupportedTokenScreenProps) {
 
   const { data: chainMetadata } = useChainMetadata(chain);
 
-  useQuery({
-    queryFn: () => {
-      trackPayEvent({
-        chainId: chain.id,
-        client,
-        event: "ub:ui:unsupported_token",
-        fromToken: tokenAddress,
-      });
-    },
-    queryKey: ["unsupported_token"],
-  });
+  const hasFiredUnsupportedEvent = useRef(false);
+  useEffect(() => {
+    if (hasFiredUnsupportedEvent.current) return;
+    hasFiredUnsupportedEvent.current = true;
+    trackPayEvent({
+      chainId: chain.id,
+      client,
+      event: "ub:ui:unsupported_token",
+      fromToken: tokenAddress,
+    });
+  }, [chain.id, client, tokenAddress]);
 
   if (chainMetadata?.testnet) {
     return (

--- a/packages/thirdweb/src/react/web/ui/Bridge/bridge-widget/bridge-widget.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/bridge-widget/bridge-widget.tsx
@@ -1,5 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { trackPayEvent } from "../../../../../analytics/track/pay.js";
 import { defineChain } from "../../../../../chains/utils.js";
 import type { ThirdwebClient } from "../../../../../client/client.js";
@@ -251,16 +250,15 @@ export type BridgeWidgetProps = {
 export function BridgeWidget(props: BridgeWidgetProps) {
   const [tab, setTab] = useState<"swap" | "buy">("swap");
 
-  useQuery({
-    queryFn: () => {
-      trackPayEvent({
-        client: props.client,
-        event: "ub:ui:bridge_widget:render",
-      });
-      return true;
-    },
-    queryKey: ["bridge_widget:render"],
-  });
+  const hasFiredRenderEvent = useRef(false);
+  useEffect(() => {
+    if (hasFiredRenderEvent.current) return;
+    hasFiredRenderEvent.current = true;
+    trackPayEvent({
+      client: props.client,
+      event: "ub:ui:bridge_widget:render",
+    });
+  }, [props.client]);
 
   return (
     <CustomThemeProvider theme={props.theme}>

--- a/packages/thirdweb/src/react/web/ui/Bridge/payment-details/PaymentDetails.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/payment-details/PaymentDetails.tsx
@@ -1,7 +1,5 @@
 "use client";
-import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
-import { trackPayEvent } from "../../../../../analytics/track/pay.js";
 import { defineChain } from "../../../../../chains/utils.js";
 import type { ThirdwebClient } from "../../../../../client/client.js";
 import type { SupportedFiatCurrency } from "../../../../../pay/convert/type.js";
@@ -81,41 +79,6 @@ export function PaymentDetails({
       onError(error as Error);
     }
   };
-
-  useQuery({
-    queryFn: () => {
-      if (
-        preparedQuote.type === "buy" ||
-        preparedQuote.type === "sell" ||
-        preparedQuote.type === "transfer"
-      ) {
-        trackPayEvent({
-          chainId:
-            preparedQuote.type === "transfer"
-              ? preparedQuote.intent.chainId
-              : preparedQuote.intent.originChainId,
-          client,
-          event: "payment_details",
-          fromToken:
-            preparedQuote.type === "transfer"
-              ? preparedQuote.intent.tokenAddress
-              : preparedQuote.intent.originTokenAddress,
-          toChainId:
-            preparedQuote.type === "transfer"
-              ? preparedQuote.intent.chainId
-              : preparedQuote.intent.destinationChainId,
-          toToken:
-            preparedQuote.type === "transfer"
-              ? preparedQuote.intent.tokenAddress
-              : preparedQuote.intent.destinationTokenAddress,
-          walletAddress: paymentMethod.payerWallet?.getAccount()?.address,
-          walletType: paymentMethod.payerWallet?.id,
-        });
-      }
-      return true;
-    },
-    queryKey: ["payment_details", preparedQuote.type],
-  });
 
   const chainsQuery = useChainsQuery(
     preparedQuote.steps.flatMap((s) => [

--- a/packages/thirdweb/src/react/web/ui/Bridge/payment-selection/PaymentSelection.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/payment-selection/PaymentSelection.tsx
@@ -1,5 +1,4 @@
 "use client";
-import { useQuery } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { trackPayEvent } from "../../../../../analytics/track/pay.js";
 import type { Token } from "../../../../../bridge/types/Token.js";
@@ -129,21 +128,6 @@ export function PaymentSelection({
 
   const [currentStep, setCurrentStep] = useState<Step>(initialStep);
 
-  useQuery({
-    queryFn: () => {
-      trackPayEvent({
-        client,
-        event: "payment_selection",
-        toChainId: destinationToken.chainId,
-        toToken: destinationToken.address,
-        walletAddress: payerWallet?.getAccount()?.address,
-        walletType: payerWallet?.id,
-      });
-      return true;
-    },
-    queryKey: ["payment_selection"],
-  });
-
   const payerWallet =
     currentStep.type === "tokenSelection"
       ? currentStep.selectedWallet
@@ -176,6 +160,10 @@ export function PaymentSelection({
   };
 
   const handleWalletSelected = (wallet: Wallet) => {
+    trackPayEvent({
+      client,
+      event: "ub:ui:token_selection",
+    });
     setCurrentStep({ selectedWallet: wallet, type: "tokenSelection" });
   };
 
@@ -184,6 +172,10 @@ export function PaymentSelection({
   };
 
   const handleFiatSelected = () => {
+    trackPayEvent({
+      client,
+      event: "ub:ui:fiat_provider_selection",
+    });
     setCurrentStep({ type: "fiatProviderSelection" });
   };
 


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing payment selection tracking across various components in the `thirdweb` package, replacing `useQuery` with `useEffect` and `useRef` to ensure events are tracked correctly without redundant calls.

### Detailed summary
- Replaced `useQuery` with `useEffect` and `useRef` in multiple components for tracking payment events.
- Components updated include:
  - `UnsupportedTokenScreen.tsx`
  - `BridgeWidget.tsx`
  - `ErrorBanner.tsx`
  - `QuoteLoader.tsx`
  - `PaymentSelection.tsx`
  - `PaymentDetails.tsx`
  - `SwapWidget.tsx`
  - `SuccessScreen.tsx`
  - `CheckoutWidget.tsx`
  - `TransactionWidget.tsx`
  - `BuyWidget.tsx`
  - `BridgeWidgetContent.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refined Bridge telemetry: replaced reactive query-based tracking with guarded one-time render and interaction events to avoid duplicate signals.
  * Broadened analytics coverage across buy/checkout/transaction/bridge/swap flows, payment selection, loading/quote stages, payment details, unsupported-token and success screens.
  * Consolidated and simplified tracking behavior, removing legacy query-driven trackers and centralizing invalidation steps for more reliable telemetry.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->