### PR TITLE
[Dashboard] Send the vault rotation mode when rotating an admin key

### DIFF
--- a/apps/dashboard/src/@/actions/vault.ts
+++ b/apps/dashboard/src/@/actions/vault.ts
@@ -190,14 +190,26 @@ export async function createVaultServiceAccount(params: {
   return res.data.data;
 }
 
+/**
+ * Rotates the project's vault admin key.
+ *
+ * `mode` is the state to leave the vault in. `managed` re-seals the new
+ * credentials with the project secret key and returns only the mask; `ejected`
+ * returns the admin key and wallet token once and keeps no copy. Omitting it
+ * keeps the vault as it is.
+ */
 export async function rotateVaultServiceAccount(params: {
   project: ProjectRef;
+  mode?: "managed" | "ejected";
   projectSecretKey?: string;
 }): Promise<RotateVaultServiceAccountResult> {
   const res = await apiServerProxy<{
     data: RotateVaultServiceAccountResult;
   }>({
-    body: JSON.stringify({ projectSecretKey: params.projectSecretKey }),
+    body: JSON.stringify({
+      mode: params.mode,
+      projectSecretKey: params.projectSecretKey,
+    }),
     headers: { "Content-Type": "application/json" },
     method: "POST",
     pathname: vaultPath(params.project, "/service-account/rotate"),

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/vault/components/rotate-admin-key.client.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/vault/components/rotate-admin-key.client.tsx
@@ -48,6 +48,7 @@ export default function RotateAdminKeyButton(props: {
   const rotateAdminKeyMutation = useMutation({
     mutationFn: async () => {
       return rotateVaultServiceAccount({
+        mode: willStayManaged ? "managed" : "ejected",
         project: {
           projectId: props.project.id,
           teamId: props.project.teamId,

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/vault/components/rotate-admin-key.client.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/vault/components/rotate-admin-key.client.tsx
@@ -48,7 +48,7 @@ export default function RotateAdminKeyButton(props: {
   const rotateAdminKeyMutation = useMutation({
     mutationFn: async () => {
       return rotateVaultServiceAccount({
-        mode: willStayManaged ? "managed" : "ejected",
+        mode: stayManaged ? "managed" : "ejected",
         project: {
           projectId: props.project.id,
           teamId: props.project.teamId,


### PR DESCRIPTION
Completes the server-side vault rotation API by sending the new `mode` parameter, which fixes unticking "Keep this vault managed" in the Rotate Admin Key dialog.

The rotate endpoint used to take only an optional project secret key and infer managed-vs-ejected from what it had stored, so a managed vault always stayed managed. Unticking the box sent an absent secret key, which the server read as a managed vault missing its key rather than as a request to eject. It now takes `mode: "managed" | "ejected"` alongside the secret key, matching what `createVaultServiceAccount` already sends.

## Changes

- [x] `@/actions/vault.ts`: `rotateVaultServiceAccount` takes an optional `mode: "managed" | "ejected"` and forwards it in the body, following the conventions of `createVaultServiceAccount` in the same file.
- [x] `rotate-admin-key.client.tsx`: `willStayManaged` already drives the dialog copy and the submit button; it now also picks the mode. Ejecting sends no secret key, since there is nothing to re-encrypt.

`mode` is optional and omitting it preserves the vault's current state, so this is backward compatible and the two sides can deploy in either order.

## No UX change

- An ejected result still shows the admin key and wallet access token, offers the `.txt` download, and gates dialog close behind "I confirm that I've securely stored these keys".
- A managed result still shows the masked key.
- A vault that is already ejected is unaffected: the checkbox only renders for a managed vault, so that path sends `"ejected"` and behaves as before.

## Verification

`npx tsc --noEmit` from `apps/dashboard` exits 0. `biome check` on both changed files reports no lint or import-order diagnostics; the only complaint is the repo-wide CRLF format one, which this checkout also produces on untouched files.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `rotateVaultServiceAccount` function by introducing a new `mode` parameter, which allows for different behaviors when rotating the vault admin key.

### Detailed summary
- Added `mode` parameter to `rotateVaultServiceAccount`, allowing values `"managed"` or `"ejected"`.
- Updated the request body in the API call to include the `mode`.
- Added documentation comments explaining the `mode` functionality and its effects.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vault service account rotation now supports managed and ejected modes.
  * The rotation mode is automatically selected based on whether the vault remains managed or is ejected.
  * Rotation requests include the selected mode and project secret key when available, ensuring the vault configuration is handled correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->