### PR TITLE
[MNY-316] SDK: directly show token selection after wallet connection in bridge widgets

### DIFF
--- a/.changeset/heavy-clowns-stay.md
+++ b/.changeset/heavy-clowns-stay.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Move directly to token selection screen after connecting wallet in "Choose Payment" screen instead of showing the "Choose Payment" screen again after connecting wallet in bridge widgets

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/WalletSwitcherConnectionScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/WalletSwitcherConnectionScreen.tsx
@@ -70,7 +70,6 @@ export function WalletSwitcherConnectionScreen(
       onClose={() => {}}
       onConnect={(w) => {
         props.onSelect(w);
-        props.onBack();
       }}
       recommendedWallets={props.recommendedWallets}
       screenSetup={screenSetup}


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR modifies the behavior of the wallet connection process within the `WalletSwitcherConnectionScreen`. Upon connecting a wallet, it now directly transitions to the token selection screen, bypassing the intermediate "Choose Payment" screen.

### Detailed summary
- Updated `onConnect` function to remove the call to `props.onBack()`, allowing direct navigation to the token selection screen after wallet connection.
- Updated documentation to reflect the change in user flow for the wallet connection process in bridge widgets.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Streamlined wallet connection in bridge widgets: after connecting a wallet on the Choose Payment screen, the flow now advances directly to token selection instead of returning to or redisplaying the payment screen.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->