### PR TITLE
[MNY-314] SDK: Token Selection UX improvements in SwapWidget

### DIFF
--- a/.changeset/eager-loops-obey.md
+++ b/.changeset/eager-loops-obey.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Token Selection UX improvements in SwapWidget

--- a/packages/thirdweb/src/react/web/ui/Bridge/swap-widget/swap-ui.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/swap-widget/swap-ui.tsx
@@ -6,8 +6,10 @@ import { Buy, Sell } from "../../../../../bridge/index.js";
 import type { prepare as SellPrepare } from "../../../../../bridge/Sell.js";
 import type { TokenWithPrices } from "../../../../../bridge/types/Token.js";
 import type { ThirdwebClient } from "../../../../../client/client.js";
+import { NATIVE_TOKEN_ADDRESS } from "../../../../../constants/addresses.js";
 import { getToken } from "../../../../../pay/convert/get-token.js";
 import type { SupportedFiatCurrency } from "../../../../../pay/convert/type.js";
+import { getAddress } from "../../../../../utils/address.js";
 import { toTokens, toUnits } from "../../../../../utils/units.js";
 import { useCustomTheme } from "../../../../core/design-system/CustomThemeProvider.js";
 import {
@@ -245,6 +247,18 @@ export function SwapUI(props: SwapUIProps) {
               ) {
                 props.setSellToken(undefined);
               }
+
+              // if sell token is not selected, set it as native token of the buy token's chain if buy token is not a native token itself
+              if (
+                !props.sellToken &&
+                token.tokenAddress.toLowerCase() !==
+                  NATIVE_TOKEN_ADDRESS.toLowerCase()
+              ) {
+                props.setSellToken({
+                  tokenAddress: getAddress(NATIVE_TOKEN_ADDRESS),
+                  chainId: token.chainId,
+                });
+              }
             }}
           />
         )}
@@ -269,6 +283,18 @@ export function SwapUI(props: SwapUIProps) {
                 token.chainId === props.buyToken.chainId
               ) {
                 props.setBuyToken(undefined);
+              }
+
+              // if buy token is not selected, set it as native token of the sell token's chain if sell token is not a native token itself
+              if (
+                !props.buyToken &&
+                token.tokenAddress.toLowerCase() !==
+                  NATIVE_TOKEN_ADDRESS.toLowerCase()
+              ) {
+                props.setBuyToken({
+                  tokenAddress: getAddress(NATIVE_TOKEN_ADDRESS),
+                  chainId: token.chainId,
+                });
               }
             }}
             activeWalletInfo={props.activeWalletInfo}


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the token selection user experience in the `SwapWidget` by automatically setting the sell or buy token to the native token of the respective chain when no token is selected.

### Detailed summary
- Added logic to set `sellToken` to the native token of the buy token's chain if not selected.
- Added logic to set `buyToken` to the native token of the sell token's chain if not selected.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced SwapWidget Token Selection: When you select a buy token without a sell token already chosen, the widget now automatically sets the sell token to the native token of that chain. The same applies when selecting a sell token first.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->