### PR TITLE
Dashboard: Fix webhooks link in project/contracts page

### DIFF
--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/contracts/page.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/contracts/page.tsx
@@ -102,7 +102,7 @@ export default async function Page(props: {
             },
             {
               type: "webhooks",
-              href: `/team/${params.team_slug}/${params.project_slug}/webhooks/contracts`,
+              href: `/team/${params.team_slug}/${params.project_slug}/tokens/webhooks`,
             },
           ],
         }}


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `href` path for webhooks in the `page.tsx` file of the contracts sidebar, changing the URL structure from pointing to contracts to pointing to tokens.

### Detailed summary
- Updated `href` from `/team/${params.team_slug}/${params.project_slug}/webhooks/contracts` 
- Changed to `/team/${params.team_slug}/${params.project_slug}/tokens/webhooks`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the Contracts page sidebar link so the "Webhooks" item now opens the Tokens → Webhooks section instead of the Contracts section.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->