### PR TITLE
[Portal] Fix Transactions link in Archived Documentation section

### DIFF
--- a/apps/portal/src/app/page.tsx
+++ b/apps/portal/src/app/page.tsx
@@ -96,7 +96,7 @@ function ArchiveSection() {
         />
         <ArticleCardIndex
           description="Transactions knowledge base and guides"
-          href="/wallets/server/send-transactions"
+          href="/engine"
           icon={ArchiveIcon}
           title="Transactions"
           external


### PR DESCRIPTION
https://linear.app/thirdweb/issue/PRO-149/fix-archive-link-for-transactions

Update the Transactions link to point to /engine instead of /wallets/server/send-transactions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `href` property of the `ArticleCardIndex` component in the `page.tsx` file to point to a new URL.

### Detailed summary
- Changed the `href` property of the `ArticleCardIndex` from `"/wallets/server/send-transactions"` to `"/engine"`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Transactions card navigation destination in the Archive section to point to the new engine route.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->