### PR TITLE
[SDK] Allow passing activeWallet to SwapWidget

### DIFF
--- a/.changeset/shaky-hoops-battle.md
+++ b/.changeset/shaky-hoops-battle.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Allow passing an activeWallet to SwapWidget

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,6 @@
 {
+  "editor.insertSpaces": true,
+  "editor.tabSize": 2,
   "[css]": {
     "editor.defaultFormatter": "biomejs.biome"
   },
@@ -18,8 +20,9 @@
     "editor.defaultFormatter": "biomejs.biome"
   },
   "editor.codeActionsOnSave": {
-    "quickfix.biome": "explicit",
-    "source.fixAll.biome": "explicit"
+    "quickfix.biome": "always",
+    "source.fixAll.biome": "always",
+    "source.organizeImports.biome": "always"
   },
   "editor.defaultFormatter": "biomejs.biome",
   "editor.formatOnSave": true,

--- a/apps/dashboard/src/@/constants/thirdweb.server.ts
+++ b/apps/dashboard/src/@/constants/thirdweb.server.ts
@@ -13,6 +13,7 @@ import {
 import {
   THIRDWEB_BRIDGE_URL,
   THIRDWEB_BUNDLER_DOMAIN,
+  THIRDWEB_ENGINE_CLOUD_URL,
   THIRDWEB_INAPP_WALLET_DOMAIN,
   THIRDWEB_INSIGHT_API_DOMAIN,
   THIRDWEB_PAY_DOMAIN,
@@ -38,6 +39,7 @@ export function getConfiguredThirdwebClient(options: {
       rpc: THIRDWEB_RPC_DOMAIN,
       social: THIRDWEB_SOCIAL_API_DOMAIN,
       storage: THIRDWEB_STORAGE_DOMAIN,
+      engineCloud: new URL(THIRDWEB_ENGINE_CLOUD_URL).hostname,
     });
   }
 

--- a/apps/dashboard/src/@/constants/urls.ts
+++ b/apps/dashboard/src/@/constants/urls.ts
@@ -25,3 +25,6 @@ export const THIRDWEB_INSIGHT_API_DOMAIN =
 
 export const THIRDWEB_BRIDGE_URL =
   process.env.NEXT_PUBLIC_BRIDGE_URL || "bridge.thirdweb-dev.com";
+
+export const THIRDWEB_ENGINE_CLOUD_URL =
+  process.env.NEXT_PUBLIC_ENGINE_CLOUD_URL || "https://engine.thirdweb-dev.com";

--- a/packages/thirdweb/src/react/web/ui/Bridge/swap-widget/SwapWidget.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/swap-widget/SwapWidget.tsx
@@ -8,6 +8,7 @@ import type { ThirdwebClient } from "../../../../../client/client.js";
 import { NATIVE_TOKEN_ADDRESS } from "../../../../../constants/addresses.js";
 import type { SupportedFiatCurrency } from "../../../../../pay/convert/type.js";
 import { getAddress } from "../../../../../utils/address.js";
+import type { Wallet } from "../../../../../wallets/interfaces/wallet.js";
 import { CustomThemeProvider } from "../../../../core/design-system/CustomThemeProvider.js";
 import type { Theme } from "../../../../core/design-system/index.js";
 import type { BridgePrepareRequest } from "../../../../core/hooks/useBridgePrepare.js";
@@ -169,6 +170,10 @@ export type SwapWidgetProps = {
    * Called when the user disconnects the active wallet
    */
   onDisconnect?: () => void;
+  /**
+   * The wallet that should be pre-selected in the SwapWidget UI.
+   */
+  activeWallet?: Wallet;
 };
 
 /**
@@ -320,7 +325,7 @@ function SwapWidgetContent(
   },
 ) {
   const [screen, setScreen] = useState<SwapWidgetScreen>({ id: "1:swap-ui" });
-  const activeWalletInfo = useActiveWalletInfo();
+  const activeWalletInfo = useActiveWalletInfo(props.activeWallet);
   const isPersistEnabled = props.persistTokenSelections !== false;
 
   const [amountSelection, setAmountSelection] = useState<{

--- a/packages/thirdweb/src/react/web/ui/Bridge/swap-widget/hooks.ts
+++ b/packages/thirdweb/src/react/web/ui/Bridge/swap-widget/hooks.ts
@@ -1,21 +1,27 @@
 import { useMemo } from "react";
+import type { Wallet } from "../../../../../wallets/interfaces/wallet.js";
 import { useActiveAccount } from "../../../../core/hooks/wallets/useActiveAccount.js";
 import { useActiveWallet } from "../../../../core/hooks/wallets/useActiveWallet.js";
 import { useActiveWalletChain } from "../../../../core/hooks/wallets/useActiveWalletChain.js";
 import type { ActiveWalletInfo } from "./types.js";
 
-export function useActiveWalletInfo(): ActiveWalletInfo | undefined {
+export function useActiveWalletInfo(
+  activeWalletOverride?: Wallet,
+): ActiveWalletInfo | undefined {
   const activeAccount = useActiveAccount();
   const activeWallet = useActiveWallet();
   const activeChain = useActiveWalletChain();
 
   return useMemo(() => {
-    return activeAccount && activeWallet && activeChain
+    const wallet = activeWalletOverride || activeWallet;
+    const chain = activeWalletOverride?.getChain() || activeChain;
+    const account = activeWalletOverride?.getAccount() || activeAccount;
+    return wallet && chain && account
       ? {
-          activeChain,
-          activeWallet,
-          activeAccount,
+          activeChain: chain,
+          activeWallet: wallet,
+          activeAccount: account,
         }
       : undefined;
-  }, [activeAccount, activeWallet, activeChain]);
+  }, [activeAccount, activeWallet, activeChain, activeWalletOverride]);
 }


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the ability to pass an `activeWallet` to the `SwapWidget`, enhances the configuration for the `THIRDWEB_ENGINE_CLOUD_URL`, and adds a swap functionality in the `ProjectWalletDetailsSection`, allowing users to swap tokens with a project wallet.

### Detailed summary
- Added `THIRDWEB_ENGINE_CLOUD_URL` to constants.
- Updated `getConfiguredThirdwebClient` to include `engineCloud`.
- Modified `SwapWidgetProps` to accept `activeWallet`.
- Enhanced `useActiveWalletInfo` to support an `activeWalletOverride`.
- Introduced swap functionality in `ProjectWalletDetailsSection`.
- Added `SwapProjectWalletModalContent` for token swapping UI.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-app token swap for project wallets with a guided credential flow and modal-based swap UI.
  * Swap widget now supports pre-selecting an active wallet for faster swap initiation.

* **Chores**
  * Patch release metadata added for an upcoming patch.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->