### PR TITLE
[CLI] Deprecate `create`

### DIFF
--- a/.changeset/deprecate-create-command.md
+++ b/.changeset/deprecate-create-command.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Deprecate the `thirdweb create` CLI command

--- a/packages/thirdweb/src/cli/bin.ts
+++ b/packages/thirdweb/src/cli/bin.ts
@@ -44,6 +44,14 @@ async function main() {
       break;
     }
 
+    case "create": {
+      console.info(
+        "The 'thirdweb create' command is deprecated. Please use the thirdweb dashboard instead: https://thirdweb.com/dashboard",
+      );
+      process.exit(1);
+      break;
+    }
+
     case "login": {
       // Not implemented yet
       console.info(


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on deprecating the `thirdweb create` CLI command, advising users to switch to the `thirdweb` dashboard instead.

### Detailed summary
- Added a deprecation notice for the `thirdweb create` command in `packages/thirdweb/src/cli/bin.ts`.
- Informs users to use the `thirdweb dashboard` at the provided URL.
- Exits the process with a status of 1 when the `create` command is invoked.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecations**
  * The `thirdweb create` CLI command has been deprecated and will display a deprecation message when invoked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->