### PR TITLE
[Dashboard] Point AI requests at the gateway

### DIFF
--- a/apps/dashboard/src/@/constants/public-envs.ts
+++ b/apps/dashboard/src/@/constants/public-envs.ts
@@ -28,7 +28,7 @@ export const NEXT_PUBLIC_DEMO_ENGINE_URL =
   process.env.NEXT_PUBLIC_DEMO_ENGINE_URL || "";
 
 export const NEXT_PUBLIC_THIRDWEB_AI_HOST =
-  process.env.NEXT_PUBLIC_THIRDWEB_AI_HOST || "https://nebula-api.thirdweb.com";
+  process.env.NEXT_PUBLIC_THIRDWEB_AI_HOST || "https://api.thirdweb.com/ai";
 
 export const NEXT_PUBLIC_BRIDGE_PAGE_CLIENT_ID =
   process.env.NEXT_PUBLIC_BRIDGE_PAGE_CLIENT_ID;

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/ai/api/chat.ts
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/ai/api/chat.ts
@@ -18,25 +18,22 @@ export async function promptNebula(params: {
   project: Project;
 }) {
   const body: Record<string, string | boolean | object> = {
+    context: {
+      chain_ids: params.context?.chainIds || [],
+      from: params.context?.walletAddress,
+      networks: params.context?.networks,
+      session_id: params.sessionId,
+    },
     messages: [params.message],
-    session_id: params.sessionId,
     stream: true,
   };
-
-  if (params.context) {
-    body.context = {
-      chain_ids: params.context.chainIds || [],
-      networks: params.context.networks,
-      wallet_address: params.context.walletAddress,
-    };
-  }
 
   try {
     const events = await stream(`${NEXT_PUBLIC_THIRDWEB_AI_HOST}/chat`, {
       body: JSON.stringify(body),
       headers: {
         Authorization: `Bearer ${params.authToken}`,
-        "x-team-id": params.project.teamId,
+        "x-thirdweb-team-id": params.project.teamId,
         "x-client-id": params.project.publishableKey,
         "Content-Type": "application/json",
       },

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/ai/api/fetchWithAuthToken.ts
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/ai/api/fetchWithAuthToken.ts
@@ -33,7 +33,7 @@ export async function fetchWithAuthToken(options: FetchWithKeyOptions) {
       headers: {
         Accept: "application/json",
         Authorization: `Bearer ${authToken}`,
-        "x-team-id": options.project.teamId,
+        "x-thirdweb-team-id": options.project.teamId,
         "x-client-id": options.project.publishableKey,
         "Content-Type": "application/json",
       },

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/vault/components/rotate-admin-key.client.tsx
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/vault/components/rotate-admin-key.client.tsx
@@ -90,8 +90,7 @@ export default function RotateAdminKeyButton(props: {
   // The confirm checkbox is the only way out of this dialog, and closing it
   // discards the response. Require the keys to actually leave the screen
   // first: a download, or a copy of both values.
-  const keysCaptured =
-    keysDownloaded || (adminKeyCopied && accessTokenCopied);
+  const keysCaptured = keysDownloaded || (adminKeyCopied && accessTokenCopied);
 
   const closeBlocked =
     rotateAdminKeyMutation.isPending || (!!ejectedKeys && !keysConfirmed);


### PR DESCRIPTION
Routes the project AI features at their current host and matches the expected request shape.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the API interactions and constants related to the `thirdweb` service, enhancing the way team IDs are handled in requests, and refining the context structure for chat API calls.

### Detailed summary
- Changed header key from `x-team-id` to `x-thirdweb-team-id` in `fetchWithAuthToken.ts`.
- Updated the default value of `NEXT_PUBLIC_THIRDWEB_AI_HOST` in `public-envs.ts` to a new API endpoint.
- Refined the `keysCaptured` assignment in `rotate-admin-key.client.tsx`.
- Enhanced the context structure in the chat API body in `chat.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated AI service connectivity to use the current API endpoint.
  * Improved AI chat request handling, including session context and wallet information.
  * Updated team authentication headers for reliable project requests.

* **Style**
  * Simplified internal key-capture formatting without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->