### PR TITLE
docs(portal): fix syntax and compilation errors in v5 guide snippets

### DIFF
--- a/apps/portal/src/app/typescript/v5/auth/page.mdx
+++ b/apps/portal/src/app/typescript/v5/auth/page.mdx
@@ -42,13 +42,13 @@ import { privateKeyToAccount } from "thirdweb/wallets";
 
 const privateKey = process.env.THIRDWEB_PRIVATE_KEY;
 const thirdwebClient = createThirdwebClient({
-	secretKey: process.env.THIRDWEB_SECRET_KEY;
+	secretKey: process.env.THIRDWEB_SECRET_KEY,
 });
 
 const auth = createAuth({
 	domain: "localhost:3000",
 	client: thirdwebClient,
-	adminAccount: privateKeyToAccount({client, privateKey})
+	adminAccount: privateKeyToAccount({ client: thirdwebClient, privateKey }),
 });
 
 // 1. generate a login payload for a client on the server side

--- a/apps/portal/src/app/typescript/v5/getting-started/page.mdx
+++ b/apps/portal/src/app/typescript/v5/getting-started/page.mdx
@@ -81,7 +81,7 @@ import { inAppWallet } from "thirdweb/wallets"
 // create or access a wallet
  const wallet = inAppWallet();
 const account = await wallet.connect({
-  client: TEST_CLIENT,
+  client,
   strategy: "backend", // we use backend strategy to generate a wallet from a secret key
   walletSecret: "my-test-wallet-secret", // use this secret to access the same wallet across multiple scripts
 });
@@ -102,7 +102,8 @@ import { getWalletBalance } from "thirdweb/wallets";
 
 // Get the balance of the account
 const balance = await getWalletBalance({
-	account,
+	client,
+	address: account.address,
 	chain: sepolia,
 });
 console.log("Balance:", balance.displayValue, balance.symbol);


### PR DESCRIPTION
## docs(portal): fix syntax and compilation errors in v5 guide snippets

_Note: Continuation of PR #8854, which was closed by the stale bot. CodeRabbit review was clean — no actionable issues found._

### Problem
Two code snippets in the v5 TypeScript documentation portal have syntax/compilation errors that would confuse developers copying code directly from the docs.

### Fixes

**`getting-started/page.mdx`:**
- Fixed `TEST_CLIENT` → `client` (undefined variable reference)
- Fixed `getWalletBalance` parameters: added missing `client` and changed `account` to `address: account.address` to match the current SDK API signature

**`auth/page.mdx`:**
- Fixed semicolon → comma in object literal (`secretKey: process.env.THIRDWEB_SECRET_KEY;` → `,`)
- Fixed `privateKeyToAccount({ client, privateKey })` → `privateKeyToAccount({ client: thirdwebClient, privateKey })` to use the correctly scoped variable

### Changes
- `[MOD]` `apps/portal/src/app/typescript/v5/getting-started/page.mdx`
- `[MOD]` `apps/portal/src/app/typescript/v5/auth/page.mdx`

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the authentication and wallet connection logic in the application, improving the handling of client instances and account management.

### Detailed summary
- In `page.mdx`:
  - Changed `client` to `thirdwebClient` in `adminAccount` parameter of `createAuth`.
  
- In `page.mdx`:
  - Updated `client` to be passed directly in the wallet connection.
  - Added `address: account.address` to the `getWalletBalance` function call.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected authentication server examples to use the proper secret key and client configuration.
  * Fixed wallet connection examples to use the configured client.
  * Updated wallet balance examples to reference the connected wallet correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->