### PR TITLE
Fix getCallStatus via EIP1193 provider

### DIFF
--- a/.changeset/yummy-sloths-live.md
+++ b/.changeset/yummy-sloths-live.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix getCallStatus via EIP1193 provider

--- a/apps/wagmi-demo/src/App.tsx
+++ b/apps/wagmi-demo/src/App.tsx
@@ -1,13 +1,14 @@
 import type { ConnectionOptions } from "@thirdweb-dev/wagmi-adapter";
 import { ConnectButton } from "thirdweb/react";
+import { stringify } from "thirdweb/utils";
 import { createWallet } from "thirdweb/wallets";
 import {
   useAccount,
-  useCallsStatus,
   useConnect,
   useDisconnect,
   useSendCalls,
   useSendTransaction,
+  useWaitForCallsStatus,
 } from "wagmi";
 import { chain, client, thirdwebChainForWallet, wallet } from "./wagmi.js";
 
@@ -28,7 +29,7 @@ function App() {
     data: callStatus,
     isLoading: isLoadingCallStatus,
     error: callStatusError,
-  } = useCallsStatus({
+  } = useWaitForCallsStatus({
     id: data?.id || "",
     query: {
       enabled: !!data?.id,
@@ -42,7 +43,7 @@ function App() {
         <div>
           status: {account.status}
           <br />
-          addresses: {JSON.stringify(account.addresses)}
+          addresses: {stringify(account.addresses)}
           <br />
           chainId: {account.chainId}
         </div>
@@ -122,6 +123,12 @@ function App() {
                 calls: [
                   {
                     to: "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
+                    data: "0x1234",
+                    value: 0n,
+                  },
+                  {
+                    to: "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
+                    data: "0x1234",
                     value: 0n,
                   },
                 ],
@@ -145,7 +152,7 @@ function App() {
           </div>
           <div>
             {callStatus
-              ? `Success: ${JSON.stringify(callStatus, null, 2)}`
+              ? `Success: ${stringify(callStatus, null, 2)}`
               : callStatusError
                 ? callStatusError?.message
                 : ""}

--- a/packages/thirdweb/src/adapters/eip1193/to-eip1193.ts
+++ b/packages/thirdweb/src/adapters/eip1193/to-eip1193.ts
@@ -194,14 +194,15 @@ export function toProvider(options: ToEip1193ProviderOptions): EIP1193Provider {
           if (!account) {
             throw new Error("Account not connected");
           }
-          if (!account.getCallsStatus) {
+          if (!account.getCallsStatusRaw) {
             throw new Error("Wallet does not support EIP-5792");
           }
-          return account.getCallsStatus({
+          const result = await account.getCallsStatusRaw({
             id: request.params[0],
             chain: chain,
             client: client,
           });
+          return result;
         }
         default:
           return rpcClient(request);

--- a/packages/thirdweb/src/wallets/coinbase/coinbase-web.ts
+++ b/packages/thirdweb/src/wallets/coinbase/coinbase-web.ts
@@ -326,6 +326,22 @@ function createAccount({
         throw error;
       }
     },
+    async getCallsStatusRaw(options) {
+      try {
+        const rawResponse = (await provider.request({
+          method: "wallet_getCallsStatus",
+          params: [options.id],
+        })) as GetCallsStatusRawResponse;
+        return rawResponse;
+      } catch (error) {
+        if (/unsupport|not support/i.test((error as Error).message)) {
+          throw new Error(
+            `${COINBASE} does not support wallet_getCallsStatus, reach out to them directly to request EIP-5792 support.`,
+          );
+        }
+        throw error;
+      }
+    },
     async getCapabilities(options) {
       const chainId = options.chainId;
       try {

--- a/packages/thirdweb/src/wallets/in-app/core/eip7702/minimal-account.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/eip7702/minimal-account.ts
@@ -351,6 +351,12 @@ export const create7702MinimalAccount = (args: {
       );
       return inAppWalletGetCallsStatus(options);
     },
+    getCallsStatusRaw: async (options) => {
+      const { inAppWalletGetCallsStatusRaw } = await import(
+        "../eip5792/in-app-wallet-calls.js"
+      );
+      return inAppWalletGetCallsStatusRaw(options);
+    },
     getCapabilities: async (options) => {
       return {
         [options.chainId ?? 1]: {

--- a/packages/thirdweb/src/wallets/in-app/core/wallet/enclave-wallet.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/wallet/enclave-wallet.ts
@@ -287,6 +287,12 @@ export class EnclaveWallet implements IWebWallet {
         );
         return inAppWalletGetCallsStatus(options);
       },
+      getCallsStatusRaw: async (options) => {
+        const { inAppWalletGetCallsStatusRaw } = await import(
+          "../eip5792/in-app-wallet-calls.js"
+        );
+        return inAppWalletGetCallsStatusRaw(options);
+      },
       getCapabilities: async (options) => {
         return {
           [options.chainId ?? 1]: {

--- a/packages/thirdweb/src/wallets/injected/index.ts
+++ b/packages/thirdweb/src/wallets/injected/index.ts
@@ -373,6 +373,22 @@ function createAccount({
         throw error;
       }
     },
+    async getCallsStatusRaw(options) {
+      try {
+        const rawResponse = (await provider.request({
+          method: "wallet_getCallsStatus",
+          params: [options.id],
+        })) as GetCallsStatusRawResponse;
+        return rawResponse;
+      } catch (error) {
+        if (/unsupport|not support/i.test((error as Error).message)) {
+          throw new Error(
+            `${id} does not support wallet_getCallsStatus, reach out to them directly to request EIP-5792 support.`,
+          );
+        }
+        throw error;
+      }
+    },
     async getCapabilities(options) {
       const chainIdFilter = options.chainId;
       try {

--- a/packages/thirdweb/src/wallets/interfaces/wallet.ts
+++ b/packages/thirdweb/src/wallets/interfaces/wallet.ts
@@ -19,6 +19,7 @@ import type {
   SendCallsResult,
 } from "../eip5792/send-calls.js";
 import type {
+  GetCallsStatusRawResponse,
   GetCallsStatusResponse,
   WalletSendCallsId,
 } from "../eip5792/types.js";
@@ -325,6 +326,14 @@ export type Account = {
     chain: Chain;
     client: ThirdwebClient;
   }) => Promise<GetCallsStatusResponse>;
+  /**
+   * EIP-5792: Get the raw (unprocessed) status of the given call bundle
+   */
+  getCallsStatusRaw?: (options: {
+    id: WalletSendCallsId;
+    chain: Chain;
+    client: ThirdwebClient;
+  }) => Promise<GetCallsStatusRawResponse>;
   /**
    * EIP-5792: Get the capabilities of the wallet
    */

--- a/packages/thirdweb/src/wallets/smart/index.ts
+++ b/packages/thirdweb/src/wallets/smart/index.ts
@@ -389,6 +389,12 @@ async function createSmartAccount(
       );
       return inAppWalletGetCallsStatus(options);
     },
+    getCallsStatusRaw: async (options) => {
+      const { inAppWalletGetCallsStatusRaw } = await import(
+        "../in-app/core/eip5792/in-app-wallet-calls.js"
+      );
+      return inAppWalletGetCallsStatusRaw(options);
+    },
     getCapabilities: async (options) => {
       return {
         [options.chainId ?? 1]: {
@@ -566,6 +572,12 @@ function createZkSyncAccount(args: {
         "../in-app/core/eip5792/in-app-wallet-calls.js"
       );
       return inAppWalletGetCallsStatus(options);
+    },
+    getCallsStatusRaw: async (options) => {
+      const { inAppWalletGetCallsStatusRaw } = await import(
+        "../in-app/core/eip5792/in-app-wallet-calls.js"
+      );
+      return inAppWalletGetCallsStatusRaw(options);
     },
     getCapabilities: async (options) => {
       return {


### PR DESCRIPTION
<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding support for the `wallet_getCallsStatusRaw` method across various wallet implementations, enhancing the functionality for retrieving raw call statuses in compliance with EIP-5792.

### Detailed summary
- Introduced `getCallsStatusRaw` method in several wallet files.
- Updated `getCallsStatus` calls to `getCallsStatusRaw` where applicable.
- Enhanced error handling for unsupported wallets in `getCallsStatusRaw`.
- Added documentation for `getCallsStatusRaw` in type definitions.
- Implemented `inAppWalletGetCallsStatusRaw` function for retrieving call statuses.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed getCallStatus to work correctly with EIP1193 provider implementations.

* **New Features**
  * Added getCallsStatusRaw method to wallet accounts for direct access to raw transaction call status responses.

* **Updates**
  * Updated demo application to use latest wagmi utilities and enhanced utility functions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->