### PR TITLE
Dedicated channel for Pro plan

### DIFF
--- a/apps/dashboard/src/@/utils/pricing.tsx
+++ b/apps/dashboard/src/@/utils/pricing.tsx
@@ -19,25 +19,30 @@ export const TEAM_PLANS: Record<
   }
 > = {
   growth: {
-    description: "Ideal for teams building production-grade apps.",
+    description: "Ideal for small scale teams and startups.",
     features: [
-      "Email Support",
-      "48hr Guaranteed Response",
-      "Custom User Wallet Auth",
+      "Custom In-App Wallet Auth",
+      "Web, Mobile & Gaming SDKs",
+      "Server Wallets",
+      "Contract & Wallet APIs",
+      "Account Abstraction",
+      "Managed Infrastructure (RPC, IPFS, etc.)",
+      "Audited smart contracts",
     ],
     price: 99,
-    subTitle: "Everything in Starter, plus:",
+    subTitle: null,
     title: "Growth",
     trialPeriodDays: 0,
   },
   pro: {
-    description: "For large organizations with custom needs.",
+    description: "For large orgs with custom needs.",
     features: [
       "Dedicated Account Executive",
+      "Slack & Telegram Support",
       "12hr Guaranteed Response",
       "No Rate Limits",
-      ["Custom Infrastructure Add-Ons", "Infrastructure for custom chains."],
-      ["Volume Discounts", "Negotiated volume discounts that fit your scale."],
+      "Custom Infrastructure Add-Ons",
+      "Negotiated Volume Discounts",
     ],
     isStartingPriceOnly: true,
     price: 1499,
@@ -46,20 +51,14 @@ export const TEAM_PLANS: Record<
     trialPeriodDays: 0,
   },
   scale: {
-    description: "For funded startups and mid-size businesses.",
+    description: "Ideal for mid-size businesses.",
     features: [
-      "Slack & Telegram Support",
+      "Email Support",
       "24hr Guaranteed Response",
       "Remove thirdweb branding",
       "Audit Logs",
-      [
-        "Ecosystem Wallet Add-On",
-        "Unlocks the ability to deploy your own ecosystem wallets.",
-      ],
-      [
-        "Dedicated Infrastructure Add-Ons",
-        "Dedicated RPC nodes, indexers, etc.",
-      ],
+      "Ecosystem Wallet Add-On",
+      "Dedicated Infrastructure Add-Ons (RPC, Insight)",
     ],
     price: 499,
     subTitle: "Everything in Growth, plus:",

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/billing/components/PlanInfoCard.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/billing/components/PlanInfoCard.tsx
@@ -177,10 +177,7 @@ export function PlanInfoCardUI(props: {
           <div className="flex flex-col items-center py-8 text-center max-sm:gap-4">
             <CircleAlertIcon className="mb-3 text-muted-foreground lg:size-6" />
             <p>Your plan includes a fixed amount of free usage.</p>
-            <p>
-              To unlock additional usage, upgrade your plan to Starter or
-              Growth.
-            </p>
+            <p>To unlock additional usage, upgrade your plan to Growth.</p>
 
             <div className="mt-4">
               <ToolTipLabel

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/billing/components/Pricing.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/billing/components/Pricing.tsx
@@ -69,7 +69,6 @@ export const BillingPricing: React.FC<BillingPricingProps> = ({
         validTeamPlan === "starter" ||
         validTeamPlan === "growth_legacy"));
 
-  const highlightStarterPlan = highlightPlan === "starter";
   const highlightScalePlan =
     highlightPlan === "scale" ||
     (!highlightPlan &&
@@ -94,23 +93,7 @@ export const BillingPricing: React.FC<BillingPricingProps> = ({
 
       <div className="h-5" />
 
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
-        {/* Starter */}
-        <PricingCard
-          billingPlan="starter"
-          billingStatus={team.billingStatus}
-          cta={getPlanCta(
-            validTeamPlan,
-            "starter",
-            isCurrentPlanScheduledToCancel,
-          )}
-          current={validTeamPlan === "starter"}
-          getTeam={getTeam}
-          highlighted={highlightStarterPlan}
-          teamId={team.id}
-          teamSlug={team.slug}
-        />
-
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
         {/* Growth */}
         <PricingCard
           activeTrialEndsAt={

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/settings/_components/settings-cards/dedicated-support.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/settings/_components/settings-cards/dedicated-support.tsx
@@ -124,17 +124,7 @@ export function TeamDedicatedSupportCard(props: {
       }
       saveButton={
         isFeatureEnabled
-          ? {
-              disabled: createMutation.isPending,
-              isPending: createMutation.isPending,
-              label: "Create Support Channel",
-              onClick: () =>
-                createMutation.mutate({
-                  channelType: selectedChannelType,
-                  teamId: props.team.id,
-                }),
-            }
-          : hasDefaultTeamName
+          ? hasDefaultTeamName
             ? {
                 disabled: false,
                 isPending: false,
@@ -143,14 +133,24 @@ export function TeamDedicatedSupportCard(props: {
                   router.push(`/team/${props.team.slug}/~/settings`),
               }
             : {
-                disabled: false,
-                isPending: false,
-                label: "Upgrade Plan",
+                disabled: createMutation.isPending,
+                isPending: createMutation.isPending,
+                label: "Create Support Channel",
                 onClick: () =>
-                  router.push(
-                    `/team/${props.team.slug}/~/billing?showPlans=true&highlight=pro`,
-                  ),
+                  createMutation.mutate({
+                    channelType: selectedChannelType,
+                    teamId: props.team.id,
+                  }),
               }
+          : {
+              disabled: false,
+              isPending: false,
+              label: "Upgrade Plan",
+              onClick: () =>
+                router.push(
+                  `/team/${props.team.slug}/~/billing?showPlans=true&highlight=pro`,
+                ),
+            }
       }
     >
       <div className="md:w-[450px]">

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/settings/_components/settings-cards/dedicated-support.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/(team)/~/settings/_components/settings-cards/dedicated-support.tsx
@@ -31,8 +31,7 @@ export function TeamDedicatedSupportCard(props: {
   const [selectedChannelType, setSelectedChannelType] =
     useState<ChannelType>("slack");
 
-  const isFeatureEnabled =
-    props.team.billingPlan === "scale" || props.team.billingPlan === "pro";
+  const isFeatureEnabled = props.team.billingPlan === "pro";
 
   const createMutation = useMutation({
     mutationFn: async (params: {
@@ -107,8 +106,7 @@ export function TeamDedicatedSupportCard(props: {
       bottomText={
         !isFeatureEnabled ? (
           <>
-            Upgrade to the <b>Scale</b> or <b>Pro</b> plan to unlock this
-            feature.
+            Upgrade to the <b>Pro</b> plan to unlock this feature.
           </>
         ) : hasDefaultTeamName ? (
           "Please update your team name before requesting a dedicated support channel."
@@ -150,7 +148,7 @@ export function TeamDedicatedSupportCard(props: {
                 label: "Upgrade Plan",
                 onClick: () =>
                   router.push(
-                    `/team/${props.team.slug}/~/billing?showPlans=true&highlight=scale`,
+                    `/team/${props.team.slug}/~/billing?showPlans=true&highlight=pro`,
                   ),
               }
       }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the billing and plan information within the application, specifically refining descriptions, modifying plan options, and adjusting feature availability.

### Detailed summary
- Updated the `PlanInfoCard` to change the upgrade suggestion to only `Growth`.
- Reduced the grid columns in `Pricing` from 4 to 3.
- Modified descriptions and features for the `Growth` and `Pro` plans.
- Changed the feature enablement logic in `TeamDedicatedSupportCard` to only require the `Pro` plan.
- Adjusted the upgrade prompts to reflect the new plan structure.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Billing & Plans**
  * Updated plan descriptions and feature lists for Growth, Pro, and Scale.
  * Removed the Starter plan from the pricing grid and adjusted layout accordingly.
  * Free-plan messaging now prompts upgrade to Growth only.

* **Dedicated Support**
  * Dedicated Support now requires the Pro plan only.
  * Upgrade prompts and billing navigation highlight Pro when unavailable; Create Support Channel behavior adjusted for default vs. non-default team names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->