### PR TITLE
docs(portal): fix syntax and compilation errors in v5 guide snippets

### DIFF
--- a/apps/portal/src/app/typescript/v5/auth/page.mdx
+++ b/apps/portal/src/app/typescript/v5/auth/page.mdx
@@ -42,13 +42,13 @@ import { privateKeyToAccount } from "thirdweb/wallets";
 
 const privateKey = process.env.THIRDWEB_PRIVATE_KEY;
 const thirdwebClient = createThirdwebClient({
-	secretKey: process.env.THIRDWEB_SECRET_KEY;
+	secretKey: process.env.THIRDWEB_SECRET_KEY,
 });
 
 const auth = createAuth({
 	domain: "localhost:3000",
 	client: thirdwebClient,
-	adminAccount: privateKeyToAccount({client, privateKey})
+	adminAccount: privateKeyToAccount({ client: thirdwebClient, privateKey }),
 });
 
 // 1. generate a login payload for a client on the server side

--- a/apps/portal/src/app/typescript/v5/getting-started/page.mdx
+++ b/apps/portal/src/app/typescript/v5/getting-started/page.mdx
@@ -81,7 +81,7 @@ import { inAppWallet } from "thirdweb/wallets"
 // create or access a wallet
  const wallet = inAppWallet();
 const account = await wallet.connect({
-  client: TEST_CLIENT,
+  client,
   strategy: "backend", // we use backend strategy to generate a wallet from a secret key
   walletSecret: "my-test-wallet-secret", // use this secret to access the same wallet across multiple scripts
 });
@@ -102,7 +102,8 @@ import { getWalletBalance } from "thirdweb/wallets";
 
 // Get the balance of the account
 const balance = await getWalletBalance({
-	account,
+	client,
+	address: account.address,
 	chain: sepolia,
 });
 console.log("Balance:", balance.displayValue, balance.symbol);


### PR DESCRIPTION
## docs(portal): fix syntax and compilation errors in v5 guide snippets

### What
This PR fixes critical syntax and compilation errors in the code examples on the **Getting Started** and **Auth** landing pages in the documentation portal.

### Why
Currently, copying and pasting the official snippets results in direct compilation or runtime errors:
- `getting-started/page.mdx` referenced an undefined `TEST_CLIENT` variable and passed an invalid type to `getWalletBalance` (missing `client` parameter and passing `account` instead of `address`).
- `auth/page.mdx` contained a syntax error (semicolon inside an object literal) and used an undefined `client` variable (should be `thirdwebClient`).

### Changes
- Updated `getting-started/page.mdx` wallet connect example and `getWalletBalance` signature.
- Fixed typo semicolon and renamed `client` to `thirdwebClient` in `auth/page.mdx`.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the authentication and wallet connection logic in the application, ensuring that the correct client and parameters are used for creating the `thirdwebClient` and fetching wallet balances.

### Detailed summary
- Changed the instantiation of `thirdwebClient` to use a comma instead of a semicolon.
- Updated the `adminAccount` parameter in `createAuth` to use `thirdwebClient`.
- Modified the wallet connection to use the `client` variable directly.
- Adjusted the `getWalletBalance` call to include `address: account.address`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated TypeScript v5 authentication examples with the current secret key and admin account configuration.
  * Refined getting-started wallet examples to use the current client setup and wallet balance parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->