### PR TITLE
[MNY-331] SDK: Alphabetically sort chains in SwapWidget UI

### DIFF
--- a/.changeset/ninety-trains-tell.md
+++ b/.changeset/ninety-trains-tell.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Alphabetically sort the chains in SwapWidget UI

--- a/packages/thirdweb/src/react/web/ui/Bridge/swap-widget/use-bridge-chains.ts
+++ b/packages/thirdweb/src/react/web/ui/Bridge/swap-widget/use-bridge-chains.ts
@@ -5,8 +5,25 @@ import type { ThirdwebClient } from "../../../../../client/client.js";
 export function useBridgeChains(client: ThirdwebClient) {
   return useQuery({
     queryKey: ["bridge-chains"],
-    queryFn: () => {
-      return chains({ client });
+    queryFn: async () => {
+      const data = await chains({ client });
+      const dataCopy = [...data];
+      // sort by name, but if name starts with number, put it at the end
+
+      return dataCopy.sort((a, b) => {
+        const aStartsWithNumber = a.name[0]?.match(/^\d/);
+        const bStartsWithNumber = b.name[0]?.match(/^\d/);
+
+        if (aStartsWithNumber && !bStartsWithNumber) {
+          return 1;
+        }
+
+        if (!aStartsWithNumber && bStartsWithNumber) {
+          return -1;
+        }
+
+        return a.name.localeCompare(b.name);
+      });
     },
     refetchOnMount: false,
     refetchOnWindowFocus: false,


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the sorting of chains in the `SwapWidget` UI by implementing a new sorting logic that places chains with names starting with numbers at the end.

### Detailed summary
- Updated the `queryFn` in `useQuery` to be asynchronous.
- Added a copy of the fetched `data` for sorting.
- Implemented custom sorting logic to handle names starting with numbers, placing them at the end of the sorted list.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chains in the SwapWidget are now alphabetically sorted for improved navigation; chain names starting with digits are listed after alphabetic entries.

* **Chores**
  * Patch release entry added to the changelog.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->