### PR TITLE
fix(auth): fail closed on non-finite JWT nbf and exp

### DIFF
--- a/.changeset/jwt-fail-closed-exp-nbf.md
+++ b/.changeset/jwt-fail-closed-exp-nbf.md
@@ -1,0 +1,5 @@
+---
+"thirdweb": patch
+---
+
+Reject JWTs whose nbf or exp is missing or not a finite number instead of skipping the time-bound checks.

--- a/packages/thirdweb/src/auth/core/verify-jwt.test.ts
+++ b/packages/thirdweb/src/auth/core/verify-jwt.test.ts
@@ -3,12 +3,29 @@ import {
   TEST_ACCOUNT_A,
   TEST_ACCOUNT_B,
 } from "../../../test/src/test-wallets.js";
+import { stringToBytes } from "../../utils/encoding/to-bytes.js";
+import { stringify } from "../../utils/json.js";
+import { PRECOMPILED_B64_ENCODED_JWT_HEADER } from "../../utils/jwt/jwt-header.js";
+import { decodeJWT } from "../../utils/jwt/decode-jwt.js";
+import { uint8ArrayToBase64 } from "../../utils/uint8-array.js";
 import { generateJWT } from "./generate-jwt.js";
 import { generateLoginPayload } from "./generate-login-payload.js";
 import { signLoginPayload } from "./sign-login-payload.js";
 import type { AuthOptions } from "./types.js";
 import { verifyJWT } from "./verify-jwt.js";
 import { verifyLoginPayload } from "./verify-login-payload.js";
+
+async function signJwtPayload(payload: Record<string, unknown>) {
+  const message = stringify(payload);
+  const signature = await TEST_ACCOUNT_A.signMessage({ message });
+  const encodedData = uint8ArrayToBase64(stringToBytes(message), {
+    urlSafe: true,
+  });
+  const encodedSignature = uint8ArrayToBase64(stringToBytes(signature), {
+    urlSafe: true,
+  });
+  return `${PRECOMPILED_B64_ENCODED_JWT_HEADER}.${encodedData}.${encodedSignature}`;
+}
 
 const options: AuthOptions = {
   adminAccount: TEST_ACCOUNT_A,
@@ -117,4 +134,58 @@ describe("verifyJWT", () => {
       );
     }
   });
+
+  test("should fail closed on a non-numeric expiration", async () => {
+    const jwt = await validJwt();
+    const { payload } = decodeJWT(jwt);
+    const forged = await signJwtPayload({ ...payload, exp: "never" });
+    const result = await verifyJWT(options)({ jwt: forged });
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toBe("Payload has invalid Expiration Time");
+    }
+  });
+
+  test("should fail closed when expiration is missing", async () => {
+    const jwt = await validJwt();
+    const { payload } = decodeJWT(jwt);
+    const { exp: _exp, ...rest } = payload;
+    const forged = await signJwtPayload(rest);
+    const result = await verifyJWT(options)({ jwt: forged });
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toBe("Payload has invalid Expiration Time");
+    }
+  });
+
+  test("should fail closed on a non-numeric not-before", async () => {
+    const jwt = await validJwt();
+    const { payload } = decodeJWT(jwt);
+    const forged = await signJwtPayload({ ...payload, nbf: null });
+    const result = await verifyJWT(options)({ jwt: forged });
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toBe("Payload has invalid Not Before time");
+    }
+  });
 });
+
+async function validJwt() {
+  const generatedPayload = await generateLoginPayload(options)({
+    address: TEST_ACCOUNT_B.address,
+  });
+  const signedPayload = await signLoginPayload({
+    account: TEST_ACCOUNT_B,
+    payload: generatedPayload,
+  });
+  const verifiedPayload = await verifyLoginPayload(options)({
+    payload: signedPayload.payload,
+    signature: signedPayload.signature,
+  });
+  if (!verifiedPayload.valid) {
+    throw new Error("Invalid payload");
+  }
+  return generateJWT(options)({
+    payload: verifiedPayload.payload,
+  });
+}

--- a/packages/thirdweb/src/auth/core/verify-jwt.ts
+++ b/packages/thirdweb/src/auth/core/verify-jwt.ts
@@ -57,19 +57,36 @@ export function verifyJWT(options: AuthOptions) {
       };
     }
 
+    // Invalid Date / missing NumericDate comparisons are always false in JS,
+    // so a non-finite nbf or exp previously skipped the time bounds.
+    const nbf = finiteEpoch(payload.nbf);
+    if (nbf === undefined) {
+      return {
+        error: "Payload has invalid Not Before time",
+        valid: false,
+      };
+    }
+    const exp = finiteEpoch(payload.exp);
+    if (exp === undefined) {
+      return {
+        error: "Payload has invalid Expiration Time",
+        valid: false,
+      };
+    }
+
     // Check that the token is past the invalid before time
     const currentTime = Math.floor(Date.now() / 1000);
-    if (currentTime < payload.nbf) {
+    if (currentTime < nbf) {
       return {
-        error: `This token is invalid before epoch time '${payload.nbf}', current epoch time is '${currentTime}'`,
+        error: `This token is invalid before epoch time '${nbf}', current epoch time is '${currentTime}'`,
         valid: false,
       };
     }
 
     // Check that the token hasn't expired
-    if (currentTime > payload.exp) {
+    if (currentTime > exp) {
       return {
-        error: `This token expired at epoch time '${payload.exp}', current epoch time is '${currentTime}'`,
+        error: `This token expired at epoch time '${exp}', current epoch time is '${currentTime}'`,
         valid: false,
       };
     }
@@ -100,4 +117,11 @@ export function verifyJWT(options: AuthOptions) {
       valid: true,
     };
   };
+}
+
+function finiteEpoch(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return undefined;
+  }
+  return value;
 }


### PR DESCRIPTION
## Summary
- Sibling of #8875. That PR fail-closed SIWE `invalid_before` / `expiration_time` when `new Date(...)` was unparseable. `verifyJWT` had the same class of hole on `nbf` / `exp`.
- `currentTime < payload.nbf` and `currentTime > payload.exp` are always false when the claim is missing, `null`, or a non-numeric value such as `"never"`. Signature verification still ran, so those tokens skipped both time bounds.
- Require a finite number for `nbf` and `exp` before comparing.

## Test plan
- [x] Added cases in `src/auth/core/verify-jwt.test.ts`: `exp: "never"`, missing `exp`, `nbf: null`
- [ ] CI: `pnpm exec vitest run src/auth/core/verify-jwt.test.ts`


Made with [Cursor](https://cursor.com)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving JWT validation by rejecting tokens with missing or non-finite `nbf` (Not Before) or `exp` (Expiration) fields, ensuring stricter time-bound checks.

### Detailed summary
- Added checks for `nbf` and `exp` to ensure they are finite numbers.
- Introduced the `finiteEpoch` function to validate `nbf` and `exp`.
- Updated error messages to reflect the new validation.
- Added tests to verify behavior for non-numeric and missing `nbf`/`exp` values.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved JWT validation to reject tokens with missing, non-numeric, or non-finite expiration and not-before timestamps.
  - Added clearer validation errors for malformed time claims.
  - Strengthened time-bound checks to accept only valid finite timestamps.

- **Tests**
  - Added regression coverage for invalid and missing JWT time claims.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->