### PR TITLE
Retry transport failures

### DIFF
--- a/.changeset/in-app-wallet-transport-retry.md
+++ b/.changeset/in-app-wallet-transport-retry.md
@@ -1,0 +1,7 @@
+---
+"thirdweb": patch
+---
+
+Retry SDK and in-app wallet auth requests on transient network failures
+
+Requests now automatically retry (with jittered exponential backoff) when they fail at the network layer before any HTTP response is received — for example a `TypeError: Network request failed` on React Native. Received HTTP responses and aborted/timed-out requests are never retried, so this does not duplicate side effects such as sending a verification code.

--- a/packages/thirdweb/src/utils/fetch.test.ts
+++ b/packages/thirdweb/src/utils/fetch.test.ts
@@ -116,6 +116,20 @@ describe("getClientFetch", () => {
   it("should abort the request after timeout", async () => {
     vi.useFakeTimers();
     const abortSpy = vi.spyOn(AbortController.prototype, "abort");
+    // Model real fetch: reject with an AbortError when the signal aborts. The
+    // transport-retry layer must NOT retry aborts (timeouts), so this should
+    // surface as a single rejection.
+    vi.spyOn(global, "fetch").mockImplementation(
+      (_url, init?: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          const signal = init?.signal;
+          signal?.addEventListener("abort", () => {
+            reject(
+              new DOMException("The operation was aborted.", "AbortError"),
+            );
+          });
+        }),
+    );
     const clientFetch = getClientFetch(mockClient);
 
     const fetchPromise = clientFetch("https://api.thirdweb.com/test", {

--- a/packages/thirdweb/src/utils/fetch.ts
+++ b/packages/thirdweb/src/utils/fetch.ts
@@ -10,8 +10,49 @@ import {
 import { getServiceKey } from "./domains.js";
 import { isJWT } from "./jwt/is-jwt.js";
 import { IS_DEV } from "./process.js";
+import { retry } from "./retry.js";
 
 const DEFAULT_REQUEST_TIMEOUT = 60000;
+
+const TRANSPORT_RETRY_ATTEMPTS = 3;
+const TRANSPORT_RETRY_BASE_DELAY_MS = 300;
+
+/**
+ * Returns true if the error is a network failure that occurred before any HTTP
+ * response was received, which `fetch` surfaces as a `TypeError`. Aborts
+ * (timeouts / cancellation) are not considered transport errors.
+ * @internal
+ */
+export function isTransportError(error: unknown): boolean {
+  // Duck-type the abort check so it works on engines where `DOMException`
+  // is not defined (e.g. older React Native runtimes).
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "name" in error &&
+    (error as { name?: unknown }).name === "AbortError"
+  ) {
+    return false;
+  }
+  return error instanceof TypeError;
+}
+
+/**
+ * Retries a `fetch` thunk with jittered exponential backoff, but only when the
+ * request fails before receiving any HTTP response. Received responses are
+ * never retried.
+ * @internal
+ */
+export function fetchWithTransportRetry(
+  doFetch: () => Promise<Response>,
+): Promise<Response> {
+  return retry(doFetch, {
+    backoff: true,
+    delay: TRANSPORT_RETRY_BASE_DELAY_MS,
+    retries: TRANSPORT_RETRY_ATTEMPTS,
+    shouldRetry: isTransportError,
+  });
+}
 
 /**
  * @internal
@@ -107,24 +148,30 @@ export function getClientFetch(client: ThirdwebClient, ecosystem?: Ecosystem) {
       }
     }
 
-    let controller: AbortController | undefined;
-    let abortTimeout: ReturnType<typeof setTimeout> | undefined;
-    if (requestTimeoutMs) {
-      controller = new AbortController();
-      abortTimeout = setTimeout(() => {
-        controller?.abort("timeout");
-      }, requestTimeoutMs);
-    }
-
-    return fetch(url, {
-      ...restInit,
-      headers,
-      signal: controller?.signal,
-    }).finally(() => {
-      if (abortTimeout) {
-        clearTimeout(abortTimeout);
+    // Each attempt gets its own AbortController/timeout so that a timeout on
+    // one attempt doesn't poison subsequent transport-retry attempts.
+    const doFetch = () => {
+      let controller: AbortController | undefined;
+      let abortTimeout: ReturnType<typeof setTimeout> | undefined;
+      if (requestTimeoutMs) {
+        controller = new AbortController();
+        abortTimeout = setTimeout(() => {
+          controller?.abort("timeout");
+        }, requestTimeoutMs);
       }
-    });
+
+      return fetch(url, {
+        ...restInit,
+        headers,
+        signal: controller?.signal,
+      }).finally(() => {
+        if (abortTimeout) {
+          clearTimeout(abortTimeout);
+        }
+      });
+    };
+
+    return fetchWithTransportRetry(doFetch);
   }
   return fetchWithHeaders;
 }

--- a/packages/thirdweb/src/utils/retry.test.ts
+++ b/packages/thirdweb/src/utils/retry.test.ts
@@ -48,4 +48,45 @@ describe("retry", () => {
     expect(endTime - startTime).toBeGreaterThanOrEqual(2 * delay);
     expect(mockFn).toHaveBeenCalledTimes(3);
   });
+
+  it("should not retry when shouldRetry returns false", async () => {
+    const error = new Error("non-retryable");
+    const mockFn = vi.fn().mockRejectedValue(error);
+
+    await expect(
+      retry(mockFn, { delay: 0, retries: 3, shouldRetry: () => false }),
+    ).rejects.toThrow("non-retryable");
+    expect(mockFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("should retry while shouldRetry returns true and then succeed", async () => {
+    const error = new TypeError("Network request failed");
+    const mockFn = vi.fn().mockRejectedValueOnce(error).mockResolvedValue("ok");
+
+    await expect(
+      retry(mockFn, {
+        delay: 0,
+        retries: 3,
+        shouldRetry: (e) => e instanceof TypeError,
+      }),
+    ).resolves.toBe("ok");
+    expect(mockFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("should not sleep after the final attempt with backoff enabled", async () => {
+    const error = new Error("always fails");
+    const mockFn = vi.fn().mockRejectedValue(error);
+
+    const delay = 50;
+    const startTime = Date.now();
+    await expect(
+      retry(mockFn, { backoff: true, delay, retries: 2 }),
+    ).rejects.toThrow();
+    const elapsed = Date.now() - startTime;
+
+    // 2 attempts => only 1 sleep (after attempt 1), so elapsed should be well
+    // under the time two sleeps would take.
+    expect(mockFn).toHaveBeenCalledTimes(2);
+    expect(elapsed).toBeLessThan(delay * 4);
+  });
 });

--- a/packages/thirdweb/src/utils/retry.ts
+++ b/packages/thirdweb/src/utils/retry.ts
@@ -4,24 +4,43 @@
  * @param {Function} fn - A function that returns a promise to be executed.
  * @param {Object} options - Configuration options for the retry behavior.
  * @param {number} [options.retries=1] - The number of times to retry the function before failing.
- * @param {number} [options.delay=0] - The delay in milliseconds between retries.
+ * @param {number} [options.delay=0] - The base delay in milliseconds between retries.
+ * @param {boolean} [options.backoff=false] - When true, applies exponential backoff with jitter to the delay between attempts.
+ * @param {Function} [options.shouldRetry] - Predicate that decides whether a thrown error is retryable. When it returns false, the error is rethrown immediately without further retries.
  * @returns {Promise<void>} The result of the function execution if successful.
  */
 
 export async function retry<T>(
   fn: () => Promise<T>,
-  options: { retries?: number; delay?: number },
+  options: {
+    retries?: number;
+    delay?: number;
+    backoff?: boolean;
+    shouldRetry?: (error: unknown) => boolean;
+  },
 ): Promise<T> {
   const retries = options.retries ?? 1;
   const delay = options.delay ?? 0;
+  const backoff = options.backoff ?? false;
+  const shouldRetry = options.shouldRetry;
   let lastError: Error | null = null;
   for (let i = 0; i < retries; i++) {
     try {
       return await fn();
     } catch (error) {
       lastError = error as Error;
-      if (delay > 0) {
-        await new Promise((resolve) => setTimeout(resolve, delay));
+      // Bail out immediately on non-retryable errors (e.g. aborts, HTTP responses).
+      if (shouldRetry && !shouldRetry(error)) {
+        throw error;
+      }
+      // Don't sleep after the final attempt.
+      const isLastAttempt = i === retries - 1;
+      if (!isLastAttempt && delay > 0) {
+        // Exponential backoff with full jitter to avoid thundering-herd retries.
+        const waitMs = backoff
+          ? Math.round(delay * 2 ** i * (0.5 + Math.random() * 0.5))
+          : delay;
+        await new Promise((resolve) => setTimeout(resolve, waitMs));
       }
     }
   }

--- a/packages/thirdweb/src/wallets/in-app/web/lib/auth/otp.ts
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/auth/otp.ts
@@ -1,4 +1,5 @@
 import type { ThirdwebClient } from "../../../../../client/client.js";
+import { fetchWithTransportRetry } from "../../../../../utils/fetch.js";
 import { stringify } from "../../../../../utils/json.js";
 import {
   getLoginCallbackUrl,
@@ -44,11 +45,15 @@ export const sendOtp = async (args: PreAuthArgsType): Promise<void> => {
     }
   })();
 
-  const response = await fetch(url, {
-    body: stringify(body),
-    headers,
-    method: "POST",
-  });
+  // Only retried when the request fails before a response is received, so a
+  // verification code is never sent more than once.
+  const response = await fetchWithTransportRetry(() =>
+    fetch(url, {
+      body: stringify(body),
+      headers,
+      method: "POST",
+    }),
+  );
 
   if (!response.ok) {
     const raw = await response.text();
@@ -111,11 +116,15 @@ export const verifyOtp = async (
     }
   })();
 
-  const response = await fetch(url, {
-    body: stringify(body),
-    headers,
-    method: "POST",
-  });
+  // Only retried when the request fails before a response is received, so the
+  // code is never consumed more than once.
+  const response = await fetchWithTransportRetry(() =>
+    fetch(url, {
+      body: stringify(body),
+      headers,
+      method: "POST",
+    }),
+  );
 
   if (!response.ok) {
     throw new Error("Failed to verify verification code");


### PR DESCRIPTION
Add transport-layer retrying for network failures and wire it into OTP auth.

- Introduce fetchWithTransportRetry and isTransportError to retry fetch thunks that fail before an HTTP response (TypeError), while excluding aborts/timeouts (AbortError). Retries use jittered exponential backoff (3 attempts, 300ms base).
- Update getClientFetch to perform each attempt with its own AbortController/timeout and call fetchWithTransportRetry.
- Extend retry utility with backoff and shouldRetry options, ensure no sleep after final attempt, and add tests for retry behavior.
- Update fetch and OTP tests to model abort behavior and verify retry semantics.
- Use fetchWithTransportRetry for sendOtp and verifyOtp so transient transport errors are retried without causing duplicate side effects.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces automatic retries for SDK and in-app wallet authentication requests during transient network failures, with a focus on avoiding duplicate side effects. It implements jittered exponential backoff for retries and updates relevant functions to utilize this new behavior.

### Detailed summary
- Added automatic retry mechanism for network failures in SDK and in-app wallet auth requests.
- Implemented `fetchWithTransportRetry` to handle fetch requests with retries.
- Updated `sendOtp` and `verifyOtp` functions to use `fetchWithTransportRetry`.
- Enhanced `retry` function to include options for backoff and non-retryable errors.
- Introduced utility `isTransportError` to identify network errors for retry logic.
- Updated tests to cover new retry behavior and conditions for non-retryable errors.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * In-app wallet now automatically retries transport and authentication requests when transient network failures occur (such as timeouts or connection errors), using jittered exponential backoff for improved reliability. Retries only apply before receiving an HTTP response, preventing duplicate operations such as verification-code sending.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thirdweb-dev/js/pull/8783?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->