### PR TITLE
[SDK] Update token balances query to use client instead of clientId

### DIFF
--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/components/project-wallet/project-wallet-details.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/components/project-wallet/project-wallet-details.tsx
@@ -419,6 +419,7 @@ export function ProjectWalletDetailsSection(props: ProjectWalletControlsProps) {
       <Dialog onOpenChange={setIsSwapOpen} open={isSwapOpen}>
         <DialogContent className="gap-0 p-0 overflow-hidden max-w-md">
           <SwapProjectWalletModalContent
+            client={props.client}
             chainId={selectedChainId}
             tokenAddress={selectedTokenAddress}
             walletAddress={projectWallet.address}
@@ -613,6 +614,7 @@ function ChangeProjectWalletDialogContent(props: {
 }
 
 type SwapProjectWalletModalContentProps = {
+  client: ThirdwebClient;
   chainId: number;
   tokenAddress: string | undefined;
   walletAddress: string;
@@ -630,6 +632,7 @@ function SwapProjectWalletModalContent(
   props: SwapProjectWalletModalContentProps,
 ) {
   const {
+    client,
     chainId,
     tokenAddress,
     walletAddress,
@@ -655,6 +658,7 @@ function SwapProjectWalletModalContent(
     if (!secretKey.trim()) {
       return null;
     }
+    // use the inputted secret key to create the client used for the serverWallet
     return createThirdwebClient({
       clientId: publishableKey,
       secretKey: secretKey.trim(),
@@ -777,9 +781,9 @@ function SwapProjectWalletModalContent(
       </DialogHeader>
 
       <div className="px-4 pb-4 lg:px-6 lg:pb-6 flex justify-center">
-        {swapClient && activeWallet && (
+        {activeWallet && (
           <SwapWidget
-            client={swapClient}
+            client={props.client}
             prefill={{
               sellToken: {
                 chainId: chainId,

--- a/packages/thirdweb/src/react/web/ui/Bridge/swap-widget/select-token-ui.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/swap-widget/select-token-ui.tsx
@@ -90,7 +90,7 @@ export function SelectToken(props: SelectTokenUIProps) {
 
   // owned tokens
   const ownedTokensQuery = useTokenBalances({
-    clientId: props.client.clientId,
+    client: props.client,
     chainId: selectedChain?.chainId,
     limit,
     page: 1,

--- a/packages/thirdweb/src/react/web/ui/Bridge/swap-widget/use-tokens.ts
+++ b/packages/thirdweb/src/react/web/ui/Bridge/swap-widget/use-tokens.ts
@@ -4,6 +4,7 @@ import { tokens } from "../../../../../bridge/Token.js";
 import type { ThirdwebClient } from "../../../../../client/client.js";
 import { isAddress } from "../../../../../utils/address.js";
 import { getThirdwebBaseUrl } from "../../../../../utils/domains.js";
+import { getClientFetch } from "../../../../../utils/fetch.js";
 
 export function useTokens(options: {
   client: ThirdwebClient;
@@ -72,7 +73,7 @@ type TokenBalancesResponse = {
 };
 
 export function useTokenBalances(options: {
-  clientId: string;
+  client: ThirdwebClient;
   page: number;
   limit: number;
   walletAddress: string | undefined;
@@ -101,11 +102,8 @@ export function useTokenBalances(options: {
       url.searchParams.set("sortOrder", "desc");
       url.searchParams.set("includeWithoutPrice", "false"); // filter out tokens with no price
 
-      const response = await fetch(url.toString(), {
-        headers: {
-          "x-client-id": options.clientId,
-        },
-      });
+      const clientFetch = getClientFetch(options.client);
+      const response = await clientFetch(url.toString());
 
       if (!response.ok) {
         throw new Error(


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the handling of `client` in the `useTokenBalances` and `SwapProjectWalletModalContent` components, enhancing the way tokens are fetched and passed to the swap widget.

### Detailed summary
- Changed `clientId` to `client` in `ownedTokensQuery` and `useTokenBalances`.
- Updated token fetching to use `getClientFetch` with the new `client` parameter.
- Modified `SwapProjectWalletModalContent` to accept `client` as a prop.
- Adjusted `SwapWidget` to use `props.client` instead of `swapClient`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Token balance requests now accept the full client object instead of an ID, use the client-based fetch mechanism, and include the active wallet address in queries.
  * Component props updated to accept a client prop; the swap widget now relies on the provided client alongside the active wallet for rendering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->