### PR TITLE
[Dashboard] Create vault service accounts through api-server

### DIFF
--- a/apps/dashboard/src/@/actions/vault.ts
+++ b/apps/dashboard/src/@/actions/vault.ts
@@ -45,6 +45,11 @@ type RotateVaultServiceAccountResult = {
   walletAccessToken?: string;
 };
 
+type CreateVaultServiceAccountResult = RotateVaultServiceAccountResult & {
+  /** The project's default server wallet, null when none was created. */
+  projectWalletAddress: string | null;
+};
+
 /**
  * Credentials the caller supplies to unlock a vault. A managed vault takes the
  * project secret key, an ejected one takes the vault admin key.
@@ -148,6 +153,38 @@ export async function setVaultProjectWallet(params: {
 
   if (!res.ok) {
     throw new Error(errorMessage(res.error, "Failed to update project wallet"));
+  }
+
+  return res.data.data;
+}
+
+/**
+ * Creates the project's vault service account and its access tokens.
+ *
+ * A managed vault seals its admin key and wallet token with the project secret
+ * key and returns neither. An ejected vault returns both, once.
+ */
+export async function createVaultServiceAccount(params: {
+  project: ProjectRef;
+  mode: "managed" | "ejected";
+  projectSecretKey?: string;
+  skipWalletCreation?: boolean;
+}): Promise<CreateVaultServiceAccountResult> {
+  const res = await apiServerProxy<{
+    data: CreateVaultServiceAccountResult;
+  }>({
+    body: JSON.stringify({
+      mode: params.mode,
+      projectSecretKey: params.projectSecretKey,
+      skipWalletCreation: params.skipWalletCreation,
+    }),
+    headers: { "Content-Type": "application/json" },
+    method: "POST",
+    pathname: vaultPath(params.project, "/service-account"),
+  });
+
+  if (!res.ok) {
+    throw new Error(errorMessage(res.error, "Failed to create vault"));
   }
 
   return res.data.data;

--- a/apps/dashboard/src/@/components/project/create-project-modal/index.tsx
+++ b/apps/dashboard/src/@/components/project/create-project-modal/index.tsx
@@ -7,6 +7,7 @@ import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
+import { createVaultServiceAccount } from "@/actions/vault";
 import type { Project } from "@/api/project/projects";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -38,7 +39,6 @@ import { createProjectClient } from "@/hooks/useApi";
 import { useDashboardRouter } from "@/lib/DashboardRouter";
 import { projectDomainsSchema, projectNameSchema } from "@/schema/validations";
 import { toArrFromList } from "@/utils/string";
-import { createVaultAccountAndAccessToken } from "../../../../app/(app)/team/[team_slug]/[project_slug]/(sidebar)/transactions/lib/vault.client";
 
 const ALL_PROJECT_SERVICES = SERVICES.filter(
   (srv) => srv.name !== "relayer" && srv.name !== "chainsaw",
@@ -64,8 +64,12 @@ const CreateProjectDialog = (props: CreateProjectDialogProps) => {
     <CreateProjectDialogUI
       createProject={async (params) => {
         const res = await createProjectClient(props.teamId, params);
-        const vaultTokens = await createVaultAccountAndAccessToken({
-          project: res.project,
+        await createVaultServiceAccount({
+          mode: "managed",
+          project: {
+            projectId: res.project.id,
+            teamId: res.project.teamId,
+          },
           projectSecretKey: res.secret,
         }).catch((error) => {
           console.error(
@@ -74,12 +78,6 @@ const CreateProjectDialog = (props: CreateProjectDialogProps) => {
           );
           throw error;
         });
-
-        const managementAccessToken = vaultTokens.managementToken?.accessToken;
-
-        if (!managementAccessToken) {
-          throw new Error("Missing management access token for project wallet");
-        }
 
         return {
           project: res.project,

--- a/apps/dashboard/src/app/(app)/get-started/team/[team_slug]/create-project/_components/create-project-form.tsx
+++ b/apps/dashboard/src/app/(app)/get-started/team/[team_slug]/create-project/_components/create-project-form.tsx
@@ -8,6 +8,7 @@ import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
+import { createVaultServiceAccount } from "@/actions/vault";
 import { reportOnboardingCompleted } from "@/analytics/report";
 import type { Project } from "@/api/project/projects";
 import type { CreateProjectPrefillOptions } from "@/components/project/create-project-modal";
@@ -33,7 +34,6 @@ import { createProjectClient } from "@/hooks/useApi";
 import { useDashboardRouter } from "@/lib/DashboardRouter";
 import { projectDomainsSchema, projectNameSchema } from "@/schema/validations";
 import { toArrFromList } from "@/utils/string";
-import { createVaultAccountAndAccessToken } from "../../../../../team/[team_slug]/[project_slug]/(sidebar)/transactions/lib/vault.client";
 
 const ALL_PROJECT_SERVICES = SERVICES.filter(
   (srv) => srv.name !== "relayer" && srv.name !== "chainsaw",
@@ -55,8 +55,12 @@ export function CreateProjectFormOnboarding(props: {
           <CreateProjectForm
             createProject={async (params) => {
               const res = await createProjectClient(props.teamId, params);
-              const vaultTokens = await createVaultAccountAndAccessToken({
-                project: res.project,
+              await createVaultServiceAccount({
+                mode: "managed",
+                project: {
+                  projectId: res.project.id,
+                  teamId: res.project.teamId,
+                },
                 projectSecretKey: res.secret,
               }).catch((error) => {
                 console.error(
@@ -65,15 +69,6 @@ export function CreateProjectFormOnboarding(props: {
                 );
                 throw error;
               });
-
-              const managementAccessToken =
-                vaultTokens.managementToken?.accessToken;
-
-              if (!managementAccessToken) {
-                throw new Error(
-                  "Missing management access token for project wallet",
-                );
-              }
 
               return {
                 project: res.project,

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/transactions/lib/vault.client.ts
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/transactions/lib/vault.client.ts
@@ -3,12 +3,9 @@
 import { decrypt, encrypt } from "@thirdweb-dev/service-utils";
 import {
   createAccessToken,
-  createEoa,
-  createServiceAccount,
   createVaultClient,
   type VaultClient,
 } from "@thirdweb-dev/vault-sdk";
-import { engineCloudProxy } from "@/actions/proxies";
 import {
   createVaultServerWallet,
   setVaultProjectWallet,
@@ -16,7 +13,6 @@ import {
 import type { Project } from "@/api/project/projects";
 import { NEXT_PUBLIC_THIRDWEB_VAULT_URL } from "@/constants/public-envs";
 import { updateProjectClient } from "@/hooks/useApi";
-import { getProjectWalletLabel } from "@/lib/project-wallet";
 
 const SERVER_WALLET_ACCESS_TOKEN_PURPOSE =
   "Access Token for All Server Wallets";
@@ -24,44 +20,11 @@ const SERVER_WALLET_ACCESS_TOKEN_PURPOSE =
 const SERVER_WALLET_MANAGEMENT_ACCESS_TOKEN_PURPOSE =
   "Management Token for Dashboard";
 
-/**
- * Retry a function with exponential backoff.
- */
-async function withRetry<T>(
-  fn: () => Promise<T>,
-  options: { maxAttempts?: number; baseDelayMs?: number } = {},
-): Promise<T> {
-  const { maxAttempts = 3, baseDelayMs = 1000 } = options;
-  if (!Number.isInteger(maxAttempts) || maxAttempts < 1) {
-    throw new Error("maxAttempts must be at least 1");
-  }
-  if (!Number.isFinite(baseDelayMs) || baseDelayMs < 0) {
-    throw new Error("baseDelayMs must be a non-negative number");
-  }
-  let lastError: Error | undefined;
-
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    try {
-      return await fn();
-    } catch (error) {
-      lastError = error instanceof Error ? error : new Error(String(error));
-      if (attempt < maxAttempts) {
-        // Exponential backoff with cap at 30s and jitter to prevent thundering herd
-        const delay = Math.min(baseDelayMs * 2 ** (attempt - 1), 30_000);
-        const jitter = Math.floor(Math.random() * Math.min(250, delay));
-        await new Promise<void>((resolve) =>
-          setTimeout(resolve, delay + jitter),
-        );
-      }
-    }
-  }
-
-  throw lastError ?? new Error("withRetry failed without capturing an error");
-}
-
 let vc: VaultClient | null = null;
 
-export async function initVaultClient() {
+// Only `upgradeAccessTokensForSolana` still needs this; every other vault
+// operation goes through api-server.
+async function initVaultClient() {
   if (vc) {
     return vc;
   }
@@ -69,57 +32,6 @@ export async function initVaultClient() {
     baseUrl: NEXT_PUBLIC_THIRDWEB_VAULT_URL,
   });
   return vc;
-}
-
-export async function createVaultAccountAndAccessToken(props: {
-  project: Project;
-  projectSecretKey?: string;
-  projectSecretHash?: string;
-}) {
-  try {
-    const vaultClient = await initVaultClient();
-
-    const serviceAccountResult = await createServiceAccount({
-      client: vaultClient,
-      request: {
-        options: {
-          metadata: {
-            projectId: props.project.id,
-            purpose: "Thirdweb Project Server Wallet Service Account",
-            teamId: props.project.teamId,
-          },
-        },
-      },
-    });
-    if (serviceAccountResult.success === false) {
-      throw new Error(
-        `Failed to create service account: ${serviceAccountResult.error}`,
-      );
-    }
-    const serviceAccount = serviceAccountResult.data;
-    const adminKey = serviceAccount.adminKey;
-    const rotationCode = serviceAccount.rotationCode;
-
-    const { managementToken, walletToken } =
-      await createAndEncryptVaultAccessTokens({
-        project: props.project,
-        projectSecretKey: props.projectSecretKey,
-        projectSecretHash: props.projectSecretHash,
-        vaultClient,
-        adminKey,
-        rotationCode,
-      });
-
-    return {
-      adminKey,
-      managementToken,
-      walletToken,
-    };
-  } catch (error) {
-    throw new Error(
-      `Failed to create vault account and access token: ${error}`,
-    );
-  }
 }
 
 export async function createProjectServerWallet(props: {
@@ -145,166 +57,6 @@ export async function updateDefaultProjectWallet(props: {
     address: props.projectWalletAddress,
     project: { projectId: props.project.id, teamId: props.project.teamId },
   });
-}
-
-/**
- * Creates the project's first server wallet during vault setup. Runs before the
- * management token is stored on the project, so it uses the token it was handed.
- */
-async function createDefaultServerWallet(props: {
-  project: Project;
-  managementAccessToken: string;
-  vaultClient: VaultClient;
-}) {
-  const eoa = await createEoa({
-    client: props.vaultClient,
-    request: {
-      auth: {
-        accessToken: props.managementAccessToken,
-      },
-      options: {
-        metadata: {
-          label: getProjectWalletLabel(props.project.name),
-          projectId: props.project.id,
-          teamId: props.project.teamId,
-          type: "server-wallet",
-        },
-      },
-    },
-  });
-
-  if (!eoa.success) {
-    throw new Error(eoa.error?.message || "Failed to create server wallet");
-  }
-
-  engineCloudProxy({
-    body: JSON.stringify({
-      signerAddress: eoa.data.address,
-    }),
-    headers: {
-      "Content-Type": "application/json",
-      "x-client-id": props.project.publishableKey,
-      "x-team-id": props.project.teamId,
-    },
-    method: "POST",
-    pathname: "/cache/smart-account",
-  }).catch((err) => {
-    console.warn("failed to cache server wallet", err);
-  });
-
-  return eoa.data;
-}
-
-async function createAndEncryptVaultAccessTokens(props: {
-  project: Project;
-  vaultClient: VaultClient;
-  projectSecretKey?: string;
-  projectSecretHash?: string;
-  adminKey: string;
-  rotationCode: string;
-}) {
-  const {
-    project,
-    projectSecretKey,
-    projectSecretHash,
-    vaultClient,
-    adminKey,
-    rotationCode,
-  } = props;
-
-  const [managementTokenResult, walletTokenResult] = await Promise.all([
-    createManagementAccessToken({ project, adminKey, vaultClient }),
-    createWalletAccessToken({ project, adminKey, vaultClient }),
-  ]);
-
-  if (!managementTokenResult.success) {
-    throw new Error(
-      `Failed to create management token: ${managementTokenResult.error}`,
-    );
-  }
-
-  if (!walletTokenResult.success) {
-    throw new Error(
-      `Failed to create wallet token: ${walletTokenResult.error}`,
-    );
-  }
-
-  const managementToken = managementTokenResult.data;
-  const walletToken = walletTokenResult.data;
-
-  // CRITICAL: Save credentials IMMEDIATELY after creating tokens.
-  // This prevents a broken state if wallet creation or other operations fail.
-  // The rotationCode is consumed when rotating, so if we don't save the new one,
-  // the project becomes unrecoverable.
-  let encryptedAdminKey: string | null = null;
-  let encryptedWalletAccessToken: string | null = null;
-
-  if (projectSecretKey) {
-    // verify that the project secret key is valid
-    const projectSecretKeyHash = await hashSecretKey(projectSecretKey);
-    const secretKeysHashed = [
-      ...project.secretKeys,
-      // for newly rotated secret keys, we don't have the secret key in the project secret keys yet
-      ...(projectSecretHash ? [{ hash: projectSecretHash }] : []),
-    ];
-    if (!secretKeysHashed.some((key) => key?.hash === projectSecretKeyHash)) {
-      throw new Error("Invalid project secret key");
-    }
-
-    // encrypt admin key and wallet token with project secret key
-    [encryptedAdminKey, encryptedWalletAccessToken] = await Promise.all([
-      encrypt(adminKey, projectSecretKey),
-      encrypt(walletToken.accessToken, projectSecretKey),
-    ]);
-  }
-
-  let projectWalletAddress: string | null | undefined = project.services.find(
-    (s) => s.name === "engineCloud",
-  )?.projectWalletAddress;
-
-  if (!projectWalletAddress) {
-    const defaultProjectServerWallet = await createDefaultServerWallet({
-      project,
-      managementAccessToken: managementToken.accessToken,
-      vaultClient,
-    });
-    projectWalletAddress = defaultProjectServerWallet.address;
-  }
-
-  // Save credentials with retry - this is critical because if rotation succeeded
-  // but this save fails, the new rotation code is lost and project becomes unrecoverable
-  await withRetry(
-    () =>
-      updateProjectClient(
-        {
-          projectId: project.id,
-          teamId: project.teamId,
-        },
-        {
-          services: [
-            ...project.services.filter(
-              (service) => service.name !== "engineCloud",
-            ),
-            {
-              name: "engineCloud",
-              actions: [],
-              managementAccessToken: managementToken.accessToken,
-              maskedAdminKey: maskSecret(adminKey),
-              encryptedAdminKey,
-              encryptedWalletAccessToken,
-              rotationCode: rotationCode,
-              projectWalletAddress: projectWalletAddress ?? null,
-            },
-          ],
-        },
-      ),
-    { maxAttempts: 3, baseDelayMs: 1000 },
-  );
-
-  return {
-    managementToken,
-    walletToken,
-  };
 }
 
 async function createWalletAccessToken(props: {

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/vault/components/create-vault-account.client.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/vault/components/create-vault-account.client.tsx
@@ -9,6 +9,7 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
+import { createVaultServiceAccount } from "@/actions/vault";
 import type { Project } from "@/api/project/projects";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -25,10 +26,7 @@ import { Label } from "@/components/ui/label";
 import { Spinner } from "@/components/ui/Spinner";
 import { useDashboardRouter } from "@/lib/DashboardRouter";
 import { cn } from "@/lib/utils";
-import {
-  createVaultAccountAndAccessToken,
-  maskSecret,
-} from "../../transactions/lib/vault.client";
+import { maskSecret } from "../../transactions/lib/vault.client";
 
 export function CreateVaultAccountButton(props: { project: Project }) {
   const [secretKeyModalOpen, setSecretKeyModalOpen] = useState(false);
@@ -45,12 +43,14 @@ export function CreateVaultAccountButton(props: { project: Project }) {
       setModalOpen(true);
       setSecretKeyModalOpen(false);
 
-      const result = await createVaultAccountAndAccessToken({
-        project: props.project,
+      return createVaultServiceAccount({
+        mode: projectSecretKey ? "managed" : "ejected",
+        project: {
+          projectId: props.project.id,
+          teamId: props.project.teamId,
+        },
         projectSecretKey,
       });
-
-      return result;
     },
     onError: (error) => {
       setErrorMessage(error.message);
@@ -90,12 +90,23 @@ export function CreateVaultAccountButton(props: { project: Project }) {
     setManageSelfChecked(false);
   };
 
+  // Only an ejected vault returns its keys; a managed vault keeps them.
+  const createdKeys =
+    initialiseProjectWithVaultMutation.data?.adminKey &&
+    initialiseProjectWithVaultMutation.data.walletAccessToken
+      ? {
+          adminKey: initialiseProjectWithVaultMutation.data.adminKey,
+          walletAccessToken:
+            initialiseProjectWithVaultMutation.data.walletAccessToken,
+        }
+      : undefined;
+
   const handleDownloadKeys = () => {
-    if (!initialiseProjectWithVaultMutation.data) {
+    if (!createdKeys) {
       return;
     }
 
-    const fileContent = `Project:\n${props.project.name} (${props.project.publishableKey})\n\nVault Admin Key:\n${initialiseProjectWithVaultMutation.data.adminKey}\n\nVault Access Token:\n${initialiseProjectWithVaultMutation.data.walletToken.accessToken}\n`;
+    const fileContent = `Project:\n${props.project.name} (${props.project.publishableKey})\n\nVault Admin Key:\n${createdKeys.adminKey}\n\nVault Access Token:\n${createdKeys.walletAccessToken}\n`;
     const blob = new Blob([fileContent], { type: "text/plain;charset=utf-8" });
     const url = URL.createObjectURL(blob);
     const link = document.createElement("a");
@@ -114,7 +125,7 @@ export function CreateVaultAccountButton(props: { project: Project }) {
   };
 
   const handleCloseModal = () => {
-    if (!keysConfirmed) {
+    if (createdKeys && !keysConfirmed) {
       return;
     }
 
@@ -234,7 +245,7 @@ export function CreateVaultAccountButton(props: { project: Project }) {
       <Dialog modal={true} onOpenChange={handleCloseModal} open={modalOpen}>
         <DialogContent
           className="overflow-hidden p-0"
-          dialogCloseClassName={cn(!keysConfirmed && "hidden")}
+          dialogCloseClassName={cn(createdKeys && !keysConfirmed && "hidden")}
         >
           {initialiseProjectWithVaultMutation.isPending ? (
             <>
@@ -248,7 +259,7 @@ export function CreateVaultAccountButton(props: { project: Project }) {
                 </p>
               </div>
             </>
-          ) : initialiseProjectWithVaultMutation.data ? (
+          ) : createdKeys ? (
             <div>
               <DialogHeader className="p-6">
                 <DialogTitle>Save your Vault Admin Key</DialogTitle>
@@ -265,12 +276,8 @@ export function CreateVaultAccountButton(props: { project: Project }) {
                       <CopyTextButton
                         className="!h-auto w-full justify-between bg-background px-3 py-3 font-mono text-xs"
                         copyIconPosition="right"
-                        textToCopy={
-                          initialiseProjectWithVaultMutation.data.adminKey
-                        }
-                        textToShow={maskSecret(
-                          initialiseProjectWithVaultMutation.data.adminKey,
-                        )}
+                        textToCopy={createdKeys.adminKey}
+                        textToShow={maskSecret(createdKeys.adminKey)}
                         tooltip="Copy Admin Key"
                       />
                       <p className="text-muted-foreground text-xs">
@@ -319,6 +326,34 @@ export function CreateVaultAccountButton(props: { project: Project }) {
                   onClick={handleCloseModal}
                   variant={"primary"}
                 >
+                  Close
+                </Button>
+              </div>
+            </div>
+          ) : initialiseProjectWithVaultMutation.data ? (
+            <div>
+              <DialogHeader className="p-6">
+                <DialogTitle>Vault Created</DialogTitle>
+              </DialogHeader>
+
+              <div className="space-y-6 p-6 pt-0">
+                <div>
+                  <h3 className="mb-2 font-medium text-sm">Vault Admin Key</h3>
+                  <div className="flex flex-col gap-2">
+                    <div className="flex w-full items-center rounded-lg border bg-background px-3 py-3 font-mono text-xs">
+                      {initialiseProjectWithVaultMutation.data.maskedAdminKey}
+                    </div>
+                    <p className="text-muted-foreground text-xs">
+                      Your admin key and wallet access token were encrypted with
+                      your project secret key. Use your project secret key to
+                      access your vault.
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              <div className="flex justify-end gap-3 border-t bg-card px-6 py-4">
+                <Button onClick={handleCloseModal} variant="primary">
                   Close
                 </Button>
               </div>

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/wallets/server-wallets/wallets/vault-recovery-card.client.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/wallets/server-wallets/wallets/vault-recovery-card.client.tsx
@@ -9,6 +9,7 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
+import { createVaultServiceAccount } from "@/actions/vault";
 import type { Project } from "@/api/project/projects";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import {
@@ -27,11 +28,7 @@ import { CopyTextButton } from "@/components/ui/CopyTextButton";
 import { Checkbox, CheckboxWithLabel } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Spinner } from "@/components/ui/Spinner";
-import {
-  createVaultAccountAndAccessToken,
-  initVaultClient,
-  maskSecret,
-} from "../../../transactions/lib/vault.client";
+import { maskSecret } from "../../../transactions/lib/vault.client";
 
 interface VaultRecoveryCardProps {
   errorMessage: string;
@@ -66,15 +63,12 @@ export function VaultRecoveryCard({
 
   const regenerateMutation = useMutation({
     mutationFn: async () => {
-      await initVaultClient();
-
-      const result = await createVaultAccountAndAccessToken({
-        project,
+      return createVaultServiceAccount({
+        mode: willCreateEjectedVault ? "ejected" : "managed",
+        project: { projectId: project.id, teamId: project.teamId },
         // Only pass secret key if creating managed vault (not ejected)
         projectSecretKey: willCreateEjectedVault ? undefined : secretKeyInput,
       });
-
-      return result;
     },
     onSuccess: () => {
       // For managed vaults (with secret key), reload immediately
@@ -86,12 +80,22 @@ export function VaultRecoveryCard({
     },
   });
 
+  // Only an ejected vault returns its keys; a managed vault keeps them.
+  const createdKeys =
+    regenerateMutation.data?.adminKey &&
+    regenerateMutation.data.walletAccessToken
+      ? {
+          adminKey: regenerateMutation.data.adminKey,
+          walletAccessToken: regenerateMutation.data.walletAccessToken,
+        }
+      : undefined;
+
   const handleDownloadKeys = () => {
-    if (!regenerateMutation.data) {
+    if (!createdKeys) {
       return;
     }
 
-    const fileContent = `Project:\n${project.name} (${project.publishableKey})\n\nVault Admin Key:\n${regenerateMutation.data.adminKey}\n\nVault Access Token:\n${regenerateMutation.data.walletToken.accessToken}\n`;
+    const fileContent = `Project:\n${project.name} (${project.publishableKey})\n\nVault Admin Key:\n${createdKeys.adminKey}\n\nVault Access Token:\n${createdKeys.walletAccessToken}\n`;
     const blob = new Blob([fileContent], { type: "text/plain;charset=utf-8" });
     const url = URL.createObjectURL(blob);
     const link = document.createElement("a");
@@ -170,7 +174,7 @@ export function VaultRecoveryCard({
           </AlertDialogTrigger>
           <AlertDialogContent>
             {/* Show key download UI for ejected vaults after success */}
-            {willCreateEjectedVault && regenerateMutation.data ? (
+            {createdKeys ? (
               <>
                 <AlertDialogHeader>
                   <AlertDialogTitle>Save your Vault Admin Key</AlertDialogTitle>
@@ -185,10 +189,8 @@ export function VaultRecoveryCard({
                         <CopyTextButton
                           className="!h-auto w-full justify-between bg-background px-3 py-3 font-mono text-xs"
                           copyIconPosition="right"
-                          textToCopy={regenerateMutation.data.adminKey}
-                          textToShow={maskSecret(
-                            regenerateMutation.data.adminKey,
-                          )}
+                          textToCopy={createdKeys.adminKey}
+                          textToShow={maskSecret(createdKeys.adminKey)}
                           tooltip="Copy Admin Key"
                         />
                         <p className="text-muted-foreground text-xs">


### PR DESCRIPTION
Moves the last vault operation still running in the browser — service-account creation — onto the api-server endpoint added for it.

### Changes

- [x] `@/actions/vault.ts`: added `createVaultServiceAccount`, posting `{ mode, projectSecretKey?, skipWalletCreation? }` to `POST /v1/teams/:teamIdOrSlug/projects/:projectIdOrSlug/vault/service-account` and returning `{ isManagedVault, maskedAdminKey, projectWalletAddress, adminKey?, walletAccessToken? }`. Follows the conventions of the actions added in #8916.
- [x] Removed `createVaultAccountAndAccessToken` from `transactions/lib/vault.client.ts`, along with the browser-side token minting, encryption, default-wallet creation and project-write retry it owned. The server does all of it in one call.
- [x] Updated the four callers: `create-vault-account.client.tsx`, `vault-recovery-card.client.tsx`, `create-project-modal/index.tsx`, `create-project-form.tsx`.
- [x] `initVaultClient` is no longer exported.

### Behaviour

Project creation is unchanged: one call, managed mode, default server wallet created server-side. The management token is now persisted by the server rather than round-tripped through the browser, so the client-side "missing management access token" guard is gone.

A managed vault no longer returns its admin key or wallet token — the server seals both with the project secret key. The creation dialog therefore shows the masked admin key for a managed vault, matching the rotate dialog, and keeps the existing key display, `.txt` download and "I confirm I've stored these" gating for ejected vaults.

The endpoint refuses with a typed 409 when the project already has a service account, pointing the caller at rotation. `vault-recovery-card.client.tsx` surfaces that message; giving that card a rotation-based path is worth a follow-up.

### Not migrated

`upgradeAccessTokensForSolana` stays in the browser. It reissues a project's management and wallet tokens in place under the existing admin key, and no api-server endpoint does that — `access-tokens` mints wallet-policy tokens only and never writes `managementAccessToken`, and rotation replaces the admin key. `initVaultClient`, `NEXT_PUBLIC_THIRDWEB_VAULT_URL` and the `@thirdweb-dev/vault-sdk` import stay for that one caller and can be deleted once it has an endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `createVaultServiceAccount` function and updates various components to utilize this function for creating vault service accounts instead of the previous method. It also enhances type definitions and error handling.

### Detailed summary
- Added `CreateVaultServiceAccountResult` type with `projectWalletAddress`.
- Implemented `createVaultServiceAccount` function in `vault.ts`.
- Updated `createProject` logic in multiple components to use `createVaultServiceAccount`.
- Removed references to `createVaultAccountAndAccessToken` in favor of the new function.
- Enhanced error handling when creating vault service accounts.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added streamlined Vault service account creation during project setup.
  - Added support for managed and ejected Vault configurations.
  - Ejected configurations now provide downloadable administrator credentials.
  - Managed configurations display a masked administrator key without requiring credential confirmation.
  - Added project server wallet creation and default wallet updates through Vault actions.

- **Improvements**
  - Simplified Vault recovery with consistent credential display, copying, and download options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->