### PR TITLE
DO NOT MERGE - Add Your tokens tab

### DIFF
--- a/packages/thirdweb/src/react/web/ui/Bridge/FundWallet.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/FundWallet.tsx
@@ -213,6 +213,8 @@ export function FundWallet(props: FundWalletProps) {
       >
         <SelectToken
           type="buy"
+          theme={props.theme}
+          connectOptions={props.connectOptions}
           currency={props.currency}
           selections={{
             buyChainId: props.selectedToken?.chainId,
@@ -645,7 +647,7 @@ function ReceiverWalletSection(props: {
         gap="xs"
         color="secondaryText"
       >
-        <WalletDotIcon size={iconSize.xs} color="secondaryText" />
+        <WalletDotIcon size={iconSize.xs} />
         <Text size="sm" color="primaryText">
           {ensNameQuery.data || shortenAddress(props.address)}
         </Text>

--- a/packages/thirdweb/src/react/web/ui/Bridge/payment-selection/PaymentSelection.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/payment-selection/PaymentSelection.tsx
@@ -13,7 +13,7 @@ import { useActiveWallet } from "../../../../core/hooks/wallets/useActiveWallet.
 import { useConnectedWallets } from "../../../../core/hooks/wallets/useConnectedWallets.js";
 import type { SupportedTokens } from "../../../../core/utils/defaultTokens.js";
 import type { ConnectLocale } from "../../ConnectWallet/locale/types.js";
-import { WalletSwitcherConnectionScreen } from "../../ConnectWallet/screens/WalletSwitcherConnectionScreen.js";
+import { WalletConnectionScreen } from "../../ConnectWallet/screens/WalletSwitcherConnectionScreen.js";
 import { Container, ModalHeader } from "../../components/basic.js";
 import { Spacer } from "../../components/Spacer.js";
 import type { PayEmbedConnectOptions } from "../../PayEmbed.js";
@@ -239,7 +239,9 @@ export function PaymentSelection({
       : connectOptions?.chains;
 
     return (
-      <WalletSwitcherConnectionScreen
+      <WalletConnectionScreen
+        shouldSetActive={false}
+        size="compact"
         accountAbstraction={connectOptions?.accountAbstraction}
         appMetadata={connectOptions?.appMetadata}
         chain={destinationChain || connectOptions?.chain}

--- a/packages/thirdweb/src/react/web/ui/Bridge/swap-widget/SelectChainButton.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/swap-widget/SelectChainButton.tsx
@@ -1,50 +1,134 @@
 import { ChevronDownIcon } from "@radix-ui/react-icons";
-import type { BridgeChain } from "../../../../../bridge/types/Chain.js";
 import type { ThirdwebClient } from "../../../../../client/client.js";
+import { useCustomTheme } from "../../../../core/design-system/CustomThemeProvider.js";
 import {
   fontSize,
   iconSize,
   radius,
   spacing,
 } from "../../../../core/design-system/index.js";
+import { Container } from "../../components/basic.js";
 import { Button } from "../../components/buttons.js";
 import { Img } from "../../components/Img.js";
+import { Spacer } from "../../components/Spacer.js";
+import type { SelectedTab } from "./types.js";
 import { cleanedChainName } from "./utils.js";
 
-export function SelectChainButton(props: {
-  selectedChain: BridgeChain;
+export function MobileTabSelector(props: {
+  selectedTab: SelectedTab;
+  onSelect: (tab: "your-tokens" | "all-tokens" | "chain-selector") => void;
   client: ThirdwebClient;
-  onClick: () => void;
 }) {
-  return (
-    <Button
-      variant="outline"
-      bg="tertiaryBg"
-      fullWidth
-      style={{
-        justifyContent: "flex-start",
-        fontWeight: 500,
-        fontSize: fontSize.md,
-        padding: `${spacing.sm} ${spacing.sm}`,
-        borderRadius: radius.lg,
-        minHeight: "48px",
-      }}
-      gap="sm"
-      onClick={props.onClick}
-    >
-      <Img
-        src={props.selectedChain.icon}
-        client={props.client}
-        width={iconSize.lg}
-        height={iconSize.lg}
-      />
-      <span> {cleanedChainName(props.selectedChain.name)} </span>
+  if (props.selectedTab.type === "your-tokens") {
+    return <Tabs selectedTab={props.selectedTab} onSelect={props.onSelect} />;
+  }
 
-      <ChevronDownIcon
-        width={iconSize.sm}
-        height={iconSize.sm}
-        style={{ marginLeft: "auto" }}
+  if (props.selectedTab.type === "chain") {
+    return (
+      <div>
+        <Tabs selectedTab={props.selectedTab} onSelect={props.onSelect} />
+        <Spacer y="sm" />
+        <Container px="md">
+          <Button
+            variant="outline"
+            bg="tertiaryBg"
+            fullWidth
+            style={{
+              justifyContent: "flex-start",
+              fontWeight: 500,
+              fontSize: fontSize.md,
+              padding: `${spacing.sm} ${spacing.sm}`,
+              borderRadius: radius.lg,
+              minHeight: "48px",
+            }}
+            gap="sm"
+            onClick={() => props.onSelect("chain-selector")}
+          >
+            <Img
+              src={props.selectedTab.chain.icon}
+              client={props.client}
+              width={iconSize.md}
+              height={iconSize.md}
+            />
+            <span> {cleanedChainName(props.selectedTab.chain.name)} </span>
+            <ChevronDownIcon
+              width={iconSize.sm}
+              height={iconSize.sm}
+              style={{ marginLeft: "auto" }}
+            />
+          </Button>
+        </Container>
+      </div>
+    );
+  }
+
+  return null;
+}
+
+function Tabs(props: {
+  selectedTab: SelectedTab;
+  onSelect: (tab: "your-tokens" | "all-tokens") => void;
+}) {
+  const theme = useCustomTheme();
+  return (
+    <Container
+      flex="row"
+      gap="xs"
+      px="md"
+      style={{ borderBottom: `1px solid ${theme.colors.borderColor}` }}
+    >
+      <TabButton
+        isSelected={props.selectedTab.type === "your-tokens"}
+        onSelect={() => props.onSelect("your-tokens")}
+        label="Your Tokens"
       />
-    </Button>
+      <TabButton
+        isSelected={props.selectedTab.type === "chain"}
+        onSelect={() => props.onSelect("all-tokens")}
+        label="All Tokens"
+      />
+    </Container>
+  );
+}
+
+function TabButton(props: {
+  isSelected: boolean;
+  onSelect: () => void;
+  label: string;
+}) {
+  const theme = useCustomTheme();
+  return (
+    <div
+      style={{
+        paddingBottom: "4px",
+        position: "relative",
+      }}
+    >
+      <Button
+        variant="ghost-solid"
+        onClick={props.onSelect}
+        style={{
+          fontSize: fontSize.sm,
+          padding: `10px ${spacing.xs}`,
+          color: props.isSelected
+            ? theme.colors.primaryText
+            : theme.colors.secondaryText,
+        }}
+      >
+        {props.label}
+      </Button>
+
+      {props.isSelected && (
+        <div
+          style={{
+            position: "absolute",
+            left: 0,
+            right: 0,
+            bottom: "-1.5px",
+            borderBottom: `2px solid ${theme.colors.primaryText}`,
+          }}
+        ></div>
+      )}
+    </div>
   );
 }

--- a/packages/thirdweb/src/react/web/ui/Bridge/swap-widget/swap-ui.tsx
+++ b/packages/thirdweb/src/react/web/ui/Bridge/swap-widget/swap-ui.tsx
@@ -208,6 +208,8 @@ export function SwapUI(props: SwapUIProps) {
         {modalState.screen === "select-buy-token" && (
           <SelectToken
             type="buy"
+            theme={props.theme}
+            connectOptions={props.connectOptions}
             selections={{
               buyChainId: props.buyToken?.chainId,
               sellChainId: props.sellToken?.chainId,
@@ -252,6 +254,8 @@ export function SwapUI(props: SwapUIProps) {
         {/* sell token modal */}
         {modalState.screen === "select-sell-token" && (
           <SelectToken
+            theme={props.theme}
+            connectOptions={props.connectOptions}
             onClose={() => {
               setModalState((v) => ({
                 ...v,

--- a/packages/thirdweb/src/react/web/ui/Bridge/swap-widget/types.ts
+++ b/packages/thirdweb/src/react/web/ui/Bridge/swap-widget/types.ts
@@ -1,3 +1,4 @@
+import type { BridgeChain } from "../../../../../bridge/types/Chain.js";
 import type { Chain } from "../../../../../chains/types.js";
 import type {
   Account,
@@ -155,3 +156,7 @@ export type SwapPreparedQuote = Extract<
   BridgePrepareResult,
   { type: "buy" | "sell" }
 >;
+
+export type SelectedTab =
+  | { type: "chain"; chain: BridgeChain }
+  | { type: "your-tokens" };

--- a/packages/thirdweb/src/react/web/ui/Bridge/swap-widget/use-tokens.ts
+++ b/packages/thirdweb/src/react/web/ui/Bridge/swap-widget/use-tokens.ts
@@ -77,13 +77,13 @@ export function useTokenBalances(options: {
   page: number;
   limit: number;
   walletAddress: string | undefined;
-  chainId: number | undefined;
+  chainId: number | number[] | undefined;
 }) {
   return useQuery({
     queryKey: ["bridge/v1/wallets", options],
-    enabled: !!options.chainId && !!options.walletAddress,
+    enabled: !!options.walletAddress,
     queryFn: async () => {
-      if (!options.chainId || !options.walletAddress) {
+      if (!options.walletAddress) {
         throw new Error("invalid options");
       }
       const baseUrl = getThirdwebBaseUrl("bridge");
@@ -91,7 +91,18 @@ export function useTokenBalances(options: {
       const url = new URL(
         `https://api.${isDev ? "thirdweb-dev" : "thirdweb"}.com/v1/wallets/${options.walletAddress}/tokens`,
       );
-      url.searchParams.set("chainId", options.chainId.toString());
+
+      // Set chainId param(s) if provided
+      if (options.chainId !== undefined) {
+        if (Array.isArray(options.chainId)) {
+          for (const id of options.chainId) {
+            url.searchParams.append("chainId", id.toString());
+          }
+        } else {
+          url.searchParams.set("chainId", options.chainId.toString());
+        }
+      }
+
       url.searchParams.set("limit", options.limit.toString());
       url.searchParams.set("page", options.page.toString());
       url.searchParams.set("metadata", "true");

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/icons/WalletDotIcon.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/icons/WalletDotIcon.tsx
@@ -1,9 +1,10 @@
-import type { IconFC } from "./types.js";
-
 /**
  * @internal
  */
-export const WalletDotIcon: IconFC = (props) => {
+export const WalletDotIcon = (props: {
+  size?: string;
+  style?: React.CSSProperties;
+}) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -11,7 +12,7 @@ export const WalletDotIcon: IconFC = (props) => {
       viewBox="0 0 18 18"
       width={props.size}
       height={props.size}
-      style={{ color: props.color }}
+      style={props.style}
       role="presentation"
     >
       <path

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Details/WalletManagerScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/Details/WalletManagerScreen.tsx
@@ -28,14 +28,14 @@ import { WalletImage } from "../../../components/WalletImage.js";
 import { WalletButtonEl } from "../../WalletEntryButton.js";
 import { formatTokenBalance } from "../formatTokenBalance.js";
 import {
-  WalletSwitcherConnectionScreen,
-  type WalletSwitcherConnectionScreenProps,
+  WalletConnectionScreen,
+  type WalletConnectionScreenProps,
 } from "../WalletSwitcherConnectionScreen.js";
 
 export function WalletManagerScreen(
   props: Omit<
-    WalletSwitcherConnectionScreenProps,
-    "onSelect" | "isEmbed" | "selectedWallet"
+    WalletConnectionScreenProps,
+    "onSelect" | "isEmbed" | "selectedWallet" | "size" | "shouldSetActive"
   > & {
     activeAccount: Account;
     activeWallet: Wallet;
@@ -53,13 +53,15 @@ export function WalletManagerScreen(
 
   if (screen === "connect") {
     return (
-      <WalletSwitcherConnectionScreen
+      <WalletConnectionScreen
         {...props}
         isEmbed={false}
         onSelect={(w) => {
           setActive(w);
           props.onBack();
         }}
+        shouldSetActive={false}
+        size="compact"
       />
     );
   }

--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/WalletSwitcherConnectionScreen.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/screens/WalletSwitcherConnectionScreen.tsx
@@ -11,7 +11,7 @@ import type { ConnectLocale } from "../locale/types.js";
 import { ConnectModalContent } from "../Modal/ConnectModalContent.js";
 import { useSetupScreen } from "../Modal/screen.js";
 
-export type WalletSwitcherConnectionScreenProps = {
+export type WalletConnectionScreenProps = {
   chain: Chain | undefined;
   chains: Chain[] | undefined;
   client: ThirdwebClient;
@@ -24,17 +24,17 @@ export type WalletSwitcherConnectionScreenProps = {
   recommendedWallets: Wallet[] | undefined;
   showAllWallets: boolean;
   hiddenWallets?: WalletId[];
+  size: "compact" | "wide";
   walletConnect:
     | {
         projectId?: string;
       }
     | undefined;
   onBack: () => void;
+  shouldSetActive: boolean;
 };
 
-export function WalletSwitcherConnectionScreen(
-  props: WalletSwitcherConnectionScreenProps,
-) {
+export function WalletConnectionScreen(props: WalletConnectionScreenProps) {
   const walletChain = useActiveWalletChain();
   const connectedWallets = useConnectedWallets();
   const wallets =
@@ -74,9 +74,9 @@ export function WalletSwitcherConnectionScreen(
       recommendedWallets={props.recommendedWallets}
       screenSetup={screenSetup}
       setModalVisibility={() => {}}
-      shouldSetActive={false}
+      shouldSetActive={props.shouldSetActive}
       showAllWallets={props.showAllWallets}
-      size="compact"
+      size={props.size}
       walletConnect={props.walletConnect}
       walletIdsToHide={connectedWallets.map((x) => x.id)}
       wallets={wallets}

--- a/packages/thirdweb/src/react/web/ui/components/DynamicHeight.tsx
+++ b/packages/thirdweb/src/react/web/ui/components/DynamicHeight.tsx
@@ -5,10 +5,7 @@ import { useEffect, useRef, useState } from "react";
 /**
  * @internal
  */
-export function DynamicHeight(props: {
-  children: React.ReactNode;
-  maxHeight?: string;
-}) {
+export function DynamicHeight(props: { children: React.ReactNode }) {
   const { height, elementRef } = useHeightObserver();
 
   return (
@@ -20,14 +17,7 @@ export function DynamicHeight(props: {
         transition: "height 210ms ease",
       }}
     >
-      <div
-        ref={elementRef}
-        style={{
-          maxHeight: props.maxHeight,
-        }}
-      >
-        {props.children}
-      </div>
+      <div ref={elementRef}>{props.children}</div>
     </div>
   );
 }

--- a/packages/thirdweb/src/react/web/ui/components/Modal.tsx
+++ b/packages/thirdweb/src/react/web/ui/components/Modal.tsx
@@ -99,6 +99,10 @@ export const Modal: React.FC<{
                 props.hide
                   ? { height: 0, opacity: 0, overflow: "hidden", width: 0 }
                   : {
+                      maxHeight:
+                        props.size === "compact"
+                          ? compactModalMaxHeight
+                          : undefined,
                       height:
                         props.size === "compact" ? "auto" : wideModalMaxHeight,
                       maxWidth:
@@ -125,9 +129,7 @@ export const Modal: React.FC<{
                 {props.title}
               </Dialog.Title>
               {props.size === "compact" ? (
-                <DynamicHeight maxHeight={compactModalMaxHeight}>
-                  {props.children}
-                </DynamicHeight>
+                <DynamicHeight>{props.children}</DynamicHeight>
               ) : (
                 props.children
               )}

--- a/packages/thirdweb/src/stories/Bridge/Swap/SelectChain.stories.tsx
+++ b/packages/thirdweb/src/stories/Bridge/Swap/SelectChain.stories.tsx
@@ -1,11 +1,11 @@
 import type { Meta } from "@storybook/react-vite";
 import { useState } from "react";
-import type { BridgeChain } from "../../../bridge/types/Chain.js";
 import { SwapWidgetContainer } from "../../../react/web/ui/Bridge/swap-widget/SwapWidget.js";
 import {
   SelectBridgeChain,
   SelectBridgeChainUI,
 } from "../../../react/web/ui/Bridge/swap-widget/select-chain.js";
+import type { SelectedTab } from "../../../react/web/ui/Bridge/swap-widget/types.js";
 import { storyClient } from "../../utils.js";
 
 const meta = {
@@ -17,9 +17,9 @@ const meta = {
 export default meta;
 
 export function WithDataDesktop() {
-  const [selectedChain, setSelectedChain] = useState<BridgeChain | undefined>(
-    undefined,
-  );
+  const [selectedTab, setSelectedTab] = useState<SelectedTab>({
+    type: "your-tokens",
+  });
   return (
     <SwapWidgetContainer theme="dark" className="w-full">
       <SelectBridgeChain
@@ -30,18 +30,18 @@ export function WithDataDesktop() {
         }}
         isMobile={false}
         client={storyClient}
-        onSelectChain={setSelectedChain}
+        onSelectTab={setSelectedTab}
         onBack={() => {}}
-        selectedChain={selectedChain}
+        selectedTab={selectedTab}
       />
     </SwapWidgetContainer>
   );
 }
 
 export function LoadingDesktop() {
-  const [selectedChain, setSelectedChain] = useState<BridgeChain | undefined>(
-    undefined,
-  );
+  const [selectedTab, setSelectedTab] = useState<SelectedTab>({
+    type: "your-tokens",
+  });
   return (
     <SwapWidgetContainer theme="dark" className="w-full">
       <SelectBridgeChainUI
@@ -52,20 +52,20 @@ export function LoadingDesktop() {
         }}
         isMobile={false}
         client={storyClient}
-        onSelectChain={setSelectedChain}
+        onSelectTab={setSelectedTab}
         onBack={() => {}}
         isPending={true}
         chains={[]}
-        selectedChain={selectedChain}
+        selectedTab={selectedTab}
       />
     </SwapWidgetContainer>
   );
 }
 
 export function WithDataMobile() {
-  const [selectedChain, setSelectedChain] = useState<BridgeChain | undefined>(
-    undefined,
-  );
+  const [selectedTab, setSelectedTab] = useState<SelectedTab>({
+    type: "your-tokens",
+  });
   return (
     <SwapWidgetContainer theme="dark" className="w-full">
       <SelectBridgeChain
@@ -76,18 +76,18 @@ export function WithDataMobile() {
         }}
         isMobile={true}
         client={storyClient}
-        onSelectChain={setSelectedChain}
+        onSelectTab={setSelectedTab}
         onBack={() => {}}
-        selectedChain={selectedChain}
+        selectedTab={selectedTab}
       />
     </SwapWidgetContainer>
   );
 }
 
 export function LoadingMobile() {
-  const [selectedChain, setSelectedChain] = useState<BridgeChain | undefined>(
-    undefined,
-  );
+  const [selectedTab, setSelectedTab] = useState<SelectedTab>({
+    type: "your-tokens",
+  });
   return (
     <SwapWidgetContainer theme="dark" className="w-full">
       <SelectBridgeChainUI
@@ -98,11 +98,11 @@ export function LoadingMobile() {
         }}
         isMobile={true}
         client={storyClient}
-        onSelectChain={setSelectedChain}
+        onSelectTab={setSelectedTab}
         onBack={() => {}}
         isPending={true}
         chains={[]}
-        selectedChain={selectedChain}
+        selectedTab={selectedTab}
       />
     </SwapWidgetContainer>
   );


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `SelectedTab` type for managing tab states in the swap widget and refines various components related to wallet connections and token selections, enhancing the user interface and functionality.

### Detailed summary
- Added `SelectedTab` type to manage tab states.
- Updated `WalletDotIcon` to accept `style` prop.
- Enhanced `SwapUI` and `FundWallet` to support `theme` and `connectOptions`.
- Refactored `DynamicHeight` to remove `maxHeight` prop.
- Renamed `WalletSwitcherConnectionScreen` to `WalletConnectionScreen`.
- Modified `SelectToken` to use `selectedTab`.
- Implemented mobile and desktop token selection screens.
- Added `YourTokenButton` for improved token display.
- Introduced `ScreenHeader` for consistent header formatting.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Tab-based token selection UI with "Your Tokens" and "All Tokens" sections for clearer organization.
  * Multi-chain support for token balance queries and selection.
  * Enhanced wallet connection screens with configurable sizing options.

* **Refactor**
  * Reorganized swap widget token and chain selection flows for improved UX structure.
  * Updated wallet connection component architecture and theming integration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->