### PR TITLE
docs: use pnpm add in README install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 The main SDK package providing all-in-one web3 functionality for Browser, Node, and Mobile applications.
 
 ```bash
-npm install thirdweb
+pnpm add thirdweb
 ```
 
 **Features:**
@@ -46,7 +46,7 @@ Visit the [developer portal](https://portal.thirdweb.com) for full documentation
 #### For React Applications
 
 ```bash
-npm install thirdweb
+pnpm add thirdweb
 ```
 
 ```typescript
@@ -70,7 +70,7 @@ For React Native Applications, you'll also need to install the `@thirdweb-dev/re
 #### For Backend Applications
 
 ```bash
-npm install thirdweb
+pnpm add thirdweb
 ```
 
 ```typescript
@@ -107,7 +107,7 @@ await wallet.enqueueTransaction({
 Required polyfills and configuration for running the thirdweb SDK in React Native applications.
 
 ```bash
-npm install @thirdweb-dev/react-native-adapter
+pnpm add @thirdweb-dev/react-native-adapter
 ```
 
 #### [`@thirdweb-dev/wagmi-adapter`](./packages/wagmi-adapter/README.md)
@@ -115,7 +115,7 @@ npm install @thirdweb-dev/react-native-adapter
 Integration layer for using thirdweb's in-app wallets with wagmi.
 
 ```bash
-npm install @thirdweb-dev/wagmi-adapter
+pnpm add @thirdweb-dev/wagmi-adapter
 ```
 
 ## Type safe API wrappers
@@ -125,7 +125,7 @@ npm install @thirdweb-dev/wagmi-adapter
 TypeScript SDK for thirdweb's API, combining all of thirdweb products.
 
 ```bash
-npm install @thirdweb-dev/api
+pnpm add @thirdweb-dev/api
 ```
 
 #### [`@thirdweb-dev/engine`](./packages/engine/README.md)
@@ -133,7 +133,7 @@ npm install @thirdweb-dev/api
 TypeScript SDK for Engine, thirdweb's backend onchain executor service.
 
 ```bash
-npm install @thirdweb-dev/engine
+pnpm add @thirdweb-dev/engine
 ```
 
 #### [`@thirdweb-dev/insight`](./packages/insight/README.md)
@@ -141,7 +141,7 @@ npm install @thirdweb-dev/engine
 TypeScript SDK for Insight, thirdweb's multichain indexer service.
 
 ```bash
-npm install @thirdweb-dev/insight
+pnpm add @thirdweb-dev/insight
 ```
 
 #### [`@thirdweb-dev/vault-sdk`](./packages/vault-sdk/README.md)
@@ -149,7 +149,7 @@ npm install @thirdweb-dev/insight
 SDK for interacting with Vault, thirdweb's secure key management service.
 
 ```bash
-npm install @thirdweb-dev/vault-sdk
+pnpm add @thirdweb-dev/vault-sdk
 ```
 
 #### [`@thirdweb-dev/nebula`](./packages/nebula/README.md)
@@ -157,7 +157,7 @@ npm install @thirdweb-dev/vault-sdk
 TypeScript SDK for Nebula, thirdweb's AI agent service.
 
 ```bash
-npm install @thirdweb-dev/nebula
+pnpm add @thirdweb-dev/nebula
 ```
 
 ## Contributing


### PR DESCRIPTION
Fix incorrect install commands in README.
The repository uses pnpm workspaces, but the README referenced npm install.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the installation commands in the `README.md` file from using `npm` to `pnpm`, aligning with the preferred package manager for the project.

### Detailed summary
- Changed installation command from `npm install thirdweb` to `pnpm add thirdweb` for:
  - React Applications
  - Backend Applications
- Updated installation command for `@thirdweb-dev/react-native-adapter` to `pnpm add @thirdweb-dev/react-native-adapter`.
- Updated installation command for `@thirdweb-dev/wagmi-adapter` to `pnpm add @thirdweb-dev/wagmi-adapter`.
- Updated installation command for `@thirdweb-dev/api` to `pnpm add @thirdweb-dev/api`.
- Updated installation command for `@thirdweb-dev/engine` to `pnpm add @thirdweb-dev/engine`.
- Updated installation command for `@thirdweb-dev/insight` to `pnpm add @thirdweb-dev/insight`.
- Updated installation command for `@thirdweb-dev/vault-sdk` to `pnpm add @thirdweb-dev/vault-sdk`.
- Updated installation command for `@thirdweb-dev/nebula` to `pnpm add @thirdweb-dev/nebula`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions across multiple package documentation sections to ensure consistent and current setup guidance for all components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->