### PR TITLE
[MNY-336] Portal: Fix spacing issue on menu with link

### DIFF
--- a/apps/portal/src/app/bridge/sidebar.tsx
+++ b/apps/portal/src/app/bridge/sidebar.tsx
@@ -19,6 +19,7 @@ export const sidebar: SideBar = {
     },
     { separator: true },
     {
+      name: "Guides",
       isCollapsible: false,
       links: [
         {
@@ -76,7 +77,6 @@ export const sidebar: SideBar = {
           name: "Custom Data",
         },
       ],
-      name: "Guides",
     },
     { separator: true },
     {

--- a/apps/portal/src/components/others/Sidebar.tsx
+++ b/apps/portal/src/components/others/Sidebar.tsx
@@ -203,7 +203,7 @@ function DocSidebarCategory(props: {
         "text-muted-foreground hover:text-foreground",
       )}
     >
-      <div className="flex gap-2" ref={triggerRef}>
+      <div className="flex gap-2 py-1.5 px-3" ref={triggerRef}>
         {icon && <SidebarIcon icon={icon} />}
         {name}
       </div>
@@ -211,7 +211,7 @@ function DocSidebarCategory(props: {
   );
 
   const triggerEl = href ? (
-    <Link className={cn("w-full py-1.5 px-3 text-left")} href={href}>
+    <Link className={cn("w-full text-left")} href={href}>
       {triggerElContent}
     </Link>
   ) : (


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying the sidebar structure and styling in the `sidebar.tsx` and `Sidebar.tsx` files, enhancing the visual layout and organization of sidebar items.

### Detailed summary
- In `sidebar.tsx`, the `name: "Guides"` entry was removed.
- In `Sidebar.tsx`, the padding classes were updated for a `div` element to include `py-1.5` and `px-3`.
- The `Link` component's class was modified to remove the `py-1.5` and `px-3` classes, simplifying its styling.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved sidebar category spacing with adjusted padding for clearer layout.
  * Increased and redistributed interactive area for sidebar navigation items for easier tapping/clicking.
  * Improved organization of the Guides section for better readability and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->