### PR TITLE
portal: Fix sidebar spacing on top

### DIFF
--- a/apps/portal/src/components/Layouts/DocLayout.tsx
+++ b/apps/portal/src/components/Layouts/DocLayout.tsx
@@ -49,7 +49,6 @@ export function DocLayout(props: DocLayoutProps) {
           <DocSidebar
             {...props.sideBar}
             header={props.sidebarHeader}
-            className="pt-1"
           />
         </aside>
       )}

--- a/apps/portal/src/components/others/Sidebar.tsx
+++ b/apps/portal/src/components/others/Sidebar.tsx
@@ -68,7 +68,7 @@ export function DocSidebar(props: ReferenceSideBarProps) {
         {props.links.map((link, i) => (
           // biome-ignore lint/suspicious/noArrayIndexKey: TODO - fix this
           <li key={i}>
-            <SidebarItem link={link} onLinkClick={props.onLinkClick} />
+            <SidebarItem link={link} onLinkClick={props.onLinkClick} isFirst={i === 0} />
           </li>
         ))}
       </ul>
@@ -76,7 +76,7 @@ export function DocSidebar(props: ReferenceSideBarProps) {
   );
 }
 
-function SidebarItem(props: { link: SidebarLink; onLinkClick?: () => void }) {
+function SidebarItem(props: { link: SidebarLink; onLinkClick?: () => void, isFirst: boolean }) {
   const pathname = usePathname();
 
   if ("separator" in props.link) {
@@ -92,6 +92,7 @@ function SidebarItem(props: { link: SidebarLink; onLinkClick?: () => void }) {
     if (link.isCollapsible === false) {
       return (
         <DocSidebarNonCollapsible
+          isFirst={props.isFirst}
           key={link.name}
           linkGroup={link}
           onLinkClick={props.onLinkClick}
@@ -145,13 +146,14 @@ function SidebarItem(props: { link: SidebarLink; onLinkClick?: () => void }) {
 function DocSidebarNonCollapsible(props: {
   linkGroup: LinkGroup;
   onLinkClick?: () => void;
+  isFirst: boolean;
 }) {
   const pathname = usePathname();
   const { href, name, links, icon } = props.linkGroup;
   const isCategoryActive = href ? isSamePage(pathname, href) : false;
 
   return (
-    <div className="my-4">
+    <div className={cn("my-4", props.isFirst && "mt-0")}>
       <div className="mb-2 flex items-center gap-2 rounded-lg text-foreground">
         {icon && <SidebarIcon icon={icon} />}
         {href ? (
@@ -173,7 +175,7 @@ function DocSidebarNonCollapsible(props: {
           return (
             // biome-ignore lint/suspicious/noArrayIndexKey: TODO - fix this
             <li key={i}>
-              <SidebarItem link={link} onLinkClick={props.onLinkClick} />
+              <SidebarItem link={link} onLinkClick={props.onLinkClick} isFirst={i === 0} />
             </li>
           );
         })}
@@ -238,7 +240,7 @@ function DocSidebarCategory(props: {
             return (
               // biome-ignore lint/suspicious/noArrayIndexKey: TODO - fix this
               <li key={i}>
-                <SidebarItem link={link} onLinkClick={props.onLinkClick} />
+                <SidebarItem link={link} onLinkClick={props.onLinkClick} isFirst={i === 0} />
               </li>
             );
           })}


### PR DESCRIPTION
Fixes spacing issue on sidebar 

Before

<img width="942" height="358" alt="image" src="https://github.com/user-attachments/assets/f86f801f-e977-49a3-b7ca-514cf913820b" />


After

<img width="902" height="340" alt="image" src="https://github.com/user-attachments/assets/c37aae4e-00bc-4670-9c0e-ee43a5363a89" />


<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `SidebarItem` component by adding an `isFirst` prop to manage specific styling for the first item in the sidebar.

### Detailed summary
- Added `isFirst` prop to `SidebarItem` to indicate if it is the first item.
- Updated the `DocSidebarNonCollapsible` component to apply conditional styling based on the `isFirst` prop.
- Adjusted the rendering of `SidebarItem` in multiple places to pass the `isFirst` prop.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced sidebar spacing and alignment for improved visual consistency across the entire navigation section. Removed unnecessary top padding from the sidebar header and optimized spacing distribution for first items in categories, resulting in better layout harmony and a more refined appearance throughout the navigation interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->