### PR TITLE
allow managed rotation as an option

### DIFF
--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/vault/components/rotate-admin-key.client.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/vault/components/rotate-admin-key.client.tsx
@@ -23,6 +23,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
 import { Spinner } from "@/components/ui/Spinner";
 import { useDashboardRouter } from "@/lib/DashboardRouter";
 import { cn } from "@/lib/utils";
@@ -38,13 +39,17 @@ export default function RotateAdminKeyButton(props: {
   const [modalOpen, setModalOpen] = useState(false);
   const [keysConfirmed, setKeysConfirmed] = useState(false);
   const [keysDownloaded, setKeysDownloaded] = useState(false);
+  const [stayManaged, setStayManaged] = useState(props.isManagedVault);
+  const [secretKeyInput, setSecretKeyInput] = useState("");
   const router = useDashboardRouter();
+
+  const willStayManaged = stayManaged && secretKeyInput.trim().length > 0;
 
   const rotateAdminKeyMutation = useMutation({
     mutationFn: async () => {
-      // passing no secret key means we're rotating the admin key and deleting any stored keys
       const result = await rotateVaultAccountAndAccessToken({
         project: props.project,
+        projectSecretKey: willStayManaged ? secretKeyInput.trim() : undefined,
       });
 
       return {
@@ -105,12 +110,12 @@ export default function RotateAdminKeyButton(props: {
         variant="outline"
       >
         {isLoading && <Loader2Icon className="size-4 animate-spin" />}
-        {!isLoading && props.isManagedVault ? (
-          <LogOutIcon className="size-4" />
-        ) : (
+        {!isLoading && !props.isManagedVault ? (
           <RefreshCcwIcon className="size-4" />
+        ) : (
+          <LogOutIcon className="size-4" />
         )}
-        {props.isManagedVault ? "Eject From Managed Vault" : "Rotate Admin Key"}
+        Rotate Admin Key
       </Button>
 
       <Dialog modal={true} onOpenChange={handleCloseModal} open={modalOpen}>
@@ -241,13 +246,66 @@ export default function RotateAdminKeyButton(props: {
                   <p className="text-md text-primary-foreground">
                     Revoke your current keys and generates new ones.
                   </p>
+
+                  {props.isManagedVault && (
+                    <div className="flex flex-col gap-3 rounded-lg border bg-card p-4">
+                      <div className="flex items-start gap-2">
+                        <Checkbox
+                          checked={stayManaged}
+                          id="stay-managed"
+                          onCheckedChange={(checked) => {
+                            setStayManaged(checked === true);
+                            if (checked !== true) {
+                              setSecretKeyInput("");
+                            }
+                          }}
+                        />
+                        <label
+                          className="cursor-pointer text-sm leading-tight"
+                          htmlFor="stay-managed"
+                        >
+                          Keep this vault managed by thirdweb (recommended)
+                        </label>
+                      </div>
+
+                      {stayManaged ? (
+                        <>
+                          <label
+                            className="font-medium text-sm"
+                            htmlFor="rotate-secret-key"
+                          >
+                            Project Secret Key
+                          </label>
+                          <Input
+                            id="rotate-secret-key"
+                            onChange={(e) => setSecretKeyInput(e.target.value)}
+                            placeholder="Your project secret key"
+                            type="password"
+                            value={secretKeyInput}
+                          />
+                          <p className="text-muted-foreground text-xs">
+                            Used to re-encrypt your new admin key and wallet
+                            access token so your existing backend keeps working
+                            without changes. It is never stored.
+                          </p>
+                        </>
+                      ) : (
+                        <p className="text-muted-foreground text-xs">
+                          Your vault will be ejected. You will receive the new
+                          admin key to store yourself, and your backend must be
+                          updated to pass a wallet access token directly.
+                        </p>
+                      )}
+                    </div>
+                  )}
+
                   <Alert variant="destructive">
                     <CircleAlertIcon className="size-5" />
                     <AlertTitle>Important</AlertTitle>
                     <AlertDescription>
-                      This action will invalidate your current admin key and all
-                      existing access tokens. You will need to update your
-                      backend to use these new access tokens.
+                      {willStayManaged
+                        ? "This will invalidate your current admin key and all existing access tokens. Your stored credentials will be re-encrypted automatically, so your server wallets keep working."
+                        : "This action will invalidate your current admin key and all existing access tokens. You will need to update your backend to use these new access tokens."}
                     </AlertDescription>
                   </Alert>
                 </div>

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/vault/components/rotate-admin-key.client.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/vault/components/rotate-admin-key.client.tsx
@@ -44,6 +44,7 @@ export default function RotateAdminKeyButton(props: {
   const router = useDashboardRouter();
 
   const willStayManaged = stayManaged && secretKeyInput.trim().length > 0;
+  const missingSecretKey = stayManaged && secretKeyInput.trim().length === 0;
 
   const rotateAdminKeyMutation = useMutation({
     mutationFn: async () => {
@@ -288,6 +289,12 @@ export default function RotateAdminKeyButton(props: {
                             access token so your existing backend keeps working
                             without changes. It is never stored.
                           </p>
+                          {missingSecretKey && (
+                            <p className="text-destructive-text text-xs">
+                              Enter your project secret key to keep this vault
+                              managed, or uncheck the box above to eject.
+                            </p>
+                          )}
                         </>
                       ) : (
                         <p className="text-muted-foreground text-xs">
@@ -319,7 +326,7 @@ export default function RotateAdminKeyButton(props: {
                     Cancel
                   </Button>
                   <Button
-                    disabled={rotateAdminKeyMutation.isPending}
+                    disabled={rotateAdminKeyMutation.isPending || missingSecretKey}
                     onClick={() => rotateAdminKeyMutation.mutate()}
                     variant="destructive"
                   >


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the `RotateAdminKeyButton` component by adding functionality for managing a vault with an optional project secret key, improving user feedback regarding the vault's management status.

### Detailed summary
- Added `Input` for project secret key.
- Introduced `stayManaged` state to track vault management preference.
- Updated mutation to conditionally include `projectSecretKey`.
- Enhanced UI feedback for managed and unmanaged vaults.
- Added validation messages for missing secret key.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to keep a vault managed when rotating its admin key.
  * Added a project secret key entry to re-encrypt the rotated admin key and access token when keeping the vault managed.
  * Updated the rotation modal UI and confirmation button behavior, including conditional messaging and disabling until a secret key is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->