### PR TITLE
[MNY-327] SDK: Display error returned from API in login with phone number UI

### DIFF
--- a/packages/thirdweb/src/wallets/in-app/web/lib/auth/otp.ts
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/auth/otp.ts
@@ -51,7 +51,17 @@ export const sendOtp = async (args: PreAuthArgsType): Promise<void> => {
   });
 
   if (!response.ok) {
-    throw new Error("Failed to send verification code");
+    const raw = await response.text();
+    let message: string | undefined;
+    try {
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed.message === "string") {
+        message = parsed.message;
+      }
+    } catch {
+      // ignore parse errors
+    }
+    throw new Error(message || "Failed to send verification code");
   }
 
   return await response.json();


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances error handling and state management in the OTP authentication process. It improves the way error messages are displayed and refines the `AccountStatus` type to better represent different states during the OTP login process.

### Detailed summary
- Improved error handling in `otp.ts` by parsing the response and providing a specific error message.
- Modified `AccountStatus` type in `OTPLoginUI.tsx` to use a discriminated union with `type` and optional `message`.
- Updated state management in `OTPLoginUI` to reflect the new `AccountStatus` structure.
- Adjusted rendering logic to display error messages based on the new `AccountStatus`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OTP error handling now surfaces detailed server error messages to users instead of generic text.
  * Status handling in the OTP login flow has been made more reliable, ensuring correct display of sending/sent/error states and associated messages.

* **Style**
  * Adjusted OTP login UI layout, spacing, and alignment for clearer status presentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->