### PR TITLE
[SDK] Fix: EIP1193.toProvider() removeListener is now functional

### DIFF
--- a/.changeset/eip1193-remove-listener-noop.md
+++ b/.changeset/eip1193-remove-listener-noop.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix: `EIP1193.toProvider()`'s `removeListener` is no longer a no-op. Previously, `removeListener` discarded the unsubscribe function returned by `wallet.subscribe()`, so listeners registered via `provider.on(...)` (e.g. `accountsChanged`, `chainChanged`, `disconnect`) could never actually be detached — they kept firing after callers (such as wagmi connectors) believed they had unsubscribed. `removeListener` now tracks and invokes the correct unsubscribe function per `(event, listener)` pair.

--- a/packages/thirdweb/src/adapters/eip1193/to-eip1193.test.ts
+++ b/packages/thirdweb/src/adapters/eip1193/to-eip1193.test.ts
@@ -190,6 +190,25 @@ describe("toProvider", () => {
     ).resolves.toEqual([]);
   });
 
+  test("removeListener should detach a listener registered via on", () => {
+    const provider = toProvider({
+      chain: ANVIL_CHAIN,
+      client: TEST_CLIENT,
+      wallet: mockWallet,
+    });
+
+    const listener = vi.fn();
+    provider.on("accountsChanged", listener);
+
+    emitter.emit("accountsChanged", [mockAccount.address]);
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    provider.removeListener("accountsChanged", listener);
+
+    emitter.emit("accountsChanged", [mockAccount.address]);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
   test("should use custom connect override when provided", async () => {
     const walletWithoutAccount = {
       ...mockWallet,

--- a/packages/thirdweb/src/adapters/eip1193/to-eip1193.test.ts
+++ b/packages/thirdweb/src/adapters/eip1193/to-eip1193.test.ts
@@ -209,6 +209,30 @@ describe("toProvider", () => {
     expect(listener).toHaveBeenCalledTimes(1);
   });
 
+  test("removeListener fully detaches a listener registered twice via on", () => {
+    const provider = toProvider({
+      chain: ANVIL_CHAIN,
+      client: TEST_CLIENT,
+      wallet: mockWallet,
+    });
+
+    const listener = vi.fn();
+    // register the same listener reference for the same event twice, then
+    // confirm a single removeListener call fully detaches it (the underlying
+    // wallet emitter dedupes by callback reference via a Set, so this must
+    // not require two removeListener calls).
+    provider.on("accountsChanged", listener);
+    provider.on("accountsChanged", listener);
+
+    emitter.emit("accountsChanged", [mockAccount.address]);
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    provider.removeListener("accountsChanged", listener);
+
+    emitter.emit("accountsChanged", [mockAccount.address]);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
   test("should use custom connect override when provided", async () => {
     const walletWithoutAccount = {
       ...mockWallet,

--- a/packages/thirdweb/src/adapters/eip1193/to-eip1193.ts
+++ b/packages/thirdweb/src/adapters/eip1193/to-eip1193.ts
@@ -58,10 +58,30 @@ export type ToEip1193ProviderOptions = {
 export function toProvider(options: ToEip1193ProviderOptions): EIP1193Provider {
   const { chain, client, wallet, connectOverride } = options;
   const rpcClient = getRpcClient({ chain, client });
+  // tracks the unsubscribe fn returned by wallet.subscribe for each (event, listener)
+  // pair so removeListener can actually detach it, per the EIP-1193 contract.
+  const unsubscribes = new Map<
+    unknown,
+    // biome-ignore lint/suspicious/noExplicitAny: matches EIP1193Provider's loose typing
+    Map<(params: any) => any, () => void>
+  >();
   return {
-    on: wallet.subscribe,
-    removeListener: () => {
-      // should invoke the return fn from subscribe instead
+    on: (event, listener) => {
+      const unsubscribe = wallet.subscribe(event, listener);
+      let listeners = unsubscribes.get(event);
+      if (!listeners) {
+        listeners = new Map();
+        unsubscribes.set(event, listeners);
+      }
+      listeners.set(listener, unsubscribe);
+    },
+    removeListener: (event, listener) => {
+      const listeners = unsubscribes.get(event);
+      const unsubscribe = listeners?.get(listener);
+      if (unsubscribe) {
+        unsubscribe();
+        listeners?.delete(listener);
+      }
     },
     request: async (request) => {
       switch (request.method) {


### PR DESCRIPTION
## Notes for the reviewer

`EIP1193.toProvider()` converts a thirdweb `Wallet` into a standard EIP-1193 `provider` for use with any EIP-1193-consuming library (wagmi, viem's `custom()` transport, ethers, etc.).

`removeListener` was a permanent no-op — the code itself left a comment admitting the gap:

```ts
on: wallet.subscribe,
removeListener: () => {
  // should invoke the return fn from subscribe instead
},
```

`wallet.subscribe(event, cb)` returns an unsubscribe function, but assigning `on: wallet.subscribe` directly discards that return value (the `EIP1193Provider.on` type is declared `void`), so nothing ever called it. Any consumer that does `provider.on("accountsChanged", handler)` and later `provider.removeListener("accountsChanged", handler)` — the standard pattern for cleanup on unmount/disconnect — leaked the listener; `handler` kept firing after the caller believed it had unsubscribed.

This isn't hypothetical inside this repo either: `packages/wagmi-adapter/src/connector.ts` calls `EIP1193.toProvider()` directly to implement a wagmi `Connector`'s `getProvider()`, which is exactly the kind of caller that registers/deregisters provider listeners for lifecycle management.

I checked git history and the original PR (#5354) review before filing this — the no-op was introduced in the adapter's founding commit and hasn't been touched across 7 follow-up PRs to this file; no issue or PR has discussed it since. Looks like a straightforward oversight rather than an intentional simplification.

**Fix:** track the unsubscribe function returned by `wallet.subscribe()` per `(event, listener)` pair, and have `removeListener` invoke and clear it. No signature/type changes — `on`/`removeListener` keep the same shape, just implemented correctly.

## How to test

```
cd packages/thirdweb
pnpm test:dev src/adapters/eip1193/to-eip1193.test.ts
```

Added test `removeListener should detach a listener registered via on`:
- registers a listener via `provider.on(...)`, emits the event, confirms it fires
- calls `provider.removeListener(...)`, emits again, confirms it does **not** fire again

Confirmed this test fails on `main` (listener fires twice instead of once) and passes with this fix. The only other failure in this file (`should handle eth_sendTransaction`) is pre-existing on `main` and unrelated — it requires a `TW_SECRET_KEY` for the mainnet fork that isn't set in this environment.

Ran `pnpm lint` from repo root — clean, no new warnings introduced by this change.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `removeListener` method in `EIP1193.toProvider()` to properly detach event listeners, addressing a previous issue where listeners could not be unsubscribed. 

### Detailed summary
- Updated `removeListener` to invoke the correct unsubscribe function for each `(event, listener)` pair.
- Introduced a `Map` to track unsubscribe functions for registered listeners.
- Added tests to verify that `removeListener` correctly detaches listeners.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed event listener removal for EIP-1193 providers.
  * Listeners registered through `provider.on` are now properly detached when removed, preventing further callbacks.

* **Tests**
  * Added coverage confirming removed listeners no longer receive event notifications.

* **Documentation**
  * Added a patch release note for the listener removal fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->