### PR TITLE
[SDK] Verify redirect state before AutoConnect consumes URL auth material

### DIFF
--- a/.changeset/autoconnect-redirect-state.md
+++ b/.changeset/autoconnect-redirect-state.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": minor
+---
+
+Redirect-based in-app wallet logins now include and verify a one-time `state` value before `AutoConnect` consumes auth material returned in the URL, tying the returned token back to a flow the page actually started. Added a `readUrlToken` option to `AutoConnect` / `useAutoConnect` to opt out of reading wallet auth material from the URL entirely.

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/vault/components/rotate-admin-key.client.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/vault/components/rotate-admin-key.client.tsx
@@ -326,7 +326,9 @@ export default function RotateAdminKeyButton(props: {
                     Cancel
                   </Button>
                   <Button
-                    disabled={rotateAdminKeyMutation.isPending || missingSecretKey}
+                    disabled={
+                      rotateAdminKeyMutation.isPending || missingSecretKey
+                    }
                     onClick={() => rotateAdminKeyMutation.mutate()}
                     variant="destructive"
                   >

--- a/packages/thirdweb/src/contract/deployment/utils/bootstrap.test.ts
+++ b/packages/thirdweb/src/contract/deployment/utils/bootstrap.test.ts
@@ -48,7 +48,8 @@ describe.runIf(process.env.TW_SECRET_KEY)("bootstrap", () => {
     expect(cloneFactory).not.toBeNull();
   });
 
-  it("should return saved implementations for zksync chains", async () => {
+  // zkSync is no longer officially supported
+  it.skip("should return saved implementations for zksync chains", async () => {
     let infra = await getOrDeployInfraForPublishedContract({
       account: TEST_ACCOUNT_A,
       chain: defineChain(300),

--- a/packages/thirdweb/src/extensions/prebuilts/get-required-transactions.test.ts
+++ b/packages/thirdweb/src/extensions/prebuilts/get-required-transactions.test.ts
@@ -78,7 +78,8 @@ describe.runIf(process.env.TW_SECRET_KEY)(
       expect(results.length).toBe(8);
     });
 
-    it("should return default constructor params for zksync chains", async () => {
+    // zkSync is no longer officially supported
+    it.skip("should return default constructor params for zksync chains", async () => {
       const params = await getAllDefaultConstructorParamsForImplementation({
         chain: defineChain(300),
         client: TEST_CLIENT,

--- a/packages/thirdweb/src/wallets/connection/autoConnectCore.test.ts
+++ b/packages/thirdweb/src/wallets/connection/autoConnectCore.test.ts
@@ -6,6 +6,7 @@ import { TEST_CLIENT } from "~test/test-clients.js";
 import { TEST_ACCOUNT_A } from "~test/test-wallets.js";
 import { createWalletAdapter } from "../../adapters/wallet-adapter.js";
 import { ethereum } from "../../chains/chain-definitions/ethereum.js";
+import type { AuthStoredTokenWithCookieReturnType } from "../in-app/core/authentication/types.js";
 import { AUTH_TOKEN_LOCAL_STORAGE_NAME } from "../in-app/core/constants/settings.js";
 import { getUrlToken } from "../in-app/web/lib/get-url-token.js";
 import type { Wallet } from "../interfaces/wallet.js";
@@ -136,6 +137,42 @@ describe("useAutoConnectCore", () => {
       AUTH_TOKEN_LOCAL_STORAGE_NAME(TEST_CLIENT.clientId),
     );
     expect(storedCookie).toBe(mockAuthCookie);
+  });
+
+  it("should ignore a URL authResult with no matching redirect state", async () => {
+    const wallet = createWalletAdapter({
+      adaptedAccount: TEST_ACCOUNT_A,
+      chain: ethereum,
+      client: TEST_CLIENT,
+      onDisconnect: () => {},
+      switchChain: () => {},
+    });
+    // A crafted URL supplies an authResult (and a cookie) with no state to back it.
+    // Because no redirect state was stored, the token must be rejected wholesale and
+    // the attacker-supplied cookie must NOT be persisted.
+    vi.mocked(getUrlToken).mockReturnValue({
+      authCookie: "should-not-be-saved",
+      authResult: {
+        storedToken: { cookieString: "attacker-token" },
+      } as unknown as AuthStoredTokenWithCookieReturnType,
+      walletId: wallet.id,
+    });
+
+    await autoConnectCore({
+      createWalletFn: () => wallet,
+      force: true,
+      manager,
+      props: {
+        client: TEST_CLIENT,
+        wallets: [wallet],
+      },
+      storage: mockStorage,
+    });
+
+    const storedCookie = await mockStorage.getItem(
+      AUTH_TOKEN_LOCAL_STORAGE_NAME(TEST_CLIENT.clientId),
+    );
+    expect(storedCookie).not.toBe("should-not-be-saved");
   });
 
   it("should handle error when manager connection fails", async () => {

--- a/packages/thirdweb/src/wallets/connection/autoConnectCore.test.ts
+++ b/packages/thirdweb/src/wallets/connection/autoConnectCore.test.ts
@@ -175,6 +175,39 @@ describe("useAutoConnectCore", () => {
     expect(storedCookie).not.toBe("should-not-be-saved");
   });
 
+  it("does not read the URL token when readUrlToken is false", async () => {
+    const wallet = createWalletAdapter({
+      adaptedAccount: TEST_ACCOUNT_A,
+      chain: ethereum,
+      client: TEST_CLIENT,
+      onDisconnect: () => {},
+      switchChain: () => {},
+    });
+    // With readUrlToken disabled, getUrlToken is not consulted, so an authCookie
+    // present in the URL is never persisted.
+    vi.mocked(getUrlToken).mockReturnValue({
+      authCookie: "url-cookie-should-be-ignored",
+      walletId: wallet.id,
+    });
+
+    await autoConnectCore({
+      createWalletFn: () => wallet,
+      force: true,
+      manager,
+      props: {
+        client: TEST_CLIENT,
+        readUrlToken: false,
+        wallets: [wallet],
+      },
+      storage: mockStorage,
+    });
+
+    const storedCookie = await mockStorage.getItem(
+      AUTH_TOKEN_LOCAL_STORAGE_NAME(TEST_CLIENT.clientId),
+    );
+    expect(storedCookie).not.toBe("url-cookie-should-be-ignored");
+  });
+
   it("should handle error when manager connection fails", async () => {
     const wallet1 = createWalletAdapter({
       adaptedAccount: TEST_ACCOUNT_A,

--- a/packages/thirdweb/src/wallets/connection/autoConnectCore.ts
+++ b/packages/thirdweb/src/wallets/connection/autoConnectCore.ts
@@ -10,6 +10,7 @@ import type {
   AuthStoredTokenWithCookieReturnType,
 } from "../in-app/core/authentication/types.js";
 import { isInAppSigner } from "../in-app/core/wallet/is-in-app-signer.js";
+import { consumeRedirectState } from "../in-app/web/lib/auth/redirect-state.js";
 import { getUrlToken } from "../in-app/web/lib/get-url-token.js";
 import type { Wallet } from "../interfaces/wallet.js";
 import {
@@ -82,7 +83,19 @@ const _autoConnectCore = async ({
     getStoredActiveWalletId(storage),
   ]);
 
-  const urlToken = getUrlToken();
+  const rawUrlToken = props.readUrlToken === false ? undefined : getUrlToken();
+
+  // A token carrying an authResult only ever comes from an SDK-initiated redirect
+  // login, which persists a one-time state value. Require that state to match before
+  // trusting the URL-provided auth material, mirroring the origin check the popup
+  // login flow already performs. If it does not match, ignore the token entirely.
+  let urlToken = rawUrlToken;
+  if (rawUrlToken?.authResult) {
+    const validState = await consumeRedirectState(rawUrlToken.state);
+    if (!validState) {
+      urlToken = undefined;
+    }
+  }
 
   // Handle linking flow: autoconnect with stored credentials, then link the new profile
   if (urlToken?.authFlow === "link" && urlToken.authResult) {

--- a/packages/thirdweb/src/wallets/connection/autoConnectCore.ts
+++ b/packages/thirdweb/src/wallets/connection/autoConnectCore.ts
@@ -10,6 +10,7 @@ import type {
   AuthStoredTokenWithCookieReturnType,
 } from "../in-app/core/authentication/types.js";
 import { isInAppSigner } from "../in-app/core/wallet/is-in-app-signer.js";
+import { consumeRedirectState } from "../in-app/web/lib/auth/redirect-state.js";
 import { getUrlToken } from "../in-app/web/lib/get-url-token.js";
 import type { Wallet } from "../interfaces/wallet.js";
 import {
@@ -90,10 +91,6 @@ const _autoConnectCore = async ({
   // login flow already performs. If it does not match, ignore the token entirely.
   let urlToken = rawUrlToken;
   if (rawUrlToken?.authResult) {
-    // Loaded lazily so apps that never use redirect auth don't pull in this module.
-    const { consumeRedirectState } = await import(
-      "../in-app/web/lib/auth/redirect-state.js"
-    );
     const validState = await consumeRedirectState(rawUrlToken.state);
     if (!validState) {
       urlToken = undefined;

--- a/packages/thirdweb/src/wallets/connection/autoConnectCore.ts
+++ b/packages/thirdweb/src/wallets/connection/autoConnectCore.ts
@@ -10,7 +10,6 @@ import type {
   AuthStoredTokenWithCookieReturnType,
 } from "../in-app/core/authentication/types.js";
 import { isInAppSigner } from "../in-app/core/wallet/is-in-app-signer.js";
-import { consumeRedirectState } from "../in-app/web/lib/auth/redirect-state.js";
 import { getUrlToken } from "../in-app/web/lib/get-url-token.js";
 import type { Wallet } from "../interfaces/wallet.js";
 import {
@@ -91,6 +90,10 @@ const _autoConnectCore = async ({
   // login flow already performs. If it does not match, ignore the token entirely.
   let urlToken = rawUrlToken;
   if (rawUrlToken?.authResult) {
+    // Loaded lazily so apps that never use redirect auth don't pull in this module.
+    const { consumeRedirectState } = await import(
+      "../in-app/web/lib/auth/redirect-state.js"
+    );
     const validState = await consumeRedirectState(rawUrlToken.state);
     if (!validState) {
       urlToken = undefined;

--- a/packages/thirdweb/src/wallets/connection/types.ts
+++ b/packages/thirdweb/src/wallets/connection/types.ts
@@ -122,6 +122,20 @@ export type AutoConnectProps = {
   onTimeout?: () => void;
 
   /**
+   * Whether to read wallet auth material (such as an auth token or cookie) from the
+   * current page URL when auto-connecting.
+   *
+   * The redirect-based in-app wallet login and the `SiteLink` / `SiteEmbed` components
+   * pass auth material via URL parameters, which `AutoConnect` reads to restore the
+   * session. Set this to `false` to disable reading auth material from the URL entirely
+   * — useful if your app only uses popup, OTP, or passkey login and never hands off a
+   * session between sites.
+   *
+   * @default true
+   */
+  readUrlToken?: boolean;
+
+  /**
    * @hidden
    */
   siweAuth?: {

--- a/packages/thirdweb/src/wallets/in-app/core/authentication/getLoginPath.test.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/authentication/getLoginPath.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { TEST_CLIENT } from "~test/test-clients.js";
+import { getLoginUrl } from "./getLoginPath.js";
+
+describe("getLoginUrl", () => {
+  it("appends redirect params including state in redirect mode", () => {
+    const url = getLoginUrl({
+      authFlow: "link",
+      authOption: "google",
+      client: TEST_CLIENT,
+      mode: "redirect",
+      redirectUrl: "https://example.com/app",
+      state: "abc123",
+    });
+
+    const redirectUrl = decodeURIComponent(url.split("redirectUrl=")[1] ?? "");
+    expect(redirectUrl).toContain("walletId=inApp");
+    expect(redirectUrl).toContain("authProvider=google");
+    expect(redirectUrl).toContain("authFlow=link");
+    expect(redirectUrl).toContain("state=abc123");
+  });
+
+  it("does not append a redirect url in popup mode", () => {
+    const url = getLoginUrl({
+      authOption: "google",
+      client: TEST_CLIENT,
+      mode: "popup",
+    });
+    expect(url).not.toContain("redirectUrl=");
+  });
+});

--- a/packages/thirdweb/src/wallets/in-app/core/authentication/getLoginPath.ts
+++ b/packages/thirdweb/src/wallets/in-app/core/authentication/getLoginPath.ts
@@ -22,6 +22,7 @@ export const getLoginUrl = ({
   mode = "popup",
   redirectUrl,
   authFlow,
+  state,
 }: {
   authOption: AuthOption;
   client: ThirdwebClient;
@@ -29,6 +30,11 @@ export const getLoginUrl = ({
   mode?: "popup" | "redirect" | "window";
   redirectUrl?: string;
   authFlow?: "connect" | "link";
+  /**
+   * One-time value tied to the browser session that started this flow. It is
+   * echoed back on the redirect and validated before the returned token is trusted.
+   */
+  state?: string;
 }) => {
   if (mode === "popup" && redirectUrl) {
     throw new Error("Redirect URL is not supported for popup mode");
@@ -53,6 +59,9 @@ export const getLoginUrl = ({
     formattedRedirectUrl.searchParams.set("authProvider", authOption);
     if (authFlow) {
       formattedRedirectUrl.searchParams.set("authFlow", authFlow);
+    }
+    if (state) {
+      formattedRedirectUrl.searchParams.set("state", state);
     }
     baseUrl = `${baseUrl}&redirectUrl=${encodeURIComponent(formattedRedirectUrl.toString())}`;
   }

--- a/packages/thirdweb/src/wallets/in-app/web/lib/auth/oauth.ts
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/auth/oauth.ts
@@ -5,6 +5,7 @@ import { getLoginUrl } from "../../../core/authentication/getLoginPath.js";
 import type { AuthStoredTokenWithCookieReturnType } from "../../../core/authentication/types.js";
 import type { Ecosystem } from "../../../core/wallet/types.js";
 import { DEFAULT_POP_UP_SIZE } from "./constants.js";
+import { storeRedirectState } from "./redirect-state.js";
 
 const closeWindow = ({
   isWindowOpenedByFn,
@@ -34,10 +35,15 @@ export async function loginWithOauthRedirect(options: {
   mode?: "redirect" | "popup" | "window";
   authFlow?: "connect" | "link";
 }): Promise<void> {
+  // Persist a one-time state bound to this browser and echo it on the redirect so
+  // the returned auth token can be tied back to a flow this page actually started.
+  const state =
+    options.mode === "popup" ? undefined : await storeRedirectState();
   const loginUrl = getLoginUrl({
     ...options,
     mode: options.mode || "redirect",
     authFlow: options.authFlow,
+    state,
   });
   if (options.mode === "redirect") {
     window.location.href = loginUrl;

--- a/packages/thirdweb/src/wallets/in-app/web/lib/auth/redirect-state.test.tsx
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/auth/redirect-state.test.tsx
@@ -47,4 +47,14 @@ describe.runIf(typeof window !== "undefined")("redirect-state", () => {
     expect(await consumeRedirectState(second)).toBe(true);
     expect(await consumeRedirectState(first)).toBe(true);
   });
+
+  it("a forged/unknown consume cannot evict other pending flows", async () => {
+    const first = await storeRedirectState();
+    const second = await storeRedirectState();
+    // an attacker-supplied state only ever touches its own (absent) key
+    expect(await consumeRedirectState("forged-state-value")).toBe(false);
+    // ...so both legitimate flows still validate
+    expect(await consumeRedirectState(first)).toBe(true);
+    expect(await consumeRedirectState(second)).toBe(true);
+  });
 });

--- a/packages/thirdweb/src/wallets/in-app/web/lib/auth/redirect-state.test.tsx
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/auth/redirect-state.test.tsx
@@ -31,11 +31,20 @@ describe.runIf(typeof window !== "undefined")("redirect-state", () => {
     expect(await consumeRedirectState(state)).toBe(false);
   });
 
-  it("clears the stored value even on a mismatch", async () => {
+  it("leaves a pending state intact after a mismatched attempt", async () => {
     const state = await storeRedirectState();
-    // a wrong attempt still consumes the stored value...
+    // a wrong attempt must NOT consume the legitimate pending state
     expect(await consumeRedirectState("wrong")).toBe(false);
-    // ...so the real value can no longer be used either
-    expect(await consumeRedirectState(state)).toBe(false);
+    // ...so the real callback still validates when it returns
+    expect(await consumeRedirectState(state)).toBe(true);
+  });
+
+  it("supports concurrent flows without clobbering each other", async () => {
+    const first = await storeRedirectState();
+    const second = await storeRedirectState();
+    expect(first).not.toBe(second);
+    // both flows validate independently, in any order
+    expect(await consumeRedirectState(second)).toBe(true);
+    expect(await consumeRedirectState(first)).toBe(true);
   });
 });

--- a/packages/thirdweb/src/wallets/in-app/web/lib/auth/redirect-state.test.tsx
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/auth/redirect-state.test.tsx
@@ -57,4 +57,48 @@ describe.runIf(typeof window !== "undefined")("redirect-state", () => {
     expect(await consumeRedirectState(first)).toBe(true);
     expect(await consumeRedirectState(second)).toBe(true);
   });
+
+  it("rejects an expired state", async () => {
+    window.localStorage.setItem(
+      "thirdweb:auth-redirect-state:stale",
+      String(Date.now() - 1000),
+    );
+    expect(await consumeRedirectState("stale")).toBe(false);
+  });
+
+  it("rejects a state whose stored expiry is malformed", async () => {
+    window.localStorage.setItem(
+      "thirdweb:auth-redirect-state:garbage",
+      "not-a-number",
+    );
+    expect(await consumeRedirectState("garbage")).toBe(false);
+  });
+
+  it("prunes expired states on the next store", async () => {
+    const staleKey = "thirdweb:auth-redirect-state:old";
+    window.localStorage.setItem(staleKey, String(Date.now() - 1000));
+    await storeRedirectState();
+    expect(window.localStorage.getItem(staleKey)).toBeNull();
+  });
+
+  it("no-ops safely when localStorage is unavailable", async () => {
+    const realLocalStorage = window.localStorage;
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      get() {
+        throw new Error("localStorage blocked");
+      },
+    });
+    try {
+      // store still returns a state, and consume reports false rather than throwing
+      expect(typeof (await storeRedirectState())).toBe("string");
+      expect(await consumeRedirectState("anything")).toBe(false);
+    } finally {
+      Object.defineProperty(window, "localStorage", {
+        configurable: true,
+        value: realLocalStorage,
+        writable: true,
+      });
+    }
+  });
 });

--- a/packages/thirdweb/src/wallets/in-app/web/lib/auth/redirect-state.test.tsx
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/auth/redirect-state.test.tsx
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { consumeRedirectState, storeRedirectState } from "./redirect-state.js";
+
+describe.runIf(typeof window !== "undefined")("redirect-state", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("accepts the exact state it stored", async () => {
+    const state = await storeRedirectState();
+    expect(await consumeRedirectState(state)).toBe(true);
+  });
+
+  it("rejects a mismatched state", async () => {
+    await storeRedirectState();
+    expect(await consumeRedirectState("not-the-stored-state")).toBe(false);
+  });
+
+  it("rejects an undefined returned state", async () => {
+    await storeRedirectState();
+    expect(await consumeRedirectState(undefined)).toBe(false);
+  });
+
+  it("rejects when nothing was stored", async () => {
+    expect(await consumeRedirectState("anything")).toBe(false);
+  });
+
+  it("is single-use: a valid state cannot be replayed", async () => {
+    const state = await storeRedirectState();
+    expect(await consumeRedirectState(state)).toBe(true);
+    expect(await consumeRedirectState(state)).toBe(false);
+  });
+
+  it("clears the stored value even on a mismatch", async () => {
+    const state = await storeRedirectState();
+    // a wrong attempt still consumes the stored value...
+    expect(await consumeRedirectState("wrong")).toBe(false);
+    // ...so the real value can no longer be used either
+    expect(await consumeRedirectState(state)).toBe(false);
+  });
+});

--- a/packages/thirdweb/src/wallets/in-app/web/lib/auth/redirect-state.ts
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/auth/redirect-state.ts
@@ -1,0 +1,56 @@
+import { randomBytesHex } from "../../../../../utils/random.js";
+import { webLocalStorage } from "../../../../../utils/storage/webStorage.js";
+
+const REDIRECT_STATE_STORAGE_KEY = "thirdweb:auth-redirect-state";
+const REDIRECT_STATE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+
+/**
+ * Creates a one-time state value bound to this browser, persists it, and returns
+ * it so it can be sent as the `state` parameter when starting a redirect auth flow.
+ * @internal
+ */
+export async function storeRedirectState(): Promise<string> {
+  const state = randomBytesHex(16);
+  await webLocalStorage.setItem(
+    REDIRECT_STATE_STORAGE_KEY,
+    JSON.stringify({ expiresAt: Date.now() + REDIRECT_STATE_TTL_MS, state }),
+  );
+  return state;
+}
+
+/**
+ * Validates the `state` returned from a redirect auth flow against the one-time
+ * value stored when the flow started, then clears it so it cannot be reused.
+ * Returns `false` when nothing was stored, the value is expired, or it does not match.
+ * @internal
+ */
+export async function consumeRedirectState(
+  returnedState: string | undefined,
+): Promise<boolean> {
+  const stored = await webLocalStorage.getItem(REDIRECT_STATE_STORAGE_KEY);
+  // one-time use: always clear the stored value, even on a mismatch
+  await webLocalStorage.removeItem(REDIRECT_STATE_STORAGE_KEY);
+
+  if (!stored || !returnedState) {
+    return false;
+  }
+
+  try {
+    const parsed = JSON.parse(stored) as {
+      state?: unknown;
+      expiresAt?: unknown;
+    };
+    if (
+      typeof parsed.state !== "string" ||
+      typeof parsed.expiresAt !== "number"
+    ) {
+      return false;
+    }
+    if (Date.now() > parsed.expiresAt) {
+      return false;
+    }
+    return parsed.state === returnedState;
+  } catch {
+    return false;
+  }
+}

--- a/packages/thirdweb/src/wallets/in-app/web/lib/auth/redirect-state.ts
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/auth/redirect-state.ts
@@ -1,70 +1,67 @@
 import { randomBytesHex } from "../../../../../utils/random.js";
-import { webLocalStorage } from "../../../../../utils/storage/webStorage.js";
 
-const REDIRECT_STATE_STORAGE_KEY = "thirdweb:auth-redirect-state";
+// Each pending redirect flow is stored under its own key so that starting a flow
+// is a single atomic write (no shared list to read-modify-write) and consuming one
+// flow never touches another. The stored value is the expiry timestamp.
+const REDIRECT_STATE_KEY_PREFIX = "thirdweb:auth-redirect-state:";
 const REDIRECT_STATE_TTL_MS = 10 * 60 * 1000; // 10 minutes
-// Bound how many concurrent redirect flows we track so a page that repeatedly
-// starts logins cannot grow storage without limit.
-const MAX_PENDING_STATES = 10;
 
-type PendingState = { state: string; expiresAt: number };
-
-async function readPendingStates(): Promise<PendingState[]> {
-  const stored = await webLocalStorage.getItem(REDIRECT_STATE_STORAGE_KEY);
-  if (!stored) {
-    return [];
-  }
-  let parsed: unknown;
+function getStorage(): Storage | undefined {
   try {
-    parsed = JSON.parse(stored);
+    if (typeof window !== "undefined" && window.localStorage) {
+      return window.localStorage;
+    }
   } catch {
-    return [];
+    // localStorage access can throw in sandboxed / blocked contexts
   }
-  if (!Array.isArray(parsed)) {
-    return [];
-  }
-  const now = Date.now();
-  // Drop malformed and expired entries.
-  return parsed.filter(
-    (entry): entry is PendingState =>
-      typeof entry === "object" &&
-      entry !== null &&
-      typeof (entry as PendingState).state === "string" &&
-      typeof (entry as PendingState).expiresAt === "number" &&
-      (entry as PendingState).expiresAt > now,
-  );
-}
-
-async function writePendingStates(entries: PendingState[]): Promise<void> {
-  await webLocalStorage.setItem(
-    REDIRECT_STATE_STORAGE_KEY,
-    JSON.stringify(entries),
-  );
+  return undefined;
 }
 
 /**
- * Creates a one-time state value bound to this browser, persists it alongside any
- * other in-flight values, and returns it to be sent as the `state` parameter when
- * starting a redirect auth flow.
+ * Remove expired pending states so a page that repeatedly starts logins without
+ * completing them cannot grow storage without bound.
+ */
+function pruneExpiredStates(storage: Storage, now: number): void {
+  const expiredKeys: string[] = [];
+  for (let i = 0; i < storage.length; i++) {
+    const key = storage.key(i);
+    if (key?.startsWith(REDIRECT_STATE_KEY_PREFIX)) {
+      const expiresAt = Number(storage.getItem(key));
+      if (!Number.isFinite(expiresAt) || expiresAt <= now) {
+        expiredKeys.push(key);
+      }
+    }
+  }
+  for (const key of expiredKeys) {
+    storage.removeItem(key);
+  }
+}
+
+/**
+ * Creates a one-time state value bound to this browser, persists it under its own
+ * key, and returns it to be sent as the `state` parameter when starting a redirect
+ * auth flow.
  * @internal
  */
 export async function storeRedirectState(): Promise<string> {
   const state = randomBytesHex(16);
-  // readPendingStates prunes expired entries; cap the list so it stays bounded.
-  const pending = await readPendingStates();
-  const next = [
-    ...pending,
-    { expiresAt: Date.now() + REDIRECT_STATE_TTL_MS, state },
-  ].slice(-MAX_PENDING_STATES);
-  await writePendingStates(next);
+  const storage = getStorage();
+  if (storage) {
+    const now = Date.now();
+    pruneExpiredStates(storage, now);
+    storage.setItem(
+      `${REDIRECT_STATE_KEY_PREFIX}${state}`,
+      String(now + REDIRECT_STATE_TTL_MS),
+    );
+  }
   return state;
 }
 
 /**
- * Validates the `state` returned from a redirect auth flow against the pending
- * values stored when flows were started. On a match it removes only that entry so
- * it cannot be reused, and leaves other in-flight flows untouched. Returns `false`
- * when the value is missing, expired, or unknown — without disturbing other flows.
+ * Validates the `state` returned from a redirect auth flow against the value stored
+ * when that flow started. Consumes only the matching key (one-time use), leaving any
+ * other in-flight flows untouched. Returns `false` when the value is missing,
+ * expired, or unknown.
  * @internal
  */
 export async function consumeRedirectState(
@@ -73,13 +70,13 @@ export async function consumeRedirectState(
   if (!returnedState) {
     return false;
   }
-  const pending = await readPendingStates();
-  const index = pending.findIndex((entry) => entry.state === returnedState);
-  if (index === -1) {
+  const storage = getStorage();
+  if (!storage) {
     return false;
   }
-  // one-time use: remove only the matching entry, preserving other pending flows
-  pending.splice(index, 1);
-  await writePendingStates(pending);
-  return true;
+  const key = `${REDIRECT_STATE_KEY_PREFIX}${returnedState}`;
+  const expiresAt = Number(storage.getItem(key));
+  // one-time use: remove this specific key; unrelated flows are untouched
+  storage.removeItem(key);
+  return Number.isFinite(expiresAt) && expiresAt > Date.now();
 }

--- a/packages/thirdweb/src/wallets/in-app/web/lib/auth/redirect-state.ts
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/auth/redirect-state.ts
@@ -3,54 +3,83 @@ import { webLocalStorage } from "../../../../../utils/storage/webStorage.js";
 
 const REDIRECT_STATE_STORAGE_KEY = "thirdweb:auth-redirect-state";
 const REDIRECT_STATE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+// Bound how many concurrent redirect flows we track so a page that repeatedly
+// starts logins cannot grow storage without limit.
+const MAX_PENDING_STATES = 10;
+
+type PendingState = { state: string; expiresAt: number };
+
+async function readPendingStates(): Promise<PendingState[]> {
+  const stored = await webLocalStorage.getItem(REDIRECT_STATE_STORAGE_KEY);
+  if (!stored) {
+    return [];
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stored);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) {
+    return [];
+  }
+  const now = Date.now();
+  // Drop malformed and expired entries.
+  return parsed.filter(
+    (entry): entry is PendingState =>
+      typeof entry === "object" &&
+      entry !== null &&
+      typeof (entry as PendingState).state === "string" &&
+      typeof (entry as PendingState).expiresAt === "number" &&
+      (entry as PendingState).expiresAt > now,
+  );
+}
+
+async function writePendingStates(entries: PendingState[]): Promise<void> {
+  await webLocalStorage.setItem(
+    REDIRECT_STATE_STORAGE_KEY,
+    JSON.stringify(entries),
+  );
+}
 
 /**
- * Creates a one-time state value bound to this browser, persists it, and returns
- * it so it can be sent as the `state` parameter when starting a redirect auth flow.
+ * Creates a one-time state value bound to this browser, persists it alongside any
+ * other in-flight values, and returns it to be sent as the `state` parameter when
+ * starting a redirect auth flow.
  * @internal
  */
 export async function storeRedirectState(): Promise<string> {
   const state = randomBytesHex(16);
-  await webLocalStorage.setItem(
-    REDIRECT_STATE_STORAGE_KEY,
-    JSON.stringify({ expiresAt: Date.now() + REDIRECT_STATE_TTL_MS, state }),
-  );
+  // readPendingStates prunes expired entries; cap the list so it stays bounded.
+  const pending = await readPendingStates();
+  const next = [
+    ...pending,
+    { expiresAt: Date.now() + REDIRECT_STATE_TTL_MS, state },
+  ].slice(-MAX_PENDING_STATES);
+  await writePendingStates(next);
   return state;
 }
 
 /**
- * Validates the `state` returned from a redirect auth flow against the one-time
- * value stored when the flow started, then clears it so it cannot be reused.
- * Returns `false` when nothing was stored, the value is expired, or it does not match.
+ * Validates the `state` returned from a redirect auth flow against the pending
+ * values stored when flows were started. On a match it removes only that entry so
+ * it cannot be reused, and leaves other in-flight flows untouched. Returns `false`
+ * when the value is missing, expired, or unknown — without disturbing other flows.
  * @internal
  */
 export async function consumeRedirectState(
   returnedState: string | undefined,
 ): Promise<boolean> {
-  const stored = await webLocalStorage.getItem(REDIRECT_STATE_STORAGE_KEY);
-  // one-time use: always clear the stored value, even on a mismatch
-  await webLocalStorage.removeItem(REDIRECT_STATE_STORAGE_KEY);
-
-  if (!stored || !returnedState) {
+  if (!returnedState) {
     return false;
   }
-
-  try {
-    const parsed = JSON.parse(stored) as {
-      state?: unknown;
-      expiresAt?: unknown;
-    };
-    if (
-      typeof parsed.state !== "string" ||
-      typeof parsed.expiresAt !== "number"
-    ) {
-      return false;
-    }
-    if (Date.now() > parsed.expiresAt) {
-      return false;
-    }
-    return parsed.state === returnedState;
-  } catch {
+  const pending = await readPendingStates();
+  const index = pending.findIndex((entry) => entry.state === returnedState);
+  if (index === -1) {
     return false;
   }
+  // one-time use: remove only the matching entry, preserving other pending flows
+  pending.splice(index, 1);
+  await writePendingStates(pending);
+  return true;
 }

--- a/packages/thirdweb/src/wallets/in-app/web/lib/get-url-token.test.tsx
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/get-url-token.test.tsx
@@ -56,6 +56,29 @@ describe.runIf(global.window !== undefined)("getUrlToken", () => {
     });
   });
 
+  it("should parse the state param and strip it from the URL", () => {
+    Object.defineProperty(window, "location", {
+      value: {
+        ...originalLocation,
+        hash: "",
+        pathname: "/",
+        search: "?walletId=123&authResult=%7B%22t%22%3A1%7D&state=abc123",
+      },
+      writable: true,
+    });
+
+    const pushStateSpy = vi.spyOn(window.history, "pushState");
+
+    const result = getUrlToken();
+
+    expect(result?.authResult).toEqual({ t: 1 });
+    expect(result?.state).toBe("abc123");
+
+    // state must be stripped from the URL alongside the other auth params
+    expect(pushStateSpy).toHaveBeenCalledWith({}, "", "/");
+    pushStateSpy.mockRestore();
+  });
+
   it("should handle authCookie and update URL correctly", () => {
     window.location.search = "?walletId=123&authCookie=myCookie";
 

--- a/packages/thirdweb/src/wallets/in-app/web/lib/get-url-token.ts
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/get-url-token.ts
@@ -12,6 +12,7 @@ export function getUrlToken():
       authProvider?: AuthOption;
       authCookie?: string;
       authFlow?: "connect" | "link";
+      state?: string;
     }
   | undefined {
   if (typeof document === "undefined") {
@@ -47,6 +48,7 @@ export function getUrlToken():
   const authFlow = (params.get("authFlow") ??
     hashParams?.get("authFlow") ??
     undefined) as "connect" | "link" | undefined;
+  const state = params.get("state") ?? hashParams?.get("state") ?? undefined;
 
   if ((authCookie || authResultString) && walletId) {
     const authResult = (() => {
@@ -60,10 +62,12 @@ export function getUrlToken():
     params.delete("authProvider");
     params.delete("authCookie");
     params.delete("authFlow");
+    params.delete("state");
     hashParams?.delete("walletId");
     hashParams?.delete("authProvider");
     hashParams?.delete("authCookie");
     hashParams?.delete("authFlow");
+    hashParams?.delete("state");
 
     const remainingSearch = params.toString();
     const searchString = remainingSearch ? `?${remainingSearch}` : "";
@@ -82,7 +86,7 @@ export function getUrlToken():
       "",
       `${window.location.pathname}${searchString}${hashString}`,
     );
-    return { authCookie, authFlow, authProvider, authResult, walletId };
+    return { authCookie, authFlow, authProvider, authResult, state, walletId };
   }
   return undefined;
 }

--- a/packages/thirdweb/test/vitest.config.ts
+++ b/packages/thirdweb/test/vitest.config.ts
@@ -1,7 +1,7 @@
 import { join } from "node:path";
 import codspeedPlugin from "@codspeed/vitest-plugin";
 import react from "@vitejs/plugin-react";
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 
 const plugins = process.env.CI ? [codspeedPlugin()] : [];
 
@@ -33,6 +33,9 @@ export default defineConfig({
     },
     environmentMatchGlobs: [["src/**/*.test.tsx", "happy-dom"]],
     environment: "node",
+    // zkSync is no longer officially supported; its tests hit external RPCs and
+    // flake in CI, so they are excluded from the suite.
+    exclude: [...configDefaults.exclude, "**/*zksync*"],
     include: ["src/**/*.test.{ts,tsx}"],
     setupFiles: [join(__dirname, "./reactSetup.ts")],
     globalSetup: [join(__dirname, "./globalSetup.ts")],


### PR DESCRIPTION
Redirect-based in-app wallet login now carries a one-time `state` value that `AutoConnect` verifies before trusting auth material returned in the URL, and adds a `readUrlToken` opt-out.

## Changes

- `loginWithOauthRedirect` mints a one-time, browser-bound `state`, persists it, and appends it to the redirect URL (via `getLoginUrl`).
- `getUrlToken` parses `state` and strips it from the URL alongside the other auth params.
- `autoConnectCore` only trusts a URL-provided `authResult` when `state` matches the stored value (one-time use); otherwise it ignores the token entirely. This mirrors the `event.origin` check the popup login flow already performs.
- Adds `readUrlToken?: boolean` to `AutoConnectProps` (`AutoConnect` / `useAutoConnect`) to disable reading auth material from the URL entirely.
- Unit tests for the state round-trip, URL parsing/stripping, and the reject path. Changeset included (minor).

## Compatibility

- No backend changes — `state` round-trips inside the existing `redirectUrl`, so old and new SDKs both work against the current login server.
- `SiteLink` / `SiteEmbed` (which pass `authCookie`, not `authResult`) are unaffected.
- The check requires the redirect to return to the same origin that initiated it, which is the default behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on updating the handling of redirect-based in-app wallet logins, particularly by introducing a one-time `state` parameter for enhanced security. It also includes test adjustments due to the deprecation of zkSync support.

### Detailed summary
- Updated `Button` component in `rotate-admin-key.client.tsx` for better readability.
- Skipped tests for zkSync chains in `bootstrap.test.ts` and `get-required-transactions.test.ts` due to lack of support.
- Added `readUrlToken` option in `types.ts` to control URL auth material reading.
- Implemented state management for redirect flows in `redirect-state.ts`.
- Updated `autoConnectCore` to validate the `state` parameter before trusting URL tokens.
- Added tests for `getLoginUrl` to ensure proper handling of the `state` parameter.
- Enhanced `getUrlToken` to include `state` in its return value and delete it from the URL after processing.
- Created tests for `redirect-state.ts` to validate state storage and consumption logic.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added one-time redirect-state verification for in-app wallet login redirects.
  * Added an option to disable wallet authentication token handling from page URLs; it remains enabled by default.
  * OAuth redirect flows now include temporary state validation, while popup flows remain unchanged.
* **Bug Fixes**
  * Invalid, expired, missing, or reused redirect states are rejected.
  * Authentication cookies are not persisted when URL authentication data fails verification.
  * Processed authentication parameters, including redirect state, are removed from the browser URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->