### PR TITLE
Fix Arc Testnet native currency decimals

### DIFF
--- a/.changeset/arc-testnet-decimals.md
+++ b/.changeset/arc-testnet-decimals.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix Arc Testnet native currency decimals (USDC) from 6 to 18 to match the chain's RPC balance encoding

--- a/packages/thirdweb/src/chains/chain-definitions/arc-testnet.ts
+++ b/packages/thirdweb/src/chains/chain-definitions/arc-testnet.ts
@@ -12,6 +12,6 @@ export const arcTestnet = /* @__PURE__ */ defineChain({
   ],
   id: 5042002,
   name: "Arc Testnet",
-  nativeCurrency: { decimals: 6, name: "USDC", symbol: "USDC" },
+  nativeCurrency: { decimals: 18, name: "USDC", symbol: "USDC" },
   testnet: true,
 });


### PR DESCRIPTION
Change Arc Testnet native currency decimals from 6 to 18 to match the chain's RPC balance encoding.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the native currency decimals for the `Arc Testnet` from 6 to 18 for `USDC`, aligning it with the chain's RPC balance encoding.

### Detailed summary
- Updated the `nativeCurrency` in `arc-testnet.ts`:
  - Changed `decimals` from 6 to 18 for `USDC`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Arc Testnet native currency (USDC) decimal precision from 6 to 18 for correct balance representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->