### PR TITLE
[Dashboard] Close the unlock dialog on Enter and accept className

### DIFF
--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/vault/components/list-access-tokens.client.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/vault/components/list-access-tokens.client.tsx
@@ -20,9 +20,13 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
 import { toDateTimeLocal } from "@/utils/date-utils";
 
-export default function ListAccessTokens(props: { project: Project }) {
+export default function ListAccessTokens(props: {
+  project: Project;
+  className?: string;
+}) {
   const [modalOpen, setModalOpen] = useState(false);
   const [typedUnlockKey, setTypedUnlockKey] = useState("");
   const [unlockKey, setUnlockKey] = useState("");
@@ -99,7 +103,12 @@ export default function ListAccessTokens(props: { project: Project }) {
   };
 
   return (
-    <div className="flex flex-col gap-6 overflow-hidden rounded-lg border border-border bg-card">
+    <div
+      className={cn(
+        "flex flex-col gap-6 overflow-hidden rounded-lg border border-border bg-card",
+        props.className,
+      )}
+    >
       <div className="flex flex-col px-6 pt-6">
         <div className="flex flex-row items-center justify-between">
           <div className="flex flex-col">
@@ -252,6 +261,7 @@ export default function ListAccessTokens(props: { project: Project }) {
                   onKeyDown={(e) => {
                     if (e.key === "Enter") {
                       setUnlockKey(typedUnlockKey);
+                      handleCloseModal();
                     }
                   }}
                   placeholder={

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/vault/components/rotate-admin-key.client.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/vault/components/rotate-admin-key.client.tsx
@@ -33,6 +33,7 @@ import { maskSecret } from "../../transactions/lib/vault.client";
 export default function RotateAdminKeyButton(props: {
   project: Project;
   isManagedVault: boolean;
+  className?: string;
 }) {
   const [modalOpen, setModalOpen] = useState(false);
   const [keysConfirmed, setKeysConfirmed] = useState(false);
@@ -110,7 +111,10 @@ export default function RotateAdminKeyButton(props: {
   return (
     <>
       <Button
-        className="h-auto gap-2 rounded-lg bg-background px-4 py-3"
+        className={cn(
+          "h-auto gap-2 rounded-lg bg-background px-4 py-3",
+          props.className,
+        )}
         disabled={isLoading}
         onClick={() => setModalOpen(true)}
         variant="outline"


### PR DESCRIPTION
Follow-ups from review on #8916.

- Pressing Enter in the vault unlock dialog set the key but left the dialog open, while the button path closed it. Both paths now behave the same.
- `ListAccessTokens` and `RotateAdminKeyButton` accept a `className` and merge it onto their root element.

Not taking the suggestion to split the seven server actions in `@/actions/vault.ts` into separate files — it is a file-layout change over freshly landed code with no behavioural benefit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `RotateAdminKeyButton` and `ListAccessTokens` components by adding a `className` prop for better styling customization and updates the class name handling using the `cn` utility function.

### Detailed summary
- Added `className?` prop to `RotateAdminKeyButton` and `ListAccessTokens`.
- Updated the `className` handling in `RotateAdminKeyButton` using `cn`.
- Updated the `className` handling in `ListAccessTokens` using `cn`.
- Added `handleCloseModal()` call in `ListAccessTokens` on Enter key press.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pressing Enter while unlocking the vault now closes the unlock dialog after the key is set.

* **Improvements**
  * Vault access-token lists and admin key rotation controls now support flexible styling for improved layout integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->