### PR TITLE
Connect modal require approval

### DIFF
--- a/packages/thirdweb/src/react/web/ui/ConnectWallet/useConnectModal.tsx
+++ b/packages/thirdweb/src/react/web/ui/ConnectWallet/useConnectModal.tsx
@@ -118,6 +118,7 @@ function Modal(
       termsOfServiceUrl: props.termsOfServiceUrl,
       title: props.title,
       titleIconUrl: props.titleIcon,
+      requireApproval: props.requireApproval,
     };
   }, [
     props.privacyPolicyUrl,
@@ -125,6 +126,7 @@ function Modal(
     props.termsOfServiceUrl,
     props.title,
     props.titleIcon,
+    props.requireApproval,
   ]);
 
   return (
@@ -449,6 +451,22 @@ export type UseConnectModalOptions = {
    * Refer to the [`SiweAuthOptions`](https://portal.thirdweb.com/references/typescript/v5/SiweAuthOptions) for more details
    */
   auth?: SiweAuthOptions;
+
+  /**
+   * Require terms of service and privacy policy to be accepted before connecting an in-app wallet.
+   *
+   * By default it's `false`
+   * @example
+   * ```tsx
+   * function Example() {
+   *   const { connect } = useConnectModal();
+   *   return <button onClick={() => connect({ client, requireApproval: true })}>
+   *     Connect
+   *   </button>
+   * }
+   * ```
+   */
+  requireApproval?: boolean;
 };
 
 // TODO: consilidate Button/Embed/Modal props into one type with extras


### PR DESCRIPTION
<!--

## [SDK] Feature: Add requireApproval option to useConnectModalOptions

## Notes for the reviewer

This PR adds the `requireApproval` option to `useConnectModalOptions`, ensuring consistency with the `ConnectButton` and `ConnectEmbed` components. This allows developers to require user approval for terms of service or privacy policies when using the `useConnectModal` hook.

The default value for `requireApproval` is `false`.

## How to test

1.  Use the `useConnectModal` hook in a component.
2.  Pass `requireApproval: true` along with `termsOfServiceUrl` and `privacyPolicyUrl` to the `connect` function:

    ```tsx
    import { useConnectModal, createThirdwebClient } from "thirdweb/react";

    const client = createThirdwebClient({ clientId: "your-client-id" });

    function MyComponent() {
      const { connect } = useConnectModal();

      return (
        <button onClick={() => connect({
          client,
          requireApproval: true,
          termsOfServiceUrl: "https://example.com/tos",
          privacyPolicyUrl: "https://example.com/privacy"
        })}>
          Connect Wallet
        </button>
      );
    }
    ```

3.  Verify that the connect modal displays the approval message and checkboxes.
4.  Verify that omitting `requireApproval` or setting it to `false` does not show the approval message.

-->

---
[Slack Thread](https://thirdwebdev.slack.com/archives/C09DS2CKGP2/p1771831224239329?thread_ts=1771831224.239329&cid=C09DS2CKGP2)

<p><a href="https://cursor.com/agents?id=bc-693d6dbe-a88a-547d-b8bb-2fc1e2e99570"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-693d6dbe-a88a-547d-b8bb-2fc1e2e99570"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>



<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new optional property `requireApproval` to the `useConnectModal` hook, which allows requiring users to accept terms of service and privacy policy before connecting their wallets.

### Detailed summary
- Added `requireApproval` to the modal options in `useConnectModal`.
- Updated the `Modal` component to include `props.requireApproval`.
- Added documentation for `requireApproval` with an example usage.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Connect Wallet modal now supports optional approval requirement enforcement during the wallet connection process. This enhancement provides greater control over connection security and authentication workflows. The feature remains fully backward compatible when not enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->