### PR TITLE
[SDK] Fix: wagmi-adapter getProvider ignores the persisted active chain

### DIFF
--- a/.changeset/olive-moons-repeat.md
+++ b/.changeset/olive-moons-repeat.md
@@ -1,0 +1,7 @@
+---
+"@thirdweb-dev/wagmi-adapter": patch
+---
+
+Fix `getProvider` reading the last active chain from storage
+
+`switchChain` persists the active chain under `thirdweb:active-chain` as a JSON-serialized `Chain` object, and `connect` reads it back with `JSON.parse(...)`. `getProvider` instead parsed the same value with `Number(...)`, which produces `NaN` for the stored object. Because `NaN` is falsy, `getProvider` silently fell back to chain `1` instead of the user's last active chain when auto-connecting. It now parses the value the same way `connect` does.

--- a/packages/wagmi-adapter/src/connector.ts
+++ b/packages/wagmi-adapter/src/connector.ts
@@ -218,7 +218,10 @@ export function inAppWalletConnector(
     },
     getProvider: async (params) => {
       const lastChainIdStr = await rawStorage?.getItem(activeChainIdKey);
-      const lastChainId = lastChainIdStr ? Number(lastChainIdStr) : undefined;
+      const lastChain = lastChainIdStr
+        ? (JSON.parse(lastChainIdStr) as Chain)
+        : undefined;
+      const lastChainId = lastChain ? lastChain.id : undefined;
       const chain = defineChain(
         params?.chainId || args.smartAccount?.chain?.id || lastChainId || 1,
       );


### PR DESCRIPTION
## Notes for the reviewer

`packages/wagmi-adapter/src/connector.ts` stores the active chain under one key, `thirdweb:active-chain`, but reads it back two different ways.

**Writer** — `switchChain` (line 274) stores a serialized `Chain` **object**:

```ts
rawStorage?.setItem(activeChainIdKey, JSON.stringify(defineChain(chain.id)));
```

**Reader 1** — `connect` (line 124) parses it correctly:

```ts
const lastChain = lastChainIdStr ? (JSON.parse(lastChainIdStr) as Chain) : undefined;
const lastChainId = lastChain ? lastChain.id : undefined;
```

**Reader 2** — `getProvider` (line 220) parsed it as a number:

```ts
const lastChainId = lastChainIdStr ? Number(lastChainIdStr) : undefined;
```

`Number('{"id":137,"rpc":"…"}')` is `NaN`, and `NaN` is falsy, so the `|| 1` in the next line always won:

```ts
const chain = defineChain(
  params?.chainId || args.smartAccount?.chain?.id || lastChainId || 1,
);
```

Running the three code paths against the same stored value:

```
stored value  : {"id":137,"rpc":"https://137.rpc.thirdweb.com"}
connect()     : 137
getProvider() : NaN -> falsy? true => defineChain( 1 )
fixed         : 137 => defineChain( 137 )
```

**Impact:** when `getProvider` is the first thing to run after a page load (wagmi calls it before `connect` on a cold `getProvider`/`getAccounts` path), the persisted chain is discarded and `autoConnect` is handed chain `1` instead of the user's last active chain — even though `connect` on the same storage value resolves it correctly. The two readers disagree about the same key.

`packages/thirdweb/src/wallets/manager/index.ts` uses the identical key and the same JSON-object format (`stringify(_chain)` on write, `JSON.parse(value) as Chain` in `getLastConnectedChain`), so the object form is the intended encoding and `getProvider` is the odd one out.

The fix makes `getProvider` read the value exactly the way `connect` does, 90 lines above it in the same file.

## How to test

- `pnpm lint` in `packages/wagmi-adapter` is clean apart from the 3 pre-existing `noExplicitAny` warnings that are also present on `main`.
- `tsc --project ./tsconfig.build.json --noEmit` produces the same output as on a clean checkout (only `TS2307` for the unbuilt workspace `thirdweb` package). The new expression is type-identical to the one already in `connect`, and `Chain` was already imported.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed automatic connection behavior so the app consistently restores the previously active blockchain network.
  * Prevented unintended fallback to the default network when restoring the active chain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->