### PR TITLE
Etherlink shadownet chain

### DIFF
--- a/.changeset/etherlink-shadownet-chain.md
+++ b/.changeset/etherlink-shadownet-chain.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Add Etherlink Shadownet testnet chain (chain ID 127823)

--- a/packages/thirdweb/src/chains/chain-definitions/etherlink-shadownet.ts
+++ b/packages/thirdweb/src/chains/chain-definitions/etherlink-shadownet.ts
@@ -1,0 +1,21 @@
+import { defineChain } from "../utils.js";
+
+/**
+ * @chain
+ */
+export const etherlinkShadownet = /* @__PURE__ */ defineChain({
+  blockExplorers: [
+    {
+      name: "Etherlink Shadownet Explorer",
+      url: "https://shadownet.explorer.etherlink.com/",
+    },
+  ],
+  id: 127823,
+  name: "Etherlink Shadownet",
+  nativeCurrency: {
+    decimals: 18,
+    name: "Etherlink",
+    symbol: "XTZ",
+  },
+  testnet: true,
+});

--- a/packages/thirdweb/src/exports/chains.ts
+++ b/packages/thirdweb/src/exports/chains.ts
@@ -32,6 +32,7 @@ export { degen } from "../chains/chain-definitions/degen.js";
 // mainnet = alias for ethereum
 export { ethereum, mainnet } from "../chains/chain-definitions/ethereum.js";
 export { etherlink } from "../chains/chain-definitions/etherlink.js";
+export { etherlinkShadownet } from "../chains/chain-definitions/etherlink-shadownet.js";
 export { etherlinkTestnet } from "../chains/chain-definitions/etherlink-testnet.js";
 export { fantom } from "../chains/chain-definitions/fantom.js";
 export { fantomTestnet } from "../chains/chain-definitions/fantom-testnet.js";


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

-->
[SDK] Feature: Add Etherlink Shadownet Testnet chain

## Notes for the reviewer

Adds the Etherlink Shadownet testnet chain (ID 127823) to the predefined chains in the SDK. This includes its native currency (XTZ) and block explorer URL.

## How to test

- Verify the `etherlinkShadownet` chain can be imported from `thirdweb/chains`.
- Check that the chain object contains the correct `id`, `name`, `nativeCurrency`, and `blockExplorers` properties.
- Run `pnpm build` and `pnpm lint` to ensure no new issues are introduced.

---
[Slack Thread](https://thirdwebdev.slack.com/archives/C09DS2CKGP2/p1767789368607579?thread_ts=1767789368.607579&cid=C09DS2CKGP2)

<a href="https://cursor.com/background-agent?bcId=bc-a0f088a7-057b-46f0-b6a6-3ba957d1e261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a0f088a7-057b-46f0-b6a6-3ba957d1e261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the `Etherlink Shadownet`, a new testnet chain with its configuration and details added to the codebase.

### Detailed summary
- Added a new chain definition for `etherlinkShadownet` in `etherlink-shadownet.ts`.
- Defined properties such as `id`, `name`, `nativeCurrency`, and `blockExplorers`.
- Exported `etherlinkShadownet` from `chains.ts` for use in the application.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Etherlink Shadownet testnet (chain ID 127823). This enables development and testing on that network with block explorer integration and native currency configured as Etherlink (XTZ, 18 decimals). The chain is now available in the product's supported chains list for use in development workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->