### PR TITLE
fix(auth): fail closed on unparseable SIWE Not Before / Expiration

### DIFF
--- a/.changeset/siwe-fail-closed-invalid-dates.md
+++ b/.changeset/siwe-fail-closed-invalid-dates.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Reject SIWE login payloads with an unparseable Not Before or Expiration Time instead of skipping the time-bound checks.

--- a/packages/thirdweb/src/auth/core/verify-login-payload.test.ts
+++ b/packages/thirdweb/src/auth/core/verify-login-payload.test.ts
@@ -146,3 +146,77 @@ describe("verifyLoginPayload", () => {
     expect(verificationResult.valid).toBe(false);
   });
 });
+
+  test("should fail closed on unparseable expiration_time", async () => {
+    const options = {
+      client: TEST_CLIENT,
+      domain: "example.com",
+      login: {
+        nonce: {
+          generate() {
+            return "20cd4ddb-6857-4d36-8e44-9f6e026b8de9";
+          },
+          validate(uuid: string) {
+            return uuid === "20cd4ddb-6857-4d36-8e44-9f6e026b8de9";
+          },
+        },
+        payloadExpirationTimeSeconds: 3600,
+        uri: "https://example.com",
+        version: "1.0",
+      },
+    };
+
+    const generatePayload = generateLoginPayload(options);
+    const payloadToSign = await generatePayload({
+      address: TEST_ACCOUNT_A.address,
+    });
+    payloadToSign.expiration_time = "never";
+
+    const signatureResult = await signLoginPayload({
+      account: TEST_ACCOUNT_A,
+      payload: payloadToSign,
+    });
+
+    const verificationResult = await verifyLoginPayload(options)(signatureResult);
+    expect(verificationResult.valid).toBe(false);
+    if (!verificationResult.valid) {
+      expect(verificationResult.error).toMatch(/invalid Expiration Time/i);
+    }
+  });
+
+  test("should fail closed on unparseable invalid_before", async () => {
+    const options = {
+      client: TEST_CLIENT,
+      domain: "example.com",
+      login: {
+        nonce: {
+          generate() {
+            return "20cd4ddb-6857-4d36-8e44-9f6e026b8de9";
+          },
+          validate(uuid: string) {
+            return uuid === "20cd4ddb-6857-4d36-8e44-9f6e026b8de9";
+          },
+        },
+        payloadExpirationTimeSeconds: 3600,
+        uri: "https://example.com",
+        version: "1.0",
+      },
+    };
+
+    const generatePayload = generateLoginPayload(options);
+    const payloadToSign = await generatePayload({
+      address: TEST_ACCOUNT_A.address,
+    });
+    payloadToSign.invalid_before = "";
+
+    const signatureResult = await signLoginPayload({
+      account: TEST_ACCOUNT_A,
+      payload: payloadToSign,
+    });
+
+    const verificationResult = await verifyLoginPayload(options)(signatureResult);
+    expect(verificationResult.valid).toBe(false);
+    if (!verificationResult.valid) {
+      expect(verificationResult.error).toMatch(/invalid Not Before/i);
+    }
+  });

--- a/packages/thirdweb/src/auth/core/verify-login-payload.test.ts
+++ b/packages/thirdweb/src/auth/core/verify-login-payload.test.ts
@@ -147,76 +147,76 @@ describe("verifyLoginPayload", () => {
   });
 });
 
-  test("should fail closed on unparseable expiration_time", async () => {
-    const options = {
-      client: TEST_CLIENT,
-      domain: "example.com",
-      login: {
-        nonce: {
-          generate() {
-            return "20cd4ddb-6857-4d36-8e44-9f6e026b8de9";
-          },
-          validate(uuid: string) {
-            return uuid === "20cd4ddb-6857-4d36-8e44-9f6e026b8de9";
-          },
+test("should fail closed on unparseable expiration_time", async () => {
+  const options = {
+    client: TEST_CLIENT,
+    domain: "example.com",
+    login: {
+      nonce: {
+        generate() {
+          return "20cd4ddb-6857-4d36-8e44-9f6e026b8de9";
         },
-        payloadExpirationTimeSeconds: 3600,
-        uri: "https://example.com",
-        version: "1.0",
+        validate(uuid: string) {
+          return uuid === "20cd4ddb-6857-4d36-8e44-9f6e026b8de9";
+        },
       },
-    };
+      payloadExpirationTimeSeconds: 3600,
+      uri: "https://example.com",
+      version: "1.0",
+    },
+  };
 
-    const generatePayload = generateLoginPayload(options);
-    const payloadToSign = await generatePayload({
-      address: TEST_ACCOUNT_A.address,
-    });
-    payloadToSign.expiration_time = "never";
+  const generatePayload = generateLoginPayload(options);
+  const payloadToSign = await generatePayload({
+    address: TEST_ACCOUNT_A.address,
+  });
+  payloadToSign.expiration_time = "never";
 
-    const signatureResult = await signLoginPayload({
-      account: TEST_ACCOUNT_A,
-      payload: payloadToSign,
-    });
-
-    const verificationResult = await verifyLoginPayload(options)(signatureResult);
-    expect(verificationResult.valid).toBe(false);
-    if (!verificationResult.valid) {
-      expect(verificationResult.error).toMatch(/invalid Expiration Time/i);
-    }
+  const signatureResult = await signLoginPayload({
+    account: TEST_ACCOUNT_A,
+    payload: payloadToSign,
   });
 
-  test("should fail closed on unparseable invalid_before", async () => {
-    const options = {
-      client: TEST_CLIENT,
-      domain: "example.com",
-      login: {
-        nonce: {
-          generate() {
-            return "20cd4ddb-6857-4d36-8e44-9f6e026b8de9";
-          },
-          validate(uuid: string) {
-            return uuid === "20cd4ddb-6857-4d36-8e44-9f6e026b8de9";
-          },
+  const verificationResult = await verifyLoginPayload(options)(signatureResult);
+  expect(verificationResult.valid).toBe(false);
+  if (!verificationResult.valid) {
+    expect(verificationResult.error).toMatch(/invalid Expiration Time/i);
+  }
+});
+
+test("should fail closed on unparseable invalid_before", async () => {
+  const options = {
+    client: TEST_CLIENT,
+    domain: "example.com",
+    login: {
+      nonce: {
+        generate() {
+          return "20cd4ddb-6857-4d36-8e44-9f6e026b8de9";
         },
-        payloadExpirationTimeSeconds: 3600,
-        uri: "https://example.com",
-        version: "1.0",
+        validate(uuid: string) {
+          return uuid === "20cd4ddb-6857-4d36-8e44-9f6e026b8de9";
+        },
       },
-    };
+      payloadExpirationTimeSeconds: 3600,
+      uri: "https://example.com",
+      version: "1.0",
+    },
+  };
 
-    const generatePayload = generateLoginPayload(options);
-    const payloadToSign = await generatePayload({
-      address: TEST_ACCOUNT_A.address,
-    });
-    payloadToSign.invalid_before = "";
-
-    const signatureResult = await signLoginPayload({
-      account: TEST_ACCOUNT_A,
-      payload: payloadToSign,
-    });
-
-    const verificationResult = await verifyLoginPayload(options)(signatureResult);
-    expect(verificationResult.valid).toBe(false);
-    if (!verificationResult.valid) {
-      expect(verificationResult.error).toMatch(/invalid Not Before/i);
-    }
+  const generatePayload = generateLoginPayload(options);
+  const payloadToSign = await generatePayload({
+    address: TEST_ACCOUNT_A.address,
   });
+  payloadToSign.invalid_before = "";
+
+  const signatureResult = await signLoginPayload({
+    account: TEST_ACCOUNT_A,
+    payload: payloadToSign,
+  });
+
+  const verificationResult = await verifyLoginPayload(options)(signatureResult);
+  expect(verificationResult.valid).toBe(false);
+  if (!verificationResult.valid) {
+    expect(verificationResult.error).toMatch(/invalid Not Before/i);
+  }
+});

--- a/packages/thirdweb/src/auth/core/verify-login-payload.ts
+++ b/packages/thirdweb/src/auth/core/verify-login-payload.ts
@@ -100,14 +100,30 @@ export function verifyLoginPayload(options: AuthOptions) {
 
     const currentDate = new Date();
 
-    if (currentDate < new Date(payload.invalid_before)) {
+    // Invalid Date comparisons are always false in JS, so unparseable
+    // invalid_before / expiration_time previously skipped time bounds.
+    const notBefore = new Date(payload.invalid_before);
+    if (Number.isNaN(notBefore.getTime())) {
+      return {
+        error: "Payload has invalid Not Before time",
+        valid: false,
+      };
+    }
+    if (currentDate < notBefore) {
       return {
         error: "Payload is not yet valid",
         valid: false,
       };
     }
 
-    if (currentDate > new Date(payload.expiration_time)) {
+    const expiration = new Date(payload.expiration_time);
+    if (Number.isNaN(expiration.getTime())) {
+      return {
+        error: "Payload has invalid Expiration Time",
+        valid: false,
+      };
+    }
+    if (currentDate > expiration) {
       return {
         error: "Payload has expired",
         valid: false,


### PR DESCRIPTION
## Summary
- `verifyLoginPayload` compared `currentDate` to `new Date(invalid_before)` / `new Date(expiration_time)`.
- In JavaScript, comparisons with `Invalid Date` are always false, so unparseable times skipped Not Before / Expiration checks while signature verification still ran.
- Fail closed when `Number.isNaN(date.getTime())`.

## Test plan
- [x] `pnpm exec vitest run src/auth/core/verify-login-payload.test.ts` (5 passed), including unparseable `never` / empty string cases

Made with [Cursor](https://cursor.com)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the validation of SIWE login payloads by rejecting those with unparseable `Not Before` or `Expiration Time` values, ensuring stricter adherence to time-bound checks.

### Detailed summary
- Added validation for `invalid_before` and `expiration_time` in `verify-login-payload.ts`.
- Introduced error messages for invalid timestamps.
- Created tests to verify failure cases for unparseable `expiration_time` and `invalid_before` in `verify-login-payload.test.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Login verification now rejects payloads with invalid or unparseable expiration and start-time values.
  * Valid timestamps continue to be checked against expiration and not-before rules.

* **Tests**
  * Added coverage confirming clear validation errors are returned for malformed time values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->