### PR TITLE
[SDK] Fix null options handling in useFetchWithPayment hook

### DIFF
--- a/packages/thirdweb/src/react/web/hooks/x402/useFetchWithPayment.tsx
+++ b/packages/thirdweb/src/react/web/hooks/x402/useFetchWithPayment.tsx
@@ -259,7 +259,7 @@ export function useFetchWithPayment(
   // Default to webLocalStorage for permit signature caching
   const resolvedOptions = useMemo(
     () => ({
-      ...options,
+      ...(options ?? {}),
       storage: options?.storage ?? webLocalStorage,
     }),
     [options],


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the handling of `options` in the `useFetchWithPayment` hook by ensuring that it defaults to an empty object if `options` is `null` or `undefined`.

### Detailed summary
- Updated the spread operator for `options` to use `options ?? {}` instead of just `options`, ensuring it defaults to an empty object when `options` is `null` or `undefined`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to enhance application stability in edge case scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->