### PR TITLE
[service-utils] Scope service-key auth cache by teamId; drop timestampless cache entries

### DIFF
--- a/.changeset/spicy-donuts-argue.md
+++ b/.changeset/spicy-donuts-argue.md
@@ -1,0 +1,5 @@
+---
+"@thirdweb-dev/service-utils": patch
+---
+
+Scope service-key authorization cache entries by teamId, and ignore cache entries that lack a timestamp

--- a/packages/service-utils/src/core/authorize/index.ts
+++ b/packages/service-utils/src/core/authorize/index.ts
@@ -50,7 +50,10 @@ export async function authorize(
   // Use a separate cache key per auth method.
   const cacheKey = authData.incomingServiceApiKey
     ? // incoming service key + teamId + clientId case
-      `key-v2:service-key:${authData.incomingServiceApiKeyHash}:${authData.teamId ?? "team_default"}:${authData.clientId ?? "client_default"}`
+      // do not cache service-key requests that carry no tenant selector
+      authData.teamId || authData.clientId
+      ? `key-v2:service-key:${authData.incomingServiceApiKeyHash}:${authData.teamId ?? "team_default"}:${authData.clientId ?? "client_default"}`
+      : null
     : authData.secretKeyHash
       ? // secret key case
         `key-v2:secret-key:${authData.secretKeyHash}`

--- a/packages/service-utils/src/core/authorize/index.ts
+++ b/packages/service-utils/src/core/authorize/index.ts
@@ -49,8 +49,8 @@ export async function authorize(
 
   // Use a separate cache key per auth method.
   const cacheKey = authData.incomingServiceApiKey
-    ? // incoming service key + clientId case
-      `key-v2:service-key:${authData.incomingServiceApiKeyHash}:${authData.clientId ?? "client_default"}`
+    ? // incoming service key + teamId + clientId case
+      `key-v2:service-key:${authData.incomingServiceApiKeyHash}:${authData.teamId ?? "team_default"}:${authData.clientId ?? "client_default"}`
     : authData.secretKeyHash
       ? // secret key case
         `key-v2:secret-key:${authData.secretKeyHash}`
@@ -80,8 +80,6 @@ export async function authorize(
           if (diff < cacheTtlMs) {
             teamAndProjectResponse = parsed.teamAndProjectResponse;
           }
-        } else {
-          teamAndProjectResponse = parsed;
         }
       }
     } catch {


### PR DESCRIPTION
The service-key authorization cache key included only the clientId, so requests authenticated with the same service key but different `teamId` (and no clientId) resolved to a single shared cache entry. The key now includes the teamId.

Cached entries without an `updatedAt` timestamp were used without any TTL check; they are now treated as cache misses and refreshed.

Both changes only alter cache keying/expiry: entries under old keys are simply never read again and expire naturally.

<!-- start pr checklist -->
- [x] Changeset added
- [x] `pnpm build` and authorize tests pass
<!-- end pr checklist -->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the caching mechanism for service-key authorization by scoping cache entries to `teamId` and ensuring that entries without a timestamp are ignored.

### Detailed summary
- Changed cache key construction to include `teamId` alongside `clientId`.
- Added a condition to skip caching for requests without a `teamId` or `clientId`.
- Removed unnecessary assignment to `teamAndProjectResponse` when the cache is valid.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved service API key authorization caching by separating cache entries by team.
  - Prevented cache entries from being created without team or client identification.
  - Prevented cached authorization results without expiration metadata from being accepted.
  - Ensured only valid, non-expired cached responses are used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->