### PR TITLE
[SDK] Cache and reuse x402 permit signatures for upto schemes

### DIFF
--- a/.changeset/warm-clouds-judge.md
+++ b/.changeset/warm-clouds-judge.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Automatically store and re-use permit x402 signatures for upto schemes

--- a/apps/portal/src/app/x402/server/page.mdx
+++ b/apps/portal/src/app/x402/server/page.mdx
@@ -132,30 +132,7 @@ You can call verifyPayment() and settlePayment() multiple times using the same p
 
  If any of these checks fail, `verifyPayment()` will return a 402 response requiring a new payment authorization.
 
-You can retrieve the previously signed paymentData from any storage mechanism, for example:
-
-```typescript
-const paymentData = retrievePaymentDataFromStorage(userId, sessionId); // example implementation, can be any storage mechanism
-const paymentArgs = { ...otherPaymentArgs, paymentData };
-
-// verify paymentData is still valid
-const verifyResult = await verifyPayment(paymentArgs);
-
-if (verifyResult.status !== 200) {
-	return Response.json(verifyResult.responseBody, {
-		status: verifyResult.status,
-		headers: verifyResult.responseHeaders,
-	});
-}
-
-// settle payment based on usage, re-using the previous paymentData
-const settleResult = await settlePayment({
-	...paymentArgs,
-	price: tokensUsed * pricePerTokenUsed, // adjust final price based on usage
-});
-
-return Response.json(answer);
-```
+`wrapFetchWithPayment()` and `useFetchWithPayment()` will automatically handle the caching and re-use of the payment data for you, so you don't need to have any additional state or storage on the backend.
 
 ## Signature expiration configuration
 

--- a/packages/thirdweb/src/react/core/hooks/x402/useFetchWithPaymentCore.ts
+++ b/packages/thirdweb/src/react/core/hooks/x402/useFetchWithPaymentCore.ts
@@ -2,6 +2,7 @@
 
 import { useMutation } from "@tanstack/react-query";
 import type { ThirdwebClient } from "../../../../client/client.js";
+import type { AsyncStorage } from "../../../../utils/storage/AsyncStorage.js";
 import type { Wallet } from "../../../../wallets/interfaces/wallet.js";
 import { wrapFetchWithPayment } from "../../../../x402/fetchWithPayment.js";
 import type { RequestedPaymentRequirements } from "../../../../x402/schemas.js";
@@ -14,6 +15,11 @@ export type UseFetchWithPaymentOptions = {
     paymentRequirements: RequestedPaymentRequirements[],
   ) => RequestedPaymentRequirements | undefined;
   parseAs?: "json" | "text" | "raw";
+  /**
+   * Storage for caching permit signatures (for "upto" scheme).
+   * When provided, permit signatures will be cached and reused if the on-chain allowance is sufficient.
+   */
+  storage?: AsyncStorage;
 };
 
 type ShowErrorModalCallback = (data: {
@@ -81,7 +87,11 @@ export function useFetchWithPaymentCore(
           globalThis.fetch,
           client,
           currentWallet,
-          options,
+          {
+            maxValue: options?.maxValue,
+            paymentRequirementsSelector: options?.paymentRequirementsSelector,
+            storage: options?.storage,
+          },
         );
 
         const response = await wrappedFetch(input, init);

--- a/packages/thirdweb/src/react/native/hooks/x402/useFetchWithPayment.ts
+++ b/packages/thirdweb/src/react/native/hooks/x402/useFetchWithPayment.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import type { ThirdwebClient } from "../../../../client/client.js";
+import { nativeLocalStorage } from "../../../../utils/storage/nativeStorage.js";
 import {
   type UseFetchWithPaymentOptions,
   useFetchWithPaymentCore,
@@ -29,6 +30,7 @@ export type { UseFetchWithPaymentOptions };
  * @param options.maxValue - The maximum allowed payment amount in base units
  * @param options.paymentRequirementsSelector - Custom function to select payment requirements from available options
  * @param options.parseAs - How to parse the response: "json" (default), "text", or "raw"
+ * @param options.storage - Storage for caching permit signatures (for "upto" scheme). Provide your own AsyncStorage implementation for React Native.
  * @returns An object containing:
  * - `fetchWithPayment`: Function to make fetch requests with automatic payment handling (returns parsed data)
  * - `isPending`: Boolean indicating if a request is in progress
@@ -92,5 +94,8 @@ export function useFetchWithPayment(
   options?: UseFetchWithPaymentOptions,
 ) {
   // Native version doesn't show modal, errors bubble up naturally
-  return useFetchWithPaymentCore(client, options);
+  return useFetchWithPaymentCore(client, {
+    ...options,
+    storage: options?.storage ?? nativeLocalStorage,
+  });
 }

--- a/packages/thirdweb/src/react/web/hooks/x402/useFetchWithPayment.tsx
+++ b/packages/thirdweb/src/react/web/hooks/x402/useFetchWithPayment.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useContext } from "react";
+import { useContext, useMemo } from "react";
 import type { ThirdwebClient } from "../../../../client/client.js";
+import { webLocalStorage } from "../../../../utils/storage/webStorage.js";
 import type { Wallet } from "../../../../wallets/interfaces/wallet.js";
 import type { Theme } from "../../../core/design-system/index.js";
 import {
@@ -255,9 +256,18 @@ export function useFetchWithPayment(
       }
     : undefined;
 
+  // Default to webLocalStorage for permit signature caching
+  const resolvedOptions = useMemo(
+    () => ({
+      ...options,
+      storage: options?.storage ?? webLocalStorage,
+    }),
+    [options],
+  );
+
   return useFetchWithPaymentCore(
     client,
-    options,
+    resolvedOptions,
     showErrorModal,
     showConnectModal,
   );

--- a/packages/thirdweb/src/x402/permitSignatureStorage.ts
+++ b/packages/thirdweb/src/x402/permitSignatureStorage.ts
@@ -1,0 +1,99 @@
+import type { AsyncStorage } from "../utils/storage/AsyncStorage.js";
+import type { RequestedPaymentPayload } from "./schemas.js";
+
+/**
+ * Cached permit signature data structure
+ */
+type CachedPermitSignature = {
+  payload: RequestedPaymentPayload;
+  deadline: string;
+  maxAmount: string;
+};
+
+/**
+ * Parameters for generating a permit cache key
+ */
+export type PermitCacheKeyParams = {
+  chainId: number;
+  asset: string;
+  owner: string;
+  spender: string;
+};
+
+const CACHE_KEY_PREFIX = "x402:permit";
+
+/**
+ * Generates a cache key for permit signature storage
+ * @param params - The parameters to generate the cache key from
+ * @returns The cache key string
+ */
+function getPermitCacheKey(params: PermitCacheKeyParams): string {
+  return `${CACHE_KEY_PREFIX}:${params.chainId}:${params.asset.toLowerCase()}:${params.owner.toLowerCase()}:${params.spender.toLowerCase()}`;
+}
+
+/**
+ * Retrieves a cached permit signature from storage
+ * @param storage - The AsyncStorage instance to use
+ * @param params - The parameters identifying the cached signature
+ * @returns The cached signature data or null if not found
+ */
+export async function getPermitSignatureFromCache(
+  storage: AsyncStorage,
+  params: PermitCacheKeyParams,
+): Promise<CachedPermitSignature | null> {
+  try {
+    const key = getPermitCacheKey(params);
+    const cached = await storage.getItem(key);
+    if (!cached) {
+      return null;
+    }
+    return JSON.parse(cached) as CachedPermitSignature;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Saves a permit signature to storage cache
+ * @param storage - The AsyncStorage instance to use
+ * @param params - The parameters identifying the signature
+ * @param payload - The signed payment payload to cache
+ * @param deadline - The deadline timestamp of the permit
+ * @param maxAmount - The maximum amount authorized
+ */
+export async function savePermitSignatureToCache(
+  storage: AsyncStorage,
+  params: PermitCacheKeyParams,
+  payload: RequestedPaymentPayload,
+  deadline: string,
+  maxAmount: string,
+): Promise<void> {
+  try {
+    const key = getPermitCacheKey(params);
+    const data: CachedPermitSignature = {
+      payload,
+      deadline,
+      maxAmount,
+    };
+    await storage.setItem(key, JSON.stringify(data));
+  } catch {
+    // Silently fail - caching is optional
+  }
+}
+
+/**
+ * Clears a cached permit signature from storage
+ * @param storage - The AsyncStorage instance to use
+ * @param params - The parameters identifying the cached signature
+ */
+export async function clearPermitSignatureFromCache(
+  storage: AsyncStorage,
+  params: PermitCacheKeyParams,
+): Promise<void> {
+  try {
+    const key = getPermitCacheKey(params);
+    await storage.removeItem(key);
+  } catch {
+    // Silently fail
+  }
+}


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces caching for permit signatures in the `thirdweb` library, specifically for the "upto" scheme. It enhances the `useFetchWithPayment` functionality to automatically reuse cached signatures, improving efficiency in payment handling.

### Detailed summary
- Added `storage` option for caching permit signatures in `useFetchWithPayment` and `wrapFetchWithPayment`.
- Implemented caching logic in `signPaymentHeader` to reuse signatures based on allowance checks.
- Updated documentation to reflect new caching behavior in payment processes.
- Removed outdated example code from documentation regarding manual payment data retrieval.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Permit signatures for x402 payments are automatically cached and re-used on web and native, with platform-default storage and an optional override.
* **Improvements**
  * Cached signatures are validated (deadline and on-chain allowance) before reuse and are cleared if a subsequent 402 invalidates them.
* **Documentation**
  * Client docs updated to remove the manual storage example and describe automatic caching behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->