### PR TITLE
[SDK] Fix SiteLink and SiteEmbed stripping URL hash fragments

### DIFF
--- a/packages/thirdweb/src/react/web/ui/SiteLink.test.tsx
+++ b/packages/thirdweb/src/react/web/ui/SiteLink.test.tsx
@@ -62,4 +62,25 @@ describe("SiteLink", () => {
     expect(anchor).toBeTruthy();
     await waitFor(() => expect(anchor?.href).toContain("walletId=inApp"));
   });
+
+  it("preserves hash fragment for hash-routed URLs", async () => {
+    const testUrl = "https://snapshot.org/#/s:wampei.eth";
+    const { container } = render(
+      <SiteLink client={TEST_CLIENT} href={testUrl}>
+        Test Link
+      </SiteLink>,
+      {
+        setConnectedWallet: true,
+      },
+    );
+
+    const anchor = container.querySelector("a");
+    expect(anchor).toBeTruthy();
+    await waitFor(() => {
+      const href = anchor?.href ?? "";
+      // Hash fragment must be preserved in the URL
+      expect(href).toContain("#/s:wampei.eth");
+      expect(href).toContain("walletId=");
+    });
+  });
 });

--- a/packages/thirdweb/src/wallets/in-app/web/lib/get-url-token.ts
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/get-url-token.ts
@@ -19,18 +19,40 @@ export function getUrlToken():
     return undefined;
   }
 
-  const queryString = window.location.search;
-  const params = new URLSearchParams(queryString);
-  const authResultString = params.get("authResult");
-  const walletId = params.get("walletId") as WalletId | undefined;
-  const authProvider = params.get("authProvider") as AuthOption | undefined;
-  const authCookie = params.get("authCookie") as string | undefined;
-  const authFlow = params.get("authFlow") as "connect" | "link" | undefined;
+  // Read params from the standard query string
+  const params = new URLSearchParams(window.location.search);
+
+  // Also check for params embedded inside the hash fragment (e.g. #/route?walletId=...)
+  // This supports hash-routed apps where params may be placed after the hash path
+  let hashParams: URLSearchParams | undefined;
+  const hash = window.location.hash || "";
+  let cleanHash = hash;
+  const hashQueryIndex = hash.indexOf("?");
+  if (hashQueryIndex !== -1) {
+    hashParams = new URLSearchParams(hash.substring(hashQueryIndex));
+    cleanHash = hash.substring(0, hashQueryIndex);
+  }
+
+  const walletId = (params.get("walletId") ??
+    hashParams?.get("walletId") ??
+    undefined) as WalletId | undefined;
+  const authResultString =
+    params.get("authResult") ?? hashParams?.get("authResult") ?? undefined;
+  const authProvider = (params.get("authProvider") ??
+    hashParams?.get("authProvider") ??
+    undefined) as AuthOption | undefined;
+  const authCookie = (params.get("authCookie") ??
+    hashParams?.get("authCookie") ??
+    undefined) as string | undefined;
+  const authFlow = (params.get("authFlow") ??
+    hashParams?.get("authFlow") ??
+    undefined) as "connect" | "link" | undefined;
 
   if ((authCookie || authResultString) && walletId) {
     const authResult = (() => {
       if (authResultString) {
         params.delete("authResult");
+        hashParams?.delete("authResult");
         return JSON.parse(decodeURIComponent(authResultString));
       }
     })();
@@ -38,10 +60,27 @@ export function getUrlToken():
     params.delete("authProvider");
     params.delete("authCookie");
     params.delete("authFlow");
+    hashParams?.delete("walletId");
+    hashParams?.delete("authProvider");
+    hashParams?.delete("authCookie");
+    hashParams?.delete("authFlow");
+
+    const remainingSearch = params.toString();
+    const searchString = remainingSearch ? `?${remainingSearch}` : "";
+
+    // Reconstruct hash, preserving the hash path and any remaining non-auth params
+    let hashString = cleanHash;
+    if (hashParams) {
+      const remainingHashParams = hashParams.toString();
+      if (remainingHashParams) {
+        hashString = `${cleanHash}?${remainingHashParams}`;
+      }
+    }
+
     window.history.pushState(
       {},
       "",
-      `${window.location.pathname}?${params.toString()}`,
+      `${window.location.pathname}${searchString}${hashString}`,
     );
     return { authCookie, authFlow, authProvider, authResult, walletId };
   }


### PR DESCRIPTION
https://linear.app/thirdweb/issue/PRO-186/bug-in-sitelink-and-siteembed-for-urls

SiteLink/SiteEmbed now append wallet params inside the hash fragment for hash-routed URLs (e.g. https://snapshot.org/#/s:wampei.eth) instead of placing them in the standard query string where they get separated from the hash router. Also fix getUrlToken dropping window.location.hash when cleaning up auth params via pushState.

<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the handling of URL parameters in hash-routed applications, ensuring that both query parameters and hash fragments are processed correctly. It includes tests to validate the preservation of hash fragments and modifies the `getUrlToken` function to accommodate these changes.

### Detailed summary
- Added a test in `SiteLink.test.tsx` to verify preservation of hash fragments in URLs.
- Updated `get-url-token.test.tsx` to:
  - Check for hash fragments and their parameters.
  - Ensure `authFlow` and `authProvider` return `undefined` instead of `null`.
- Modified `get-url-token.ts` to:
  - Read parameters from both the query string and hash fragments.
  - Preserve hash fragments when constructing the URL for `pushState`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better handling of hash-routed URLs: authentication parameters are now read from both query and hash fragments, and URL cleanup preserves the original hash path while removing auth tokens.

* **Tests**
  * Added coverage for hash-fragment preservation and parsing of authentication parameters embedded in hashed URLs; updated expectations for parsed auth values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->