### PR TITLE
ENS: add coinType param to reverse resolver

### DIFF
--- a/.changeset/every-donuts-stop.md
+++ b/.changeset/every-donuts-stop.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+ENS: add coinType param to reverse resolver

--- a/packages/thirdweb/src/extensions/ens/__generated__/UniversalResolver/read/reverse.ts
+++ b/packages/thirdweb/src/extensions/ens/__generated__/UniversalResolver/read/reverse.ts
@@ -14,21 +14,26 @@ export type ReverseParams = {
     type: "bytes";
     name: "reverseName";
   }>;
+  coinType: AbiParameterToPrimitiveType<{
+    type: "uint256";
+    name: "coinType";
+  }>;
 };
 
-export const FN_SELECTOR = "0xec11c823" as const;
+export const FN_SELECTOR = "0x5d78a217" as const;
 const FN_INPUTS = [
   {
     name: "reverseName",
     type: "bytes",
   },
+  {
+    name: "coinType",
+    type: "uint256",
+  },
 ] as const;
 const FN_OUTPUTS = [
   {
     type: "string",
-  },
-  {
-    type: "address",
   },
   {
     type: "address",
@@ -70,7 +75,10 @@ export function isReverseSupported(availableSelectors: string[]) {
  * ```
  */
 export function encodeReverseParams(options: ReverseParams) {
-  return encodeAbiParameters(FN_INPUTS, [options.reverseName]);
+  return encodeAbiParameters(FN_INPUTS, [
+    options.reverseName,
+    options.coinType,
+  ]);
 }
 
 /**
@@ -128,6 +136,6 @@ export async function reverse(options: BaseTransactionOptions<ReverseParams>) {
   return readContract({
     contract: options.contract,
     method: [FN_SELECTOR, FN_INPUTS, FN_OUTPUTS] as const,
-    params: [options.reverseName],
+    params: [options.reverseName, options.coinType],
   });
 }

--- a/packages/thirdweb/src/extensions/ens/resolve-name.ts
+++ b/packages/thirdweb/src/extensions/ens/resolve-name.ts
@@ -3,8 +3,6 @@ import { ethereum } from "../../chains/chain-definitions/ethereum.js";
 import type { Chain } from "../../chains/types.js";
 import type { ThirdwebClient } from "../../client/client.js";
 import { getContract } from "../../contract/contract.js";
-import { toHex } from "../../utils/encoding/hex.js";
-import { packetToBytes } from "../../utils/ens/packetToBytes.js";
 import { withCache } from "../../utils/promise/withCache.js";
 import { reverse } from "./__generated__/UniversalResolver/read/reverse.js";
 import { UNIVERSAL_RESOLVER_ADDRESS } from "./constants.js";
@@ -44,25 +42,15 @@ export async function resolveName(options: ResolveNameOptions) {
         client,
       });
 
-      const reverseName = toHex(
-        packetToBytes(`${address.toLowerCase().substring(2)}.addr.reverse`),
-      );
-
-      const [name, resolvedAddress] = await reverse({
+      const [name] = await reverse({
         contract,
-        reverseName,
-      }).catch((e) => {
-        if ("data" in e && e.data === "0x7199966d") {
-          return [null, address] as const;
-        }
-        throw e;
+        reverseName: address as `0x${string}`,
+        coinType: 60n,
+      }).catch(() => {
+        return [null] as const;
       });
 
-      if (address.toLowerCase() !== resolvedAddress.toLowerCase()) {
-        return null;
-      }
-
-      return name;
+      return name || null;
     },
     {
       cacheKey: `ens:name:${resolverChain?.id || 1}:${address}`,

--- a/packages/thirdweb/src/extensions/ens/resolve-name.ts
+++ b/packages/thirdweb/src/extensions/ens/resolve-name.ts
@@ -31,7 +31,9 @@ export type ResolveNameOptions = {
  * @extension ENS
  * @returns A promise that resolves to the Ethereum address.
  */
-export async function resolveName(options: ResolveNameOptions) {
+export async function resolveName(
+  options: ResolveNameOptions,
+): Promise<string | null> {
   const { client, address, resolverAddress, resolverChain } = options;
 
   return withCache(
@@ -46,7 +48,20 @@ export async function resolveName(options: ResolveNameOptions) {
         contract,
         reverseName: address as `0x${string}`,
         coinType: 60n,
-      }).catch(() => {
+      }).catch((e) => {
+        // Re-throw verification errors so callers can detect data integrity issues
+        if (
+          typeof e === "object" &&
+          e !== null &&
+          "data" in e &&
+          typeof e.data === "string"
+        ) {
+          // ReverseAddressMismatch(string,bytes) = 0xef9c03ce
+          if (e.data.startsWith("0xef9c03ce")) {
+            throw e;
+          }
+        }
+        // Swallow expected "no resolver" / "no name" errors
         return [null] as const;
       });
 


### PR DESCRIPTION
Update generated UniversalResolver reverse read to include a coinType (uint256) parameter and new function selector; adjust FN_INPUTS/FN_OUTPUTS and encode/read params accordingly. Update resolve-name to call the new reverse signature (pass the raw address as reverseName and coinType: 60n), remove packetToBytes/toHex usage and unused imports, simplify error handling, and return the resolved name or null.

<!--

## title your PR with this format: "[SDK/Dashboard/Portal] Feature/Fix: Concise title for the changes"

If you did not copy the branch name from Linear, paste the issue tag here (format is TEAM-0000):

## Notes for the reviewer

Anything important to call out? Be sure to also clarify these in your comments.

## How to test

Unit tests, playground, etc.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a `coinType` parameter to the reverse resolver in the ENS extension of the `thirdweb` SDK, updating function signatures and logic to accommodate this new parameter.

### Detailed summary
- Added `coinType` parameter to `ReverseParams` and `FN_INPUTS`.
- Updated `FN_SELECTOR` from `"0xec11c823"` to `"0x5d78a217"`.
- Modified `encodeReverseParams` to include `options.coinType`.
- Changed `reverse` function to accept and pass `options.coinType`.
- Updated `resolveName` to use a default `coinType` of `60n`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ENS name resolution: lookups now accept an additional coinType for more accurate cross-chain reverse resolution and more consistent results with updated error handling.

* **Chores**
  * Release metadata added to mark a patch release for the package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->