### PR TITLE
[SDK] Fix: Route in-app wallet OTP login through getClientFetch

### DIFF
--- a/.changeset/fix-otp-getclientfetch-bundle-id.md
+++ b/.changeset/fix-otp-getclientfetch-bundle-id.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Fix: in-app wallet email/phone OTP login (`sendOtp`/`verifyOtp`) now routes through `getClientFetch` instead of the global `fetch`. Previously these calls never attached the SDK's platform headers, so on React Native the `x-bundle-id` header was never sent — making it impossible to use email/phone OTP login with a Bundle ID access restriction configured on the client ID, since the backend rejects requests missing that header with a 401.

--- a/packages/thirdweb/src/wallets/in-app/web/lib/auth/otp.test.ts
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/auth/otp.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+import { TEST_CLIENT } from "~test/test-clients.js";
+import { getClientFetch } from "../../../../../utils/fetch.js";
+import { sendOtp, verifyOtp } from "./otp.js";
+
+vi.mock("../../../../../utils/fetch.js");
+
+describe("sendOtp", () => {
+  it("should route the request through getClientFetch so platform headers (x-bundle-id) are attached", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve({}),
+      ok: true,
+    });
+    vi.mocked(getClientFetch).mockReturnValue(mockFetch);
+
+    await sendOtp({
+      client: TEST_CLIENT,
+      email: "user@example.com",
+      strategy: "email",
+    });
+
+    expect(getClientFetch).toHaveBeenCalledWith(TEST_CLIENT, undefined);
+    expect(mockFetch).toHaveBeenCalled();
+  });
+
+  it("should forward the ecosystem to getClientFetch so ecosystem headers are attached", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve({}),
+      ok: true,
+    });
+    vi.mocked(getClientFetch).mockReturnValue(mockFetch);
+
+    const ecosystem = { id: "ecosystem.test" as const, partnerId: "partner-1" };
+    await sendOtp({
+      client: TEST_CLIENT,
+      ecosystem,
+      email: "user@example.com",
+      strategy: "email",
+    });
+
+    expect(getClientFetch).toHaveBeenCalledWith(TEST_CLIENT, ecosystem);
+  });
+});
+
+describe("verifyOtp", () => {
+  it("should route the request through getClientFetch so platform headers (x-bundle-id) are attached", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve({}),
+      ok: true,
+    });
+    vi.mocked(getClientFetch).mockReturnValue(mockFetch);
+
+    await verifyOtp({
+      client: TEST_CLIENT,
+      email: "user@example.com",
+      strategy: "email",
+      verificationCode: "123456",
+    });
+
+    expect(getClientFetch).toHaveBeenCalledWith(TEST_CLIENT, undefined);
+    expect(mockFetch).toHaveBeenCalled();
+  });
+
+  it("should forward the ecosystem to getClientFetch so ecosystem headers are attached", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve({}),
+      ok: true,
+    });
+    vi.mocked(getClientFetch).mockReturnValue(mockFetch);
+
+    const ecosystem = { id: "ecosystem.test" as const, partnerId: "partner-1" };
+    await verifyOtp({
+      client: TEST_CLIENT,
+      ecosystem,
+      email: "user@example.com",
+      strategy: "email",
+      verificationCode: "123456",
+    });
+
+    expect(getClientFetch).toHaveBeenCalledWith(TEST_CLIENT, ecosystem);
+  });
+});

--- a/packages/thirdweb/src/wallets/in-app/web/lib/auth/otp.ts
+++ b/packages/thirdweb/src/wallets/in-app/web/lib/auth/otp.ts
@@ -1,4 +1,5 @@
 import type { ThirdwebClient } from "../../../../../client/client.js";
+import { getClientFetch } from "../../../../../utils/fetch.js";
 import { stringify } from "../../../../../utils/json.js";
 import {
   getLoginCallbackUrl,
@@ -20,16 +21,7 @@ export const sendOtp = async (args: PreAuthArgsType): Promise<void> => {
 
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
-    "x-client-id": client.clientId,
   };
-
-  if (ecosystem?.id) {
-    headers["x-ecosystem-id"] = ecosystem.id;
-  }
-
-  if (ecosystem?.partnerId) {
-    headers["x-ecosystem-partner-id"] = ecosystem.partnerId;
-  }
 
   const body = (() => {
     switch (args.strategy) {
@@ -44,7 +36,7 @@ export const sendOtp = async (args: PreAuthArgsType): Promise<void> => {
     }
   })();
 
-  const response = await fetch(url, {
+  const response = await getClientFetch(client, ecosystem)(url, {
     body: stringify(body),
     headers,
     method: "POST",
@@ -85,16 +77,7 @@ export const verifyOtp = async (
 
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
-    "x-client-id": client.clientId,
   };
-
-  if (ecosystem?.id) {
-    headers["x-ecosystem-id"] = ecosystem.id;
-  }
-
-  if (ecosystem?.partnerId) {
-    headers["x-ecosystem-partner-id"] = ecosystem.partnerId;
-  }
 
   const body = (() => {
     switch (args.strategy) {
@@ -111,7 +94,7 @@ export const verifyOtp = async (
     }
   })();
 
-  const response = await fetch(url, {
+  const response = await getClientFetch(client, ecosystem)(url, {
     body: stringify(body),
     headers,
     method: "POST",


### PR DESCRIPTION
Fixes #8774

## Notes for the reviewer

`sendOtp`/`verifyOtp` (`packages/thirdweb/src/wallets/in-app/web/lib/auth/otp.ts`) built request headers by hand and called the global `fetch` directly, instead of going through `getClientFetch` like every other in-app wallet call (`rg -l "getClientFetch" packages/thirdweb/src/wallets/in-app/` → 18 files; `otp.ts` was the only file in that tree calling bare `fetch`).

`getClientFetch` is the only place that attaches platform headers, including `x-bundle-id` on React Native (via `getPlatformHeaders()` in `utils/fetch.ts`). Because OTP login skipped it, `x-bundle-id` was never sent — even when it was available from `globalThis.Application.applicationId`. Since the backend enforces the Bundle ID access restriction on this endpoint, any client ID with that restriction configured rejected every email/phone OTP login with a 401 `UNAUTHORIZED`, and the only workaround was disabling the restriction ("Allow all bundle IDs") entirely.

Fix: route both functions through `getClientFetch(client, ecosystem)`, matching the existing pattern in `siwe.ts` (the closest analog — another login endpoint on the same host). Dropped the now-redundant manual `x-client-id`/`x-ecosystem-id`/`x-ecosystem-partner-id` headers since `getClientFetch` sets those itself; kept only `Content-Type`, which it doesn't set.

Confirmed the swap is safe: both URLs resolve to `embedded-wallet.thirdweb.com`, which `getClientFetch`'s `isInAppWalletUrl` branch already excludes from the Bearer-token/auth-token path — so this only adds the missing headers, it doesn't change which credential gets sent.

## How to test

Added `otp.test.ts`, following the `vi.mock`/`vi.mocked(getClientFetch).mockReturnValue(...)` pattern already used in `backend.test.ts`:
- `sendOtp`/`verifyOtp` call `getClientFetch(client, ecosystem)` and invoke the returned fetch.
- Before this fix, mocking `getClientFetch` did nothing (the real `fetch` still fired), so the tests hit the live API and failed (`KEY_NOT_FOUND` / `Failed to verify verification code`) — that failure is the proof the bug existed.
- Added a case per function asserting the `ecosystem` argument is forwarded, since that's exactly the branch the old manual-header code depended on.

```
cd packages/thirdweb
pnpm test:dev src/wallets/in-app/web/lib/auth/otp.test.ts
pnpm test:dev src/wallets/in-app/web/lib/web-connector.test.ts   # caller, no regressions
```
Both green (10/10). `biome check` on the changed files is clean.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the OTP login functionality by ensuring that the `sendOtp` and `verifyOtp` functions use `getClientFetch` instead of the global `fetch`. This change allows the necessary platform headers to be attached, enabling proper authentication with Bundle ID access restrictions.

### Detailed summary
- Updated `sendOtp` and `verifyOtp` to use `getClientFetch` instead of global `fetch`.
- Removed unnecessary headers (`x-client-id`, `x-ecosystem-id`, `x-ecosystem-partner-id`) from `sendOtp` and `verifyOtp`.
- Added tests to ensure requests route through `getClientFetch` and attach necessary headers.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved in-app wallet email and phone OTP requests by ensuring required SDK platform information is included.
  - Preserved optional ecosystem details during OTP authentication requests.

- **Tests**
  - Added coverage for sending and verifying OTPs, including request handling and optional ecosystem data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->