### PR TITLE
chore(dashboard): move chain SEO fetch to seo-pages.thirdweb.xyz

### DIFF
--- a/apps/dashboard/src/app/(app)/(dashboard)/(chain)/[chain_id]/(chainPage)/apis/chain-seo.ts
+++ b/apps/dashboard/src/app/(app)/(dashboard)/(chain)/[chain_id]/(chainPage)/apis/chain-seo.ts
@@ -30,20 +30,24 @@ type ChainSeo = {
 
 export const fetchChainSeo = unstable_cache(
   async (chainId: number) => {
-    const url = new URL(
-      `https://seo-pages-generator-5814.zeet-nftlabs.zeet.app/chain/${chainId}`,
-    );
-    const res = await fetch(url, {
-      headers: {
-        "Content-Type": "application/json",
-      },
-    });
+    const url = new URL(`https://seo-pages.thirdweb.xyz/chain/${chainId}`);
 
-    if (!res.ok) {
+    // SEO copy is decorative -- never let a fetch failure take down the page.
+    try {
+      const res = await fetch(url, {
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+
+      if (!res.ok) {
+        return undefined;
+      }
+
+      return (await res.json()) as ChainSeo;
+    } catch {
       return undefined;
     }
-
-    return res.json() as Promise<ChainSeo>;
   },
   ["chain-seo"],
   { revalidate: 60 * 60 * 24 }, // 24 hours

--- a/apps/dashboard/src/app/(app)/(dashboard)/(chain)/[chain_id]/(chainPage)/apis/chain-seo.ts
+++ b/apps/dashboard/src/app/(app)/(dashboard)/(chain)/[chain_id]/(chainPage)/apis/chain-seo.ts
@@ -28,27 +28,43 @@ type ChainSeo = {
   };
 };
 
-export const fetchChainSeo = unstable_cache(
-  async (chainId: number) => {
-    const url = new URL(`https://seo-pages.thirdweb.xyz/chain/${chainId}`);
+async function fetchChainSeoUncached(
+  chainId: number,
+): Promise<ChainSeo | undefined> {
+  const url = new URL(`https://seo-pages.thirdweb.xyz/chain/${chainId}`);
 
-    // SEO copy is decorative -- never let a fetch failure take down the page.
-    try {
-      const res = await fetch(url, {
-        headers: {
-          "Content-Type": "application/json",
-        },
-      });
+  const res = await fetch(url, {
+    headers: { "Content-Type": "application/json" },
+  });
 
-      if (!res.ok) {
-        return undefined;
-      }
+  // 4xx means this chain simply has no SEO entry -- a stable answer worth caching.
+  if (res.status >= 400 && res.status < 500) {
+    return undefined;
+  }
 
-      return (await res.json()) as ChainSeo;
-    } catch {
-      return undefined;
-    }
-  },
+  // 5xx (or any other non-OK) is transient. Throw so unstable_cache does not
+  // persist the failure and starve the page of SEO for a full day.
+  if (!res.ok) {
+    throw new Error(`chain SEO fetch failed: ${res.status}`);
+  }
+
+  return (await res.json()) as ChainSeo;
+}
+
+const fetchChainSeoCached = unstable_cache(
+  fetchChainSeoUncached,
   ["chain-seo"],
   { revalidate: 60 * 60 * 24 }, // 24 hours
 );
+
+export async function fetchChainSeo(
+  chainId: number,
+): Promise<ChainSeo | undefined> {
+  // SEO copy is decorative: a failure must never take the page down. A transient
+  // error propagates out of the cache uncached, and we degrade to undefined here.
+  try {
+    return await fetchChainSeoCached(chainId);
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
Point the chain SEO fetch at `seo-pages.thirdweb.xyz`; degrade to `undefined` on failure instead of caching it.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR refactors the SEO fetching logic for chains in the `chain-seo.ts` file. It introduces a new uncached function and modifies error handling to improve reliability and caching behavior.

### Detailed summary
- Renamed `fetchChainSeo` to `fetchChainSeoUncached`.
- Updated the URL to a new endpoint.
- Changed error handling to differentiate between 4xx and 5xx status codes.
- Introduced `fetchChainSeoCached` with caching settings.
- Added a new `fetchChainSeo` function that uses the cached version and handles transient errors gracefully.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of chain SEO data requests.
  * 4xx responses are handled gracefully and cached appropriately.
  * Temporary server or processing failures are no longer cached, allowing later requests to recover automatically.
  * Unexpected request, parsing, and caching errors now fail safely without disrupting the experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->