### PR TITLE
Fix wallet chain id normalization

### DIFF
--- a/packages/thirdweb/src/wallets/utils/normalizeChainId.test.ts
+++ b/packages/thirdweb/src/wallets/utils/normalizeChainId.test.ts
@@ -17,4 +17,14 @@ describe("normalizeChainId", () => {
   it("should try to convert a string to a decimal (base 10) integer", () => {
     expect(normalizeChainId("1")).toBe(1);
   });
+
+  it("should reject invalid chain ids", () => {
+    expect(() => normalizeChainId("1abc")).toThrow("Invalid chain ID");
+    expect(() => normalizeChainId("abc")).toThrow("Invalid chain ID");
+    expect(() => normalizeChainId("0x")).toThrow("Invalid chain ID");
+    expect(() => normalizeChainId(Number.NaN)).toThrow("Invalid chain ID");
+    expect(() =>
+      normalizeChainId(BigInt(Number.MAX_SAFE_INTEGER) + 1n),
+    ).toThrow("Invalid chain ID");
+  });
 });

--- a/packages/thirdweb/src/wallets/utils/normalizeChainId.ts
+++ b/packages/thirdweb/src/wallets/utils/normalizeChainId.ts
@@ -4,14 +4,28 @@ import { hexToNumber, isHex } from "../../utils/encoding/hex.js";
  * @internal
  */
 export function normalizeChainId(chainId: string | number | bigint): number {
+  let normalizedChainId: number;
+
   if (typeof chainId === "number") {
-    return chainId;
+    normalizedChainId = chainId;
+  } else if (isHex(chainId)) {
+    normalizedChainId = hexToNumber(chainId);
+  } else if (typeof chainId === "bigint") {
+    if (chainId < 0n || chainId > BigInt(Number.MAX_SAFE_INTEGER)) {
+      throw new Error(`Invalid chain ID: ${chainId.toString()}`);
+    }
+    normalizedChainId = Number(chainId);
+  } else {
+    const trimmed = chainId.trim();
+    if (!/^\d+$/u.test(trimmed)) {
+      throw new Error(`Invalid chain ID: ${chainId}`);
+    }
+    normalizedChainId = Number.parseInt(trimmed, 10);
   }
-  if (isHex(chainId)) {
-    return hexToNumber(chainId);
+
+  if (!Number.isSafeInteger(normalizedChainId) || normalizedChainId < 0) {
+    throw new Error(`Invalid chain ID: ${chainId.toString()}`);
   }
-  if (typeof chainId === "bigint") {
-    return Number(chainId);
-  }
-  return Number.parseInt(chainId, 10);
+
+  return normalizedChainId;
 }


### PR DESCRIPTION
Fixes wallet chain id normalization so malformed decimal strings are rejected instead of being partially parsed. It also rejects NaN, negative, and unsafe numeric values, with regression coverage for invalid chain IDs.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `normalizeChainId` function to handle various invalid input scenarios by throwing errors. It also improves the logic for processing different types of `chainId`, ensuring that only valid chain IDs are accepted.

### Detailed summary
- Added a new test case in `normalizeChainId.test.ts` to check for invalid `chainId` inputs.
- Updated `normalizeChainId` function in `normalizeChainId.ts` to:
  - Introduce a `normalizedChainId` variable for cleaner logic.
  - Validate `bigint` inputs to ensure they are within safe limits.
  - Trim and validate string inputs against a regex for digits.
  - Throw errors for invalid inputs, ensuring robust error handling.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test case to verify chain ID validation rejects malformed inputs, invalid formats, and values exceeding safe integer limits.

* **Bug Fixes**
  * Improved chain ID normalization with stricter validation. Now rejects invalid strings, out-of-bounds values, and negative numbers, ensuring only safe integers are accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->