### PR TITLE
[X402] Update payment data retrieval example in server documentation

### DIFF
--- a/apps/portal/src/app/x402/server/page.mdx
+++ b/apps/portal/src/app/x402/server/page.mdx
@@ -55,7 +55,7 @@ Use `settlePayment()` to verify and settle the payment in one step. This is the 
 const result = await settlePayment({
 	resourceUrl: "https://api.example.com/premium-content",
 	method: "GET",
-	paymentData,
+	paymentData: request.headers.get("x-payment"),
 	payTo: "0x1234567890123456789012345678901234567890",
 	network: arbitrum,
 	price: "$0.10",
@@ -93,7 +93,7 @@ Here's a high level example of how to use the `upto` payment scheme with a dynam
 const paymentArgs = {
 	resourceUrl: "https://api.example.com/premium-content",
 	method: "GET",
-	paymentData,
+	paymentData: request.headers.get("x-payment"),
 	payTo: "0x1234567890123456789012345678901234567890",
 	network: arbitrum,
 	scheme: "upto", // enables dynamic pricing
@@ -135,7 +135,8 @@ You can call verifyPayment() and settlePayment() multiple times using the same p
 You can retrieve the previously signed paymentData from any storage mechanism, for example:
 
 ```typescript
-const paymentData = retrievePaymentDataFromStorage(userId, sessionId); // example implementation, can be any storage mechanism
+// example implementation: get payment data from storage, if not present, use the payment data from the request headers
+const paymentData = retrievePaymentDataFromStorage(userId, sessionId) || request.headers.get("x-payment");
 const paymentArgs = { ...otherPaymentArgs, paymentData };
 
 // verify paymentData is still valid


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating how `paymentData` is retrieved in the payment processing flow, ensuring it can be sourced from request headers when necessary.

### Detailed summary
- Changed the assignment of `paymentData` to retrieve it from `request.headers.get("x-payment")` instead of using a direct variable.
- Updated the example for retrieving `paymentData` to prioritize request headers if stored data is unavailable.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated payment data handling examples in X402 server documentation. Payment data is now sourced from request headers with fallback support, affecting settlement and verification flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->