### PR TITLE
[SDK] Skip swap review step when coming from swap widget

### DIFF
--- a/.changeset/floppy-carrots-own.md
+++ b/.changeset/floppy-carrots-own.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Skip swap review step when coming from swap widget


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying the `SwapWidget` component by skipping the swap review step when coming from the swap widget, streamlining the user experience during token swaps.

### Detailed summary
- Removed the `handleError` function and its usage.
- Skipped the `PaymentDetails` component in the swap process.
- Changed the screen ID transition from `"2:preview"` to `"3:execute"` directly.
- Adjusted the back navigation to return to `"1:swap-ui"`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Simplified swap widget workflow by removing the payment details review screen. Users now proceed directly from swap selection to execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->